### PR TITLE
8289689: (fs) Re-examine the need for normalization to Unicode Normalization Format D (macOS)

### DIFF
--- a/src/java.base/macosx/classes/sun/nio/fs/MacOSXFileSystem.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/MacOSXFileSystem.java
@@ -36,15 +36,16 @@ import static sun.nio.fs.MacOSXNativeDispatcher.*;
 
 class MacOSXFileSystem extends BsdFileSystem {
 
-    private static final String PROPERTY_ENABLE_FILE_NAME_ENCODING =
+    private static final String PROPERTY_NORMALIZE_FILE_PATHS =
         "jdk.nio.path.useNormalizationFormD";
 
-    private static final boolean ENCODE_FILE_NAMES;
+    private static final boolean NORMALIZE_FILE_PATHS;
 
     static {
-        final String name = PROPERTY_ENABLE_FILE_NAME_ENCODING;
+        final String name = PROPERTY_NORMALIZE_FILE_PATHS;
         String value = GetPropertyAction.privilegedGetProperty(name);
-        ENCODE_FILE_NAMES = "true".equalsIgnoreCase(value);
+        NORMALIZE_FILE_PATHS = (value != null)
+            && ("".equals(value) || Boolean.parseBoolean(value));
     }
 
     MacOSXFileSystem(UnixFileSystemProvider provider, String dir) {
@@ -58,7 +59,7 @@ class MacOSXFileSystem extends BsdFileSystem {
 
     @Override
     String normalizeNativePath(String path) {
-        if (ENCODE_FILE_NAMES) {
+        if (NORMALIZE_FILE_PATHS) {
             for (int i = 0; i < path.length(); i++) {
                 char c = path.charAt(i);
                 if (c > 0x80)
@@ -71,7 +72,7 @@ class MacOSXFileSystem extends BsdFileSystem {
 
     @Override
     String normalizeJavaPath(String path) {
-        if (ENCODE_FILE_NAMES) {
+        if (NORMALIZE_FILE_PATHS) {
             for (int i = 0; i < path.length(); i++) {
                 if (path.charAt(i) > 0x80)
                     return new String(normalizepath(path.toCharArray(),

--- a/src/java.base/macosx/classes/sun/nio/fs/MacOSXFileSystem.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/MacOSXFileSystem.java
@@ -26,6 +26,7 @@
 package sun.nio.fs;
 
 import java.util.regex.Pattern;
+import sun.security.action.GetPropertyAction;
 
 import static sun.nio.fs.MacOSXNativeDispatcher.*;
 
@@ -36,10 +37,15 @@ import static sun.nio.fs.MacOSXNativeDispatcher.*;
 class MacOSXFileSystem extends BsdFileSystem {
 
     private static final String PROPERTY_ENABLE_FILE_NAME_ENCODING =
-        "java.nio.file.Path.ENABLE_FILE_NAME_ENCODING";
+        "jdk.nio.path.useNormalizationFormD";
 
-    private static final boolean ENCODE_FILE_NAMES =
-        Boolean.getBoolean(PROPERTY_ENABLE_FILE_NAME_ENCODING);
+    private static final boolean ENCODE_FILE_NAMES;
+
+    static {
+        final String name = PROPERTY_ENABLE_FILE_NAME_ENCODING;
+        String value = GetPropertyAction.privilegedGetProperty(name);
+        ENCODE_FILE_NAMES = "true".equalsIgnoreCase(value);
+    }
 
     MacOSXFileSystem(UnixFileSystemProvider provider, String dir) {
         super(provider, dir);

--- a/src/java.base/macosx/classes/sun/nio/fs/MacOSXFileSystem.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/MacOSXFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,12 @@ import static sun.nio.fs.MacOSXNativeDispatcher.*;
 
 class MacOSXFileSystem extends BsdFileSystem {
 
+    private static final String PROPERTY_ENABLE_FILE_NAME_ENCODING =
+        "java.nio.file.Path.ENABLE_FILE_NAME_ENCODING";
+
+    private static final boolean ENCODE_FILE_NAMES =
+        Boolean.getBoolean(PROPERTY_ENABLE_FILE_NAME_ENCODING);
+
     MacOSXFileSystem(UnixFileSystemProvider provider, String dir) {
         super(provider, dir);
     }
@@ -46,21 +52,25 @@ class MacOSXFileSystem extends BsdFileSystem {
 
     @Override
     String normalizeNativePath(String path) {
-        for (int i = 0; i < path.length(); i++) {
-            char c = path.charAt(i);
-            if (c > 0x80)
-                return new String(normalizepath(path.toCharArray(),
+        if (ENCODE_FILE_NAMES) {
+            for (int i = 0; i < path.length(); i++) {
+                char c = path.charAt(i);
+                if (c > 0x80)
+                    return new String(normalizepath(path.toCharArray(),
                                   kCFStringNormalizationFormD));
+            }
         }
         return path;
     }
 
     @Override
     String normalizeJavaPath(String path) {
-        for (int i = 0; i < path.length(); i++) {
-            if (path.charAt(i) > 0x80)
-                return new String(normalizepath(path.toCharArray(),
-                                  kCFStringNormalizationFormC));
+        if (ENCODE_FILE_NAMES) {
+            for (int i = 0; i < path.length(); i++) {
+                if (path.charAt(i) > 0x80)
+                    return new String(normalizepath(path.toCharArray(),
+                                      kCFStringNormalizationFormC));
+            }
         }
         return path;
     }

--- a/test/jdk/java/nio/file/Path/MacPath.java
+++ b/test/jdk/java/nio/file/Path/MacPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
 import java.text.Normalizer;
+import java.text.Normalizer.Form;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -81,8 +82,11 @@ public class MacPath {
         throws Throwable
     {
         String fname = null;
-        String dname_nfd = Normalizer.normalize(dname, Normalizer.Form.NFD);
-        String fname_nfd = Normalizer.normalize(fname_nfc, Normalizer.Form.NFD);
+        Normalizer.Form form =
+            Boolean.getBoolean("java.nio.file.Path.ENABLE_FILE_NAME_ENCODING") ?
+            Normalizer.Form.NFD : Normalizer.Form.NFC;
+        String dname_nfd = Normalizer.normalize(dname, form);
+        String fname_nfd = Normalizer.normalize(fname_nfc, form);
 
         System.out.printf("%n%n--------Testing...----------%n");
         Path bpath = Paths.get(testdir);

--- a/test/jdk/java/nio/file/Path/MacPath.java
+++ b/test/jdk/java/nio/file/Path/MacPath.java
@@ -32,7 +32,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 public class MacPath {
-    private static final String FILE_NAME_ENCODING_PROPERTY =
+    private static final String PROPERTY_NORMALIZE_FILE_PATHS =
         "jdk.nio.path.useNormalizationFormD";
 
     public static void main(String args[]) throws Throwable {
@@ -84,8 +84,8 @@ public class MacPath {
         throws Throwable
     {
         String fname = null;
-        Normalizer.Form form = Boolean.getBoolean(FILE_NAME_ENCODING_PROPERTY) ?
-            Normalizer.Form.NFD : Normalizer.Form.NFC;
+        Normalizer.Form form = Boolean.getBoolean(PROPERTY_NORMALIZE_FILE_PATHS)
+            ? Normalizer.Form.NFD : Normalizer.Form.NFC;
         String dname_nfd = Normalizer.normalize(dname, form);
         String fname_nfd = Normalizer.normalize(fname_nfc, form);
 

--- a/test/jdk/java/nio/file/Path/MacPath.java
+++ b/test/jdk/java/nio/file/Path/MacPath.java
@@ -32,6 +32,8 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 public class MacPath {
+    private static final String FILE_NAME_ENCODING_PROPERTY =
+        "jdk.nio.path.useNormalizationFormD";
 
     public static void main(String args[]) throws Throwable {
         System.out.printf("sun.jnu.encoding=%s, file.encoding=%s%n",
@@ -82,8 +84,7 @@ public class MacPath {
         throws Throwable
     {
         String fname = null;
-        Normalizer.Form form =
-            Boolean.getBoolean("java.nio.file.Path.ENABLE_FILE_NAME_ENCODING") ?
+        Normalizer.Form form = Boolean.getBoolean(FILE_NAME_ENCODING_PROPERTY) ?
             Normalizer.Form.NFD : Normalizer.Form.NFC;
         String dname_nfd = Normalizer.normalize(dname, form);
         String fname_nfd = Normalizer.normalize(fname_nfc, form);

--- a/test/jdk/java/nio/file/Path/MacPathTest.java
+++ b/test/jdk/java/nio/file/Path/MacPathTest.java
@@ -40,15 +40,15 @@
 import jdk.test.lib.process.ProcessTools;
 
 public class MacPathTest {
-    private static final String FILE_NAME_ENCODING_PROPERTY =
+    private static final String PROPERTY_NORMALIZE_FILE_PATHS =
         "jdk.nio.path.useNormalizationFormD";
-    private static final boolean ENABLE_FILE_NAME_ENCODING =
-        Boolean.getBoolean(FILE_NAME_ENCODING_PROPERTY);
+    private static final boolean NORMALIZE_FILE_PATHS =
+        Boolean.getBoolean(PROPERTY_NORMALIZE_FILE_PATHS);
 
     public static void main(String args[]) throws Exception {
         ProcessBuilder pb;
-        if (ENABLE_FILE_NAME_ENCODING) {
-            String option = "-D" + FILE_NAME_ENCODING_PROPERTY + "=true";
+        if (NORMALIZE_FILE_PATHS) {
+            String option = "-D" + PROPERTY_NORMALIZE_FILE_PATHS + "=true";
             pb = ProcessTools.createTestJvm(option, MacPath.class.getName());
         } else {
             pb = ProcessTools.createTestJvm(MacPath.class.getName());

--- a/test/jdk/java/nio/file/Path/MacPathTest.java
+++ b/test/jdk/java/nio/file/Path/MacPathTest.java
@@ -48,8 +48,7 @@ public class MacPathTest {
     public static void main(String args[]) throws Exception {
         ProcessBuilder pb;
         if (ENABLE_FILE_NAME_ENCODING) {
-            String option = ENABLE_FILE_NAME_ENCODING ?
-                "-D" + FILE_NAME_ENCODING_PROPERTY + "=true" : "";
+            String option = "-D" + FILE_NAME_ENCODING_PROPERTY + "=true";
             pb = ProcessTools.createTestJvm(option, MacPath.class.getName());
         } else {
             pb = ProcessTools.createTestJvm(MacPath.class.getName());

--- a/test/jdk/java/nio/file/Path/MacPathTest.java
+++ b/test/jdk/java/nio/file/Path/MacPathTest.java
@@ -34,14 +34,14 @@
  *        jdk.test.lib.process.*
  *        TestUtil MacPath
  * @run main MacPathTest
- * @run main/othervm -Djava.nio.file.Path.ENABLE_FILE_NAME_ENCODING=true MacPathTest
+ * @run main/othervm -Djdk.nio.path.useNormalizationFormD=true MacPathTest
  */
 
 import jdk.test.lib.process.ProcessTools;
 
 public class MacPathTest {
     private static final String FILE_NAME_ENCODING_PROPERTY =
-        "java.nio.file.Path.ENABLE_FILE_NAME_ENCODING";
+        "jdk.nio.path.useNormalizationFormD";
     private static final boolean ENABLE_FILE_NAME_ENCODING =
         Boolean.getBoolean(FILE_NAME_ENCODING_PROPERTY);
 

--- a/test/jdk/java/nio/file/Path/MacPathTest.java
+++ b/test/jdk/java/nio/file/Path/MacPathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 7130915
+ * @bug 7130915 8289689
  * @summary Tests file path with nfc/nfd forms on MacOSX
  * @requires (os.family == "mac")
  * @library /test/lib ..
@@ -34,14 +34,26 @@
  *        jdk.test.lib.process.*
  *        TestUtil MacPath
  * @run main MacPathTest
+ * @run main/othervm -Djava.nio.file.Path.ENABLE_FILE_NAME_ENCODING=true MacPathTest
  */
 
 import jdk.test.lib.process.ProcessTools;
 
 public class MacPathTest {
+    private static final String FILE_NAME_ENCODING_PROPERTY =
+        "java.nio.file.Path.ENABLE_FILE_NAME_ENCODING";
+    private static final boolean ENABLE_FILE_NAME_ENCODING =
+        Boolean.getBoolean(FILE_NAME_ENCODING_PROPERTY);
 
     public static void main(String args[]) throws Exception {
-        ProcessBuilder pb = ProcessTools.createTestJvm(MacPath.class.getName());
+        ProcessBuilder pb;
+        if (ENABLE_FILE_NAME_ENCODING) {
+            String option = ENABLE_FILE_NAME_ENCODING ?
+                "-D" + FILE_NAME_ENCODING_PROPERTY + "=true" : "";
+            pb = ProcessTools.createTestJvm(option, MacPath.class.getName());
+        } else {
+            pb = ProcessTools.createTestJvm(MacPath.class.getName());
+        }
         pb.environment().put("LC_ALL", "en_US.UTF-8");
         ProcessTools.executeProcess(pb)
                     .outputTo(System.out)


### PR DESCRIPTION
On macOS, perform file name normalization if and only if a specific system property is set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8289689](https://bugs.openjdk.org/browse/JDK-8289689): (fs) Re-examine the need for normalization to Unicode Normalization Format D (macOS)
 * [JDK-8296141](https://bugs.openjdk.org/browse/JDK-8296141): (fs) Re-examine the need for normalization to Unicode Normalization Format D (macOS) (**CSR**)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [b420d2ce](https://git.openjdk.org/jdk/pull/10885/files/b420d2cea162ef7a3abde0522d687a290fe154f2)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10885/head:pull/10885` \
`$ git checkout pull/10885`

Update a local copy of the PR: \
`$ git checkout pull/10885` \
`$ git pull https://git.openjdk.org/jdk pull/10885/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10885`

View PR using the GUI difftool: \
`$ git pr show -t 10885`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10885.diff">https://git.openjdk.org/jdk/pull/10885.diff</a>

</details>
