### PR TITLE
Udpate NonNMethodCodeHeapSize init value and compiler buffers formula

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c1_globals_aarch64.hpp
@@ -47,7 +47,7 @@ define_pd_global(intx, InitialCodeCacheSize,         160*K);
 define_pd_global(intx, ReservedCodeCacheSize,        32*M );
 define_pd_global(intx, NonProfiledCodeHeapSize,      13*M );
 define_pd_global(intx, ProfiledCodeHeapSize,         14*M );
-define_pd_global(intx, NonNMethodCodeHeapSize,       5*M  );
+define_pd_global(intx, NonNMethodCodeHeapSize,       3*M  );
 define_pd_global(bool, ProfileInterpreter,           false);
 define_pd_global(intx, CodeCacheExpansionSize,       32*K );
 define_pd_global(uintx, CodeCacheMinBlockLength,     1);

--- a/src/hotspot/cpu/aarch64/c2_globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c2_globals_aarch64.hpp
@@ -71,7 +71,7 @@ define_pd_global(bool, IdealizeClearArrayNode,       true);
 define_pd_global(intx, ReservedCodeCacheSize,        48*M);
 define_pd_global(intx, NonProfiledCodeHeapSize,      21*M);
 define_pd_global(intx, ProfiledCodeHeapSize,         22*M);
-define_pd_global(intx, NonNMethodCodeHeapSize,       5*M );
+define_pd_global(intx, NonNMethodCodeHeapSize,       3*M );
 define_pd_global(uintx, CodeCacheMinBlockLength,     6);
 define_pd_global(uintx, CodeCacheMinimumUseSpace,    400*K);
 

--- a/src/hotspot/cpu/arm/c1_globals_arm.hpp
+++ b/src/hotspot/cpu/arm/c1_globals_arm.hpp
@@ -48,7 +48,7 @@ define_pd_global(size_t, InitialCodeCacheSize,       160*K);
 define_pd_global(size_t, ReservedCodeCacheSize,      32*M );
 define_pd_global(size_t, NonProfiledCodeHeapSize,    13*M );
 define_pd_global(size_t, ProfiledCodeHeapSize,       14*M );
-define_pd_global(size_t, NonNMethodCodeHeapSize,     5*M  );
+define_pd_global(size_t, NonNMethodCodeHeapSize,     3*M  );
 define_pd_global(bool, ProfileInterpreter,           false);
 define_pd_global(size_t, CodeCacheExpansionSize,     32*K );
 define_pd_global(uintx, CodeCacheMinBlockLength,     1);

--- a/src/hotspot/cpu/arm/c2_globals_arm.hpp
+++ b/src/hotspot/cpu/arm/c2_globals_arm.hpp
@@ -77,7 +77,7 @@ define_pd_global(size_t, InitialCodeCacheSize,       2048*K); // Integral multip
 define_pd_global(size_t, ReservedCodeCacheSize,      48*M);
 define_pd_global(size_t, NonProfiledCodeHeapSize,    21*M);
 define_pd_global(size_t, ProfiledCodeHeapSize,       22*M);
-define_pd_global(size_t, NonNMethodCodeHeapSize,     5*M );
+define_pd_global(size_t, NonNMethodCodeHeapSize,     3*M );
 define_pd_global(size_t, CodeCacheExpansionSize,     64*K);
 
 // Ergonomics related flags
@@ -88,7 +88,7 @@ define_pd_global(size_t, InitialCodeCacheSize,       1536*K); // Integral multip
 define_pd_global(size_t, ReservedCodeCacheSize,      32*M);
 define_pd_global(size_t, NonProfiledCodeHeapSize,    13*M);
 define_pd_global(size_t, ProfiledCodeHeapSize,       14*M);
-define_pd_global(size_t, NonNMethodCodeHeapSize,     5*M );
+define_pd_global(size_t, NonNMethodCodeHeapSize,     3*M );
 define_pd_global(size_t, CodeCacheExpansionSize,     32*K);
 // Ergonomics related flags
 define_pd_global(uint64_t, MaxRAM,                   4ULL*G);

