### PR TITLE
8296101: nmethod::is_unloading result unstable with concurrent unloading

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1655,11 +1655,22 @@ bool nmethod::is_unloading() {
   // or because is_cold() heuristically determines it is time to unload.
   state_unloading_cycle = current_cycle;
   state_is_unloading = IsUnloadingBehaviour::is_unloading(this);
-  state = IsUnloadingState::create(state_is_unloading, state_unloading_cycle);
+  uint8_t new_state = IsUnloadingState::create(state_is_unloading, state_unloading_cycle);
 
-  RawAccess<MO_RELAXED>::store(&_is_unloading_state, state);
+  // Note that if an nmethod has dead oops, everyone will agree that the
+  // nmethod is_unloading. However, the is_cold heuristics can yield
+  // different outcomes, so we guard the computed result with a CAS
+  // to ensure all threads have a shared view of whether an nmethod
+  // is_unloading or not.
+  if (Atomic::cmpxchg(&_is_unloading_state, state, new_state, memory_order_relaxed) == state) {
+    // Our view of the world won
+    return state_is_unloading;
+  }
 
-  return state_is_unloading;
+  // If we lost the race, we call is_unloading again to see what the winner
+  // determined. This can't recurse as the second time we call the state is
+  // guaranteed to be cached for the current unloading cycle.
+  return is_unloading();
 }
 
 void nmethod::clear_unloading_state() {


### PR DESCRIPTION
If an nmethod is not called during a concurrent full GC, then after marking has terminated, multiple threads can call is_unloading. If at the same time, the nmethod is made not_entrant, then we run into a source of instability in the is_cold() calculation used when computing is_unloading. There we check if the nmethod is_not_entrant(), which some concurrent observers will think is true, while others think it's false.
The current code that sets the is_unloading_state in is_unloading() assumes that the computed state is the same across all observers. However, that is no longer true.

I propose to set the is_unloading_state with a CAS instead of plain store. Then, as is_unloading() is computed before making nmethods not_entrant, we can guarantee that all concurrent readers of is_unloading in this scenario will return false in the current unloading cycle, instead of racingly returning either false or true. One thread wins, and it will say false, and the other threads will compute conflicting results, but end up agreeing after the CAS, that they should all return false.

Tested with mach5 tier1-7. Also tried replacing the is_not_entrant() ingredient in is_cold with os::random() to simulate the instability source. Without my fix RunThese crashes almost immediately, and with my fix it doesn't crash.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296101](https://bugs.openjdk.org/browse/JDK-8296101): nmethod::is_unloading result unstable with concurrent unloading


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10926/head:pull/10926` \
`$ git checkout pull/10926`

Update a local copy of the PR: \
`$ git checkout pull/10926` \
`$ git pull https://git.openjdk.org/jdk pull/10926/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10926`

View PR using the GUI difftool: \
`$ git pr show -t 10926`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10926.diff">https://git.openjdk.org/jdk/pull/10926.diff</a>

</details>
