### PR TITLE
JDK-8296360: Track native memory used by zlib via NMT

### DIFF
--- a/make/data/hotspot-symbols/symbols-unix
+++ b/make/data/hotspot-symbols/symbols-unix
@@ -172,6 +172,10 @@ JVM_LookupLambdaProxyClassFromArchive
 JVM_LogLambdaFormInvoker
 JVM_MaxMemory
 JVM_MaxObjectInspectionAge
+JVM_MemoryAlloc
+JVM_MemoryCalloc
+JVM_MemoryFree
+JVM_MemoryRealloc
 JVM_MonitorNotify
 JVM_MonitorNotifyAll
 JVM_MonitorWait

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -1159,6 +1159,26 @@ JVM_VirtualThreadHideFrames(JNIEnv* env, jobject vthread, jboolean hide);
 JNIEXPORT jint JNICALL
 JVM_GetClassFileVersion(JNIEnv *env, jclass current);
 
+/**** External access to JVM C-Heap allocation functions. */
+typedef enum {
+  MT_JUZI = 0, /* Buffers used by java.util.zip inflaters */
+  MT_JUZD,     /* Buffers used by java.util.zip deflaters */
+  MT_ZLIB,     /* Buffers used by other users of zlib */
+  MT_OTHER
+} allocation_category_t;
+
+JNIEXPORT void* JNICALL
+JVM_MemoryAlloc(size_t size, allocation_category_t category);
+
+JNIEXPORT void* JNICALL
+JVM_MemoryRealloc(void* p, size_t size, allocation_category_t category);
+
+JNIEXPORT void* JNICALL
+JVM_MemoryCalloc(size_t numelems, size_t elemsize, allocation_category_t category);
+
+JNIEXPORT void JNICALL
+JVM_MemoryFree(void* p);
+
 /*
  * This structure is used by the launcher to get the default thread
  * stack size from the VM using JNI_GetDefaultJavaVMInitArgs() with a

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -100,6 +100,7 @@ typedef AllocFailStrategy::AllocFailEnum AllocFailType;
 //
 
 #define MEMORY_TYPES_DO(f)                                                           \
+  /* Intra-VM categories */                                                          \
   /* Memory type by sub systems. It occupies lower byte. */                          \
   f(mtJavaHeap,       "Java Heap")   /* Java heap                                 */ \
   f(mtClass,          "Class")       /* Java classes                              */ \
@@ -113,7 +114,6 @@ typedef AllocFailStrategy::AllocFailEnum AllocFailType;
   f(mtInternal,       "Internal")    /* memory used by VM, but does not belong to */ \
                                      /* any of above categories, and not used by  */ \
                                      /* NMT                                       */ \
-  f(mtOther,          "Other")       /* memory not used by VM                     */ \
   f(mtSymbol,         "Symbol")                                                      \
   f(mtNMT,            "Native Memory Tracking")  /* memory used by NMT            */ \
   f(mtClassShared,    "Shared class space")      /* class data sharing            */ \
@@ -130,6 +130,14 @@ typedef AllocFailStrategy::AllocFailEnum AllocFailType;
   f(mtMetaspace,      "Metaspace")                                                   \
   f(mtStringDedup,    "String Deduplication")                                        \
   f(mtObjectMonitor,  "Object Monitors")                                             \
+  /* Non-VM categories used by allocation from outside hotspot.          */          \
+  /* These must appear in the same order as their counterparts in jvm.h  */          \
+  /* (see allocation_category_t). */                                                 \
+  f(mtJuzD,           "j.u.zip (deflate)") /* Used by j.u.zip Deflaters. */          \
+  f(mtJuzI,           "j.u.zip (inflate)") /* Used by j.u.zip Inflaters. */          \
+  f(mtZip,            "Zip (other)")       /* Used by zlib (none-j.u.zip usage). */  \
+  f(mtOther,          "Other")             /* Outside memory, unspecified. */        \
+  /* Let this be the last */                                                         \
   f(mtNone,           "Unknown")                                                     \
   //end
 
