### PR TITLE
8296390: Incremental build failed with a NPE

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java
@@ -1223,6 +1223,10 @@ public class Modules extends JCTree.Visitor {
         Assert.checkNonNull(rootModules);
         Assert.checkNull(allModules);
 
+        //java.base may not be completed yet and computeTransitiveClosure
+        //may not complete it either, make sure it is completed:
+        syms.java_base.complete();
+
         Set<ModuleSymbol> observable;
 
         if (limitModsOpt == null && extraLimitMods.isEmpty()) {


### PR DESCRIPTION
In [Enter](https://github.com/openjdk/jdk/blob/22347e46f7e66a864ea987fa084c44792cae2e6a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java#L617), we finish verification that imports in files are valid. But, if the module graph is not finished yet (modules are not initialized), we defer checking imports in module-infos until the modules are setup.

What can happen is that `java.base`', if load lazily, may not be completed as part of module system initialization, and can trigger imports check in other module prematurely.

The proposal is to explicitly complete `java.base` while setting up the compile-time module system. Other (named) modules are normally completed around the same time while [building all modules](https://github.com/openjdk/jdk/blob/22347e46f7e66a864ea987fa084c44792cae2e6a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java#L1414).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296390](https://bugs.openjdk.org/browse/JDK-8296390): Incremental build failed with a NPE


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10985/head:pull/10985` \
`$ git checkout pull/10985`

Update a local copy of the PR: \
`$ git checkout pull/10985` \
`$ git pull https://git.openjdk.org/jdk pull/10985/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10985`

View PR using the GUI difftool: \
`$ git pr show -t 10985`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10985.diff">https://git.openjdk.org/jdk/pull/10985.diff</a>

</details>
