### PR TITLE
8294020: improve errors for record declarations

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3774,9 +3774,6 @@ compiler.err.instance.initializer.not.allowed.in.records=\
 compiler.err.static.declaration.not.allowed.in.inner.classes=\
     static declarations not allowed in inner classes
 
-compiler.err.record.header.expected=\
-    record header expected
-
 ############################################
 # messages previously at javac.properties
 

--- a/test/langtools/tools/javac/diags/examples/IncorrectRecordDeclaration.java
+++ b/test/langtools/tools/javac/diags/examples/IncorrectRecordDeclaration.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
-// key: compiler.err.record.header.expected
+// key: compiler.err.expected
+// key: compiler.err.illegal.start.of.type
 
 record R {}

--- a/test/langtools/tools/javac/records/RecordCompilationTests.java
+++ b/test/langtools/tools/javac/records/RecordCompilationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * RecordCompilationTests
  *
  * @test
- * @bug 8250629 8252307 8247352 8241151 8246774 8259025 8288130 8282714 8289647
+ * @bug 8250629 8252307 8247352 8241151 8246774 8259025 8288130 8282714 8289647 8294020
  * @summary Negative compilation tests, and positive compilation (smoke) tests for records
  * @library /lib/combo /tools/lib /tools/javac/lib
  * @modules
@@ -149,7 +149,7 @@ public class RecordCompilationTests extends CompilationTestCase {
         assertFail("compiler.err.expected", "record R();");
         assertFail("compiler.err.illegal.start.of.type", "record R(,) { }");
         assertFail("compiler.err.illegal.start.of.type", "record R((int x)) { }");
-        assertFail("compiler.err.record.header.expected", "record R { }");
+        assertFail("compiler.err.expected", "record R { }");
         assertFail("compiler.err.expected", "record R(foo) { }");
         assertFail("compiler.err.expected", "record R(int int) { }");
         assertFail("compiler.err.mod.not.allowed.here", "abstract record R(String foo) { }");

--- a/test/langtools/tools/javac/records/RecordDeclarationSyntaxTest.java
+++ b/test/langtools/tools/javac/records/RecordDeclarationSyntaxTest.java
@@ -1,0 +1,10 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8294020
+ * @summary improve error position for records without header
+ * @compile/fail/ref=RecordDeclarationSyntaxTest.out -XDrawDiagnostics RecordDeclarationSyntaxTest.java
+ */
+
+class RecordDeclarationSyntaxTest {
+    record R {} // no header
+}

--- a/test/langtools/tools/javac/records/RecordDeclarationSyntaxTest.out
+++ b/test/langtools/tools/javac/records/RecordDeclarationSyntaxTest.out
@@ -1,0 +1,3 @@
+RecordDeclarationSyntaxTest.java:9:13: compiler.err.expected: '('
+RecordDeclarationSyntaxTest.java:9:14: compiler.err.illegal.start.of.type
+2 errors


### PR DESCRIPTION
Although the reporter originally referred to the error message for records with no header, I think the issue is deeper. We intentionally didn't follow the same path for parsing record declarations as we do for, for example, classes. This is mainly because `class` is a keyword but `record` is a contextual keyword. So when we find `record` we are not sure if it is an identifier or a record declaration. Although I think that given a context where the compiler expects a type declaration, we can be more aggressive than before and if we find `record` + `identifier` consider it a record declaration. The current implementation of `JavacParser::isRecordStart` is trying to be too clever but it is actually leaving several cases uncovered. So the proposed simpler version should be more stable and make record related errors more similar to those for other class declarations. Test `RecordDeclarationSyntaxTest.java` has been added just to have a golden file that stores the error position.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294020](https://bugs.openjdk.org/browse/JDK-8294020): improve errors for record declarations


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10963/head:pull/10963` \
`$ git checkout pull/10963`

Update a local copy of the PR: \
`$ git checkout pull/10963` \
`$ git pull https://git.openjdk.org/jdk pull/10963/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10963`

View PR using the GUI difftool: \
`$ git pr show -t 10963`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10963.diff">https://git.openjdk.org/jdk/pull/10963.diff</a>

</details>
