### PR TITLE
8296305: Remove unimplemented deoptimized_wrt_marked_nmethods

### DIFF
--- a/src/hotspot/share/runtime/threads.hpp
+++ b/src/hotspot/share/runtime/threads.hpp
@@ -143,9 +143,6 @@ class Threads: AllStatic {
   // Number of non-daemon threads on the active threads list
   static int number_of_non_daemon_threads()      { return _number_of_non_daemon_threads; }
 
-  // Deoptimizes all frames tied to marked nmethods
-  static void deoptimized_wrt_marked_nmethods();
-
   struct Test;                  // For private gtest access.
 };
 


### PR DESCRIPTION
Trivial change of removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296305](https://bugs.openjdk.org/browse/JDK-8296305): Remove unimplemented deoptimized_wrt_marked_nmethods


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10968/head:pull/10968` \
`$ git checkout pull/10968`

Update a local copy of the PR: \
`$ git checkout pull/10968` \
`$ git pull https://git.openjdk.org/jdk pull/10968/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10968`

View PR using the GUI difftool: \
`$ git pr show -t 10968`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10968.diff">https://git.openjdk.org/jdk/pull/10968.diff</a>

</details>
