### PR TITLE
8296030: compiler/c2/irTests/TestVectorizeTypeConversion.java fails with release VMs after JDK-8291781

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeTypeConversion.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeTypeConversion.java
@@ -51,7 +51,7 @@ public class TestVectorizeTypeConversion {
     private static float[] floatb = new float[SIZE];
 
     public static void main(String[] args) {
-        TestFramework.runWithFlags("-XX:+SuperWordRTDepCheck");
+        TestFramework.runWithFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:+SuperWordRTDepCheck");
     }
 
     @Test


### PR DESCRIPTION


Hi all,

compiler/c2/irTests/TestVectorizeTypeConversion.java fails with release VMs due to 'SuperWordRTDepCheck' is develop and is available only in debug version of VM.
To fix it, `-XX:+IgnoreUnrecognizedVMOptions` is added in the test.

Thanks.
Best regards,
Jie