### PR TITLE
8296190: TestMD5Intrinsics and TestMD5MultiBlockIntrinsics don't test the intrinsics

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/DigestSanityTestBase.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/DigestSanityTestBase.java
@@ -54,7 +54,7 @@ public class DigestSanityTestBase {
     private static final int MSG_SIZE = 1024;
     private static final int OFFSET = 0;
     private static final int ITERATIONS = 10000;
-    private static final int WARMUP_ITERATIONS = 1;
+    private static final int WARMUP_ITERATIONS = 550;
     private static final String PROVIDER = "SUN";
 
     private final BooleanSupplier predicate;

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/DigestSanityTestBase.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/DigestSanityTestBase.java
@@ -54,7 +54,7 @@ public class DigestSanityTestBase {
     private static final int MSG_SIZE = 1024;
     private static final int OFFSET = 0;
     private static final int ITERATIONS = 10000;
-    private static final int WARMUP_ITERATIONS = 550;
+    private static final int WARMUP_ITERATIONS = WHITE_BOX.getIntxVMFlag("Tier4InvocationThreshold").intValue() + 50;
     private static final String PROVIDER = "SUN";
 
     private final BooleanSupplier predicate;


### PR DESCRIPTION
Increase WARMUP_ITERATIONS to get MD5 hash from the intrinsic.

Both TestMD5Intrinsics and TestMD5MultiBlockIntrinsics are run with options "-XX:CompileThreshold=500 -XX:Tier4InvocationThreshold=500", so the current value is too low for the intrinsic to be executed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296190](https://bugs.openjdk.org/browse/JDK-8296190): TestMD5Intrinsics and TestMD5MultiBlockIntrinsics don't test the intrinsics


### Reviewers
 * [Evgeny Astigeevich](https://openjdk.org/census#eastigeevich) (@eastig - Committer)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10954/head:pull/10954` \
`$ git checkout pull/10954`

Update a local copy of the PR: \
`$ git checkout pull/10954` \
`$ git pull https://git.openjdk.org/jdk pull/10954/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10954`

View PR using the GUI difftool: \
`$ git pr show -t 10954`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10954.diff">https://git.openjdk.org/jdk/pull/10954.diff</a>

</details>
