### PR TITLE
8295968: RISC-V: Rename some assembler intrinsic functions for RVV 1.0

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1136,7 +1136,7 @@ enum VectorMask {
   }
 
   // Vector Mask
-  INSN(vpopc_m,  0b1010111, 0b010, 0b10000, 0b010000);
+  INSN(vcpop_m,  0b1010111, 0b010, 0b10000, 0b010000);
   INSN(vfirst_m, 0b1010111, 0b010, 0b10001, 0b010000);
 #undef INSN
 
@@ -1492,11 +1492,11 @@ enum VectorMask {
 
   // Vector Mask-Register Logical Instructions
   INSN(vmxnor_mm,   0b1010111, 0b010, 0b1, 0b011111);
-  INSN(vmornot_mm,  0b1010111, 0b010, 0b1, 0b011100);
+  INSN(vmorn_mm,  0b1010111, 0b010, 0b1, 0b011100);
   INSN(vmnor_mm,    0b1010111, 0b010, 0b1, 0b011110);
   INSN(vmor_mm,     0b1010111, 0b010, 0b1, 0b011010);
   INSN(vmxor_mm,    0b1010111, 0b010, 0b1, 0b011011);
-  INSN(vmandnot_mm, 0b1010111, 0b010, 0b1, 0b011000);
+  INSN(vmandn_mm, 0b1010111, 0b010, 0b1, 0b011000);
   INSN(vmnand_mm,   0b1010111, 0b010, 0b1, 0b011101);
   INSN(vmand_mm,    0b1010111, 0b010, 0b1, 0b011001);
 

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1282,7 +1282,7 @@ enum VectorMask {
   }
 
   // Vector Single-Width Floating-Point Reduction Instructions
-  INSN(vfredsum_vs,   0b1010111, 0b001, 0b000001);
+  INSN(vfredusum_vs,  0b1010111, 0b001, 0b000001);
   INSN(vfredosum_vs,  0b1010111, 0b001, 0b000011);
   INSN(vfredmin_vs,   0b1010111, 0b001, 0b000101);
   INSN(vfredmax_vs,   0b1010111, 0b001, 0b000111);
@@ -1596,7 +1596,7 @@ enum Nf {
   }
 
   // Vector Load/Store Instructions
-  INSN(vl1r_v, 0b0000111, 0b01000, 0b1, 0b00, g1);
+  INSN(vl1re8_v, 0b0000111, 0b01000, 0b1, 0b00, g1);
 
 #undef INSN
 
@@ -1617,8 +1617,8 @@ enum Nf {
   }
 
   // Vector Unit-Stride Instructions
-  INSN(vle1_v, 0b0000111, 0b000, 0b01011, 0b00, 0b0);
-  INSN(vse1_v, 0b0100111, 0b000, 0b01011, 0b00, 0b0);
+  INSN(vlm_v, 0b0000111, 0b000, 0b01011, 0b00, 0b0);
+  INSN(vsm_v, 0b0100111, 0b000, 0b01011, 0b00, 0b0);
 
 #undef INSN
 

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1492,11 +1492,11 @@ enum VectorMask {
 
   // Vector Mask-Register Logical Instructions
   INSN(vmxnor_mm,   0b1010111, 0b010, 0b1, 0b011111);
-  INSN(vmorn_mm,  0b1010111, 0b010, 0b1, 0b011100);
+  INSN(vmorn_mm,    0b1010111, 0b010, 0b1, 0b011100);
   INSN(vmnor_mm,    0b1010111, 0b010, 0b1, 0b011110);
   INSN(vmor_mm,     0b1010111, 0b010, 0b1, 0b011010);
   INSN(vmxor_mm,    0b1010111, 0b010, 0b1, 0b011011);
-  INSN(vmandn_mm, 0b1010111, 0b010, 0b1, 0b011000);
+  INSN(vmandn_mm,   0b1010111, 0b010, 0b1, 0b011000);
   INSN(vmnand_mm,   0b1010111, 0b010, 0b1, 0b011101);
   INSN(vmand_mm,    0b1010111, 0b010, 0b1, 0b011001);
 

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1673,7 +1673,7 @@ void C2_MacroAssembler::reduce_minmax_FD_v(FloatRegister dst,
 
   bind(L_NaN);
   vfmv_s_f(tmp2, src1);
-  vfredsum_vs(tmp1, src2, tmp2);
+  vfredusum_vs(tmp1, src2, tmp2);
 
   bind(L_done);
   vfmv_f_s(dst, tmp1);

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -134,7 +134,7 @@
 
   void unspill(VectorRegister v, int offset) {
     add(t0, sp, offset);
-    vl1r_v(v, t0);
+    vl1re8_v(v, t0);
   }
 
   void spill_copy_vector_stack_to_stack(int src_offset, int dst_offset, int vec_reg_size_in_bytes) {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1310,7 +1310,7 @@ int MacroAssembler::pop_v(unsigned int bitset, Register stack) {
   int count = bitset_to_regs(bitset, regs);
 
   for (int i = count - 1; i >= 0; i--) {
-    vl1r_v(as_VectorRegister(regs[i]), stack);
+    vl1re8_v(as_VectorRegister(regs[i]), stack);
     add(stack, stack, vector_size_in_bytes);
   }
 


### PR DESCRIPTION
Hi,

Some instructions previously had old assembler notation, but were renamed in RVV1.0 to be consistent with scalar instructions, such as `vpopc_m->vcpop_m`[1] , `vfredsum_vs->vfredusum_vs`[2], `vmornot_mm->vmorn_mm/vmandnot_mm->vmandn_mm`[3], `vle1_v->vlm_v/vse1_v->vsm_v`[4]. We'd better keep the name the same as the new assembler mnemonics.

The instruction `vl1r.v` in rvv0.9[5] is the same logic as `vl1re8.v` in rvv1.0[6], while in rvv1.0 it becomes a pseudoinstruction which is equal to `vl1re8.v`.

By the way, we can find all the rvv aliases here[7].

Please take a look and have some reviews. Thanks a lot.


[1] https://github.com/riscv/riscv-v-spec/blob/v1.0/v-spec.adoc#152-vector-count-population-in-mask-vcpopm
[2] https://github.com/riscv/riscv-v-spec/blob/v1.0/v-spec.adoc#143-vector-single-width-floating-point-reduction-instructions
[3] https://github.com/riscv/riscv-v-spec/blob/v1.0/v-spec.adoc#151-vector-mask-register-logical-instructions
[4] https://github.com/riscv/riscv-v-spec/blob/v1.0/v-spec.adoc#74-vector-unit-stride-instructions
[5] https://github.com/riscv/riscv-v-spec/blob/0.9/v-spec.adoc#79-vector-loadstore-whole-register-instructions
[6] https://github.com/riscv/riscv-v-spec/blob/v1.0/v-spec.adoc#79-vector-loadstore-whole-register-instructions
[7] https://github.com/riscv/riscv-opcodes/blob/master/rv_v_aliases

## Testing:

- hotspot and jdk tier1 on unmatched board without new failures

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295968](https://bugs.openjdk.org/browse/JDK-8295968): RISC-V: Rename some assembler intrinsic functions for RVV 1.0


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10878/head:pull/10878` \
`$ git checkout pull/10878`

Update a local copy of the PR: \
`$ git checkout pull/10878` \
`$ git pull https://git.openjdk.org/jdk pull/10878/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10878`

View PR using the GUI difftool: \
`$ git pr show -t 10878`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10878.diff">https://git.openjdk.org/jdk/pull/10878.diff</a>

</details>
