### PR TITLE
8296337: CDS SharedArchiveConsistency tests fail after JDK-8296157

### DIFF
--- a/test/lib/jdk/test/lib/cds/CDSArchiveUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSArchiveUtils.java
@@ -100,7 +100,7 @@ public class CDSArchiveUtils {
             offsetJvmIdent = wb.getCDSOffsetForName("FileMapHeader::_jvm_ident");
             spOffsetCrc = wb.getCDSOffsetForName("CDSFileMapRegion::_crc");
             spUsedOffset = wb.getCDSOffsetForName("CDSFileMapRegion::_used") - spOffsetCrc;
-            spOffset = wb.getCDSOffsetForName("CDSFileMapHeaderBase::_space[0]") - offsetMagic;
+            spOffset = wb.getCDSOffsetForName("CDSFileMapHeaderBase::_regions[0]") - offsetMagic;
             // constants
             staticMagic = wb.getCDSConstantForName("static_magic");
             dynamicMagic = wb.getCDSConstantForName("dynamic_magic");


### PR DESCRIPTION
Please review this trivial fix for some tier2 failures after [JDK-8296157](https://bugs.openjdk.org/browse/JDK-8296157)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296337](https://bugs.openjdk.org/browse/JDK-8296337): CDS SharedArchiveConsistency tests fail after JDK-8296157


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10971/head:pull/10971` \
`$ git checkout pull/10971`

Update a local copy of the PR: \
`$ git checkout pull/10971` \
`$ git pull https://git.openjdk.org/jdk pull/10971/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10971`

View PR using the GUI difftool: \
`$ git pr show -t 10971`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10971.diff">https://git.openjdk.org/jdk/pull/10971.diff</a>

</details>
