### PR TITLE
8296072: CertAttrSet::encode and DerEncoder::derEncode should write into DerOutputStream

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
@@ -26,7 +26,6 @@
 package sun.security.pkcs;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.security.cert.CertificateException;
 import java.util.Date;
 
@@ -525,7 +524,7 @@ public class PKCS9Attribute implements DerEncoder {
      * should be encoded as <code>T61String</code>s.
      */
     @Override
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         DerOutputStream temp = new DerOutputStream();
         temp.putOID(oid);
         switch (index) {
@@ -643,11 +642,7 @@ public class PKCS9Attribute implements DerEncoder {
         default: // can't happen
         }
 
-        DerOutputStream derOut = new DerOutputStream();
-        derOut.write(DerValue.tag_Sequence, temp.toByteArray());
-
-        out.write(derOut.toByteArray());
-
+        out.write(DerValue.tag_Sequence, temp.toByteArray());
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/pkcs/SignerInfo.java
+++ b/src/java.base/share/classes/sun/security/pkcs/SignerInfo.java
@@ -26,7 +26,6 @@
 package sun.security.pkcs;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.math.BigInteger;
 import java.security.*;
 import java.security.cert.*;
@@ -223,7 +222,7 @@ public class SignerInfo implements DerEncoder {
      *
      * @exception IOException on encoding error.
      */
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         DerOutputStream seq = new DerOutputStream();
         seq.putInteger(version);
         DerOutputStream issuerAndSerialNumber = new DerOutputStream();
@@ -245,10 +244,7 @@ public class SignerInfo implements DerEncoder {
         if (unauthenticatedAttributes != null)
             unauthenticatedAttributes.encode((byte)0xA1, seq);
 
-        DerOutputStream tmp = new DerOutputStream();
-        tmp.write(DerValue.tag_Sequence, seq);
-
-        out.write(tmp.toByteArray());
+        out.write(DerValue.tag_Sequence, seq);
     }
 
     /*

--- a/src/java.base/share/classes/sun/security/pkcs10/PKCS10Attribute.java
+++ b/src/java.base/share/classes/sun/security/pkcs10/PKCS10Attribute.java
@@ -25,7 +25,6 @@
 
 package sun.security.pkcs10;
 
-import java.io.OutputStream;
 import java.io.IOException;
 
 import sun.security.pkcs.PKCS9Attribute;
@@ -108,7 +107,7 @@ public class PKCS10Attribute implements DerEncoder {
      *
      * @exception IOException on encoding errors.
      */
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         PKCS9Attribute attr = new PKCS9Attribute(attributeId, attributeValue);
         attr.derEncode(out);
     }

--- a/src/java.base/share/classes/sun/security/pkcs10/PKCS10Attributes.java
+++ b/src/java.base/share/classes/sun/security/pkcs10/PKCS10Attributes.java
@@ -26,7 +26,6 @@
 package sun.security.pkcs10;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -94,7 +93,7 @@ public class PKCS10Attributes implements DerEncoder {
      * @param out the OutputStream to marshal the contents to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
+    public void encode(DerOutputStream out) throws IOException {
         derEncode(out);
     }
 
@@ -105,17 +104,14 @@ public class PKCS10Attributes implements DerEncoder {
      * @param out the OutputStream to marshal the contents to.
      * @exception IOException on encoding errors.
      */
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         // first copy the elements into an array
         Collection<PKCS10Attribute> allAttrs = map.values();
         PKCS10Attribute[] attribs =
                 allAttrs.toArray(new PKCS10Attribute[map.size()]);
 
-        DerOutputStream attrOut = new DerOutputStream();
-        attrOut.putOrderedSetOf(DerValue.createTag(DerValue.TAG_CONTEXT,
-                                                   true, (byte)0),
-                                attribs);
-        out.write(attrOut.toByteArray());
+        out.putOrderedSetOf(
+                DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte)0), attribs);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/util/DerEncoder.java
+++ b/src/java.base/share/classes/sun/security/util/DerEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 1922, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.util;
 
 import java.io.IOException;
-import java.io.OutputStream;
 
 /**
  * Interface to an object that knows how to write its own DER
@@ -41,7 +40,7 @@ public interface DerEncoder {
      *
      * @param out  the stream on which the DER encoding is written.
      */
-    void derEncode(OutputStream out)
+    void derEncode(DerOutputStream out)
         throws IOException;
 
 }

--- a/src/java.base/share/classes/sun/security/util/DerOutputStream.java
+++ b/src/java.base/share/classes/sun/security/util/DerOutputStream.java
@@ -27,7 +27,6 @@ package sun.security.util;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.math.BigInteger;
 import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
@@ -583,7 +582,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      *  @exception IOException on output error.
      */
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         out.write(toByteArray());
     }
 

--- a/src/java.base/share/classes/sun/security/x509/AVA.java
+++ b/src/java.base/share/classes/sun/security/x509/AVA.java
@@ -27,7 +27,6 @@ package sun.security.x509;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.Reader;
 import java.text.Normalizer;
 import java.util.*;
