### PR TITLE
8293858: Change PKCS7 code to use default SecureRandom impl instead of SHA1PRNG

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs/PKCS7.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS7.java
@@ -37,6 +37,7 @@ import java.security.cert.CertificateFactory;
 import java.security.*;
 import java.util.function.Function;
 
+import sun.security.jca.JCAUtil;
 import sun.security.provider.SHAKE256;
 import sun.security.timestamp.*;
 import sun.security.util.*;
@@ -64,23 +65,6 @@ public class PKCS7 {
     private boolean oldStyle = false; // Is this JDK1.1.x-style?
 
     private Principal[] certIssuerNames;
-
-    /*
-     * Random number generator for creating nonce values
-     * (Lazy initialization)
-     */
-    private static class SecureRandomHolder {
-        static final SecureRandom RANDOM;
-        static {
-            SecureRandom tmp = null;
-            try {
-                tmp = SecureRandom.getInstance("SHA1PRNG");
-            } catch (NoSuchAlgorithmException e) {
-                // should not happen
-            }
-            RANDOM = tmp;
-        }
-    }
 
     /**
      * Unmarshals a PKCS7 block from its encoded form, parsing the
@@ -1017,11 +1001,9 @@ public class PKCS7 {
         }
 
         // Generate a nonce
-        BigInteger nonce = null;
-        if (SecureRandomHolder.RANDOM != null) {
-            nonce = new BigInteger(64, SecureRandomHolder.RANDOM);
-            tsQuery.setNonce(nonce);
-        }
+        BigInteger nonce = new BigInteger(64, JCAUtil.getDefSecureRandom());
+        tsQuery.setNonce(nonce);
+
         tsQuery.requestCertificate(true);
 
         TSResponse tsReply = tsa.generateTimestamp(tsQuery);


### PR DESCRIPTION
For timestamp nonces, change the PKCS7 code to use the default SecureRandom PRNG (which varies depending on the OS), instead of SHA1PRNG.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293858](https://bugs.openjdk.org/browse/JDK-8293858): Change PKCS7 code to use default SecureRandom impl instead of SHA1PRNG


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10883/head:pull/10883` \
`$ git checkout pull/10883`

Update a local copy of the PR: \
`$ git checkout pull/10883` \
`$ git pull https://git.openjdk.org/jdk pull/10883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10883`

View PR using the GUI difftool: \
`$ git pr show -t 10883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10883.diff">https://git.openjdk.org/jdk/pull/10883.diff</a>

</details>
