### PR TITLE
8295774: Write a test to verify List sends ItemEvent/ActionEvent

### DIFF
--- a/test/jdk/java/awt/event/ComponentEvent/ListItemEventsTest.java
+++ b/test/jdk/java/awt/event/ComponentEvent/ListItemEventsTest.java
@@ -21,20 +21,17 @@
  * questions.
  */
 
+import java.awt.Dimension;
 import java.awt.EventQueue;
 import java.awt.FlowLayout;
 import java.awt.Frame;
 import java.awt.List;
 import java.awt.Point;
-import java.awt.Rectangle;
 import java.awt.Robot;
-import java.awt.event.FocusAdapter;
-import java.awt.event.FocusEvent;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 /*
  * @test
@@ -47,12 +44,11 @@ public class ListItemEventsTest {
 
     private static final int waitDelay = 1000;
 
-    private volatile static Frame frame;
+    private static Frame frame;
     private volatile static List list;
     private volatile static boolean actionPerformed = false;
     private volatile static boolean itemStateChanged = false;
-    private volatile static Robot robot;
-    private volatile static CountDownLatch latch;
+    private static Robot robot;
 
     public static void initializeGUI() {
         frame = new Frame("Test Frame");
@@ -71,12 +67,6 @@ public class ListItemEventsTest {
             System.out.println("Got an ActionEvent:" + event);
             actionPerformed = true;
         });
-        list.addFocusListener(new FocusAdapter() {
-            public void focusGained(FocusEvent event) {
-                System.out.println("Got an FocusEvent:" + event);
-                latch.countDown();
-            }
-        });
 
         frame.add(list);
         frame.pack();
@@ -85,7 +75,6 @@ public class ListItemEventsTest {
     }
 
     public static void main(String[] s) throws Exception {
-        latch = new CountDownLatch(1);
         robot = new Robot();
         try {
 
@@ -96,19 +85,14 @@ public class ListItemEventsTest {
             robot.waitForIdle();
 
             Point listAt = list.getLocationOnScreen();
-            // get bounds of button
-            Rectangle bounds = list.getBounds();
 
-            robot.mouseMove(listAt.x + bounds.width / 2,
-                listAt.y + bounds.height / 2);
+            Dimension listDimension = list.getSize();
+
+            robot.mouseMove(listAt.x + listDimension.width / 2,
+                listAt.y + listDimension.height / 2);
 
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-
-            if (!latch.await(15, TimeUnit.SECONDS)) {
-                throw new RuntimeException(
-                    "Fail: Timed out waiting for list to gain focus, test cannot proceed!!");
-            }
 
             if (!itemStateChanged) {
                 throw new RuntimeException(
@@ -140,7 +124,7 @@ public class ListItemEventsTest {
             robot.setAutoDelay(waitDelay);
 
             itemStateChanged = false;
-            keyType(KeyEvent.VK_DOWN);
+            typeKey(KeyEvent.VK_DOWN);
 
             if (!itemStateChanged) {
                 throw new RuntimeException(
@@ -149,7 +133,7 @@ public class ListItemEventsTest {
             }
 
             itemStateChanged = false;
-            keyType(KeyEvent.VK_UP);
+            typeKey(KeyEvent.VK_UP);
 
             if (!itemStateChanged) {
                 throw new RuntimeException(
@@ -164,7 +148,7 @@ public class ListItemEventsTest {
             }
 
             actionPerformed = false;
-            keyType(KeyEvent.VK_ENTER);
+            typeKey(KeyEvent.VK_ENTER);
 
             if (!actionPerformed) {
                 throw new RuntimeException(
@@ -186,7 +170,7 @@ public class ListItemEventsTest {
         }
     }
 
-    private static void keyType(int key) throws Exception {
+    private static void typeKey(int key) throws Exception {
         robot.keyPress(key);
         robot.keyRelease(key);
     }

--- a/test/jdk/java/awt/event/ComponentEvent/ListItemEventsTest.java
+++ b/test/jdk/java/awt/event/ComponentEvent/ListItemEventsTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.List;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/*
+ * @test
+ * @key headful
+ * @bug 8295774
+ * @summary Verify that List Item selection via mouse/keys generates ItemEvent/ActionEvent appropriately.
+ * @run main ListItemEventsTest
+ */
+public class ListItemEventsTest {
+
+    private static final int waitDelay = 1000;
+
+    private volatile static Frame frame;
+    private volatile static List list;
+    private volatile static boolean actionPerformed = false;
+    private volatile static boolean itemStateChanged = false;
+    private volatile static Robot robot;
+    private volatile static CountDownLatch latch;
+
+    public static void initializeGUI() {
+        frame = new Frame("Test Frame");
+        frame.setLayout(new FlowLayout());
+        list = new List();
+        list.add("One");
+        list.add("Two");
+        list.add("Three");
+        list.add("Four");
+        list.add("Five");
+        list.addItemListener((event) -> {
+            System.out.println("Got an ItemEvent:" + event);
+            itemStateChanged = true;
+        });
+        list.addActionListener((event) -> {
+            System.out.println("Got an ActionEvent:" + event);
+            actionPerformed = true;
+        });
+        list.addFocusListener(new FocusAdapter() {
+            public void focusGained(FocusEvent event) {
+                System.out.println("Got an FocusEvent:" + event);
+                latch.countDown();
+            }
+        });
+
+        frame.add(list);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    public static void main(String[] s) throws Exception {
+        latch = new CountDownLatch(1);
+        robot = new Robot();
+        try {
+
+            robot.setAutoDelay(100);
+            robot.setAutoWaitForIdle(true);
+
+            EventQueue.invokeLater(ListItemEventsTest::initializeGUI);
+            robot.waitForIdle();
+
+            Point listAt = list.getLocationOnScreen();
+            // get bounds of button
+            Rectangle bounds = list.getBounds();
+
+            robot.mouseMove(listAt.x + bounds.width / 2,
+                listAt.y + bounds.height / 2);
+
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+            if (!latch.await(15, TimeUnit.SECONDS)) {
+                throw new RuntimeException(
+                    "Fail: Timed out waiting for list to gain focus, test cannot proceed!!");
+            }
+
+            if (!itemStateChanged) {
+                throw new RuntimeException(
+                    "FAIL: List did not trigger ItemEvent when item selected!");
+            }
+
+            robot.mousePress(MouseEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(MouseEvent.BUTTON1_DOWN_MASK);
+            robot.mousePress(MouseEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(MouseEvent.BUTTON1_DOWN_MASK);
+
+            if (!actionPerformed) {
+                throw new RuntimeException(
+                    "FAIL: List did not trigger ActionEvent when double"
+                        + " clicked!");
+            }
+
+            itemStateChanged = false;
+            actionPerformed = false;
+
+            EventQueue.invokeAndWait(() -> list.select(0));
+
+            if (itemStateChanged) {
+                throw new RuntimeException(
+                    "FAIL: List triggered ItemEvent when item selected by "
+                        + "calling the API!");
+            }
+
+            robot.setAutoDelay(waitDelay);
+
+            itemStateChanged = false;
+            keyType(KeyEvent.VK_DOWN);
+
+            if (!itemStateChanged) {
+                throw new RuntimeException(
+                    "FAIL: List did not trigger ItemEvent when item selected by"
+                        + " down arrow key!");
+            }
+
+            itemStateChanged = false;
+            keyType(KeyEvent.VK_UP);
+
+            if (!itemStateChanged) {
+                throw new RuntimeException(
+                    "FAIL: List did not trigger ItemEvent when item selected by"
+                        + " up arrow key!");
+            }
+
+            if (actionPerformed) {
+                throw new RuntimeException(
+                    "FAIL: List triggerd ActionEvent unnecessarily. Action generated"
+                        + " when item selected using API or UP/DOWN keys!");
+            }
+
+            actionPerformed = false;
+            keyType(KeyEvent.VK_ENTER);
+
+            if (!actionPerformed) {
+                throw new RuntimeException(
+                    "FAIL: List did not trigger ActionEvent when enter"
+                        + " key typed!");
+            }
+
+            System.out.println("Test passed!");
+
+        } finally {
+            EventQueue.invokeAndWait(ListItemEventsTest::disposeFrame);
+        }
+    }
+
+    public static void disposeFrame() {
+        if (frame != null) {
+            frame.dispose();
+            frame = null;
+        }
+    }
+
+    private static void keyType(int key) throws Exception {
+        robot.keyPress(key);
+        robot.keyRelease(key);
+    }
+}

--- a/test/jdk/java/awt/event/ComponentEvent/ListItemEventsTest.java
+++ b/test/jdk/java/awt/event/ComponentEvent/ListItemEventsTest.java
@@ -84,10 +84,9 @@ public class ListItemEventsTest {
             robot.waitForIdle();
 
             Point listAt = list.getLocationOnScreen();
-            Dimension listSize  = list.getSize();
-            
-            robot.mouseMove(listAt.x + listSize .width / 2,
-                listAt.y + listSize .height / 2);
+            Dimension listSize = list.getSize();
+            robot.mouseMove(listAt.x + listSize.width / 2,
+                listAt.y + listSize.height / 2);
 
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);

--- a/test/jdk/java/awt/event/ComponentEvent/ListItemEventsTest.java
+++ b/test/jdk/java/awt/event/ComponentEvent/ListItemEventsTest.java
@@ -60,11 +60,11 @@ public class ListItemEventsTest {
         list.add("Four");
         list.add("Five");
         list.addItemListener((event) -> {
-            System.out.println("Got an ItemEvent:" + event);
+            System.out.println("Got an ItemEvent: " + event);
             itemStateChanged = true;
         });
         list.addActionListener((event) -> {
-            System.out.println("Got an ActionEvent:" + event);
+            System.out.println("Got an ActionEvent: " + event);
             actionPerformed = true;
         });
 

--- a/test/jdk/java/awt/event/ComponentEvent/ListItemEventsTest.java
+++ b/test/jdk/java/awt/event/ComponentEvent/ListItemEventsTest.java
@@ -31,7 +31,6 @@ import java.awt.Robot;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
-import java.util.concurrent.CountDownLatch;
 
 /*
  * @test
@@ -42,7 +41,8 @@ import java.util.concurrent.CountDownLatch;
  */
 public class ListItemEventsTest {
 
-    private static final int waitDelay = 1000;
+    private static final int MOUSE_DELAY = 100;
+    private static final int KEYBOARD_DELAY = 1000;
 
     private static Frame frame;
     private volatile static List list;
@@ -77,19 +77,17 @@ public class ListItemEventsTest {
     public static void main(String[] s) throws Exception {
         robot = new Robot();
         try {
-
-            robot.setAutoDelay(100);
+            robot.setAutoDelay(MOUSE_DELAY);
             robot.setAutoWaitForIdle(true);
 
             EventQueue.invokeLater(ListItemEventsTest::initializeGUI);
             robot.waitForIdle();
 
             Point listAt = list.getLocationOnScreen();
-
-            Dimension listDimension = list.getSize();
-
-            robot.mouseMove(listAt.x + listDimension.width / 2,
-                listAt.y + listDimension.height / 2);
+            Dimension listSize  = list.getSize();
+            
+            robot.mouseMove(listAt.x + listSize .width / 2,
+                listAt.y + listSize .height / 2);
 
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
@@ -114,6 +112,7 @@ public class ListItemEventsTest {
             actionPerformed = false;
 
             EventQueue.invokeAndWait(() -> list.select(0));
+            robot.waitForIdle();
 
             if (itemStateChanged) {
                 throw new RuntimeException(
@@ -121,7 +120,7 @@ public class ListItemEventsTest {
                         + "calling the API!");
             }
 
-            robot.setAutoDelay(waitDelay);
+            robot.setAutoDelay(KEYBOARD_DELAY);
 
             itemStateChanged = false;
             typeKey(KeyEvent.VK_DOWN);


### PR DESCRIPTION
This testcase verify that List Item selection via mouse/keys generates ItemEvent/ActionEvent appropriately.

a. Single click on the list generate ItemEvent and double click on item generates ActionEvent.
b. UP/DOWN keys on the list generate ItemEvent and enter key on item generates ActionEvent.

Testing:
Tested using Mach5(20 times per platform) in macos,linux and windows and got all pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295774](https://bugs.openjdk.org/browse/JDK-8295774): Write a test to verify List sends ItemEvent/ActionEvent


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to [c4cf5168](https://git.openjdk.org/jdk/pull/10899/files/c4cf5168bd06fb11b2555a6956310adf6433739f)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10899/head:pull/10899` \
`$ git checkout pull/10899`

Update a local copy of the PR: \
`$ git checkout pull/10899` \
`$ git pull https://git.openjdk.org/jdk pull/10899/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10899`

View PR using the GUI difftool: \
`$ git pr show -t 10899`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10899.diff">https://git.openjdk.org/jdk/pull/10899.diff</a>

</details>
