### PR TITLE
8283101: serviceability/jvmti/thread/GetFrameCount/framecnt01/framecnt01.java failing #VirtualThread-Frozen: number of frames expected: 14, got: 9

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetFrameCount/framecnt01/framecnt01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetFrameCount/framecnt01/framecnt01.java
@@ -74,7 +74,9 @@ public class framecnt01 {
             Thread.sleep(1);
         }
         // Let vthread1 to park
-        Thread.sleep(100);
+        while(vThread1.getState() != Thread.State.WAITING) {
+            Thread.sleep(1);
+        }
 
         // this is too fragile, implementation can change at any time.
         checkFrames(vThread1, false, 14);
@@ -95,7 +97,10 @@ public class framecnt01 {
         while (!pThread1Started) {
             Thread.sleep(1);
         }
-        Thread.sleep(10);
+
+        while(pThread1.getState() != Thread.State.WAITING) {
+            Thread.sleep(1);
+        }
         checkFrames(pThread1, false, 5);
         LockSupport.unpark(pThread1);
         pThread1.join();


### PR DESCRIPTION
…t01.java failing #VirtualThread-Frozen: number of frames expected: 14, got: 9

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283101](https://bugs.openjdk.org/browse/JDK-8283101): serviceability/jvmti/thread/GetFrameCount/framecnt01/framecnt01.java failing #VirtualThread-Frozen: number of frames expected: 14, got: 9


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10951/head:pull/10951` \
`$ git checkout pull/10951`

Update a local copy of the PR: \
`$ git checkout pull/10951` \
`$ git pull https://git.openjdk.org/jdk pull/10951/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10951`

View PR using the GUI difftool: \
`$ git pr show -t 10951`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10951.diff">https://git.openjdk.org/jdk/pull/10951.diff</a>

</details>
