### PR TITLE
JDK-8296137: diags-examples.xml is broken

### DIFF
--- a/make/langtools/diags-examples.xml
+++ b/make/langtools/diags-examples.xml
@@ -35,20 +35,20 @@ Usage:
 By default, the reports will be generated in langtools/build/diags-examples/report/.
 -->
 
-<project name="diags-examples" default="diags-examples" basedir="..">
+<project name="diags-examples" default="diags-examples" basedir="../..">
     <import file="build.xml"/>
 
     <!-- specify working directory for the tool -->
     <property name="diags.examples.dir" location="${build.dir}/diag-examples"/>
 
     <!-- compiled classes for the tool -->
-    <property name="diags.examples.classes" location="${diags.examples.dir}/classes}"/>
+    <property name="diags.examples.classes" location="${diags.examples.dir}/classes"/>
 
     <!-- directory for generated reports -->
     <property name="diags.examples.report" location="${diags.examples.dir}/report"/>
 
     <!-- default target, generates reports for all available locales -->
-    <target name="diags-examples" depends="run-en_US,run-ja,run-zh_CN"/>
+    <target name="diags-examples" depends="run-en_US,run-ja,run-zh_CN,run-de"/>
 
     <!-- generate report for US English locale -->
     <target name="run-en_US" depends="-build-runner,-def-runner">
@@ -68,12 +68,18 @@ By default, the reports will be generated in langtools/build/diags-examples/repo
         <runner lang="zh" country="CN" outfile="${diags.examples.report}/zh_CN.html"/>
     </target>
 
+    <!-- generate report for German locale -->
+    <target name="run-de" depends="-build-runner,-def-runner">
+        <mkdir dir="${diags.examples.report}"/>
+        <runner lang="de" outfile="${diags.examples.report}/de.html"/>
+    </target>
+
     <!-- compile the tool that runs the examples -->
     <target name="-build-runner" depends="build">
         <mkdir dir="${diags.examples.classes}"/>
         <javac fork="true"
             executable="${build.bin}/javac"
-            srcdir="test/tools/javac/diags"
+            srcdir="test/langtools/tools/javac/diags"
             destdir="${diags.examples.classes}"
             includes="ArgTypeCompilerFactory.java,Example.java,FileManager.java,HTMLWriter.java,RunExamples.java,DocCommentProcessor.java"
             sourcepath=""
@@ -98,7 +104,7 @@ By default, the reports will be generated in langtools/build/diags-examples/repo
             <sequential>
             <java fork="true"
                   jvm="${langtools.jdk.home}/bin/java"
-                  dir="test/tools/javac/diags"
+                  dir="test/langtools/tools/javac/diags"
                   classpath="${diags.examples.classes};${dist.lib.dir}/javac.jar;${dist.lib.dir}/javap.jar"
                   classname="RunExamples">
                 <jvmarg value="-Duser.language=@{lang}"/>

--- a/test/langtools/tools/javac/diags/Example.java
+++ b/test/langtools/tools/javac/diags/Example.java
@@ -234,7 +234,7 @@ class Example implements Comparable<Example> {
                 //automatic modules:
                 Map<String, List<Path>> module2Files =
                         modulePathFiles.stream()
-                                       .map(f -> f.toPath())
+                                       .map(f -> f.toPath().toAbsolutePath())
                                        .collect(Collectors.groupingBy(p -> modulePath.relativize(p)
                                                                             .getName(0)
                                                                             .toString()));


### PR DESCRIPTION
Please review some minor updates to the `diags/examples` mechanism, repairing some bitrot after one of the not-so-recent repo reorgs.

For bonus, I've added a target for the German version of the output.