### PR TITLE
8296136: Use correct register in aarch64_enc_fast_unlock()

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3866,7 +3866,7 @@ encode %{
 
     // Handle existing monitor.
     __ ldr(tmp, Address(oop, oopDesc::mark_offset_in_bytes()));
-    __ tbnz(disp_hdr, exact_log2(markWord::monitor_value), object_has_monitor);
+    __ tbnz(tmp, exact_log2(markWord::monitor_value), object_has_monitor);
 
     if (!UseHeavyMonitors) {
       // Check if it is still a light weight lock, this is is true if we

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2474,7 +2474,7 @@ encode %{
 
     // Handle existing monitor.
     __ ld(tmp, Address(oop, oopDesc::mark_offset_in_bytes()));
-    __ andi(t0, disp_hdr, markWord::monitor_value);
+    __ andi(t0, tmp, markWord::monitor_value);
     __ bnez(t0, object_has_monitor);
 
     if (!UseHeavyMonitors) {


### PR DESCRIPTION
In aarch64_enc_fast_unlock() (aarch64.ad) we have this piece of code:

```
    __ ldr(tmp, Address(oop, oopDesc::mark_offset_in_bytes()));
    __ tbnz(disp_hdr, exact_log2(markWord::monitor_value), object_has_monitor);
```

The tbnz uses the wrong register - it should really use tmp. disp_hdr has been loaded with the displaced header of the stack-lock, which would never have its monitor bits set, thus the branch will always take the slow path. In this common case, it is only a performance nuisance. In the case of !UseHeavyMonitors it is even worse, then disp_hdr will be unitialized, and we are facing a correctness problem.

As far as I can tell, the problem dates back to when aarch64 C2 parts have been added to OpenJDK.

Testing:
 - [x] tier1
 - [x] tier2
 - [x] tier3
 - [x] tier4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296136](https://bugs.openjdk.org/browse/JDK-8296136): Use correct register in aarch64_enc_fast_unlock()


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**) ⚠️ Review applies to [0b8cfea5](https://git.openjdk.org/jdk/pull/10921/files/0b8cfea547128fc366c08d72623050c40bb86646)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10921/head:pull/10921` \
`$ git checkout pull/10921`

Update a local copy of the PR: \
`$ git checkout pull/10921` \
`$ git pull https://git.openjdk.org/jdk pull/10921/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10921`

View PR using the GUI difftool: \
`$ git pr show -t 10921`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10921.diff">https://git.openjdk.org/jdk/pull/10921.diff</a>

</details>
