### PR TITLE
8298090: Use String.join() instead of manual loop in DescriptorSupport.toString

### DIFF
--- a/src/java.management/share/classes/javax/management/modelmbean/DescriptorSupport.java
+++ b/src/java.management/share/classes/javax/management/modelmbean/DescriptorSupport.java
@@ -1234,14 +1234,13 @@ public class DescriptorSupport
             MODELMBEAN_LOGGER.log(Level.TRACE, "Entry");
         }
 
-        String respStr = "";
         String[] fields = getFields();
 
         if ((fields == null) || (fields.length == 0)) {
             if (MODELMBEAN_LOGGER.isLoggable(Level.TRACE)) {
                 MODELMBEAN_LOGGER.log(Level.TRACE, "Empty Descriptor");
             }
-            return respStr;
+            return "";
         }
 
         if (MODELMBEAN_LOGGER.isLoggable(Level.TRACE)) {
@@ -1249,13 +1248,7 @@ public class DescriptorSupport
                     "Printing " + fields.length + " fields");
         }
 
-        for (int i=0; i < fields.length; i++) {
-            if (i == (fields.length - 1)) {
-                respStr = respStr.concat(fields[i]);
-            } else {
-                respStr = respStr.concat(fields[i] + ", ");
-            }
-        }
+        String respStr = String.join(", ", fields);
 
         if (MODELMBEAN_LOGGER.isLoggable(Level.TRACE)) {
             MODELMBEAN_LOGGER.log(Level.TRACE, "Exit returning " + respStr);


### PR DESCRIPTION
There is opportunity to use String.join in DescriptorSupport.toString implementation. Result code is much shorter and clearer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298090](https://bugs.openjdk.org/browse/JDK-8298090): Use String.join() instead of manual loop in DescriptorSupport.toString


### Reviewers
 * [Sergey Tsypanov](https://openjdk.org/census#stsypanov) (@stsypanov - Author)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10960/head:pull/10960` \
`$ git checkout pull/10960`

Update a local copy of the PR: \
`$ git checkout pull/10960` \
`$ git pull https://git.openjdk.org/jdk pull/10960/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10960`

View PR using the GUI difftool: \
`$ git pr show -t 10960`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10960.diff">https://git.openjdk.org/jdk/pull/10960.diff</a>

</details>
