### PR TITLE
8296231: Fix MEMFLAGS for CHeapBitMaps

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -58,7 +58,7 @@ ArchiveBuilder::OtherROAllocMark::~OtherROAllocMark() {
   ArchiveBuilder::alloc_stats()->record_other_type(int(newtop - _oldtop), true);
 }
 
-ArchiveBuilder::SourceObjList::SourceObjList() : _ptrmap(16 * K) {
+ArchiveBuilder::SourceObjList::SourceObjList() : _ptrmap(16 * K, mtClassShared) {
   _total_bytes = 0;
   _objs = new (ResourceObj::C_HEAP, mtClassShared) GrowableArray<SourceObjInfo*>(128 * K, mtClassShared);
 }
@@ -155,6 +155,7 @@ ArchiveBuilder::ArchiveBuilder() :
   _buffer_to_requested_delta(0),
   _rw_region("rw", MAX_SHARED_DELTA),
   _ro_region("ro", MAX_SHARED_DELTA),
+  _ptrmap(mtClassShared),
   _rw_src_objs(),
   _ro_src_objs(),
   _src_obj_table(INITIAL_TABLE_SIZE, MAX_TABLE_SIZE),

--- a/src/hotspot/share/gc/g1/g1YoungGCEvacFailureInjector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCEvacFailureInjector.cpp
@@ -50,6 +50,11 @@ public:
   }
 };
 