@@ -140,9 +148,12 @@ typedef AllocFailStrategy::AllocFailEnum AllocFailType;
  * Memory types
  */
 enum class MEMFLAGS : uint8_t  {
+  mt_first,
   MEMORY_TYPES_DO(MEMORY_TYPE_DECLARE_ENUM)
-  mt_number_of_types   // number of memory types (mtDontTrack
+  mt_number_of_types,  // number of memory types (mtDontTrack
                        // is not included as validate type)
+  mt_outside_range_first = mtJuzD,
+  mt_outside_range_last = mtOther
 };
 // Extra insurance that MEMFLAGS truly has the same size as uint8_t.
 STATIC_ASSERT(sizeof(MEMFLAGS) == sizeof(uint8_t));

--- a/src/java.base/share/native/libzip/Deflater.c
+++ b/src/java.base/share/native/libzip/Deflater.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,20 +35,24 @@
 #include <zlib.h>
 
 #include "java_util_zip_Deflater.h"
+#include "zip_allocation.h"
 
 #define DEF_MEM_LEVEL 8
+
+#define NMT_CATEGORY ((allocation_category_t) MT_JUZD)
 
 JNIEXPORT jlong JNICALL
 Java_java_util_zip_Deflater_init(JNIEnv *env, jclass cls, jint level,
                                  jint strategy, jboolean nowrap)
 {
-    z_stream *strm = calloc(1, sizeof(z_stream));
+    z_stream *strm = JVM_MemoryCalloc(1, sizeof(z_stream), NMT_CATEGORY);
 
     if (strm == 0) {
         JNU_ThrowOutOfMemoryError(env, 0);
         return jlong_zero;
     } else {
         const char *msg;
+        ZIP_InitializeStreamAllocationHooks(strm, MT_JUZD);
         int ret = deflateInit2(strm, level, Z_DEFLATED,
                                nowrap ? -MAX_WBITS : MAX_WBITS,
                                DEF_MEM_LEVEL, strategy);
@@ -56,11 +60,11 @@ Java_java_util_zip_Deflater_init(JNIEnv *env, jclass cls, jint level,
           case Z_OK:
             return ptr_to_jlong(strm);
           case Z_MEM_ERROR:
-            free(strm);
+            JVM_MemoryFree(strm);
             JNU_ThrowOutOfMemoryError(env, 0);
             return jlong_zero;
           case Z_STREAM_ERROR:
-            free(strm);
+            JVM_MemoryFree(strm);
             JNU_ThrowIllegalArgumentException(env, 0);
             return jlong_zero;
           default:
@@ -69,7 +73,7 @@ Java_java_util_zip_Deflater_init(JNIEnv *env, jclass cls, jint level,
                    "zlib returned Z_VERSION_ERROR: "
                    "compile time and runtime zlib implementations differ" :
                    "unknown error initializing zlib library");
-            free(strm);
+            JVM_MemoryFree(strm);
             JNU_ThrowInternalError(env, msg);
             return jlong_zero;
         }
@@ -306,6 +310,6 @@ Java_java_util_zip_Deflater_end(JNIEnv *env, jclass cls, jlong addr)
     if (deflateEnd((z_stream *)jlong_to_ptr(addr)) == Z_STREAM_ERROR) {
         JNU_ThrowInternalError(env, "deflateEnd failed");
     } else {
-        free((z_stream *)jlong_to_ptr(addr));
+        JVM_MemoryFree((z_stream *)jlong_to_ptr(addr));
     }
 }

--- a/src/java.base/share/native/libzip/zip_allocation.c
+++ b/src/java.base/share/native/libzip/zip_allocation.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022 SAP. All rights reserved.
+ * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * Support for reading ZIP/JAR files.
+ */
+
+#include <string.h>
+#include "zip_allocation.h"
+
+/* Function prototypes must exactly match zalloc and zfree. */
+static voidpf local_allocation(voidpf opaque, uInt items, uInt size) {
+    return JVM_MemoryCalloc(items, size, (allocation_category_t)opaque);
+}
+
+static void local_deallocation(voidpf opaque, voidpf address) {
+    JVM_MemoryFree(address);
+}
+
+JNIEXPORT void ZIP_InitializeStreamAllocationHooks(z_stream* strm, allocation_category_t cat) {
+    strm->zalloc = local_allocation;
+    strm->zfree = local_deallocation;
+    strm->opaque = (voidpf) cat;
+}
+

--- a/src/java.base/share/native/libzip/zip_allocation.h
+++ b/src/java.base/share/native/libzip/zip_allocation.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 SAP. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * Helpers for JVM allocation redirection
+ */
+
+#ifndef _ZIP_ALLOCATION_H_
+#define _ZIP_ALLOCATION_H_
+
+#include <zlib.h> /* for z_stream */
+#include "jvm.h"  /* for allocation_category_t */
+
+JNIEXPORT void ZIP_InitializeStreamAllocationHooks(z_stream* strm, allocation_category_t cat);
+
+/* calloc-like convenience wrapper around JVM_MemoryAllocate */
+JNIEXPORT voidpf ZIP_MemoryCalloc(size_t num, size_t size, allocation_category_t cat);
+
+#endif /* !_ZIP_ALLOCATION_H_ */

--- a/src/java.base/share/native/libzip/zip_util.c
+++ b/src/java.base/share/native/libzip/zip_util.c
@@ -43,6 +43,7 @@
 #include "jvm.h"
 #include "io_util.h"
 #include "io_util_md.h"
+#include "zip_allocation.h"
 #include "zip_util.h"
 #include <zlib.h>
 
@@ -1423,6 +1424,7 @@ InflateFully(jzfile *zip, jzentry *entry, void *buf, char **msg)
     }
 
     memset(&strm, 0, sizeof(z_stream));
