### PR TITLE
8296154: [macos] Change "/Applications" to "Applications" in DMG image

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacBaseInstallerBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacBaseInstallerBundler.java
@@ -96,7 +96,8 @@ public abstract class MacBaseInstallerBundler extends AbstractBundler {
             },
             (s, p) -> s);
 
-    static String getInstallDir(
+     // Returns full path to installation directory
+     static String getInstallDir(
             Map<String, ? super Object>  params, boolean defaultOnly) {
         String returnValue = INSTALL_DIR.fetchFrom(params);
         if (defaultOnly && returnValue != null) {
@@ -108,6 +109,27 @@ public abstract class MacBaseInstallerBundler extends AbstractBundler {
                 returnValue = "/Library/Java/JavaVirtualMachines";
             } else {
                returnValue = "/Applications";
+            }
+        }
+        return returnValue;
+    }
+
+    // Returns display name of installation directory. Display name is used to
+    // show user installation location and for well known (default only) we will
+    // use "Applications" or "JavaVirtualMachines". For user provided installation
+    // directory we will use full path as display name.
+    static String getInstallDirDisplayName(
+            Map<String, ? super Object>  params, boolean defaultOnly) {
+        String returnValue = INSTALL_DIR.fetchFrom(params);
+        if (defaultOnly && returnValue != null) {
+            Log.info(I18N.getString("message.install-dir-ignored"));
+            returnValue = null;
+        }
+        if (returnValue == null) {
+            if (StandardBundlerParam.isRuntimeInstaller(params)) {
+                returnValue = "JavaVirtualMachines";
+            } else {
+               returnValue = "Applications";
             }
         }
         return returnValue;

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacBaseInstallerBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacBaseInstallerBundler.java
@@ -116,23 +116,14 @@ public abstract class MacBaseInstallerBundler extends AbstractBundler {
 
     // Returns display name of installation directory. Display name is used to
     // show user installation location and for well known (default only) we will
-    // use "Applications" or "JavaVirtualMachines". For user provided installation
-    // directory we will use full path as display name.
+    // use "Applications" or "JavaVirtualMachines".
     static String getInstallDirDisplayName(
-            Map<String, ? super Object>  params, boolean defaultOnly) {
-        String returnValue = INSTALL_DIR.fetchFrom(params);
-        if (defaultOnly && returnValue != null) {
-            Log.info(I18N.getString("message.install-dir-ignored"));
-            returnValue = null;
+            Map<String, ? super Object>  params) {
+        if (StandardBundlerParam.isRuntimeInstaller(params)) {
+            return "JavaVirtualMachines";
+        } else {
+            return "Applications";
         }
-        if (returnValue == null) {
-            if (StandardBundlerParam.isRuntimeInstaller(params)) {
-                returnValue = "JavaVirtualMachines";
-            } else {
-               returnValue = "Applications";
-            }
-        }
-        return returnValue;
     }
 
     public MacBaseInstallerBundler() {

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacDmgBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacDmgBundler.java
@@ -121,7 +121,7 @@ public class MacDmgBundler extends MacBaseInstallerBundler {
         Path bgFile = Path.of(rootPath.toString(), APP_NAME.fetchFrom(params),
                               BACKGROUND_IMAGE_FOLDER, BACKGROUND_IMAGE);
 
-        //prepare config for exe
+        // Prepare DMG setup script
         Map<String, String> data = new HashMap<>();
         data.put("DEPLOY_VOLUME_URL", volumeUrl);
         data.put("DEPLOY_BG_FILE", bgFile.toString());
@@ -131,6 +131,8 @@ public class MacDmgBundler extends MacBaseInstallerBundler {
               APP_NAME.fetchFrom(params) : appLocation.getFileName().toString();
         data.put("DEPLOY_TARGET", targetItem);
         data.put("DEPLOY_INSTALL_LOCATION", getInstallDir(params, true));
+        data.put("DEPLOY_INSTALL_LOCATION_DISPLAY_NAME",
+                getInstallDirDisplayName(params, true));
 
         createResource(DEFAULT_DMG_SETUP_SCRIPT, params)
                 .setCategory(I18N.getString("resource.dmg-setup-script"))

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacDmgBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacDmgBundler.java
@@ -132,7 +132,7 @@ public class MacDmgBundler extends MacBaseInstallerBundler {
         data.put("DEPLOY_TARGET", targetItem);
         data.put("DEPLOY_INSTALL_LOCATION", getInstallDir(params, true));
         data.put("DEPLOY_INSTALL_LOCATION_DISPLAY_NAME",
-                getInstallDirDisplayName(params, true));
+                getInstallDirDisplayName(params));
 
         createResource(DEFAULT_DMG_SETUP_SCRIPT, params)
                 .setCategory(I18N.getString("resource.dmg-setup-script"))

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/DMGsetup.scpt
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/DMGsetup.scpt
@@ -17,14 +17,14 @@ tell application "Finder"
   set background picture of theViewOptions to POSIX file "DEPLOY_BG_FILE"
 
   -- Create alias for install location
-  make new alias file at POSIX file "DEPLOY_VOLUME_PATH" to POSIX file "DEPLOY_INSTALL_LOCATION" with properties {name:"DEPLOY_INSTALL_LOCATION"}
+  make new alias file at POSIX file "DEPLOY_VOLUME_PATH" to POSIX file "DEPLOY_INSTALL_LOCATION" with properties {name:"DEPLOY_INSTALL_LOCATION_DISPLAY_NAME"}
 
   set allTheFiles to the name of every item of theWindow
   set xpos to 120
   repeat with theFile in allTheFiles
     set theFilePath to POSIX path of theFile
     set appFilePath to POSIX path of "/DEPLOY_TARGET"
-    if theFilePath is "DEPLOY_INSTALL_LOCATION" then
+    if theFilePath ends with "DEPLOY_INSTALL_LOCATION_DISPLAY_NAME" then
       -- Position install location
       set position of item theFile of theWindow to {390, 130}
     else if theFilePath ends with appFilePath then


### PR DESCRIPTION
Changed names of symbolic links for drag and drop location in DMG image. See attached images in JBS.
"/Applications" -> "Applications" for app DMG image.
"/Library/Java/JavaVirtualMachines" -> "JavaVirtualMachines" for runtime DMG image.

Automated test was not added, since DMGsetup.scpt is not getting executed in headless environment and thus symbolic links are not created during automated testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296154](https://bugs.openjdk.org/browse/JDK-8296154): [macos] Change "/Applications" to "Applications" in DMG image


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11001/head:pull/11001` \
`$ git checkout pull/11001`

Update a local copy of the PR: \
`$ git checkout pull/11001` \
`$ git pull https://git.openjdk.org/jdk pull/11001/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11001`

View PR using the GUI difftool: \
`$ git pr show -t 11001`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11001.diff">https://git.openjdk.org/jdk/pull/11001.diff</a>

</details>
