### PR TITLE
8296435: RISC-V: Small refactoring for increment/decrement

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -3271,60 +3271,60 @@ address MacroAssembler::emit_trampoline_stub(int insts_call_instruction_offset,
   return stub_start_addr;
 }
 
-Address MacroAssembler::add_memory_helper(const Address dst) {
+Address MacroAssembler::add_memory_helper(const Address dst, Register tmp) {
   switch (dst.getMode()) {
     case Address::base_plus_offset:
       // This is the expected mode, although we allow all the other
       // forms below.
-      return form_address(t1, dst.base(), dst.offset());
+      return form_address(tmp, dst.base(), dst.offset());
     default:
-      la(t1, dst);
-      return Address(t1);
+      la(tmp, dst);
+      return Address(tmp);
   }
 }
 
-void MacroAssembler::increment(const Address dst, int64_t value) {
+void MacroAssembler::increment(const Address dst, int64_t value, Register tmp1, Register tmp2) {
   assert(((dst.getMode() == Address::base_plus_offset &&
            is_offset_in_range(dst.offset(), 12)) || is_imm_in_range(value, 12, 0)),
           "invalid value and address mode combination");
-  Address adr = add_memory_helper(dst);
-  assert(!adr.uses(t0), "invalid dst for address increment");
-  ld(t0, adr);
-  add(t0, t0, value, t1);
-  sd(t0, adr);
+  Address adr = add_memory_helper(dst, tmp2);
+  assert(!adr.uses(tmp1), "invalid dst for address increment");
+  ld(tmp1, adr);
+  add(tmp1, tmp1, value, tmp2);
+  sd(tmp1, adr);
 }
 
-void MacroAssembler::incrementw(const Address dst, int32_t value) {
+void MacroAssembler::incrementw(const Address dst, int32_t value, Register tmp1, Register tmp2) {
   assert(((dst.getMode() == Address::base_plus_offset &&
            is_offset_in_range(dst.offset(), 12)) || is_imm_in_range(value, 12, 0)),
           "invalid value and address mode combination");
-  Address adr = add_memory_helper(dst);
-  assert(!adr.uses(t0), "invalid dst for address increment");
-  lwu(t0, adr);
-  addw(t0, t0, value, t1);
-  sw(t0, adr);
+  Address adr = add_memory_helper(dst, tmp2);
+  assert(!adr.uses(tmp1), "invalid dst for address increment");
+  lwu(tmp1, adr);
+  addw(tmp1, tmp1, value, tmp2);
+  sw(tmp2, adr);
 }
 
-void MacroAssembler::decrement(const Address dst, int64_t value) {
+void MacroAssembler::decrement(const Address dst, int64_t value, Register tmp1, Register tmp2) {
   assert(((dst.getMode() == Address::base_plus_offset &&
            is_offset_in_range(dst.offset(), 12)) || is_imm_in_range(value, 12, 0)),
           "invalid value and address mode combination");
-  Address adr = add_memory_helper(dst);
-  assert(!adr.uses(t0), "invalid dst for address decrement");
-  ld(t0, adr);
-  sub(t0, t0, value, t1);
-  sd(t0, adr);
+  Address adr = add_memory_helper(dst, tmp2);
+  assert(!adr.uses(tmp1), "invalid dst for address decrement");
+  ld(tmp1, adr);
+  sub(tmp1, tmp1, value, tmp2);
+  sd(tmp1, adr);
 }
 
-void MacroAssembler::decrementw(const Address dst, int32_t value) {
+void MacroAssembler::decrementw(const Address dst, int32_t value, Register tmp1, Register tmp2) {
   assert(((dst.getMode() == Address::base_plus_offset &&
            is_offset_in_range(dst.offset(), 12)) || is_imm_in_range(value, 12, 0)),
           "invalid value and address mode combination");
-  Address adr = add_memory_helper(dst);
-  assert(!adr.uses(t0), "invalid dst for address decrement");
-  lwu(t0, adr);
-  subw(t0, t0, value, t1);
-  sw(t0, adr);
+  Address adr = add_memory_helper(dst, tmp2);
+  assert(!adr.uses(tmp1), "invalid dst for address decrement");
+  lwu(tmp1, adr);
+  subw(tmp1, tmp1, value, tmp2);
+  sw(tmp1, adr);
 }
 
 void MacroAssembler::cmpptr(Register src1, Address src2, Label& equal) {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -3302,7 +3302,7 @@ void MacroAssembler::incrementw(const Address dst, int32_t value, Register tmp1,
   assert(!adr.uses(tmp1), "invalid dst for address increment");
   lwu(tmp1, adr);
   addw(tmp1, tmp1, value, tmp2);
-  sw(tmp2, adr);
+  sw(tmp1, adr);
 }
 
 void MacroAssembler::decrement(const Address dst, int64_t value, Register tmp1, Register tmp2) {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1054,11 +1054,11 @@ public:
   // to use a 2nd scratch register to hold the constant. so, an address
   // increment/decrement may trash both t0 and t1.
 
-  void increment(const Address dst, int64_t value = 1);
-  void incrementw(const Address dst, int32_t value = 1);
+  void increment(const Address dst, int64_t value = 1, Register tmp1 = t0, Register tmp2 = t1);
+  void incrementw(const Address dst, int32_t value = 1, Register tmp1 = t0, Register tmp2 = t1);
 
-  void decrement(const Address dst, int64_t value = 1);
-  void decrementw(const Address dst, int32_t value = 1);
+  void decrement(const Address dst, int64_t value = 1, Register tmp1 = t0, Register tmp2 = t1);
+  void decrementw(const Address dst, int32_t value = 1, Register tmp1 = t0, Register tmp2 = t1);
 
   void cmpptr(Register src1, Address src2, Label& equal);
 
@@ -1272,7 +1272,7 @@ private:
   }
 
   int bitset_to_regs(unsigned int bitset, unsigned char* regs);
-  Address add_memory_helper(const Address dst);
+  Address add_memory_helper(const Address dst, Register tmp);
 
   void load_reserved(Register addr, enum operand_size size, Assembler::Aqrl acquire);
   void store_conditional(Register addr, Register new_val, enum operand_size size, Assembler::Aqrl release);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2450,17 +2450,13 @@ encode %{
 
     // Recursive lock case
     __ mv(flag, zr);
-    __ ld(tmp, Address(disp_hdr, ObjectMonitor::recursions_offset_in_bytes() - markWord::monitor_value));
-    __ add(tmp, tmp, 1);
-    __ sd(tmp, Address(disp_hdr, ObjectMonitor::recursions_offset_in_bytes() - markWord::monitor_value));
+    __ increment(Address(disp_hdr, ObjectMonitor::recursions_offset_in_bytes() - markWord::monitor_value), 1, t0, tmp);
 
     __ bind(cont);
 
     __ bnez(flag, no_count);
 
-    __ ld(tmp, Address(xthread, JavaThread::held_monitor_count_offset()));
-    __ add(tmp, tmp, 1);
-    __ sd(tmp, Address(xthread, JavaThread::held_monitor_count_offset()));
+    __ increment(Address(xthread, JavaThread::held_monitor_count_offset()), 1, t0, tmp)
 
     __ bind(no_count);
   %}
@@ -2537,9 +2533,7 @@ encode %{
 
     __ bnez(flag, no_count);
 
-    __ ld(tmp, Address(xthread, JavaThread::held_monitor_count_offset()));
-    __ sub(tmp, tmp, 1);
-    __ sd(tmp, Address(xthread, JavaThread::held_monitor_count_offset()));
+    __ decrement(Address(xthread, JavaThread::held_monitor_count_offset()), 1, t0, tmp);
 
     __ bind(no_count);
   %}

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2456,7 +2456,7 @@ encode %{
 
     __ bnez(flag, no_count);
 
-    __ increment(Address(xthread, JavaThread::held_monitor_count_offset()), 1, t0, tmp)
+    __ increment(Address(xthread, JavaThread::held_monitor_count_offset()), 1, t0, tmp);
 
     __ bind(no_count);
   %}


### PR DESCRIPTION
The `increment` and `decrement` use t1 as tmp register, while t1 was the flag register in c2.
We can make tmp registers as the arguments of `increment` and `decrement` so that c2 can reuse them.

Testing:

full tier1 tests passed on  Linux-riscv64 HiFive Unmathced board with release build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296435](https://bugs.openjdk.org/browse/JDK-8296435): RISC-V: Small refactoring for increment/decrement


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11005/head:pull/11005` \
`$ git checkout pull/11005`

Update a local copy of the PR: \
`$ git checkout pull/11005` \
`$ git pull https://git.openjdk.org/jdk pull/11005/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11005`

View PR using the GUI difftool: \
`$ git pr show -t 11005`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11005.diff">https://git.openjdk.org/jdk/pull/11005.diff</a>

</details>
