### PR TITLE
8295099: vmTestbase/nsk/stress/strace/strace013.java failed with "TestFailure: wrong lengths of stack traces: strace013Thread0: NNN strace013Thread83: MMM"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace013.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace013.java
@@ -78,7 +78,7 @@ public class strace013 {
     static Object lockedObject = new Object();
     static int waitingCount = 0; // accessed while holding lockedObject
 
-    // Must synchronized on the lockedObject so thh right count guarantees
+    // Must synchronize on the lockedObject so the right count guarantees
     // the wait() call has been entered.
     static int waitingCount() {
         synchronized(strace013.lockedObject) {
@@ -172,7 +172,7 @@ public class strace013 {
         for (int i = 1; i < THRD_COUNT; i++) {
             all = (StackTraceElement[]) traces.get(threads[i]);
             int k = all.length;
-            if (count - k > 2) {
+            if (count != k) {
                 complain("wrong lengths of stack traces:\n\t"
                         + threads[0].getName() + ": " + count
                         + "\t"
@@ -282,6 +282,8 @@ class strace013Thread extends Thread {
             synchronized (strace013.lockedObject) {
                 strace013.waitingCount++;
                 try {
+                    // If we get a spurious wakeup then the test may break,
+                    // but there is nothing we can do to prevent that.
                     strace013.lockedObject.wait();
                 } catch (InterruptedException e) {
                     strace013.complain("" + e);


### PR DESCRIPTION
The test is incorrectly synchronized and may take the stack trace of a thread before it has entered the wait() and thus be three frames short of the correct stack. So I cleaned that up to ensure things are correctly synchronized.

A number of comments in the test description etc were wrong so I also fixed those.

These tests are stylistically awful but I refrained from embarking on a major cleanup and adopted the prevailing styles.

Testing: local plus 50x on each platform (in progress)

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295099](https://bugs.openjdk.org/browse/JDK-8295099): vmTestbase/nsk/stress/strace/strace013.java failed with "TestFailure: wrong lengths of stack traces:  strace013Thread0: NNN strace013Thread83: MMM"


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11011/head:pull/11011` \
`$ git checkout pull/11011`

Update a local copy of the PR: \
`$ git checkout pull/11011` \
`$ git pull https://git.openjdk.org/jdk pull/11011/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11011`

View PR using the GUI difftool: \
`$ git pr show -t 11011`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11011.diff">https://git.openjdk.org/jdk/pull/11011.diff</a>

</details>
