### PR TITLE
8296208: AArch64: Enable SHA512 intrinsic by default on supported hardware

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -345,10 +345,9 @@ void VM_Version::initialize() {
   }
 
   if (UseSHA && VM_Version::supports_sha512()) {
-    // Do not auto-enable UseSHA512Intrinsics until it has been fully tested on hardware
-    // if (FLAG_IS_DEFAULT(UseSHA512Intrinsics)) {
-      // FLAG_SET_DEFAULT(UseSHA512Intrinsics, true);
-    // }
+    if (FLAG_IS_DEFAULT(UseSHA512Intrinsics)) {
+      FLAG_SET_DEFAULT(UseSHA512Intrinsics, true);
+    }
   } else if (UseSHA512Intrinsics) {
     warning("Intrinsics for SHA-384 and SHA-512 crypto hash functions not available on this CPU.");
     FLAG_SET_DEFAULT(UseSHA512Intrinsics, false);


### PR DESCRIPTION
SHA512 intrinsic for AArch64 was implemented in JDK-8165404. But it was not auto-enabled due to the lack of full test on real hardware. In this patch, we set this intrinsic enabled by default on hardware with sha512 feature support, after we did the following evaluation.

1) tier1~3 passed without new failures.

2) we ran the JMH test case MessageDigests.java on all available sha512 feature supported CPUs on our hands including Neoverse V1, Neoverse N2 and Apple silicon(M1). We witnessed about 1.3x ~ 3x performance uplifts. Here shows the data on V1.

```
Benchmark                    (digesterName)  (length)  (provider)   Mode  Cnt    Before     After   Units
MessageDigests.digest               SHA-384        64     DEFAULT  thrpt    5  2381.028  6161.576  ops/ms
MessageDigests.digest               SHA-384     16384     DEFAULT  thrpt    5    20.641    60.493  ops/ms
MessageDigests.digest               SHA-512        64     DEFAULT  thrpt    5  2407.225  6140.680  ops/ms
MessageDigests.digest               SHA-512     16384     DEFAULT  thrpt    5    20.633    60.942  ops/ms
MessageDigests.getAndDigest         SHA-384        64     DEFAULT  thrpt    5  1962.740  4714.510  ops/ms
MessageDigests.getAndDigest         SHA-384     16384     DEFAULT  thrpt    5    20.474    61.360  ops/ms
MessageDigests.getAndDigest         SHA-512        64     DEFAULT  thrpt    5  1949.511  4552.723  ops/ms
MessageDigests.getAndDigest         SHA-512     16384     DEFAULT  thrpt    5    20.477    59.693  ops/ms
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296208](https://bugs.openjdk.org/browse/JDK-8296208): AArch64: Enable SHA512 intrinsic by default on supported hardware


### Reviewers
 * [Ningsheng Jian](https://openjdk.org/census#njian) (@nsjian - Committer)
 * [Nick Gasson](https://openjdk.org/census#ngasson) (@nick-arm - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10925/head:pull/10925` \
`$ git checkout pull/10925`

Update a local copy of the PR: \
`$ git checkout pull/10925` \
`$ git pull https://git.openjdk.org/jdk pull/10925/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10925`

View PR using the GUI difftool: \
`$ git pr show -t 10925`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10925.diff">https://git.openjdk.org/jdk/pull/10925.diff</a>

</details>
