### PR TITLE
8290714: Make com.sun.jndi.dns.DnsClient virtual threads friendly

### DIFF
--- a/src/jdk.naming.dns/share/classes/com/sun/jndi/dns/DNSDatagramChannelFactory.java
+++ b/src/jdk.naming.dns/share/classes/com/sun/jndi/dns/DNSDatagramChannelFactory.java
@@ -27,7 +27,6 @@ package com.sun.jndi.dns;
 import java.io.IOException;
 import java.net.DatagramSocket;
 import java.net.ProtocolFamily;
-import java.net.SocketException;
 import java.net.InetSocketAddress;
 import java.nio.channels.DatagramChannel;
 import java.security.AccessController;
@@ -35,7 +34,7 @@ import java.security.PrivilegedExceptionAction;
 import java.util.Objects;
 import java.util.Random;
 
-class DNSDatagramSocketFactory {
+class DNSDatagramChannelFactory {
     static final int DEVIATION = 3;
     static final int THRESHOLD = 6;
     static final int BIT_DEVIATION = 2;
@@ -120,17 +119,17 @@ class DNSDatagramSocketFactory {
     final Random random;
     final PortHistory history;
 
-    DNSDatagramSocketFactory() {
+    DNSDatagramChannelFactory() {
         this(new Random());
     }
 
-    DNSDatagramSocketFactory(Random random) {
+    DNSDatagramChannelFactory(Random random) {
         this(Objects.requireNonNull(random), null, DEVIATION, THRESHOLD);
     }
-    DNSDatagramSocketFactory(Random random,
-                             ProtocolFamily family,
-                             int deviation,
-                             int threshold) {
+    DNSDatagramChannelFactory(Random random,
+                              ProtocolFamily family,
+                              int deviation,
+                              int threshold) {
         this.random = Objects.requireNonNull(random);
         this.history = new PortHistory(HISTORY, random);
         this.family = family;
@@ -145,12 +144,13 @@ class DNSDatagramSocketFactory {
      * port) then the underlying OS implementation is used. Otherwise, this
      * method will allocate and bind a socket on a randomly selected ephemeral
      * port in the dynamic range.
-     * @return A new DatagramSocket bound to a random port.
-     * @throws SocketException if the socket cannot be created.
+     *
+     * @return A new DatagramChannel bound to a random port.
+     * @throws IOException if the socket cannot be created.
      */
-    public synchronized DatagramSocket open() throws SocketException {
+    public synchronized DatagramChannel open() throws IOException {
         int lastseen = lastport;
-        DatagramSocket s;
+        DatagramChannel s;
 
         boolean thresholdCrossed = unsuitablePortCount > thresholdCount;
         if (thresholdCrossed) {
@@ -166,7 +166,7 @@ class DNSDatagramSocketFactory {
 
         // Allocate an ephemeral port (port 0)
         s = openDefault();
-        lastport = s.getLocalPort();
+        lastport = getLocalPort(s);
         if (lastseen == 0) {
             lastSystemAllocated = lastport;
             history.offer(lastport);
@@ -199,36 +199,27 @@ class DNSDatagramSocketFactory {
         // Undecided... the new port was too close. Let's allocate a random
         // port using our own algorithm
         assert !thresholdCrossed;
-        DatagramSocket ss = openRandom();
+        DatagramChannel ss = openRandom();
         if (ss == null) return s;
         unsuitablePortCount++;
         s.close();
         return ss;
     }
 
-    private DatagramSocket openDefault() throws SocketException {
-        if (family != null) {
-            try {
-                DatagramChannel c = DatagramChannel.open(family);
-                try {
-                    DatagramSocket s = c.socket();
-                    s.bind(null);
-                    return s;
-                } catch (Throwable x) {
-                    c.close();
-                    throw x;
-                }
-            } catch (SocketException x) {
-                throw x;
-            } catch (IOException x) {
-                throw new SocketException(x.getMessage(), x);
-            }
+    private DatagramChannel openDefault() throws IOException {
+        DatagramChannel c = family != null ? DatagramChannel.open(family)
+                                           : DatagramChannel.open();
+        try {
+            c.bind(null);
+            return c;
+        } catch (Throwable x) {
+            c.close();
+            throw x;
         }
-        return new DatagramSocket();
     }
 
     synchronized boolean isUsingNativePortRandomization() {
-        return  unsuitablePortCount <= thresholdCount
+        return unsuitablePortCount <= thresholdCount
                 && suitablePortCount > thresholdCount;
     }
 
@@ -246,7 +237,7 @@ class DNSDatagramSocketFactory {
                 && Math.abs(port - lastport) > deviation;
     }
 
-    private DatagramSocket openRandom() {
+    private DatagramChannel openRandom() {
         int maxtries = MAX_RANDOM_TRIES;
         while (maxtries-- > 0) {
             int port;
@@ -269,25 +260,29 @@ class DNSDatagramSocketFactory {
                 if (family != null) {
                     DatagramChannel c = DatagramChannel.open(family);
                     try {
-                        DatagramSocket s = c.socket();
-                        s.bind(new InetSocketAddress(port));
-                        lastport = s.getLocalPort();
+                        c.bind(new InetSocketAddress(port));
+                        lastport = getLocalPort(c);
                         if (!recycled) history.add(port);
-                        return s;
+                        return c;
                     } catch (Throwable x) {
                         c.close();
                         throw x;
                     }
                 }
-                DatagramSocket s = new DatagramSocket(port);
-                lastport = s.getLocalPort();
+                var dc = DatagramChannel.open();
+                dc.bind(new InetSocketAddress(port));
+                lastport = getLocalPort(dc);
                 if (!recycled) history.add(port);
-                return s;
+                return dc;
             } catch (IOException x) {
                 // try again until maxtries == 0;
             }
         }
         return null;
+    }
+
+    private static int getLocalPort(DatagramChannel dc) throws IOException {
+        return ((InetSocketAddress) dc.getLocalAddress()).getPort();
     }
 
 }

--- a/src/jdk.naming.dns/share/classes/com/sun/jndi/dns/DnsClient.java
+++ b/src/jdk.naming.dns/share/classes/com/sun/jndi/dns/DnsClient.java
@@ -27,19 +27,28 @@ package com.sun.jndi.dns;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.net.DatagramSocket;
-import java.net.DatagramPacket;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.PortUnreachableException;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
 import java.security.SecureRandom;
-import javax.naming.*;
+import javax.naming.CommunicationException;
+import javax.naming.ConfigurationException;
+import javax.naming.NameNotFoundException;
+import javax.naming.NamingException;
+import javax.naming.OperationNotSupportedException;
+import javax.naming.ServiceUnavailableException;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import sun.security.jca.JCAUtil;
 
@@ -83,15 +92,19 @@ public class DnsClient {
 
     private static final int DEFAULT_PORT = 53;
     private static final int TRANSACTION_ID_BOUND = 0x10000;
+    private static final int MIN_TIMEOUT = 50; // msec after which there are no retries.
     private static final SecureRandom random = JCAUtil.getSecureRandom();
     private InetAddress[] servers;
     private int[] serverPorts;
     private int timeout;                // initial timeout on UDP and TCP queries in ms
     private int retries;                // number of UDP retries
 
-    private final Object udpSocketLock = new Object();
-    private static final DNSDatagramSocketFactory factory =
-            new DNSDatagramSocketFactory(random);
+    private final ReentrantLock udpChannelLock = new ReentrantLock();
+
+    private final Selector udpChannelSelector;
+
+    private static final DNSDatagramChannelFactory factory =
+            new DNSDatagramChannelFactory(random);
 
     // Requests sent
     private Map<Integer, ResourceRecord> reqs;
@@ -135,15 +148,24 @@ public class DnsClient {
                 throw ne;
             }
         }
+
+        try {
+            udpChannelSelector = Selector.open();
+        } catch (IOException e) {
+            NamingException ne = new ConfigurationException(
+                    "Channel selector configuration error");
+            ne.setRootCause(e);
+            throw ne;
+        }
         reqs = Collections.synchronizedMap(
             new HashMap<Integer, ResourceRecord>());
         resps = Collections.synchronizedMap(new HashMap<Integer, byte[]>());
     }
 
-    DatagramSocket getDatagramSocket() throws NamingException {
+    DatagramChannel getDatagramChannel() throws NamingException {
         try {
             return factory.open();
-        } catch (java.net.SocketException e) {
+        } catch (IOException e) {
             NamingException ne = new ConfigurationException();
             ne.setRootCause(e);
             throw ne;
@@ -159,6 +181,10 @@ public class DnsClient {
     private Object queuesLock = new Object();
 
     public void close() {
+        try {
+            udpChannelSelector.close();
+        } catch (IOException ioException) {
+        }
         synchronized (queuesLock) {
             reqs.clear();
             resps.clear();
@@ -402,22 +428,28 @@ public class DnsClient {
                                      int port, int retry, int xid)
             throws IOException, NamingException {
 
-        int minTimeout = 50; // msec after which there are no retries.
-
-        synchronized (udpSocketLock) {
-            try (DatagramSocket udpSocket = getDatagramSocket()) {
-                DatagramPacket opkt = new DatagramPacket(
-                        pkt.getData(), pkt.length(), server, port);
-                DatagramPacket ipkt = new DatagramPacket(new byte[8000], 8000);
+        udpChannelLock.lock();
+        try {
+            try (DatagramChannel udpChannel = getDatagramChannel()) {
+                ByteBuffer opkt = ByteBuffer.wrap(pkt.getData(), 0, pkt.length());
+                byte[] data = new byte[8000];
+                ByteBuffer ipkt = ByteBuffer.wrap(data);
                 // Packets may only be sent to or received from this server address
-                udpSocket.connect(server, port);
+                InetSocketAddress target = new InetSocketAddress(server, port);
+                udpChannel.connect(target);
                 int pktTimeout = (timeout * (1 << retry));
-                udpSocket.send(opkt);
+                udpChannel.send(opkt, target);
 
                 // timeout remaining after successive 'receive()'
                 int timeoutLeft = pktTimeout;
                 int cnt = 0;
+                boolean gotData = false;
                 do {
+                    // prepare for retry
+                    if (gotData) {
+                        Arrays.fill(data, 0, ipkt.position(), (byte) 0);
+                        ipkt.clear();
+                    }
                     if (debug) {
                         cnt++;
                         dprint("Trying RECEIVE(" +
@@ -425,20 +457,43 @@ public class DnsClient {
                                 ") for:" + xid + "    sock-timeout:" +
                                 timeoutLeft + " ms.");
                     }
-                    udpSocket.setSoTimeout(timeoutLeft);
                     long start = System.currentTimeMillis();
-                    udpSocket.receive(ipkt);
+                    gotData = blockingReceive(udpChannel, ipkt, timeoutLeft);
                     long end = System.currentTimeMillis();
-
-                    byte[] data = ipkt.getData();
-                    if (isMatchResponse(data, xid)) {
+                    assert gotData || ipkt.position() == 0;
+                    if (gotData && isMatchResponse(data, xid)) {
                         return data;
                     }
                     timeoutLeft = pktTimeout - ((int) (end - start));
-                } while (timeoutLeft > minTimeout);
-                return null; // no matching packet received within the timeout
+                } while (timeoutLeft > MIN_TIMEOUT);
+                // no matching packet received within the timeout
+                throw new SocketTimeoutException();
             }
+        } finally {
+            udpChannelLock.unlock();
         }
+    }
+
+    boolean blockingReceive(DatagramChannel dc, ByteBuffer buffer, long timeout) throws IOException {
+        boolean dataReceived = false;
+        // The provided datagram channel will be used by the caller only to receive data after
+        // it is put to non-blocking mode
+        dc.configureBlocking(false);
+        var selectionKey = dc.register(udpChannelSelector, SelectionKey.OP_READ);
+        try {
+            udpChannelSelector.select(timeout);
+            var keys = udpChannelSelector.selectedKeys();
+            if (keys.contains(selectionKey) && selectionKey.isReadable()) {
+                dc.receive(buffer);
+                dataReceived = true;
+            }
+            keys.clear();
+        } finally {
+            selectionKey.cancel();
+            // Flush the canceled key out of the selected key set
+            udpChannelSelector.selectNow();
+        }
+        return dataReceived;
     }
 
     /*
@@ -629,7 +684,7 @@ public class DnsClient {
         //
         synchronized (queuesLock) {
             if (reqs.containsKey(hdr.xid)) { // enqueue only the first response
-                resps.put(hdr.xid, pkt);
+                resps.put(hdr.xid, pkt.clone());
             }
         }
 

--- a/test/jdk/com/sun/jndi/dns/ConfigTests/Timeout.java
+++ b/test/jdk/com/sun/jndi/dns/ConfigTests/Timeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,28 +24,26 @@
 import javax.naming.CommunicationException;
 import javax.naming.Context;
 import javax.naming.directory.InitialDirContext;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.time.Instant;
+
+import jdk.test.lib.net.URIBuilder;
 
 /*
  * @test
  * @bug 8200151 8265309
  * @summary Tests that we can set the initial UDP timeout interval and the
  *          number of retries.
- * @library ../lib/
+ * @library ../lib/ /test/lib
  * @modules java.base/sun.security.util
  * @run main Timeout
  */
 
 public class Timeout extends DNSTestBase {
-    // Host 10.0.0.0 is a bit bucket, used here to simulate a DNS server that
-    // doesn't respond. 10.0.0.0 server shouldn't be reachable.
-    // Ping to this address should not give any reply
-    private static final String HOST = "10.0.0.0";
-    // Port 9 is a bit bucket, used here to simulate a DNS server that
-    // doesn't respond.
-    private static final int PORT = 9;
     // initial timeout = 1/4 sec
     private static final int TIMEOUT = 250;
     // try 5 times per server
@@ -67,7 +65,16 @@ public class Timeout extends DNSTestBase {
      */
     @Override
     public void runTest() throws Exception {
-        String allQuietUrl = "dns://" + HOST + ":" + PORT;
+        // Create a DatagramSocket and bind it to the loopback address to simulate
+        // UDP DNS server that doesn't respond
+        DatagramSocket ds = new DatagramSocket(
+                new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+        String allQuietUrl = URIBuilder.newBuilder()
+                .scheme("dns")
+                .loopback()
+                .port(ds.getLocalPort())
+                .build()
+                .toString();
         env().put(Context.PROVIDER_URL, allQuietUrl);
         env().put("com.sun.jndi.dns.timeout.initial", String.valueOf(TIMEOUT));
         env().put("com.sun.jndi.dns.timeout.retries", String.valueOf(RETRIES));

--- a/test/jdk/com/sun/jndi/dns/ConfigTests/Timeout.java
+++ b/test/jdk/com/sun/jndi/dns/ConfigTests/Timeout.java
@@ -67,25 +67,26 @@ public class Timeout extends DNSTestBase {
     public void runTest() throws Exception {
         // Create a DatagramSocket and bind it to the loopback address to simulate
         // UDP DNS server that doesn't respond
-        DatagramSocket ds = new DatagramSocket(
-                new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
-        String allQuietUrl = URIBuilder.newBuilder()
-                .scheme("dns")
-                .loopback()
-                .port(ds.getLocalPort())
-                .build()
-                .toString();
-        env().put(Context.PROVIDER_URL, allQuietUrl);
-        env().put("com.sun.jndi.dns.timeout.initial", String.valueOf(TIMEOUT));
-        env().put("com.sun.jndi.dns.timeout.retries", String.valueOf(RETRIES));
-        setContext(new InitialDirContext(env()));
+        try (DatagramSocket ds = new DatagramSocket(
+                new InetSocketAddress(InetAddress.getLoopbackAddress(), 0))) {
+            String allQuietUrl = URIBuilder.newBuilder()
+                    .scheme("dns")
+                    .loopback()
+                    .port(ds.getLocalPort())
+                    .build()
+                    .toString();
+            env().put(Context.PROVIDER_URL, allQuietUrl);
+            env().put("com.sun.jndi.dns.timeout.initial", String.valueOf(TIMEOUT));
+            env().put("com.sun.jndi.dns.timeout.retries", String.valueOf(RETRIES));
+            setContext(new InitialDirContext(env()));
 
-        // Any request should fail after timeouts have expired.
-        startTime = Instant.now();
-        context().getAttributes("");
+            // Any request should fail after timeouts have expired.
+            startTime = Instant.now();
+            context().getAttributes("");
 
-        throw new RuntimeException(
-                "Failed: getAttributes succeeded unexpectedly");
+            throw new RuntimeException(
+                    "Failed: getAttributes succeeded unexpectedly");
+        }
     }
 
     @Override


### PR DESCRIPTION
### The Proposed Change

The proposed change updates JNDI's `DnsClient` internal implementation to use `DatagramChannel` (DC) as a replacement for `DatagramSocket` (DS).
The main motivation behind this change is to make JNDI/DNS lookups friendly to virtual-thread environments and update its underlying implementation to use efficient `DatagramChannel` APIs.
 The list of proposed changes:
- Replace DS usage with DC. That includes the `DNSDatagramSocketFactory` class updates to return DC instead of DS. The factory class was renamed to `DNSDatagramChannelFactory` to reflect that.
- Change DNS query timeouts implementation - the current version introduces a nio channels selector to implement timeouts. One selector is created for each instance of `DnsClient`.
- Adjust query retries logic to the new implementation of timeouts.
- Modify the `Timeout` test to create a bound UDP socket to simulate an unresponsive DNS server. Before this change, the test was using the '10.0.0.0' network address that doesn't belong to any host. The proposed change with a bound unresponsive UDP socket is better for test stability on different platforms.


### Testing
`jdk-tier1` to `jdk-tier3 `tests are showing no failures related to the changes.
JNDI regression and JCK tests also didn't highlight any problems with the changes. 

Also, an app performing a DNS lookup from a virtual thread context executed with the following options `--enable-preview -Djdk.tracePinnedThreads=full` showed no pinned carrier threads. Before the proposed change the following pinned stack trace was observed:
```    java.base/sun.nio.ch.DatagramChannelImpl.park(DatagramChannelImpl.java:486)
    java.base/sun.nio.ch.DatagramChannelImpl.trustedBlockingReceive(DatagramChannelImpl.java:734)
    java.base/sun.nio.ch.DatagramChannelImpl.blockingReceive(DatagramChannelImpl.java:661)
    java.base/sun.nio.ch.DatagramSocketAdaptor.receive(DatagramSocketAdaptor.java:241) <== monitors:1
    java.base/java.net.DatagramSocket.receive(DatagramSocket.java:714)
    jdk.naming.dns/com.sun.jndi.dns.DnsClient.doUdpQuery(DnsClient.java:430) <== monitors:1
    jdk.naming.dns/com.sun.jndi.dns.DnsClient.query(DnsClient.java:216)
    jdk.naming.dns/com.sun.jndi.dns.Resolver.query(Resolver.java:81)
    jdk.naming.dns/com.sun.jndi.dns.DnsContext.c_lookup(DnsContext.java:290)
    java.naming/com.sun.jndi.toolkit.ctx.ComponentContext.p_lookup(ComponentContext.java:542)
    java.naming/com.sun.jndi.toolkit.ctx.PartialCompositeContext.lookup(PartialCompositeContext.java:177)
    java.naming/com.sun.jndi.toolkit.ctx.PartialCompositeContext.lookup(PartialCompositeContext.java:166)
    java.naming/javax.naming.InitialContext.lookup(InitialContext.java:409)
```
After proposed changes - pinned threads are not detectable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290714](https://bugs.openjdk.org/browse/JDK-8290714): Make com.sun.jndi.dns.DnsClient virtual threads friendly


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11007/head:pull/11007` \
`$ git checkout pull/11007`

Update a local copy of the PR: \
`$ git checkout pull/11007` \
`$ git pull https://git.openjdk.org/jdk pull/11007/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11007`

View PR using the GUI difftool: \
`$ git pr show -t 11007`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11007.diff">https://git.openjdk.org/jdk/pull/11007.diff</a>

</details>
