### PR TITLE
8294816: C2: Math.min/max vectorization miscompilation

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2093,6 +2093,12 @@ bool SuperWord::implemented(Node_List* p) {
       }
     } else if (VectorNode::is_convert_opcode(opc)) {
       retValue = VectorCastNode::implemented(opc, size, velt_basic_type(p0->in(1)), velt_basic_type(p0));
+    } else if (VectorNode::is_minmax_opcode(opc) && is_subword_type(velt_basic_type(p0))) {
+      // Java API for Math.min/max operations supports only int, long, float
+      // and double types. Thus, avoid generating vector min/max nodes for
+      // integer subword types with superword vectorization.
+      // See JDK-8294816 for miscompilation issues with shorts.
+      return false;
     } else {
       // Vector unsigned right shift for signed subword types behaves differently
       // from Java Spec. But when the shift amount is a constant not greater than

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -476,6 +476,10 @@ bool VectorNode::is_convert_opcode(int opc) {
   }
 }
 
+bool VectorNode::is_minmax_opcode(int opc) {
+  return opc == Op_MinI || opc == Op_MaxI;
+}
+
 bool VectorNode::is_shift(Node* n) {
   return is_shift_opcode(n->Opcode());
 }

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -84,6 +84,7 @@ class VectorNode : public TypeNode {
   static bool is_shift_opcode(int opc);
   static bool can_transform_shift_op(Node* n, BasicType bt);
   static bool is_convert_opcode(int opc);
+  static bool is_minmax_opcode(int opc);
 
   static bool is_vshift_cnt_opcode(int opc);
 

--- a/test/hotspot/jtreg/compiler/c2/TestMinMaxSubword.java
+++ b/test/hotspot/jtreg/compiler/c2/TestMinMaxSubword.java
@@ -61,7 +61,7 @@ public class TestMinMaxSubword {
     // as Java APIs for Math.min/max do not support integer subword types and superword
     // should not generate vectorized Min/Max nodes for them.
     @Test
-    @IR(failOn = {IRNode.Min_V})
+    @IR(failOn = {IRNode.MIN_V})
     public static void testMinShort() {
         for (int i = 0; i < LENGTH; i++) {
            sb[i] = (short) Math.min(sa[i], val);
@@ -77,7 +77,7 @@ public class TestMinMaxSubword {
     }
 
     @Test
-    @IR(failOn = {IRNode.Max_V})
+    @IR(failOn = {IRNode.MAX_V})
     public static void testMaxShort() {
         for (int i = 0; i < LENGTH; i++) {
             sb[i] = (short) Math.max(sa[i], val);
@@ -92,7 +92,7 @@ public class TestMinMaxSubword {
     }
 
     @Test
-    @IR(failOn = {IRNode.Min_V})
+    @IR(failOn = {IRNode.MIN_V})
     public static void testMinByte() {
         for (int i = 0; i < LENGTH; i++) {
            bb[i] = (byte) Math.min(ba[i], val);
@@ -108,7 +108,7 @@ public class TestMinMaxSubword {
     }
 
     @Test
-    @IR(failOn = {IRNode.Max_V})
+    @IR(failOn = {IRNode.MAX_V})
     public static void testMaxByte() {
         for (int i = 0; i < LENGTH; i++) {
             bb[i] = (byte) Math.max(ba[i], val);

--- a/test/hotspot/jtreg/compiler/c2/TestMinMaxSubword.java
+++ b/test/hotspot/jtreg/compiler/c2/TestMinMaxSubword.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2;
+
+import compiler.lib.ir_framework.*;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
+import java.util.Random;
+
+/*
+ * @test
+ * @bug 8294816
+ * @summary Test Math.min/max vectorization miscompilation for integer subwords
+ * @library /test/lib /
+ * @requires vm.compiler2.enabled
+ * @run driver compiler.c2.TestMinMaxSubword
+ */
+
+public class TestMinMaxSubword {
+    private static final int LENGTH = 256;
+    private static final Random RANDOM = Utils.getRandomInstance();
+    private static int val = 65536;
+    private static short[] sa;
+    private static short[] sb;
+    private static byte[] ba;
+    private static byte[] bb;
+
+    static {
+        sa = new short[LENGTH];
+        sb = new short[LENGTH];
+        ba = new byte[LENGTH];
+        bb = new byte[LENGTH];
+        for(int i = 0; i < LENGTH; i++) {
+            sa[i] = (short) (RANDOM.nextInt(999) + 1);
+            ba[i] = (byte) (RANDOM.nextInt(99) + 1);
+        }
+    }
+
+    // Ensure vector max/min instructions are not generated for integer subword types
+    // as Java APIs for Math.min/max do not support integer subword types and superword
+    // should not generate vectorized Min/Max nodes for them.
+    @Test
+    @IR(failOn = {IRNode.Min_V})
+    public static void testMinShort() {
+        for (int i = 0; i < LENGTH; i++) {
+           sb[i] = (short) Math.min(sa[i], val);
+        }
+    }
+
+    @Run(test = "testMinShort")
+    public static void testMinShort_runner() {
+        testMinShort();
+        for (int i = 0; i < LENGTH; i++) {
+            Asserts.assertEquals(sb[i], sa[i]);
+        }
+    }
+
+    @Test
+    @IR(failOn = {IRNode.Max_V})
+    public static void testMaxShort() {
+        for (int i = 0; i < LENGTH; i++) {
+            sb[i] = (short) Math.max(sa[i], val);
+        }
+    }
+    @Run(test = "testMaxShort")
+    public static void testMaxShort_runner() {
+        testMaxShort();
+        for (int i = 0; i < LENGTH; i++) {
+            Asserts.assertEquals(sb[i], (short) 0);
+        }
+    }
+
+    @Test
+    @IR(failOn = {IRNode.Min_V})
+    public static void testMinByte() {
+        for (int i = 0; i < LENGTH; i++) {
+           bb[i] = (byte) Math.min(ba[i], val);
+        }
+    }
+
+    @Run(test = "testMinByte")
+    public static void testMinByte_runner() {
+        testMinByte();
+        for (int i = 0; i < LENGTH; i++) {
+            Asserts.assertEquals(bb[i], ba[i]);
+        }
+    }
+
+    @Test
+    @IR(failOn = {IRNode.Max_V})
+    public static void testMaxByte() {
+        for (int i = 0; i < LENGTH; i++) {
+            bb[i] = (byte) Math.max(ba[i], val);
+        }
+    }
+    @Run(test = "testMaxByte")
+    public static void testMaxByte_runner() {
+        testMaxByte();
+        for (int i = 0; i < LENGTH; i++) {
+            Asserts.assertEquals(bb[i], (byte) 0);
+        }
+    }
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+}


### PR DESCRIPTION
C2 miscompiles during auto-vectorization of MinI/MaxI nodes when "short" type operands are involved. When a short and an integer value is compared, C2 generates vector min/max nodes for "short" types which does not result in correct output as it disregards the higher order bits of the integer input. Java API for Math.min/max also only supports the int, long, float and double types but not the subword integer types namely - char, byte and short. Hence, char/short/byte min/max vector instructions should not be generated.
This patch ensures that MaxV and MinV vector nodes are only generated for the "int" type for MaxI and MinI nodes during auto-vectorization.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294816](https://bugs.openjdk.org/browse/JDK-8294816): C2: Math.min/max vectorization miscompilation


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Nick Gasson](https://openjdk.org/census#ngasson) (@nick-arm - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10944/head:pull/10944` \
`$ git checkout pull/10944`

Update a local copy of the PR: \
`$ git checkout pull/10944` \
`$ git pull https://git.openjdk.org/jdk pull/10944/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10944`

View PR using the GUI difftool: \
`$ git pr show -t 10944`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10944.diff">https://git.openjdk.org/jdk/pull/10944.diff</a>

</details>
