### PR TITLE
8294217: Assertion failure: parsing found no loops but there are some

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -4180,6 +4180,8 @@ bool PhaseIdealLoop::process_expensive_nodes() {
 }
 
 #ifdef ASSERT
+// Goes over all children of the root of the loop tree, collects all controls for the loop and its inner loops then
+// checks whether any control is a branch out of the loop and if it is, whether it's not a NeverBranch.
 bool PhaseIdealLoop::only_has_infinite_loops() {
   for (IdealLoopTree* l = _ltree_root->_child; l != NULL; l = l->_next) {
     Unique_Node_List wq;
@@ -4206,7 +4208,7 @@ bool PhaseIdealLoop::only_has_infinite_loops() {
     assert(wq.member(head), "");
     for (uint i = 0; i < wq.size(); ++i) {
       Node* c = wq.at(i);
-      if (c->isa_MultiBranch()) {
+      if (c->is_MultiBranch()) {
         for (DUIterator_Fast jmax, j = c->fast_outs(jmax); j < jmax; j++) {
           Node* u = c->fast_out(j);
           assert(u->is_CFG(), "");

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -4212,6 +4212,8 @@ void PhaseIdealLoop::build_and_optimize() {
 
   bool do_split_ifs = (_mode == LoopOptsDefault);
   bool skip_loop_opts = (_mode == LoopOptsNone);
+  bool do_max_unroll = (_mode == LoopOptsMaxUnroll);
+
 
   int old_progress = C->major_progress();
   uint orig_worklist_size = _igvn._worklist.size();
@@ -4281,8 +4283,8 @@ void PhaseIdealLoop::build_and_optimize() {
 
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
   // Nothing to do, so get out
-  bool stop_early = !C->has_loops() && !skip_loop_opts && !do_split_ifs && !_verify_me && !_verify_only &&
-    !bs->is_gc_specific_loop_opts_pass(_mode);
+  bool stop_early = !C->has_loops() && !skip_loop_opts && !do_split_ifs && !do_max_unroll && !_verify_me &&
+          !_verify_only && !bs->is_gc_specific_loop_opts_pass(_mode);
   bool do_expensive_nodes = C->should_optimize_expensive_nodes(_igvn);
   bool strip_mined_loops_expanded = bs->strip_mined_loops_expanded(_mode);
   if (stop_early && !do_expensive_nodes) {
@@ -4421,7 +4423,7 @@ void PhaseIdealLoop::build_and_optimize() {
     return;
   }
 
-  if (_mode == LoopOptsMaxUnroll) {
+  if (do_max_unroll) {
     for (LoopTreeIterator iter(_ltree_root); !iter.done(); iter.next()) {
       IdealLoopTree* lpt = iter.current();
       if (lpt->is_innermost() && lpt->_allow_optimizations && !lpt->_has_call && lpt->is_counted()) {

--- a/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopNest.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopNest.java
@@ -52,16 +52,16 @@ public class TestInfiniteLoopNest {
 
     public static void main(String[] p) throws Exception {
         Thread thread = new Thread() {
-                public void run() {
-                    TestInfiniteLoopNest t = new TestInfiniteLoopNest();
-                    for (int i = 524; i < 19710; i += 1) {
-                        b = true;
-                        t.q();
-                        b = false;
-                    }
+            public void run() {
+                TestInfiniteLoopNest t = new TestInfiniteLoopNest();
+                for (int i = 524; i < 19710; i += 1) {
+                    b = true;
                     t.q();
+                    b = false;
                 }
-            };
+                t.q();
+            }
+        };
         // Give thread some time to trigger compilation
         thread.setDaemon(true);
         thread.start();

--- a/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopNest.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopNest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8294217
+ * @summary Assertion failure: parsing found no loops but there are some
+ * @library /test/lib
+ *
+ * @run main/othervm -Xmx1G -XX:-BackgroundCompilation TestInfiniteLoopNest
+ *
+ */
+
+import jdk.test.lib.Utils;
+
+public class TestInfiniteLoopNest {
+    long l;
+
+    void q() {
+        if (b) {
+            Object o = new Object();
+            return;
+        }
+
+        do {
+            l++;
+            while (l != 1) --l;
+            l = 9;
+        } while (l != 5);
+
+    }
+
+    public static void main(String[] p) throws Exception {
+        Thread thread = new Thread() {
+                public void run() {
+                    TestInfiniteLoopNest t = new TestInfiniteLoopNest();
+                    for (int i = 524; i < 19710; i += 1) {
+                        b = true;
+                        t.q();
+                        b = false;
+                    }
+                    t.q();
+                }
+            };
+        // Give thread some time to trigger compilation
+        thread.setDaemon(true);
+        thread.start();
+        Thread.sleep(Utils.adjustTimeout(4000));
+    }
+
+    static Boolean b;
+}


### PR DESCRIPTION
This was reported on 11 and is not reproducible with the current
jdk. The reason is that the PhaseIdealLoop invocation before EA was
changed from LoopOptsNone to LoopOptsMaxUnroll. In the absence of
loops, LoopOptsMaxUnroll exits earlier than LoopOptsNone. That wasn't
intended and this patch makes sure they behave the same. Once that's
changed, the crash reproduces with the current jdk.

The assert fires because PhaseIdealLoop::only_has_infinite_loops()
returns false even though the IR only has infinite loops. There's a
single loop nest and the inner most loop is an infinite loop. The
current logic only looks at loops that are direct children of the root
of the loop tree. It's not the first bug where
PhaseIdealLoop::only_has_infinite_loops() fails to catch an infinite
loop (8257574 was the previous one) and it's proving challenging to
have PhaseIdealLoop::only_has_infinite_loops() handle corner cases
robustly. I reworked PhaseIdealLoop::only_has_infinite_loops() once
more. This time it goes over all children of the root of the loop
tree, collects all controls for the loop and its inner loop. It then
checks whether any control is a branch out of the loop and if it is
whether it's not a NeverBranch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294217](https://bugs.openjdk.org/browse/JDK-8294217): Assertion failure: parsing found no loops but there are some


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10904/head:pull/10904` \
`$ git checkout pull/10904`

Update a local copy of the PR: \
`$ git checkout pull/10904` \
`$ git pull https://git.openjdk.org/jdk pull/10904/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10904`

View PR using the GUI difftool: \
`$ git pr show -t 10904`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10904.diff">https://git.openjdk.org/jdk/pull/10904.diff</a>

</details>
