### PR TITLE
JDK-8294536: Update troff form of man page for new --spec-base-url option

### DIFF
--- a/src/jdk.javadoc/share/man/javadoc.1
+++ b/src/jdk.javadoc/share/man/javadoc.1
@@ -1139,6 +1139,15 @@ Specifies the number of spaces each tab uses in the source.
 .RS
 .RE
 .TP
+.B \f[CB]\-\-spec\-base\-url\f[R] \f[I]url\f[R]
+Specifies the base URL for relative URLs in \f[CB]\@spec\f[R] tags, to be
+used when generating links to any external specifications.
+It can either be an absolute URL, or a relative URL, in which case it is
+evaluated relative to the base directory of the generated output files.
+The default value is equivalent to \f[CB]{\@docRoot}/../specs\f[R].
+.RS
+.RE
+.TP
 .B \f[CB]\-splitindex\f[R]
 Splits the index file into multiple files, alphabetically, one file per
 letter, plus a file for any index entries that start with

--- a/test/langtools/jdk/javadoc/tool/CheckManPageOptions.java
+++ b/test/langtools/jdk/javadoc/tool/CheckManPageOptions.java
@@ -66,7 +66,7 @@ public class CheckManPageOptions {
 
     static final PrintStream out = System.err;
 
-    List<String> MISSING_IN_MAN_PAGE = List.of("--spec-base-url");
+    List<String> MISSING_IN_MAN_PAGE = List.of();
 
     void run(String... args) throws Exception {
         var file = args.length == 0 ? findDefaultFile() : Path.of(args[0]);


### PR DESCRIPTION
Please review a trivial change to update the open form of the javadoc man page.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294536](https://bugs.openjdk.org/browse/JDK-8294536): Update troff form of man page for new --spec-base-url option


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10972/head:pull/10972` \
`$ git checkout pull/10972`

Update a local copy of the PR: \
`$ git checkout pull/10972` \
`$ git pull https://git.openjdk.org/jdk pull/10972/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10972`

View PR using the GUI difftool: \
`$ git pr show -t 10972`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10972.diff">https://git.openjdk.org/jdk/pull/10972.diff</a>

</details>
