### PR TITLE
8279913: obsolete ExtendedDTraceProbes

### DIFF
--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -360,14 +360,8 @@ bool ciEnv::jvmti_state_changed() const {
 // Cache DTrace flags
 void ciEnv::cache_dtrace_flags() {
   // Need lock?
-  _dtrace_extended_probes = ExtendedDTraceProbes;
-  if (_dtrace_extended_probes) {
-    _dtrace_method_probes   = true;
-    _dtrace_alloc_probes    = true;
-  } else {
-    _dtrace_method_probes   = DTraceMethodProbes;
-    _dtrace_alloc_probes    = DTraceAllocProbes;
-  }
+  _dtrace_method_probes = DTraceMethodProbes;
+  _dtrace_alloc_probes  = DTraceAllocProbes;
 }
 
 // ------------------------------------------------------------------
@@ -1087,8 +1081,7 @@ void ciEnv::register_method(ciMethod* target,
 
     // Change in DTrace flags may invalidate compilation.
     if (!failing() &&
-        ( (!dtrace_extended_probes() && ExtendedDTraceProbes) ||
-          (!dtrace_method_probes() && DTraceMethodProbes) ||
+        ( (!dtrace_method_probes() && DTraceMethodProbes) ||
           (!dtrace_alloc_probes() && DTraceAllocProbes) )) {
       record_failure("DTrace flags change invalidated dependencies");
     }

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -79,7 +79,6 @@ private:
   bool  _jvmti_can_walk_any_space;
 
   // Cache DTrace flags
-  bool  _dtrace_extended_probes;
   bool  _dtrace_method_probes;
   bool  _dtrace_alloc_probes;
 
@@ -358,7 +357,6 @@ public:
 
   // Cache DTrace flags
   void  cache_dtrace_flags();
-  bool  dtrace_extended_probes() const { return _dtrace_extended_probes; }
   bool  dtrace_method_probes()   const { return _dtrace_method_probes; }
   bool  dtrace_alloc_probes()    const { return _dtrace_alloc_probes; }
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2836,26 +2836,7 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
                     tail);
         return JNI_EINVAL;
       }
-    } else if (match_option(option, "-XX:+ExtendedDTraceProbes")) {
-#if defined(DTRACE_ENABLED)
-      warning("Option ExtendedDTraceProbes was deprecated in version 19 and will likely be removed in a future release.");
-      warning("Use the combination of -XX:+DTraceMethodProbes, -XX:+DTraceAllocProbes and -XX:+DTraceMonitorProbes instead.");
-      if (FLAG_SET_CMDLINE(ExtendedDTraceProbes, true) != JVMFlag::SUCCESS) {
-        return JNI_EINVAL;
-      }
-      if (FLAG_SET_CMDLINE(DTraceMethodProbes, true) != JVMFlag::SUCCESS) {
-        return JNI_EINVAL;
-      }
-      if (FLAG_SET_CMDLINE(DTraceAllocProbes, true) != JVMFlag::SUCCESS) {
-        return JNI_EINVAL;
-      }
-      if (FLAG_SET_CMDLINE(DTraceMonitorProbes, true) != JVMFlag::SUCCESS) {
-        return JNI_EINVAL;
-      }
-#else // defined(DTRACE_ENABLED)
-      jio_fprintf(defaultStream::error_stream(),
-                  "ExtendedDTraceProbes flag is not applicable for this configuration\n");
-      return JNI_EINVAL;
+#if !defined(DTRACE_ENABLED)
     } else if (match_option(option, "-XX:+DTraceMethodProbes")) {
       jio_fprintf(defaultStream::error_stream(),
                   "DTraceMethodProbes flag is not applicable for this configuration\n");
@@ -2868,7 +2849,7 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
       jio_fprintf(defaultStream::error_stream(),
                   "DTraceMonitorProbes flag is not applicable for this configuration\n");
       return JNI_EINVAL;
-#endif // defined(DTRACE_ENABLED)
+#endif // !defined(DTRACE_ENABLED)
 #ifdef ASSERT
     } else if (match_option(option, "-XX:+FullGCALot")) {
       if (FLAG_SET_CMDLINE(FullGCALot, true) != JVMFlag::SUCCESS) {

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1819,11 +1819,6 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, PauseAtExit, false, DIAGNOSTIC,                             \
           "Pause and wait for keypress on exit if a debugger is attached")  \
                                                                             \
-  product(bool, ExtendedDTraceProbes,    false,                             \
-          "(Deprecated) Enable performance-impacting dtrace probes. "       \
-          "Use the combination of -XX:+DTraceMethodProbes, "                \
-          "-XX:+DTraceAllocProbes and -XX:+DTraceMonitorProbes instead.")   \
-                                                                            \
   product(bool, DTraceMethodProbes, false,                                  \
           "Enable dtrace tool probes for method-entry and method-exit")     \
                                                                             \

--- a/test/hotspot/jtreg/serviceability/dtrace/DTraceOptionsTest.java
+++ b/test/hotspot/jtreg/serviceability/dtrace/DTraceOptionsTest.java
@@ -56,7 +56,6 @@ public class DTraceOptionsTest {
         }
 
         String[] options = {
-            "ExtendedDTraceProbes",
             "DTraceMethodProbes",
             "DTraceAllocProbes",
             "DTraceMonitorProbes",


### PR DESCRIPTION
Obsoleted ExtendedDTraceProbes.
Removed all uses of the flag, it now shows this warning when used:
`Ignoring option ExtendedDTraceProbes; support was removed in 20.0`

Documentation was already changed in [JDK-8279047](https://bugs.openjdk.org/browse/JDK-8279047)

Verified warning message in dtrace build, and regular build.
Ran automatic regression tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279913](https://bugs.openjdk.org/browse/JDK-8279913): obsolete ExtendedDTraceProbes


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10930/head:pull/10930` \
`$ git checkout pull/10930`

Update a local copy of the PR: \
`$ git checkout pull/10930` \
`$ git pull https://git.openjdk.org/jdk pull/10930/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10930`

View PR using the GUI difftool: \
`$ git pr show -t 10930`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10930.diff">https://git.openjdk.org/jdk/pull/10930.diff</a>

</details>
