### PR TITLE
8295967: RISC-V: Support negVI/negVL instructions for Vector API

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -725,6 +725,10 @@ void MacroAssembler::vncvt_x_x_w(VectorRegister vd, VectorRegister vs, VectorMas
   vnsrl_wx(vd, vs, x0, vm);
 }
 
+void MacroAssembler::vneg_v(VectorRegister vd, VectorRegister vs) {
+  vrsub_vx(vd, x0, vs);
+}
+
 void MacroAssembler::vfneg_v(VectorRegister vd, VectorRegister vs) {
   vfsgnjn_vv(vd, vs, vs);
 }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1192,6 +1192,7 @@ public:
   // vext
   void vmnot_m(VectorRegister vd, VectorRegister vs);
   void vncvt_x_x_w(VectorRegister vd, VectorRegister vs, VectorMask vm = unmasked);
+  void vneg_v(VectorRegister vd, VectorRegister vs);
   void vfneg_v(VectorRegister vd, VectorRegister vs);
 
 

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -761,6 +761,30 @@ instruct vmulD(vReg dst, vReg src1, vReg src2) %{
   ins_pipe(pipe_slow);
 %}
 
+// vector neg
+
+instruct vnegI(vReg dst, vReg src) %{
+  match(Set dst (NegVI src));
+  ins_cost(VEC_COST);
+  format %{ "vrsub.vx $dst, $src, $src\t#@vnegI" %}
+  ins_encode %{
+    __ vsetvli(t0, x0, Assembler::e32);
+    __ vneg_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vnegL(vReg dst, vReg src) %{
+  match(Set dst (NegVL src));
+  ins_cost(VEC_COST);
+  format %{ "vrsub.vx $dst, $src, $src\t#@vnegL" %}
+  ins_encode %{
+    __ vsetvli(t0, x0, Assembler::e64);
+    __ vneg_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 // vector fneg
 
 instruct vnegF(vReg dst, vReg src) %{


### PR DESCRIPTION
Hi,

This patch will add support of `NegVI`, `NegVL` for RISC-V and was implemented by referring to riscv-v-spec v1.0 [1]. 

Tests are performed on qemu with parameter `-cpu rv64,v=true,vlen=256,vext_spec=v1.0`. By adding the `-XX:+PrintAssembly -Xcomp -XX:-TieredCompilation -XX:+LogCompilation -XX:LogFile=compile.log` parameter when executing the test cases[2] [3] , the compilation log is as follows:

```
100     B16: #	out( B37 B17 ) &lt;- in( B15 )  Freq: 77.0109
100     # castII of R9, #@castII
100     addw  R29, R9, zr	#@convI2L_reg_reg
104     slli  R29, R29, (#2 &amp; 0x3f)	#@lShiftL_reg_imm
108     add R12, R30, R29	# ptr, #@addP_reg_reg
10c     addi  R12, R12, #16	# ptr, #@addP_reg_imm
110     vle V1, [R12]	#@loadV
118     vrsub.vx V1, V1, V1	#@vnegI
120     bgeu  R9, R10, B37	#@cmpU_branch  P=0.000001 C=-1.000000
```

At the same time, the following assembly code will be generated: 

```
  0x000000400ccfa618:   .4byte	0x10072d7
  0x000000400ccfa61c:   .4byte	0xe1040d7                   ;*invokestatic unaryOp {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - jdk.incubator.vector.IntVector::lanewiseTemplate@91 (line 684)
                                                            ; - jdk.incubator.vector.Int256Vector::lanewise@2 (line 273)
                                                            ; - jdk.incubator.vector.Int256Vector::lanewise@2 (line 41)
                                                            ; - Int256VectorTests::NEGInt256VectorTests@73 (line 5216)
```

PS: `0x10072d7/0xe1040d7` are the machine code for `vsetvli/vrsub`.

After we implement these nodes, by using `-XX:+UseRVV`, the number of assembly instructions is reduced by about ~50% because of the different execution paths with the number of loops, similar to `AddTest` [4].

In the meantime, I also add an assembly pseudoinstruction `vneg.v` in macroAssembler_riscv.

[1] https://github.com/riscv/riscv-v-spec/blob/v1.0/v-spec.adoc#111-vector-single-width-integer-add-and-subtract
[2] https://github.com/openjdk/jdk/tree/master/test/jdk/jdk/incubator/vector/Int256VectorTests.java
[3] https://github.com/openjdk/jdk/tree/master/test/jdk/jdk/incubator/vector/Long256VectorTests.java
[4] https://github.com/zifeihan/vector-api-test-rvv/blob/master/vector-api-rvv-performance.md

Please take a look and have some reviews. Thanks a lot.

## Testing:

- hotspot and jdk tier1 on unmatched board without new failures
- test/jdk/jdk/incubator/vector/Int256VectorTests.java with fastdebug on qemu
- test/jdk/jdk/incubator/vector/Long256VectorTests.java with fastdebug on qemu

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295967](https://bugs.openjdk.org/browse/JDK-8295967): RISC-V: Support negVI/negVL instructions for Vector API


### Reviewers
 * [Yadong Wang](https://openjdk.org/census#yadongwang) (@yadongw - Author)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10880/head:pull/10880` \
`$ git checkout pull/10880`

Update a local copy of the PR: \
`$ git checkout pull/10880` \
`$ git pull https://git.openjdk.org/jdk pull/10880/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10880`

View PR using the GUI difftool: \
`$ git pr show -t 10880`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10880.diff">https://git.openjdk.org/jdk/pull/10880.diff</a>

</details>
