### PR TITLE
8296224: G1: Remove unnecessary update in VM_G1CollectForAllocation

### DIFF
--- a/src/hotspot/share/gc/g1/g1VMOperations.cpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.cpp
@@ -121,9 +121,7 @@ VM_G1CollectForAllocation::VM_G1CollectForAllocation(size_t         word_size,
                                                      uint           gc_count_before,
                                                      GCCause::Cause gc_cause) :
   VM_CollectForAllocation(word_size, gc_count_before, gc_cause),
-  _gc_succeeded(false) {
-  _gc_cause = gc_cause;
-}
+  _gc_succeeded(false) {}
 
 bool VM_G1CollectForAllocation::should_try_allocation_before_gc() {
   // Don't allocate before a preventive GC.

--- a/src/hotspot/share/gc/shared/gcVMOperations.hpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.hpp
@@ -121,7 +121,6 @@ class VM_GC_Operation: public VM_GC_Sync_Operation {
     _prologue_succeeded = false;
     _gc_count_before    = gc_count_before;
 
-    // A subclass constructor will likely overwrite the following
     _gc_cause           = _cause;
 
     _gc_locked = false;


### PR DESCRIPTION
Simple change of removing an unnecessary assignment.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296224](https://bugs.openjdk.org/browse/JDK-8296224): G1: Remove unnecessary update in VM_G1CollectForAllocation


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10949/head:pull/10949` \
`$ git checkout pull/10949`

Update a local copy of the PR: \
`$ git checkout pull/10949` \
`$ git pull https://git.openjdk.org/jdk pull/10949/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10949`

View PR using the GUI difftool: \
`$ git pr show -t 10949`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10949.diff">https://git.openjdk.org/jdk/pull/10949.diff</a>

</details>
