### PR TITLE
JDK-8296235: IGV: Change shortcut to delete graph from ctrl+del to del

### DIFF
--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/resources/com/sun/hotspot/igv/coordinator/layer.xml
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/resources/com/sun/hotspot/igv/coordinator/layer.xml
@@ -14,7 +14,7 @@
         <file name="D-BACK_SPACE.shadow">
             <attr name="originalFile" stringvalue="Actions/File/com-sun-hotspot-igv-coordinator-actions-RemoveAction.instance"/>
         </file>
-        <file name="D-DELETE.shadow">
+        <file name="DELETE.shadow">
             <attr name="originalFile" stringvalue="Actions/File/com-sun-hotspot-igv-coordinator-actions-RemoveAction.instance"/>
         </file>
         <file name="DS-W.shadow">


### PR DESCRIPTION
Change the current shortcut to delete a graph from `ctrl`+`delete` to `delete` only (dropping ctrl).

For keyboards without the `delete` key (like Mac) the alternative shortcut `ctrl`+`backspace` is unchanged

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296235](https://bugs.openjdk.org/browse/JDK-8296235): IGV: Change shortcut to delete graph from ctrl+del to del


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10950/head:pull/10950` \
`$ git checkout pull/10950`

Update a local copy of the PR: \
`$ git checkout pull/10950` \
`$ git pull https://git.openjdk.org/jdk pull/10950/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10950`

View PR using the GUI difftool: \
`$ git pr show -t 10950`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10950.diff">https://git.openjdk.org/jdk/pull/10950.diff</a>

</details>
