### PR TITLE
8294881: test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003/TestDescription.java fails

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -127,14 +127,14 @@ public class dispose002a {
                          while (true) {
                              instruction = pipe.readln();
                              if (instruction.equals("check_done")) {
-                                 if (test_thread.isAlive()) {
+                                 if (Utils.isAlive(test_thread)) {
                                      logErr("ERROR: thread thread2 is still alive");
                                      exitCode = FAILED;
                                  }
                                  break;
                              } else if (instruction.equals("check_alive")) {
                                  log1("checking on: thread2.isAlive");
-                                 if (test_thread.isAlive()) {
+                                 if (Utils.isAlive(test_thread)) {
                                      pipe.println("alive");
                                      test_thread.interrupt();
                                  } else {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002a.java
@@ -127,14 +127,14 @@ public class dispose002a {
                          while (true) {
                              instruction = pipe.readln();
                              if (instruction.equals("check_done")) {
-                                 if (Utils.isAlive(test_thread)) {
+                                 if (test_thread.isAlive()) {
                                      logErr("ERROR: thread thread2 is still alive");
                                      exitCode = FAILED;
                                  }
                                  break;
                              } else if (instruction.equals("check_alive")) {
-                                 log1("checking on: thread2.isAlive");
-                                 if (Utils.isAlive(test_thread)) {
+                                 if (!JDIUtils.waitForCompletion(test_thread)) {
+                                     log1("thread2 is alive after vm.dispose().");
                                      pipe.println("alive");
                                      test_thread.interrupt();
                                  } else {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002a.java
@@ -133,6 +133,7 @@ public class dispose002a {
                                  }
                                  break;
                              } else if (instruction.equals("check_alive")) {
+                                 log1("checking if thread2 completed");
                                  if (!JDIUtils.waitForCompletion(test_thread)) {
                                      log1("thread2 is alive after vm.dispose().");
                                      pipe.println("alive");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,9 +135,23 @@ public class dispose003a {
                                  break;
                              } else if (instruction.equals("check_alive")) {
                                  log1("checking on: thread2.isAlive");
-                                 if (test_thread.isAlive()) {
-                                     test_thread.resume();
+                                 // There is no sync between vm.dispose() and test_thread
+                                 // let give thread some time to complete
+                                 boolean isAlive = test_thread.isAlive();
+                                 for (int attempt = 0; attempt < 10; i++) {
+                                     isAlive = test_thread.isAlive();
+                                     if (!isAlive) {
+                                         break;
+                                     }
+                                     try {
+                                         Thread.sleep(attempt * 1000);
+                                     } catch (InterruptedException ie) {
+                                     }
+                                 }
+                                 if (isAlive) {
                                      pipe.println("alive");
+                                     logErr("ERROR thread is alive after vm.dispose()");
+                                     exitCode = FAILED;
                                  } else {
                                      pipe.println("not_alive");
                                  }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003a.java
@@ -137,8 +137,8 @@ public class dispose003a {
                                  log1("checking on: thread2.isAlive");
                                  // There is no sync between vm.dispose() and test_thread
                                  // let give thread some time to complete
-                                 boolean isAlive = test_thread.isAlive();
-                                 for (int attempt = 0; attempt < 10; i++) {
+                                 boolean isAlive = true;
+                                 for (int attempt = 0; attempt < 5; i++) {
                                      isAlive = test_thread.isAlive();
                                      if (!isAlive) {
                                          break;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003a.java
@@ -128,14 +128,14 @@ public class dispose003a {
                          while (true) {
                              instruction = pipe.readln();
                              if (instruction.equals("check_done")) {
-                                 if (Utils.isAlive(test_thread)) {
+                                 if (test_thread.isAlive()) {
                                      logErr("ERROR: thread2 thread is still alive");
                                      exitCode = FAILED;
                                  }
                                  break;
                              } else if (instruction.equals("check_alive")) {
                                  log1("checking on: thread2.isAlive");
-                                 if (Utils.isAlive(test_thread)) {
+                                 if (!JDIUtils.waitForCompletion(test_thread)) {
                                      pipe.println("alive");
                                      logErr("ERROR thread is alive after vm.dispose()");
                                      exitCode = FAILED;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003a.java
@@ -128,30 +128,18 @@ public class dispose003a {
                          while (true) {
                              instruction = pipe.readln();
                              if (instruction.equals("check_done")) {
-                                 if (test_thread.isAlive()) {
+                                 if (Utils.isAlive(test_thread)) {
                                      logErr("ERROR: thread2 thread is still alive");
                                      exitCode = FAILED;
                                  }
                                  break;
                              } else if (instruction.equals("check_alive")) {
                                  log1("checking on: thread2.isAlive");
-                                 // There is no sync between vm.dispose() and test_thread
-                                 // let give thread some time to complete
-                                 boolean isAlive = true;
-                                 for (int attempt = 0; attempt < 5; i++) {
-                                     isAlive = test_thread.isAlive();
-                                     if (!isAlive) {
-                                         break;
-                                     }
-                                     try {
-                                         Thread.sleep(attempt * 1000);
-                                     } catch (InterruptedException ie) {
-                                     }
-                                 }
-                                 if (isAlive) {
+                                 if (Utils.isAlive(test_thread)) {
                                      pipe.println("alive");
                                      logErr("ERROR thread is alive after vm.dispose()");
                                      exitCode = FAILED;
+                                     break;
                                  } else {
                                      pipe.println("not_alive");
                                  }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose004a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -129,16 +129,17 @@ public class dispose004a {
                          while (true) {
                              instruction = pipe.readln();
                              if (instruction.equals("check_done")) {
-                                 if (test_thread.isAlive()) {
+                                 if (Utils.isAlive(test_thread)) {
                                      logErr("thread thread2 is still alive");
                                      exitCode = FAILED;
                                  }
                                  break;
                              } else if (instruction.equals("check_alive")) {
                                  log1("checking on: thread2.isAlive");
-                                 if (test_thread.isAlive()) {
-                                     test_thread.resume();
+                                 if (Utils.isAlive(test_thread)) {
                                      pipe.println("alive");
+                                     exitCode = FAILED;
+                                     break;
                                  } else {
                                      pipe.println("not_alive");
                                  }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose004a.java
@@ -129,15 +129,16 @@ public class dispose004a {
                          while (true) {
                              instruction = pipe.readln();
                              if (instruction.equals("check_done")) {
-                                 if (Utils.isAlive(test_thread)) {
+                                 if (test_thread.isAlive()) {
                                      logErr("thread thread2 is still alive");
                                      exitCode = FAILED;
                                  }
                                  break;
                              } else if (instruction.equals("check_alive")) {
                                  log1("checking on: thread2.isAlive");
-                                 if (Utils.isAlive(test_thread)) {
+                                 if (!JDIUtils.waitForCompletion(test_thread)) {
                                      pipe.println("alive");
+                                     logErr("ERROR thread is alive after vm.dispose()");
                                      exitCode = FAILED;
                                      break;
                                  } else {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose005a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose005a.java
@@ -152,9 +152,10 @@ public class dispose005a {
                                  logErr("ERROR: unexpected instruction: " + instruction);
                                  exitCode = FAILED;
                              } else {
-                                 log1("checking on: testedThread.isAlive");
+                                 log1("checking on: test_tread.done");
                                  if (!test_thread.done) {
                                      pipe.println("alive");
+                                     logErr("ERROR thread_thread.done is false after vm.dispose()");
                                      exitCode = FAILED;
                                      break;
                                  } else {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose005a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose005a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -154,8 +154,9 @@ public class dispose005a {
                              } else {
                                  log1("checking on: testedThread.isAlive");
                                  if (!test_thread.done) {
-                                     test_thread.resume();
                                      pipe.println("alive");
+                                     exitCode = FAILED;
+                                     break;
                                  } else {
                                      pipe.println("not_alive");
                                  }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose005a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose005a.java
@@ -152,10 +152,10 @@ public class dispose005a {
                                  logErr("ERROR: unexpected instruction: " + instruction);
                                  exitCode = FAILED;
                              } else {
-                                 log1("checking on: test_tread.done");
+                                 log1("checking on: test_thread.done");
                                  if (!test_thread.done) {
                                      pipe.println("alive");
-                                     logErr("ERROR thread_thread.done is false after vm.dispose()");
+                                     logErr("ERROR test_thread.done is false after vm.dispose()");
                                      exitCode = FAILED;
                                      break;
                                  } else {

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/JDIUtils.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/JDIUtils.java
@@ -23,18 +23,21 @@
 
 package nsk.share.jdi;
 
-public class Utils {
+public class JDIUtils {
 
-    public static boolean isAlive(Thread thread) {
-         for (int attempt = 1; attempt <= 5; attempt++) {
-             if (!thread.isAlive()) {
-                 return false;
-             }
-             try {
-                 Thread.sleep(attempt * 1000);
-             } catch (InterruptedException ie) {
-             }
-         }
-         return true;
+    /*
+     * Wait until thread which is supposed to complet become not alive.
+     */
+    public static boolean waitForCompletion(Thread thread) {
+        for (int attempt = 1; attempt <= 5; attempt++) {
+            if (!thread.isAlive()) {
+                return true;
+            }
+            try {
+                Thread.sleep(attempt * 1000);
+            } catch (InterruptedException ie) {
+            }
+        }
+        return false;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/JDIUtils.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/JDIUtils.java
@@ -26,7 +26,8 @@ package nsk.share.jdi;
 public class JDIUtils {
 
     /*
-     * Wait until thread which is supposed to complet become not alive.
+     * Wait until thread is no longer alive, but only wait
+     * for a short period of time since it shouldn't take long.
      */
     public static boolean waitForCompletion(Thread thread) {
         for (int attempt = 1; attempt <= 5; attempt++) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Utils.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Utils.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package nsk.share.jdi;
+
+public class Utils {
+
+    public static boolean isAlive(Thread thread) {
+         for (int attempt = 1; attempt <= 5; attempt++) {
+             if (!thread.isAlive()) {
+                 return false;
+             }
+             try {
+                 Thread.sleep(attempt * 1000);
+             } catch (InterruptedException ie) {
+             }
+         }
+         return true;
+    }
+}


### PR DESCRIPTION
Change Thread.resume() to error reporting and add some time to complete thread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294881](https://bugs.openjdk.org/browse/JDK-8294881): test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003/TestDescription.java fails


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10877/head:pull/10877` \
`$ git checkout pull/10877`

Update a local copy of the PR: \
`$ git checkout pull/10877` \
`$ git pull https://git.openjdk.org/jdk pull/10877/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10877`

View PR using the GUI difftool: \
`$ git pr show -t 10877`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10877.diff">https://git.openjdk.org/jdk/pull/10877.diff</a>

</details>
