### PR TITLE
8296007: crash in runtime/DefineClass/NullClassBytesTest.java

### DIFF
--- a/test/hotspot/jtreg/runtime/DefineClass/libNullClassBytesTest.c
+++ b/test/hotspot/jtreg/runtime/DefineClass/libNullClassBytesTest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 #include <jni.h>
 
-JNIEXPORT void JNICALL
+JNIEXPORT jclass JNICALL
 Java_NullClassBytesTest_nativeDefineClass(JNIEnv *env, jclass klass, jstring className, jobject ldr,
                                           jbyte* class_bytes, jint length) {
     if (class_bytes == NULL) {
@@ -32,8 +32,8 @@ Java_NullClassBytesTest_nativeDefineClass(JNIEnv *env, jclass klass, jstring cla
         if (cls != 0) {
             (*env)->ThrowNew(env, cls, "class_bytes are null");
         }
-        return;
+        return NULL;
     }
     const char* c_name = (*env)->GetStringUTFChars(env, className, NULL);
-    (*env)->DefineClass(env, c_name, ldr, class_bytes, length);
+    return (*env)->DefineClass(env, c_name, ldr, class_bytes, length);
 }


### PR DESCRIPTION
This is a simple fix to Java_NullClassBytesTest_nativeDefineClass so that it returns the jclass as expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296007](https://bugs.openjdk.org/browse/JDK-8296007): crash in runtime/DefineClass/NullClassBytesTest.java


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10892/head:pull/10892` \
`$ git checkout pull/10892`

Update a local copy of the PR: \
`$ git checkout pull/10892` \
`$ git pull https://git.openjdk.org/jdk pull/10892/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10892`

View PR using the GUI difftool: \
`$ git pr show -t 10892`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10892.diff">https://git.openjdk.org/jdk/pull/10892.diff</a>

</details>
