### PR TITLE
8296157: Rename FileMapInfo::space_at() to region_at()

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -1221,8 +1221,8 @@ void ArchiveBuilder::print_region_stats(FileMapInfo *mapinfo,
                                         GrowableArray<MemRegion>* closed_heap_regions,
                                         GrowableArray<MemRegion>* open_heap_regions) {
   // Print statistics of all the regions
-  const size_t bitmap_used = mapinfo->space_at(MetaspaceShared::bm)->used();
-  const size_t bitmap_reserved = mapinfo->space_at(MetaspaceShared::bm)->used_aligned();
+  const size_t bitmap_used = mapinfo->region_at(MetaspaceShared::bm)->used();
+  const size_t bitmap_reserved = mapinfo->region_at(MetaspaceShared::bm)->used_aligned();
   const size_t total_reserved = _ro_region.reserved()  + _rw_region.reserved() +
                                 bitmap_reserved +
                                 _total_closed_heap_region_size +

--- a/src/hotspot/share/cds/archiveHeapLoader.cpp
+++ b/src/hotspot/share/cds/archiveHeapLoader.cpp
@@ -256,7 +256,7 @@ int ArchiveHeapLoader::init_loaded_regions(FileMapInfo* mapinfo, LoadedArchiveHe
   int num_loaded_regions = 0;
   for (int i = MetaspaceShared::first_archive_heap_region;
        i <= MetaspaceShared::last_archive_heap_region; i++) {
-    FileMapRegion* r = mapinfo->space_at(i);
+    FileMapRegion* r = mapinfo->region_at(i);
     r->assert_is_heap_region();
     if (r->used() > 0) {
       assert(is_aligned(r->used(), HeapWordSize), "must be");
@@ -309,7 +309,7 @@ bool ArchiveHeapLoader::load_regions(FileMapInfo* mapinfo, LoadedArchiveHeapRegi
   uintptr_t load_address = buffer;
   for (int i = 0; i < num_loaded_regions; i++) {
     LoadedArchiveHeapRegion* ri = &loaded_regions[i];
-    FileMapRegion* r = mapinfo->space_at(ri->_region_index);
+    FileMapRegion* r = mapinfo->region_at(ri->_region_index);
 
     if (!mapinfo->read_region(ri->_region_index, (char*)load_address, r->used(), /* do_commit = */ false)) {
       // There's no easy way to free the buffer, so we will fill it with zero later
@@ -465,7 +465,7 @@ void ArchiveHeapLoader::patch_native_pointers() {
 
   for (int i = MetaspaceShared::first_archive_heap_region;
        i <= MetaspaceShared::last_archive_heap_region; i++) {
-    FileMapRegion* r = FileMapInfo::current_info()->space_at(i);
+    FileMapRegion* r = FileMapInfo::current_info()->region_at(i);
     if (r->mapped_base() != NULL && r->has_ptrmap()) {
       log_info(cds, heap)("Patching native pointers in heap region %d", i);
       BitMapView bm = r->ptrmap_view();

--- a/src/hotspot/share/cds/cdsConstants.cpp
+++ b/src/hotspot/share/cds/cdsConstants.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/cds/cdsConstants.cpp
+++ b/src/hotspot/share/cds/cdsConstants.cpp
@@ -38,7 +38,7 @@ CDSConst CDSConstants::offsets[] = {
   { "GenericCDSFileMapHeader::_common_app_classpath_prefix_size", offset_of(GenericCDSFileMapHeader, _common_app_classpath_prefix_size) },
   { "GenericCDSFileMapHeader::_base_archive_name_offset",  offset_of(GenericCDSFileMapHeader, _base_archive_name_offset) },
   { "GenericCDSFileMapHeader::_base_archive_name_size",    offset_of(GenericCDSFileMapHeader, _base_archive_name_size)   },
-  { "CDSFileMapHeaderBase::_space[0]",                     offset_of(CDSFileMapHeaderBase, _space)             },
+  { "CDSFileMapHeaderBase::_space[0]",                     offset_of(CDSFileMapHeaderBase, _regions)             },
   { "FileMapHeader::_jvm_ident",                           offset_of(FileMapHeader, _jvm_ident)                },
   { "CDSFileMapRegion::_crc",                              offset_of(CDSFileMapRegion, _crc)                   },
   { "CDSFileMapRegion::_used",                             offset_of(CDSFileMapRegion, _used)                  },

--- a/src/hotspot/share/cds/cdsConstants.cpp
+++ b/src/hotspot/share/cds/cdsConstants.cpp
@@ -38,7 +38,7 @@ CDSConst CDSConstants::offsets[] = {
   { "GenericCDSFileMapHeader::_common_app_classpath_prefix_size", offset_of(GenericCDSFileMapHeader, _common_app_classpath_prefix_size) },
   { "GenericCDSFileMapHeader::_base_archive_name_offset",  offset_of(GenericCDSFileMapHeader, _base_archive_name_offset) },
   { "GenericCDSFileMapHeader::_base_archive_name_size",    offset_of(GenericCDSFileMapHeader, _base_archive_name_size)   },
-  { "CDSFileMapHeaderBase::_space[0]",                     offset_of(CDSFileMapHeaderBase, _regions)             },
+  { "CDSFileMapHeaderBase::_regions[0]",                   offset_of(CDSFileMapHeaderBase, _regions)           },
   { "FileMapHeader::_jvm_ident",                           offset_of(FileMapHeader, _jvm_ident)                },
   { "CDSFileMapRegion::_crc",                              offset_of(CDSFileMapRegion, _crc)                   },
   { "CDSFileMapRegion::_used",                             offset_of(CDSFileMapRegion, _used)                  },

--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -190,7 +190,7 @@ void DynamicArchiveBuilder::init_header() {
 
   _header->set_base_header_crc(base_info->crc());
   for (int i = 0; i < MetaspaceShared::n_regions; i++) {
-    _header->set_base_region_crc(i, base_info->space_crc(i));
+    _header->set_base_region_crc(i, base_info->region_crc(i));
   }
 }
 
@@ -426,7 +426,7 @@ bool DynamicArchive::validate(FileMapInfo* dynamic_info) {
 
   // Check each space's crc
   for (int i = 0; i < MetaspaceShared::n_regions; i++) {
-    if (dynamic_header->base_region_crc(i) != base_info->space_crc(i)) {
+    if (dynamic_header->base_region_crc(i) != base_info->region_crc(i)) {
       FileMapInfo::fail_continue("Dynamic archive cannot be used: static archive region #%d checksum verification failed.", i);
       return false;
     }

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1761,7 +1761,7 @@ size_t FileMapInfo::write_heap_regions(GrowableArray<MemRegion>* regions,
       int oopmap_idx = i * 2;
       int ptrmap_idx = i * 2 + 1;
       region_at(region_idx)->init_bitmaps(bitmaps->at(oopmap_idx),
-                                         bitmaps->at(ptrmap_idx));
+                                          bitmaps->at(ptrmap_idx));
     }
   }
   return total_size;
@@ -2610,11 +2610,11 @@ char* FileMapInfo::region_addr(int idx) {
 }
 
 // The 2 core spaces are RW->RO
-FileMapRegion* FileMapInfo::first_core_space() const {
+FileMapRegion* FileMapInfo::first_core_region() const {
   return region_at(MetaspaceShared::rw);
 }
 
-FileMapRegion* FileMapInfo::last_core_space() const {
+FileMapRegion* FileMapInfo::last_core_region() const {
   return region_at(MetaspaceShared::ro);
 }
 

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -323,8 +323,8 @@ void FileMapHeader::print(outputStream* st) {
   st->print_cr("- base_archive_name_size:         " UINT32_FORMAT, base_archive_name_size());
 
   for (int i = 0; i < NUM_CDS_REGIONS; i++) {
-    FileMapRegion* si = space_at(i);
-    si->print(st, i);
+    FileMapRegion* r = region_at(i);
+    r->print(st, i);
   }
   st->print_cr("============ end regions ======== ");
 
@@ -1463,8 +1463,8 @@ bool FileMapInfo::init_from_file(int fd) {
   size_t len = os::lseek(fd, 0, SEEK_END);
 
   for (int i = 0; i <= MetaspaceShared::last_valid_region; i++) {
-    FileMapRegion* si = space_at(i);
-    if (si->file_offset() > len || len - si->file_offset() < si->used()) {
+    FileMapRegion* r = region_at(i);
+    if (r->file_offset() > len || len - r->file_offset() < r->used()) {
       fail_continue("The shared archive file has been truncated.");
       return false;
     }
@@ -1616,7 +1616,7 @@ void FileMapInfo::write_region(int region, char* base, size_t size,
                                bool read_only, bool allow_exec) {
   Arguments::assert_is_dumping_archive();
 
-  FileMapRegion* si = space_at(region);
+  FileMapRegion* r = region_at(region);
   char* requested_base;
   size_t mapping_offset = 0;
 
@@ -1643,7 +1643,7 @@ void FileMapInfo::write_region(int region, char* base, size_t size,
     mapping_offset = requested_base - requested_SharedBaseAddress;
   }
 
-  si->set_file_offset(_file_offset);
+  r->set_file_offset(_file_offset);
   int crc = ClassLoader::crc32(0, base, (jint)size);
   if (size > 0) {
     log_info(cds)("Shared file region (%-3s)  %d: " SIZE_FORMAT_W(8)
@@ -1652,7 +1652,7 @@ void FileMapInfo::write_region(int region, char* base, size_t size,
                    region_name(region), region, size, p2i(requested_base), _file_offset, crc);
   }
 
-  si->init(region, mapping_offset, size, read_only, allow_exec, crc);
+  r->init(region, mapping_offset, size, read_only, allow_exec, crc);
 
   if (base != NULL) {
     write_bytes_aligned(base, size);
@@ -1760,7 +1760,7 @@ size_t FileMapInfo::write_heap_regions(GrowableArray<MemRegion>* regions,
     if (size > 0) {
       int oopmap_idx = i * 2;
       int ptrmap_idx = i * 2 + 1;
-      space_at(region_idx)->init_bitmaps(bitmaps->at(oopmap_idx),
+      region_at(region_idx)->init_bitmaps(bitmaps->at(oopmap_idx),
                                          bitmaps->at(ptrmap_idx));
     }
   }
@@ -1829,19 +1829,19 @@ void FileMapInfo::close() {
 // Remap the shared readonly space to shared readwrite, private.
 bool FileMapInfo::remap_shared_readonly_as_readwrite() {
   int idx = MetaspaceShared::ro;
-  FileMapRegion* si = space_at(idx);
-  if (!si->read_only()) {
+  FileMapRegion* r = region_at(idx);
+  if (!r->read_only()) {
     // the space is already readwrite so we are done
     return true;
   }
-  size_t size = si->used_aligned();
+  size_t size = r->used_aligned();
   if (!open_for_read()) {
     return false;
   }
   char *addr = region_addr(idx);
-  char *base = os::remap_memory(_fd, _full_path, si->file_offset(),
+  char *base = os::remap_memory(_fd, _full_path, r->file_offset(),
                                 addr, size, false /* !read_only */,
-                                si->allow_exec());
+                                r->allow_exec());
   close();
   // These have to be errors because the shared region is now unmapped.
   if (base == NULL) {
@@ -1852,7 +1852,7 @@ bool FileMapInfo::remap_shared_readonly_as_readwrite() {
     log_error(cds)("Unable to remap shared readonly space (errno=%d).", errno);
     vm_exit(1);
   }
-  si->set_read_only(false);
+  r->set_read_only(false);
   return true;
 }
 
@@ -1868,21 +1868,21 @@ MapArchiveResult FileMapInfo::map_regions(int regions[], int num_regions, char* 
   // it's been successfully mapped.
   DEBUG_ONLY(header()->set_mapped_base_address((char*)(uintptr_t)0xdeadbeef);)
 
-  for (int r = 0; r < num_regions; r++) {
-    int idx = regions[r];
+  for (int i = 0; i < num_regions; i++) {
+    int idx = regions[i];
     MapArchiveResult result = map_region(idx, addr_delta, mapped_base_address, rs);
     if (result != MAP_ARCHIVE_SUCCESS) {
       return result;
     }
-    FileMapRegion* si = space_at(idx);
+    FileMapRegion* r = region_at(idx);
     DEBUG_ONLY(if (last_region != NULL) {
         // Ensure that the OS won't be able to allocate new memory spaces between any mapped
         // regions, or else it would mess up the simple comparison in MetaspaceObj::is_shared().
-        assert(si->mapped_base() == last_region->mapped_end(), "must have no gaps");
+        assert(r->mapped_base() == last_region->mapped_end(), "must have no gaps");
       }
-      last_region = si;)
+      last_region = r;)
     log_info(cds)("Mapped %s region #%d at base " INTPTR_FORMAT " top " INTPTR_FORMAT " (%s)", is_static() ? "static " : "dynamic",
-                  idx, p2i(si->mapped_base()), p2i(si->mapped_end()),
+                  idx, p2i(r->mapped_base()), p2i(r->mapped_end()),
                   shared_region_name[idx]);
 
   }
@@ -1896,23 +1896,23 @@ MapArchiveResult FileMapInfo::map_regions(int regions[], int num_regions, char* 
 }
 
 bool FileMapInfo::read_region(int i, char* base, size_t size, bool do_commit) {
-  FileMapRegion* si = space_at(i);
+  FileMapRegion* r = region_at(i);
   if (do_commit) {
     log_info(cds)("Commit %s region #%d at base " INTPTR_FORMAT " top " INTPTR_FORMAT " (%s)%s",
                   is_static() ? "static " : "dynamic", i, p2i(base), p2i(base + size),
-                  shared_region_name[i], si->allow_exec() ? " exec" : "");
-    if (!os::commit_memory(base, size, si->allow_exec())) {
+                  shared_region_name[i], r->allow_exec() ? " exec" : "");
+    if (!os::commit_memory(base, size, r->allow_exec())) {
       log_error(cds)("Failed to commit %s region #%d (%s)", is_static() ? "static " : "dynamic",
                      i, shared_region_name[i]);
       return false;
     }
   }
-  if (os::lseek(_fd, (long)si->file_offset(), SEEK_SET) != (int)si->file_offset() ||
+  if (os::lseek(_fd, (long)r->file_offset(), SEEK_SET) != (int)r->file_offset() ||
       read_bytes(base, size) != size) {
     return false;
   }
 
-  if (VerifySharedSpaces && !region_crc_check(base, si->used(), si->crc())) {
+  if (VerifySharedSpaces && !region_crc_check(base, r->used(), r->crc())) {
     return false;
   }
 
@@ -1921,24 +1921,24 @@ bool FileMapInfo::read_region(int i, char* base, size_t size, bool do_commit) {
 
 MapArchiveResult FileMapInfo::map_region(int i, intx addr_delta, char* mapped_base_address, ReservedSpace rs) {
   assert(!HeapShared::is_heap_region(i), "sanity");
-  FileMapRegion* si = space_at(i);
-  size_t size = si->used_aligned();
-  char *requested_addr = mapped_base_address + si->mapping_offset();
-  assert(si->mapped_base() == NULL, "must be not mapped yet");
+  FileMapRegion* r = region_at(i);
+  size_t size = r->used_aligned();
+  char *requested_addr = mapped_base_address + r->mapping_offset();
+  assert(r->mapped_base() == NULL, "must be not mapped yet");
   assert(requested_addr != NULL, "must be specified");
 
-  si->set_mapped_from_file(false);
+  r->set_mapped_from_file(false);
 
   if (MetaspaceShared::use_windows_memory_mapping()) {
     // Windows cannot remap read-only shared memory to read-write when required for
     // RedefineClasses, which is also used by JFR.  Always map windows regions as RW.
-    si->set_read_only(false);
+    r->set_read_only(false);
   } else if (JvmtiExport::can_modify_any_class() || JvmtiExport::can_walk_any_space() ||
              Arguments::has_jfr_option()) {
     // If a tool agent is in use (debugging enabled), or JFR, we must map the address space RW
-    si->set_read_only(false);
+    r->set_read_only(false);
   } else if (addr_delta != 0) {
-    si->set_read_only(false); // Need to patch the pointers
+    r->set_read_only(false); // Need to patch the pointers
   }
 
   if (MetaspaceShared::use_windows_memory_mapping() && rs.is_reserved()) {
@@ -1955,18 +1955,18 @@ MapArchiveResult FileMapInfo::map_region(int i, intx addr_delta, char* mapped_ba
     // Note that this may either be a "fresh" mapping into unreserved address
     // space (Windows, first mapping attempt), or a mapping into pre-reserved
     // space (Posix). See also comment in MetaspaceShared::map_archives().
-    char* base = os::map_memory(_fd, _full_path, si->file_offset(),
-                                requested_addr, size, si->read_only(),
-                                si->allow_exec(), mtClassShared);
+    char* base = os::map_memory(_fd, _full_path, r->file_offset(),
+                                requested_addr, size, r->read_only(),
+                                r->allow_exec(), mtClassShared);
     if (base != requested_addr) {
       log_info(cds)("Unable to map %s shared space at " INTPTR_FORMAT,
                     shared_region_name[i], p2i(requested_addr));
       _memory_mapping_failed = true;
       return MAP_ARCHIVE_MMAP_FAILURE;
     }
-    si->set_mapped_from_file(true);
+    r->set_mapped_from_file(true);
   }
-  si->set_mapped_base(requested_addr);
+  r->set_mapped_base(requested_addr);
 
   if (VerifySharedSpaces && !verify_region_checksum(i)) {
     return MAP_ARCHIVE_OTHER_FAILURE;
@@ -1977,32 +1977,32 @@ MapArchiveResult FileMapInfo::map_region(int i, intx addr_delta, char* mapped_ba
 
 // The return value is the location of the archive relocation bitmap.
 char* FileMapInfo::map_bitmap_region() {
-  FileMapRegion* si = space_at(MetaspaceShared::bm);
-  if (si->mapped_base() != NULL) {
-    return si->mapped_base();
+  FileMapRegion* r = region_at(MetaspaceShared::bm);
+  if (r->mapped_base() != NULL) {
+    return r->mapped_base();
   }
   bool read_only = true, allow_exec = false;
   char* requested_addr = NULL; // allow OS to pick any location
-  char* bitmap_base = os::map_memory(_fd, _full_path, si->file_offset(),
-                                     requested_addr, si->used_aligned(), read_only, allow_exec, mtClassShared);
+  char* bitmap_base = os::map_memory(_fd, _full_path, r->file_offset(),
+                                     requested_addr, r->used_aligned(), read_only, allow_exec, mtClassShared);
   if (bitmap_base == NULL) {
     log_info(cds)("failed to map relocation bitmap");
     return NULL;
   }
 
-  if (VerifySharedSpaces && !region_crc_check(bitmap_base, si->used(), si->crc())) {
+  if (VerifySharedSpaces && !region_crc_check(bitmap_base, r->used(), r->crc())) {
     log_error(cds)("relocation bitmap CRC error");
-    if (!os::unmap_memory(bitmap_base, si->used_aligned())) {
+    if (!os::unmap_memory(bitmap_base, r->used_aligned())) {
       fatal("os::unmap_memory of relocation bitmap failed");
     }
     return NULL;
   }
 
-  si->set_mapped_base(bitmap_base);
-  si->set_mapped_from_file(true);
+  r->set_mapped_base(bitmap_base);
+  r->set_mapped_from_file(true);
   log_info(cds)("Mapped %s region #%d at base " INTPTR_FORMAT " top " INTPTR_FORMAT " (%s)",
                 is_static() ? "static " : "dynamic",
-                MetaspaceShared::bm, p2i(si->mapped_base()), p2i(si->mapped_end()),
+                MetaspaceShared::bm, p2i(r->mapped_base()), p2i(r->mapped_end()),
                 shared_region_name[MetaspaceShared::bm]);
   return bitmap_base;
 }
@@ -2077,7 +2077,7 @@ static int num_open_heap_regions = 0;
 
 #if INCLUDE_CDS_JAVA_HEAP
 bool FileMapInfo::has_heap_regions() {
-  return (space_at(MetaspaceShared::first_closed_heap_region)->used() > 0);
+  return (region_at(MetaspaceShared::first_closed_heap_region)->used() > 0);
 }
 
 // Returns the address range of the archived heap regions computed using the
@@ -2091,10 +2091,10 @@ MemRegion FileMapInfo::get_heap_regions_range_with_current_oop_encoding_mode() {
   for (int i = MetaspaceShared::first_closed_heap_region;
            i <= MetaspaceShared::last_valid_region;
            i++) {
-    FileMapRegion* si = space_at(i);
-    size_t size = si->used();
+    FileMapRegion* r = region_at(i);
+    size_t size = r->used();
     if (size > 0) {
-      address s = start_address_as_decoded_with_current_oop_encoding_mode(si);
+      address s = start_address_as_decoded_with_current_oop_encoding_mode(r);
       address e = s + size;
       if (start > s) {
         start = s;
@@ -2271,8 +2271,8 @@ void FileMapInfo::map_heap_regions_impl() {
 
   set_shared_heap_runtime_delta(delta);
 
-  FileMapRegion* si = space_at(MetaspaceShared::first_closed_heap_region);
-  address relocated_closed_heap_region_bottom = heap_region_runtime_start_address(si);
+  FileMapRegion* r = region_at(MetaspaceShared::first_closed_heap_region);
+  address relocated_closed_heap_region_bottom = heap_region_runtime_start_address(r);
 
   if (!is_aligned(relocated_closed_heap_region_bottom, HeapRegion::GrainBytes)) {
     // Align the bottom of the closed archive heap regions at G1 region boundary.
@@ -2285,7 +2285,7 @@ void FileMapInfo::map_heap_regions_impl() {
                   " bytes to " INTX_FORMAT " to be aligned with HeapRegion::GrainBytes",
                   align, delta);
     set_shared_heap_runtime_delta(delta);
-    relocated_closed_heap_region_bottom = heap_region_runtime_start_address(si);
+    relocated_closed_heap_region_bottom = heap_region_runtime_start_address(r);
     _heap_pointers_need_patching = true;
   }
   assert(is_aligned(relocated_closed_heap_region_bottom, HeapRegion::GrainBytes),
@@ -2345,15 +2345,15 @@ bool FileMapInfo::map_heap_regions(int first, int max,  bool is_open_archive,
     ~Cleanup() { if (_aborted) { MemRegion::destroy_array(_regions, _length); } }
   } cleanup(regions, max);
 
-  FileMapRegion* si;
+  FileMapRegion* r;
   int num_regions = 0;
 
   for (int i = first;
            i < first + max; i++) {
-    si = space_at(i);
-    size_t size = si->used();
+    r = region_at(i);
+    size_t size = r->used();
     if (size > 0) {
-      HeapWord* start = (HeapWord*)heap_region_runtime_start_address(si);
+      HeapWord* start = (HeapWord*)heap_region_runtime_start_address(r);
       regions[num_regions] = MemRegion(start, size / HeapWordSize);
       num_regions ++;
       log_info(cds)("Trying to map heap data: region[%d] at " INTPTR_FORMAT ", size = " SIZE_FORMAT_W(8) " bytes",
@@ -2382,11 +2382,11 @@ bool FileMapInfo::map_heap_regions(int first, int max,  bool is_open_archive,
   // for mapped regions as they are part of the reserved java heap, which is
   // already recorded.
   for (int i = 0; i < num_regions; i++) {
-    si = space_at(first + i);
+    r = region_at(first + i);
     char* addr = (char*)regions[i].start();
-    char* base = os::map_memory(_fd, _full_path, si->file_offset(),
-                                addr, regions[i].byte_size(), si->read_only(),
-                                si->allow_exec());
+    char* base = os::map_memory(_fd, _full_path, r->file_offset(),
+                                addr, regions[i].byte_size(), r->read_only(),
+                                r->allow_exec());
     if (base == NULL || base != addr) {
       // dealloc the regions from java heap
       dealloc_heap_regions(regions, num_regions);
@@ -2396,14 +2396,14 @@ bool FileMapInfo::map_heap_regions(int first, int max,  bool is_open_archive,
       return false;
     }
 
-    if (VerifySharedSpaces && !region_crc_check(addr, regions[i].byte_size(), si->crc())) {
+    if (VerifySharedSpaces && !region_crc_check(addr, regions[i].byte_size(), r->crc())) {
       // dealloc the regions from java heap
       dealloc_heap_regions(regions, num_regions);
       log_info(cds)("UseSharedSpaces: mapped heap regions are corrupt");
       return false;
     }
 
-    si->set_mapped_base(base);
+    r->set_mapped_base(base);
   }
 
   cleanup._aborted = false;
@@ -2433,11 +2433,11 @@ void FileMapInfo::patch_heap_embedded_pointers(MemRegion* regions, int num_regio
   char* bitmap_base = map_bitmap_region();
   assert(bitmap_base != NULL, "must have already been mapped");
   for (int i=0; i<num_regions; i++) {
-    FileMapRegion* si = space_at(i + first_region_idx);
+    FileMapRegion* r = region_at(i + first_region_idx);
     ArchiveHeapLoader::patch_embedded_pointers(
       regions[i],
-      (address)(space_at(MetaspaceShared::bm)->mapped_base()) + si->oopmap_offset(),
-      si->oopmap_size_in_bits());
+      (address)(region_at(MetaspaceShared::bm)->mapped_base()) + r->oopmap_offset(),
+      r->oopmap_size_in_bits());
   }
 }
 
@@ -2494,12 +2494,12 @@ bool FileMapInfo::region_crc_check(char* buf, size_t size, int expected_crc) {
 
 bool FileMapInfo::verify_region_checksum(int i) {
   assert(VerifySharedSpaces, "sanity");
-  size_t sz = space_at(i)->used();
+  size_t sz = region_at(i)->used();
 
   if (sz == 0) {
     return true; // no data
   } else {
-    return region_crc_check(region_addr(i), sz, space_at(i)->crc());
+    return region_crc_check(region_addr(i), sz, region_at(i)->crc());
   }
 }
 
@@ -2514,19 +2514,19 @@ void FileMapInfo::unmap_regions(int regions[], int num_regions) {
 
 void FileMapInfo::unmap_region(int i) {
   assert(!HeapShared::is_heap_region(i), "sanity");
-  FileMapRegion* si = space_at(i);
-  char* mapped_base = si->mapped_base();
-  size_t size = si->used_aligned();
+  FileMapRegion* r = region_at(i);
+  char* mapped_base = r->mapped_base();
+  size_t size = r->used_aligned();
 
   if (mapped_base != NULL) {
-    if (size > 0 && si->mapped_from_file()) {
+    if (size > 0 && r->mapped_from_file()) {
       log_info(cds)("Unmapping region #%d at base " INTPTR_FORMAT " (%s)", i, p2i(mapped_base),
                     shared_region_name[i]);
       if (!os::unmap_memory(mapped_base, size)) {
         fatal("os::unmap_memory failed");
       }
     }
-    si->set_mapped_base(NULL);
+    r->set_mapped_base(NULL);
   }
 }
 
@@ -2599,23 +2599,23 @@ bool FileMapInfo::initialize() {
 }
 
 char* FileMapInfo::region_addr(int idx) {
-  FileMapRegion* si = space_at(idx);
+  FileMapRegion* r = region_at(idx);
   if (HeapShared::is_heap_region(idx)) {
     assert(DumpSharedSpaces, "The following doesn't work at runtime");
-    return si->used() > 0 ?
-          (char*)start_address_as_decoded_with_current_oop_encoding_mode(si) : NULL;
+    return r->used() > 0 ?
+          (char*)start_address_as_decoded_with_current_oop_encoding_mode(r) : NULL;
   } else {
-    return si->mapped_base();
+    return r->mapped_base();
   }
 }
 
 // The 2 core spaces are RW->RO
 FileMapRegion* FileMapInfo::first_core_space() const {
-  return space_at(MetaspaceShared::rw);
+  return region_at(MetaspaceShared::rw);
 }
 
 FileMapRegion* FileMapInfo::last_core_space() const {
-  return space_at(MetaspaceShared::ro);
+  return region_at(MetaspaceShared::ro);
 }
 
 void FileMapHeader::set_as_offset(char* p, size_t *offset) {
@@ -2731,7 +2731,7 @@ bool FileMapInfo::is_in_shared_region(const void* p, int idx) {
   assert(idx == MetaspaceShared::ro ||
          idx == MetaspaceShared::rw, "invalid region index");
   char* base = region_addr(idx);
-  if (p >= base && p < base + space_at(idx)->used()) {
+  if (p >= base && p < base + region_at(idx)->used()) {
     return true;
   }
   return false;

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -309,7 +309,7 @@ public:
 
   FileMapRegion* region_at(int i) {
     assert(is_valid_region(i), "invalid region");
-    return FileMapRegion::cast(&_space[i]);
+    return FileMapRegion::cast(&_regions[i]);
   }
 
   void populate(FileMapInfo *info, size_t core_region_alignment, size_t header_size,
@@ -378,7 +378,7 @@ public:
   // Accessors
   int    compute_header_crc()  const { return header()->compute_crc(); }
   void   set_header_crc(int crc)     { header()->set_crc(crc); }
-  int    space_crc(int i)      const { return region_at(i)->crc(); }
+  int    region_crc(int i)      const { return region_at(i)->crc(); }
   void   populate_header(size_t core_region_alignment);
   bool   validate_header();
   void   invalidate();
@@ -527,20 +527,20 @@ public:
   char* region_addr(int idx);
 
   // The offset of the first core region in the archive, relative to SharedBaseAddress
-  size_t mapping_base_offset() const { return first_core_space()->mapping_offset(); }
+  size_t mapping_base_offset() const { return first_core_region()->mapping_offset(); }
   // The offset of the (exclusive) end of the last core region in this archive, relative to SharedBaseAddress
-  size_t mapping_end_offset()  const { return last_core_space()->mapping_end_offset(); }
+  size_t mapping_end_offset()  const { return last_core_region()->mapping_end_offset(); }
 
-  char* mapped_base()    const { return first_core_space()->mapped_base(); }
-  char* mapped_end()     const { return last_core_space()->mapped_end();   }
+  char* mapped_base()    const { return first_core_region()->mapped_base(); }
+  char* mapped_end()     const { return last_core_region()->mapped_end();   }
 
   // Non-zero if the archive needs to be mapped a non-default location due to ASLR.
   intx relocation_delta() const {
     return header()->mapped_base_address() - header()->requested_base_address();
   }
 
-  FileMapRegion* first_core_space() const;
-  FileMapRegion* last_core_space() const;
+  FileMapRegion* first_core_region() const;
+  FileMapRegion* last_core_region() const;
 
   FileMapRegion* region_at(int i) const {
     return header()->region_at(i);

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -378,7 +378,7 @@ public:
   // Accessors
   int    compute_header_crc()  const { return header()->compute_crc(); }
   void   set_header_crc(int crc)     { header()->set_crc(crc); }
-  int    region_crc(int i)      const { return region_at(i)->crc(); }
+  int    region_crc(int i)     const { return region_at(i)->crc(); }
   void   populate_header(size_t core_region_alignment);
   bool   validate_header();
   void   invalidate();
@@ -527,7 +527,7 @@ public:
   char* region_addr(int idx);
 
   // The offset of the first core region in the archive, relative to SharedBaseAddress
-  size_t mapping_base_offset() const { return first_core_region()->mapping_offset(); }
+  size_t mapping_base_offset() const { return first_core_region()->mapping_offset();    }
   // The offset of the (exclusive) end of the last core region in this archive, relative to SharedBaseAddress
   size_t mapping_end_offset()  const { return last_core_region()->mapping_end_offset(); }
 
@@ -540,7 +540,7 @@ public:
   }
 
   FileMapRegion* first_core_region() const;
-  FileMapRegion* last_core_region() const;
+  FileMapRegion* last_core_region()  const;
 
   FileMapRegion* region_at(int i) const {
     return header()->region_at(i);

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -307,7 +307,7 @@ public:
   bool validate();
   int compute_crc();
 
-  FileMapRegion* space_at(int i) {
+  FileMapRegion* region_at(int i) {
     assert(is_valid_region(i), "invalid region");
     return FileMapRegion::cast(&_space[i]);
   }
@@ -378,7 +378,7 @@ public:
   // Accessors
   int    compute_header_crc()  const { return header()->compute_crc(); }
   void   set_header_crc(int crc)     { header()->set_crc(crc); }
-  int    space_crc(int i)      const { return space_at(i)->crc(); }
+  int    space_crc(int i)      const { return region_at(i)->crc(); }
   void   populate_header(size_t core_region_alignment);
   bool   validate_header();
   void   invalidate();
@@ -542,8 +542,8 @@ public:
   FileMapRegion* first_core_space() const;
   FileMapRegion* last_core_space() const;
 
-  FileMapRegion* space_at(int i) const {
-    return header()->space_at(i);
+  FileMapRegion* region_at(int i) const {
+    return header()->region_at(i);
   }
 
   void print(outputStream* st) {

--- a/src/hotspot/share/include/cds.h
+++ b/src/hotspot/share/include/cds.h
@@ -39,7 +39,7 @@
 #define CDS_ARCHIVE_MAGIC 0xf00baba2
 #define CDS_DYNAMIC_ARCHIVE_MAGIC 0xf00baba8
 #define CDS_GENERIC_HEADER_SUPPORTED_MIN_VERSION 13
-#define CURRENT_CDS_ARCHIVE_VERSION 15
+#define CURRENT_CDS_ARCHIVE_VERSION 16
 
 typedef struct CDSFileMapRegion {
   int     _crc;               // CRC checksum of this region.
@@ -96,7 +96,7 @@ typedef struct CDSFileMapHeaderBase {
   // We cannot inherit from GenericCDSFileMapHeader as this type may be used
   // by both C and C++ code.
   GenericCDSFileMapHeader _generic_header;
-  CDSFileMapRegion _space[NUM_CDS_REGIONS];
+  CDSFileMapRegion _regions[NUM_CDS_REGIONS];
 } CDSFileMapHeaderBase;
 
 #endif // SHARE_INCLUDE_CDS_H

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -1047,7 +1047,7 @@
                                                                                                                                      \
   CDS_ONLY(nonstatic_field(FileMapInfo,        _header,                   FileMapHeader*))                                           \
   CDS_ONLY(   static_field(FileMapInfo,        _current_info,             FileMapInfo*))                                             \
-  CDS_ONLY(nonstatic_field(FileMapHeader,      _regions[0],                 CDSFileMapRegion))                                         \
+  CDS_ONLY(nonstatic_field(FileMapHeader,      _regions[0],               CDSFileMapRegion))                                         \
   CDS_ONLY(nonstatic_field(FileMapHeader,      _cloned_vtables_offset,    size_t))                                                   \
   CDS_ONLY(nonstatic_field(FileMapHeader,      _mapped_base_address,      char*))                                                    \
   CDS_ONLY(nonstatic_field(CDSFileMapRegion,   _mapped_base,              char*))                                                    \

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -1047,7 +1047,7 @@
                                                                                                                                      \
   CDS_ONLY(nonstatic_field(FileMapInfo,        _header,                   FileMapHeader*))                                           \
   CDS_ONLY(   static_field(FileMapInfo,        _current_info,             FileMapInfo*))                                             \
-  CDS_ONLY(nonstatic_field(FileMapHeader,      _space[0],                 CDSFileMapRegion))                                         \
+  CDS_ONLY(nonstatic_field(FileMapHeader,      _regions[0],                 CDSFileMapRegion))                                         \
   CDS_ONLY(nonstatic_field(FileMapHeader,      _cloned_vtables_offset,    size_t))                                                   \
   CDS_ONLY(nonstatic_field(FileMapHeader,      _mapped_base_address,      char*))                                                    \
   CDS_ONLY(nonstatic_field(CDSFileMapRegion,   _mapped_base,              char*))                                                    \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/FileMapInfo.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/FileMapInfo.java
@@ -70,16 +70,16 @@ public class FileMapInfo {
     return field.getValue(instance);
   }
 
-  // C equivalent:   return &header->_space[index];
+  // C equivalent:   return &header->_regions[index];
   static Address get_CDSFileMapRegion(Type FileMapHeader_type, Address header, int index) {
-    AddressField spaceField = FileMapHeader_type.getAddressField("_space[0]");
+    AddressField regionsField = FileMapHeader_type.getAddressField("_regions[0]");
 
-    // size_t offset = offsetof(FileMapHeader, _space[0]);
-    // CDSFileMapRegion* space_0 = ((char*)header) + offset; // space_0 = &header->_space[index];
-    // return ((char*)space_0) + index * sizeof(CDSFileMapRegion);
-    long offset = spaceField.getOffset();
-    Address space_0 = header.addOffsetTo(offset);
-    return space_0.addOffsetTo(index * spaceField.getSize());
+    // size_t offset = offsetof(FileMapHeader, _regions[0]);
+    // CDSFileMapRegion* regions_0 = ((char*)header) + offset; // regions_0 = &header->_regions[index];
+    // return ((char*)regions_0) + index * sizeof(CDSFileMapRegion);
+    long offset = regionsField.getOffset();
+    Address regions_0 = header.addOffsetTo(offset);
+    return regions_0.addOffsetTo(index * regionsField.getSize());
   }
 
   private static void initialize(TypeDataBase db) {
@@ -100,13 +100,13 @@ public class FileMapInfo {
     long cloned_vtable_offset = get_CIntegerField(FileMapHeader_type, header, "_cloned_vtables_offset");
     vtablesIndex = mapped_base_address.addOffsetTo(cloned_vtable_offset);
 
-    // CDSFileMapRegion* rw_space = &header->_space[rw];
-    // char* rwRegionBaseAddress = rw_space->_mapped_base;
-    // size_t used = rw_space->_used;
+    // CDSFileMapRegion* rw_region = &header->_region[rw];
+    // char* rwRegionBaseAddress = rw_region->_mapped_base;
+    // size_t used = rw_region->_used;
     // char* rwRegionEndAddress = rwRegionBaseAddress + used;
-    Address rw_space = get_CDSFileMapRegion(FileMapHeader_type, header, 0);
-    rwRegionBaseAddress = get_AddressField(CDSFileMapRegion_type, rw_space, "_mapped_base");
-    long used = get_CIntegerField(CDSFileMapRegion_type, rw_space, "_used");
+    Address rw_region = get_CDSFileMapRegion(FileMapHeader_type, header, 0);
+    rwRegionBaseAddress = get_AddressField(CDSFileMapRegion_type, rw_region, "_mapped_base");
+    long used = get_CIntegerField(CDSFileMapRegion_type, rw_region, "_used");
     rwRegionEndAddress = rwRegionBaseAddress.addOffsetTo(used);
 
     populateMetadataTypeArray(db);

--- a/src/jdk.hotspot.agent/share/native/libsaproc/ps_core_common.c
+++ b/src/jdk.hotspot.agent/share/native/libsaproc/ps_core_common.c
@@ -386,17 +386,17 @@ bool init_classsharing_workaround(struct ps_prochandle* ph) {
       ph->core->classes_jsa_fd = fd;
       // add read-only maps from classes.jsa to the list of maps
       for (m = 0; m < NUM_CDS_REGIONS; m++) {
-        if (header._space[m]._read_only &&
-            !header._space[m]._is_heap_region &&
-            !header._space[m]._is_bitmap_region) {
+        if (header._regions[m]._read_only &&
+            !header._regions[m]._is_heap_region &&
+            !header._regions[m]._is_bitmap_region) {
           // With *some* linux versions, the core file doesn't include read-only mmap'ed
           // files regions, so let's add them here. This is harmless if the core file also
           // include these regions.
-          uintptr_t base = sharedBaseAddress + (uintptr_t) header._space[m]._mapping_offset;
-          size_t size = header._space[m]._used;
+          uintptr_t base = sharedBaseAddress + (uintptr_t) header._regions[m]._mapping_offset;
+          size_t size = header._regions[m]._used;
           // no need to worry about the fractional pages at-the-end.
           // possible fractional pages are handled by core_read_data.
-          add_class_share_map_info(ph, (off_t) header._space[m]._file_offset,
+          add_class_share_map_info(ph, (off_t) header._regions[m]._file_offset,
                                    base, size);
           print_debug("added a share archive map [%d] at 0x%lx (size 0x%lx bytes)\n", m, base, size);
         }


### PR DESCRIPTION
Most of the CDS code refers to a memory blocks inside a CDS file as "regions", represented by the type FileMapRegion. The method FileRegion* space_at() has been renamed to region_at() and all instances of its use have been replaced. Verified with tier 1-4 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296157](https://bugs.openjdk.org/browse/JDK-8296157): Rename FileMapInfo::space_at() to region_at()


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**) ⚠️ Review applies to [272861ed](https://git.openjdk.org/jdk/pull/10937/files/272861edb1ca3559c5dc4e515fbf81341df8add7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10937/head:pull/10937` \
`$ git checkout pull/10937`

Update a local copy of the PR: \
`$ git checkout pull/10937` \
`$ git pull https://git.openjdk.org/jdk pull/10937/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10937`

View PR using the GUI difftool: \
`$ git pr show -t 10937`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10937.diff">https://git.openjdk.org/jdk/pull/10937.diff</a>

</details>
