### PR TITLE
8296445: C++ syntax error in jdwpTransport.h

### DIFF
--- a/src/jdk.jdwp.agent/share/native/include/jdwpTransport.h
+++ b/src/jdk.jdwp.agent/share/native/include/jdwpTransport.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdwp.agent/share/native/include/jdwpTransport.h
+++ b/src/jdk.jdwp.agent/share/native/include/jdwpTransport.h
@@ -262,7 +262,7 @@ struct _jdwpTransportEnv {
     }
 
     /*  SetTransportConfiguration added in JDWPTRANSPORT_VERSION_1_1 */
-    jdwpTransportError SetTransportConfiguration(jdwpTransportEnv* env,
+    jdwpTransportError SetTransportConfiguration(jdwpTransportConfiguration *config) {
         return functions->SetTransportConfiguration(this, config);
     }
 


### PR DESCRIPTION
Fix a syntax error in the code in jdwpTransport.h

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296445](https://bugs.openjdk.org/browse/JDK-8296445): C++ syntax error in jdwpTransport.h


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [bf70681a](https://git.openjdk.org/jdk/pull/11008/files/bf70681a007c7f1a7f990105876e732f56f0cfd1)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [bf70681a](https://git.openjdk.org/jdk/pull/11008/files/bf70681a007c7f1a7f990105876e732f56f0cfd1)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11008/head:pull/11008` \
`$ git checkout pull/11008`

Update a local copy of the PR: \
`$ git checkout pull/11008` \
`$ git pull https://git.openjdk.org/jdk pull/11008/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11008`

View PR using the GUI difftool: \
`$ git pr show -t 11008`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11008.diff">https://git.openjdk.org/jdk/pull/11008.diff</a>

</details>
