### PR TITLE
8296285: test/hotspot/jtreg/compiler/intrinsics/TestFloatIsFinite.java fails after JDK-8280378

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/TestFloatIsFinite.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestFloatIsFinite.java
@@ -40,7 +40,7 @@ public class TestFloatIsFinite extends TestFloatClassCheck {
 
     @Test // needs to be run in (fast) debug mode
     @Warmup(10000)
-    @IR(counts = {IRNode.IS_FINITE_F", ">= 1"}) // At least one IsFiniteF node is generated if intrinsic is used
+    @IR(counts = {IRNode.IS_FINITE_F, ">= 1"}) // At least one IsFiniteF node is generated if intrinsic is used
     public void testIsFinite() {
         for (int i = 0; i < BUFFER_SIZE; i++) {
             outputs[i] = Float.isFinite(inputs[i]);


### PR DESCRIPTION
Hi,
    Please review this trivial change fixing a typo in jtreg test: test/hotspot/jtreg/compiler/intrinsics/TestFloatIsFinite.java
    This typo is introduced by JDK-8280378 and the test case fails to compile by javac when running on RISC-V.
    Testing: Test case passed on RISC-V after this typo is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296285](https://bugs.openjdk.org/browse/JDK-8296285): test/hotspot/jtreg/compiler/intrinsics/TestFloatIsFinite.java fails after JDK-8280378


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10965/head:pull/10965` \
`$ git checkout pull/10965`

Update a local copy of the PR: \
`$ git checkout pull/10965` \
`$ git pull https://git.openjdk.org/jdk pull/10965/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10965`

View PR using the GUI difftool: \
`$ git pr show -t 10965`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10965.diff">https://git.openjdk.org/jdk/pull/10965.diff</a>

</details>
