### PR TITLE
JDK-8296226: Add constructors (String,Throwable) and (Throwable) to InvalidParameterException

### DIFF
--- a/src/java.base/share/classes/java/security/InvalidParameterException.java
+++ b/src/java.base/share/classes/java/security/InvalidParameterException.java
@@ -61,20 +61,39 @@ public class InvalidParameterException extends IllegalArgumentException {
 
     /**
      * Constructs an {@code InvalidParameterException} with the
-     * specified detail message and cause.
+     * specified detail message and cause. A detail message is a {@code String} that describes
+     * this particular exception.
      *
-     * @param msg the detail message.
-     * @param cause the cause.
+     * <p>Note that the detail message associated with {@code cause} is
+     * <i>not</i> automatically incorporated in this exception's detail
+     * message.
+     *
+     * @param  msg the detail message (which is saved for later retrieval
+     *         by the {@link Throwable#getMessage()} method).
+     * @param  cause the cause (which is saved for later retrieval by the
+     *         {@link Throwable#getCause()} method).  (A {@code null} value
+     *         is permitted, and indicates that the cause is nonexistent or
+     *         unknown.)
+     *
+     * @since 20
      */
     public InvalidParameterException(String msg, Throwable cause) {
         super(msg, cause);
     }
 
     /**
-     * Constructs an {@code InvalidParameterException} with the
-     * specified cause.
+     * Constructs an {@code InvalidParameterException} with the specified cause and a detail
+     * message of {@code (cause==null ? null : cause.toString())} (which
+     * typically contains the class and detail message of {@code cause}).
+     * This constructor is useful for exceptions that are little more than
+     * wrappers for other throwables.
      *
-     * @param cause the cause.
+     * @param  cause the cause (which is saved for later retrieval by the
+     *         {@link Throwable#getCause()} method).  (A {@code null} value is
+     *         permitted, and indicates that the cause is nonexistent or
+     *         unknown.)
+     *
+     * @since  20
      */
     public InvalidParameterException(Throwable cause) {
         super(cause);

--- a/src/java.base/share/classes/java/security/InvalidParameterException.java
+++ b/src/java.base/share/classes/java/security/InvalidParameterException.java
@@ -58,4 +58,25 @@ public class InvalidParameterException extends IllegalArgumentException {
     public InvalidParameterException(String msg) {
         super(msg);
     }
+
+    /**
+     * Constructs an {@code InvalidParameterException} with the
+     * specified detail message and cause.
+     *
+     * @param msg the detail message.
+     * @param cause the cause.
+     */
+    public InvalidParameterException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+    /**
+     * Constructs an {@code InvalidParameterException} with the
+     * specified cause.
+     *
+     * @param cause the cause.
+     */
+    public InvalidParameterException(Throwable cause) {
+        super(cause);
+    }
 }

--- a/src/java.base/share/classes/java/security/InvalidParameterException.java
+++ b/src/java.base/share/classes/java/security/InvalidParameterException.java
@@ -60,9 +60,9 @@ public class InvalidParameterException extends IllegalArgumentException {
     }
 
     /**
-     * Constructs an {@code InvalidParameterException} with the
-     * specified detail message and cause. A detail message is a {@code String} that describes
-     * this particular exception.
+     * Constructs an {@code InvalidParameterException} with the specified
+     * detail message and cause. A detail message is a {@code String}
+     * that describes this particular exception.
      *
      * <p>Note that the detail message associated with {@code cause} is
      * <i>not</i> automatically incorporated in this exception's detail
@@ -71,25 +71,25 @@ public class InvalidParameterException extends IllegalArgumentException {
      * @param  msg the detail message (which is saved for later retrieval
      *         by the {@link Throwable#getMessage()} method).
      * @param  cause the cause (which is saved for later retrieval by the
-     *         {@link Throwable#getCause()} method).  (A {@code null} value
+     *         {@link Throwable#getCause()} method). (A {@code null} value
      *         is permitted, and indicates that the cause is nonexistent or
      *         unknown.)
      *
-     * @since 20
+     * @since  20
      */
     public InvalidParameterException(String msg, Throwable cause) {
         super(msg, cause);
     }
 
     /**
-     * Constructs an {@code InvalidParameterException} with the specified cause and a detail
-     * message of {@code (cause==null ? null : cause.toString())} (which
-     * typically contains the class and detail message of {@code cause}).
+     * Constructs an {@code InvalidParameterException} with the specified cause
+     * and a detail message of {@code (cause==null ? null : cause.toString())}
+     * (which typically contains the class and detail message of {@code cause}).
      * This constructor is useful for exceptions that are little more than
      * wrappers for other throwables.
      *
      * @param  cause the cause (which is saved for later retrieval by the
-     *         {@link Throwable#getCause()} method).  (A {@code null} value is
+     *         {@link Throwable#getCause()} method). (A {@code null} value is
      *         permitted, and indicates that the cause is nonexistent or
      *         unknown.)
      *

--- a/src/java.base/share/classes/sun/security/rsa/RSAKeyPairGenerator.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAKeyPairGenerator.java
@@ -87,7 +87,7 @@ abstract class RSAKeyPairGenerator extends KeyPairGeneratorSpi {
             initialize(new RSAKeyGenParameterSpec(keySize,
                     RSAKeyGenParameterSpec.F4), random);
         } catch (InvalidAlgorithmParameterException iape) {
-            throw new InvalidParameterException(iape.getMessage());
+            throw new InvalidParameterException(iape);
         }
     }
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyGenerator.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyGenerator.java
@@ -335,8 +335,7 @@ final class P11KeyGenerator extends KeyGeneratorSpi {
         try {
             newSignificantKeySize = checkKeySize(mechanism, keySize, range);
         } catch (InvalidAlgorithmParameterException iape) {
-            throw (InvalidParameterException)
-                    (new InvalidParameterException().initCause(iape));
+            throw new InvalidParameterException("Invalid algorithm parameter", iape);
         }
         if ((mechanism == CKM_DES2_KEY_GEN) ||
             (mechanism == CKM_DES3_KEY_GEN))  {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyGenerator.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyGenerator.java
@@ -335,7 +335,7 @@ final class P11KeyGenerator extends KeyGeneratorSpi {
         try {
             newSignificantKeySize = checkKeySize(mechanism, keySize, range);
         } catch (InvalidAlgorithmParameterException iape) {
-            throw new InvalidParameterException("Invalid algorithm parameter", iape);
+            throw new InvalidParameterException(iape);
         }
         if ((mechanism == CKM_DES2_KEY_GEN) ||
             (mechanism == CKM_DES3_KEY_GEN))  {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyPairGenerator.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyPairGenerator.java
@@ -151,7 +151,7 @@ final class P11KeyPairGenerator extends KeyPairGeneratorSpi {
         try {
             checkKeySize(keySize, null);
         } catch (InvalidAlgorithmParameterException e) {
-            throw (InvalidParameterException) new InvalidParameterException(e.getMessage()).initCause(e);
+            throw new InvalidParameterException(e.getMessage(), e);
         }
         this.params = null;
         if (algorithm.equals("EC")) {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyPairGenerator.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyPairGenerator.java
@@ -151,7 +151,7 @@ final class P11KeyPairGenerator extends KeyPairGeneratorSpi {
         try {
             checkKeySize(keySize, null);
         } catch (InvalidAlgorithmParameterException e) {
-            throw new InvalidParameterException(e.getMessage(), e);
+            throw new InvalidParameterException(e);
         }
         this.params = null;
         if (algorithm.equals("EC")) {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,9 +126,7 @@ public final class SunPKCS11 extends AuthProvider {
                 }
             });
         } catch (PrivilegedActionException pae) {
-            InvalidParameterException ipe =
-                new InvalidParameterException("Error configuring SunPKCS11 provider");
-            throw (InvalidParameterException) ipe.initCause(pae.getException());
+            throw new InvalidParameterException("Error configuring SunPKCS11 provider", pae.getException());
         }
     }
 

--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CKeyPairGenerator.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CKeyPairGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,7 @@ public abstract class CKeyPairGenerator extends KeyPairGeneratorSpi {
                 RSAKeyFactory.checkKeyLengths(keySize, null,
                         KEY_SIZE_MIN, KEY_SIZE_MAX);
             } catch (InvalidKeyException e) {
-                throw new InvalidParameterException(e.getMessage());
+                throw new InvalidParameterException(e);
             }
 
             this.keySize = keySize;

--- a/test/jdk/java/security/Exceptions/ChainingConstructors.java
+++ b/test/jdk/java/security/Exceptions/ChainingConstructors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -183,6 +183,16 @@ public class ChainingConstructors {
         cee = new CertificateEncodingException(MSG, cause);
         if (!cee.getMessage().equals(MSG) || !cee.getCause().equals(cause)) {
             throw new SecurityException("Test 16 failed");
+        }
+
+        InvalidParameterException ipe =
+                new InvalidParameterException(cause);
+        if (!ipe.getCause().equals(cause)) {
+            throw new SecurityException("Test 17 failed");
+        }
+        ipe = new InvalidParameterException(MSG, cause);
+        if (!ipe.getMessage().equals(MSG) || !ipe.getCause().equals(cause)) {
+            throw new SecurityException("Test 17 failed");
         }
 
 /*

--- a/test/jdk/sun/security/tools/keytool/fakegen/java.base/sun/security/rsa/RSAKeyPairGenerator.java
+++ b/test/jdk/sun/security/tools/keytool/fakegen/java.base/sun/security/rsa/RSAKeyPairGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ public abstract class RSAKeyPairGenerator extends KeyPairGeneratorSpi {
             initialize(new RSAKeyGenParameterSpec(keySize,
                     RSAKeyGenParameterSpec.F4), random);
         } catch (InvalidAlgorithmParameterException iape) {
-            throw new InvalidParameterException(iape.getMessage());
+            throw new InvalidParameterException(iape.getMessage(), iape);
         }
     }
 

--- a/test/jdk/sun/security/tools/keytool/fakegen/java.base/sun/security/rsa/RSAKeyPairGenerator.java
+++ b/test/jdk/sun/security/tools/keytool/fakegen/java.base/sun/security/rsa/RSAKeyPairGenerator.java
@@ -57,7 +57,7 @@ public abstract class RSAKeyPairGenerator extends KeyPairGeneratorSpi {
             initialize(new RSAKeyGenParameterSpec(keySize,
                     RSAKeyGenParameterSpec.F4), random);
         } catch (InvalidAlgorithmParameterException iape) {
-            throw new InvalidParameterException(iape.getMessage(), iape);
+            throw new InvalidParameterException(iape);
         }
     }
 


### PR DESCRIPTION
This change adds constructors (String,Throwable) and (Throwable) to InvalidParameterException and uses them at a few places in the jdk coding.
<!-- csr: 'update' -->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8296226](https://bugs.openjdk.org/browse/JDK-8296226): Add constructors (String,Throwable) and (Throwable) to InvalidParameterException
 * [JDK-8296237](https://bugs.openjdk.org/browse/JDK-8296237): Add constructors (String,Throwable) and (Throwable) to InvalidParameterException (**CSR**)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10966/head:pull/10966` \
`$ git checkout pull/10966`

Update a local copy of the PR: \
`$ git checkout pull/10966` \
`$ git pull https://git.openjdk.org/jdk pull/10966/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10966`

View PR using the GUI difftool: \
`$ git pr show -t 10966`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10966.diff">https://git.openjdk.org/jdk/pull/10966.diff</a>

</details>
