### PR TITLE
JDK-8292427: Improve specification of InflaterInputStream.fill()

### DIFF
--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -251,6 +251,7 @@ public class InflaterInputStream extends FilterInputStream {
 
     /**
      * Fills input buffer with more data to decompress.
+     * @implSpec
      * This method will read up to {@link #buf}.length bytes into the input
      * buffer, {@link #buf}, starting at element {@code 0}. The {@link #len}
      * field will be set to the number of bytes read.

--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -251,11 +251,12 @@ public class InflaterInputStream extends FilterInputStream {
 
     /**
      * Fills input buffer with more data to decompress.
+     * This method will read up to {@link #buf}.length bytes into the input
+     * buffer, {@link #buf}, starting at element {@code 0}. The {@link #len}
+     * field will be set to the number of bytes read.
      * @throws    IOException if an I/O error has occurred
      * @throws    EOFException if the end of input stream has been reached
      *            unexpectedly
-     * @apiNote
-     * The {@link #len} field will be updated when this method is invoked.
      */
     protected void fill() throws IOException {
         ensureOpen();

--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -252,6 +252,10 @@ public class InflaterInputStream extends FilterInputStream {
     /**
      * Fills input buffer with more data to decompress.
      * @throws    IOException if an I/O error has occurred
+     * @throws    EOFException if the end of input stream has been reached
+     *            unexpectedly
+     * @apiNote
+     * The {@link #len} field will be updated when this method is invoked.
      */
     protected void fill() throws IOException {
         ensureOpen();

--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -52,7 +52,7 @@ public class InflaterInputStream extends FilterInputStream {
     protected byte[] buf;
 
     /**
-     * Length of input buffer.
+     * The total number of bytes read into the buffer.
      */
     protected int len;
 

--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -52,7 +52,7 @@ public class InflaterInputStream extends FilterInputStream {
     protected byte[] buf;
 
     /**
-     * The total number of bytes read into the buffer.
+     * The total number of bytes read into the input buffer.
      */
     protected int len;
 


### PR DESCRIPTION
Hi all,

This PR will update the javadoc to clarify the existing behavior of InflaterInputStream::fill as it currently omits the possibility that a EOFException may be thrown and that the protected `len` field is also updated by this method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8292427](https://bugs.openjdk.org/browse/JDK-8292427): Improve specification of InflaterInputStream.fill()
 * [JDK-8296223](https://bugs.openjdk.org/browse/JDK-8296223): Improve specification of InflaterInputStream.fill() (**CSR**)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10945/head:pull/10945` \
`$ git checkout pull/10945`

Update a local copy of the PR: \
`$ git checkout pull/10945` \
`$ git pull https://git.openjdk.org/jdk pull/10945/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10945`

View PR using the GUI difftool: \
`$ git pr show -t 10945`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10945.diff">https://git.openjdk.org/jdk/pull/10945.diff</a>

</details>
