### PR TITLE
8296270: Memory leak in ClassLoader::setup_bootstrap_search_path_impl

### DIFF
--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -649,10 +649,7 @@ void ClassLoader::setup_bootstrap_search_path_impl(JavaThread* current, const ch
           _jrt_entry = new ClassPathImageEntry(JImage_file, canonical_path);
           assert(_jrt_entry != NULL && _jrt_entry->is_modules_image(), "No java runtime image present");
           assert(_jrt_entry->jimage() != NULL, "No java runtime image");
-        } else {
-          // It's an exploded build.
-          ClassPathEntry* new_entry = create_class_path_entry(current, path, &st, false, false);
-        }
+        } // else it's an exploded build.
       } else {
         // If path does not exist, exit
         vm_exit_during_initialization("Unable to establish the boot loader search path", path);


### PR DESCRIPTION
Hi all,

Could anyone help review this fix for a memory leak? There is a redundant code branch in ClassLoader::setup_bootstrap_search_path_impl() for exploded-image build that is unnecessary and causes a leak.

I'm sponsoring colleague Justin King (jcking@google.com) for this contribution, who remarkably made LeakSanitizer working for HotSpot and found this leak.

@jianglizhou also helped validate this fix. Quoting her comment:
> For the ClassPathEntry* new_entry = create_class_path_entry(current, path, &st, false, false); else case with an exploded build in jdk head codebase, it does appear to be not needed. It only creates the class path entry for <path>/modules/java.base, which is handled by [ClassLoader::add_to_exploded_build_list](http://google3/third_party/java_src/jdk/head/src/src/hotspot/share/classfile/classLoader.cpp;l=671;rcl=478881875) later again. Just to be sure, I checked in lldb. The <path>/modules/java.base module path entry is created twice.

-Man

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296270](https://bugs.openjdk.org/browse/JDK-8296270): Memory leak in ClassLoader::setup_bootstrap_search_path_impl


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Jiangli Zhou](https://openjdk.org/census#jiangli) (@jianglizhou - **Reviewer**)


### Contributors
 * Justin King `<jcking@google.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10973/head:pull/10973` \
`$ git checkout pull/10973`

Update a local copy of the PR: \
`$ git checkout pull/10973` \
`$ git pull https://git.openjdk.org/jdk pull/10973/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10973`

View PR using the GUI difftool: \
`$ git pr show -t 10973`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10973.diff">https://git.openjdk.org/jdk/pull/10973.diff</a>

</details>
