### PR TITLE
8296447: RISC-V: Make the operands order of vrsub_vx/vrsub_vi consistent with RVV 1.0 spec

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1455,7 +1455,7 @@ enum VectorMask {
 #define INSN(NAME, op, funct3, funct6)                                                             \
   void NAME(VectorRegister Vd, VectorRegister Vs2, int32_t imm, VectorMask vm = unmasked) {        \
     guarantee(is_imm_in_range(imm, 5, 0), "imm is invalid");                                       \
-    patch_VArith(op, Vd, funct3, (uint32_t)imm & 0x1f, Vs2, vm, funct6);                           \
+    patch_VArith(op, Vd, funct3, (uint32_t)(imm & 0x1f), Vs2, vm, funct6);                         \
   }
 
   INSN(vmsgt_vi,  0b1010111, 0b011, 0b011111);

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1255,8 +1255,6 @@ enum VectorMask {
   INSN(vnmsac_vx, 0b1010111, 0b110, 0b101111);
   INSN(vmacc_vx,  0b1010111, 0b110, 0b101101);
 
-  INSN(vrsub_vx,  0b1010111, 0b100, 0b000011);
-
 #undef INSN
 
 #define INSN(NAME, op, funct3, funct6)                                                             \
@@ -1414,8 +1412,9 @@ enum VectorMask {
   INSN(vand_vx, 0b1010111, 0b100, 0b001001);
 
   // Vector Single-Width Integer Add and Subtract
-  INSN(vsub_vx, 0b1010111, 0b100, 0b000010);
-  INSN(vadd_vx, 0b1010111, 0b100, 0b000000);
+  INSN(vsub_vx,  0b1010111, 0b100, 0b000010);
+  INSN(vadd_vx,  0b1010111, 0b100, 0b000000);
+  INSN(vrsub_vx, 0b1010111, 0b100, 0b000011);
 
 #undef INSN
 
@@ -1473,7 +1472,7 @@ enum VectorMask {
 #undef INSN
 
 #define INSN(NAME, op, funct3, funct6)                                                             \
-  void NAME(VectorRegister Vd, int32_t imm, VectorRegister Vs2, VectorMask vm = unmasked) {        \
+  void NAME(VectorRegister Vd, VectorRegister Vs2, int32_t imm, VectorMask vm = unmasked) {        \
     guarantee(is_imm_in_range(imm, 5, 0), "imm is invalid");                                       \
     patch_VArith(op, Vd, funct3, (uint32_t)(imm & 0x1f), Vs2, vm, funct6);                         \
   }

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1468,16 +1468,7 @@ enum VectorMask {
   INSN(vor_vi,    0b1010111, 0b011, 0b001010);
   INSN(vand_vi,   0b1010111, 0b011, 0b001001);
   INSN(vadd_vi,   0b1010111, 0b011, 0b000000);
-
-#undef INSN
-
-#define INSN(NAME, op, funct3, funct6)                                                             \
-  void NAME(VectorRegister Vd, VectorRegister Vs2, int32_t imm, VectorMask vm = unmasked) {        \
-    guarantee(is_imm_in_range(imm, 5, 0), "imm is invalid");                                       \
-    patch_VArith(op, Vd, funct3, (uint32_t)(imm & 0x1f), Vs2, vm, funct6);                         \
-  }
-
-  INSN(vrsub_vi, 0b1010111, 0b011, 0b000011);
+  INSN(vrsub_vi,  0b1010111, 0b011, 0b000011);
 
 #undef INSN
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -753,7 +753,7 @@ void MacroAssembler::vncvt_x_x_w(VectorRegister vd, VectorRegister vs, VectorMas
 }
 
 void MacroAssembler::vneg_v(VectorRegister vd, VectorRegister vs) {
-  vrsub_vx(vd, x0, vs);
+  vrsub_vx(vd, vs, x0);
 }
 
 void MacroAssembler::vfneg_v(VectorRegister vd, VectorRegister vs) {

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -136,7 +136,7 @@ instruct vabsB(vReg dst, vReg src, vReg tmp) %{
             "vmax.vv $dst, $tmp, $src" %}
   ins_encode %{
     __ vsetvli(t0, x0, Assembler::e8);
-    __ vrsub_vi(as_VectorRegister($tmp$$reg), 0, as_VectorRegister($src$$reg));
+    __ vrsub_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg), 0);
     __ vmax_vv(as_VectorRegister($dst$$reg), as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -150,7 +150,7 @@ instruct vabsS(vReg dst, vReg src, vReg tmp) %{
             "vmax.vv $dst, $tmp, $src" %}
   ins_encode %{
     __ vsetvli(t0, x0, Assembler::e16);
-    __ vrsub_vi(as_VectorRegister($tmp$$reg), 0, as_VectorRegister($src$$reg));
+    __ vrsub_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg), 0);
     __ vmax_vv(as_VectorRegister($dst$$reg), as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -164,7 +164,7 @@ instruct vabsI(vReg dst, vReg src, vReg tmp) %{
             "vmax.vv $dst, $tmp, $src" %}
   ins_encode %{
     __ vsetvli(t0, x0, Assembler::e32);
-    __ vrsub_vi(as_VectorRegister($tmp$$reg), 0, as_VectorRegister($src$$reg));
+    __ vrsub_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg), 0);
     __ vmax_vv(as_VectorRegister($dst$$reg), as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -178,7 +178,7 @@ instruct vabsL(vReg dst, vReg src, vReg tmp) %{
             "vmax.vv $dst, $tmp, $src" %}
   ins_encode %{
     __ vsetvli(t0, x0, Assembler::e64);
-    __ vrsub_vi(as_VectorRegister($tmp$$reg), 0, as_VectorRegister($src$$reg));
+    __ vrsub_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg), 0);
     __ vmax_vv(as_VectorRegister($dst$$reg), as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);


### PR DESCRIPTION
Hi,

At the moment, the operands order of `vrsub_vx` and ` vrsub_vi` is not the same as in the RVV1.0 spec[1]. These instructions use the wrong assembly syntax pattern for vector binary arithmetic instructions (multiply-add)[2].

 `vrsub_vx` was classified as `Vector Single-Width Integer Add and Subtract` in rvv1.0 spec, but is currently classified as `Vector Single-Width Integer Multiply-Add Instructions` and generate the functions under the corresponding macros, which results in the reverse order of the operands `Vs2` and `Rs1` compared to the spec.

 `vrsub_vi` has its own separate macro definition to generate the corresponding function and the order of these operands(`Vs2` and `imm`) is reversed too.

I think it is better to adjust the operands order of these two instructions to be consistent with the spec.

Please take a look and have some reviews. Thanks a lot.


[1] https://github.com/riscv/riscv-v-spec/blob/v1.0/v-spec.adoc
[2] https://github.com/riscv/riscv-v-spec/blob/v1.0/v-spec.adoc#101-vector-arithmetic-instruction-encoding

## Testing:

- hotspot and jdk tier1 on unmatched board without new failures
- test/jdk/jdk/incubator/vector/Int256VectorTests.java with fastdebug on qemu
- test/jdk/jdk/incubator/vector/Long256VectorTests.java with fastdebug on qemu

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296447](https://bugs.openjdk.org/browse/JDK-8296447): RISC-V: Make the operands order of vrsub_vx/vrsub_vi consistent with RVV 1.0 spec


### Reviewers
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Author) ⚠️ Review applies to [0930a669](https://git.openjdk.org/jdk/pull/11009/files/0930a669979c2e0cf50f935520165df8e6aec92f)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11009/head:pull/11009` \
`$ git checkout pull/11009`

Update a local copy of the PR: \
`$ git checkout pull/11009` \
`$ git pull https://git.openjdk.org/jdk pull/11009/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11009`

View PR using the GUI difftool: \
`$ git pr show -t 11009`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11009.diff">https://git.openjdk.org/jdk/pull/11009.diff</a>

</details>