+G1YoungGCEvacFailureInjector::G1YoungGCEvacFailureInjector()
+  : _inject_evacuation_failure_for_current_gc(),
+    _last_collection_with_evacuation_failure(),
+    _evac_failure_regions(mtGC) {}
+
 void G1YoungGCEvacFailureInjector::select_evac_failure_regions() {
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
   _evac_failure_regions.reinitialize(g1h->max_reserved_regions());

--- a/src/hotspot/share/gc/g1/g1YoungGCEvacFailureInjector.hpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCEvacFailureInjector.hpp
@@ -69,6 +69,8 @@ class G1YoungGCEvacFailureInjector {
   void select_evac_failure_regions() EVAC_FAILURE_INJECTOR_RETURN;
 public:
 
+  G1YoungGCEvacFailureInjector() EVAC_FAILURE_INJECTOR_RETURN;
+
   // Arm the evacuation failure injector if needed for the current
   // GC (based upon the type of GC and which command line flags are set);
   void arm_if_needed() EVAC_FAILURE_INJECTOR_RETURN;

--- a/src/hotspot/share/memory/metaspace/commitMask.cpp
+++ b/src/hotspot/share/memory/metaspace/commitMask.cpp
@@ -34,7 +34,7 @@
 namespace metaspace {
 
 CommitMask::CommitMask(const MetaWord* start, size_t word_size) :
-  CHeapBitMap(mask_size(word_size, Settings::commit_granule_words())),
+  CHeapBitMap(mask_size(word_size, Settings::commit_granule_words()), mtMetaspace, true),
   _base(start),
   _word_size(word_size),
   _words_per_bit(Settings::commit_granule_words())

--- a/test/hotspot/gtest/utilities/test_bitMap.cpp
+++ b/test/hotspot/gtest/utilities/test_bitMap.cpp
@@ -113,24 +113,29 @@ class BitMapTest {
 #endif
 };
 
+class TestCHeapBitMap : public CHeapBitMap {
+public:
+  TestCHeapBitMap(size_t size = 0) : CHeapBitMap(size, mtTest) {}
+};
+
 TEST_VM(BitMap, resize_grow) {
   BitMapTest::testResizeGrow<ResourceBitMap>();
   EXPECT_FALSE(HasFailure()) << "Failed on type ResourceBitMap";
-  BitMapTest::testResizeGrow<CHeapBitMap>();
+  BitMapTest::testResizeGrow<TestCHeapBitMap>();
   EXPECT_FALSE(HasFailure()) << "Failed on type CHeapBitMap";
 }
 
 TEST_VM(BitMap, resize_shrink) {
   BitMapTest::testResizeShrink<ResourceBitMap>();
   EXPECT_FALSE(HasFailure()) << "Failed on type ResourceBitMap";
-  BitMapTest::testResizeShrink<CHeapBitMap>();
+  BitMapTest::testResizeShrink<TestCHeapBitMap>();
   EXPECT_FALSE(HasFailure()) << "Failed on type CHeapBitMap";
 }
 
 TEST_VM(BitMap, resize_same) {
   BitMapTest::testResizeSame<ResourceBitMap>();
   EXPECT_FALSE(HasFailure()) << "Failed on type ResourceBitMap";
-  BitMapTest::testResizeSame<CHeapBitMap>();
+  BitMapTest::testResizeSame<TestCHeapBitMap>();
   EXPECT_FALSE(HasFailure()) << "Failed on type CHeapBitMap";
 }
 
@@ -155,7 +160,7 @@ TEST_VM(BitMap, resize_grow_clear) {
 TEST_VM(BitMap, initialize) {
   BitMapTest::testInitialize<ResourceBitMap>();
   EXPECT_FALSE(HasFailure()) << "Failed on type ResourceBitMap";
-  BitMapTest::testInitialize<CHeapBitMap>();
+  BitMapTest::testInitialize<TestCHeapBitMap>();
   EXPECT_FALSE(HasFailure()) << "Failed on type CHeapBitMap";
 }
 

--- a/test/hotspot/gtest/utilities/test_bitMap_large.cpp
+++ b/test/hotspot/gtest/utilities/test_bitMap_large.cpp
@@ -46,7 +46,7 @@ static void verify_unset(CHeapBitMap& map, BitMap::idx_t l, BitMap::idx_t r) {
 }
 
 TEST(BitMap, clear_large_range) {
-  CHeapBitMap map(BITMAP_SIZE);
+  CHeapBitMap map(BITMAP_SIZE, mtTest);
 
   map.set_range(0, BITMAP_SIZE);
   verify_set(map, 0, BITMAP_SIZE);
@@ -70,7 +70,7 @@ TEST(BitMap, clear_large_range) {
 }
 
 TEST(BitMap, set_large_range) {
-  CHeapBitMap map(BITMAP_SIZE);
+  CHeapBitMap map(BITMAP_SIZE, mtTest);
 
   map.clear();
   verify_unset(map, 0, BITMAP_SIZE);
@@ -94,7 +94,7 @@ TEST(BitMap, set_large_range) {
 }
 
 TEST(BitMap, par_at_put_large_range) {
-  CHeapBitMap map(BITMAP_SIZE);
+  CHeapBitMap map(BITMAP_SIZE, mtTest);
 
   map.clear();
   verify_unset(map, 0, BITMAP_SIZE);

--- a/test/hotspot/gtest/utilities/test_bitMap_popcnt.cpp
+++ b/test/hotspot/gtest/utilities/test_bitMap_popcnt.cpp
@@ -102,7 +102,7 @@ static void set_or_clear_random_range(BitMap& bm, SimpleFakeBitmap& fbm, int beg
 }
 
 static void test_bitmap_popcnt(int bitsize) {
-  CHeapBitMap bm(bitsize);
+  CHeapBitMap bm(bitsize, mtTest);
   SimpleFakeBitmap fbm(bitsize);
 
   ASSERT_POPCNT_ALL(bm, 0);
@@ -148,7 +148,7 @@ TEST_VM(BitMap, popcnt_300) { test_bitmap_popcnt(300); }
 
 TEST_VM(BitMap, popcnt_large) {
 
-  CHeapBitMap bm(64 * K);
+  CHeapBitMap bm(64 * K, mtTest);
 
   ASSERT_POPCNT_ALL(bm, 0);
   ASSERT_POPCNT_RANGE(bm, 0, 64 * K, 0);
@@ -169,4 +169,3 @@ TEST_VM(BitMap, popcnt_large) {
   ASSERT_POPCNT_RANGE(bm, 199, 299, 100);
 
 }
-

--- a/test/hotspot/gtest/utilities/test_bitMap_search.cpp
+++ b/test/hotspot/gtest/utilities/test_bitMap_search.cpp
@@ -195,8 +195,8 @@ static void test_search_ranges(BitMap& test_ones,
 }
 
 TEST(BitMap, search) {
-  CHeapBitMap test_ones(BITMAP_SIZE);
-  CHeapBitMap test_zeros(BITMAP_SIZE);
+  CHeapBitMap test_ones(BITMAP_SIZE, mtTest);
+  CHeapBitMap test_zeros(BITMAP_SIZE, mtTest);
 
   // test_ones is used to test searching for 1s in a region of 0s.
   // test_zeros is used to test searching for 0s in a region of 1s.


### PR DESCRIPTION
Some usages of CHeapBitMaps rely on the default value of the MEMFLAGS argument (mtInternal). This is undesirable, and should be fixed.

I'd prefer to remove the default value, but there is currently a PR touching the BitMap classes, so I'd like to limit this Bug to only fixing the incorrect usage of mtInternal.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296231](https://bugs.openjdk.org/browse/JDK-8296231): Fix MEMFLAGS for CHeapBitMaps


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10948/head:pull/10948` \
`$ git checkout pull/10948`

Update a local copy of the PR: \
`$ git checkout pull/10948` \
`$ git pull https://git.openjdk.org/jdk pull/10948/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10948`

View PR using the GUI difftool: \
`$ git pr show -t 10948`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10948.diff">https://git.openjdk.org/jdk/pull/10948.diff</a>

</details>
