### PR TITLE
8296384: [TESTBUG] sun/security/provider/SecureRandom/AbstractDrbg/SpecTest.java intermittently timeout

### DIFF
--- a/test/jdk/java/security/SecureRandom/NoSync.java
+++ b/test/jdk/java/security/SecureRandom/NoSync.java
@@ -30,7 +30,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /*
  * @test
  * @bug 7004967
- * @run main/othervm NoSync
+ * @run main/othervm -Djava.security.egd=file:/dev/urandom NoSync
  * @summary SecureRandom should be more explicit about threading
  */
 public class NoSync {

--- a/test/jdk/sun/security/provider/SecureRandom/AbstractDrbg/SpecTest.java
+++ b/test/jdk/sun/security/provider/SecureRandom/AbstractDrbg/SpecTest.java
@@ -25,7 +25,7 @@
  * @bug 8051408 8157308 8130181
  * @modules java.base/sun.security.provider
  * @build java.base/sun.security.provider.S
- * @run main SpecTest
+ * @run main/othervm -Djava.security.egd=file:/dev/urandom SpecTest
  * @summary check the AbstractDrbg API etc
  */
 


### PR DESCRIPTION
Reviewed-by: Yi Yang

Signed-off-by: sendaoYan <yansendao.ysd@alibaba-inc.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8296384](https://bugs.openjdk.org/browse/JDK-8296384): [TESTBUG] sun/security/provider/SecureRandom/AbstractDrbg/SpecTest.java intermittently timeout


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11013/head:pull/11013` \
`$ git checkout pull/11013`

Update a local copy of the PR: \
`$ git checkout pull/11013` \
`$ git pull https://git.openjdk.org/jdk pull/11013/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11013`

View PR using the GUI difftool: \
`$ git pr show -t 11013`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11013.diff">https://git.openjdk.org/jdk/pull/11013.diff</a>

</details>
