### PR TITLE
8293785: Add a jtreg test for TraceOptoParse

### DIFF
--- a/test/hotspot/jtreg/compiler/print/TestTraceOptoParse.java
+++ b/test/hotspot/jtreg/compiler/print/TestTraceOptoParse.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8293785
  * @summary test for -XX:+TraceOptoParse
- * @requires vm.debug
+ * @requires vm.debug & vm.compiler2.enabled
  * @run main/othervm -XX:+TraceOptoParse compiler.print.TestTraceOptoParse
  *
  */

--- a/test/hotspot/jtreg/compiler/print/TestTraceOptoParse.java
+++ b/test/hotspot/jtreg/compiler/print/TestTraceOptoParse.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8293785
+ * @summary test for -XX:+TraceOptoParse
+ * @requires vm.debug
+ * @run main/othervm -XX:+TraceOptoParse compiler.print.TestTraceOptoParse
+ *
+ */
+
+package compiler.print;
+
+public class TestTraceOptoParse {
+    public static void main(String[] args) {
+        System.out.println("Passed");
+    }
+}


### PR DESCRIPTION
Add a jtreg test for TraceOptoParse after [JDK-8293774](https://bugs.openjdk.org/browse/JDK-8293774)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293785](https://bugs.openjdk.org/browse/JDK-8293785): Add a jtreg test for TraceOptoParse


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10898/head:pull/10898` \
`$ git checkout pull/10898`

Update a local copy of the PR: \
`$ git checkout pull/10898` \
`$ git pull https://git.openjdk.org/jdk pull/10898/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10898`

View PR using the GUI difftool: \
`$ git pr show -t 10898`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10898.diff">https://git.openjdk.org/jdk/pull/10898.diff</a>

</details>
