### PR TITLE
JDK-8296661 : Typo Found In CSSParser.java

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/CSSParser.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSSParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/text/html/CSSParser.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSSParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/text/html/CSSParser.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSSParser.java
@@ -49,7 +49,7 @@ import java.io.*;
  * <a href=http://www.w3.org/TR/REC-CSS1>http://www.w3.org/TR/REC-CSS1</a>.
  * If an error results in parsing, a RuntimeException will be thrown.
  * <p>
- * This will preserve case. If the callback wishes to treat certain poritions
+ * This will preserve case. If the callback wishes to treat certain portions
  * case insensitively (such as selectors), it should use toLowerCase, or
  * something similar.
  *

--- a/src/java.desktop/share/classes/javax/swing/text/html/CSSParser.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSSParser.java
@@ -37,7 +37,7 @@ import java.io.*;
  *       would be notified 4 times, for 'p,' 'bar' ',' and 'a'.
  *   <li>When a rule starts, <code>startRule</code>
  *   <li>Properties in the rule via the <code>handleProperty</code>. This
- *       is invoked one per property/value key, eg font size: foo;, would
+ *       is invoked once per property/value key, eg font size: foo;, would
  *       cause the delegate to be notified once with a value of 'font size'.
  *   <li>Values in the rule via the <code>handleValue</code>, this is notified
  *       for the total value.

--- a/src/java.desktop/share/classes/javax/swing/text/html/CSSParser.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSSParser.java
@@ -50,7 +50,7 @@ import java.io.*;
  * If an error results in parsing, a RuntimeException will be thrown.
  * <p>
  * This will preserve case. If the callback wishes to treat certain portions
- * case insensitively (such as selectors), it should use toLowerCase, or
+ * case-insensitively (such as selectors), it should use toLowerCase, or
  * something similar.
  *
  * @author Scott Violet

--- a/src/java.desktop/share/classes/javax/swing/text/html/CSSParser.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSSParser.java
@@ -28,29 +28,30 @@ import java.io.*;
 
 /**
  * A CSS parser. This works by way of a delegate that implements the
- * CSSParserCallback interface. The delegate is notified of the following
+ * {@code CSSParserCallback} interface. The delegate is notified of the following
  * events:
  * <ul>
- *   <li>Import statement: <code>handleImport</code>
- *   <li>Selectors <code>handleSelector</code>. This is invoked for each
+ *   <li>Import statement: {@code handleImport}.
+ *   <li>Selectors {@code handleSelector}. This is invoked for each
  *       string. For example if the Reader contained p, bar , a {}, the delegate
  *       would be notified 4 times, for 'p,' 'bar' ',' and 'a'.
- *   <li>When a rule starts, <code>startRule</code>
- *   <li>Properties in the rule via the <code>handleProperty</code>. This
- *       is invoked once per property/value key, eg font size: foo;, would
+ *   <li>When a rule starts, {@code startRule}.
+ *   <li>Properties in the rule via the {@code handleProperty}. This
+ *       is invoked once per property/value key, for example font size: foo;, would
  *       cause the delegate to be notified once with a value of 'font size'.
- *   <li>Values in the rule via the <code>handleValue</code>, this is notified
+ *   <li>Values in the rule via the {@code handleValue}, this is notified
  *       for the total value.
- *   <li>When a rule ends, <code>endRule</code>
+ *   <li>When a rule ends, {@code endRule}.
  * </ul>
  * This will parse much more than CSS 1, and loosely implements the
  * recommendation for <i>Forward-compatible parsing</i> in section
  * 7.1 of the CSS spec found at:
  * <a href=http://www.w3.org/TR/REC-CSS1>http://www.w3.org/TR/REC-CSS1</a>.
- * If an error results in parsing, a RuntimeException will be thrown.
+ * <p>
+ * If parsing results in an error, a {@code RuntimeException} will be thrown.
  * <p>
  * This will preserve case. If the callback wishes to treat certain portions
- * case-insensitively (such as selectors), it should use toLowerCase, or
+ * case-insensitively (such as selectors), it should use {@code toLowerCase}, or
  * something similar.
  *
  * @author Scott Violet
@@ -118,7 +119,7 @@ class CSSParser {
 
     // The delegate interface.
     static interface CSSParserCallback {
-        /** Called when an @import is encountered. */
+        /** Called when an {@code @import} is encountered. */
         void handleImport(String importString);
         // There is currently no way to distinguish between '"foo,"' and
         // 'foo,'. But this generally isn't valid CSS. If it becomes
@@ -360,9 +361,9 @@ class CSSParser {
     }
 
     /**
-     * Parses identifiers until <code>extraChar</code> is encountered,
-     * returning the ending token, which will be IDENTIFIER if extraChar
-     * is found.
+     * Parses identifiers until {@code extraChar} is encountered,
+     * returning the ending token, which will be {@code IDENTIFIER} if
+     * {@code extraChar} is found.
      */
     private int parseIdentifiers(char extraChar,
                                  boolean wantsBlocks) throws IOException {
@@ -508,9 +509,9 @@ class CSSParser {
     }
 
     /**
-     * Gets an identifier, returning true if the length of the string is greater than 0,
-     * stopping when <code>stopChar</code>, whitespace, or one of {}()[] is
-     * hit.
+     * Gets an identifier, returning {@code true} if the length of the string is
+     * greater than 0, stopping when {@code stopChar}, whitespace, or one of
+     * {}()[] is hit.
      */
     // NOTE: this could be combined with readTill, as they contain somewhat
     // similar functionality.
@@ -631,7 +632,7 @@ class CSSParser {
     }
 
     /**
-     * Reads till a <code>stopChar</code> is encountered, escaping characters
+     * Reads till a {@code stopChar} is encountered, escaping characters
      * as necessary.
      */
     private void readTill(char stopChar) throws IOException {


### PR DESCRIPTION
This is referenced in Java Bug Database as
- [JDK-8296661 : Typo Found In CSSParser.java](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8296661)

This is tracked in JBS as 
- [JDK-8296661 : Typo Found In CSSParser.java](https://bugs.openjdk.java.net/browse/JDK-8296661)

I suspect a typo in the documentation comments.

Designed from : [ScientificWare JDK-8296661 : Typo Found In CSSParser.java](https://github.com/scientificware/jdk/issues/18)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296661](https://bugs.openjdk.org/browse/JDK-8296661): Typo Found In CSSParser.java


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - no project role)
 * @SWinxy (no known github.com user name / role) ⚠️ Review applies to [4bfba96a](https://git.openjdk.org/jdk/pull/10975/files/4bfba96a43439111f2680ffe10dc0dcab5de9705)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [3a6eac4c](https://git.openjdk.org/jdk/pull/10975/files/3a6eac4c563c5ca9c6c90028f59b47840ebd41e8)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10975/head:pull/10975` \
`$ git checkout pull/10975`

Update a local copy of the PR: \
`$ git checkout pull/10975` \
`$ git pull https://git.openjdk.org/jdk pull/10975/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10975`

View PR using the GUI difftool: \
`$ git pr show -t 10975`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10975.diff">https://git.openjdk.org/jdk/pull/10975.diff</a>

</details>
