### PR TITLE
8297749: Remove duplicate space in the ProtocolException message being thrown from HttpURLConnection

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
@@ -1996,8 +1996,8 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
                 return inputStream;
             } while (redirects < maxRedirects);
 
-            throw new ProtocolException("Server redirected too many " +
-                                        " times ("+ redirects + ")");
+            throw new ProtocolException("Server redirected too many times (" +
+                    redirects + ")");
         } catch (RuntimeException e) {
             disconnectInternal();
             rememberedException = e;

--- a/test/jdk/sun/net/www/protocol/http/NTLMTest.java
+++ b/test/jdk/sun/net/www/protocol/http/NTLMTest.java
@@ -70,7 +70,7 @@ public class NTLMTest
             uc.getInputStream().readAllBytes();
 
         } catch (ProtocolException e) {
-            /* java.net.ProtocolException: Server redirected too many  times (20) */
+            /* java.net.ProtocolException: Server redirected too many times (20) */
             throw new RuntimeException("Failed: ProtocolException", e);
         } catch (IOException ioe) {
             /* IOException is OK. We are expecting "java.io.IOException: Server


### PR DESCRIPTION
This PR removes a duplicate space in `ProtocolException` message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297749](https://bugs.openjdk.org/browse/JDK-8297749): Remove duplicate space in the ProtocolException message being thrown from HttpURLConnection


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11002/head:pull/11002` \
`$ git checkout pull/11002`

Update a local copy of the PR: \
`$ git checkout pull/11002` \
`$ git pull https://git.openjdk.org/jdk pull/11002/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11002`

View PR using the GUI difftool: \
`$ git pr show -t 11002`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11002.diff">https://git.openjdk.org/jdk/pull/11002.diff</a>

</details>
