### PR TITLE
8232933: Javac inferred type does not conform to equality constraint

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/InferenceContext.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/InferenceContext.java
@@ -337,6 +337,17 @@ public class InferenceContext {
         if (roots.length() == inferencevars.length()) {
             return this;
         }
+        /* if any of the inference vars is a captured variable bail out, this is because
+         * we could end up generating more than necessary captured variables in an outer
+         * inference context and then when we need to propagate back to an inner inference
+         * context that has been minimized it could be that some bounds constraints doesn't
+         * hold like subtyping constraints between bonds etc.
+         */
+        for (Type iv : inferencevars) {
+            if (iv.hasTag(TypeTag.TYPEVAR) && ((TypeVar)iv).isCaptured()) {
+                return this;
+            }
+        }
         ReachabilityVisitor rv = new ReachabilityVisitor();
         rv.scan(roots);
         if (rv.min.size() == inferencevars.length()) {

--- a/test/langtools/tools/javac/inference_context_min/DontMinimizeInfContextTest.java
+++ b/test/langtools/tools/javac/inference_context_min/DontMinimizeInfContextTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8232933
+ * @summary Javac inferred type does not conform to equality constraint
+ * @compile DontMinimizeInfContextTest.java
+ */
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+class DontMinimizeInfContextTest {
+    void m() {
+        List<? extends A<?, ?>> a = new LinkedList<>();
+        Map<String, List<A<?, ?>>> b = a.stream().collect(
+                Collectors.groupingBy(A::getval, Collectors.toList())
+        );
+    }
+
+    class A<K, V> {
+        String getval() {
+            return "s";
+        }
+    }
+}


### PR DESCRIPTION
When dealing with nested invocations it could be that the inference context of a nested invocation is propagated to the inference context of the outer invocation. There are occasions when the propagated inference context can be minimized if some of its inference variables are deemed redundant. This is an optimization that is done in order to speed up the type inference algo which can take a while if the number of variables to be reduced is large. Of course by removing some variables from an inference context we have an inherent risk of cutting too much and not being able to produce the same results compared to not minimizing it. My understanding is that this bug shows one of those cases in which an inference context has been reduced too much.

The proposed solution is not to minimize an inference context if at least one of its inference variables is a capture type. The reason is because when capture types are present, some bounds are wildcards which could be captured again generating new capture types etc., this could make impossible to prove that some constraints hold for an inference context, thus making the compiler wrongly reject correct code.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8232933](https://bugs.openjdk.org/browse/JDK-8232933): Javac inferred type does not conform to equality constraint


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10897/head:pull/10897` \
`$ git checkout pull/10897`

Update a local copy of the PR: \
`$ git checkout pull/10897` \
`$ git pull https://git.openjdk.org/jdk pull/10897/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10897`

View PR using the GUI difftool: \
`$ git pr show -t 10897`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10897.diff">https://git.openjdk.org/jdk/pull/10897.diff</a>

</details>
