### PR TITLE
8296414: [BACKOUT] JDK-8295319: pending_cards_at_gc_start doesn't include cards in thread buffers

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1063,7 +1063,7 @@ void G1CollectedHeap::abort_refinement() {
   }
 
   // Discard all remembered set updates and reset refinement statistics.
-  G1BarrierSet::dirty_card_queue_set().abandon_logs_and_stats();
+  G1BarrierSet::dirty_card_queue_set().abandon_logs();
   assert(G1BarrierSet::dirty_card_queue_set().num_cards() == 0,
          "DCQS should be empty");
   concurrent_refine()->get_and_reset_refinement_stats();

--- a/src/hotspot/share/gc/g1/g1DirtyCardQueue.cpp
+++ b/src/hotspot/share/gc/g1/g1DirtyCardQueue.cpp
@@ -530,13 +530,16 @@ bool G1DirtyCardQueueSet::refine_completed_buffer_concurrently(uint worker_id,
   return true;
 }
 
-void G1DirtyCardQueueSet::abandon_logs_and_stats() {
+void G1DirtyCardQueueSet::abandon_logs() {
   assert_at_safepoint();
+  abandon_completed_buffers();
+  _detached_refinement_stats.reset();
 
   // Disable mutator refinement until concurrent refinement decides otherwise.
   set_mutator_refinement_threshold(SIZE_MAX);
 
-  // Iterate over all the threads, resetting per-thread queues and stats.
+  // Since abandon is done only at safepoints, we can safely manipulate
+  // these queues.
   struct AbandonThreadLogClosure : public ThreadClosure {
     G1DirtyCardQueueSet& _qset;
     AbandonThreadLogClosure(G1DirtyCardQueueSet& qset) : _qset(qset) {}
@@ -547,16 +550,9 @@ void G1DirtyCardQueueSet::abandon_logs_and_stats() {
     }
   } closure(*this);
   Threads::threads_do(&closure);
-
-  enqueue_all_paused_buffers();
-  abandon_completed_buffers();
-
-  // Reset stats from detached threads.
-  MutexLocker ml(G1DetachedRefinementStats_lock, Mutex::_no_safepoint_check_flag);
-  _detached_refinement_stats.reset();
 }
 
-void G1DirtyCardQueueSet::concatenate_logs_and_stats() {
+void G1DirtyCardQueueSet::concatenate_logs() {
   assert_at_safepoint();
 
   // Disable mutator refinement until concurrent refinement decides otherwise.
@@ -566,39 +562,47 @@ void G1DirtyCardQueueSet::concatenate_logs_and_stats() {
   // the global list of logs.
   struct ConcatenateThreadLogClosure : public ThreadClosure {
     G1DirtyCardQueueSet& _qset;
-    G1ConcurrentRefineStats _total_stats;
-
-    ConcatenateThreadLogClosure(G1DirtyCardQueueSet& qset) :
-      _qset{qset}, _total_stats{} {}
-
+    ConcatenateThreadLogClosure(G1DirtyCardQueueSet& qset) : _qset(qset) {}
     virtual void do_thread(Thread* t) {
       G1DirtyCardQueue& queue = G1ThreadLocalData::dirty_card_queue(t);
-      // Flush the buffer if non-empty.  Flush before accumulating and
-      // resetting stats, since flushing may modify the stats.
       if ((queue.buffer() != nullptr) &&
           (queue.index() != _qset.buffer_size())) {
         _qset.flush_queue(queue);
       }
-      G1ConcurrentRefineStats& qstats = *queue.refinement_stats();
-      _total_stats += qstats;
-      qstats.reset();
     }
   } closure(*this);
   Threads::threads_do(&closure);
-  _concatenated_refinement_stats = closure._total_stats;
 
   enqueue_all_paused_buffers();
   verify_num_cards();
+}
+
+G1ConcurrentRefineStats G1DirtyCardQueueSet::get_and_reset_refinement_stats() {
+  assert_at_safepoint();
+
+  // Since we're at a safepoint, there aren't any races with recording of
+  // detached refinement stats.  In particular, there's no risk of double
+  // counting a thread that detaches after we've examined it but before
+  // we've processed the detached stats.
+
+  // Collect and reset stats for attached threads.
+  struct CollectStats : public ThreadClosure {
+    G1ConcurrentRefineStats _total_stats;
+    virtual void do_thread(Thread* t) {
+      G1DirtyCardQueue& dcq = G1ThreadLocalData::dirty_card_queue(t);
+      G1ConcurrentRefineStats& stats = *dcq.refinement_stats();
+      _total_stats += stats;
+      stats.reset();
+    }
+  } closure;
+  Threads::threads_do(&closure);
 
   // Collect and reset stats from detached threads.
   MutexLocker ml(G1DetachedRefinementStats_lock, Mutex::_no_safepoint_check_flag);
-  _concatenated_refinement_stats += _detached_refinement_stats;
+  closure._total_stats += _detached_refinement_stats;
   _detached_refinement_stats.reset();
-}
 
-G1ConcurrentRefineStats G1DirtyCardQueueSet::concatenated_refinement_stats() const {
-  assert_at_safepoint();
-  return _concatenated_refinement_stats;
+  return closure._total_stats;
 }
 
 void G1DirtyCardQueueSet::record_detached_refinement_stats(G1ConcurrentRefineStats* stats) {

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -585,14 +585,12 @@ static void log_refinement_stats(const char* kind, const G1ConcurrentRefineStats
             stats.dirtied_cards());
 }
 
-void G1Policy::record_concurrent_refinement_stats(size_t pending_cards,
-                                                  size_t thread_buffer_cards) {
-  _pending_cards_at_gc_start = pending_cards;
-  _analytics->report_dirtied_cards_in_thread_buffers(thread_buffer_cards);
+void G1Policy::record_concurrent_refinement_stats() {
+  G1DirtyCardQueueSet& dcqs = G1BarrierSet::dirty_card_queue_set();
+  _pending_cards_at_gc_start = dcqs.num_cards();
 
   // Collect per-thread stats, mostly from mutator activity.
-  G1DirtyCardQueueSet& dcqs = G1BarrierSet::dirty_card_queue_set();
-  G1ConcurrentRefineStats mut_stats = dcqs.concatenated_refinement_stats();
+  G1ConcurrentRefineStats mut_stats = dcqs.get_and_reset_refinement_stats();
 
   // Collect specialized concurrent refinement thread stats.
   G1ConcurrentRefine* cr = _g1h->concurrent_refine();
@@ -629,6 +627,11 @@ void G1Policy::record_concurrent_refinement_stats(size_t pending_cards,
   }
 }
 
+void G1Policy::record_concatenate_dirty_card_logs(Tickspan concat_time, size_t num_cards) {
+  _analytics->report_dirtied_cards_in_thread_buffers(num_cards);
+  phase_times()->record_concatenate_dirty_card_logs_time_ms(concat_time.seconds() * MILLIUNITS);
+}
+
 void G1Policy::record_young_collection_start() {
   Ticks now = Ticks::now();
   // We only need to do this here as the policy will only be applied
@@ -642,6 +645,8 @@ void G1Policy::record_young_collection_start() {
   assert_used_and_recalculate_used_equal(_g1h);
 
   phase_times()->record_cur_collection_start_sec(now.seconds());
+
+  record_concurrent_refinement_stats();
 
   _collection_set->reset_bytes_used_before();
 

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -278,6 +278,9 @@ private:
   // Indicate that we aborted marking before doing any mixed GCs.
   void abort_time_to_mixed_tracking();
 
+  // Record and log stats before not-full collection.
+  void record_concurrent_refinement_stats();
+
 public:
 
   G1Policy(STWGCTimer* gc_timer);
@@ -295,6 +298,8 @@ public:
 
   // This should be called after the heap is resized.
   void record_new_heap_size(uint new_number_of_regions);
+
+  void record_concatenate_dirty_card_logs(Tickspan concat_time, size_t num_cards);
 
   void init(G1CollectedHeap* g1h, G1CollectionSet* collection_set);
 
@@ -392,12 +397,6 @@ public:
   size_t estimate_used_young_bytes_locked() const;
 
   void transfer_survivors_to_cset(const G1SurvivorRegions* survivors);
-
-  // Record and log stats and pending cards before not-full collection.
-  // thread_buffer_cards is the number of cards that were in per-thread
-  // buffers.  pending_cards includes thread_buffer_cards.
-  void record_concurrent_refinement_stats(size_t pending_cards,
-                                          size_t thread_buffer_cards);
 
 private:
   //

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -467,16 +467,14 @@ void G1YoungCollector::set_young_collection_default_active_worker_threads(){
   log_info(gc,task)("Using %u workers of %u for evacuation", active_workers, workers()->max_workers());
 }
 
-void G1YoungCollector::concatenate_dirty_card_logs_and_stats() {
+void G1YoungCollector::flush_dirty_card_queues() {
   Ticks start = Ticks::now();
   G1DirtyCardQueueSet& qset = G1BarrierSet::dirty_card_queue_set();
   size_t old_cards = qset.num_cards();
-  qset.concatenate_logs_and_stats();
-  size_t pending_cards = qset.num_cards();
-  size_t thread_buffer_cards = pending_cards - old_cards;
-  policy()->record_concurrent_refinement_stats(pending_cards, thread_buffer_cards);
-  double concat_time = (Ticks::now() - start).seconds() * MILLIUNITS;
-  phase_times()->record_concatenate_dirty_card_logs_time_ms(concat_time);
+  qset.concatenate_logs();
+  size_t added_cards = qset.num_cards() - old_cards;
+  Tickspan concat_time = Ticks::now() - start;
+  policy()->record_concatenate_dirty_card_logs(concat_time, added_cards);
 }
 
 void G1YoungCollector::pre_evacuate_collection_set(G1EvacInfo* evacuation_info, G1ParScanThreadStateSet* per_thread_states) {
@@ -494,6 +492,10 @@ void G1YoungCollector::pre_evacuate_collection_set(G1EvacInfo* evacuation_info, 
     _g1h->retire_tlabs();
     phase_times()->record_prepare_tlab_time_ms((Ticks::now() - start).seconds() * 1000.0);
   }
+
+  // Flush dirty card queues to qset, so later phases don't need to account
+  // for partially filled per-thread queues and such.
+  flush_dirty_card_queues();
 
   hot_card_cache()->reset_hot_cache_claimed_index();
 
@@ -1070,9 +1072,6 @@ void G1YoungCollector::collect() {
     // policy for the collection deliberately elides verification (and some
     // other trivial setup above).
     policy()->record_young_collection_start();
-
-    // Flush early, so later phases don't need to account for per-thread stuff.
-    concatenate_dirty_card_logs_and_stats();
 
     calculate_collection_set(jtm.evacuation_info(), policy()->max_pause_time_ms());
 

--- a/src/hotspot/share/gc/g1/g1YoungCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.hpp
@@ -98,7 +98,7 @@ class G1YoungCollector {
 
   void set_young_collection_default_active_worker_threads();
 
-  void concatenate_dirty_card_logs_and_stats();
+  void flush_dirty_card_queues();
 
   void pre_evacuate_collection_set(G1EvacInfo* evacuation_info, G1ParScanThreadStateSet* pss);
   // Actually do the work of evacuating the parts of the collection set.


### PR DESCRIPTION
Hi all,

  can I have reviews for this clean backout of JDK-8295319: pending_cards_at_gc_start doesn't include cards in thread buffers because it causes quite a few crashes.

Clean revert.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296414](https://bugs.openjdk.org/browse/JDK-8296414): [BACKOUT] JDK-8295319: pending_cards_at_gc_start doesn't include cards in thread buffers


### Reviewers
 * [Leo Korinth](https://openjdk.org/census#lkorinth) (@lkorinth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/10993/head:pull/10993` \
`$ git checkout pull/10993`

Update a local copy of the PR: \
`$ git checkout pull/10993` \
`$ git pull https://git.openjdk.org/jdk pull/10993/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10993`

View PR using the GUI difftool: \
`$ git pr show -t 10993`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/10993.diff">https://git.openjdk.org/jdk/pull/10993.diff</a>

</details>
