### PR TITLE
8296087: Problem list headful tests which may fail on Linux VMs

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -623,6 +623,7 @@ sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-
 javax/sound/sampled/DirectAudio/bug6372428.java                      8055097 generic-all
 javax/sound/sampled/Clip/bug5070081.java                             8055097 generic-all
 javax/sound/sampled/DataLine/LongFramePosition.java                  8055097 generic-all
+javax/sound/sampled/Clip/DataPusherThreadCheck.java                  8282463 linux-all
 
 javax/sound/sampled/Clip/Drain/ClipDrain.java          7062792 generic-all
 
@@ -650,6 +651,8 @@ javax/swing/JWindow/ShapedAndTranslucentWindows/TranslucentJComboBox.java 802462
 # The next test below is an intermittent failure
 javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all
 javax/swing/JTree/4633594/JTreeFocusTest.java 7105441 macosx-all
+javax/swing/JTree/6263446/bug6263446.java 8296083 linux-all
+javax/swing/JSpinner/4788637/bug4788637.java 8296084 linux-all
 javax/swing/AbstractButton/6711682/bug6711682.java 8060765 windows-all,macosx-all
 javax/swing/JFileChooser/6396844/TwentyThousandTest.java 8198003 generic-all
 javax/swing/JPopupMenu/6800513/bug6800513.java 7184956 macosx-all

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -623,7 +623,6 @@ sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-
 javax/sound/sampled/DirectAudio/bug6372428.java                      8055097 generic-all
 javax/sound/sampled/Clip/bug5070081.java                             8055097 generic-all
 javax/sound/sampled/DataLine/LongFramePosition.java                  8055097 generic-all
-javax/sound/sampled/Clip/DataPusherThreadCheck.java                  8282463 linux-all
 
 javax/sound/sampled/Clip/Drain/ClipDrain.java          7062792 generic-all
 


### PR DESCRIPTION
Problem list 2 tests which fail on Linux VMs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296087](https://bugs.openjdk.org/browse/JDK-8296087): Problem list headful tests which may fail on Linux VMs


### Reviewers
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10911/head:pull/10911` \
`$ git checkout pull/10911`

Update a local copy of the PR: \
`$ git checkout pull/10911` \
`$ git pull https://git.openjdk.org/jdk pull/10911/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10911`

View PR using the GUI difftool: \
`$ git pr show -t 10911`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10911.diff">https://git.openjdk.org/jdk/pull/10911.diff</a>

</details>
