### PR TITLE
8296124: G1: Call record_root_region_scan_wait_time conditionally

### DIFF
--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -246,11 +246,10 @@ void G1YoungCollector::wait_for_root_region_scanning() {
   // objects on them have been correctly scanned before we start
   // moving them during the GC.
   bool waited = concurrent_mark()->wait_until_root_region_scan_finished();
-  Tickspan wait_time;
   if (waited) {
-    wait_time = (Ticks::now() - start);
+    Tickspan wait_time = (Ticks::now() - start);
+    phase_times()->record_root_region_scan_wait_time(wait_time.seconds() * MILLIUNITS);
   }
-  phase_times()->record_root_region_scan_wait_time(wait_time.seconds() * MILLIUNITS);
 }
 
 class G1PrintCollectionSetClosure : public HeapRegionClosure {


### PR DESCRIPTION
Simple change of making an update conditional in young-gc-pause.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296124](https://bugs.openjdk.org/browse/JDK-8296124): G1: Call record_root_region_scan_wait_time conditionally


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10915/head:pull/10915` \
`$ git checkout pull/10915`

Update a local copy of the PR: \
`$ git checkout pull/10915` \
`$ git pull https://git.openjdk.org/jdk pull/10915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10915`

View PR using the GUI difftool: \
`$ git pr show -t 10915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10915.diff">https://git.openjdk.org/jdk/pull/10915.diff</a>

</details>
