### PR TITLE
8293166: jdk/jfr/jvm/TestDumpOnCrash.java fails on Linux ppc64le and Linux aarch64

### DIFF
--- a/test/jdk/jdk/jfr/jvm/TestDumpOnCrash.java
+++ b/test/jdk/jdk/jfr/jvm/TestDumpOnCrash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/jfr/jvm/TestDumpOnCrash.java
+++ b/test/jdk/jdk/jfr/jvm/TestDumpOnCrash.java
@@ -123,6 +123,7 @@ public class TestDumpOnCrash {
         List<String> options = new ArrayList<>();
         options.add("-Xmx64m");
         options.add("-XX:-CreateCoredumpOnCrash");
+        options.add("-XX:-TieredCompilation"); // Avoid secondary crashes (see JDK-8293166)
         options.add("--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED");
         options.add("-XX:StartFlightRecording:dumponexit=true,disk=" + Boolean.toString(disk));
         if (dumppath != null) {


### PR DESCRIPTION
Disabling tiered compilation avoids the sporadic failures of the test.

On ppc64 and aarch64 a trap-based mechanism is used to switch from tier 1 to higher tiers. In the test a crash is provoked and a secondary error handler is installed at the start of error reporting, which doesn't handle these traps anymore and just stops the thread. But since the thread state is 'in Java', this prevents any safepoint to be executed. And this causes the JFR emergency dump to hang in a native to VM transition, so the dump is not written and the test fails (see the  bug report for more details).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293166](https://bugs.openjdk.org/browse/JDK-8293166): jdk/jfr/jvm/TestDumpOnCrash.java fails on Linux ppc64le and Linux aarch64


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**) ⚠️ Review applies to [3cb5dd1b](https://git.openjdk.org/jdk/pull/10943/files/3cb5dd1b429cd0c5d6070321f73e30efbaa698ae)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10943/head:pull/10943` \
`$ git checkout pull/10943`

Update a local copy of the PR: \
`$ git checkout pull/10943` \
`$ git pull https://git.openjdk.org/jdk pull/10943/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10943`

View PR using the GUI difftool: \
`$ git pr show -t 10943`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10943.diff">https://git.openjdk.org/jdk/pull/10943.diff</a>

</details>