+    ZIP_InitializeStreamAllocationHooks(&strm, MT_ZLIB);
     if (inflateInit2(&strm, -MAX_WBITS) != Z_OK) {
         *msg = strm.msg;
         return JNI_FALSE;
@@ -1553,6 +1555,7 @@ ZIP_InflateFully(void *inBuf, jlong inLen, void *outBuf, jlong outLen, char **pm
 {
     z_stream strm;
     memset(&strm, 0, sizeof(z_stream));
+    ZIP_InitializeStreamAllocationHooks(&strm, MT_ZLIB);
 
     *pmsg = 0; /* Reset error message */
 
@@ -1595,6 +1598,10 @@ ZIP_InflateFully(void *inBuf, jlong inLen, void *outBuf, jlong outLen, char **pm
     inflateEnd(&strm);
     return JNI_TRUE;
 }
+
+/* Below are utility functions needed for heap dump compression. These are not used by
+ * j.u.zip.
+ */
 
 static voidpf tracking_zlib_alloc(voidpf opaque, uInt items, uInt size) {
   size_t* needed = (size_t*) opaque;


### PR DESCRIPTION
This patch adds NMT tracking to the zlib.

*Please note: we currently discuss whether NMT can be expanded across the JDK in this ML discussion [1]. This PR depends on the outcome of that discussion and won't proceed unless greenlighted. But since [1] is stalled, I post the PR for RFR to get some feedback on the code itself and for people to try it out.*

NMT tracks hotspot native allocations but does not cover the JDK (apart from small exceptions). But the native memory
footprint of JDK libraries can be very significant. Recently we had a customer whose zlib footprint went into the ~40GB range. We analyzed the problem with an in-house memory tracker, but things would have been a lot simpler using NMT.

This patch instruments the zlib via zalloc hooks, which is minimally invasive. It does not touch zlib sources, so it works with both the bundled zlib and system zlib. All the instrumentation happens in the JVM zlib wrapper.

```
-         j.u.zip (deflate) (reserved=624, committed=624)
                            (malloc=624 #3) 
 
-         j.u.zip (inflate) (reserved=221377904, committed=221377904)
                            (malloc=221377904 #60877) 
 
-               Zip (other) (reserved=8163446896, committed=8163446896)
                            (malloc=8163446896 #182622) 
```

[1] https://mail.openjdk.org/pipermail/core-libs-dev/2022-November/096197.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blockers
&nbsp;⚠️ Too few reviewers with at least role reviewer found (have 0, need at least 1) (failed with the updated jcheck configuration)
&nbsp;⚠️ Whitespace errors (failed with the updated jcheck configuration)

### Issue
 * [JDK-8296360](https://bugs.openjdk.org/browse/JDK-8296360): Track native memory used by zlib via NMT (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/10988/head:pull/10988` \
`$ git checkout pull/10988`

Update a local copy of the PR: \
`$ git checkout pull/10988` \
`$ git pull https://git.openjdk.org/jdk.git pull/10988/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10988`

View PR using the GUI difftool: \
`$ git pr show -t 10988`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10988.diff">https://git.openjdk.org/jdk/pull/10988.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/10988#issuecomment-1337065260)