### PR TITLE
8295970: Add vector api sanity tests in tier1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,7 @@ jobs:
           - 'jdk/tier1 part 1'
           - 'jdk/tier1 part 2'
           - 'jdk/tier1 part 3'
+          - 'jdk/tier3 jdk_vector'
           - 'langtools/tier1'
           - 'hs/tier1 common'
           - 'hs/tier1 compiler'
@@ -74,6 +75,9 @@ jobs:
 
           - test-name: 'jdk/tier1 part 3'
             test-suite: 'test/jdk/:tier1_part3'
+
+          - test-name: 'jdk/tier3 jdk_vector'
+            test-suite: 'test/jdk/:jdk_vector'
 
           - test-name: 'langtools/tier1'
             test-suite: 'test/langtools/:tier1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,6 @@ jobs:
           - 'jdk/tier1 part 1'
           - 'jdk/tier1 part 2'
           - 'jdk/tier1 part 3'
-          - 'jdk/tier3 jdk_vector'
           - 'langtools/tier1'
           - 'hs/tier1 common'
           - 'hs/tier1 compiler'
@@ -75,9 +74,6 @@ jobs:
 
           - test-name: 'jdk/tier1 part 3'
             test-suite: 'test/jdk/:tier1_part3'
-
-          - test-name: 'jdk/tier3 jdk_vector'
-            test-suite: 'test/jdk/:jdk_vector'
 
           - test-name: 'langtools/tier1'
             test-suite: 'test/langtools/:tier1'

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -365,28 +365,28 @@ jdk_vector = \
 
 jdk_vector_sanity = \
     jdk/incubator/vector/AddTest.java \
-    jdk/incubator/vector/CovarOverrideTest.java \
-    jdk/incubator/vector/ImageTest.java \
-    jdk/incubator/vector/LoadJsvmlTest.java \
-    jdk/incubator/vector/MethodOverideTest.java \
-    jdk/incubator/vector/MismatchTest.java \
-    jdk/incubator/vector/PreferredSpeciesTest.java \
-    jdk/incubator/vector/VectorHash.java \
-    jdk/incubator/vector/VectorRuns.java \
-    jdk/incubator/vector/VectorReshapeTests.java \
     jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java \
     jdk/incubator/vector/ByteMaxVectorTests.java \
+    jdk/incubator/vector/CovarOverrideTest.java \
     jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java \
     jdk/incubator/vector/DoubleMaxVectorTests.java \
     jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java \
     jdk/incubator/vector/FloatMaxVectorTests.java \
+    jdk/incubator/vector/ImageTest.java \
     jdk/incubator/vector/IntMaxVectorLoadStoreTests.java \
     jdk/incubator/vector/IntMaxVectorTests.java \
+    jdk/incubator/vector/LoadJsvmlTest.java \
     jdk/incubator/vector/LongMaxVectorLoadStoreTests.java \
     jdk/incubator/vector/LongMaxVectorTests.java \
+    jdk/incubator/vector/MethodOverideTest.java \
+    jdk/incubator/vector/MismatchTest.java \
+    jdk/incubator/vector/PreferredSpeciesTest.java \
     jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java \
     jdk/incubator/vector/ShortMaxVectorTests.java \
-    jdk/incubator/vector/VectorMaxConversionTests.java
+    jdk/incubator/vector/VectorHash.java \
+    jdk/incubator/vector/VectorMaxConversionTests.java \
+    jdk/incubator/vector/VectorReshapeTests.java \
+    jdk/incubator/vector/VectorRuns.java
 
 #############################
 

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -76,8 +76,8 @@ tier3 = \
     :jdk_vector \
     :jdk_rmi \
     :jdk_svc \
-   -:jdk_vector_sanity \
    -:jdk_svc_sanity \
+   -:jdk_vector_sanity \
    -:svc_tools
 
 # Everything not in other tiers

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -39,6 +39,7 @@ tier1_part2 = \
 
 tier1_part3 = \
     :jdk_math \
+    :jdk_vector_sanity \
     :jdk_svc_sanity \
     :jdk_foreign \
     java/nio/Buffer \
@@ -75,6 +76,7 @@ tier3 = \
     :jdk_vector \
     :jdk_rmi \
     :jdk_svc \
+   -:jdk_vector_sanity \
    -:jdk_svc_sanity \
    -:svc_tools
 
@@ -360,6 +362,31 @@ jdk_foreign = \
 
 jdk_vector = \
     jdk/incubator/vector
+
+jdk_vector_sanity = \
+    jdk/incubator/vector/AddTest.java \
+    jdk/incubator/vector/CovarOverrideTest.java \
+    jdk/incubator/vector/ImageTest.java \
+    jdk/incubator/vector/LoadJsvmlTest.java \
+    jdk/incubator/vector/MethodOverideTest.java \
+    jdk/incubator/vector/MismatchTest.java \
+    jdk/incubator/vector/PreferredSpeciesTest.java \
+    jdk/incubator/vector/VectorHash.java \
+    jdk/incubator/vector/VectorRuns.java \
+    jdk/incubator/vector/VectorReshapeTests.java \
+    jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java \
+    jdk/incubator/vector/ByteMaxVectorTests.java \
+    jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java \
+    jdk/incubator/vector/DoubleMaxVectorTests.java \
+    jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java \
+    jdk/incubator/vector/FloatMaxVectorTests.java \
+    jdk/incubator/vector/IntMaxVectorLoadStoreTests.java \
+    jdk/incubator/vector/IntMaxVectorTests.java \
+    jdk/incubator/vector/LongMaxVectorLoadStoreTests.java \
+    jdk/incubator/vector/LongMaxVectorTests.java \
+    jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java \
+    jdk/incubator/vector/ShortMaxVectorTests.java \
+    jdk/incubator/vector/VectorMaxConversionTests.java
 
 #############################
 

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -39,9 +39,9 @@ tier1_part2 = \
 
 tier1_part3 = \
     :jdk_math \
-    :jdk_vector_sanity \
     :jdk_svc_sanity \
     :jdk_foreign \
+    :jdk_vector_sanity \
     java/nio/Buffer \
     com/sun/crypto/provider/Cipher \
     sun/nio/cs/ISO8859x.java


### PR DESCRIPTION
Hi all,

As discussed here https://github.com/openjdk/jdk/pull/10807#pullrequestreview-1150314487 , it would be better to add the vector api tests in GHA.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295970](https://bugs.openjdk.org/browse/JDK-8295970): Add vector api sanity tests in tier1


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [f901b907](https://git.openjdk.org/jdk/pull/10879/files/f901b9072dd4659b9d4cb67d27793e1f47f20a1e)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [f901b907](https://git.openjdk.org/jdk/pull/10879/files/f901b9072dd4659b9d4cb67d27793e1f47f20a1e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10879/head:pull/10879` \
`$ git checkout pull/10879`

Update a local copy of the PR: \
`$ git checkout pull/10879` \
`$ git pull https://git.openjdk.org/jdk pull/10879/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10879`

View PR using the GUI difftool: \
`$ git pr show -t 10879`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10879.diff">https://git.openjdk.org/jdk/pull/10879.diff</a>

</details>
