### PR TITLE
8296140: Drop unused field java.util.Calendar.DATE_MASK

### DIFF
--- a/src/java.base/share/classes/java/util/Calendar.java
+++ b/src/java.base/share/classes/java/util/Calendar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1016,7 +1016,6 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
     static final int WEEK_OF_YEAR_MASK  = (1 << WEEK_OF_YEAR);
     static final int WEEK_OF_MONTH_MASK = (1 << WEEK_OF_MONTH);
     static final int DAY_OF_MONTH_MASK  = (1 << DAY_OF_MONTH);
-    static final int DATE_MASK          = DAY_OF_MONTH_MASK;
     static final int DAY_OF_YEAR_MASK   = (1 << DAY_OF_YEAR);
     static final int DAY_OF_WEEK_MASK   = (1 << DAY_OF_WEEK);
     static final int DAY_OF_WEEK_IN_MONTH_MASK  = (1 << DAY_OF_WEEK_IN_MONTH);


### PR DESCRIPTION
There is no usages for this field. As it has the same value as `DAY_OF_MONTH_MASK` we can drop it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296140](https://bugs.openjdk.org/browse/JDK-8296140): Drop unused field java.util.Calendar.DATE_MASK


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10888/head:pull/10888` \
`$ git checkout pull/10888`

Update a local copy of the PR: \
`$ git checkout pull/10888` \
`$ git pull https://git.openjdk.org/jdk pull/10888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10888`

View PR using the GUI difftool: \
`$ git pr show -t 10888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10888.diff">https://git.openjdk.org/jdk/pull/10888.diff</a>

</details>
