### PR TITLE
JDK-8295993 : use K instead of 1024 in a couple of hotspot outputs

### DIFF
--- a/src/hotspot/os/linux/osContainer_linux.cpp
+++ b/src/hotspot/os/linux/osContainer_linux.cpp
@@ -141,7 +141,7 @@ void OSContainer::print_container_helper(outputStream* st, jlong j, const char* 
   st->print("%s: ", metrics);
   if (j > 0) {
     if (j >= 1024) {
-      st->print_cr(UINT64_FORMAT " k", uint64_t(j) / 1024);
+      st->print_cr(UINT64_FORMAT " k", uint64_t(j) / K);
     } else {
       st->print_cr(UINT64_FORMAT, uint64_t(j));
     }

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -138,7 +138,7 @@ void os::check_dump_limit(char* buffer, size_t bufferSize) {
         success = false;
         break;
       default:
-        jio_snprintf(buffer, bufferSize, "%s (max size " UINT64_FORMAT " kB). To ensure a full core dump, try \"ulimit -c unlimited\" before starting Java again", core_path, uint64_t(rlim.rlim_cur) / 1024);
+        jio_snprintf(buffer, bufferSize, "%s (max size " UINT64_FORMAT " k). To ensure a full core dump, try \"ulimit -c unlimited\" before starting Java again", core_path, uint64_t(rlim.rlim_cur) / K);
         success = true;
         break;
     }
@@ -479,14 +479,14 @@ static void print_rlimit(outputStream* st, const char* msg,
     // soft limit
     if (rlim.rlim_cur == RLIM_INFINITY) { st->print("infinity"); }
     else {
-      if (output_k) { st->print(UINT64_FORMAT "k", uint64_t(rlim.rlim_cur) / 1024); }
+      if (output_k) { st->print(UINT64_FORMAT "k", uint64_t(rlim.rlim_cur) / K); }
       else { st->print(UINT64_FORMAT, uint64_t(rlim.rlim_cur)); }
     }
     // hard limit
     st->print("/");
     if (rlim.rlim_max == RLIM_INFINITY) { st->print("infinity"); }
     else {
-      if (output_k) { st->print(UINT64_FORMAT "k", uint64_t(rlim.rlim_max) / 1024); }
+      if (output_k) { st->print(UINT64_FORMAT "k", uint64_t(rlim.rlim_max) / K); }
       else { st->print(UINT64_FORMAT, uint64_t(rlim.rlim_max)); }
     }
   }
@@ -897,7 +897,7 @@ char* os::Posix::describe_pthread_attr(char* buf, size_t buflen, const pthread_a
   LINUX_ONLY(stack_size -= guard_size);
   pthread_attr_getdetachstate(attr, &detachstate);
   jio_snprintf(buf, buflen, "stacksize: " SIZE_FORMAT "k, guardsize: " SIZE_FORMAT "k, %s",
-    stack_size / 1024, guard_size / 1024,
+    stack_size / K, guard_size / K,
     (detachstate == PTHREAD_CREATE_DETACHED ? "detached" : "joinable"));
   return buf;
 }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -532,7 +532,7 @@ static unsigned __stdcall thread_native_entry(Thread* thread) {
     res = 20115;    // java thread
   }
 
-  log_info(os, thread)("Thread is alive (tid: " UINTX_FORMAT ", stacksize: " SIZE_FORMAT "k).", os::current_thread_id(), thread->stack_size() / 1024);
+  log_info(os, thread)("Thread is alive (tid: " UINTX_FORMAT ", stacksize: " SIZE_FORMAT "k).", os::current_thread_id(), thread->stack_size() / K);
 
 #ifdef USE_VECTORED_EXCEPTION_HANDLING
   // Any exception is caught by the Vectored Exception Handler, so VM can
@@ -650,7 +650,7 @@ static char* describe_beginthreadex_attributes(char* buf, size_t buflen,
   if (stacksize == 0) {
     ss.print("stacksize: default, ");
   } else {
-    ss.print("stacksize: " SIZE_FORMAT "k, ", stacksize / 1024);
+    ss.print("stacksize: " SIZE_FORMAT "k, ", stacksize / K);
   }
   ss.print("flags: ");
   #define PRINT_FLAG(f) if (initflag & f) ss.print( #f " ");

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -876,8 +876,7 @@ void SymbolTable::print_histogram() {
   _local_table->do_scan(Thread::current(), hi);
   tty->print_cr("Symbol Table Histogram:");
   tty->print_cr("  Total number of symbols  " SIZE_FORMAT_W(7), hi.total_count);
-  tty->print_cr("  Total size in memory     " SIZE_FORMAT_W(7) "K",
-          (hi.total_size * wordSize) / 1024);
+  tty->print_cr("  Total size in memory     " SIZE_FORMAT_W(7) "K", (hi.total_size * wordSize) / K);
   tty->print_cr("  Total counted            " SIZE_FORMAT_W(7), _symbols_counted);
   tty->print_cr("  Total removed            " SIZE_FORMAT_W(7), _symbols_removed);
   if (_symbols_counted > 0) {
@@ -885,8 +884,8 @@ void SymbolTable::print_histogram() {
           ((float)_symbols_removed / _symbols_counted) * 100);
   }
   tty->print_cr("  Reference counts         " SIZE_FORMAT_W(7), Symbol::_total_count);
-  tty->print_cr("  Symbol arena used        " SIZE_FORMAT_W(7) "K", arena()->used() / 1024);
-  tty->print_cr("  Symbol arena size        " SIZE_FORMAT_W(7) "K", arena()->size_in_bytes() / 1024);
+  tty->print_cr("  Symbol arena used        " SIZE_FORMAT_W(7) "K", arena()->used() / K);
+  tty->print_cr("  Symbol arena size        " SIZE_FORMAT_W(7) "K", arena()->size_in_bytes() / K);
   tty->print_cr("  Total symbol length      " SIZE_FORMAT_W(7), hi.total_length);
   tty->print_cr("  Maximum symbol length    " SIZE_FORMAT_W(7), hi.max_length);
   tty->print_cr("  Average symbol length    %7.2f", ((float)hi.total_length / hi.total_count));
@@ -895,11 +894,11 @@ void SymbolTable::print_histogram() {
   for (size_t i = 0; i < hi.results_length; i++) {
     if (hi.counts[i] > 0) {
       tty->print_cr("    " SIZE_FORMAT_W(6) " " SIZE_FORMAT_W(10) " " SIZE_FORMAT_W(10) "K",
-                    i, hi.counts[i], (hi.sizes[i] * wordSize) / 1024);
+                    i, hi.counts[i], (hi.sizes[i] * wordSize) / K);
     }
   }
   tty->print_cr("  >=" SIZE_FORMAT_W(6) " " SIZE_FORMAT_W(10) " " SIZE_FORMAT_W(10) "K\n",
-                hi.results_length, hi.out_of_range_count, (hi.out_of_range_size*wordSize) / 1024);
+                hi.results_length, hi.out_of_range_count, (hi.out_of_range_size*wordSize) / K);
 }
 #endif // PRODUCT
 


### PR DESCRIPTION
There are a couple of outputs of values in k  (e.g. in os_posix.cpp and os_windows.cpp) where the K constant could be used nicely instead of 1024 (this is done already at a number of places but not everywhere).

(This is NOT about replacing all 1024 in the codebase by K because I think this would not be a good idea.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295993](https://bugs.openjdk.org/browse/JDK-8295993): use K instead of 1024 in a couple of hotspot outputs


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10902/head:pull/10902` \
`$ git checkout pull/10902`

Update a local copy of the PR: \
`$ git checkout pull/10902` \
`$ git pull https://git.openjdk.org/jdk pull/10902/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10902`

View PR using the GUI difftool: \
`$ git pr show -t 10902`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10902.diff">https://git.openjdk.org/jdk/pull/10902.diff</a>

</details>
