### PR TITLE
8295871: G1: Use different explicit claim marks for CLDs

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -975,8 +975,8 @@ void ClassLoaderData::print_on(outputStream* out) const {
     case _claim_other:                      out->print_cr("other"); break;
     case _claim_other | _claim_finalizable: out->print_cr("other and finalizable"); break;
     case _claim_other | _claim_strong:      out->print_cr("other and strong"); break;
-    case _claim_strong_g1_fullgc_mark:             out->print_cr("g1 full gc mark phase"); break;
-    case _claim_strong_g1_fullgc_adjust:           out->print_cr("g1 full gc adjust phase"); break;
+    case _claim_strong_g1_fullgc_mark:      out->print_cr("g1 full gc mark phase"); break;
+    case _claim_strong_g1_fullgc_adjust:    out->print_cr("g1 full gc adjust phase"); break;
     default:                                ShouldNotReachHere();
   }
   out->print_cr(" - handles             %d", _handles.count());

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -975,6 +975,8 @@ void ClassLoaderData::print_on(outputStream* out) const {
     case _claim_other:                      out->print_cr("other"); break;
     case _claim_other | _claim_finalizable: out->print_cr("other and finalizable"); break;
     case _claim_other | _claim_strong:      out->print_cr("other and strong"); break;
+    case _claim_strong_g1_fullgc_mark:             out->print_cr("g1 full gc mark phase"); break;
+    case _claim_strong_g1_fullgc_adjust:           out->print_cr("g1 full gc adjust phase"); break;
     default:                                ShouldNotReachHere();
   }
   out->print_cr(" - handles             %d", _handles.count());

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -972,11 +972,11 @@ void ClassLoaderData::print_on(outputStream* out) const {
     case _claim_none:                       out->print_cr("none"); break;
     case _claim_finalizable:                out->print_cr("finalizable"); break;
     case _claim_strong:                     out->print_cr("strong"); break;
+    case _claim_strong_stw_fullgc_mark:     out->print_cr("stw full gc mark"); break;
+    case _claim_strong_stw_fullgc_adjust:   out->print_cr("stw full gc adjust"); break;
     case _claim_other:                      out->print_cr("other"); break;
     case _claim_other | _claim_finalizable: out->print_cr("other and finalizable"); break;
     case _claim_other | _claim_strong:      out->print_cr("other and strong"); break;
-    case _claim_strong_g1_fullgc_mark:      out->print_cr("g1 full gc mark phase"); break;
-    case _claim_strong_g1_fullgc_adjust:    out->print_cr("g1 full gc adjust phase"); break;
     default:                                ShouldNotReachHere();
   }
   out->print_cr(" - handles             %d", _handles.count());

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -972,8 +972,8 @@ void ClassLoaderData::print_on(outputStream* out) const {
     case _claim_none:                       out->print_cr("none"); break;
     case _claim_finalizable:                out->print_cr("finalizable"); break;
     case _claim_strong:                     out->print_cr("strong"); break;
-    case _claim_strong_stw_fullgc_mark:     out->print_cr("stw full gc mark"); break;
-    case _claim_strong_stw_fullgc_adjust:   out->print_cr("stw full gc adjust"); break;
+    case _claim_stw_fullgc_mark:            out->print_cr("stw full gc mark"); break;
+    case _claim_stw_fullgc_adjust:          out->print_cr("stw full gc adjust"); break;
     case _claim_other:                      out->print_cr("other"); break;
     case _claim_other | _claim_finalizable: out->print_cr("other and finalizable"); break;
     case _claim_other | _claim_strong:      out->print_cr("other and strong"); break;

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -202,12 +202,12 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   // The "claim" is typically used to check if oops_do needs to be applied on
   // the CLD or not. Most GCs only perform strong marking during the marking phase.
   enum Claim {
-    _claim_none                    = 0,
-    _claim_finalizable             = 2,
-    _claim_strong                  = 3,
-    _claim_other                   = 4,
-    _claim_strong_g1_fullgc_mark   = 8,
-    _claim_strong_g1_fullgc_adjust = 16
+    _claim_none                     = 0,
+    _claim_finalizable              = 2,
+    _claim_strong                   = 3,
+    _claim_strong_stw_fullgc_mark   = 4,
+    _claim_strong_stw_fullgc_adjust = 8,
+    _claim_other                    = 16
   };
   void clear_claim() { _claim = 0; }
   void clear_claim(int claim);

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -202,10 +202,12 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   // The "claim" is typically used to check if oops_do needs to be applied on
   // the CLD or not. Most GCs only perform strong marking during the marking phase.
   enum Claim {
-    _claim_none         = 0,
-    _claim_finalizable  = 2,
-    _claim_strong       = 3,
-    _claim_other        = 4
+    _claim_none                    = 0,
+    _claim_finalizable             = 2,
+    _claim_strong                  = 3,
+    _claim_other                   = 4,
+    _claim_strong_g1_fullgc_mark   = 8,
+    _claim_strong_g1_fullgc_adjust = 16
   };
   void clear_claim() { _claim = 0; }
   void clear_claim(int claim);

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -202,12 +202,12 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   // The "claim" is typically used to check if oops_do needs to be applied on
   // the CLD or not. Most GCs only perform strong marking during the marking phase.
   enum Claim {
-    _claim_none                     = 0,
-    _claim_finalizable              = 2,
-    _claim_strong                   = 3,
-    _claim_strong_stw_fullgc_mark   = 4,
-    _claim_strong_stw_fullgc_adjust = 8,
-    _claim_other                    = 16
+    _claim_none              = 0,
+    _claim_finalizable       = 2,
+    _claim_strong            = 3,
+    _claim_stw_fullgc_mark   = 4,
+    _claim_stw_fullgc_adjust = 8,
+    _claim_other             = 16
   };
   void clear_claim() { _claim = 0; }
   void clear_claim(int claim);

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "classfile/classLoaderData.hpp"
 #include "classfile/classLoaderDataGraph.hpp"
 #include "classfile/systemDictionary.hpp"
 #include "code/codeCache.hpp"
@@ -2108,7 +2109,7 @@ static ReferenceProcessor* get_cm_oop_closure_ref_processor(G1CollectedHeap* g1h
 
 G1CMOopClosure::G1CMOopClosure(G1CollectedHeap* g1h,
                                G1CMTask* task)
-  : MetadataVisitingOopIterateClosure(get_cm_oop_closure_ref_processor(g1h)),
+  : ClaimMetadataVisitingOopIterateClosure(ClassLoaderData::_claim_strong, get_cm_oop_closure_ref_processor(g1h)),
     _g1h(g1h), _task(task)
 { }
 

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -181,10 +181,6 @@ void G1FullCollector::prepare_collection() {
   if (in_concurrent_cycle) {
     GCTraceTime(Debug, gc) debug("Clear Bitmap");
     _heap->concurrent_mark()->clear_bitmap(_heap->workers());
-    // Need cleared claim bits for the mark phase.
-    ClassLoaderDataGraph::clear_claimed_marks();
-  } else {
-    ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_strong);
   }
 
   _heap->gc_prologue(true);
@@ -227,7 +223,7 @@ void G1FullCollector::complete_collection() {
   // update the derived pointer table.
   update_derived_pointers();
 
-  // Need cleared claim bits for the next concurrent marking.
+  // Need completely cleared claim bits for the next concurrent marking or full gc.
   ClassLoaderDataGraph::clear_claimed_marks();
 
   // Prepare the bitmap for the next (potentially concurrent) marking.

--- a/src/hotspot/share/gc/g1/g1FullGCAdjustTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCAdjustTask.cpp
@@ -85,7 +85,7 @@ G1FullGCAdjustTask::G1FullGCAdjustTask(G1FullCollector* collector) :
     _weak_proc_task(collector->workers()),
     _hrclaimer(collector->workers()),
     _adjust(collector) {
-  ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_strong_stw_fullgc_adjust);
+  ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_stw_fullgc_adjust);
 }
 
 void G1FullGCAdjustTask::work(uint worker_id) {
@@ -102,7 +102,7 @@ void G1FullGCAdjustTask::work(uint worker_id) {
     _weak_proc_task.work(worker_id, &always_alive, &_adjust);
   }
 
-  CLDToOopClosure adjust_cld(&_adjust, ClassLoaderData::_claim_strong_stw_fullgc_adjust);
+  CLDToOopClosure adjust_cld(&_adjust, ClassLoaderData::_claim_stw_fullgc_adjust);
   CodeBlobToOopClosure adjust_code(&_adjust, CodeBlobToOopClosure::FixRelocations);
   _root_processor.process_all_roots(&_adjust, &adjust_cld, &adjust_code);
 

--- a/src/hotspot/share/gc/g1/g1FullGCAdjustTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCAdjustTask.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "classfile/classLoaderData.hpp"
 #include "classfile/classLoaderDataGraph.hpp"
 #include "gc/g1/g1CollectedHeap.hpp"
 #include "gc/g1/g1ConcurrentMarkBitMap.inline.hpp"

--- a/src/hotspot/share/gc/g1/g1FullGCAdjustTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCAdjustTask.cpp
@@ -84,8 +84,7 @@ G1FullGCAdjustTask::G1FullGCAdjustTask(G1FullCollector* collector) :
     _weak_proc_task(collector->workers()),
     _hrclaimer(collector->workers()),
     _adjust(collector) {
-  // Need cleared claim bits for the roots processing
-  ClassLoaderDataGraph::clear_claimed_marks();
+  ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_strong_g1_fullgc_adjust);
 }
 
 void G1FullGCAdjustTask::work(uint worker_id) {
@@ -102,7 +101,7 @@ void G1FullGCAdjustTask::work(uint worker_id) {
     _weak_proc_task.work(worker_id, &always_alive, &_adjust);
   }
 
-  CLDToOopClosure adjust_cld(&_adjust, ClassLoaderData::_claim_strong);
+  CLDToOopClosure adjust_cld(&_adjust, ClassLoaderData::_claim_strong_g1_fullgc_adjust);
   CodeBlobToOopClosure adjust_code(&_adjust, CodeBlobToOopClosure::FixRelocations);
   _root_processor.process_all_roots(&_adjust, &adjust_cld, &adjust_code);
 

--- a/src/hotspot/share/gc/g1/g1FullGCAdjustTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCAdjustTask.cpp
@@ -85,7 +85,7 @@ G1FullGCAdjustTask::G1FullGCAdjustTask(G1FullCollector* collector) :
     _weak_proc_task(collector->workers()),
     _hrclaimer(collector->workers()),
     _adjust(collector) {
-  ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_strong_g1_fullgc_adjust);
+  ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_strong_stw_fullgc_adjust);
 }
 
 void G1FullGCAdjustTask::work(uint worker_id) {
@@ -102,7 +102,7 @@ void G1FullGCAdjustTask::work(uint worker_id) {
     _weak_proc_task.work(worker_id, &always_alive, &_adjust);
   }
 
-  CLDToOopClosure adjust_cld(&_adjust, ClassLoaderData::_claim_strong_g1_fullgc_adjust);
+  CLDToOopClosure adjust_cld(&_adjust, ClassLoaderData::_claim_strong_stw_fullgc_adjust);
   CodeBlobToOopClosure adjust_code(&_adjust, CodeBlobToOopClosure::FixRelocations);
   _root_processor.process_all_roots(&_adjust, &adjust_cld, &adjust_code);
 

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
@@ -44,9 +44,9 @@ G1FullGCMarker::G1FullGCMarker(G1FullCollector* collector,
     _mark_closure(worker_id, this, G1CollectedHeap::heap()->ref_processor_stw()),
     _verify_closure(VerifyOption::G1UseFullMarking),
     _stack_closure(this),
-    _cld_closure(mark_closure(), ClassLoaderData::_claim_strong_stw_fullgc_mark),
+    _cld_closure(mark_closure(), ClassLoaderData::_claim_stw_fullgc_mark),
     _mark_stats_cache(mark_stats, G1RegionMarkStatsCache::RegionMarkStatsCacheSize) {
-  ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_strong_stw_fullgc_mark);
+  ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_stw_fullgc_mark);
 }
 
 G1FullGCMarker::~G1FullGCMarker() {

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
@@ -44,9 +44,9 @@ G1FullGCMarker::G1FullGCMarker(G1FullCollector* collector,
     _mark_closure(worker_id, this, G1CollectedHeap::heap()->ref_processor_stw()),
     _verify_closure(VerifyOption::G1UseFullMarking),
     _stack_closure(this),
-    _cld_closure(mark_closure(), ClassLoaderData::_claim_strong_g1_fullgc_mark),
+    _cld_closure(mark_closure(), ClassLoaderData::_claim_strong_stw_fullgc_mark),
     _mark_stats_cache(mark_stats, G1RegionMarkStatsCache::RegionMarkStatsCacheSize) {
-  ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_strong_g1_fullgc_mark);
+  ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_strong_stw_fullgc_mark);
 }
 
 G1FullGCMarker::~G1FullGCMarker() {

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "classfile/classLoaderData.hpp"
+#include "classfile/classLoaderDataGraph.hpp"
 #include "gc/g1/g1FullGCMarker.inline.hpp"
 #include "gc/shared/referenceProcessor.hpp"
 #include "gc/shared/taskTerminator.hpp"

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
@@ -43,8 +43,9 @@ G1FullGCMarker::G1FullGCMarker(G1FullCollector* collector,
     _mark_closure(worker_id, this, G1CollectedHeap::heap()->ref_processor_stw()),
     _verify_closure(VerifyOption::G1UseFullMarking),
     _stack_closure(this),
-    _cld_closure(mark_closure(), ClassLoaderData::_claim_strong),
+    _cld_closure(mark_closure(), ClassLoaderData::_claim_strong_g1_fullgc_mark),
     _mark_stats_cache(mark_stats, G1RegionMarkStatsCache::RegionMarkStatsCacheSize) {
+  ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_strong_g1_fullgc_mark);
 }
 
 G1FullGCMarker::~G1FullGCMarker() {

--- a/src/hotspot/share/gc/g1/g1OopClosures.hpp
+++ b/src/hotspot/share/gc/g1/g1OopClosures.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_GC_G1_G1OOPCLOSURES_HPP
 #define SHARE_GC_G1_G1OOPCLOSURES_HPP
 
+#include "classfile/classLoaderData.hpp"
 #include "gc/g1/g1HeapRegionAttr.hpp"
 #include "memory/iterator.hpp"
 #include "oops/markWord.hpp"
@@ -179,7 +180,7 @@ public:
 };
 
 // Closure for iterating over object fields during concurrent marking
-class G1CMOopClosure : public MetadataVisitingOopIterateClosure {
+class G1CMOopClosure : public ClaimMetadataVisitingOopIterateClosure {
   G1CollectedHeap*   _g1h;
   G1CMTask*          _task;
 public:
@@ -190,13 +191,13 @@ public:
 };
 
 // Closure to scan the root regions during concurrent marking
-class G1RootRegionScanClosure : public MetadataVisitingOopIterateClosure {
-private:
+class G1RootRegionScanClosure : public ClaimMetadataVisitingOopIterateClosure {
   G1CollectedHeap* _g1h;
   G1ConcurrentMark* _cm;
   uint _worker_id;
 public:
   G1RootRegionScanClosure(G1CollectedHeap* g1h, G1ConcurrentMark* cm, uint worker_id) :
+    ClaimMetadataVisitingOopIterateClosure(ClassLoaderData::_claim_strong, nullptr),
     _g1h(g1h), _cm(cm), _worker_id(worker_id) { }
   template <class T> void do_oop_work(T* p);
   virtual void do_oop(      oop* p) { do_oop_work(p); }


### PR DESCRIPTION
Hi all,

  can I have reviews for this follow-up to [JDK-8295118](https://bugs.openjdk.org/browse/JDK-8295118) that removes the need to clear CLD claim marks for every full gc phase by using different claim values for the different phases.

Some comments:
* I used new g1 specific claim values instead of overloading the existing ones, which is imho clearer. I am open to better names, but something like `_claim_strong_2/3` seemed too cryptic. Then again, there is now a collector specific name in the enum. Maybe the enum values should be made collector-specific in some way? Currently they already are (e.g. `_claim_finalizable` is only used in ZGC) as G1 does not need the values except for (multiple) `_claim_strong`.
* I moved the CLD mark verification for the mark phase from `prepare_collection` to the constructor of `G1FullGCMarker`; I think this place is more fitting as directly above there is the use in the `CLDToOopClosure`. Also this pattern aligns with the use in the `G1FullGCAdjustTask`.

Testing: tier1-5

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295871](https://bugs.openjdk.org/browse/JDK-8295871): G1: Use different explicit claim marks for CLDs


### Reviewers
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to [8631a235](https://git.openjdk.org/jdk/pull/10989/files/8631a235e5a6f821c7a3359bd453227e4ece1ae3)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [8631a235](https://git.openjdk.org/jdk/pull/10989/files/8631a235e5a6f821c7a3359bd453227e4ece1ae3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10989/head:pull/10989` \
`$ git checkout pull/10989`

Update a local copy of the PR: \
`$ git checkout pull/10989` \
`$ git pull https://git.openjdk.org/jdk pull/10989/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10989`

View PR using the GUI difftool: \
`$ git pr show -t 10989`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10989.diff">https://git.openjdk.org/jdk/pull/10989.diff</a>

</details>
