### PR TITLE
JDK-8290063: IGV: Give the graphs a unique number in the outline

### DIFF
--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/FolderNode.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/FolderNode.java
@@ -30,6 +30,8 @@ import com.sun.hotspot.igv.util.StringUtils;
 import java.awt.Image;
 import java.util.HashMap;
 import java.util.Map;
+import javax.swing.Action;
+import org.openide.actions.PropertiesAction;
 import org.openide.actions.RenameAction;
 import org.openide.nodes.*;
 import org.openide.util.ImageUtilities;

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/FolderNode.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/FolderNode.java
@@ -28,10 +28,8 @@ import com.sun.hotspot.igv.data.*;
 import com.sun.hotspot.igv.util.PropertiesSheet;
 import com.sun.hotspot.igv.util.StringUtils;
 import java.awt.Image;
-import java.beans.PropertyChangeEvent;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import org.openide.nodes.*;
 import org.openide.util.ImageUtilities;
 import org.openide.util.lookup.AbstractLookup;
@@ -65,32 +63,13 @@ public class FolderNode extends AbstractNode {
 
         @Override
         protected Node[] createNodes(FolderElement folderElement) {
-
             if (folderElement instanceof InputGraph) {
                 InputGraph inputGraph = (InputGraph) folderElement;
                 GraphNode graphNode = new GraphNode(inputGraph);
                 graphNodeMap.put(inputGraph, graphNode);
-                graphNode.addNodeListener(new NodeAdapter() {
-                    @Override
-                    public void propertyChange(PropertyChangeEvent ev) {
-                        if (Objects.equals(ev.getPropertyName(), "displayName")) {
-
-                            folderElement.getDisplayNameChangedEvent().fire();
-                        }
-                    }
-                });
                 return new Node[]{graphNode};
             } else if (folderElement instanceof Group) {
-                FolderNode folderNode = new FolderNode((Group) folderElement);
-                folderNode.addNodeListener(new NodeAdapter() {
-                    @Override
-                    public void propertyChange(PropertyChangeEvent ev) {
-                        if (Objects.equals(ev.getPropertyName(), "displayName")) {
-                            folderElement.getDisplayNameChangedEvent().fire();
-                        }
-                    }
-                });
-                return new Node[]{folderNode};
+                return new Node[]{new FolderNode((Group) folderElement)};
             } else {
                 return null;
             }
@@ -102,20 +81,20 @@ public class FolderNode extends AbstractNode {
                 // Each node is only present once in the graphNode map.
                 graphNodeMap.values().remove(n);
             }
+            for (Node node : getNodes()) {
+                node.setDisplayName(node.getDisplayName());
+            }
         }
 
         @Override
         public void addNotify() {
-            this.setKeys(folder.getElements());
+            super.addNotify();
+            setKeys(folder.getElements());
         }
 
         @Override
         public void changed(Object source) {
             addNotify();
-            for (Node node : getNodes()) {
-                // refresh the display name
-                node.setDisplayName(node.getDisplayName());
-            }
         }
     }
 
@@ -182,6 +161,7 @@ public class FolderNode extends AbstractNode {
         return children.getFolder().getDisplayName();
     }
 
