### PR TITLE
8296167: test/langtools/tools/jdeps/jdkinternals/ShowReplacement.java failing after JDK-8296072

### DIFF
--- a/test/langtools/tools/jdeps/jdkinternals/src/q/NoRepl.java
+++ b/test/langtools/tools/jdeps/jdkinternals/src/q/NoRepl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,11 +24,11 @@
 package q;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import sun.security.util.DerEncoder;
+import sun.security.util.DerOutputStream;
 
 public class NoRepl implements DerEncoder {
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         throw new IOException();
     }
 }


### PR DESCRIPTION
The argument of `DerEncoder::derEncode` changed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296167](https://bugs.openjdk.org/browse/JDK-8296167): test/langtools/tools/jdeps/jdkinternals/ShowReplacement.java failing after JDK-8296072


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10935/head:pull/10935` \
`$ git checkout pull/10935`

Update a local copy of the PR: \
`$ git checkout pull/10935` \
`$ git pull https://git.openjdk.org/jdk pull/10935/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10935`

View PR using the GUI difftool: \
`$ git pr show -t 10935`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10935.diff">https://git.openjdk.org/jdk/pull/10935.diff</a>

</details>
