### PR TITLE
8156593: DataOutput.write(byte[],int,int) and its implementations do not specify index out bounds

### DIFF
--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -355,6 +355,7 @@ public class BufferedInputStream extends FilterInputStream {
      * @throws     IOException  if this input stream has been closed by
      *                          invoking its {@link #close()} method,
      *                          or an I/O error occurs.
+     * @throws     IndexOutOfBoundsException {@inheritDoc}
      */
     public int read(byte[] b, int off, int len) throws IOException {
         if (lock != null) {

--- a/src/java.base/share/classes/java/io/BufferedOutputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedOutputStream.java
@@ -190,6 +190,7 @@ public class BufferedOutputStream extends FilterOutputStream {
      * @param      off   the start offset in the data.
      * @param      len   the number of bytes to write.
      * @throws     IOException  if an I/O error occurs.
+     * @throws     IndexOutOfBoundsException {@inheritDoc}
      */
     @Override
     public void write(byte[] b, int off, int len) throws IOException {

--- a/src/java.base/share/classes/java/io/DataOutputStream.java
+++ b/src/java.base/share/classes/java/io/DataOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,6 +104,7 @@ public class DataOutputStream extends FilterOutputStream implements DataOutput {
      * @param      off   the start offset in the data.
      * @param      len   the number of bytes to write.
      * @throws     IOException  if an I/O error occurs.
+     * @throws     IndexOutOfBoundsException {@inheritDoc}
      * @see        java.io.FilterOutputStream#out
      */
     public synchronized void write(byte[] b, int off, int len)

--- a/src/java.base/share/classes/java/io/FileOutputStream.java
+++ b/src/java.base/share/classes/java/io/FileOutputStream.java
@@ -343,6 +343,7 @@ public class FileOutputStream extends OutputStream
      *
      * @param      b   {@inheritDoc}
      * @throws     IOException  {@inheritDoc}
+     * @throws     IndexOutOfBoundsException {@inheritDoc}
      */
     @Override
     public void write(byte[] b) throws IOException {
@@ -363,6 +364,7 @@ public class FileOutputStream extends OutputStream
      * @param      off   {@inheritDoc}
      * @param      len   {@inheritDoc}
      * @throws     IOException  if an I/O error occurs.
+     * @throws     IndexOutOfBoundsException {@inheritDoc}
      */
     @Override
     public void write(byte[] b, int off, int len) throws IOException {

--- a/src/java.base/share/classes/java/io/FileOutputStream.java
+++ b/src/java.base/share/classes/java/io/FileOutputStream.java
@@ -343,7 +343,6 @@ public class FileOutputStream extends OutputStream
      *
      * @param      b   {@inheritDoc}
      * @throws     IOException  {@inheritDoc}
-     * @throws     IndexOutOfBoundsException {@inheritDoc}
      */
     @Override
     public void write(byte[] b) throws IOException {

--- a/src/java.base/share/classes/java/io/FilterOutputStream.java
+++ b/src/java.base/share/classes/java/io/FilterOutputStream.java
@@ -126,6 +126,7 @@ public class FilterOutputStream extends OutputStream {
      * @param      off   {@inheritDoc}
      * @param      len   {@inheritDoc}
      * @throws     IOException  if an I/O error occurs.
+     * @throws     IndexOutOfBoundsException {@inheritDoc}
      * @see        java.io.FilterOutputStream#write(int)
      */
     @Override

--- a/src/java.base/share/classes/java/io/ObjectInput.java
+++ b/src/java.base/share/classes/java/io/ObjectInput.java
@@ -79,6 +79,9 @@ public interface ObjectInput extends DataInput, AutoCloseable {
      *          {@code -1} if there is no more data because the end of
      *          the stream has been reached.
      * @throws  IOException If an I/O error has occurred.
+     * @throws  IndexOutOfBoundsException If {@code off} is negative,
+     *          {@code len} is negative, or {@code len} is greater than
+     *          {@code b.length - off}
      */
     public int read(byte[] b, int off, int len) throws IOException;
 

--- a/src/java.base/share/classes/java/io/ObjectOutput.java
+++ b/src/java.base/share/classes/java/io/ObjectOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,6 +69,7 @@ public interface ObjectOutput extends DataOutput, AutoCloseable {
      * @param     off       the start offset in the data
      * @param     len       the number of bytes that are written
      * @throws    IOException If an I/O error has occurred.
+     * @throws    IndexOutOfBoundsException {@inheritDoc}
      */
     public void write(byte[] b, int off, int len) throws IOException;
 

--- a/src/java.base/share/classes/java/io/ObjectOutputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectOutputStream.java
@@ -713,6 +713,7 @@ public class ObjectOutputStream
      * @param   off the start offset in the data
      * @param   len the number of bytes that are written
      * @throws  IOException {@inheritDoc}
+     * @throws  IndexOutOfBoundsException {@inheritDoc}
      */
     @Override
     public void write(byte[] buf, int off, int len) throws IOException {

--- a/src/java.base/share/classes/java/io/OutputStream.java
+++ b/src/java.base/share/classes/java/io/OutputStream.java
@@ -156,6 +156,9 @@ public abstract class OutputStream implements Closeable, Flushable {
      * @throws     IOException  if an I/O error occurs. In particular,
      *             an {@code IOException} is thrown if the output
      *             stream is closed.
+     * @throws     IndexOutOfBoundsException If {@code off} is negative,
+     *             {@code len} is negative, or {@code len} is greater than
+     *             {@code b.length - off}
      */
     public void write(byte[] b, int off, int len) throws IOException {
         Objects.checkFromIndexSize(off, len, b.length);

--- a/src/java.base/share/classes/java/io/PipedOutputStream.java
+++ b/src/java.base/share/classes/java/io/PipedOutputStream.java
@@ -135,6 +135,7 @@ public class PipedOutputStream extends OutputStream {
      * @throws  IOException if the pipe is <a href=#BROKEN> broken</a>,
      *          {@link #connect(java.io.PipedInputStream) unconnected},
      *          closed, or if an I/O error occurs.
+     * @throws  IndexOutOfBoundsException {@inheritDoc}
      */
     @Override
     public void write(byte[] b, int off, int len) throws IOException {

--- a/src/java.base/share/classes/java/io/PrintStream.java
+++ b/src/java.base/share/classes/java/io/PrintStream.java
@@ -612,6 +612,7 @@ public class PrintStream extends FilterOutputStream
      * @param  buf   A byte array
      * @param  off   Offset from which to start taking bytes
      * @param  len   Number of bytes to write
+     * @throws IndexOutOfBoundsException {@inheritDoc}
      */
     @Override
     public void write(byte[] buf, int off, int len) {


### PR DESCRIPTION
Add `@throws IndexOutOfBoundsException {@inheritDoc}` to some `write(byte[],int,int)` and `read(byte[],int,int)` methods of some classes in the `java.io` package to make things a bit clearer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8156593](https://bugs.openjdk.org/browse/JDK-8156593): DataOutput.write(byte[],int,int) and its implementations do not specify index out bounds
 * [JDK-8296138](https://bugs.openjdk.org/browse/JDK-8296138): DataOutput.write(byte[],int,int) and its implementations do not specify index out bounds (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Andrey Turbanov](https://openjdk.org/census#aturbanov) (@turbanoff - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10890/head:pull/10890` \
`$ git checkout pull/10890`

Update a local copy of the PR: \
`$ git checkout pull/10890` \
`$ git pull https://git.openjdk.org/jdk pull/10890/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10890`

View PR using the GUI difftool: \
`$ git pr show -t 10890`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10890.diff">https://git.openjdk.org/jdk/pull/10890.diff</a>

</details>