@@ -633,14 +632,12 @@ public class AVA implements DerEncoder {
      *
      * @exception IOException on encoding error.
      */
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         DerOutputStream         tmp = new DerOutputStream();
-        DerOutputStream         tmp2 = new DerOutputStream();
 
         tmp.putOID(oid);
         value.encode(tmp);
-        tmp2.write(DerValue.tag_Sequence, tmp);
-        out.write(tmp2.toByteArray());
+        out.write(DerValue.tag_Sequence, tmp);
     }
 
     private String toKeyword(int format, Map<String, String> oidMap) {

--- a/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
+++ b/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
@@ -164,9 +164,8 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * @exception IOException on encoding error.
      */
     @Override
-    public void derEncode (OutputStream out) throws IOException {
+    public void derEncode (DerOutputStream out) throws IOException {
         DerOutputStream bytes = new DerOutputStream();
-        DerOutputStream tmp = new DerOutputStream();
 
         bytes.putOID(algid);
 
@@ -234,8 +233,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
         } else {
             bytes.write(encodedParams);
         }
-        tmp.write(DerValue.tag_Sequence, bytes);
-        out.write(tmp.toByteArray());
+        out.write(DerValue.tag_Sequence, bytes);
     }
 
 

--- a/src/java.base/share/classes/sun/security/x509/AuthorityInfoAccessExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/AuthorityInfoAccessExtension.java
@@ -149,15 +149,13 @@ public class AuthorityInfoAccessExtension extends Extension
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.AuthInfoAccess_Id;
             this.critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/AuthorityInfoAccessExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/AuthorityInfoAccessExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 
 import java.util.*;
 
@@ -149,6 +148,7 @@ public class AuthorityInfoAccessExtension extends Extension
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.AuthInfoAccess_Id;

--- a/src/java.base/share/classes/sun/security/x509/AuthorityKeyIdentifierExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/AuthorityKeyIdentifierExtension.java
@@ -218,15 +218,13 @@ implements CertAttrSet<String> {
      * @param out the OutputStream to write the extension to.
      * @exception IOException on error.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             extensionId = PKIXExtensions.AuthorityKey_Id;
             critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/AuthorityKeyIdentifierExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/AuthorityKeyIdentifierExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.*;
@@ -218,6 +217,7 @@ implements CertAttrSet<String> {
      * @param out the OutputStream to write the extension to.
      * @exception IOException on error.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             extensionId = PKIXExtensions.AuthorityKey_Id;

--- a/src/java.base/share/classes/sun/security/x509/AuthorityKeyIdentifierExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/AuthorityKeyIdentifierExtension.java
@@ -214,7 +214,7 @@ implements CertAttrSet<String> {
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to.
+     * @param out the DerOutputStream to write the extension to.
      * @exception IOException on error.
      */
     @Override

--- a/src/java.base/share/classes/sun/security/x509/BasicConstraintsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/BasicConstraintsExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.*;
@@ -190,6 +189,7 @@ implements CertAttrSet<String> {
       *
       * @param out the DerOutputStream to encode the extension to.
       */
+     @Override
      public void encode(DerOutputStream out) throws IOException {
          if (extensionValue == null) {
              this.extensionId = PKIXExtensions.BasicConstraints_Id;

--- a/src/java.base/share/classes/sun/security/x509/BasicConstraintsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/BasicConstraintsExtension.java
@@ -190,16 +190,13 @@ implements CertAttrSet<String> {
       *
       * @param out the DerOutputStream to encode the extension to.
       */
-     public void encode(OutputStream out) throws IOException {
-         DerOutputStream tmp = new DerOutputStream();
+     public void encode(DerOutputStream out) throws IOException {
          if (extensionValue == null) {
              this.extensionId = PKIXExtensions.BasicConstraints_Id;
              critical = ca;
              encodeThis();
          }
-         super.encode(tmp);
-
-         out.write(tmp.toByteArray());
+         super.encode(out);
      }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CRLDistributionPointsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CRLDistributionPointsExtension.java
@@ -199,7 +199,7 @@ public class CRLDistributionPointsExtension extends Extension
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
+    public void encode(DerOutputStream out) throws IOException {
         encode(out, PKIXExtensions.CRLDistributionPoints_Id, false);
     }
 
@@ -207,17 +207,15 @@ public class CRLDistributionPointsExtension extends Extension
      * Write the extension to the DerOutputStream.
      * (Also called by the subclass)
      */
-    protected void encode(OutputStream out, ObjectIdentifier extensionId,
-        boolean isCritical) throws IOException {
+    protected void encode(DerOutputStream out, ObjectIdentifier extensionId,
+            boolean isCritical) throws IOException {
 
-        DerOutputStream tmp = new DerOutputStream();
         if (this.extensionValue == null) {
             this.extensionId = extensionId;
             this.critical = isCritical;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CRLDistributionPointsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CRLDistributionPointsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 
 import java.util.*;
 import java.util.Collections;
@@ -199,6 +198,7 @@ public class CRLDistributionPointsExtension extends Extension
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         encode(out, PKIXExtensions.CRLDistributionPoints_Id, false);
     }

--- a/src/java.base/share/classes/sun/security/x509/CRLExtensions.java
+++ b/src/java.base/share/classes/sun/security/x509/CRLExtensions.java
@@ -30,7 +30,6 @@ import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.security.cert.CRLException;
-import java.security.cert.CertificateException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;

--- a/src/java.base/share/classes/sun/security/x509/CRLExtensions.java
+++ b/src/java.base/share/classes/sun/security/x509/CRLExtensions.java
@@ -145,16 +145,8 @@ public class CRLExtensions {
     throws CRLException {
         try {
             DerOutputStream extOut = new DerOutputStream();
-            Collection<Extension> allExts = map.values();
-            Object[] objs = allExts.toArray();
-
-            for (int i = 0; i < objs.length; i++) {
-                if (objs[i] instanceof CertAttrSet)
-                    ((CertAttrSet)objs[i]).encode(extOut);
-                else if (objs[i] instanceof Extension)
-                    ((Extension)objs[i]).encode(extOut);
-                else
-                    throw new CRLException("Illegal extension object");
+            for (Extension ext : map.values()) {
+                ext.encode(extOut);
             }
 
             DerOutputStream seq = new DerOutputStream();
@@ -168,7 +160,7 @@ public class CRLExtensions {
                 tmp = seq;
 
             out.write(tmp.toByteArray());
-        } catch (IOException | CertificateException e) {
+        } catch (IOException e) {
             throw new CRLException("Encoding error: " + e.toString());
         }
     }

--- a/src/java.base/share/classes/sun/security/x509/CRLNumberExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CRLNumberExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.math.BigInteger;
 import java.util.Enumeration;
 
@@ -198,6 +197,7 @@ implements CertAttrSet<String> {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         encode(out, PKIXExtensions.CRLNumber_Id, true);
     }

--- a/src/java.base/share/classes/sun/security/x509/CRLNumberExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CRLNumberExtension.java
@@ -198,7 +198,7 @@ implements CertAttrSet<String> {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
+    public void encode(DerOutputStream out) throws IOException {
         encode(out, PKIXExtensions.CRLNumber_Id, true);
     }
 
@@ -206,18 +206,15 @@ implements CertAttrSet<String> {
      * Write the extension to the DerOutputStream.
      * (Also called by the subclass)
      */
-    protected void encode(OutputStream out, ObjectIdentifier extensionId,
-        boolean isCritical) throws IOException {
-
-       DerOutputStream  tmp = new DerOutputStream();
+    protected void encode(DerOutputStream out, ObjectIdentifier extensionId,
+            boolean isCritical) throws IOException {
 
        if (this.extensionValue == null) {
            this.extensionId = extensionId;
            this.critical = isCritical;
            encodeThis();
        }
-       super.encode(tmp);
-       out.write(tmp.toByteArray());
+       super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CRLReasonCodeExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CRLReasonCodeExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.security.cert.CRLReason;
 import java.util.Enumeration;
 
@@ -158,6 +157,7 @@ public class CRLReasonCodeExtension extends Extension
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.ReasonCode_Id;

--- a/src/java.base/share/classes/sun/security/x509/CRLReasonCodeExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CRLReasonCodeExtension.java
@@ -158,16 +158,13 @@ public class CRLReasonCodeExtension extends Extension
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream  tmp = new DerOutputStream();
-
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.ReasonCode_Id;
             this.critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertAttrSet.java
+++ b/src/java.base/share/classes/sun/security/x509/CertAttrSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/x509/CertAttrSet.java
+++ b/src/java.base/share/classes/sun/security/x509/CertAttrSet.java
@@ -59,7 +59,7 @@ public interface CertAttrSet<T> {
      * Encodes the attribute to the output stream in a format
      * that can be parsed by the <code>decode</code> method.
      *
-     * @param out the OutputStream to encode the attribute to.
+     * @param out the DerOutputStream to encode the attribute to.
      *
      * @exception CertificateException on encoding or validity errors.
      * @exception IOException on other errors.

--- a/src/java.base/share/classes/sun/security/x509/CertAttrSet.java
+++ b/src/java.base/share/classes/sun/security/x509/CertAttrSet.java
@@ -25,8 +25,9 @@
 
 package sun.security.x509;
 
+import sun.security.util.DerOutputStream;
+
 import java.io.IOException;
-import java.io.OutputStream;
 import java.security.cert.CertificateException;
 import java.util.Enumeration;
 
@@ -63,7 +64,7 @@ public interface CertAttrSet<T> {
      * @exception CertificateException on encoding or validity errors.
      * @exception IOException on other errors.
      */
-    void encode(OutputStream out)
+    void encode(DerOutputStream out)
         throws CertificateException, IOException;
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertificateAlgorithmId.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateAlgorithmId.java
@@ -104,6 +104,7 @@ public class CertificateAlgorithmId implements CertAttrSet<String> {
      * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         algId.encode(out);
     }

--- a/src/java.base/share/classes/sun/security/x509/CertificateAlgorithmId.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateAlgorithmId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package sun.security.x509;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.*;

--- a/src/java.base/share/classes/sun/security/x509/CertificateAlgorithmId.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateAlgorithmId.java
@@ -105,11 +105,8 @@ public class CertificateAlgorithmId implements CertAttrSet<String> {
      * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
-        algId.encode(tmp);
-
-        out.write(tmp.toByteArray());
+    public void encode(DerOutputStream out) throws IOException {
+        algId.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertificateExtensions.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateExtensions.java
@@ -147,6 +147,7 @@ public class CertificateExtensions implements CertAttrSet<Extension> {
      * @exception CertificateException on encoding errors.
      * @exception IOException on errors.
      */
+    @Override
     public void encode(DerOutputStream out)
             throws CertificateException, IOException {
         encode(out, false);

--- a/src/java.base/share/classes/sun/security/x509/CertificateExtensions.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateExtensions.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.security.cert.CertificateException;

--- a/src/java.base/share/classes/sun/security/x509/CertificateIssuerExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateIssuerExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.DerValue;
@@ -179,6 +178,7 @@ public class CertificateIssuerExtension extends Extension
      * @param out the OutputStream to write the extension to
      * @exception IOException on encoding errors
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.CertificateIssuer_Id;

--- a/src/java.base/share/classes/sun/security/x509/CertificateIssuerExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateIssuerExtension.java
@@ -175,7 +175,7 @@ public class CertificateIssuerExtension extends Extension
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to
+     * @param out the DerOutputStream to write the extension to
      * @exception IOException on encoding errors
      */
     @Override

--- a/src/java.base/share/classes/sun/security/x509/CertificateIssuerExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateIssuerExtension.java
@@ -179,15 +179,13 @@ public class CertificateIssuerExtension extends Extension
      * @param out the OutputStream to write the extension to
      * @exception IOException on encoding errors
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream  tmp = new DerOutputStream();
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.CertificateIssuer_Id;
             critical = true;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertificateIssuerName.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateIssuerName.java
@@ -106,6 +106,7 @@ public class CertificateIssuerName implements CertAttrSet<String> {
      * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         dnName.encode(out);
     }

--- a/src/java.base/share/classes/sun/security/x509/CertificateIssuerName.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateIssuerName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package sun.security.x509;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import javax.security.auth.x500.X500Principal;

--- a/src/java.base/share/classes/sun/security/x509/CertificateIssuerName.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateIssuerName.java
@@ -107,11 +107,8 @@ public class CertificateIssuerName implements CertAttrSet<String> {
      * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
-        dnName.encode(tmp);
-
-        out.write(tmp.toByteArray());
+    public void encode(DerOutputStream out) throws IOException {
+        dnName.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertificatePoliciesExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificatePoliciesExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.*;
 
 import sun.security.util.DerValue;
@@ -177,6 +176,7 @@ implements CertAttrSet<String> {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
           extensionId = PKIXExtensions.CertificatePolicies_Id;

--- a/src/java.base/share/classes/sun/security/x509/CertificatePoliciesExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificatePoliciesExtension.java
@@ -177,15 +177,13 @@ implements CertAttrSet<String> {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
           extensionId = PKIXExtensions.CertificatePolicies_Id;
           critical = false;
           encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertificateSerialNumber.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateSerialNumber.java
@@ -117,11 +117,8 @@ public class CertificateSerialNumber implements CertAttrSet<String> {
      * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
-        serial.encode(tmp);
-
-        out.write(tmp.toByteArray());
+    public void encode(DerOutputStream out) throws IOException {
+        serial.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertificateSerialNumber.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateSerialNumber.java
@@ -116,6 +116,7 @@ public class CertificateSerialNumber implements CertAttrSet<String> {
      * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         serial.encode(out);
     }

--- a/src/java.base/share/classes/sun/security/x509/CertificateSerialNumber.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateSerialNumber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@ package sun.security.x509;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.math.BigInteger;
 import java.util.Enumeration;
 import java.util.Random;

--- a/src/java.base/share/classes/sun/security/x509/CertificateSubjectName.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateSubjectName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package sun.security.x509;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import javax.security.auth.x500.X500Principal;

--- a/src/java.base/share/classes/sun/security/x509/CertificateSubjectName.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateSubjectName.java
@@ -106,6 +106,7 @@ public class CertificateSubjectName implements CertAttrSet<String> {
      * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         dnName.encode(out);
     }

--- a/src/java.base/share/classes/sun/security/x509/CertificateSubjectName.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateSubjectName.java
@@ -107,11 +107,8 @@ public class CertificateSubjectName implements CertAttrSet<String> {
      * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
-        dnName.encode(tmp);
-
-        out.write(tmp.toByteArray());
+    public void encode(DerOutputStream out) throws IOException {
+        dnName.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertificateValidity.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateValidity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.security.cert.*;
 import java.util.Date;
 import java.util.Enumeration;

--- a/src/java.base/share/classes/sun/security/x509/CertificateValidity.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateValidity.java
@@ -147,7 +147,7 @@ public class CertificateValidity implements CertAttrSet<String> {
      * @param out the OutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out) throws IOException {
+    public void encode(DerOutputStream out) throws IOException {
 
         // in cases where default constructor is used check for
         // null values
@@ -167,10 +167,7 @@ public class CertificateValidity implements CertAttrSet<String> {
         } else {
             pair.putGeneralizedTime(notAfter);
         }
-        DerOutputStream seq = new DerOutputStream();
-        seq.write(DerValue.tag_Sequence, pair);
-
-        out.write(seq.toByteArray());
+        out.write(DerValue.tag_Sequence, pair);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertificateValidity.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateValidity.java
@@ -143,9 +143,10 @@ public class CertificateValidity implements CertAttrSet<String> {
     /**
      * Encode the CertificateValidity period in DER form to the stream.
      *
-     * @param out the OutputStream to marshal the contents to.
+     * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
 
         // in cases where default constructor is used check for

--- a/src/java.base/share/classes/sun/security/x509/CertificateVersion.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package sun.security.x509;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.*;

--- a/src/java.base/share/classes/sun/security/x509/CertificateVersion.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateVersion.java
@@ -154,9 +154,10 @@ public class CertificateVersion implements CertAttrSet<String> {
     /**
      * Encode the CertificateVersion period in DER form to the stream.
      *
-     * @param out the OutputStream to marshal the contents to.
+     * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         // Nothing for default
         if (version == V1) {

--- a/src/java.base/share/classes/sun/security/x509/CertificateVersion.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateVersion.java
@@ -158,7 +158,7 @@ public class CertificateVersion implements CertAttrSet<String> {
      * @param out the OutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out) throws IOException {
+    public void encode(DerOutputStream out) throws IOException {
         // Nothing for default
         if (version == V1) {
             return;
@@ -166,11 +166,8 @@ public class CertificateVersion implements CertAttrSet<String> {
         DerOutputStream tmp = new DerOutputStream();
         tmp.putInteger(version);
 
-        DerOutputStream seq = new DerOutputStream();
-        seq.write(DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte)0),
+        out.write(DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte)0),
                   tmp);
-
-        out.write(seq.toByteArray());
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertificateX509Key.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateX509Key.java
@@ -100,11 +100,8 @@ public class CertificateX509Key implements CertAttrSet<String> {
      * @param out the OutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
-        tmp.write(key.getEncoded());
-
-        out.write(tmp.toByteArray());
+    public void encode(DerOutputStream out) throws IOException {
+        out.write(key.getEncoded());
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertificateX509Key.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateX509Key.java
@@ -96,9 +96,10 @@ public class CertificateX509Key implements CertAttrSet<String> {
     /**
      * Encode the key in DER form to the stream.
      *
-     * @param out the OutputStream to marshal the contents to.
+     * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         out.write(key.getEncoded());
     }

--- a/src/java.base/share/classes/sun/security/x509/CertificateX509Key.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateX509Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package sun.security.x509;
 import java.security.PublicKey;
 import java.io.InputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.*;

--- a/src/java.base/share/classes/sun/security/x509/DeltaCRLIndicatorExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/DeltaCRLIndicatorExtension.java
@@ -25,6 +25,8 @@
 
 package sun.security.x509;
 
+import sun.security.util.DerOutputStream;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigInteger;
@@ -106,7 +108,7 @@ public class DeltaCRLIndicatorExtension extends CRLNumberExtension {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
+    public void encode(DerOutputStream out) throws IOException {
         super.encode(out, PKIXExtensions.DeltaCRLIndicator_Id, true);
     }
 }

--- a/src/java.base/share/classes/sun/security/x509/DeltaCRLIndicatorExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/DeltaCRLIndicatorExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package sun.security.x509;
 import sun.security.util.DerOutputStream;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.math.BigInteger;
 
 /**
@@ -108,6 +107,7 @@ public class DeltaCRLIndicatorExtension extends CRLNumberExtension {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         super.encode(out, PKIXExtensions.DeltaCRLIndicator_Id, true);
     }

--- a/src/java.base/share/classes/sun/security/x509/ExtendedKeyUsageExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/ExtendedKeyUsageExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -198,6 +197,7 @@ implements CertAttrSet<String> {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
           extensionId = PKIXExtensions.ExtendedKeyUsage_Id;

--- a/src/java.base/share/classes/sun/security/x509/ExtendedKeyUsageExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/ExtendedKeyUsageExtension.java
@@ -198,15 +198,13 @@ implements CertAttrSet<String> {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
           extensionId = PKIXExtensions.ExtendedKeyUsage_Id;
           critical = false;
           encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/Extension.java
+++ b/src/java.base/share/classes/sun/security/x509/Extension.java
@@ -140,22 +140,17 @@ public class Extension implements java.security.cert.Extension {
         return ext;
     }
 
-    public void encode(OutputStream out) throws IOException {
+    public final void encode(OutputStream out) throws IOException {
         if (out == null) {
             throw new NullPointerException();
         }
-
-        DerOutputStream dos1 = new DerOutputStream();
-        DerOutputStream dos2 = new DerOutputStream();
-
-        dos1.putOID(extensionId);
-        if (critical) {
-            dos1.putBoolean(true);
+        if (out instanceof DerOutputStream dos) {
+            encode(dos);
+        } else {
+            DerOutputStream dos = new DerOutputStream();
+            encode(dos);
+            out.write(dos.toByteArray());
         }
-        dos1.putOctetString(extensionValue);
-
-        dos2.write(DerValue.tag_Sequence, dos1);
-        out.write(dos2.toByteArray());
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/Extension.java
+++ b/src/java.base/share/classes/sun/security/x509/Extension.java
@@ -140,6 +140,16 @@ public class Extension implements java.security.cert.Extension {
         return ext;
     }
 
+    /**
+     * Implementing {@link java.security.cert.Extension#encode(OutputStream)}.
+     * This implementation is made final to make sure all {@code encode()}
+     * methods in child classes are actually implementations of
+     * {@link #encode(DerOutputStream)} below.
+     *
+     * @param out the output stream
+     * @throws IOException
+     */
+    @Override
     public final void encode(OutputStream out) throws IOException {
         if (out == null) {
             throw new NullPointerException();

--- a/src/java.base/share/classes/sun/security/x509/FreshestCRLExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/FreshestCRLExtension.java
@@ -25,6 +25,8 @@
 
 package sun.security.x509;
 
+import sun.security.util.DerOutputStream;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
@@ -89,7 +91,7 @@ public class FreshestCRLExtension extends CRLDistributionPointsExtension {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
+    public void encode(DerOutputStream out) throws IOException {
         super.encode(out, PKIXExtensions.FreshestCRL_Id, false);
     }
 }

--- a/src/java.base/share/classes/sun/security/x509/FreshestCRLExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/FreshestCRLExtension.java
@@ -28,7 +28,6 @@ package sun.security.x509;
 import sun.security.util.DerOutputStream;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.List;
 
 /**
@@ -91,6 +90,7 @@ public class FreshestCRLExtension extends CRLDistributionPointsExtension {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         super.encode(out, PKIXExtensions.FreshestCRL_Id, false);
     }

--- a/src/java.base/share/classes/sun/security/x509/InhibitAnyPolicyExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/InhibitAnyPolicyExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.*;
@@ -159,6 +158,7 @@ implements CertAttrSet<String> {
       *
       * @param out the DerOutputStream to encode the extension to.
       */
+     @Override
      public void encode(DerOutputStream out) throws IOException {
          if (extensionValue == null) {
              this.extensionId = PKIXExtensions.InhibitAnyPolicy_Id;

--- a/src/java.base/share/classes/sun/security/x509/InhibitAnyPolicyExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/InhibitAnyPolicyExtension.java
@@ -159,16 +159,13 @@ implements CertAttrSet<String> {
       *
       * @param out the DerOutputStream to encode the extension to.
       */
-     public void encode(OutputStream out) throws IOException {
-         DerOutputStream tmp = new DerOutputStream();
+     public void encode(DerOutputStream out) throws IOException {
          if (extensionValue == null) {
              this.extensionId = PKIXExtensions.InhibitAnyPolicy_Id;
              critical = true;
              encodeThis();
          }
-         super.encode(tmp);
-
-         out.write(tmp.toByteArray());
+         super.encode(out);
      }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/InvalidityDateExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/InvalidityDateExtension.java
@@ -177,16 +177,13 @@ public class InvalidityDateExtension extends Extension
      * @param out the DerOutputStream to write the extension to
      * @exception IOException on encoding errors
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream  tmp = new DerOutputStream();
-
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.InvalidityDate_Id;
             this.critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/InvalidityDateExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/InvalidityDateExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Date;
 import java.util.Enumeration;
 
@@ -177,6 +176,7 @@ public class InvalidityDateExtension extends Extension
      * @param out the DerOutputStream to write the extension to
      * @exception IOException on encoding errors
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.InvalidityDate_Id;

--- a/src/java.base/share/classes/sun/security/x509/IssuerAlternativeNameExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/IssuerAlternativeNameExtension.java
@@ -162,15 +162,13 @@ extends Extension implements CertAttrSet<String> {
      * @param out the OutputStream to write the extension to.
      * @exception IOException on encoding error.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.IssuerAlternativeName_Id;
             critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/IssuerAlternativeNameExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/IssuerAlternativeNameExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.*;
@@ -162,6 +161,7 @@ extends Extension implements CertAttrSet<String> {
      * @param out the OutputStream to write the extension to.
      * @exception IOException on encoding error.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.IssuerAlternativeName_Id;

--- a/src/java.base/share/classes/sun/security/x509/IssuerAlternativeNameExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/IssuerAlternativeNameExtension.java
@@ -158,7 +158,7 @@ extends Extension implements CertAttrSet<String> {
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to.
+     * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding error.
      */
     @Override

--- a/src/java.base/share/classes/sun/security/x509/IssuingDistributionPointExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/IssuingDistributionPointExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 
 import java.util.*;
 
@@ -234,6 +233,7 @@ public class IssuingDistributionPointExtension extends Extension
      * @param out the output stream.
      * @exception IOException on encoding error.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.IssuingDistributionPoint_Id;

--- a/src/java.base/share/classes/sun/security/x509/IssuingDistributionPointExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/IssuingDistributionPointExtension.java
@@ -234,15 +234,13 @@ public class IssuingDistributionPointExtension extends Extension
      * @param out the output stream.
      * @exception IOException on encoding error.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.IssuingDistributionPoint_Id;
             this.critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/KeyUsageExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/KeyUsageExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.*;
@@ -318,6 +317,7 @@ implements CertAttrSet<String> {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
        if (this.extensionValue == null) {
            this.extensionId = PKIXExtensions.KeyUsage_Id;

--- a/src/java.base/share/classes/sun/security/x509/KeyUsageExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/KeyUsageExtension.java
@@ -318,16 +318,13 @@ implements CertAttrSet<String> {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-       DerOutputStream  tmp = new DerOutputStream();
-
+    public void encode(DerOutputStream out) throws IOException {
        if (this.extensionValue == null) {
            this.extensionId = PKIXExtensions.KeyUsage_Id;
            this.critical = true;
            encodeThis();
        }
-       super.encode(tmp);
-       out.write(tmp.toByteArray());
+       super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/NameConstraintsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/NameConstraintsExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.*;
@@ -236,6 +235,7 @@ implements CertAttrSet<String>, Cloneable {
      * @param out the OutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.NameConstraints_Id;

--- a/src/java.base/share/classes/sun/security/x509/NameConstraintsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/NameConstraintsExtension.java
@@ -236,15 +236,13 @@ implements CertAttrSet<String>, Cloneable {
      * @param out the OutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.NameConstraints_Id;
             this.critical = true;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/NameConstraintsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/NameConstraintsExtension.java
@@ -232,7 +232,7 @@ implements CertAttrSet<String>, Cloneable {
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to.
+     * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
     @Override

--- a/src/java.base/share/classes/sun/security/x509/NetscapeCertTypeExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/NetscapeCertTypeExtension.java
@@ -264,16 +264,13 @@ implements CertAttrSet<String> {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream  tmp = new DerOutputStream();
-
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = NetscapeCertType_Id;
             this.critical = true;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/NetscapeCertTypeExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/NetscapeCertTypeExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.*;
 
 import sun.security.util.*;
@@ -264,6 +263,7 @@ implements CertAttrSet<String> {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = NetscapeCertType_Id;

--- a/src/java.base/share/classes/sun/security/x509/PolicyConstraintsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/PolicyConstraintsExtension.java
@@ -201,15 +201,13 @@ implements CertAttrSet<String> {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
           extensionId = PKIXExtensions.PolicyConstraints_Id;
           critical = true;
           encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/PolicyConstraintsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/PolicyConstraintsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.*;
@@ -201,6 +200,7 @@ implements CertAttrSet<String> {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
           extensionId = PKIXExtensions.PolicyConstraints_Id;

--- a/src/java.base/share/classes/sun/security/x509/PolicyMappingsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/PolicyMappingsExtension.java
@@ -144,7 +144,7 @@ implements CertAttrSet<String> {
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to.
+     * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
     @Override

--- a/src/java.base/share/classes/sun/security/x509/PolicyMappingsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/PolicyMappingsExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.*;
 
 import sun.security.util.*;
@@ -148,6 +147,7 @@ implements CertAttrSet<String> {
      * @param out the OutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.PolicyMappings_Id;

--- a/src/java.base/share/classes/sun/security/x509/PolicyMappingsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/PolicyMappingsExtension.java
@@ -148,15 +148,13 @@ implements CertAttrSet<String> {
      * @param out the OutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.PolicyMappings_Id;
             critical = true;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/PrivateKeyUsageExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/PrivateKeyUsageExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.CertificateExpiredException;
@@ -240,6 +239,7 @@ implements CertAttrSet<String> {
      * @param out the OutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.PrivateKeyUsage_Id;

--- a/src/java.base/share/classes/sun/security/x509/PrivateKeyUsageExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/PrivateKeyUsageExtension.java
@@ -240,15 +240,13 @@ implements CertAttrSet<String> {
      * @param out the OutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.PrivateKeyUsage_Id;
             critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/PrivateKeyUsageExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/PrivateKeyUsageExtension.java
@@ -236,7 +236,7 @@ implements CertAttrSet<String> {
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to.
+     * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
     @Override

--- a/src/java.base/share/classes/sun/security/x509/SubjectAlternativeNameExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/SubjectAlternativeNameExtension.java
@@ -160,7 +160,7 @@ implements CertAttrSet<String> {
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to.
+     * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
     @Override

--- a/src/java.base/share/classes/sun/security/x509/SubjectAlternativeNameExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/SubjectAlternativeNameExtension.java
@@ -164,15 +164,13 @@ implements CertAttrSet<String> {
      * @param out the OutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.SubjectAlternativeName_Id;
             critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/SubjectAlternativeNameExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/SubjectAlternativeNameExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.*;
@@ -164,6 +163,7 @@ implements CertAttrSet<String> {
      * @param out the OutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.SubjectAlternativeName_Id;

--- a/src/java.base/share/classes/sun/security/x509/SubjectInfoAccessExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/SubjectInfoAccessExtension.java
@@ -154,15 +154,13 @@ public class SubjectInfoAccessExtension extends Extension
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.SubjectInfoAccess_Id;
             this.critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/SubjectInfoAccessExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/SubjectInfoAccessExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 
 import java.util.Collections;
 import java.util.*;
@@ -154,6 +153,7 @@ public class SubjectInfoAccessExtension extends Extension
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.SubjectInfoAccess_Id;

--- a/src/java.base/share/classes/sun/security/x509/SubjectKeyIdentifierExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/SubjectKeyIdentifierExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.*;
@@ -125,6 +124,7 @@ implements CertAttrSet<String> {
      * @param out the OutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.SubjectKey_Id;

--- a/src/java.base/share/classes/sun/security/x509/SubjectKeyIdentifierExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/SubjectKeyIdentifierExtension.java
@@ -121,7 +121,7 @@ implements CertAttrSet<String> {
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to.
+     * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
     @Override

--- a/src/java.base/share/classes/sun/security/x509/SubjectKeyIdentifierExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/SubjectKeyIdentifierExtension.java
@@ -125,15 +125,13 @@ implements CertAttrSet<String> {
      * @param out the OutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.SubjectKey_Id;
             critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
@@ -1257,7 +1257,7 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
     }
 
     @Override
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         if (signedCRL == null)
             throw new IOException("Null CRL to encode");
         out.write(signedCRL.clone());

--- a/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
@@ -330,7 +330,7 @@ public class X509CertImpl extends X509Certificate implements DerEncoder {
      *
      * @exception IOException on encoding error.
      */
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         if (signedCert == null)
             throw new IOException("Null certificate to encode");
         out.write(signedCert.clone());

--- a/src/java.base/share/classes/sun/security/x509/X509CertInfo.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CertInfo.java
@@ -179,14 +179,14 @@ public class X509CertInfo implements CertAttrSet<String> {
      * @exception CertificateException on encoding errors.
      * @exception IOException on other errors.
      */
-    public void encode(OutputStream out)
-    throws CertificateException, IOException {
+    public void encode(DerOutputStream out)
+            throws CertificateException, IOException {
         if (rawCertInfo == null) {
-            DerOutputStream tmp = new DerOutputStream();
-            emit(tmp);
-            rawCertInfo = tmp.toByteArray();
+            emit(out);
+            rawCertInfo = out.toByteArray();
+        } else {
+            out.write(rawCertInfo.clone());
         }
-        out.write(rawCertInfo.clone());
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/X509CertInfo.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CertInfo.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 
 import java.security.cert.*;
 import java.util.*;

--- a/src/java.base/share/classes/sun/security/x509/X509CertInfo.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CertInfo.java
@@ -178,6 +178,7 @@ public class X509CertInfo implements CertAttrSet<String> {
      * @exception CertificateException on encoding errors.
      * @exception IOException on other errors.
      */
+    @Override
     public void encode(DerOutputStream out)
             throws CertificateException, IOException {
         if (rawCertInfo == null) {

--- a/test/jdk/sun/security/pkcs/pkcs7/SignerOrder.java
+++ b/test/jdk/sun/security/pkcs/pkcs7/SignerOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@
  *          java.base/sun.security.x509
  * @run main SignerOrder
  */
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.KeyPair;
@@ -115,7 +114,7 @@ public class SignerOrder {
     }
 
     static void printSignerInfos(SignerInfo signerInfo) throws IOException {
-        ByteArrayOutputStream strm = new ByteArrayOutputStream();
+        DerOutputStream strm = new DerOutputStream();
         signerInfo.derEncode(strm);
         System.out.println("SignerInfo, length: "
                 + strm.toByteArray().length);
@@ -125,7 +124,7 @@ public class SignerOrder {
     }
 
     static void printSignerInfos(SignerInfo[] signerInfos) throws IOException {
-        ByteArrayOutputStream strm = new ByteArrayOutputStream();
+        DerOutputStream strm = new DerOutputStream();
         for (int i = 0; i < signerInfos.length; i++) {
             signerInfos[i].derEncode(strm);
             System.out.println("SignerInfo[" + i + "], length: "

--- a/test/jdk/sun/security/pkcs/pkcs9/UnknownAttribute.java
+++ b/test/jdk/sun/security/pkcs/pkcs9/UnknownAttribute.java
@@ -57,10 +57,10 @@ public class UnknownAttribute {
         if (p2.isKnown()) {
             throw new Exception();
         }
-        DerOutputStream bout = new DerOutputStream();
-        p2.derEncode(bout);
-        HexPrinter.simple().dest(System.err).format(bout.toByteArray());
-        if (!Arrays.equals(data, bout.toByteArray())) {
+        DerOutputStream dout = new DerOutputStream();
+        p2.derEncode(dout);
+        HexPrinter.simple().dest(System.err).format(dout.toByteArray());
+        if (!Arrays.equals(data, dout.toByteArray())) {
             throw new Exception();
         }
         // Unknown attr from value
@@ -75,9 +75,9 @@ public class UnknownAttribute {
         if (p3.isKnown()) {
             throw new Exception();
         }
-        bout = new DerOutputStream();
-        p3.derEncode(bout);
-        if (!Arrays.equals(data, bout.toByteArray())) {
+        dout = new DerOutputStream();
+        p3.derEncode(dout);
+        if (!Arrays.equals(data, dout.toByteArray())) {
             throw new Exception();
         }
     }

--- a/test/jdk/sun/security/pkcs/pkcs9/UnknownAttribute.java
+++ b/test/jdk/sun/security/pkcs/pkcs9/UnknownAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,10 +30,10 @@
  *          java.base/sun.security.util
  */
 
-import java.io.*;
 import java.util.Arrays;
 
 import sun.security.pkcs.PKCS9Attribute;
+import sun.security.util.DerOutputStream;
 import sun.security.util.DerValue;
 import sun.security.util.ObjectIdentifier;
 import jdk.test.lib.hexdump.HexPrinter;
@@ -57,7 +57,7 @@ public class UnknownAttribute {
         if (p2.isKnown()) {
             throw new Exception();
         }
-        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        DerOutputStream bout = new DerOutputStream();
         p2.derEncode(bout);
         HexPrinter.simple().dest(System.err).format(bout.toByteArray());
         if (!Arrays.equals(data, bout.toByteArray())) {
@@ -75,7 +75,7 @@ public class UnknownAttribute {
         if (p3.isKnown()) {
             throw new Exception();
         }
-        bout = new ByteArrayOutputStream();
+        bout = new DerOutputStream();
         p3.derEncode(bout);
         if (!Arrays.equals(data, bout.toByteArray())) {
             throw new Exception();

--- a/test/jdk/sun/security/tools/keytool/ExtOptionCamelCase.java
+++ b/test/jdk/sun/security/tools/keytool/ExtOptionCamelCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@
  */
 
 import sun.security.tools.keytool.Main;
+import sun.security.util.DerOutputStream;
 import sun.security.util.DerValue;
 import sun.security.x509.BasicConstraintsExtension;
 import sun.security.x509.CertificateExtensions;
@@ -41,7 +42,6 @@ import sun.security.x509.Extension;
 import sun.security.x509.KeyIdentifier;
 import sun.security.x509.KeyUsageExtension;
 
-import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -203,7 +203,7 @@ public class ExtOptionCamelCase {
             // ATTENTION: the extensions created above might contain raw
             // extensions (not of a subtype) and we need to store and reload
             // it to resolve them to subtypes.
-            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            DerOutputStream bout = new DerOutputStream();
             exts.encode(bout);
             exts = new CertificateExtensions(new DerValue(bout.toByteArray()).data);
 

--- a/test/jdk/sun/security/tools/keytool/ExtOptionCamelCase.java
+++ b/test/jdk/sun/security/tools/keytool/ExtOptionCamelCase.java
@@ -203,9 +203,9 @@ public class ExtOptionCamelCase {
             // ATTENTION: the extensions created above might contain raw
             // extensions (not of a subtype) and we need to store and reload
             // it to resolve them to subtypes.
-            DerOutputStream bout = new DerOutputStream();
-            exts.encode(bout);
-            exts = new CertificateExtensions(new DerValue(bout.toByteArray()).data);
+            DerOutputStream dout = new DerOutputStream();
+            exts.encode(dout);
+            exts = new CertificateExtensions(new DerValue(dout.toByteArray()).data);
 
             if (clazz == null) {
                 throw new Exception("Should fail");

--- a/test/jdk/sun/security/util/asn1StringTypes/StringTypes.java
+++ b/test/jdk/sun/security/util/asn1StringTypes/StringTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class StringTypes {
         derOut.putT61String(s);
         derOut.putBMPString(s);
 
-        derOut.derEncode(fout);
+        fout.write(derOut.toByteArray());
         fout.close();
 
         FileInputStream fis = new FileInputStream(fileName);


### PR DESCRIPTION
The argument of the `CertAttrSet::encode` and `DerEncoder::derEncode` interface methods are modified from `OutputStream` to `DerOutputStream`. All implementations are modified the same way.

`OutputStream` is still used by `sun.security.x509.Extension::encode(OutputStream os)` because it's inherited from `java.security.cert.Extension`. The method is now marked final to avoid accidental override.

In `CertificateExtensions` and `CRLExtensions`, only `Extension::encode(DerOutputStream out)` is called. It used to call `CertAttrSet::encode` for a known extension and `Extension::encode(DerOutputStream out)` for an unknown one. This makes sure the overridden `encode` methods in known extensions are always called. Now that they have the same argument, there is no need for this check.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296072](https://bugs.openjdk.org/browse/JDK-8296072): CertAttrSet::encode and DerEncoder::derEncode should write into DerOutputStream


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**) ⚠️ Review applies to [da7221f2](https://git.openjdk.org/jdk/pull/10906/files/da7221f2ecd3972df99e6f4fb69e240b0aeb8418)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10906/head:pull/10906` \
`$ git checkout pull/10906`

Update a local copy of the PR: \
`$ git checkout pull/10906` \
`$ git pull https://git.openjdk.org/jdk pull/10906/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10906`

View PR using the GUI difftool: \
`$ git pr show -t 10906`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10906.diff">https://git.openjdk.org/jdk/pull/10906.diff</a>

</details>
