### PR TITLE
8285635: javax/swing/JRootPane/DefaultButtonTest.java failed with Default Button not pressed for L&F: com.sun.java.swing.plaf.motif.MotifLookAndFeel

### DIFF
--- a/test/jdk/javax/swing/JRootPane/DefaultButtonTest.java
+++ b/test/jdk/javax/swing/JRootPane/DefaultButtonTest.java
@@ -89,6 +89,12 @@ public class DefaultButtonTest {
                 buttonPressed = false;
                 String lafName = laf.getClassName();
                 System.out.println("Testing L&F: " + lafName);
+
+                // Ignore obsolete/deprecated Motif
+                if (lafName.contains("Motif")) {
+                    System.out.println("Skipped Motif");
+                    continue;
+                }
                 SwingUtilities.invokeAndWait(() -> {
                     setLookAndFeel(lafName);
                     createUI();


### PR DESCRIPTION
Test sometimes fail for Motif L&F only which might require some code change in Motif code but since Motif is already deprecated and obsolete, it seems prudent to skip Motif L&F in the test.
Several iterations of the modified test pass in all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285635](https://bugs.openjdk.org/browse/JDK-8285635): javax/swing/JRootPane/DefaultButtonTest.java failed with Default Button not pressed for L&F: com.sun.java.swing.plaf.motif.MotifLookAndFeel


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10978/head:pull/10978` \
`$ git checkout pull/10978`

Update a local copy of the PR: \
`$ git checkout pull/10978` \
`$ git pull https://git.openjdk.org/jdk pull/10978/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10978`

View PR using the GUI difftool: \
`$ git pr show -t 10978`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10978.diff">https://git.openjdk.org/jdk/pull/10978.diff</a>

</details>
