### PR TITLE
fix: Make the PCSCException public accessible

### DIFF
--- a/src/java.smartcardio/share/classes/sun/security/smartcardio/PCSCException.java
+++ b/src/java.smartcardio/share/classes/sun/security/smartcardio/PCSCException.java
@@ -35,7 +35,7 @@ import static sun.security.smartcardio.PCSC.*;
  * @since   1.6
  * @author  Andreas Sterbenz
  */
-final class PCSCException extends Exception {
+final public class PCSCException extends Exception {
 
     private static final long serialVersionUID = 4181137171979130432L;
 


### PR DESCRIPTION
The `PCSCException` is thrown, but the error type is not visible due to the "private-packe" access rule. 
 By changing the visibility it is possible to handle / access this exception type explicitly in the catch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10955/head:pull/10955` \
`$ git checkout pull/10955`

Update a local copy of the PR: \
`$ git checkout pull/10955` \
`$ git pull https://git.openjdk.org/jdk pull/10955/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10955`

View PR using the GUI difftool: \
`$ git pr show -t 10955`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10955.diff">https://git.openjdk.org/jdk/pull/10955.diff</a>

</details>
