### PR TITLE
8296535: Unnecessary Vector usage in AquaFileSystemModel.FilesLoader

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaFileSystemModel.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaFileSystemModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -258,7 +258,7 @@ class AquaFileSystemModel extends AbstractTableModel implements PropertyChangeLi
     public void intervalRemoved(final ListDataEvent e) {
     }
 
-    protected void sort(final Vector<Object> v) {
+    protected void sort(ArrayList<Object> v) {
         if (fSortNames) sSortNames.quickSort(v, 0, v.size() - 1);
         else sSortDates.quickSort(v, 0, v.size() - 1);
     }
@@ -279,7 +279,7 @@ class AquaFileSystemModel extends AbstractTableModel implements PropertyChangeLi
     // @param lo0 left boundary of array partition
     // @param hi0 right boundary of array partition
     abstract static class QuickSort {
-        final void quickSort(final Vector<Object> v, final int lo0, final int hi0) {
+        final void quickSort(ArrayList<Object> v, final int lo0, final int hi0) {
             int lo = lo0;
             int hi = hi0;
             SortableFile mid;
@@ -287,7 +287,7 @@ class AquaFileSystemModel extends AbstractTableModel implements PropertyChangeLi
             if (hi0 > lo0) {
                 // Arbitrarily establishing partition element as the midpoint of
                 // the array.
-                mid = (SortableFile)v.elementAt((lo0 + hi0) / 2);
+                mid = (SortableFile)v.get((lo0 + hi0) / 2);
 
                 // loop through the array until indices cross
                 while (lo <= hi) {
@@ -296,13 +296,13 @@ class AquaFileSystemModel extends AbstractTableModel implements PropertyChangeLi
                     //
                     // Nasty to have to cast here. Would it be quicker
                     // to copy the vectors into arrays and sort the arrays?
-                    while ((lo < hi0) && lt((SortableFile)v.elementAt(lo), mid)) {
+                    while ((lo < hi0) && lt((SortableFile)v.get(lo), mid)) {
                         ++lo;
                     }
 
                     // find an element that is smaller than or equal to
                     // the partition element starting from the right Index.
-                    while ((hi > lo0) && lt(mid, (SortableFile)v.elementAt(hi))) {
+                    while ((hi > lo0) && lt(mid, (SortableFile)v.get(hi))) {
                         --hi;
                     }
 
@@ -329,10 +329,10 @@ class AquaFileSystemModel extends AbstractTableModel implements PropertyChangeLi
             }
         }
 
-        private void swap(final Vector<Object> a, final int i, final int j) {
-            final Object T = a.elementAt(i);
-            a.setElementAt(a.elementAt(j), i);
-            a.setElementAt(T, j);
+        private void swap(ArrayList<Object> a, final int i, final int j) {
+            final Object T = a.get(i);
+            a.set(i, a.get(j));
+            a.set(j, T);
         }
 
         protected abstract boolean lt(SortableFile a, SortableFile b);
@@ -398,17 +398,17 @@ class AquaFileSystemModel extends AbstractTableModel implements PropertyChangeLi
 
         @Override
         public void run() {
-            final Vector<DoChangeContents> runnables = new Vector<DoChangeContents>(10);
+            final ArrayList<DoChangeContents> runnables = new ArrayList<>(10);
             final FileSystemView fileSystem = filechooser.getFileSystemView();
 
             final File[] list = fileSystem.getFiles(currentDirectory, filechooser.isFileHidingEnabled());
 
-            final Vector<Object> acceptsList = new Vector<Object>();
+            final ArrayList<Object> acceptsList = new ArrayList<>();
 
             for (final File element : list) {
                 // Return all files to the file chooser. The UI will disable or enable
                 // the file name if the current filter approves.
-                acceptsList.addElement(new SortableFile(element));
+                acceptsList.add(new SortableFile(element));
             }
 
             // Sort based on settings.
@@ -421,11 +421,11 @@ class AquaFileSystemModel extends AbstractTableModel implements PropertyChangeLi
             for (int i = 0; i < listSize;) {
                 SortableFile f;
                 for (int j = 0; j < 10 && i < listSize; j++, i++) {
-                    f = (SortableFile)acceptsList.elementAt(i);
+                    f = (SortableFile)acceptsList.get(i);
                     chunk.addElement(f);
                 }
                 final DoChangeContents runnable = new DoChangeContents(chunk, fid);
-                runnables.addElement(runnable);
+                runnables.add(runnable);
                 SwingUtilities.invokeLater(runnable);
                 chunk = new Vector<SortableFile>(10);
                 if (loadThread.isInterrupted()) {
@@ -442,9 +442,9 @@ class AquaFileSystemModel extends AbstractTableModel implements PropertyChangeLi
             }
         }
 
-        public void cancelRunnables(final Vector<DoChangeContents> runnables) {
+        public void cancelRunnables(ArrayList<DoChangeContents> runnables) {
             for (int i = 0; i < runnables.size(); i++) {
-                runnables.elementAt(i).cancel();
+                runnables.get(i).cancel();
             }
         }
     }


### PR DESCRIPTION
Couple of local variables in `com.apple.laf.AquaFileSystemModel.FilesLoader#run` are used only within the method from single thread. So we can avoid usage of legacy synchronized `Vector` here and use `ArrayList` instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296535](https://bugs.openjdk.org/browse/JDK-8296535): Unnecessary Vector usage in AquaFileSystemModel.FilesLoader


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/10942/head:pull/10942` \
`$ git checkout pull/10942`

Update a local copy of the PR: \
`$ git checkout pull/10942` \
`$ git pull https://git.openjdk.org/jdk.git pull/10942/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10942`

View PR using the GUI difftool: \
`$ git pr show -t 10942`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10942.diff">https://git.openjdk.org/jdk/pull/10942.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/10942#issuecomment-1307186027)