--- a/src/hotspot/cpu/x86/c1_globals_x86.hpp
+++ b/src/hotspot/cpu/x86/c1_globals_x86.hpp
@@ -46,7 +46,7 @@ define_pd_global(uintx,  InitialCodeCacheSize,         160*K);
 define_pd_global(uintx,  ReservedCodeCacheSize,        32*M );
 define_pd_global(uintx,  NonProfiledCodeHeapSize,      13*M );
 define_pd_global(uintx,  ProfiledCodeHeapSize,         14*M );
-define_pd_global(uintx,  NonNMethodCodeHeapSize,       5*M  );
+define_pd_global(uintx,  NonNMethodCodeHeapSize,       3*M  );
 define_pd_global(bool,   ProfileInterpreter,           false);
 define_pd_global(uintx,  CodeCacheExpansionSize,       32*K );
 define_pd_global(uintx,  CodeCacheMinBlockLength,      1    );

--- a/src/hotspot/cpu/x86/c2_globals_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_globals_x86.hpp
@@ -81,7 +81,7 @@ define_pd_global(bool, IdealizeClearArrayNode,       true);
 define_pd_global(uintx, ReservedCodeCacheSize,       48*M);
 define_pd_global(uintx, NonProfiledCodeHeapSize,     21*M);
 define_pd_global(uintx, ProfiledCodeHeapSize,        22*M);