+    @Override
     public String getHtmlDisplayName() {
         String htmlDisplayName = StringUtils.escapeHTML(getDisplayName());
         if (selected) {

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/FolderNode.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/FolderNode.java
@@ -154,6 +154,7 @@ public class FolderNode extends AbstractNode {
         children.getFolder().setName(name);
         fireDisplayNameChange(null, null);
     }
+    
     @Override
     public String getName() {
         return children.getFolder().getName();

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/FolderNode.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/FolderNode.java
@@ -30,6 +30,7 @@ import com.sun.hotspot.igv.util.StringUtils;
 import java.awt.Image;
 import java.util.HashMap;
 import java.util.Map;
+import org.openide.actions.RenameAction;
 import org.openide.nodes.*;
 import org.openide.util.ImageUtilities;
 import org.openide.util.lookup.AbstractLookup;
@@ -178,6 +179,14 @@ public class FolderNode extends AbstractNode {
     @Override
     public Image getOpenedIcon(int i) {
         return getIcon(i);
+    }
+
+    @Override
+    public Action[] getActions(boolean b) {
+        return new Action[]{
+                RenameAction.findObject(RenameAction.class, true),
+                PropertiesAction.findObject(PropertiesAction.class, true),
+        };
     }
 
     public static void clearGraphNodeMap() {

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/FolderNode.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/FolderNode.java
@@ -169,9 +169,12 @@ public class FolderNode extends AbstractNode {
 
     @Override
     public void setName(String name) {
-        super.setName(name);
         children.getFolder().setName(name);
         fireDisplayNameChange(null, null);
+    }
+    @Override
+    public String getName() {
+        return children.getFolder().getName();
     }
 
     @Override

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/FolderNode.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/FolderNode.java
@@ -146,6 +146,18 @@ public class FolderNode extends AbstractNode {
     }
 
     @Override
+    public boolean canRename() {
+        return true;
+    }
+
+    @Override
+    public void setName(String name) {
+        super.setName(name);
+        children.getFolder().setName(name);
+        fireDisplayNameChange(null, null);
+    }
+
+    @Override
     public String getDisplayName() {
         return children.getFolder().getDisplayName();
     }

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/FolderNode.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/FolderNode.java
@@ -154,7 +154,7 @@ public class FolderNode extends AbstractNode {
         children.getFolder().setName(name);
         fireDisplayNameChange(null, null);
     }
-    
+
     @Override
     public String getName() {
         return children.getFolder().getName();

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/FolderNode.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/FolderNode.java
@@ -95,7 +95,11 @@ public class FolderNode extends AbstractNode {
         @Override
         public void changed(Object source) {
             addNotify();
-         }
+            for (Node node : getNodes()) {
+                // refresh the display name
+                node.setDisplayName(node.getDisplayName());
+            }
+        }
     }
 
     @Override
@@ -128,7 +132,7 @@ public class FolderNode extends AbstractNode {
         if (folder instanceof FolderElement) {
             final FolderElement folderElement = (FolderElement) folder;
             this.setDisplayName(folderElement.getName());
-            content.add((RemoveCookie) () -> {
+            this.content.add((RemoveCookie) () -> {
                 children.destroyNodes(children.getNodes());
                 folderElement.getParent().removeElement(folderElement);
             });
@@ -141,21 +145,17 @@ public class FolderNode extends AbstractNode {
         fireIconChange();
     }
 
+    @Override
+    public String getDisplayName() {
+        return children.getFolder().getDisplayName();
+    }
+
     public String getHtmlDisplayName() {
         String htmlDisplayName = StringUtils.escapeHTML(getDisplayName());
         if (selected) {
             htmlDisplayName = "<b>" + htmlDisplayName + "</b>";
         }
         return htmlDisplayName;
-    }
-
-    public void init(String name, List<Group> groups) {
-        this.setDisplayName(name);
-        children.addNotify();
-
-        for (Group g : groups) {
-            content.add(g);
-        }
     }
 
     public boolean isRootNode() {

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/GraphNode.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/GraphNode.java
@@ -104,13 +104,6 @@ public class GraphNode extends AbstractNode {
 
         // Action for cloning to the current graph
         content.add(new GraphCloneCookie(viewer, graph));
-
-        this.addNodeListener(new NodeAdapter() {
-            @Override
-            public void childrenRemoved(NodeMemberEvent ev) {
-                GraphNode.this.graph = null;
-            }
-        });
     }
 
     @Override

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/GraphNode.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/GraphNode.java
@@ -59,9 +59,12 @@ public class GraphNode extends AbstractNode {
 
     @Override
     public void setName(String name) {
-        super.setName(name);
         graph.setName(name);
         fireDisplayNameChange(null, null);
+    }
+    @Override
+    public String getName() {
+        return graph.getName();
     }
 
     public void setSelected(boolean selected) {

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/GraphNode.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/GraphNode.java
@@ -32,6 +32,7 @@ import com.sun.hotspot.igv.util.StringUtils;
 import java.awt.Image;
 import javax.swing.Action;
 import org.openide.actions.OpenAction;
+import org.openide.actions.RenameAction;
 import org.openide.nodes.*;
 import org.openide.util.ImageUtilities;
 import org.openide.util.Lookup;
@@ -137,7 +138,12 @@ public class GraphNode extends AbstractNode {
 
     @Override
     public Action[] getActions(boolean b) {
-        return new Action[]{DiffGraphAction.findObject(DiffGraphAction.class, true), CloneGraphAction.findObject(CloneGraphAction.class, true), OpenAction.findObject(OpenAction.class, true)};
+        return new Action[]{
+                RenameAction.findObject(RenameAction.class, true),
+                DiffGraphAction.findObject(DiffGraphAction.class, true),
+                CloneGraphAction.findObject(CloneGraphAction.class, true),
+                OpenAction.findObject(OpenAction.class, true)
+        };
     }
 
     @Override

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/GraphNode.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/GraphNode.java
@@ -44,7 +44,7 @@ import org.openide.util.lookup.InstanceContent;
  */
 public class GraphNode extends AbstractNode {
 
-    private InputGraph graph;
+    private final InputGraph graph;
     private boolean selected = false;
 
     /** Creates a new instance of GraphNode */
@@ -73,6 +73,7 @@ public class GraphNode extends AbstractNode {
         fireIconChange();
     }
 
+    @Override
     public String getHtmlDisplayName() {
         String htmlDisplayName = StringUtils.escapeHTML(getDisplayName());
         if (selected) {

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/GraphNode.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/GraphNode.java
@@ -65,6 +65,12 @@ public class GraphNode extends AbstractNode {
         }
         return htmlDisplayName;
     }
+
+    @Override
+    public String getDisplayName() {
+        return graph.getDisplayName();
+    }
+
     private GraphNode(InputGraph graph, InstanceContent content) {
         super(Children.LEAF, new AbstractLookup(content));
         this.graph = graph;

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/GraphNode.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/GraphNode.java
@@ -52,6 +52,18 @@ public class GraphNode extends AbstractNode {
         this(graph, new InstanceContent());
     }
 
+    @Override
+    public boolean canRename() {
+        return true;
+    }
+
+    @Override
+    public void setName(String name) {
+        super.setName(name);
+        graph.setName(name);
+        fireDisplayNameChange(null, null);
+    }
+
     public void setSelected(boolean selected) {
         this.selected = selected;
         fireDisplayNameChange(null, null);

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/GraphNode.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/GraphNode.java
@@ -63,6 +63,7 @@ public class GraphNode extends AbstractNode {
         graph.setName(name);
         fireDisplayNameChange(null, null);
     }
+
     @Override
     public String getName() {
         return graph.getName();

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
@@ -26,7 +26,6 @@ package com.sun.hotspot.igv.coordinator;
 import com.sun.hotspot.igv.connection.Server;
 import com.sun.hotspot.igv.coordinator.actions.*;
 import com.sun.hotspot.igv.data.ChangedListener;
-import com.sun.hotspot.igv.data.FolderElement;
 import com.sun.hotspot.igv.data.GraphDocument;
 import com.sun.hotspot.igv.data.InputGraph;
 import com.sun.hotspot.igv.data.services.GroupCallback;

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
@@ -26,6 +26,7 @@ package com.sun.hotspot.igv.coordinator;
 import com.sun.hotspot.igv.connection.Server;
 import com.sun.hotspot.igv.coordinator.actions.*;
 import com.sun.hotspot.igv.data.ChangedListener;
+import com.sun.hotspot.igv.data.FolderElement;
 import com.sun.hotspot.igv.data.GraphDocument;
 import com.sun.hotspot.igv.data.InputGraph;
 import com.sun.hotspot.igv.data.services.GroupCallback;

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/resources/com/sun/hotspot/igv/coordinator/layer.xml
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/resources/com/sun/hotspot/igv/coordinator/layer.xml
@@ -20,6 +20,9 @@
         <file name="DS-W.shadow">
             <attr name="originalFile" stringvalue="Actions/File/com-sun-hotspot-igv-coordinator-actions-RemoveAllAction.instance"/>
         </file>
+        <file name="AD-R.shadow">
+            <attr name="originalFile" stringvalue="Actions/System/org-openide-actions-RenameAction.instance"/>
+        </file>
     </folder>
     <folder name="Actions">
         <folder name="File">
@@ -58,27 +61,35 @@
             </file>
             <file name="SeparatorSave.instance">
                 <attr name="instanceClass" stringvalue="javax.swing.JSeparator"/>
-                <attr name="position" intvalue="150"/>
+                <attr name="position" intvalue="200"/>
+            </file>
+            <file name="org-openide-actions-RenameAction.shadow">
+                <attr name="originalFile" stringvalue="Actions/System/org-openide-actions-RenameAction.instance"/>
+                <attr name="position" intvalue="300"/>
+            </file>
+            <file name="SeparatorRename.instance">
+                <attr name="instanceClass" stringvalue="javax.swing.JSeparator"/>
+                <attr name="position" intvalue="400"/>
             </file>
             <file name="com-sun-hotspot-igv-coordinator-actions-SaveAsAction.shadow">
                 <attr name="originalFile" stringvalue="Actions/File/com-sun-hotspot-igv-coordinator-actions-SaveAsAction.instance"/>
-                <attr name="position" intvalue="200"/>
+                <attr name="position" intvalue="500"/>
             </file>
             <file name="com-sun-hotspot-igv-coordinator-actions-SaveAllAction.shadow">
                 <attr name="originalFile" stringvalue="Actions/File/com-sun-hotspot-igv-coordinator-actions-SaveAllAction.instance"/>
-                <attr name="position" intvalue="300"/>
+                <attr name="position" intvalue="600"/>
             </file>
             <file name="SeparatorRemove.instance">
                 <attr name="instanceClass" stringvalue="javax.swing.JSeparator"/>
-                <attr name="position" intvalue="350"/>
+                <attr name="position" intvalue="700"/>
             </file>
             <file name="com-sun-hotspot-igv-coordinator-actions-RemoveAction.shadow">
                 <attr name="originalFile" stringvalue="Actions/File/com-sun-hotspot-igv-coordinator-actions-RemoveAction.instance"/>
-                <attr name="position" intvalue="400"/>
+                <attr name="position" intvalue="800"/>
             </file>
             <file name="com-sun-hotspot-igv-coordinator-actions-RemoveAllAction.shadow">
                 <attr name="originalFile" stringvalue="Actions/File/com-sun-hotspot-igv-coordinator-actions-RemoveAllAction.instance"/>
-                <attr name="position" intvalue="500"/>
+                <attr name="position" intvalue="900"/>
             </file>
             <!-- Hidden menu entries from other modules -->
             <file name="org-netbeans-modules-editor-ExportHtmlAction.shadow_hidden"/>

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Folder.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Folder.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 public interface Folder {
     void setName(String name);
+    String getName();
     String getDisplayName();
     List<? extends FolderElement> getElements();
     void removeElement(FolderElement element);

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Folder.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Folder.java
@@ -26,6 +26,7 @@ package com.sun.hotspot.igv.data;
 import java.util.List;
 
 public interface Folder {
+    String getDisplayName();
     List<? extends FolderElement> getElements();
     void removeElement(FolderElement element);
     void addElement(FolderElement group);

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Folder.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Folder.java
@@ -26,6 +26,7 @@ package com.sun.hotspot.igv.data;
 import java.util.List;
 
 public interface Folder {
+    void setName(String name);
     String getDisplayName();
     List<? extends FolderElement> getElements();
     void removeElement(FolderElement element);

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/FolderElement.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/FolderElement.java
@@ -24,10 +24,12 @@
 package com.sun.hotspot.igv.data;
 
 public interface FolderElement {
-
+    void updateNameAndIndex();
+    ChangedEvent<? extends FolderElement> getIndexChangedEvent();
     ChangedEvent<? extends FolderElement> getDisplayNameChangedEvent();
-    Folder getParent();
+    void setName(String name);
     String getName();
     String getDisplayName();
     void setParent(Folder parent);
+    Folder getParent();
 }

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/FolderElement.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/FolderElement.java
@@ -27,5 +27,6 @@ public interface FolderElement {
 
     Folder getParent();
     String getName();
+    String getDisplayName();
     void setParent(Folder parent);
 }

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/FolderElement.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/FolderElement.java
@@ -25,6 +25,7 @@ package com.sun.hotspot.igv.data;
 
 public interface FolderElement {
 
+    ChangedEvent<? extends FolderElement> getDisplayNameChangedEvent();
     Folder getParent();
     String getName();
     String getDisplayName();

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/FolderElement.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/FolderElement.java
@@ -24,8 +24,6 @@
 package com.sun.hotspot.igv.data;
 
 public interface FolderElement {
-    void updateNameAndIndex();
-    ChangedEvent<? extends FolderElement> getIndexChangedEvent();
     ChangedEvent<? extends FolderElement> getDisplayNameChangedEvent();
     void setName(String name);
     String getName();

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/GraphDocument.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/GraphDocument.java
@@ -62,6 +62,11 @@ public class GraphDocument extends Properties.Entity implements ChangedEventProv
     }
 
     @Override
+    public String getDisplayName() {
+        return "GraphDocument";
+    }
+
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
 

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/GraphDocument.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/GraphDocument.java
@@ -100,7 +100,7 @@ public class GraphDocument extends Properties.Entity implements ChangedEventProv
             getChangedEvent().fire();
         }
         for (FolderElement folderElement : elements) {
-            folderElement.updateNameAndIndex();
+            folderElement.getDisplayNameChangedEvent().fire();
         }
     }
 

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/GraphDocument.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/GraphDocument.java
@@ -34,12 +34,12 @@ public class GraphDocument extends Properties.Entity implements ChangedEventProv
 
     private final List<FolderElement> elements;
     private final ChangedEvent<GraphDocument> changedEvent;
-    private String displayName;
+    private String name;
 
     public GraphDocument() {
         elements = new ArrayList<>();
         changedEvent = new ChangedEvent<>(this);
-        displayName = "GraphDocument";
+        setName("GraphDocument");
     }
 
     public void clear() {
@@ -65,12 +65,16 @@ public class GraphDocument extends Properties.Entity implements ChangedEventProv
 
     @Override
     public void setName(String name) {
-        displayName = name;
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
     }
 
     @Override
     public String getDisplayName() {
-        return displayName;
+        return getName();
     }
 
     @Override

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/GraphDocument.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/GraphDocument.java
@@ -34,10 +34,12 @@ public class GraphDocument extends Properties.Entity implements ChangedEventProv
 
     private final List<FolderElement> elements;
     private final ChangedEvent<GraphDocument> changedEvent;
+    private String displayName;
 
     public GraphDocument() {
         elements = new ArrayList<>();
         changedEvent = new ChangedEvent<>(this);
+        displayName = "GraphDocument";
     }
 
     public void clear() {
@@ -62,8 +64,13 @@ public class GraphDocument extends Properties.Entity implements ChangedEventProv
     }
 
     @Override
+    public void setName(String name) {
+        displayName = name;
+    }
+
+    @Override
     public String getDisplayName() {
-        return "GraphDocument";
+        return displayName;
     }
 
     @Override

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/GraphDocument.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/GraphDocument.java
@@ -80,7 +80,6 @@ public class GraphDocument extends Properties.Entity implements ChangedEventProv
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-
         sb.append("GraphDocument: ").append(getProperties().toString()).append(" \n\n");
         for (FolderElement g : getElements()) {
             sb.append(g.toString());
@@ -99,6 +98,9 @@ public class GraphDocument extends Properties.Entity implements ChangedEventProv
     public void removeElement(FolderElement element) {
         if (elements.remove(element)) {
             getChangedEvent().fire();
+        }
+        for (FolderElement folderElement : elements) {
+            folderElement.updateNameAndIndex();
         }
     }
 

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Group.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Group.java
@@ -34,6 +34,8 @@ public class Group extends Properties.Entity implements ChangedEventProvider<Gro
     private final List<InputGraph> graphs;
     private InputMethod method;
     private final transient ChangedEvent<Group> changedEvent;
+    private final ChangedEvent<Group> displayNameChangedEvent = new ChangedEvent<>(this);
+
     private Folder parent;
 
     public Group(Folder parent) {
@@ -107,9 +109,14 @@ public class Group extends Properties.Entity implements ChangedEventProvider<Gro
         return getParent().getElements().indexOf(this) + " - " + getName();
     }
 
+    public ChangedEvent<Group> getDisplayNameChangedEvent() {
+        return displayNameChangedEvent;
+    }
+
     @Override
     public void setName(String name) {
         getProperties().setProperty("name", name);
+        displayNameChangedEvent.fire();
     }
 
     @Override

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Group.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Group.java
@@ -35,6 +35,7 @@ public class Group extends Properties.Entity implements ChangedEventProvider<Gro
     private InputMethod method;
     private final transient ChangedEvent<Group> changedEvent;
     private final ChangedEvent<Group> displayNameChangedEvent = new ChangedEvent<>(this);
+    private final ChangedEvent<Group> indexChangedEvent = new ChangedEvent<>(this);
 
     private Folder parent;
 
@@ -74,6 +75,9 @@ public class Group extends Properties.Entity implements ChangedEventProvider<Gro
         if (graphs.remove((InputGraph) element)) {
             getChangedEvent().fire();
         }
+        for (InputGraph inputGraph : graphs) {
+            inputGraph.updateNameAndIndex();
+        }
     }
 
     @Override
@@ -105,10 +109,17 @@ public class Group extends Properties.Entity implements ChangedEventProvider<Gro
     }
 
     @Override
-    public String getDisplayName() {
-        return getParent().getElements().indexOf(this) + " - " + getName();
+    public void updateNameAndIndex() {
+        indexChangedEvent.fire();
+        displayNameChangedEvent.fire();
     }
 
+    @Override
+    public ChangedEvent<Group> getIndexChangedEvent() {
+        return indexChangedEvent;
+    }
+
+    @Override
     public ChangedEvent<Group> getDisplayNameChangedEvent() {
         return displayNameChangedEvent;
     }
@@ -124,9 +135,13 @@ public class Group extends Properties.Entity implements ChangedEventProvider<Gro
         return getProperties().get("name");
     }
 
+    @Override
+    public String getDisplayName() {
+        return getParent().getElements().indexOf(this) + " - " + getName();
+    }
+
     public String getType() {
         return getProperties().get("type");
-
     }
 
     InputGraph getPrev(InputGraph graph) {

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Group.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Group.java
@@ -126,7 +126,7 @@ public class Group extends Properties.Entity implements ChangedEventProvider<Gro
 
     @Override
     public String getDisplayName() {
-        return getParent().getElements().indexOf(this) + " - " + getName();
+        return getParent().getElements().indexOf(this)+1 + " - " + getName();
     }
 
     public String getType() {

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Group.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Group.java
@@ -108,6 +108,11 @@ public class Group extends Properties.Entity implements ChangedEventProvider<Gro
     }
 
     @Override
+    public void setName(String name) {
+        getProperties().setProperty("name", name);
+    }
+
+    @Override
     public String getName() {
         return getProperties().get("name");
     }

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Group.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Group.java
@@ -103,6 +103,11 @@ public class Group extends Properties.Entity implements ChangedEventProvider<Gro
     }
 
     @Override
+    public String getDisplayName() {
+        return getParent().getElements().indexOf(this) + " - " + getName();
+    }
+
+    @Override
     public String getName() {
         return getProperties().get("name");
     }

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Group.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Group.java
@@ -35,7 +35,6 @@ public class Group extends Properties.Entity implements ChangedEventProvider<Gro
     private InputMethod method;
     private final transient ChangedEvent<Group> changedEvent;
     private final ChangedEvent<Group> displayNameChangedEvent = new ChangedEvent<>(this);
-    private final ChangedEvent<Group> indexChangedEvent = new ChangedEvent<>(this);
 
     private Folder parent;
 
@@ -76,7 +75,8 @@ public class Group extends Properties.Entity implements ChangedEventProvider<Gro
             getChangedEvent().fire();
         }
         for (InputGraph inputGraph : graphs) {
-            inputGraph.updateNameAndIndex();
+            assert inputGraph.getDisplayNameChangedEvent() != null;
+            inputGraph.getDisplayNameChangedEvent().fire();
         }
     }
 
@@ -106,17 +106,6 @@ public class Group extends Properties.Entity implements ChangedEventProvider<Gro
             sb.append('\n');
         }
         return sb.toString();
-    }
-
-    @Override
-    public void updateNameAndIndex() {
-        indexChangedEvent.fire();
-        displayNameChangedEvent.fire();
-    }
-
-    @Override
-    public ChangedEvent<Group> getIndexChangedEvent() {
-        return indexChangedEvent;
     }
 
     @Override

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputGraph.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputGraph.java
@@ -220,7 +220,7 @@ public class InputGraph extends Properties.Entity implements FolderElement {
         return parentGroup.getPrev(this);
     }
 
-    private void setName(String name) {
+    public void setName(String name) {
         this.getProperties().setProperty("name", name);
     }
 

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputGraph.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputGraph.java
@@ -229,7 +229,6 @@ public class InputGraph extends Properties.Entity implements FolderElement {
 
     public void setName(String name) {
         getProperties().setProperty("name", name);
-        System.out.println("InputGraph setName() " + name);
         displayNameChangedEvent.fire();
     }
 

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputGraph.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputGraph.java
@@ -250,7 +250,7 @@ public class InputGraph extends Properties.Entity implements FolderElement {
         if (isDiffGraph) {
             return firstGraph.getDisplayName() + " Δ " + secondGraph.getDisplayName();
         } else {
-            return getIndex() + ". " + getName();
+            return getIndex()+1 + ". " + getName();
         }
     }
 

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputGraph.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputGraph.java
@@ -229,6 +229,15 @@ public class InputGraph extends Properties.Entity implements FolderElement {
         return getProperties().get("name");
     }
 
+    @Override
+    public String getDisplayName() {
+        if (isDiffGraph) {
+            return firstGraph.getDisplayName() + " Δ " + secondGraph.getDisplayName();
+        } else {
+            return getGroup().getGraphs().indexOf(this) + ". " + getName();
+        }
+    }
+
     public Collection<InputNode> getNodes() {
         return Collections.unmodifiableCollection(nodes.values());
     }

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputGraph.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputGraph.java
@@ -42,6 +42,7 @@ public class InputGraph extends Properties.Entity implements FolderElement {
     private InputGraph firstGraph;
     private InputGraph secondGraph;
     private final ChangedEvent<InputGraph> displayNameChangedEvent = new ChangedEvent<>(this);
+    private final ChangedEvent<InputGraph> indexChangedEvent = new ChangedEvent<>(this);
 
     public InputGraph(InputGraph firstGraph, InputGraph secondGraph) {
         this(firstGraph.getName() + " Δ " + secondGraph.getName(), true);
@@ -49,7 +50,9 @@ public class InputGraph extends Properties.Entity implements FolderElement {
         this.firstGraph = firstGraph;
         this.secondGraph = secondGraph;
         this.firstGraph.getDisplayNameChangedEvent().addListener(l -> displayNameChangedEvent.fire());
-        this.secondGraph.getDisplayNameChangedEvent().addListener(l -> displayNameChangedEvent.fire());
+        this.secondGraph.getIndexChangedEvent().addListener(l -> indexChangedEvent.fire());
+        this.firstGraph.getDisplayNameChangedEvent().addListener(l -> displayNameChangedEvent.fire());
+        this.secondGraph.getIndexChangedEvent().addListener(l -> indexChangedEvent.fire());
     }
 
     public InputGraph(String name) {
@@ -223,10 +226,23 @@ public class InputGraph extends Properties.Entity implements FolderElement {
         return parentGroup.getPrev(this);
     }
 
+    @Override
+    public void updateNameAndIndex() {
+        indexChangedEvent.fire();
+        displayNameChangedEvent.fire();
+    }
+
+    @Override
+    public ChangedEvent<InputGraph> getIndexChangedEvent() {
+        return indexChangedEvent;
+    }
+
+    @Override
     public ChangedEvent<InputGraph> getDisplayNameChangedEvent() {
         return displayNameChangedEvent;
     }
 
+    @Override
     public void setName(String name) {
         getProperties().setProperty("name", name);
         displayNameChangedEvent.fire();

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewModel.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewModel.java
@@ -45,7 +45,6 @@ import org.openide.util.Lookup;
  */
 public class DiagramViewModel extends RangeSliderModel implements ChangedListener<RangeSliderModel> {
 
-    // Warning: Update setData method if fields are added
     private final Group group;
     private ArrayList<InputGraph> graphs;
     private Set<Integer> hiddenNodes;

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewModel.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewModel.java
@@ -37,6 +37,7 @@ import com.sun.hotspot.igv.settings.Settings;
 import com.sun.hotspot.igv.util.RangeSliderModel;
 import java.awt.Color;
 import java.util.*;
+import java.util.function.Consumer;
 import org.openide.util.Lookup;
 
 /**
@@ -57,6 +58,7 @@ public class DiagramViewModel extends RangeSliderModel implements ChangedListene
     private final ChangedEvent<DiagramViewModel> graphChangedEvent;
     private final ChangedEvent<DiagramViewModel> selectedNodesChangedEvent;
     private final ChangedEvent<DiagramViewModel> hiddenNodesChangedEvent;
+    private ChangedListener<InputGraph> titleChangedListener = g -> {};
     private boolean showSea;
     private boolean showBlocks;
     private boolean showCFG;
@@ -389,6 +391,9 @@ public class DiagramViewModel extends RangeSliderModel implements ChangedListene
 
     @Override
     public void changed(RangeSliderModel source) {
+        if (cachedInputGraph != null) {
+            cachedInputGraph.getDisplayNameChangedEvent().removeListener(titleChangedListener);
+        }
         if (getFirstGraph() != getSecondGraph()) {
             cachedInputGraph = Difference.createDiffGraph(getFirstGraph(), getSecondGraph());
         } else {
@@ -396,6 +401,12 @@ public class DiagramViewModel extends RangeSliderModel implements ChangedListene
         }
         rebuildDiagram();
         graphChangedEvent.fire();
+        assert titleChangedListener != null;
+        cachedInputGraph.getDisplayNameChangedEvent().addListener(titleChangedListener);
+    }
+
+    void addTitleCallback(Consumer<InputGraph> titleCallback) {
+        titleChangedListener = titleCallback::accept;
     }
 
     void close() {

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorTopComponent.java
@@ -141,15 +141,17 @@ public final class EditorTopComponent extends TopComponent {
             final GraphDocument doc = (GraphDocument) group.getParent();
             doc.getChangedEvent().addListener(d -> closeOnRemovedOrEmptyGroup());
         }
-        graph.getDisplayNameChangedEvent().addListener(g -> setDisplayName(g.getDisplayName()));
-        group.getDisplayNameChangedEvent().addListener(g -> setToolTipText(g.getDisplayName()));
+
+        diagramViewModel.addTitleCallback(changedGraph -> {
+            setDisplayName(changedGraph.getDisplayName());
+            setToolTipText(diagramViewModel.getGroup().getDisplayName());
+        });
 
         diagramViewModel.getDiagramChangedEvent().addListener(model -> {
             setDisplayName(model.getGraph().getDisplayName());
             setToolTipText(model.getGroup().getDisplayName());
             graphContent.set(Collections.singletonList(new EditorInputGraphProvider(this)), null);
         });
-        diagramViewModel.getGraphChangedEvent().addListener(model -> model.getGraph().getDisplayNameChangedEvent().addListener(g -> setDisplayName(g.getDisplayName())));
 
         cardLayout = new CardLayout();
         centerPanel = new JPanel();

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorTopComponent.java
@@ -135,18 +135,21 @@ public final class EditorTopComponent extends TopComponent {
         content.add(diagramViewModel);
         associateLookup(new ProxyLookup(scene.getLookup(), new AbstractLookup(graphContent), new AbstractLookup(content)));
 
-        diagramViewModel.getDiagramChangedEvent().addListener(model -> {
-            setDisplayName(model.getGraph().getDisplayName());
-            setToolTipText(model.getGroup().getDisplayName());
-            graphContent.set(Collections.singletonList(new EditorInputGraphProvider(this)), null);
-        });
-
         Group group = diagramViewModel.getGroup();
         group.getChangedEvent().addListener(g -> closeOnRemovedOrEmptyGroup());
         if (group.getParent() instanceof GraphDocument) {
             final GraphDocument doc = (GraphDocument) group.getParent();
             doc.getChangedEvent().addListener(d -> closeOnRemovedOrEmptyGroup());
         }
+        graph.getDisplayNameChangedEvent().addListener(g -> setDisplayName(g.getDisplayName()));
+        group.getDisplayNameChangedEvent().addListener(g -> setToolTipText(g.getDisplayName()));
+
+        diagramViewModel.getDiagramChangedEvent().addListener(model -> {
+            setDisplayName(model.getGraph().getDisplayName());
+            setToolTipText(model.getGroup().getDisplayName());
+            graphContent.set(Collections.singletonList(new EditorInputGraphProvider(this)), null);
+        });
+        diagramViewModel.getGraphChangedEvent().addListener(model -> model.getGraph().getDisplayNameChangedEvent().addListener(g -> setDisplayName(g.getDisplayName())));
 
         cardLayout = new CardLayout();
         centerPanel = new JPanel();

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorTopComponent.java
@@ -136,8 +136,8 @@ public final class EditorTopComponent extends TopComponent {
         associateLookup(new ProxyLookup(scene.getLookup(), new AbstractLookup(graphContent), new AbstractLookup(content)));
 
         diagramViewModel.getDiagramChangedEvent().addListener(model -> {
-            setDisplayName(model.getGraph().getName());
-            setToolTipText(model.getGroup().getName());
+            setDisplayName(model.getGraph().getDisplayName());
+            setToolTipText(model.getGroup().getDisplayName());
             graphContent.set(Collections.singletonList(new EditorInputGraphProvider(this)), null);
         });
 

--- a/src/utils/IdealGraphVisualizer/View/src/main/resources/com/sun/hotspot/igv/view/layer.xml
+++ b/src/utils/IdealGraphVisualizer/View/src/main/resources/com/sun/hotspot/igv/view/layer.xml
@@ -23,7 +23,7 @@
         <folder name="File">
             <file name="ExportActionSeparator.instance">
                 <attr name="instanceClass" stringvalue="javax.swing.JSeparator"/>
-                <attr name="position" intvalue="700"/>
+                <attr name="position" intvalue="2000"/>
             </file>
         </folder>
     </folder>


### PR DESCRIPTION
Some graphs may have the same name more than once in IGV. To make it clearer which graph is currently open, all graphs within a group are now enumerated with `1.`, `2.`, `3.` , etc. Similarly, groups are enumerated with `1 -`, `2 -`, etc.

<img width="696" alt="overview" src="https://user-images.githubusercontent.com/71546117/198584142-887d323b-214d-4034-9b6f-318c697c8bdd.png">

The make it even further easier to distinguish different graphs and group, we can now rename them in two ways. 
**(A)** To rename a group or graph:
1. click on a graph or group once to select it (does not have to be opened). 
2. click a second time on the selected graph and wait 1-2 seconds. 
3. now you can rename the graph
4. on Linux F2 works as a shortcut for renaming
<img width="274" alt="rename_group" src="https://user-images.githubusercontent.com/71546117/198584168-2c3032fc-550f-42a9-9636-f0bf9483d18b.png">
<img width="311" alt="rename_graph" src="https://user-images.githubusercontent.com/71546117/198584177-dce038b8-ffed-411c-9547-c8f04b97474c.png">

**(B)** To rename a group or graph:
1. right-click on a graph or group once to select it (does not have to be opened). 
2. select "Rename.."
3. now a window opens to rename the graph
4. The shortcut for this `RenameAction` is `ALT-CTRL-R` or `OPT-CMD-R` on a mac keyboard
<img width="374" alt="RenameAction" src="https://user-images.githubusercontent.com/71546117/199456619-8b230fc1-4a4f-4ae1-b0a6-8e1540fe4372.png">
<img width="471" alt="Rename" src="https://user-images.githubusercontent.com/71546117/199456666-61b60849-0d08-40a5-a9a5-e4686ef7e587.png">

The numbering always starts at 1 and is continuous from 1 to N for N graphs. When a graph is deleted, the numbering of the following graphs changes. This implementation allows the keep the XML format unchanged, because the numbering is only local and not part of the name. However, if a graph/group is renamed, the name in the XML file will also change when it is saved.    

# Implementation 
The renaming is simply enabled by overriding `canRename() {return true;}` in `FolderNode` and `GraphNode`

The numbering is implemented in `getDisplayName()` in `Group` and `InputGraph` by concatenating the index of the group/graph with the name. 

When a group/graph is deleted the we trigger an update of the index in `FolderNode` -> `destroyNodes(Node[] nodes)` by calling `node.setDisplayName(node.getDisplayName())` for all nodes. 

Refresh the group/graph name in the `EditorTopComponent` of the opened graph is a bit tricky. It is implemented by adding a `Listener` to the `getDisplayNameChangedEvent()` of the currently opened `InputGraph` in `DiagramViewModel`. `getDisplayNameChangedEvent()` is fired whenever the name or the group name of the corresponding `InputGraph` is changed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290063](https://bugs.openjdk.org/browse/JDK-8290063): IGV: Give the graphs a unique number in the outline


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [4f36c623](https://git.openjdk.org/jdk/pull/10873/files/4f36c623178ac3bb2c30805f05f310d7cc361847)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [4f36c623](https://git.openjdk.org/jdk/pull/10873/files/4f36c623178ac3bb2c30805f05f310d7cc361847)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10873/head:pull/10873` \
`$ git checkout pull/10873`

Update a local copy of the PR: \
`$ git checkout pull/10873` \
`$ git pull https://git.openjdk.org/jdk pull/10873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10873`

View PR using the GUI difftool: \
`$ git pr show -t 10873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10873.diff">https://git.openjdk.org/jdk/pull/10873.diff</a>

</details>
