### PR TITLE
8295952: Problemlist existing compiler/rtm tests also on x86

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -53,17 +53,17 @@ compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java 8190680 generic-all
 
 compiler/runtime/Test8168712.java 8211769,8211771 generic-ppc64,generic-ppc64le,linux-s390x
 
-compiler/rtm/locking/TestRTMAbortRatio.java 8183263 generic-x64
-compiler/rtm/locking/TestRTMAbortThreshold.java 8183263 generic-x64
-compiler/rtm/locking/TestRTMAfterNonRTMDeopt.java 8183263 generic-x64
-compiler/rtm/locking/TestRTMDeoptOnHighAbortRatio.java 8183263 generic-x64
-compiler/rtm/locking/TestRTMDeoptOnLowAbortRatio.java 8183263 generic-x64
-compiler/rtm/locking/TestRTMLockingCalculationDelay.java 8183263 generic-x64
-compiler/rtm/locking/TestRTMLockingThreshold.java 8183263 generic-x64
-compiler/rtm/locking/TestRTMSpinLoopCount.java 8183263 generic-x64
-compiler/rtm/locking/TestUseRTMDeopt.java 8183263 generic-x64
-compiler/rtm/locking/TestUseRTMXendForLockBusy.java 8183263 generic-x64
-compiler/rtm/print/TestPrintPreciseRTMLockingStatistics.java 8183263 generic-x64
+compiler/rtm/locking/TestRTMAbortRatio.java 8183263 generic-x64,generic-i586
+compiler/rtm/locking/TestRTMAbortThreshold.java 8183263 generic-x64,generic-i586
+compiler/rtm/locking/TestRTMAfterNonRTMDeopt.java 8183263 generic-x64,generic-i586
+compiler/rtm/locking/TestRTMDeoptOnHighAbortRatio.java 8183263 generic-x64,generic-i586
+compiler/rtm/locking/TestRTMDeoptOnLowAbortRatio.java 8183263 generic-x64,generic-i586
+compiler/rtm/locking/TestRTMLockingCalculationDelay.java 8183263 generic-x64,generic-i586
+compiler/rtm/locking/TestRTMLockingThreshold.java 8183263 generic-x64,generic-i586
+compiler/rtm/locking/TestRTMSpinLoopCount.java 8183263 generic-x64,generic-i586
+compiler/rtm/locking/TestUseRTMDeopt.java 8183263 generic-x64,generic-i586
+compiler/rtm/locking/TestUseRTMXendForLockBusy.java 8183263 generic-x64,generic-i586
+compiler/rtm/print/TestPrintPreciseRTMLockingStatistics.java 8183263 generic-x64,generic-i586
 
 compiler/c2/Test8004741.java 8235801 generic-all
 


### PR DESCRIPTION
Problemlist should be extended so that existing compiler/rtm entries include x86 (32-bit) intel builds as well, as these are also affected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295952](https://bugs.openjdk.org/browse/JDK-8295952): Problemlist existing compiler/rtm tests also on x86


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10875/head:pull/10875` \
`$ git checkout pull/10875`

Update a local copy of the PR: \
`$ git checkout pull/10875` \
`$ git pull https://git.openjdk.org/jdk pull/10875/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10875`

View PR using the GUI difftool: \
`$ git pr show -t 10875`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10875.diff">https://git.openjdk.org/jdk/pull/10875.diff</a>

</details>
