### PR TITLE
8276064: CheckCastPP with raw oop input floats below a safepoint

### DIFF
--- a/src/hotspot/share/opto/buildOopMap.cpp
+++ b/src/hotspot/share/opto/buildOopMap.cpp
@@ -359,7 +359,7 @@ OopMap *OopFlow::build_oop_map( Node *n, int max_reg, PhaseRegAlloc *regalloc, i
           // Check users as well because def might be spilled
           for (DUIterator_Fast jmax, j = m->fast_outs(jmax); j < jmax; j++) {
             Node* u = m->fast_out(j);
-            if (u->is_SpillCopy() || u->is_Phi()) {
+            if ((u->is_SpillCopy() && u->in(1) == m) || u->is_Phi()) {
               worklist.push(u);
             }
           }

--- a/src/hotspot/share/opto/buildOopMap.cpp
+++ b/src/hotspot/share/opto/buildOopMap.cpp
@@ -344,10 +344,26 @@ OopMap *OopFlow::build_oop_map( Node *n, int max_reg, PhaseRegAlloc *regalloc, i
     } else {
       // Other - some reaching non-oop value
 #ifdef ASSERT
-      if( t->isa_rawptr() && C->cfg()->_raw_oops.member(def) ) {
-        def->dump();
-        n->dump();
-        assert(false, "there should be a oop in OopMap instead of a live raw oop at safepoint");
+      if (t->isa_rawptr()) {
+        ResourceMark rm;
+        Unique_Node_List worklist;
+        worklist.push(def);
+        for (uint i = 0; i < worklist.size(); i++) {
+          Node* m = worklist.at(i);
+          if (C->cfg()->_raw_oops.member(m)) {
+            def->dump();
+            m->dump();
+            n->dump();
+            assert(false, "there should be an oop in OopMap instead of a live raw oop at safepoint");
+          }
+          // Check users as well because def might be spilled
+          for (DUIterator_Fast jmax, j = m->fast_outs(jmax); j < jmax; j++) {
+            Node* u = m->fast_out(j);
+            if (u->is_SpillCopy() || u->is_Phi()) {
+              worklist.push(u);
+            }
+          }
+        }
       }
 #endif
     }

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -5892,6 +5892,11 @@ void PhaseIdealLoop::build_loop_late_post_work(Node *n, bool pinned) {
       }
     }
   }
+  // Don't extend live ranges of raw oops
+  if (least != early && n->is_ConstraintCast() && n->in(1)->bottom_type()->isa_rawptr() &&
+      !n->bottom_type()->isa_rawptr()) {
+    least = early;
+  }
 
 #ifdef ASSERT
   // If verifying, verify that 'verify_me' has a legal location

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1572,16 +1572,12 @@ bool PhaseIdealLoop::safe_for_if_replacement(const Node* dom) const {
 // like various versions of induction variable+offset.  Clone the
 // computation per usage to allow it to sink out of the loop.
 void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
-  bool is_raw_to_oop_cast = n->is_ConstraintCast() &&
-                            n->in(1)->bottom_type()->isa_rawptr() &&
-                            !n->bottom_type()->isa_rawptr();
   if (has_ctrl(n) &&
       !n->is_Phi() &&
       !n->is_Bool() &&
       !n->is_Proj() &&
       !n->is_MergeMem() &&
       !n->is_CMove() &&
-      !is_raw_to_oop_cast && // don't extend live ranges of raw oops
       n->Opcode() != Op_Opaque4 &&
       !n->is_Type()) {
     Node *n_ctrl = get_ctrl(n);

--- a/test/hotspot/jtreg/compiler/vectorapi/TestRawOopAtSafepoint.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestRawOopAtSafepoint.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import jdk.incubator.vector.IntVector;
+import jdk.test.lib.Asserts;
+
+/*
+ * @test
+ * @bug 8276064 8271600
+ * @summary Verify that CheckCastPPs with raw oop inputs are not floating below a safepoint.
+ * @library /test/lib
+ * @modules jdk.incubator.vector
+ * @run main/othervm -XX:-TieredCompilation -Xbatch
+ *                   -XX:CompileCommand=compileonly,compiler.vectorapi.TestRawOopAtSafepoint::test*
+ *                   -XX:CompileCommand=dontinline,compiler.vectorapi.TestRawOopAtSafepoint::safepoint
+ *                   compiler.vectorapi.TestRawOopAtSafepoint
+ */
+public class TestRawOopAtSafepoint {
+
+    static int iFld = 42;
+
+    public static void safepoint(boolean gc) {
+        if (gc) {
+            // Give the GC a chance to move the IntVector object on the heap
+            // and thus invalidate the oop if it's not in the oopMap.
+            System.gc();
+        }
+    }
+
+    // Loop unswitching moves a CheckCastPP out of a loop such that the raw oop
+    // input crosses a safepoint. We then SIGSEGV after the GC moved the IntVector
+    // object when deferencing the now stale oop.
+    public static IntVector test1(boolean flag, boolean gc) {
+        IntVector vector = null;
+        for (int i = 0; i < 100; i++) {
+            // Trigger loop unswitching
+            if (flag) {
+                iFld++;
+            }
+            // Allocate an IntVector that will be scalarized in the
+            // safepoint debug info but not in the return.
+            vector = IntVector.zero(IntVector.SPECIES_MAX);
+            safepoint((i == 99) && gc);
+        }
+        return vector;
+    }
+
+    // Same as test1 but we hit an assert in OopFlow::build_oop_map instead.
+    public static IntVector test2(boolean flag, boolean gc) {
+        for (int i = 0; i < 100; i++) {
+            // Trigger loop unswitching
+            if (flag) {
+                iFld++;
+            }
+            IntVector vector = IntVector.zero(IntVector.SPECIES_MAX);
+            safepoint((i == 99) && gc);
+            if (flag) {
+                return vector;
+            }
+        }
+        return IntVector.zero(IntVector.SPECIES_MAX);
+    }
+
+    // Same as test1 but PhaseIdealLoop::try_sink_out_of_loop moves the CheckCastPP.
+    public static IntVector test3(boolean flag, boolean gc) {
+        IntVector vector = null;
+        for (int i = 0; i < 10; i++) {
+            vector = IntVector.zero(IntVector.SPECIES_MAX);
+            safepoint((i == 9) && gc);
+        }
+        return vector;
+    }
+
+    // Same as test2 but PhaseIdealLoop::try_sink_out_of_loop moves the CheckCastPP.
+    public static IntVector test4(boolean flag, boolean gc) {
+        IntVector vector = null;
+        for (int i = 0; i < 2; i++) {
+            vector = IntVector.zero(IntVector.SPECIES_MAX);
+            safepoint((i == 9) && gc);
+        }
+        return vector;
+    }
+
+    public static void main(String[] args) {
+        int sum = 0;
+        for (int i = 0; i < 15_000; ++i) {
+            boolean flag = ((i % 2) == 0);
+            boolean gc = (i > 14_500);
+            IntVector vector1 = test1(flag, gc);
+            sum += vector1.lane(0);
+
+            IntVector vector2 = test2(flag, gc);
+            sum += vector2.lane(0);
+
+            IntVector vector3 = test3(flag, gc);
+            sum += vector3.lane(0);
+
+            IntVector vector4 = test4(flag, gc);
+            sum += vector4.lane(0);
+        }
+        Asserts.assertEQ(sum, 0);
+    }
+}


### PR DESCRIPTION
This bug is similar to [JDK-8271600](https://bugs.openjdk.org/browse/JDK-8271600): A CheckCastPP with a raw oop input floats out of a loop and below a safepoint. Since C2 does not generate OopMap entries for raw pointers, the GC will not update the oop if the corresponding object is moved during the safepoint. We either assert already during OopMap creation, or crash when dereferencing a stale oop during runtime (the verification code does not always detect such live raw oops at safepoints, I included a fix for that as well).

I think the fix for [JDK-8271600](https://bugs.openjdk.org/browse/JDK-8271600) is incomplete, because it only bails out of [PhaseIdealLoop::try_sink_out_of_loop](https://github.com/openjdk/jdk/commit/2ff4c01d42f1afcc53abd48e074356fb4a700754) while the underlying issue is that a raw CheckCastPP ends up with ctrl "far away" from its Allocate/Initialize and potentially even below a safepoint. Usually, the CheckCastPP would always be part of safepoint debug info and therefore late ctrl would be guaranteed to be above the safepoint. However, vector objects are aggressively scalar replaced in safepoints, which allows late ctrl to be set to further below. This is specific to vectors, since "normal" Java objects would either be fully scalarized or not be scalarized at all.

In the failing case, Loop Unswitching clones the loop body and creates a Phi to merge the oop results from the vector allocations in both loops. Since ctrl of the CheckCastPP is outside of the loop, its data input is changed to the newly created Phi and its control input is set to the region that merges the loop exits. This moves the CheckCastPP below a safepoint in the loop.

Below graphs show the details. `395 CheckCastPP` is removed from the debug info for `262 CallStaticJava` because it's scalarized (`326 SafepointScalarObject`). Late ctrl is then computed to be outside of the loop because the CheckCastPP is only used in the return.

![8276064_Before](https://user-images.githubusercontent.com/5312595/199204249-17564a59-2b67-4426-be71-19bc0eafac99.png)

Now Loop Unswitching creates a `487 Region` and `517 Phi` to merge control and data inputs to the CheckCastPP from the fast and slow loops (see `PhaseIdealLoop::clone_loop_handle_data_uses`). Control of the `395 CheckCastPP` is updated accordingly.

![8276064_After](https://user-images.githubusercontent.com/5312595/199204273-44341cd7-b5b6-4ec0-b8c9-6f349393dbd1.png)

As a result, the raw oop input of the `395 CheckCastPP` is live at `262 CallStaticJava`.

We could now add another point fix to prevent loop unswitching from moving the CheckCastPP out of the loop, but I think there is a risk that other current or future optimizations would rely on the CheckCastPP's late ctrl and do a similar thing. I would therefore suggest to pin all CheckCastPPs with a raw oop input, similar to what [JDK-5071820](https://bugs.openjdk.org/browse/JDK-5071820) did in GCM:
https://github.com/openjdk/jdk/blob/37107fc1574a4191987420d88f7182e63c7da60c/src/hotspot/share/opto/gcm.cpp#L1325-L1330

The fix for [JDK-8271600](https://bugs.openjdk.org/browse/JDK-8271600) can then be reverted, also because Roland's fix for [JDK-8272562](https://bugs.openjdk.org/browse/JDK-8272562) disabled moving **all** CheckCastPPs out of loops anyway. Roland said that he plans to revisit that decision with [JDK-8275202](https://bugs.openjdk.org/browse/JDK-8275202). The tests added with this PR will cover the `PhaseIdealLoop::try_sink_out_of_loop` case as well and therefore serve as regression tests for [JDK-8271600](https://bugs.openjdk.org/browse/JDK-8271600).

We could improve this by adding logic to set late ctrl just above the safepoint, but I'm not sure if it's worth the complexity because we would need to walk up the control paths from late to early control and compute the dominator of all safepoints.

I also fixed the verification code in `OopFlow::build_oop_map` to account for spilling. Before, compilation of `test1` would pass and only crash during execution. Now, we assert and print:

```
454  DefinitionSpillCopy  === _ 122  [[ 321 ]]  !jvms: IntVector::zero @ bci:26 (line 563) TestRawOopAtSafepoint::test1 @ bci:25 (line 74)
321  Phi  === 315 454 503  [[ 512 ]]  #rawptr:NotNull !jvms: IntVector::zero @ bci:26 (line 563) TestRawOopAtSafepoint::test1 @ bci:25 (line 74)
 38  CallStaticJavaDirect  === 40 126 136 102 0 455 452 138 139 453 460  [[ 39 84 130 37 388 ]] Static  compiler.vectorapi.TestRawOopAtSafepoint::safepoint # void ( int ) TestRawOopAtSafepoint::test1 @ bci:44 (line 75) !jvms: TestRawOopAtSafepoint::test1 @ bci:44 (line 75)
```


What do you think?

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276064](https://bugs.openjdk.org/browse/JDK-8276064): CheckCastPP with raw oop input floats below a safepoint


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10932/head:pull/10932` \
`$ git checkout pull/10932`

Update a local copy of the PR: \
`$ git checkout pull/10932` \
`$ git pull https://git.openjdk.org/jdk pull/10932/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10932`

View PR using the GUI difftool: \
`$ git pr show -t 10932`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10932.diff">https://git.openjdk.org/jdk/pull/10932.diff</a>

</details>
