### PR TITLE
JDK-8296287: Improve documentation for Types.directSupertypes()

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/util/Types.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Types.java
@@ -133,9 +133,9 @@ public interface Types {
      * will appear last in the list. For an interface type with no direct
      * super-interfaces, a type mirror representing {@code java.lang.Object}
      * is returned.
-     * The type {@code java.lang.Object} has no direct supertype
-     * ({@jls 8.1.4}) so an empty list is returned for the direct
-     * supertypes of a type mirror representing {@code
+     * The type {@code java.lang.Object} has no direct supertype (JLS
+     * {@jls 8.1.4}, {@jls 8.1.5}) so an empty list is returned for
+     * the direct supertypes of a type mirror representing {@code
      * java.lang.Object}.
      *
      * @param t  the type being examined

--- a/src/java.compiler/share/classes/javax/lang/model/util/Types.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Types.java
@@ -133,6 +133,10 @@ public interface Types {
      * will appear last in the list. For an interface type with no direct
      * super-interfaces, a type mirror representing {@code java.lang.Object}
      * is returned.
+     * The type {@code java.lang.Object} has no direct supertype
+     * ({@jls 8.1.4}) so an empty list is returned for the direct
+     * supertypes of a type mirror representing {@code
+     * java.lang.Object}.
      *
      * @param t  the type being examined
      * @return the direct supertypes, or an empty list if none

--- a/test/langtools/tools/javac/processing/model/util/types/TestDirectSupertypeObject.java
+++ b/test/langtools/tools/javac/processing/model/util/types/TestDirectSupertypeObject.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8296287
- * @summary Test Types methods on module and package TypeMirrors
+ * @summary Test direct supertypes of java.lang.Object
  * @library /tools/javac/lib
  * @build   JavacTestingAbstractProcessor TestDirectSupertypeObject
  * @compile -processor TestDirectSupertypeObject -proc:only TestDirectSupertypeObject.java
@@ -44,10 +44,10 @@ public class TestDirectSupertypeObject extends JavacTestingAbstractProcessor {
     public boolean process(Set<? extends TypeElement> annotations,
                            RoundEnvironment roundEnv) {
         if (!roundEnv.processingOver()) {
-            TypeMirror objectType  = requireNonNull(eltUtils.getTypeElement("java.lang.Object")).asType();
-            var ojectSupertypes = typeUtils.directSupertypes(objectType);
-            if (!ojectSupertypes.isEmpty()) {
-                messager.printError("Direct supertypes: " + ojectSupertypes);
+            TypeMirror objectType = requireNonNull(eltUtils.getTypeElement("java.lang.Object")).asType();
+            var objectSupertypes = typeUtils.directSupertypes(objectType);
+            if (!objectSupertypes.isEmpty()) {
+                messager.printError("Direct supertypes: " + objectSupertypes);
             }
         }
         return true;

--- a/test/langtools/tools/javac/processing/model/util/types/TestDirectSupertypeObject.java
+++ b/test/langtools/tools/javac/processing/model/util/types/TestDirectSupertypeObject.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8296287
+ * @summary Test Types methods on module and package TypeMirrors
+ * @library /tools/javac/lib
+ * @build   JavacTestingAbstractProcessor TestDirectSupertypeObject
+ * @compile -processor TestDirectSupertypeObject -proc:only TestDirectSupertypeObject.java
+ */
+
+import java.util.*;
+import javax.annotation.processing.*;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
+import static java.util.Objects.*;
+
+/**
+ * Verify java.lang.Object has an empty list of direct supertypes.
+ */
+public class TestDirectSupertypeObject extends JavacTestingAbstractProcessor {
+    public boolean process(Set<? extends TypeElement> annotations,
+                           RoundEnvironment roundEnv) {
+        if (!roundEnv.processingOver()) {
+            TypeMirror objectType  = requireNonNull(eltUtils.getTypeElement("java.lang.Object")).asType();
+            var ojectSupertypes = typeUtils.directSupertypes(objectType);
+            if (!ojectSupertypes.isEmpty()) {
+                messager.printError("Direct supertypes: " + ojectSupertypes);
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
Please review the PR and CSR (https://bugs.openjdk.org/browse/JDK-8296354) to add text to explicitly specify the behavior of Types.directSupertypes on java.lang.Object.

(This text could be added as informative text as it is implied by the existing specification, but I think it was reasonable to add the text as a normative statement instead.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8296287](https://bugs.openjdk.org/browse/JDK-8296287): Improve documentation for Types.directSupertypes()
 * [JDK-8296354](https://bugs.openjdk.org/browse/JDK-8296354): Improve documentation for Types.directSupertypes() (**CSR**)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**) ⚠️ Review applies to [e216112e](https://git.openjdk.org/jdk/pull/10977/files/e216112eeca338fb635987d175c85d5a7f40643d)
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10977/head:pull/10977` \
`$ git checkout pull/10977`

Update a local copy of the PR: \
`$ git checkout pull/10977` \
`$ git pull https://git.openjdk.org/jdk pull/10977/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10977`

View PR using the GUI difftool: \
`$ git pr show -t 10977`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10977.diff">https://git.openjdk.org/jdk/pull/10977.diff</a>

</details>
