### PR TITLE
8295984: Remove unexpected JShell feature

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
@@ -3090,7 +3090,7 @@ public class JShellTool implements MessageHandler {
                         scanner = new Scanner(new FileReader(path.toString()));
                     } else if ((resource = getResource(filename)) != null) {
                         scanner = new Scanner(new StringReader(resource));
-                    } else {
+                    } else if (interactiveModeBegun) {
                         if (url == null) {
                             try {
                                 @SuppressWarnings("deprecation")
@@ -3100,6 +3100,8 @@ public class JShellTool implements MessageHandler {
                             }
                         }
                         scanner = new Scanner(url.openStream());
+                    } else {
+                        throw new FileNotFoundException(filename);
                     }
                 }
                 try (var scannerIOContext = new ScannerIOContext(scanner)) {

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/resources/l10n.properties
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/resources/l10n.properties
@@ -327,6 +327,8 @@ Open a file and read its contents as snippets and commands.\n\
 \n\
 /open <file>\n\t\
     Read the specified file as the jshell tool input.\n\
+/open <URL>\n\t\
+    Download and use the specified URL as the jshell tool input.\n\
 \n\
 The <file> may be an operating system file name, or one of the predefined\n\
 file names: DEFAULT, PRINTING, or JAVASE.\n\

--- a/test/langtools/jdk/jshell/ReplToolTesting.java
+++ b/test/langtools/jdk/jshell/ReplToolTesting.java
@@ -229,6 +229,11 @@ public class ReplToolTesting {
         test(true, args, tests);
     }
 
+    public void test(String[] args, String expectedErrorOutput,
+                     ReplTest... tests) {
+        test(Locale.ROOT, true, args, expectedErrorOutput, DEFAULT_STARTUP_MESSAGE, tests);
+    }
+
     public void test(boolean isDefaultStartUp, String[] args, ReplTest... tests) {
         test(Locale.ROOT, isDefaultStartUp, args, DEFAULT_STARTUP_MESSAGE, tests);
     }
@@ -238,6 +243,11 @@ public class ReplToolTesting {
     }
 
     public void test(Locale locale, boolean isDefaultStartUp, String[] args, String startUpMessage, ReplTest... tests) {
+        test(locale, isDefaultStartUp, args, "", startUpMessage, tests);
+    }
+
+    public void test(Locale locale, boolean isDefaultStartUp, String[] args,
+                     String expectedErrorOutput, String startUpMessage, ReplTest... tests) {
         this.isDefaultStartUp = isDefaultStartUp;
         initSnippets();
         ReplTest[] wtests = new ReplTest[tests.length + 3];
@@ -246,7 +256,7 @@ public class ReplToolTesting {
         wtests[1] = a -> assertCommand(a, "/debug 0", null);
         System.arraycopy(tests, 0, wtests, 2, tests.length);
         wtests[tests.length + 2] = a -> assertCommand(a, "/exit", null);
-        testRaw(locale, args, wtests);
+        testRaw(locale, args, expectedErrorOutput, wtests);
     }
 
     private void initSnippets() {
@@ -291,10 +301,11 @@ public class ReplToolTesting {
                     .promptCapture(true);
     }
 
-    private void testRaw(Locale locale, String[] args, ReplTest... tests) {
+    private void testRaw(Locale locale, String[] args,
+                         String expectedErrorOutput, ReplTest... tests) {
         testRawInit(tests);
         testRawRun(locale, args);
-        testRawCheck(locale);
+        testRawCheck(locale, expectedErrorOutput);
     }
 
     private void testRawInit(ReplTest... tests) {
@@ -316,7 +327,7 @@ public class ReplToolTesting {
         }
     }
 
-    private void testRawCheck(Locale locale) {
+    private void testRawCheck(Locale locale, String expectedErrorOutput) {
         // perform internal consistency checks on state, if desired
         String cos = getCommandOutput();
         String ceos = getCommandErrorOutput();
@@ -324,7 +335,10 @@ public class ReplToolTesting {
         String ueos = getUserErrorOutput();
         assertTrue((cos.isEmpty() || cos.startsWith("|  Goodbye") || !locale.equals(Locale.ROOT)),
                 "Expected a goodbye, but got: " + cos);
-        assertTrue(ceos.isEmpty(), "Expected empty command error output, got: " + ceos);
+        assertEquals(ceos,
+                     expectedErrorOutput,
+                     "Expected \"" + expectedErrorOutput +
+                     "\" command error output, got: \"" + ceos + "\"");
         assertTrue(uos.isEmpty(), "Expected empty user output, got: " + uos);
         assertTrue(ueos.isEmpty(), "Expected empty user error output, got: " + ueos);
     }

--- a/test/langtools/jdk/jshell/ToolBasicTest.java
+++ b/test/langtools/jdk/jshell/ToolBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8143037 8142447 8144095 8140265 8144906 8146138 8147887 8147886 8148316 8148317 8143955 8157953 8080347 8154714 8166649 8167643 8170162 8172102 8165405 8174796 8174797 8175304 8167554 8180508 8166232 8196133 8199912 8211694 8223688 8254196
+ * @bug 8143037 8142447 8144095 8140265 8144906 8146138 8147887 8147886 8148316 8148317 8143955 8157953 8080347 8154714 8166649 8167643 8170162 8172102 8165405 8174796 8174797 8175304 8167554 8180508 8166232 8196133 8199912 8211694 8223688 8254196 8295984
  * @summary Tests for Basic tests for REPL tool
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
@@ -66,6 +66,8 @@ import static org.testng.Assert.fail;
 
 @Test
 public class ToolBasicTest extends ReplToolTesting {
+
+    private static final String NL = System.getProperty("line.separator");
 
     public void elideStartUpFromList() {
         test(
@@ -542,6 +544,8 @@ public class ToolBasicTest extends ReplToolTesting {
                         (a) -> assertCommand(a, "c", "c ==> 30")
                 );
             }
+            test(new String[] {urlAddress},
+                 "File '" + urlAddress + "' for 'jshell' is not found." + NL);
         } finally {
             httpServer.stop(0);
         }


### PR DESCRIPTION
This patch patches JShell to not have the ability to run URL specified on the command line. Please also review the CSR: https://bugs.openjdk.org/browse/JDK-8296326

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8295984](https://bugs.openjdk.org/browse/JDK-8295984): Remove unexpected JShell feature
 * [JDK-8296326](https://bugs.openjdk.org/browse/JDK-8296326): Remove unexpected JShell feature (**CSR**)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10979/head:pull/10979` \
`$ git checkout pull/10979`

Update a local copy of the PR: \
`$ git checkout pull/10979` \
`$ git pull https://git.openjdk.org/jdk pull/10979/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10979`

View PR using the GUI difftool: \
`$ git pr show -t 10979`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10979.diff">https://git.openjdk.org/jdk/pull/10979.diff</a>

</details>
