### PR TITLE
8296263: Uniform APIs for using archived heap regions

### DIFF
--- a/src/hotspot/share/cds/archiveHeapLoader.cpp
+++ b/src/hotspot/share/cds/archiveHeapLoader.cpp
@@ -59,9 +59,6 @@ intx ArchiveHeapLoader::_runtime_offset_2 = 0;
 intx ArchiveHeapLoader::_runtime_offset_3 = 0;
 bool ArchiveHeapLoader::_loading_failed = false;
 
-// Support for mapped heap (!UseCompressedOops only)
-ptrdiff_t ArchiveHeapLoader::_runtime_delta = 0;
-
 void ArchiveHeapLoader::init_narrow_oop_decoding(address base, int shift) {
   _narrow_oop_base = base;
   _narrow_oop_shift = shift;
@@ -70,7 +67,7 @@ void ArchiveHeapLoader::init_narrow_oop_decoding(address base, int shift) {
 void ArchiveHeapLoader::fixup_regions() {
   FileMapInfo* mapinfo = FileMapInfo::current_info();
   if (is_mapped()) {
-    mapinfo->fixup_mapped_heap_regions();
+    fill_failed_mapped_regions();
   } else if (_loading_failed) {
     fill_failed_loaded_heap();
   }
@@ -79,63 +76,6 @@ void ArchiveHeapLoader::fixup_regions() {
       // Need to remove all the archived java.lang.Module objects from HeapShared::roots().
       ClassLoaderDataShared::clear_archived_oops();
     }
-  }
-}
-
-// ------------------ Support for Region MAPPING -----------------------------------------
-
-// Patch all the embedded oop pointers inside an archived heap region,
-// to be consistent with the runtime oop encoding.
-class PatchCompressedEmbeddedPointers: public BitMapClosure {
-  narrowOop* _start;
-
- public:
-  PatchCompressedEmbeddedPointers(narrowOop* start) : _start(start) {}
-
-  bool do_bit(size_t offset) {
-    narrowOop* p = _start + offset;
-    narrowOop v = *p;
-    assert(!CompressedOops::is_null(v), "null oops should have been filtered out at dump time");
-    oop o = ArchiveHeapLoader::decode_from_archive(v);
-    RawAccess<IS_NOT_NULL>::oop_store(p, o);
-    return true;
-  }
-};
-
-class PatchUncompressedEmbeddedPointers: public BitMapClosure {
-  oop* _start;
-
- public:
-  PatchUncompressedEmbeddedPointers(oop* start) : _start(start) {}
-
-  bool do_bit(size_t offset) {
-    oop* p = _start + offset;
-    intptr_t dumptime_oop = (intptr_t)((void*)*p);
-    assert(dumptime_oop != 0, "null oops should have been filtered out at dump time");
-    intptr_t runtime_oop = dumptime_oop + ArchiveHeapLoader::runtime_delta();
-    RawAccess<IS_NOT_NULL>::oop_store(p, cast_to_oop(runtime_oop));
-    return true;
-  }
-};
-
-// Patch all the non-null pointers that are embedded in the archived heap objects
-// in this (mapped) region
-void ArchiveHeapLoader::patch_embedded_pointers(MemRegion region, address oopmap,
-                                                size_t oopmap_size_in_bits) {
-  BitMapView bm((BitMap::bm_word_t*)oopmap, oopmap_size_in_bits);
-
-#ifndef PRODUCT
-  ResourceMark rm;
-  ResourceBitMap checkBm = HeapShared::calculate_oopmap(region);
-  assert(bm.is_same(checkBm), "sanity");
-#endif
-
-  if (UseCompressedOops) {
-    PatchCompressedEmbeddedPointers patcher((narrowOop*)region.start());
-    bm.iterate(&patcher);
-  } else {
-    PatchUncompressedEmbeddedPointers patcher((oop*)region.start());
-    bm.iterate(&patcher);
   }
 }
 
@@ -391,6 +331,9 @@ class VerifyLoadedHeapEmbeddedPointers: public BasicOopIterateClosure {
 };
 
 void ArchiveHeapLoader::finish_initialization() {
+  if (is_mapped()) {
+    complete_heap_regions_mapping();
+  }
   if (is_loaded()) {
     // These operations are needed only when the heap is loaded (not mapped).
     finish_loaded_heap();
@@ -474,4 +417,296 @@ void ArchiveHeapLoader::patch_native_pointers() {
     }
   }
 }
+
+bool ArchiveHeapLoader::_heap_pointers_need_patching = false;
+ArchiveHeapRegions ArchiveHeapLoader::_closed_heap_regions;
+ArchiveHeapRegions ArchiveHeapLoader::_open_heap_regions;
+ArchiveOopDecoder* ArchiveHeapLoader::_oop_decoder = NULL;
+
+void ArchiveHeapLoader::init_archive_heap_regions(FileMapInfo* map_info, int first_region_idx, int last_region_idx, ArchiveHeapRegions* heap_regions) {
+  heap_regions->init(last_region_idx - first_region_idx + 1);
+  int count = 0;
+
+  for (int i = first_region_idx; i <= last_region_idx; i++) {
+    FileMapRegion* si = map_info->space_at(i);
+    si->assert_is_heap_region();
+    size_t size = si->used();
+    if (size > 0) {
+      HeapWord* start = (HeapWord*)map_info->start_address_at_dumptime(si);
+      heap_regions->set_dumptime_region(count, MemRegion(start, size / HeapWordSize));
+      heap_regions->set_region_index(count, i);
+      count += 1;
+    }
+  }
+  heap_regions->set_num_regions(count);
+  return;
+}
+
+void ArchiveHeapLoader::cleanup_regions(FileMapInfo* map_info, ArchiveHeapRegions* heap_regions) {
+  if (heap_regions->is_mapped()) {
+    // unmap the regions ...
+    for (int i = 0; i < heap_regions->num_regions(); i++) {
+      int region_idx = heap_regions->region_index(i);
+      assert(region_idx >= MetaspaceShared::first_archive_heap_region
+             && region_idx <= MetaspaceShared::last_archive_heap_region,
+             "invalid index");
+      map_info->unmap_region(region_idx);
+    }
+    // .. and now change state to HEAP_RESERVED.
+    heap_regions->set_state(ArchiveHeapRegions::HEAP_RESERVED);
+  }
+  if (heap_regions->is_runtime_space_reserved()) {
+    if (dealloc_heap_regions(heap_regions)) {
+      heap_regions->set_state(ArchiveHeapRegions::MAPPING_FAILED_DEALLOCATED);
+    } else {
+      // if we fail to dealloc, the regions will be filled up with dummy objects
+      // later in ArchiveHeapLoader::fixup_regions to make them parseable
+      heap_regions->set_state(ArchiveHeapRegions::MAPPING_FAILED);
+    }
+  }
+}
+
+void ArchiveHeapLoader::cleanup(FileMapInfo* map_info) {
+  cleanup_regions(map_info, &_closed_heap_regions);
+  cleanup_regions(map_info, &_open_heap_regions);
+}
+
+bool ArchiveHeapLoader::get_heap_range_for_archive_regions(ArchiveHeapRegions* heap_regions, bool is_open) {
+  if (Universe::heap()->alloc_archive_regions(heap_regions->dumptime_regions(),
+                                           heap_regions->num_regions(),
+                                           heap_regions->runtime_regions(),
+                                           is_open)) {
+    heap_regions->set_state(ArchiveHeapRegions::HEAP_RESERVED);
+    return true;
+  }
+  return false;
+}
+
+bool ArchiveHeapLoader::is_pointer_patching_needed(FileMapInfo* map_info) {
+  if (!_closed_heap_regions.is_mapped()) {
+    assert(!_open_heap_regions.is_mapped(), "open heap regions must not be mapped when closed heap regions are not mapped");
+    return false;
+  }
+  if (_closed_heap_regions.is_relocated()) {
+    log_info(cds)("CDS heap data needs to be relocated.");
+    return true;
+  }
+  assert(_open_heap_regions.is_mapped(), "open heap regions must be mapped");
+  if (_open_heap_regions.is_relocated()) {
+    log_info(cds)("CDS heap data needs to be relocated.");
+    return true;
+  }
+  if (map_info->narrow_oop_mode() != CompressedOops::mode() ||
+      map_info->narrow_oop_base() != CompressedOops::base() ||
+      map_info->narrow_oop_shift() != CompressedOops::shift()) {
+    log_info(cds)("CDS heap data needs to be relocated because the archive was created with an incompatible oop encoding mode.");
+    return true;
+  }
+  return false;
+}
+
+void ArchiveHeapLoader::log_mapped_regions(ArchiveHeapRegions* heap_regions, bool is_open) {
+  if (is_open) {
+    log_info(cds)("open heap regions:");
+  } else {
+    log_info(cds)("closed heap regions:");
+  }
+  for (int i = 0; i < heap_regions->num_regions(); i++) {
+    log_info(cds)("dumptime region: [" PTR_FORMAT " - " PTR_FORMAT "] mapped to [" PTR_FORMAT " - " PTR_FORMAT "]",
+                   p2i(heap_regions->dumptime_region(i).start()), p2i(heap_regions->dumptime_region(i).end()),
+                   p2i(heap_regions->runtime_region(i).start()), p2i(heap_regions->runtime_region(i).end()));
+  }
+}
+
+void ArchiveHeapLoader::map_heap_regions(FileMapInfo* map_info) {
+  init_archive_heap_regions(map_info, MetaspaceShared::first_closed_heap_region,
+                            MetaspaceShared::last_closed_heap_region, &_closed_heap_regions);
+  if (!get_heap_range_for_archive_regions(&_closed_heap_regions, false)) {
+    log_info(cds)("Failed to find free regions in the heap for closed heap archive space");
+    cleanup(map_info);
+    return;
+  }
+
+  init_archive_heap_regions(map_info, MetaspaceShared::first_open_heap_region,
+                            MetaspaceShared::last_open_heap_region, &_open_heap_regions);
+  if (!get_heap_range_for_archive_regions(&_open_heap_regions, true)) {
+    log_info(cds)("Failed to find free regions for in the heap for open heap archive space");
+    cleanup(map_info);
+    return;
+  }
+
+  char* bitmap_base = map_info->map_bitmap_region();
+  if (bitmap_base == NULL) {
+    log_info(cds)("CDS heap cannot be used because bitmap region cannot be mapped");
+    cleanup(map_info);
+    return;
+  }
+
+  // Map the heap regions
+  // closed regions: GC does not write into these regions.
+  // open regions: GC can write into these regions.
+  if (!map_heap_regions(map_info, &_closed_heap_regions) ||
+      !map_heap_regions(map_info, &_open_heap_regions)) {
+    cleanup(map_info);
+    return;
+  }
+
+  _heap_pointers_need_patching = is_pointer_patching_needed(map_info);
+
+  if (_closed_heap_regions.is_mapped()) {
+    log_mapped_regions(&_closed_heap_regions, false);
+  }
+  if (_open_heap_regions.is_mapped()) {
+    log_mapped_regions(&_open_heap_regions, true);
+  }
+}
+
+bool ArchiveHeapLoader::map_heap_regions(FileMapInfo* map_info, ArchiveHeapRegions* heap_regions) {
+  MemRegion* regions = heap_regions->runtime_regions();
+  int num_regions = heap_regions->num_regions();
+
+  assert(heap_regions->is_runtime_space_reserved(), "heap space for the archive heap regions must be reserved");
+  for (int i = 0; i < num_regions; i++) {
+    FileMapRegion* si = map_info->space_at(heap_regions->region_index(i));
+    char* addr = (char*)regions[i].start();
+    char* base = map_info->map_region_at_address(si, addr, regions[i].byte_size());
+    if (base == NULL || base != addr) {
+      log_info(cds)("UseSharedSpaces: Unable to map at required address in java heap. "
+                    INTPTR_FORMAT ", size = " SIZE_FORMAT " bytes",
+                    p2i(addr), regions[i].byte_size());
+      cleanup_regions(map_info, heap_regions);
+      return false;
+    }
+
+    si->set_mapped_base(base);
+    heap_regions->set_state(ArchiveHeapRegions::MAPPED);
+
+    if (VerifySharedSpaces && !map_info->region_crc_check(addr, regions[i].byte_size(), si->crc())) {
+      log_info(cds)("UseSharedSpaces: mapped heap regions are corrupt");
+      cleanup_regions(map_info, heap_regions);
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void ArchiveHeapLoader::complete_heap_regions_mapping() {
+  if (closed_regions_mapped()) {
+    Universe::heap()->complete_archive_regions_alloc(_closed_heap_regions.runtime_regions(), _closed_heap_regions.num_regions());
+  }
+  if (open_regions_mapped()) {
+    Universe::heap()->complete_archive_regions_alloc(_open_heap_regions.runtime_regions(), _open_heap_regions.num_regions());
+  }
+}
+
+// dealloc the archive regions from java heap
+bool ArchiveHeapLoader::dealloc_heap_regions(ArchiveHeapRegions* heap_regions) {
+  return Universe::heap()->dealloc_archive_regions(heap_regions->runtime_regions(), heap_regions->num_regions());
+}
+
+ArchiveOopDecoder* ArchiveHeapLoader::get_oop_decoder(FileMapInfo* map_info) {
+  if (closed_regions_mapped() && !_oop_decoder) {
+    assert(open_regions_mapped(), "open heap regions must be mapped");
+    if (UseCompressedOops) {
+      _oop_decoder = new ArchiveNarrowOopDecoder(&_closed_heap_regions, &_open_heap_regions,
+                                                 map_info->narrow_oop_base(), map_info->narrow_oop_shift());
+    } else {
+      _oop_decoder = new ArchiveWideOopDecoder(&_closed_heap_regions, &_open_heap_regions);
+    }
+  }
+  return _oop_decoder;
+}
+
+// Patch all the embedded oop pointers inside an archived heap region,
+// to be consistent with the runtime oop encoding.
+template <typename T>
+class PatchEmbeddedPointers: public BitMapClosure {
+  T* _start;
+  ArchiveOopDecoder* _oop_decoder;
+
+ public:
+  PatchEmbeddedPointers(T* start, ArchiveOopDecoder* oop_decoder) :
+    _start(start),
+    _oop_decoder(oop_decoder)
+  {}
+
+  bool do_bit(size_t offset) {
+    T* p = _start + offset;
+    uintptr_t dumptime_oop = (uintptr_t)((void *)*p);
+    oop runtime_oop = _oop_decoder->decode(dumptime_oop);
+    assert(runtime_oop != NULL, "null oops should have been filtered out at dump time");
+    RawAccess<IS_NOT_NULL>::oop_store((T *)p, runtime_oop);
+    return true;
+  }
+};
+
+void ArchiveHeapLoader::patch_embedded_pointers(FileMapInfo* map_info, MemRegion region, address oopmap, size_t oopmap_size_in_bits) {
+  BitMapView bm((BitMap::bm_word_t*)oopmap, oopmap_size_in_bits);
+  ArchiveOopDecoder* oop_decoder = get_oop_decoder(map_info);
+
+#ifndef PRODUCT
+  ResourceMark rm;
+  ResourceBitMap checkBm = HeapShared::calculate_oopmap(region);
+  assert(bm.is_same(checkBm), "sanity");
+#endif
+
+  if (UseCompressedOops) {
+    PatchEmbeddedPointers<narrowOop> patcher((narrowOop*)region.start(), oop_decoder);
+    bm.iterate(&patcher);
+  } else {
+    PatchEmbeddedPointers<oop> patcher((oop*)region.start(), oop_decoder);
+    bm.iterate(&patcher);
+  }
+}
+
+void ArchiveHeapLoader::patch_heap_embedded_pointers(FileMapInfo* map_info, ArchiveHeapRegions* heap_regions) {
+  char* bitmap_base = map_info->map_bitmap_region();
+  assert(bitmap_base != NULL, "must have already been mapped");
+
+  for (int i = 0; i < heap_regions->num_regions(); i++) {
+    FileMapRegion* si = map_info->space_at(heap_regions->region_index(i));
+    patch_embedded_pointers(map_info, heap_regions->runtime_region(i),
+      (address)(bitmap_base) + si->oopmap_offset(),
+      si->oopmap_size_in_bits());
+  }
+}
+
+void ArchiveHeapLoader::patch_heap_embedded_pointers(FileMapInfo* map_info) {
+  if (!_heap_pointers_need_patching) {
+    return;
+  }
+
+  log_info(cds)("patching heap embedded pointers");
+
+  assert(_closed_heap_regions.is_mapped(), "closed heap regions must have been successfully mapped");
+  assert(_open_heap_regions.is_mapped(), "open regions must have been successfully mapped");
+  patch_heap_embedded_pointers(map_info, &_closed_heap_regions);
+  patch_heap_embedded_pointers(map_info, &_open_heap_regions);
+}
+
+bool ArchiveHeapLoader::is_archived_object(oop object) {
+  if (_closed_heap_regions.is_mapped()) {
+    if (_closed_heap_regions.is_in_runtime_region(cast_from_oop<uintptr_t>(object))) {
+      return true;
+    }
+    assert(_open_heap_regions.is_mapped(), "open heap regions must be mapped");
+    if (_open_heap_regions.is_in_runtime_region(cast_from_oop<uintptr_t>(object))) {
+      return true;
+    }
+  } else {
+    assert(!_open_heap_regions.is_mapped(), "open heap regions should not be mapped when closed heap regions are not mapped");
+  }
+  return false;
+}
+
+void ArchiveHeapLoader::fill_failed_mapped_regions() {
+  if (_closed_heap_regions.is_mapping_failed()) {
+    Universe::heap()->fill_heap_regions(_closed_heap_regions.runtime_regions(), _closed_heap_regions.num_regions());
+  }
+  if (_open_heap_regions.is_mapping_failed()) {
+    Universe::heap()->fill_heap_regions(_open_heap_regions.runtime_regions(), _open_heap_regions.num_regions());
+  }
+}
+
 #endif // INCLUDE_CDS_JAVA_HEAP

--- a/src/hotspot/share/cds/archiveHeapLoader.cpp
+++ b/src/hotspot/share/cds/archiveHeapLoader.cpp
@@ -700,6 +700,22 @@ bool ArchiveHeapLoader::is_archived_object(oop object) {
   return false;
 }
 
+bool ArchiveHeapLoader::is_archived_object(oop object) {
+  if (_closed_heap_regions.is_mapped()) {
+    if (_closed_heap_regions.is_in_runtime_region(cast_from_oop<uintptr_t>(object))) {
+      return true;
+    }
+    if (_open_heap_regions.is_mapped()) {
+      if (_open_heap_regions.is_in_runtime_region(cast_from_oop<uintptr_t>(object))) {
+        return true;
+      }
+    }
+  } else {
+    assert(!_open_heap_regions.is_mapped(), "open heap regions should not be mapped when closed heap regions are not mapped");
+  }
+  return false;
+}
+
 void ArchiveHeapLoader::fill_failed_mapped_regions() {
   if (_closed_heap_regions.is_mapping_failed()) {
     Universe::heap()->fill_heap_regions(_closed_heap_regions.runtime_regions(), _closed_heap_regions.num_regions());

--- a/src/hotspot/share/cds/archiveHeapLoader.cpp
+++ b/src/hotspot/share/cds/archiveHeapLoader.cpp
@@ -39,385 +39,6 @@
 
 #if INCLUDE_CDS_JAVA_HEAP
 
-bool ArchiveHeapLoader::_closed_regions_mapped = false;
-bool ArchiveHeapLoader::_open_regions_mapped = false;
-bool ArchiveHeapLoader::_is_loaded = false;
-address ArchiveHeapLoader::_narrow_oop_base;
-int     ArchiveHeapLoader::_narrow_oop_shift;
-
-// Support for loaded heap.
-uintptr_t ArchiveHeapLoader::_loaded_heap_bottom = 0;
-uintptr_t ArchiveHeapLoader::_loaded_heap_top = 0;
-uintptr_t ArchiveHeapLoader::_dumptime_base_0 = UINTPTR_MAX;
-uintptr_t ArchiveHeapLoader::_dumptime_base_1 = UINTPTR_MAX;
-uintptr_t ArchiveHeapLoader::_dumptime_base_2 = UINTPTR_MAX;
-uintptr_t ArchiveHeapLoader::_dumptime_base_3 = UINTPTR_MAX;
-uintptr_t ArchiveHeapLoader::_dumptime_top    = 0;
-intx ArchiveHeapLoader::_runtime_offset_0 = 0;
-intx ArchiveHeapLoader::_runtime_offset_1 = 0;
-intx ArchiveHeapLoader::_runtime_offset_2 = 0;
-intx ArchiveHeapLoader::_runtime_offset_3 = 0;
-bool ArchiveHeapLoader::_loading_failed = false;
-
-void ArchiveHeapLoader::init_narrow_oop_decoding(address base, int shift) {
-  _narrow_oop_base = base;
-  _narrow_oop_shift = shift;
-}
-
-void ArchiveHeapLoader::fixup_regions() {
-  FileMapInfo* mapinfo = FileMapInfo::current_info();
-  if (is_mapped()) {
-    fill_failed_mapped_regions();
-  } else if (_loading_failed) {
-    fill_failed_loaded_heap();
-  }
-  if (is_fully_available()) {
-    if (!MetaspaceShared::use_full_module_graph()) {
-      // Need to remove all the archived java.lang.Module objects from HeapShared::roots().
-      ClassLoaderDataShared::clear_archived_oops();
-    }
-  }
-}
-
-// ------------------ Support for Region LOADING -----------------------------------------
-
-// The CDS archive remembers each heap object by its address at dump time, but
-// the heap object may be loaded at a different address at run time. This structure is used
-// to translate the dump time addresses for all objects in FileMapInfo::space_at(region_index)
-// to their runtime addresses.
-struct LoadedArchiveHeapRegion {
-  int       _region_index;   // index for FileMapInfo::space_at(index)
-  size_t    _region_size;    // number of bytes in this region
-  uintptr_t _dumptime_base;  // The dump-time (decoded) address of the first object in this region
-  intx      _runtime_offset; // If an object's dump time address P is within in this region, its
-                             // runtime address is P + _runtime_offset
-
-  static int comparator(const void* a, const void* b) {
-    LoadedArchiveHeapRegion* reg_a = (LoadedArchiveHeapRegion*)a;
-    LoadedArchiveHeapRegion* reg_b = (LoadedArchiveHeapRegion*)b;
-    if (reg_a->_dumptime_base < reg_b->_dumptime_base) {
-      return -1;
-    } else if (reg_a->_dumptime_base == reg_b->_dumptime_base) {
-      return 0;
-    } else {
-      return 1;
-    }
-  }
-
-  uintptr_t top() {
-    return _dumptime_base + _region_size;
-  }
-};
-
-void ArchiveHeapLoader::init_loaded_heap_relocation(LoadedArchiveHeapRegion* loaded_regions,
-                                                    int num_loaded_regions) {
-  _dumptime_base_0 = loaded_regions[0]._dumptime_base;
-  _dumptime_base_1 = loaded_regions[1]._dumptime_base;
-  _dumptime_base_2 = loaded_regions[2]._dumptime_base;
-  _dumptime_base_3 = loaded_regions[3]._dumptime_base;
-  _dumptime_top = loaded_regions[num_loaded_regions-1].top();
-
-  _runtime_offset_0 = loaded_regions[0]._runtime_offset;
-  _runtime_offset_1 = loaded_regions[1]._runtime_offset;
-  _runtime_offset_2 = loaded_regions[2]._runtime_offset;
-  _runtime_offset_3 = loaded_regions[3]._runtime_offset;
-
-  assert(2 <= num_loaded_regions && num_loaded_regions <= 4, "must be");
-  if (num_loaded_regions < 4) {
-    _dumptime_base_3 = UINTPTR_MAX;
-  }
-  if (num_loaded_regions < 3) {
-    _dumptime_base_2 = UINTPTR_MAX;
-  }
-}
-
-bool ArchiveHeapLoader::can_load() {
-  return Universe::heap()->can_load_archived_objects();
-}
-
-template <int NUM_LOADED_REGIONS>
-class PatchLoadedRegionPointers: public BitMapClosure {
-  narrowOop* _start;
-  intx _offset_0;
-  intx _offset_1;
-  intx _offset_2;
-  intx _offset_3;
-  uintptr_t _base_0;
-  uintptr_t _base_1;
-  uintptr_t _base_2;
-  uintptr_t _base_3;
-  uintptr_t _top;
-
-  static_assert(MetaspaceShared::max_num_heap_regions == 4, "can't handle more than 4 regions");
-  static_assert(NUM_LOADED_REGIONS >= 2, "we have at least 2 loaded regions");
-  static_assert(NUM_LOADED_REGIONS <= 4, "we have at most 4 loaded regions");
-
- public:
-  PatchLoadedRegionPointers(narrowOop* start, LoadedArchiveHeapRegion* loaded_regions)
-    : _start(start),
-      _offset_0(loaded_regions[0]._runtime_offset),
-      _offset_1(loaded_regions[1]._runtime_offset),
-      _offset_2(loaded_regions[2]._runtime_offset),
-      _offset_3(loaded_regions[3]._runtime_offset),
-      _base_0(loaded_regions[0]._dumptime_base),
-      _base_1(loaded_regions[1]._dumptime_base),
-      _base_2(loaded_regions[2]._dumptime_base),
-      _base_3(loaded_regions[3]._dumptime_base) {
-    _top = loaded_regions[NUM_LOADED_REGIONS-1].top();
-  }
-
-  bool do_bit(size_t offset) {
-    narrowOop* p = _start + offset;
-    narrowOop v = *p;
-    assert(!CompressedOops::is_null(v), "null oops should have been filtered out at dump time");
-    uintptr_t o = cast_from_oop<uintptr_t>(ArchiveHeapLoader::decode_from_archive(v));
-    assert(_base_0 <= o && o < _top, "must be");
-
-
-    // We usually have only 2 regions for the default archive. Use template to avoid unnecessary comparisons.
-    if (NUM_LOADED_REGIONS > 3 && o >= _base_3) {
-      o += _offset_3;
-    } else if (NUM_LOADED_REGIONS > 2 && o >= _base_2) {
-      o += _offset_2;
-    } else if (o >= _base_1) {
-      o += _offset_1;
-    } else {
-      o += _offset_0;
-    }
-    ArchiveHeapLoader::assert_in_loaded_heap(o);
-    RawAccess<IS_NOT_NULL>::oop_store(p, cast_to_oop(o));
-    return true;
-  }
-};
-
-int ArchiveHeapLoader::init_loaded_regions(FileMapInfo* mapinfo, LoadedArchiveHeapRegion* loaded_regions,
-                                           MemRegion& archive_space) {
-  size_t total_bytes = 0;
-  int num_loaded_regions = 0;
-  for (int i = MetaspaceShared::first_archive_heap_region;
-       i <= MetaspaceShared::last_archive_heap_region; i++) {
-    FileMapRegion* r = mapinfo->space_at(i);
-    r->assert_is_heap_region();
-    if (r->used() > 0) {
-      assert(is_aligned(r->used(), HeapWordSize), "must be");
-      total_bytes += r->used();
-      LoadedArchiveHeapRegion* ri = &loaded_regions[num_loaded_regions++];
-      ri->_region_index = i;
-      ri->_region_size = r->used();
-      ri->_dumptime_base = (uintptr_t)mapinfo->start_address_as_decoded_from_archive(r);
-    }
-  }
-
-  assert(is_aligned(total_bytes, HeapWordSize), "must be");
-  size_t word_size = total_bytes / HeapWordSize;
-  HeapWord* buffer = Universe::heap()->allocate_loaded_archive_space(word_size);
-  if (buffer == nullptr) {
-    return 0;
-  }
-
-  archive_space = MemRegion(buffer, word_size);
-  _loaded_heap_bottom = (uintptr_t)archive_space.start();
-  _loaded_heap_top    = _loaded_heap_bottom + total_bytes;
-
-  return num_loaded_regions;
-}
-
-void ArchiveHeapLoader::sort_loaded_regions(LoadedArchiveHeapRegion* loaded_regions, int num_loaded_regions,
-                                            uintptr_t buffer) {
-  // Find the relocation offset of the pointers in each region
-  qsort(loaded_regions, num_loaded_regions, sizeof(LoadedArchiveHeapRegion),
-        LoadedArchiveHeapRegion::comparator);
-
-  uintptr_t p = buffer;
-  for (int i = 0; i < num_loaded_regions; i++) {
-    // This region will be loaded at p, so all objects inside this
-    // region will be shifted by ri->offset
-    LoadedArchiveHeapRegion* ri = &loaded_regions[i];
-    ri->_runtime_offset = p - ri->_dumptime_base;
-    p += ri->_region_size;
-  }
-  assert(p == _loaded_heap_top, "must be");
-}
-
-bool ArchiveHeapLoader::load_regions(FileMapInfo* mapinfo, LoadedArchiveHeapRegion* loaded_regions,
-                                     int num_loaded_regions, uintptr_t buffer) {
-  uintptr_t bitmap_base = (uintptr_t)mapinfo->map_bitmap_region();
-  if (bitmap_base == 0) {
-    _loading_failed = true;
-    return false; // OOM or CRC error
-  }
-  uintptr_t load_address = buffer;
-  for (int i = 0; i < num_loaded_regions; i++) {
-    LoadedArchiveHeapRegion* ri = &loaded_regions[i];
-    FileMapRegion* r = mapinfo->space_at(ri->_region_index);
-
-    if (!mapinfo->read_region(ri->_region_index, (char*)load_address, r->used(), /* do_commit = */ false)) {
-      // There's no easy way to free the buffer, so we will fill it with zero later
-      // in fill_failed_loaded_heap(), and it will eventually be GC'ed.
-      log_warning(cds)("Loading of heap region %d has failed. Archived objects are disabled", i);
-      _loading_failed = true;
-      return false;
-    }
-    log_info(cds)("Loaded heap    region #%d at base " INTPTR_FORMAT " top " INTPTR_FORMAT
-                  " size " SIZE_FORMAT_W(6) " delta " INTX_FORMAT,
-                  ri->_region_index, load_address, load_address + ri->_region_size,
-                  ri->_region_size, ri->_runtime_offset);
-
-    uintptr_t oopmap = bitmap_base + r->oopmap_offset();
-    BitMapView bm((BitMap::bm_word_t*)oopmap, r->oopmap_size_in_bits());
-
-    if (num_loaded_regions == 4) {
-      PatchLoadedRegionPointers<4> patcher((narrowOop*)load_address, loaded_regions);
-      bm.iterate(&patcher);
-    } else if (num_loaded_regions == 3) {
-      PatchLoadedRegionPointers<3> patcher((narrowOop*)load_address, loaded_regions);
-      bm.iterate(&patcher);
-    } else {
-      assert(num_loaded_regions == 2, "must be");
-      PatchLoadedRegionPointers<2> patcher((narrowOop*)load_address, loaded_regions);
-      bm.iterate(&patcher);
-    }
-
-    r->set_mapped_base((char*)load_address);
-    load_address += r->used();
-  }
-
-  return true;
-}
-
-bool ArchiveHeapLoader::load_heap_regions(FileMapInfo* mapinfo) {
-  init_narrow_oop_decoding(mapinfo->narrow_oop_base(), mapinfo->narrow_oop_shift());
-
-  LoadedArchiveHeapRegion loaded_regions[MetaspaceShared::max_num_heap_regions];
-  memset(loaded_regions, 0, sizeof(loaded_regions));
-
-  MemRegion archive_space;
-  int num_loaded_regions = init_loaded_regions(mapinfo, loaded_regions, archive_space);
-  if (num_loaded_regions <= 0) {
-    return false;
-  }
-  sort_loaded_regions(loaded_regions, num_loaded_regions, (uintptr_t)archive_space.start());
-  if (!load_regions(mapinfo, loaded_regions, num_loaded_regions, (uintptr_t)archive_space.start())) {
-    assert(_loading_failed, "must be");
-    return false;
-  }
-
-  init_loaded_heap_relocation(loaded_regions, num_loaded_regions);
-  _is_loaded = true;
-
-  return true;
-}
-
-class VerifyLoadedHeapEmbeddedPointers: public BasicOopIterateClosure {
-  ResourceHashtable<uintptr_t, bool>* _table;
-
- public:
-  VerifyLoadedHeapEmbeddedPointers(ResourceHashtable<uintptr_t, bool>* table) : _table(table) {}
-
-  virtual void do_oop(narrowOop* p) {
-    // This should be called before the loaded regions are modified, so all the embedded pointers
-    // must be NULL, or must point to a valid object in the loaded regions.
-    narrowOop v = *p;
-    if (!CompressedOops::is_null(v)) {
-      oop o = CompressedOops::decode_not_null(v);
-      uintptr_t u = cast_from_oop<uintptr_t>(o);
-      ArchiveHeapLoader::assert_in_loaded_heap(u);
-      guarantee(_table->contains(u), "must point to beginning of object in loaded archived regions");
-    }
-  }
-  virtual void do_oop(oop* p) {
-    ShouldNotReachHere();
-  }
-};
-
-void ArchiveHeapLoader::finish_initialization() {
-  if (is_mapped()) {
-    complete_heap_regions_mapping();
-  }
-  if (is_loaded()) {
-    // These operations are needed only when the heap is loaded (not mapped).
-    finish_loaded_heap();
-    if (VerifyArchivedFields > 0) {
-      verify_loaded_heap();
-    }
-  }
-  patch_native_pointers();
-}
-
-void ArchiveHeapLoader::finish_loaded_heap() {
-  HeapWord* bottom = (HeapWord*)_loaded_heap_bottom;
-  HeapWord* top    = (HeapWord*)_loaded_heap_top;
-
-  MemRegion archive_space = MemRegion(bottom, top);
-  Universe::heap()->complete_loaded_archive_space(archive_space);
-}
-
-void ArchiveHeapLoader::verify_loaded_heap() {
-  log_info(cds, heap)("Verify all oops and pointers in loaded heap");
-
-  ResourceMark rm;
-  ResourceHashtable<uintptr_t, bool> table;
-  VerifyLoadedHeapEmbeddedPointers verifier(&table);
-  HeapWord* bottom = (HeapWord*)_loaded_heap_bottom;
-  HeapWord* top    = (HeapWord*)_loaded_heap_top;
-
-  for (HeapWord* p = bottom; p < top; ) {
-    oop o = cast_to_oop(p);
-    table.put(cast_from_oop<uintptr_t>(o), true);
-    p += o->size();
-  }
-
-  for (HeapWord* p = bottom; p < top; ) {
-    oop o = cast_to_oop(p);
-    o->oop_iterate(&verifier);
-    p += o->size();
-  }
-}
-
-void ArchiveHeapLoader::fill_failed_loaded_heap() {
-  assert(_loading_failed, "must be");
-  if (_loaded_heap_bottom != 0) {
-    assert(_loaded_heap_top != 0, "must be");
-    HeapWord* bottom = (HeapWord*)_loaded_heap_bottom;
-    HeapWord* top = (HeapWord*)_loaded_heap_top;
-    Universe::heap()->fill_with_objects(bottom, top - bottom);
-  }
-}
-
-class PatchNativePointers: public BitMapClosure {
-  Metadata** _start;
-
- public:
-  PatchNativePointers(Metadata** start) : _start(start) {}
-
-  bool do_bit(size_t offset) {
-    Metadata** p = _start + offset;
-    *p = (Metadata*)(address(*p) + MetaspaceShared::relocation_delta());
-    // Currently we have only Klass pointers in heap objects.
-    // This needs to be relaxed when we support other types of native
-    // pointers such as Method.
-    assert(((Klass*)(*p))->is_klass(), "must be");
-    return true;
-  }
-};
-
-void ArchiveHeapLoader::patch_native_pointers() {
-  if (MetaspaceShared::relocation_delta() == 0) {
-    return;
-  }
-
-  for (int i = MetaspaceShared::first_archive_heap_region;
-       i <= MetaspaceShared::last_archive_heap_region; i++) {
-    FileMapRegion* r = FileMapInfo::current_info()->space_at(i);
-    if (r->mapped_base() != NULL && r->has_ptrmap()) {
-      log_info(cds, heap)("Patching native pointers in heap region %d", i);
-      BitMapView bm = r->ptrmap_view();
-      PatchNativePointers patcher((Metadata**)r->mapped_base());
-      bm.iterate(&patcher);
-    }
-  }
-}
-
 bool ArchiveHeapLoader::_heap_pointers_need_patching = false;
 ArchiveHeapRegions ArchiveHeapLoader::_closed_heap_regions;
 ArchiveHeapRegions ArchiveHeapLoader::_open_heap_regions;
@@ -591,15 +212,6 @@ bool ArchiveHeapLoader::map_heap_regions(FileMapInfo* map_info, ArchiveHeapRegio
   return true;
 }
 
-void ArchiveHeapLoader::complete_heap_regions_mapping() {
-  if (closed_regions_mapped()) {
-    Universe::heap()->complete_archive_regions_alloc(_closed_heap_regions.runtime_regions(), _closed_heap_regions.num_regions());
-  }
-  if (open_regions_mapped()) {
-    Universe::heap()->complete_archive_regions_alloc(_open_heap_regions.runtime_regions(), _open_heap_regions.num_regions());
-  }
-}
-
 // dealloc the archive regions from java heap
 bool ArchiveHeapLoader::dealloc_heap_regions(ArchiveHeapRegions* heap_regions) {
   return Universe::heap()->dealloc_archive_regions(heap_regions->runtime_regions(), heap_regions->num_regions());
@@ -700,20 +312,48 @@ bool ArchiveHeapLoader::is_archived_object(oop object) {
   return false;
 }
 
-bool ArchiveHeapLoader::is_archived_object(oop object) {
-  if (_closed_heap_regions.is_mapped()) {
-    if (_closed_heap_regions.is_in_runtime_region(cast_from_oop<uintptr_t>(object))) {
-      return true;
-    }
-    if (_open_heap_regions.is_mapped()) {
-      if (_open_heap_regions.is_in_runtime_region(cast_from_oop<uintptr_t>(object))) {
-        return true;
-      }
-    }
-  } else {
-    assert(!_open_heap_regions.is_mapped(), "open heap regions should not be mapped when closed heap regions are not mapped");
+void ArchiveHeapLoader::complete_heap_regions_mapping() {
+  if (closed_regions_mapped()) {
+    Universe::heap()->complete_archive_regions_alloc(_closed_heap_regions.runtime_regions(), _closed_heap_regions.num_regions());
   }
-  return false;
+  if (open_regions_mapped()) {
+    Universe::heap()->complete_archive_regions_alloc(_open_heap_regions.runtime_regions(), _open_heap_regions.num_regions());
+  }
+}
+
+class PatchNativePointers: public BitMapClosure {
+  Metadata** _start;
+
+ public:
+  PatchNativePointers(Metadata** start) : _start(start) {}
+
+  bool do_bit(size_t offset) {
+    Metadata** p = _start + offset;
+    *p = (Metadata*)(address(*p) + MetaspaceShared::relocation_delta());
+    // Currently we have only Klass pointers in heap objects.
+    // This needs to be relaxed when we support other types of native
+    // pointers such as Method.
+    assert(((Klass*)(*p))->is_klass(), "must be");
+    return true;
+  }
+};
+
+void ArchiveHeapLoader::patch_native_pointers() {
+  for (int i = MetaspaceShared::first_archive_heap_region;
+       i <= MetaspaceShared::last_archive_heap_region; i++) {
+    FileMapRegion* r = FileMapInfo::current_info()->space_at(i);
+    if (r->mapped_base() != NULL && r->has_ptrmap()) {
+      log_info(cds, heap)("Patching native pointers in heap region %d", i);
+      BitMapView bm = r->ptrmap_view();
+      PatchNativePointers patcher((Metadata**)r->mapped_base());
+      bm.iterate(&patcher);
+    }
+  }
+}
+
+void ArchiveHeapLoader::finish_initialization() {
+  complete_heap_regions_mapping();
+  patch_native_pointers();
 }
 
 void ArchiveHeapLoader::fill_failed_mapped_regions() {
@@ -725,4 +365,15 @@ void ArchiveHeapLoader::fill_failed_mapped_regions() {
   }
 }
 
+void ArchiveHeapLoader::fixup_regions() {
+  if (can_use()) {
+    fill_failed_mapped_regions();
+  }
+  if (is_archived_heap_available()) {
+    if (!MetaspaceShared::use_full_module_graph()) {
+      // Need to remove all the archived java.lang.Module objects from HeapShared::roots().
+      ClassLoaderDataShared::clear_archived_oops();
+    }
+  }
+}
 #endif // INCLUDE_CDS_JAVA_HEAP

--- a/src/hotspot/share/cds/archiveHeapLoader.hpp
+++ b/src/hotspot/share/cds/archiveHeapLoader.hpp
@@ -70,7 +70,7 @@ public:
 
   // Can this VM map archived heap regions? Currently only G1+compressed{oops,cp}
   static bool can_map() {
-    CDS_JAVA_HEAP_ONLY(return ((UseG1GC || UseEpsilonGC) && UseCompressedClassPointers);)
+    CDS_JAVA_HEAP_ONLY(return ((UseG1GC || UseEpsilonGC || UseParallelGC) && UseCompressedClassPointers);)
     NOT_CDS_JAVA_HEAP(return false;)
   }
   static bool is_mapped() {

--- a/src/hotspot/share/cds/archiveHeapLoader.hpp
+++ b/src/hotspot/share/cds/archiveHeapLoader.hpp
@@ -70,7 +70,7 @@ public:
 
   // Can this VM map archived heap regions? Currently only G1+compressed{oops,cp}
   static bool can_map() {
-    CDS_JAVA_HEAP_ONLY(return (UseG1GC && UseCompressedClassPointers);)
+    CDS_JAVA_HEAP_ONLY(return ((UseG1GC || UseEpsilonGC) && UseCompressedClassPointers);)
     NOT_CDS_JAVA_HEAP(return false;)
   }
   static bool is_mapped() {
@@ -121,6 +121,7 @@ public:
   static void complete_heap_regions_mapping() NOT_CDS_JAVA_HEAP_RETURN;
   static ArchiveOopDecoder* get_oop_decoder(FileMapInfo* map_info) NOT_CDS_JAVA_HEAP_RETURN_(NULL);
   static void patch_heap_embedded_pointers(FileMapInfo* map_info) NOT_CDS_JAVA_HEAP_RETURN;
+  static bool is_archived_object(oop object) NOT_CDS_JAVA_HEAP_RETURN_(false);
 
 #if INCLUDE_CDS_JAVA_HEAP
 private:

--- a/src/hotspot/share/cds/archiveHeapLoader.hpp
+++ b/src/hotspot/share/cds/archiveHeapLoader.hpp
@@ -57,42 +57,23 @@ private:
   static void patch_embedded_pointers(FileMapInfo* map_info, MemRegion region, address oopmap, size_t oopmap_size_in_bits);
   static void patch_heap_embedded_pointers(FileMapInfo* map_info, ArchiveHeapRegions* heap_regions);
   static void fill_failed_mapped_regions();
+  static void patch_native_pointers();
 #endif /* INCLUDE_CDS_JAVA_HEAP */
 
 public:
-  // At runtime, heap regions in the CDS archive can be used in two different ways,
-  // depending on the GC type:
-  // - Mapped: (G1 only) the regions are directly mapped into the Java heap
-  // - Loaded: At VM start-up, the objects in the heap regions are copied into the
-  //           Java heap. This is easier to implement than mapping but
-  //           slightly less efficient, as the embedded pointers need to be relocated.
-  static bool can_use() { return can_map() || can_load(); }
-
-  // Can this VM map archived heap regions? Currently only G1+compressed{oops,cp}
-  static bool can_map() {
+  // Can this VM map archived heap regions?
+  static bool can_use() {
     CDS_JAVA_HEAP_ONLY(return ((UseG1GC || UseEpsilonGC || UseParallelGC || UseSerialGC) && UseCompressedClassPointers);)
     NOT_CDS_JAVA_HEAP(return false;)
   }
-  static bool is_mapped() {
+  static bool are_archived_strings_available() {
+    return closed_regions_mapped();
+  }
+  static bool is_archived_heap_available() {
     return closed_regions_mapped() && open_regions_mapped();
   }
-
-  // Can this VM load the objects from archived heap regions into the heap at start-up?
-  static bool can_load()  NOT_CDS_JAVA_HEAP_RETURN_(false);
-  static void finish_initialization() NOT_CDS_JAVA_HEAP_RETURN;
-  static bool is_loaded() {
-    CDS_JAVA_HEAP_ONLY(return _is_loaded;)
-    NOT_CDS_JAVA_HEAP(return false;)
-  }
-
-  static bool are_archived_strings_available() {
-    return is_loaded() || closed_regions_mapped();
-  }
   static bool are_archived_mirrors_available() {
-    return is_fully_available();
-  }
-  static bool is_fully_available() {
-    return is_loaded() || is_mapped();
+    return is_archived_heap_available();
   }
 
   static bool closed_regions_mapped() {
@@ -104,77 +85,13 @@ public:
     NOT_CDS_JAVA_HEAP_RETURN_(false);
   }
 
-  // NarrowOops stored in the CDS archive may use a different encoding scheme
-  // than CompressedOops::{base,shift} -- see FileMapInfo::map_heap_regions_impl.
-  // To decode them, do not use CompressedOops::decode_not_null. Use this
-  // function instead.
-  inline static oop decode_from_archive(narrowOop v) NOT_CDS_JAVA_HEAP_RETURN_(NULL);
-
-  static void init_narrow_oop_decoding(address base, int shift) NOT_CDS_JAVA_HEAP_RETURN;
-
-  static void patch_embedded_pointers(MemRegion region, address oopmap,
-                                      size_t oopmap_in_bits) NOT_CDS_JAVA_HEAP_RETURN;
-
-  static void fixup_regions() NOT_CDS_JAVA_HEAP_RETURN;
-
   static void map_heap_regions(FileMapInfo* map_info) NOT_CDS_JAVA_HEAP_RETURN;
   static void complete_heap_regions_mapping() NOT_CDS_JAVA_HEAP_RETURN;
   static ArchiveOopDecoder* get_oop_decoder(FileMapInfo* map_info) NOT_CDS_JAVA_HEAP_RETURN_(NULL);
   static void patch_heap_embedded_pointers(FileMapInfo* map_info) NOT_CDS_JAVA_HEAP_RETURN;
   static bool is_archived_object(oop object) NOT_CDS_JAVA_HEAP_RETURN_(false);
-
-#if INCLUDE_CDS_JAVA_HEAP
-private:
-  static bool _closed_regions_mapped;
-  static bool _open_regions_mapped;
-  static bool _is_loaded;
-
-  // Support for loaded archived heap. These are cached values from
-  // LoadedArchiveHeapRegion's.
-  static uintptr_t _dumptime_base_0;
-  static uintptr_t _dumptime_base_1;
-  static uintptr_t _dumptime_base_2;
-  static uintptr_t _dumptime_base_3;
-  static uintptr_t _dumptime_top;
-  static intx _runtime_offset_0;
-  static intx _runtime_offset_1;
-  static intx _runtime_offset_2;
-  static intx _runtime_offset_3;
-
-  static uintptr_t _loaded_heap_bottom;
-  static uintptr_t _loaded_heap_top;
-  static bool _loading_failed;
-
-  // UseCompressedOops only: Used by decode_from_archive
-  static address _narrow_oop_base;
-  static int     _narrow_oop_shift;
-
-  static int init_loaded_regions(FileMapInfo* mapinfo, LoadedArchiveHeapRegion* loaded_regions,
-                                 MemRegion& archive_space);
-  static void sort_loaded_regions(LoadedArchiveHeapRegion* loaded_regions, int num_loaded_regions,
-                                  uintptr_t buffer);
-  static bool load_regions(FileMapInfo* mapinfo, LoadedArchiveHeapRegion* loaded_regions,
-                           int num_loaded_regions, uintptr_t buffer);
-  static void init_loaded_heap_relocation(LoadedArchiveHeapRegion* reloc_info,
-                                          int num_loaded_regions);
-  static void patch_native_pointers();
-  static void finish_loaded_heap();
-  static void verify_loaded_heap();
-  static void fill_failed_loaded_heap();
-
-  static bool is_in_loaded_heap(uintptr_t o) {
-    return (_loaded_heap_bottom <= o && o < _loaded_heap_top);
-  }
-
-public:
-
-  static bool load_heap_regions(FileMapInfo* mapinfo);
-  static void assert_in_loaded_heap(uintptr_t o) {
-    assert(is_in_loaded_heap(o), "must be");
-  }
-
-#endif // INCLUDE_CDS_JAVA_HEAP
-
+  static void finish_initialization() NOT_CDS_JAVA_HEAP_RETURN;
+  static void fixup_regions() NOT_CDS_JAVA_HEAP_RETURN;
 };
 
 #endif // SHARE_CDS_ARCHIVEHEAPLOADER_HPP

--- a/src/hotspot/share/cds/archiveHeapLoader.hpp
+++ b/src/hotspot/share/cds/archiveHeapLoader.hpp
@@ -70,7 +70,7 @@ public:
 
   // Can this VM map archived heap regions? Currently only G1+compressed{oops,cp}
   static bool can_map() {
-    CDS_JAVA_HEAP_ONLY(return ((UseG1GC || UseEpsilonGC || UseParallelGC) && UseCompressedClassPointers);)
+    CDS_JAVA_HEAP_ONLY(return ((UseG1GC || UseEpsilonGC || UseParallelGC || UseSerialGC) && UseCompressedClassPointers);)
     NOT_CDS_JAVA_HEAP(return false;)
   }
   static bool is_mapped() {

--- a/src/hotspot/share/cds/archiveHeapLoader.inline.hpp
+++ b/src/hotspot/share/cds/archiveHeapLoader.inline.hpp
@@ -32,27 +32,6 @@
 
 #if INCLUDE_CDS_JAVA_HEAP
 
-inline oop ArchiveHeapLoader::decode_from_archive(narrowOop v) {
-  assert(!CompressedOops::is_null(v), "narrow oop value can never be zero");
-  uintptr_t p = ((uintptr_t)_narrow_oop_base) + ((uintptr_t)v << _narrow_oop_shift);
-  if (p >= _dumptime_base_0) {
-    assert(p < _dumptime_top, "must be");
-    if (p >= _dumptime_base_3) {
-      p += _runtime_offset_3;
-    } else if (p >= _dumptime_base_2) {
-      p += _runtime_offset_2;
-    } else if (p >= _dumptime_base_1) {
-      p += _runtime_offset_1;
-    } else {
-      p += _runtime_offset_0;
-    }
-  }
-
-  oop result = cast_to_oop((uintptr_t)p);
-  assert(is_object_aligned(result), "address not aligned: " INTPTR_FORMAT, p2i((void*) result));
-  return result;
-}
-
 #endif
 
 #endif // SHARE_CDS_ARCHIVEHEAPLOADER_INLINE_HPP

--- a/src/hotspot/share/cds/archiveUtils.cpp
+++ b/src/hotspot/share/cds/archiveUtils.cpp
@@ -147,6 +147,26 @@ void ArchivePtrMarker::compact(size_t max_non_null_offset) {
   _compacted = true;
 }
 
+void ArchiveHeapRegions::init(int max_region_count) {
+  _dumptime_regions = MemRegion::create_array(max_region_count, mtInternal);
+  _runtime_regions = MemRegion::create_array(max_region_count, mtInternal);
+  _region_idx = (int *)os::malloc(sizeof(int) * max_region_count, mtInternal);
+  _num_regions = max_region_count;
+  _state = ArchiveHeapRegions::UNINITIALIZED;
+}
+
+ArchiveHeapRegions::~ArchiveHeapRegions() {
+  if (_dumptime_regions) {
+    MemRegion::destroy_array(_dumptime_regions, _num_regions);
+  }
+  if (_runtime_regions) {
+    MemRegion::destroy_array(_runtime_regions, _num_regions);
+  }
+  if (_region_idx) {
+    os::free(_region_idx);
+  }
+}
+
 char* DumpRegion::expand_top_to(char* newtop) {
   assert(is_allocatable(), "must be initialized and not packed");
   assert(newtop >= _top, "must not grow backwards");
@@ -287,6 +307,36 @@ void WriteClosure::do_region(u_char* start, size_t size) {
   }
 }
 
+oop ArchiveNarrowOopDecoder::decode(uintptr_t ptr) {
+  narrowOop o = CompressedOops::narrow_oop_cast(ptr);
+  if (CompressedOops::is_null(o)) {
+    return NULL;
+  }
+  uintptr_t p = (uintptr_t)_narrow_oop_base + (ptr << _narrow_oop_shift);
+  uintptr_t result = _closed_regions->dumptime_to_runtime(p);
+  if (!result) {
+    // if ptr is not found in closed heap region, it should be present in open heap region
+    assert(_open_regions->is_mapped(), "open heap regions must be mapped");
+    result = _open_regions->dumptime_to_runtime(p);
+  }
+  assert(result != 0, "decoded oop cannot be null");
+  return cast_to_oop(result);
+}
+
+oop ArchiveWideOopDecoder::decode(uintptr_t ptr) {
+  if (ptr == 0) {
+    return NULL;
+  }
+  uintptr_t result = _closed_regions->dumptime_to_runtime(ptr);
+  if (!result) {
+    // if ptr is not found in closed heap region, it should be present in open heap region
+    assert(_open_regions->is_mapped(), "open heap regions must be mapped");
+    result = _open_regions->dumptime_to_runtime(ptr);
+  }
+  assert(result != 0, "decoded oop cannot be null");
+  return cast_to_oop(result);
+}
+
 void ReadClosure::do_ptr(void** p) {
   assert(*p == NULL, "initializing previous initialized pointer.");
   intptr_t obj = nextPtr();
@@ -314,22 +364,22 @@ void ReadClosure::do_tag(int tag) {
 }
 
 void ReadClosure::do_oop(oop *p) {
-  if (UseCompressedOops) {
-    narrowOop o = CompressedOops::narrow_oop_cast(nextPtr());
-    if (CompressedOops::is_null(o) || !ArchiveHeapLoader::is_fully_available()) {
-      *p = NULL;
-    } else {
-      assert(ArchiveHeapLoader::can_use(), "sanity");
-      assert(ArchiveHeapLoader::is_fully_available(), "must be");
-      *p = ArchiveHeapLoader::decode_from_archive(o);
-    }
+  uintptr_t ptr = nextPtr();
+  if (_oop_decoder) {
+    *p = _oop_decoder->decode(ptr);
   } else {
-    intptr_t dumptime_oop = nextPtr();
-    if (dumptime_oop == 0 || !ArchiveHeapLoader::is_fully_available()) {
-      *p = NULL;
+    if (UseCompressedOops) {
+      narrowOop o = CompressedOops::narrow_oop_cast(ptr);
+      if (CompressedOops::is_null(o) || !ArchiveHeapLoader::is_fully_available()) {
+        *p = NULL;
+      } else {
+        assert(ArchiveHeapLoader::can_use(), "sanity");
+        assert(ArchiveHeapLoader::is_fully_available(), "must be");
+        *p = ArchiveHeapLoader::decode_from_archive(o);
+      }
     } else {
-      intptr_t runtime_oop = dumptime_oop + ArchiveHeapLoader::runtime_delta();
-      *p = cast_to_oop(runtime_oop);
+      assert(!ArchiveHeapLoader::is_fully_available(), "heap loading is enabled only for UseCompressedOops");
+      *p = NULL;
     }
   }
 }

--- a/src/hotspot/share/cds/archiveUtils.cpp
+++ b/src/hotspot/share/cds/archiveUtils.cpp
@@ -368,19 +368,7 @@ void ReadClosure::do_oop(oop *p) {
   if (_oop_decoder) {
     *p = _oop_decoder->decode(ptr);
   } else {
-    if (UseCompressedOops) {
-      narrowOop o = CompressedOops::narrow_oop_cast(ptr);
-      if (CompressedOops::is_null(o) || !ArchiveHeapLoader::is_fully_available()) {
-        *p = NULL;
-      } else {
-        assert(ArchiveHeapLoader::can_use(), "sanity");
-        assert(ArchiveHeapLoader::is_fully_available(), "must be");
-        *p = ArchiveHeapLoader::decode_from_archive(o);
-      }
-    } else {
-      assert(!ArchiveHeapLoader::is_fully_available(), "heap loading is enabled only for UseCompressedOops");
-      *p = NULL;
-    }
+    *p = NULL;
   }
 }
 

--- a/src/hotspot/share/cds/archiveUtils.hpp
+++ b/src/hotspot/share/cds/archiveUtils.hpp
@@ -96,6 +96,15 @@ private:
   int _num_regions;
   State _state;
 
+  int dumptime_region_index_for(intptr_t ptr) {
+    for (int i = 0; i < num_regions(); i++) {
+      if (dumptime_region(i).contains((const void *)ptr)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
 public:
   ArchiveHeapRegions() {}
   ~ArchiveHeapRegions();
@@ -118,20 +127,11 @@ public:
   int num_regions() { return _num_regions; }
 
   uintptr_t dumptime_to_runtime(uintptr_t ptr) {
-    int idx = contains(ptr);
+    int idx = dumptime_region_index_for(ptr);
     if (idx != -1) {
       return ptr + delta_for(idx);
     }
     return 0;
-  }
-
-  int contains(intptr_t ptr) {
-    for (int i = 0; i < num_regions(); i++) {
-      if (dumptime_region(i).contains((const void *)ptr)) {
-        return i;
-      }
-    }
-    return -1;
   }
 
   ptrdiff_t delta_for(int region_idx) {
@@ -143,6 +143,15 @@ public:
       if (runtime_region(i).start() != dumptime_region(i).start()) {
         return true;
         break;
+      }
+    }
+    return false;
+  }
+
+  bool is_in_runtime_region(uintptr_t ptr) {
+    for(int i = 0; i < num_regions(); i++) {
+      if (runtime_region(i).contains((const void *)ptr)) {
+        return true;
       }
     }
     return false;

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -2070,7 +2070,7 @@ void FileMapInfo::map_or_load_heap_regions() {
     if (ArchiveHeapLoader::can_use()) {
       ArchiveHeapLoader::map_heap_regions(this);
     } else {
-      log_info(cds)("Cannot use CDS heap data."); 
+      log_info(cds)("Cannot use CDS heap data.");
     }
   }
 

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -480,7 +480,6 @@ public:
     CDS_ONLY(return _memory_mapping_failed;)
     NOT_CDS(return false;)
   }
-  bool is_in_shared_region(const void* p, int idx) NOT_CDS_RETURN_(false);
 
   static void allocate_shared_path_table(TRAPS);
   static void copy_shared_path_table(ClassLoaderData* loader_data, TRAPS);
@@ -582,14 +581,9 @@ public:
   static size_t set_bitmaps_offset(GrowableArray<ArchiveHeapBitmapInfo> *bitmaps, size_t curr_size);
   static size_t write_bitmaps(GrowableArray<ArchiveHeapBitmapInfo> *bitmaps, size_t curr_offset, char* buffer);
 
-  address decode_start_address(FileMapRegion* spc, bool with_current_oop_encoding_mode);
-
 public:
   bool region_crc_check(char* buf, size_t size, int expected_crc) NOT_CDS_RETURN_(false);
-  // The starting address of spc, as calculated with HeapShared::decode_from_archive()
-  address start_address_as_decoded_from_archive(FileMapRegion* spc) {
-    return decode_start_address(spc, false);
-  }
+
 private:
 
 #if INCLUDE_JVMTI

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -272,7 +272,7 @@ oop HeapShared::get_root(int index, bool clear) {
 void HeapShared::clear_root(int index) {
   assert(index >= 0, "sanity");
   assert(UseSharedSpaces, "must be");
-  if (ArchiveHeapLoader::is_fully_available()) {
+  if (ArchiveHeapLoader::is_archived_heap_available()) {
     if (log_is_enabled(Debug, cds, heap)) {
       oop old = roots()->obj_at(index);
       log_debug(cds, heap)("Clearing root %d: was " PTR_FORMAT, index, p2i(old));
@@ -444,7 +444,7 @@ void HeapShared::check_enum_obj(int level,
 
 // See comments in HeapShared::check_enum_obj()
 bool HeapShared::initialize_enum_klass(InstanceKlass* k, TRAPS) {
-  if (!ArchiveHeapLoader::is_fully_available()) {
+  if (!ArchiveHeapLoader::is_archived_heap_available()) {
     return false;
   }
 
@@ -841,7 +841,7 @@ void HeapShared::serialize(SerializeClosure* soc) {
     assert(oopDesc::is_oop_or_null(roots_oop), "is oop");
     // Create an OopHandle only if we have actually mapped or loaded the roots
     if (roots_oop != NULL) {
-      assert(ArchiveHeapLoader::is_fully_available(), "must be");
+      assert(ArchiveHeapLoader::is_archived_heap_available(), "must be");
       _roots = OopHandle(Universe::vm_global(), roots_oop);
     }
   } else {
@@ -896,7 +896,7 @@ static void verify_the_heap(Klass* k, const char* which) {
 // this case, we will not load the ArchivedKlassSubGraphInfoRecord and will clear its roots.
 void HeapShared::resolve_classes(JavaThread* current) {
   assert(UseSharedSpaces, "runtime only!");
-  if (!ArchiveHeapLoader::is_fully_available()) {
+  if (!ArchiveHeapLoader::is_archived_heap_available()) {
     return; // nothing to do
   }
   resolve_classes_for_subgraphs(current, closed_archive_subgraph_entry_fields);
@@ -929,7 +929,7 @@ void HeapShared::resolve_classes_for_subgraph_of(JavaThread* current, Klass* k) 
 
 void HeapShared::initialize_from_archived_subgraph(JavaThread* current, Klass* k) {
   JavaThread* THREAD = current;
-  if (!ArchiveHeapLoader::is_fully_available()) {
+  if (!ArchiveHeapLoader::is_archived_heap_available()) {
     return; // nothing to do
   }
 

--- a/src/hotspot/share/cds/heapShared.hpp
+++ b/src/hotspot/share/cds/heapShared.hpp
@@ -245,13 +245,6 @@ private:
   static void init_subgraph_entry_fields(TRAPS) NOT_CDS_JAVA_HEAP_RETURN;
   static void init_subgraph_entry_fields(ArchivableStaticFieldInfo fields[], TRAPS);
 
-  // UseCompressedOops only: Used by decode_from_archive
-  static address _narrow_oop_base;
-  static int     _narrow_oop_shift;
-
-  // !UseCompressedOops only: used to relocate pointers to the archived objects
-  static ptrdiff_t _runtime_delta;
-
   typedef ResourceHashtable<oop, bool,
       15889, // prime number
       ResourceObj::C_HEAP,

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -955,11 +955,6 @@ void MetaspaceShared::set_shared_metaspace_range(void* base, void *static_top, v
   MetaspaceObj::set_shared_metaspace_range(base, top);
 }
 
-// Return true if given address is in the misc data region
-bool MetaspaceShared::is_in_shared_region(const void* p, int idx) {
-  return UseSharedSpaces && FileMapInfo::current_info()->is_in_shared_region(p, idx);
-}
-
 bool MetaspaceShared::is_shared_dynamic(void* p) {
   if ((p < MetaspaceObj::shared_metaspace_top()) &&
       (p >= _shared_metaspace_static_top)) {

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -1488,7 +1488,7 @@ void MetaspaceShared::initialize_shared_spaces() {
   // shared string/symbol tables.
   char* buffer = static_mapinfo->serialized_data();
   intptr_t* array = (intptr_t*)buffer;
-  ReadClosure rc(&array);
+  ReadClosure rc(&array, ArchiveHeapLoader::get_oop_decoder(static_mapinfo));
   serialize(&rc);
 
   // Initialize the run-time symbol table.
@@ -1496,7 +1496,7 @@ void MetaspaceShared::initialize_shared_spaces() {
 
   // Finish up archived heap initialization. These must be
   // done after ReadClosure.
-  static_mapinfo->patch_heap_embedded_pointers();
+  ArchiveHeapLoader::patch_heap_embedded_pointers(static_mapinfo);
   ArchiveHeapLoader::finish_initialization();
 
   // Close the mapinfo file

--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -114,9 +114,6 @@ public:
 
   static void set_shared_metaspace_range(void* base, void *static_top, void* top) NOT_CDS_RETURN;
 
-  // Return true if given address is in the shared region corresponding to the idx
-  static bool is_in_shared_region(const void* p, int idx) NOT_CDS_RETURN_(false);
-
   static bool is_shared_dynamic(void* p) NOT_CDS_RETURN_(false);
 
   static void serialize(SerializeClosure* sc) NOT_CDS_RETURN;

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -1265,7 +1265,7 @@ bool java_lang_Class::restore_archived_mirror(Klass *k,
 
   // mirror is archived, restore
   log_debug(cds, mirror)("Archived mirror is: " PTR_FORMAT, p2i(m));
-  if (ArchiveHeapLoader::is_mapped()) {
+  if (ArchiveHeapLoader::is_archived_heap_available()) {
     assert(Universe::heap()->is_archived_object(m), "must be archived mirror object");
   }
   assert(as_Klass(m) == k, "must be");

--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -74,18 +74,12 @@ const double CLEAN_DEAD_HIGH_WATER_MARK = 0.5;
 inline oop read_string_from_compact_hashtable(address base_address, u4 offset) {
   FileMapInfo* current_info = FileMapInfo::current_info();
   ArchiveOopDecoder* oop_decoder = ArchiveHeapLoader::get_oop_decoder(current_info);
-  if (oop_decoder) {
-    uintptr_t ptr = (uintptr_t)offset;
-    if (!UseCompressedOops) {
-      ptr += (uintptr_t)current_info->header()->heap_begin();
-    }
-    return oop_decoder->decode(ptr);
-  } else {
-    assert(UseCompressedOops, "For loaded archive regions, UseCompressedOops must be true");
-    assert(sizeof(narrowOop) == sizeof(offset), "must be");
-    narrowOop v = CompressedOops::narrow_oop_cast(offset);
-    return ArchiveHeapLoader::decode_from_archive(v);
+  assert(oop_decoder != NULL, "oop decoder cannot be null for shared strings");
+  uintptr_t ptr = (uintptr_t)offset;
+  if (!UseCompressedOops) {
+    ptr += (uintptr_t)current_info->header()->heap_begin();
   }
+  return oop_decoder->decode(ptr);
 }
 
 typedef CompactHashtable<

--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -72,17 +72,19 @@ const double CLEAN_DEAD_HIGH_WATER_MARK = 0.5;
 
 #if INCLUDE_CDS_JAVA_HEAP
 inline oop read_string_from_compact_hashtable(address base_address, u4 offset) {
-  if (UseCompressedOops) {
+  FileMapInfo* current_info = FileMapInfo::current_info();
+  ArchiveOopDecoder* oop_decoder = ArchiveHeapLoader::get_oop_decoder(current_info);
+  if (oop_decoder) {
+    uintptr_t ptr = (uintptr_t)offset;
+    if (!UseCompressedOops) {
+      ptr += (uintptr_t)current_info->header()->heap_begin();
+    }
+    return oop_decoder->decode(ptr);
+  } else {
+    assert(UseCompressedOops, "For loaded archive regions, UseCompressedOops must be true");
     assert(sizeof(narrowOop) == sizeof(offset), "must be");
     narrowOop v = CompressedOops::narrow_oop_cast(offset);
     return ArchiveHeapLoader::decode_from_archive(v);
-  } else {
-    intptr_t dumptime_oop = (uintptr_t)offset;
-    assert(dumptime_oop != 0, "null strings cannot be interned");
-    intptr_t runtime_oop = dumptime_oop +
-                           (intptr_t)FileMapInfo::current_info()->header()->heap_begin() +
-                           (intptr_t)ArchiveHeapLoader::runtime_delta();
-    return (oop)cast_to_oop(runtime_oop);
   }
 }
 

--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -859,7 +859,6 @@ public:
 // _shared_table invalid. Therefore, we proactively copy all the shared
 // strings into the _local_table, which can deal with oop relocation.
 void StringTable::transfer_shared_strings_to_local_table() {
-  assert(ArchiveHeapLoader::is_loaded(), "must be");
   EXCEPTION_MARK;
 
   // Reset _shared_table so that during the transfer, StringTable::intern()

--- a/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
@@ -101,13 +101,22 @@ EpsilonHeap* EpsilonHeap::heap() {
   return named_heap<EpsilonHeap>(CollectedHeap::Epsilon);
 }
 
-HeapWord* EpsilonHeap::allocate_work(size_t size, bool verbose) {
+HeapWord* EpsilonHeap::allocate_work(size_t size, bool verbose, size_t alignment) {
   assert(is_object_aligned(size), "Allocation size should be aligned: " SIZE_FORMAT, size);
+  if (alignment > 0) {
+    assert(is_object_aligned(alignment), "Requested alignment of " SIZE_FORMAT
+          " bytes is not a multiple of object alignment", alignment);
+  }
 
   HeapWord* res = NULL;
   while (true) {
     // Try to allocate, assume space is available
-    res = _space->par_allocate(size);
+    if (alignment > 0) {
+      res = _space->par_allocate_aligned(size, alignment);
+      res = align_up(res, alignment);
+    } else {
+      res = _space->par_allocate(size);
+    }
     if (res != NULL) {
       break;
     }
@@ -143,6 +152,9 @@ HeapWord* EpsilonHeap::allocate_work(size_t size, bool verbose) {
       _space->set_end((HeapWord *) _virtual_space.high());
     }
   }
+
+  assert(alignment == 0 || is_aligned(res, alignment), "Allocated space " PTR_FORMAT
+           " does not have requested alignment of " SIZE_FORMAT " bytes", p2i(res), alignment);
 
   size_t used = _space->used();
 
@@ -260,9 +272,36 @@ HeapWord* EpsilonHeap::mem_allocate(size_t size, bool *gc_overhead_limit_was_exc
   return allocate_work(size);
 }
 
-HeapWord* EpsilonHeap::allocate_loaded_archive_space(size_t size) {
+bool EpsilonHeap::alloc_archive_regions(MemRegion* dumptime_regions, int num_regions, MemRegion* runtime_regions, bool is_open) {
+  size_t total_size = 0;
+  size_t alignment = os::vm_page_size();
+
+  for (int i = 0; i < num_regions; i++) {
+    size_t region_size = dumptime_regions[i].byte_size();
+    assert(is_aligned(region_size, alignment), "region size (" SIZE_FORMAT " bytes) "
+           "is not aligned to OS default page size", region_size);
+    total_size += region_size;
+  }
+
   // Cannot use verbose=true because Metaspace is not initialized
-  return allocate_work(size, /* verbose = */false);
+  HeapWord* result = allocate_work(total_size / HeapWordSize, false, alignment);
+  if (result == NULL) {
+    return false;
+  }
+
+  for (int i = 0; i < num_regions; i++) {
+    size_t word_size = dumptime_regions[i].word_size();
+    MemRegion* curr_range = &runtime_regions[i];
+    if (i == 0) {
+      curr_range->set_start(result);
+    } else {
+      // next range should be aligned to page size
+      curr_range->set_start(runtime_regions[i-1].end());
+    }
+    assert(is_aligned(curr_range->start(), alignment), "region does not start at OS default page size");
+    curr_range->set_end(curr_range->start() + word_size);
+  }
+  return true;
 }
 
 void EpsilonHeap::collect(GCCause::Cause cause) {

--- a/src/hotspot/share/gc/epsilon/epsilonHeap.hpp
+++ b/src/hotspot/share/gc/epsilon/epsilonHeap.hpp
@@ -90,7 +90,7 @@ public:
   }
 
   // Allocation
-  HeapWord* allocate_work(size_t size, bool verbose = true);
+  HeapWord* allocate_work(size_t size, bool verbose = true, size_t alignment = 0);
   virtual HeapWord* mem_allocate(size_t size, bool* gc_overhead_limit_was_exceeded);
   virtual HeapWord* allocate_new_tlab(size_t min_size,
                                       size_t requested_size,
@@ -133,8 +133,7 @@ public:
   bool is_in_reserved(const void* addr) const { return _reserved.contains(addr); }
 
   // Support for loading objects from CDS archive into the heap
-  virtual bool can_load_archived_objects() const { return UseCompressedOops; }
-  virtual HeapWord* allocate_loaded_archive_space(size_t size);
+  virtual bool alloc_archive_regions(MemRegion* dumptime_regions, int num_regions, MemRegion* runtime_regions, bool is_open);
 
   virtual void print_on(outputStream* st) const;
   virtual void print_tracing_info() const;

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -510,6 +510,14 @@ private:
 
   void verify_numa_regions(const char* desc);
 
+  // Populate the G1BlockOffsetTablePart for archived regions with the given
+  // memory ranges.
+  void populate_archive_regions_bot_part(MemRegion* range, size_t count);
+
+  bool dealloc_archive_regions_impl(MemRegion* range, int num_regions) override;
+
+  virtual bool heap_region_dealloc_supported() override { return true; }
+
 public:
   // If during a concurrent start pause we may install a pending list head which is not
   // otherwise reachable, ensure that it is marked in the bitmap for concurrent marking
@@ -701,32 +709,18 @@ public:
   void end_archive_alloc_range(GrowableArray<MemRegion>* ranges,
                                size_t end_alignment_in_bytes = 0);
 
+  // Commit the appropriate G1 regions containing the specified MemRegions
+  // and mark them as 'archive' regions. The regions in the array must be
+  // non-overlapping and in order of ascending address.
+  virtual bool alloc_archive_regions(MemRegion* dumptime_regions, int num_regions, MemRegion* runtime_regions, bool is_open) override;
+  virtual void complete_archive_regions_alloc(MemRegion* regions, int num_regions) override;
+
   // Facility for allocating a fixed range within the heap and marking
   // the containing regions as 'archive'. For use at JVM init time, when the
   // caller may mmap archived heap data at the specified range(s).
   // Verify that the MemRegions specified in the argument array are within the
   // reserved heap.
   bool check_archive_addresses(MemRegion* range, size_t count);
-
-  // Commit the appropriate G1 regions containing the specified MemRegions
-  // and mark them as 'archive' regions. The regions in the array must be
-  // non-overlapping and in order of ascending address.
-  bool alloc_archive_regions(MemRegion* range, size_t count, bool open);
-
-  // Insert any required filler objects in the G1 regions around the specified
-  // ranges to make the regions parseable. This must be called after
-  // alloc_archive_regions, and after class loading has occurred.
-  void fill_archive_regions(MemRegion* range, size_t count);
-
-  // Populate the G1BlockOffsetTablePart for archived regions with the given
-  // memory ranges.
-  void populate_archive_regions_bot_part(MemRegion* range, size_t count);
-
-  // For each of the specified MemRegions, uncommit the containing G1 regions
-  // which had been allocated by alloc_archive_regions. This should be called
-  // rather than fill_archive_regions at JVM init time if the archive file
-  // mapping failed, with the same non-overlapping and sorted MemRegion array.
-  void dealloc_archive_regions(MemRegion* range, size_t count);
 
 private:
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -709,6 +709,8 @@ public:
   void end_archive_alloc_range(GrowableArray<MemRegion>* ranges,
                                size_t end_alignment_in_bytes = 0);
 
+  virtual bool can_archive_regions_be_collected() override { return false; }
+
   // Commit the appropriate G1 regions containing the specified MemRegions
   // and mark them as 'archive' regions. The regions in the array must be
   // non-overlapping and in order of ascending address.

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -843,6 +843,13 @@ HeapWord* MutableNUMASpace::cas_allocate(size_t size) {
   return p;
 }
 
+HeapWord* MutableNUMASpace::cas_allocate_aligned(size_t size, size_t alignment) {
+  // MutableNUMASpace is never used for allocating archived regions,
+  // and this API is used only for allocating archived regions.
+  ShouldNotReachHere();
+  return NULL;
+}
+
 void MutableNUMASpace::print_short_on(outputStream* st) const {
   MutableSpace::print_short_on(st);
   st->print(" (");

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.hpp
@@ -228,6 +228,7 @@ class MutableNUMASpace : public MutableSpace {
 
   // Allocation (return NULL if full)
   virtual HeapWord* cas_allocate(size_t word_size);
+  virtual HeapWord* cas_allocate_aligned(size_t word_size, size_t alignment);
 
   // Debugging
   virtual void print_on(outputStream* st) const;

--- a/src/hotspot/share/gc/parallel/mutableSpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.cpp
@@ -208,6 +208,35 @@ HeapWord* MutableSpace::cas_allocate(size_t size) {
   } while (true);
 }
 
+HeapWord* MutableSpace::cas_allocate_aligned(size_t size, size_t alignment) {
+  do {
+    // Read top before end, else the range check may pass when it shouldn't.
+    // If end is read first, other threads may advance end and top such that
+    // current top > old end and current top + size > current end.  Then
+    // pointer_delta underflows, allowing installation of top > current end.
+    HeapWord* curr_top = Atomic::load_acquire(top_addr());
+    HeapWord* obj = align_up(curr_top, alignment);
+    if (pointer_delta(end(), obj) >= size) {
+      HeapWord* new_top = obj + size;
+      HeapWord* result = Atomic::cmpxchg(top_addr(), curr_top, new_top);
+      // result can be one of two:
+      //  the old top value: the exchange succeeded
+      //  otherwise: the new value of the top is returned.
+      if (result != curr_top) {
+        continue; // another thread beat us to the allocation, try again
+      }
+      assert(is_object_aligned(obj) && is_object_aligned(new_top),
+             "checking alignment");
+      if (curr_top != obj) {
+        CollectedHeap::fill_with_object(curr_top, obj);
+      }
+      return curr_top;
+    } else {
+      return NULL;
+    }
+  } while (true);
+}
+
 // Try to deallocate previous allocation. Returns true upon success.
 bool MutableSpace::cas_deallocate(HeapWord *obj, size_t size) {
   HeapWord* expected_top = obj + size;

--- a/src/hotspot/share/gc/parallel/mutableSpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.hpp
@@ -140,6 +140,7 @@ class MutableSpace: public CHeapObj<mtGC> {
 
   // Allocation (return NULL if full)
   virtual HeapWord* cas_allocate(size_t word_size);
+  virtual HeapWord* cas_allocate_aligned(size_t size, size_t alignment);
   // Optional deallocation. Used in NUMA-allocator.
   bool cas_deallocate(HeapWord *obj, size_t size);
   // Return true if this space needs to be expanded in order to satisfy an

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -270,9 +270,8 @@ class ParallelScavengeHeap : public CollectedHeap {
   }
 
   // Support for loading objects from CDS archive into the heap
-  bool can_load_archived_objects() const { return UseCompressedOops; }
-  HeapWord* allocate_loaded_archive_space(size_t size);
-  void complete_loaded_archive_space(MemRegion archive_space);
+  virtual bool alloc_archive_regions(MemRegion* dumptime_regions, int num_regions, MemRegion* runtime_regions, bool is_open);
+  virtual void complete_archive_regions_alloc(MemRegion* regions, int num_regions);
 };
 
 // Class that can be used to print information about the

--- a/src/hotspot/share/gc/parallel/psOldGen.cpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.cpp
@@ -283,7 +283,7 @@ void PSOldGen::shrink(size_t bytes) {
   }
 }
 
-void PSOldGen::complete_loaded_archive_space(MemRegion archive_space) {
+void PSOldGen::complete_archive_region_alloc(MemRegion archive_space) {
   HeapWord* cur = archive_space.start();
   while (cur < archive_space.end()) {
     _start_array.allocate_block(cur);

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -105,9 +105,8 @@ public:
   virtual void safepoint_synchronize_end();
 
   // Support for loading objects from CDS archive into the heap
-  bool can_load_archived_objects() const { return UseCompressedOops; }
-  HeapWord* allocate_loaded_archive_space(size_t size);
-  void complete_loaded_archive_space(MemRegion archive_space);
+  virtual bool alloc_archive_regions(MemRegion* dumptime_regions, int num_regions, MemRegion* runtime_regions, bool is_open);
+  virtual void complete_archive_regions_alloc(MemRegion* regions, int num_regions);
 };
 
 #endif // SHARE_GC_SERIAL_SERIALHEAP_HPP

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -484,10 +484,9 @@ void TenuredGeneration::object_iterate(ObjectClosure* blk) {
   _the_space->object_iterate(blk);
 }
 
-void TenuredGeneration::complete_loaded_archive_space(MemRegion archive_space) {
+void TenuredGeneration::complete_archive_region_alloc(MemRegion archive_space) {
   // Create the BOT for the archive space.
   TenuredSpace* space = (TenuredSpace*)_the_space;
-  space->initialize_threshold();
   HeapWord* start = archive_space.start();
   while (start < archive_space.end()) {
     size_t word_size = _the_space->block_size(start);

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -123,10 +123,11 @@ class TenuredGeneration: public Generation {
   // Iteration
   void object_iterate(ObjectClosure* blk);
 
-  void complete_loaded_archive_space(MemRegion archive_space);
+  void complete_archive_region_alloc(MemRegion archive_space);
 
   virtual inline HeapWord* allocate(size_t word_size, bool is_tlab);
   virtual inline HeapWord* par_allocate(size_t word_size, bool is_tlab);
+  virtual inline HeapWord* par_allocate_aligned(size_t word_size, size_t alignment, bool is_tlab);
 
   template <typename OopClosureType>
   void oop_since_save_marks_iterate(OopClosureType* cl);

--- a/src/hotspot/share/gc/serial/tenuredGeneration.inline.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.inline.hpp
@@ -65,6 +65,13 @@ HeapWord* TenuredGeneration::par_allocate(size_t word_size,
   return _the_space->par_allocate(word_size);
 }
 
+HeapWord* TenuredGeneration::par_allocate_aligned(size_t word_size,
+                                                     size_t alignment,
+                                                     bool is_tlab) {
+  assert(!is_tlab, "TenuredGeneration does not support TLAB allocation");
+  return _the_space->par_allocate_aligned(word_size, alignment);
+}
+
 size_t TenuredGeneration::block_size(const HeapWord* addr) const {
   if (addr < _the_space->top()) {
     return cast_to_oop(addr)->size();

--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -663,3 +663,16 @@ void CollectedHeap::update_capacity_and_used_at_gc() {
   _capacity_at_last_gc = capacity();
   _used_at_last_gc     = used();
 }
+
+bool CollectedHeap::dealloc_archive_regions(MemRegion* range, int num_regions) {
+  if (heap_region_dealloc_supported()) {
+    return dealloc_archive_regions_impl(range, num_regions);
+  }
+  return false;
+}
+
+void CollectedHeap::fill_heap_regions(MemRegion* range, int num_regions) {
+  for (int i = 0; i < num_regions; i++) {
+    fill_with_objects(range[i].start(), range[i].word_size());
+  }
+}

--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "cds/archiveHeapLoader.hpp"
 #include "classfile/classLoaderData.hpp"
 #include "classfile/vmClasses.hpp"
 #include "gc/shared/allocTracer.hpp"
@@ -649,7 +650,7 @@ void CollectedHeap::unpin_object(JavaThread* thread, oop obj) {
 }
 
 bool CollectedHeap::is_archived_object(oop object) const {
-  return false;
+  return ArchiveHeapLoader::is_archived_object(object);
 }
 
 uint32_t CollectedHeap::hash_oop(oop obj) const {

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -419,6 +419,16 @@ class CollectedHeap : public CHeapObj<mtGC> {
     return NULL;
   }
 
+  // For each of the specified MemRegions, deallocate the memory which had
+  // been allocated by alloc_archive_regions.
+  virtual bool dealloc_archive_regions_impl(MemRegion* range, int num_regions) {
+    return false;
+  }
+
+  virtual bool heap_region_dealloc_supported() {
+    return false;
+  }
+
  public:
   // Keep alive an object that was loaded with AS_NO_KEEPALIVE.
   virtual void keep_alive(oop obj) {}
@@ -517,6 +527,12 @@ class CollectedHeap : public CHeapObj<mtGC> {
   virtual bool can_load_archived_objects() const { return false; }
   virtual HeapWord* allocate_loaded_archive_space(size_t size) { return NULL; }
   virtual void complete_loaded_archive_space(MemRegion archive_space) { }
+
+  // Support for mapping archive regions into the heap
+  virtual bool alloc_archive_regions(MemRegion* dumptime_regions, int num_regions, MemRegion* runtime_regions, bool is_open) { return false; }
+  virtual void complete_archive_regions_alloc(MemRegion* regions, int num_regions) { return; }
+  bool dealloc_archive_regions(MemRegion* range, int num_regions);
+  virtual void fill_heap_regions(MemRegion* range, int num_regions);
 
   virtual bool is_oop(oop object) const;
   // Non product verification and debugging.

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -533,6 +533,7 @@ class CollectedHeap : public CHeapObj<mtGC> {
   virtual void complete_archive_regions_alloc(MemRegion* regions, int num_regions) { return; }
   bool dealloc_archive_regions(MemRegion* range, int num_regions);
   virtual void fill_heap_regions(MemRegion* range, int num_regions);
+  virtual bool can_archive_regions_be_collected() { return true; }
 
   virtual bool is_oop(oop object) const;
   // Non product verification and debugging.

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -522,12 +522,6 @@ class CollectedHeap : public CHeapObj<mtGC> {
   // Is the given object inside a CDS archive area?
   virtual bool is_archived_object(oop object) const;
 
-  // Support for loading objects from CDS archive into the heap
-  // (usually as a snapshot of the old generation).
-  virtual bool can_load_archived_objects() const { return false; }
-  virtual HeapWord* allocate_loaded_archive_space(size_t size) { return NULL; }
-  virtual void complete_loaded_archive_space(MemRegion archive_space) { }
-
   // Support for mapping archive regions into the heap
   virtual bool alloc_archive_regions(MemRegion* dumptime_regions, int num_regions, MemRegion* runtime_regions, bool is_open) { return false; }
   virtual void complete_archive_regions_alloc(MemRegion* regions, int num_regions) { return; }

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -214,6 +214,10 @@ class Space: public CHeapObj<mtGC> {
   // Allocation (return NULL if full).  Enforces mutual exclusion internally.
   virtual HeapWord* par_allocate(size_t word_size) = 0;
 
+  // Allocation (return NULL if full).  Enforces mutual exclusion internally.
+  // Returned address is aligned to "alignment" bytes.
+  virtual HeapWord* par_allocate_aligned(size_t word_size, size_t alignment) = 0;
+
 #if INCLUDE_SERIALGC
   // Mark-sweep-compact support: all spaces can update pointers to objects
   // moving as a part of compaction.
@@ -433,6 +437,7 @@ class ContiguousSpace: public CompactibleSpace {
   // Allocation helpers (return NULL if full).
   inline HeapWord* allocate_impl(size_t word_size);
   inline HeapWord* par_allocate_impl(size_t word_size);
+  inline HeapWord* par_allocate_aligned_impl(size_t word_size, size_t alignment);
 
  public:
   ContiguousSpace();
@@ -484,6 +489,7 @@ class ContiguousSpace: public CompactibleSpace {
   // Allocation (return NULL if full)
   virtual HeapWord* allocate(size_t word_size);
   virtual HeapWord* par_allocate(size_t word_size);
+  virtual HeapWord* par_allocate_aligned(size_t word_size, size_t alignment);
 
   // Iteration
   void oop_iterate(OopIterateClosure* cl);
@@ -628,6 +634,7 @@ class OffsetTableContigSpace: public ContiguousSpace {
   // Add offset table update.
   virtual inline HeapWord* allocate(size_t word_size);
   inline HeapWord* par_allocate(size_t word_size);
+  virtual inline HeapWord* par_allocate_aligned(size_t word_size, size_t alignment);
 
   // MarkSweep support phase3
   virtual void initialize_threshold();

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -804,7 +804,7 @@ jint universe_init() {
     // currently mapped regions.
     MetaspaceShared::initialize_shared_spaces();
     StringTable::create_table();
-    if (ArchiveHeapLoader::is_loaded()) {
+    if (Universe::heap()->can_archive_regions_be_collected()) {
       StringTable::transfer_shared_strings_to_local_table();
     }
   } else

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -332,7 +332,7 @@ void ConstantPool::restore_unshareable_info(TRAPS) {
   if (vmClasses::Object_klass_loaded()) {
     ClassLoaderData* loader_data = pool_holder()->class_loader_data();
 #if INCLUDE_CDS_JAVA_HEAP
-    if (ArchiveHeapLoader::is_fully_available() &&
+    if (ArchiveHeapLoader::is_archived_heap_available() &&
         _cache->archived_references() != NULL) {
       oop archived = _cache->archived_references();
       // Create handle for the archived resolved reference array object

--- a/src/hotspot/share/oops/oop.cpp
+++ b/src/hotspot/share/oops/oop.cpp
@@ -226,7 +226,8 @@ void oopDesc::release_double_field_put(int offset, jdouble value)     { Atomic::
 #ifdef ASSERT
 void oopDesc::verify_forwardee(oop forwardee) {
 #if INCLUDE_CDS_JAVA_HEAP
-  assert(!Universe::heap()->is_archived_object(forwardee) && !Universe::heap()->is_archived_object(this),
+  assert(Universe::heap()->can_archive_regions_be_collected() ||
+        (!Universe::heap()->is_archived_object(forwardee) && !Universe::heap()->is_archived_object(this)),
          "forwarding archive object");
 #endif
 }


### PR DESCRIPTION
This is an attempt to unify the two different approaches for using archived heap regions. Main goal is to restructure and modify the code to have a single set of GC APIs that can be called for using archived heap regions.

In current state, the VM either tries to "map" (for G1) or "load" (for non-G1 GC policies) the archived heap regions into the java heap.
When mapping, the VM determines the address range in the java heap where the archived regions should be mapped. It tries to map the regions towards the end of the heap. The APIs used for this purpose are G1 specific.
When loading, the VM asks the GC to provide a chunk of memory from the heap, into which it reads the contents of the archived heap regions. The APIs used are GC policy agnostic but challenging to use for region based collectors.

This PR attempts to add new set of GC APIs that can be used by the VM to reserve space in the heap for mapping the archived heap regions. It combines the good parts of the two existing approaches. Similar to the "loading" API, in this new approach VM is not responsible for determining the mapping address. That responsibility always resides with the GC policy. This also allows the flexibility for the GC implementation to decide where and how to reserve the space for the archived regions. For instance, G1 implementation can continue to attempt to allocate the space towards the end of the heap.
This PR also provides the implementation of the new APIs for all the existing GC policies that currently support archived heap regions viz G1, serial, parallel and epsilon.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296263](https://bugs.openjdk.org/browse/JDK-8296263): Uniform APIs for using archived heap regions


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10970/head:pull/10970` \
`$ git checkout pull/10970`

Update a local copy of the PR: \
`$ git checkout pull/10970` \
`$ git pull https://git.openjdk.org/jdk pull/10970/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10970`

View PR using the GUI difftool: \
`$ git pr show -t 10970`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10970.diff">https://git.openjdk.org/jdk/pull/10970.diff</a>

</details>
