### PR TITLE
8269235: serviceability/sa/ClhsdbJstackXcompStress.java timed out

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbJstackXcompStress.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbJstackXcompStress.java
@@ -38,7 +38,7 @@ import jdk.test.lib.process.OutputAnalyzer;
  * @requires vm.hasSA
  * @requires vm.opt.DeoptimizeALot != true
  * @library /test/lib
- * @run driver ClhsdbJstackXcompStress
+ * @run driver/timeout=300 ClhsdbJstackXcompStress
  */
 public class ClhsdbJstackXcompStress {
 


### PR DESCRIPTION
The test uses the default timeout, which is 2 minutes. The timeoutfactor being used ix 4x, so this gives 8 minutes or 480 seconds. This is why we see:

 Timeout refired 480 times

When this happens, usually the test takes a little over 10 minutes to complete (and pass). However, the most recent failure says:

 elapsed time (seconds): 764.054

So this is nearly 13 minutes. I'm going to give the test 20 minutes (when timeoutfactor 4x is used), so this translate to specifying a timeout of 5 minutes (300 seconds).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269235](https://bugs.openjdk.org/browse/JDK-8269235): serviceability/sa/ClhsdbJstackXcompStress.java timed out


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10876/head:pull/10876` \
`$ git checkout pull/10876`

Update a local copy of the PR: \
`$ git checkout pull/10876` \
`$ git pull https://git.openjdk.org/jdk pull/10876/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10876`

View PR using the GUI difftool: \
`$ git pr show -t 10876`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10876.diff">https://git.openjdk.org/jdk/pull/10876.diff</a>

</details>
