### PR TITLE
JDK-8296443 NMT: Remove cmdline_tracking_level handling code

### DIFF
--- a/src/hotspot/share/services/memTracker.cpp
+++ b/src/hotspot/share/services/memTracker.cpp
@@ -48,7 +48,6 @@
 #endif
 
 volatile NMT_TrackingLevel MemTracker::_tracking_level = NMT_unknown;
-NMT_TrackingLevel MemTracker::_cmdline_tracking_level = NMT_unknown;
 
 MemBaseline MemTracker::_baseline;
 
@@ -82,7 +81,7 @@ void MemTracker::initialize() {
 
   NMTPreInit::pre_to_post();
 
-  _tracking_level = _cmdline_tracking_level = level;
+  _tracking_level = level;
 
   // Log state right after NMT initialization
   if (log_is_enabled(Info, nmt)) {

--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -224,10 +224,6 @@ class MemTracker : AllStatic {
     return _baseline;
   }
 
-  static NMT_TrackingLevel cmdline_tracking_level() {
-    return _cmdline_tracking_level;
-  }
-
   static void tuning_statistics(outputStream* out);
 
  private:
@@ -239,8 +235,6 @@ class MemTracker : AllStatic {
   // If NMT option value passed by launcher through environment
   // variable is valid
   static bool                         _is_nmt_env_valid;
-  // command line tracking level
-  static NMT_TrackingLevel            _cmdline_tracking_level;
   // Stored baseline
   static MemBaseline      _baseline;
   // Query lock

--- a/src/hotspot/share/services/nmtDCmd.cpp
+++ b/src/hotspot/share/services/nmtDCmd.cpp
@@ -177,13 +177,9 @@ void NMTDCmd::report_diff(bool summaryOnly, size_t scale_unit) {
 }
 
 bool NMTDCmd::check_detail_tracking_level(outputStream* out) {
-  if (MemTracker::tracking_level() == NMT_detail) {
-    return true;
-  } else if (MemTracker::cmdline_tracking_level() == NMT_detail) {
-    out->print_cr("Tracking level has been downgraded due to lack of resources");
-    return false;
-  } else {
+  if (MemTracker::tracking_level() != NMT_detail) {
     out->print_cr("Detail tracking is not enabled");
     return false;
   }
+  return true;
 }


### PR DESCRIPTION
Trivial cleanup.

NMT tracking level had been shadowed by `_cmdline_tracking_level` to notice tracking level degradation due to resource exhaustion. All that tracking level handling has simplified with [8256844](https://bugs.openjdk.org/browse/JDK-8256844). Coding can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296443](https://bugs.openjdk.org/browse/JDK-8296443): NMT: Remove cmdline_tracking_level handling code


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11006/head:pull/11006` \
`$ git checkout pull/11006`

Update a local copy of the PR: \
`$ git checkout pull/11006` \
`$ git pull https://git.openjdk.org/jdk pull/11006/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11006`

View PR using the GUI difftool: \
`$ git pr show -t 11006`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11006.diff">https://git.openjdk.org/jdk/pull/11006.diff</a>

</details>