-define_pd_global(uintx, NonNMethodCodeHeapSize,      5*M );
+define_pd_global(uintx, NonNMethodCodeHeapSize,      3*M );
 define_pd_global(uintx, CodeCacheMinBlockLength,     6);
 define_pd_global(uintx, CodeCacheMinimumUseSpace,    400*K);
 

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -219,10 +219,8 @@ void CodeCache::initialize_heaps() {
   code_buffers_size += c1_count * Compiler::code_buffer_size();
 #endif
 #ifdef COMPILER2
-  // C2 scratch buffers (see Compile::init_scratch_buffer_blob())
   const int c2_count = CompilationPolicy::c2_count();
-  // Initial size of constant table (this may be increased if a compiled method needs more space)
-  code_buffers_size += c2_count * C2Compiler::initial_code_buffer_size();
+  code_buffers_size += c2_count * C2Compiler::code_buffer_size_upper_estimation(c2_count);
 #endif
 
   // Increase default non_nmethod_size to account for compiler buffers

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -447,6 +447,14 @@ void CompilationPolicy::initialize() {
       // Simple log n seems to grow too slowly for tiered, try something faster: log n * log log n
       int log_cpu = log2i(os::active_processor_count());
       int loglog_cpu = log2i(MAX2(log_cpu, 1));
+      // number of cpu / number of c1+c2 threads:
+      //     1-3:  2=1+1
+      //     4-7:  3=1+2
+      //    8-15:  4=1+3
+      //   16-31: 12=4+8
+      //   32-63: 15=5+10
+      //  64-127: 18=6+12
+      // 128-255: 21=7+14
       count = MAX2(log_cpu * loglog_cpu * 3 / 2, 2);
       // Make sure there is enough space in the code cache to hold all the compiler buffers
       size_t c1_size = 0;
@@ -455,7 +463,7 @@ void CompilationPolicy::initialize() {
 #endif
       size_t c2_size = 0;
 #ifdef COMPILER2
-      c2_size = C2Compiler::initial_code_buffer_size();
+      c2_size = C2Compiler::code_buffer_size_upper_estimation(count);
 #endif
       size_t buffer_size = c1_only ? c1_size : (c1_size/3 + 2*c2_size/3);
       int max_count = (ReservedCodeCacheSize - (CodeCacheMinimumUseSpace DEBUG_ONLY(* 3))) / (int)buffer_size;

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -200,7 +200,7 @@ void CompilerConfig::set_client_emulation_mode_flags() {
     FLAG_SET_ERGO(ProfiledCodeHeapSize, 0);
   }
   if (FLAG_IS_DEFAULT(NonNMethodCodeHeapSize)) {
-    FLAG_SET_ERGO(NonNMethodCodeHeapSize, 5*M);
+    FLAG_SET_ERGO(NonNMethodCodeHeapSize, 3*M);
   }
   if (FLAG_IS_DEFAULT(CodeCacheExpansionSize)) {
     FLAG_SET_ERGO(CodeCacheExpansionSize, 32*K);

--- a/src/hotspot/share/opto/c2compiler.hpp
+++ b/src/hotspot/share/opto/c2compiler.hpp
@@ -71,6 +71,16 @@ public:
 
   // Initial size of the code buffer (may be increased at runtime)
   static int initial_code_buffer_size(int const_size = initial_const_capacity);
+
+  // a reasonable upper bound on the average size of C2 compiler buffers
+  static int code_buffer_size_upper_estimation(int compiler_threads_number) {
+    if (compiler_threads_number < 8) {
+      return c2_max_scratch_buffer_size + c2_max_code_buffer_size;
+    } else {
+      // huge methods are rare creatures, dont waste a code heap space
+      return c2_max_scratch_buffer_size + (c2_max_code_buffer_size + c2_average_code_buffer_size) / 2;
+    }
+  }
 };
 
 #endif // SHARE_OPTO_C2COMPILER_HPP

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1374,6 +1374,7 @@ CodeBuffer* PhaseOutput::init_buffer() {
     total_req += deopt_handler_req;  // deopt MH handler
 
   CodeBuffer* cb = code_buffer();
+  assert(total_req < c2_max_code_buffer_size, "sanity");
   cb->initialize(total_req, _buf_sizes._reloc);
 
   // Have we run out of code space?
@@ -3281,6 +3282,7 @@ void PhaseOutput::init_scratch_buffer_blob(int const_size) {
     ResourceMark rm;
     _scratch_const_size = const_size;
     int size = C2Compiler::initial_code_buffer_size(const_size);
+    assert(size < c2_max_scratch_buffer_size, "sanity");
     blob = BufferBlob::create("Compile::scratch_buffer", size);
     // Record the buffer blob for next time.
     set_scratch_buffer_blob(blob);

--- a/src/hotspot/share/opto/output.hpp
+++ b/src/hotspot/share/opto/output.hpp
@@ -58,6 +58,12 @@ enum {
   initial_const_capacity =   4 * 1024
 };
 
+enum {
+  c2_max_scratch_buffer_size = 7 * K,
+  c2_average_code_buffer_size = 10 * K, // 95% of nmethods fit into 10 KB,
+  c2_max_code_buffer_size = 100 * K,    // though some methods take up to 100 KB
+};
+
 class BufferSizingData {
 public:
   int _stub;


### PR DESCRIPTION
I'm seeing several megabytes of unused space in the NonNMethod code heap segment.

Current NonNMethodCodeHeapSize setup formula is 
- 5MB + c1_threads_count * Compiler::code_buffer_size + c2_threads_count * C2Compiler::initial_code_buffer_size

On 48-core machine it turns into
- 5MB + 5 * 576716 + 10 * 6592 = 8192380

I see following flaws in the formula:
- 5MB - a default value for all platforms (arm s390 x86 riscv ppc aarch64) - a value is much bigger than required by Interpreter blob, StubRoutines and things
- C2 compiler allocates more than 6592 bytes. Each C2 instance allocates two buffers, constants buffer and code buffer, and in rare cases the last is up to 100KB

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10881/head:pull/10881` \
`$ git checkout pull/10881`

Update a local copy of the PR: \
`$ git checkout pull/10881` \
`$ git pull https://git.openjdk.org/jdk pull/10881/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10881`

View PR using the GUI difftool: \
`$ git pr show -t 10881`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10881.diff">https://git.openjdk.org/jdk/pull/10881.diff</a>

</details>
