### PR TITLE
JDK-8296380: IGV: Shortcut for quick search not working

### DIFF
--- a/src/utils/IdealGraphVisualizer/View/src/main/resources/com/sun/hotspot/igv/view/layer.xml
+++ b/src/utils/IdealGraphVisualizer/View/src/main/resources/com/sun/hotspot/igv/view/layer.xml
@@ -3,7 +3,7 @@
 <filesystem>
     <folder name="Shortcuts">
         <file name="D-F.shadow">
-            <attr name="originalFile" stringvalue="Actions/Edit/org-netbeans-modules-quicksearch-QuickSearchAction.instance"/>
+            <attr name="originalFile" stringvalue="Actions/Search/org-netbeans-modules-quicksearch-QuickSearchAction.instance"/>
         </file>
     </folder>
     <folder name="Actions">


### PR DESCRIPTION
The shortcut `Ctrl`-`F` for quick search was not working

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296380](https://bugs.openjdk.org/browse/JDK-8296380): IGV: Shortcut for quick search not working


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10980/head:pull/10980` \
`$ git checkout pull/10980`

Update a local copy of the PR: \
`$ git checkout pull/10980` \
`$ git pull https://git.openjdk.org/jdk pull/10980/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10980`

View PR using the GUI difftool: \
`$ git pr show -t 10980`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10980.diff">https://git.openjdk.org/jdk/pull/10980.diff</a>

</details>
