### PR TITLE
8294858: XMLStreamReader does not respect jdk.xml.maxXMLNameLimit=0 for namespace names

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XML11NSDocumentScannerImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XML11NSDocumentScannerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -69,6 +69,8 @@ import javax.xml.stream.events.XMLEvent;
  * @author Elena Litani, IBM
  * @author Michael Glavassevich, IBM
  * @author Sunitha Reddy, Sun Microsystems
+ *
+ * @LastModified: Nov 2022
  */
 public class XML11NSDocumentScannerImpl extends XML11DocumentScannerImpl {
 
@@ -637,7 +639,8 @@ public class XML11NSDocumentScannerImpl extends XML11DocumentScannerImpl {
         // record namespace declarations if any.
         if (fBindNamespaces) {
             if (isNSDecl) {
-                if (value.length() > fXMLNameLimit) {
+                //check the length of URI if a limit is set
+                if (fXMLNameLimit > 0 && value.length() > fXMLNameLimit) {
                     fErrorReporter.reportError(XMLMessageFormatter.XML_DOMAIN,
                             "MaxXMLNameLimit",
                             new Object[]{value, value.length(), fXMLNameLimit,

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLNSDocumentScannerImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLNSDocumentScannerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -54,6 +54,8 @@ import javax.xml.stream.events.XMLEvent;
  * @author Neeraj Bajaj, Sun Microsystems
  * @author Venugopal Rao K, Sun Microsystems
  * @author Elena Litani, IBM
+ *
+ * @LastModified: Nov 2022
  */
 public class XMLNSDocumentScannerImpl
         extends XMLDocumentScannerImpl {
@@ -453,8 +455,8 @@ public class XMLNSDocumentScannerImpl
         // record namespace declarations if any.
         if (fBindNamespaces) {
             if (isNSDecl) {
-                //check the length of URI
-                if (tmpStr.length > fXMLNameLimit) {
+                //check the length of URI if a limit is set
+                if (fXMLNameLimit > 0 && tmpStr.length > fXMLNameLimit) {
                     fErrorReporter.reportError(XMLMessageFormatter.XML_DOMAIN,
                             "MaxXMLNameLimit",
                             new Object[]{new String(tmpStr.ch,tmpStr.offset,tmpStr.length),

--- a/test/jaxp/javax/xml/jaxp/unittest/common/ProcessingLimits.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/ProcessingLimits.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package common;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamReader;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/*
+ * @test
+ * @bug 8294858
+ * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
+ * @run testng/othervm common.ProcessingLimits
+ * @summary Verifies the support of processing limits. Use this test to cover
+ * tests related to processing limits.
+ */
+public class ProcessingLimits {
+    private static final String XML_NAME_LIMIT = "jdk.xml.maxXMLNameLimit";
+
+    /*
+     * Data for tests:
+     * xml, name limit
+     */
+    @DataProvider(name = "xml-data")
+    public Object[][] xmlData() throws Exception {
+        return new Object[][]{
+            {"<foo xmlns='bar'/>", null},
+            {"<foo xmlns='bar'/>", "0"},
+            {"<?xml version=\"1.1\"?><foo xmlns='bar'/>", null},
+            {"<?xml version=\"1.1\"?><foo xmlns='bar'/>", "0"},
+        };
+    }
+    /**
+     * bug 8294858
+     * Verifies that 0 (no limit) is honored by the parser. According to the bug
+     * report, the parser treated 0 literally for namespace names.
+     *
+     * @param xml the XML content
+     * @param limit the limit to be set. "null" means not set.
+     *
+     * @throws Exception if the test fails
+     */
+    @Test(dataProvider = "xml-data")
+    public void testNameLimit(String xml, String limit)throws Exception
+    {
+        boolean success = true;
+        try {
+            if (limit != null) {
+                System.setProperty(XML_NAME_LIMIT, limit);
+            }
+            parse(xml);
+        } catch (Exception e) {
+            // catch instead of throw so that we can clear the System Property
+            success = false;
+            System.err.println("Limit is set to " + limit + " failed: " + e.getMessage());
+        }
+        if (limit != null) {
+            System.clearProperty(XML_NAME_LIMIT);
+        }
+        Assert.assertTrue(success);
+    }
+
+    private static void parse(String xml)
+        throws Exception
+    {
+        InputStream is = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+        XMLStreamReader reader = XMLInputFactory.newInstance().createXMLStreamReader(is);
+        while (reader.hasNext())
+            reader.next();
+        System.err.println("Parsed successfully");
+    }
+}


### PR DESCRIPTION
Fixed an issue where the condition check for limit=0 was missed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294858](https://bugs.openjdk.org/browse/JDK-8294858): XMLStreamReader does not respect jdk.xml.maxXMLNameLimit=0 for namespace names


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10958/head:pull/10958` \
`$ git checkout pull/10958`

Update a local copy of the PR: \
`$ git checkout pull/10958` \
`$ git pull https://git.openjdk.org/jdk pull/10958/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10958`

View PR using the GUI difftool: \
`$ git pr show -t 10958`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10958.diff">https://git.openjdk.org/jdk/pull/10958.diff</a>

</details>
