### PR TITLE
JDK-8296188: Update style and header in JDWP Protocol spec and JVMTI spec

### DIFF
--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -595,7 +595,7 @@ ifeq ($(ENABLE_PANDOC), true)
   GLOBAL_SPECS_DEFAULT_CSS_FILE := $(DOCS_OUTPUTDIR)/resources/jdk-default.css
   # Unset the following to suppress the link to the tool guides
   NAV_LINK_GUIDES := --nav-link-guides
-  HEADER_RIGHT_SIDE_INFO := '<strong>$(subst &amp;,&,$(JDK_SHORT_NAME))$(DRAFT_MARKER_STR)</strong>'
+  HEADER_RIGHT_SIDE_INFO := <strong>$(subst &amp;,&,$(JDK_SHORT_NAME))$(DRAFT_MARKER_STR)</strong>
 
   $(foreach m, $(ALL_MODULES), \
     $(eval SPECS_$m := $(call FindModuleSpecsDirs, $m)) \
@@ -612,7 +612,7 @@ ifeq ($(ENABLE_PANDOC), true)
             REPLACEMENTS := \
 		@@VERSION_SPECIFICATION@@ => $(VERSION_SPECIFICATION) ; \
 		@@VERSION_STRING@@ => $(VERSION_STRING), \
-            POST_PROCESS := $(TOOL_FIXUPPANDOC) --insert-nav --nav-right-info $(HEADER_RIGHT_SIDE_INFO) \
+            POST_PROCESS := $(TOOL_FIXUPPANDOC) --insert-nav --nav-right-info '$(HEADER_RIGHT_SIDE_INFO)' \
                 --nav-subdirs $($m_$f_NOF_SUBDIRS) $(NAV_LINK_GUIDES), \
         )) \
         $(eval JDK_SPECS_TARGETS += $($($m_$f_NAME))) \
@@ -647,7 +647,7 @@ ifeq ($(ENABLE_PANDOC), true)
 		@@VERSION_SHORT@@ => $(VERSION_SHORT) ; \
 		@@VERSION_SPECIFICATION@@ => $(VERSION_SPECIFICATION), \
             OPTIONS := --toc -V include-before='$(SPECS_TOP)' -V include-after='$(SPECS_BOTTOM_1)', \
-            POST_PROCESS := $(TOOL_FIXUPPANDOC) --insert-nav --nav-right-info $(HEADER_RIGHT_SIDE_INFO) \
+            POST_PROCESS := $(TOOL_FIXUPPANDOC) --insert-nav --nav-right-info '$(HEADER_RIGHT_SIDE_INFO)' \
                 --nav-subdirs 1 --nav-link-guides, \
             EXTRA_DEPS := $(PANDOC_HTML_MANPAGE_FILTER) \
                 $(PANDOC_HTML_MANPAGE_FILTER_SOURCE), \
@@ -663,13 +663,25 @@ endif
 
 # Special treatment for generated documentation
 
+SPEC_HEADER_BLOCK := \
+<header id="title-block-header"> \
+    <div class="navbar"> \
+        <div>$(HEADER_RIGHT_SIDE_INFO)</div> \
+        <nav><ul><li><a href="PATH_TO_SPECS/../api/index.html">API</a> \
+        <li><a href="PATH_TO_SPECS/index.html">OTHER SPECIFICATIONS \
+        <li><a href="PATH_TO_SPECS/man/index.html">TOOL GUIDES</a></ul></nav> \
+    </div> \
+</header>
+
 JDWP_PROTOCOL := $(SUPPORT_OUTPUTDIR)/gensrc/jdk.jdi/jdwp-protocol.html
 ifneq ($(call ApplySpecFilter, $(JDWP_PROTOCOL)), )
+  JDWP_HEADER_BLOCK := $(subst PATH_TO_SPECS,..,$(SPEC_HEADER_BLOCK))
   $(eval $(call SetupTextFileProcessing, PROCESS_JDWP_PROTOCOL, \
       SOURCE_FILES := $(JDWP_PROTOCOL), \
       OUTPUT_DIR := $(DOCS_OUTPUTDIR)/specs/jdwp, \
       REPLACEMENTS := \
-          <body> => <body>$(SPECS_TOP) ; \
+          <style> => <link rel="stylesheet" href="../../resources/jdk-default.css"/><style> ; \
+          <body> => <body>$(SPECS_TOP)$(JDWP_HEADER_BLOCK) ; \
           </body> => $(SPECS_BOTTOM_1)</body>, \
   ))
   JDK_SPECS_TARGETS += $(PROCESS_JDWP_PROTOCOL)
@@ -678,11 +690,13 @@ endif
 # Get jvmti.html from the main jvm variant (all variants' jvmti.html are identical).
 JVMTI_HTML ?= $(HOTSPOT_OUTPUTDIR)/variant-$(JVM_VARIANT_MAIN)/gensrc/jvmtifiles/jvmti.html
 ifneq ($(call ApplySpecFilter, $(JVMTI_HTML)), )
+  JVMTI_HEADER_BLOCK := $(subst PATH_TO_SPECS,.,$(SPEC_HEADER_BLOCK))
   $(eval $(call SetupTextFileProcessing, PROCESS_JVMTI_HTML, \
       SOURCE_FILES := $(JVMTI_HTML), \
       OUTPUT_DIR := $(DOCS_OUTPUTDIR)/specs/, \
       REPLACEMENTS := \
-          <body> => <body>$(SPECS_TOP) ; \
+          <style> => <link rel="stylesheet" href="../resources/jdk-default.css"/><style> ; \
+          <body> => <body>$(SPECS_TOP)$(JVMTI_HEADER_BLOCK) ; \
           </body> => $(SPECS_BOTTOM_0)</body>, \
   ))
   JDK_SPECS_TARGETS += $(PROCESS_JVMTI_HTML)


### PR DESCRIPTION
Please review a simple makefile-only update to inject the standard stylesheet and navigation header into the two JDK specifications that are generated as HTML files in the `gensrc` directory, to bring these docs in line with the rest of the specs documents.

Generated docs at: 
* http://cr.openjdk.java.net/~jjg/8296188/docs.00/specs/jdwp/jdwp-protocol.html
* http://cr.openjdk.java.net/~jjg/8296188/docs.00/specs/jvmti.html

The JVM TI spec has a list of links at the beginning, in bold. This is not a CSS issue ... it is in the HTML, generated by XSL scripts. Ideally, the list should be in a separate `<nav>` element and the `<b>` tags removed, and maybe the style revised using local CSS. But that is a separate issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296188](https://bugs.openjdk.org/browse/JDK-8296188): Update style and header in JDWP Protocol spec and JVMTI spec


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10957/head:pull/10957` \
`$ git checkout pull/10957`

Update a local copy of the PR: \
`$ git checkout pull/10957` \
`$ git pull https://git.openjdk.org/jdk pull/10957/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10957`

View PR using the GUI difftool: \
`$ git pr show -t 10957`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10957.diff">https://git.openjdk.org/jdk/pull/10957.diff</a>

</details>
