### PR TITLE
JDK-8296406: ChainingConstructors jtreg test reduce code duplication

### DIFF
--- a/test/jdk/java/security/Exceptions/ChainingConstructors.java
+++ b/test/jdk/java/security/Exceptions/ChainingConstructors.java
@@ -37,174 +37,35 @@ public class ChainingConstructors {
     private static final String MSG = "msg";
     private static Exception cause = new Exception("cause");
 
+    public static <E extends Exception> void test(E ex1, E ex2) throws Exception {
+        String cln = ex1.getClass().getSimpleName();
+        if (!ex1.getCause().equals(cause)) {
+            throw new SecurityException("Cause test failed for " + cln);
+        }
+        if (!ex2.getMessage().equals(MSG) || !ex2.getCause().equals(cause)) {
+            throw new SecurityException("Cause and message test failed for " + cln);
+        }
+    }
+
     public static void main(String[] args) throws Exception {
-        SecurityException se = new SecurityException(cause);
-        if (!se.getCause().equals(cause)) {
-            throw new SecurityException("Test 1 failed");
-        }
-        se = new SecurityException(MSG, cause);
-        if (!se.getMessage().equals(MSG) || !se.getCause().equals(cause)) {
-            throw new SecurityException("Test 1 failed");
-        }
-
-        DigestException de = new DigestException(cause);
-        if (!de.getCause().equals(cause)) {
-            throw new SecurityException("Test 2 failed");
-        }
-        de = new DigestException(MSG, cause);
-        if (!de.getMessage().equals(MSG) || !de.getCause().equals(cause)) {
-            throw new SecurityException("Test 2 failed");
-        }
-
-        GeneralSecurityException gse = new GeneralSecurityException(cause);
-        if (!gse.getCause().equals(cause)) {
-            throw new SecurityException("Test 3 failed");
-        }
-        gse = new GeneralSecurityException(MSG, cause);
-        if (!gse.getMessage().equals(MSG) || !gse.getCause().equals(cause)) {
-            throw new SecurityException("Test 3 failed");
-        }
-
-        InvalidAlgorithmParameterException iape =
-                new InvalidAlgorithmParameterException(cause);
-        if (!iape.getCause().equals(cause)) {
-            throw new SecurityException("Test 4 failed");
-        }
-        iape = new InvalidAlgorithmParameterException(MSG, cause);
-        if (!iape.getMessage().equals(MSG) || !iape.getCause().equals(cause)) {
-            throw new SecurityException("Test 4 failed");
-        }
-
-        InvalidKeyException ike = new InvalidKeyException(cause);
-        if (!ike.getCause().equals(cause)) {
-            throw new SecurityException("Test 5 failed");
-        }
-        ike = new InvalidKeyException(MSG, cause);
-        if (!ike.getMessage().equals(MSG) || !ike.getCause().equals(cause)) {
-            throw new SecurityException("Test 5 failed");
-        }
-
-        InvalidKeySpecException ikse = new InvalidKeySpecException(cause);
-        if (!ikse.getCause().equals(cause)) {
-            throw new SecurityException("Test 6 failed");
-        }
-        ikse = new InvalidKeySpecException(MSG, cause);
-        if (!ikse.getMessage().equals(MSG) || !ikse.getCause().equals(cause)) {
-            throw new SecurityException("Test 6 failed");
-        }
-
-        KeyException ke = new KeyException(cause);
-        if (!ke.getCause().equals(cause)) {
-            throw new SecurityException("Test 7 failed");
-        }
-        ke = new KeyException(MSG, cause);
-        if (!ke.getMessage().equals(MSG) || !ke.getCause().equals(cause)) {
-            throw new SecurityException("Test 7 failed");
-        }
-
-        KeyManagementException kme = new KeyManagementException(cause);
-        if (!kme.getCause().equals(cause)) {
-            throw new SecurityException("Test 8 failed");
-        }
-        kme = new KeyManagementException(MSG, cause);
-        if (!kme.getMessage().equals(MSG) || !kme.getCause().equals(cause)) {
-            throw new SecurityException("Test 8 failed");
-        }
-
-        KeyStoreException kse = new KeyStoreException(cause);
-        if (!kse.getCause().equals(cause)) {
-            throw new SecurityException("Test 9 failed");
-        }
-        kse = new KeyStoreException(MSG, cause);
-        if (!kse.getMessage().equals(MSG) || !kse.getCause().equals(cause)) {
-            throw new SecurityException("Test 9 failed");
-        }
-
-        NoSuchAlgorithmException nsae = new NoSuchAlgorithmException(cause);
-        if (!nsae.getCause().equals(cause)) {
-            throw new SecurityException("Test 10 failed");
-        }
-        nsae = new NoSuchAlgorithmException(MSG, cause);
-        if (!nsae.getMessage().equals(MSG) || !nsae.getCause().equals(cause)) {
-            throw new SecurityException("Test 10 failed");
-        }
-
-        ProviderException pe = new ProviderException(cause);
-        if (!pe.getCause().equals(cause)) {
-            throw new SecurityException("Test 11 failed");
-        }
-        pe = new ProviderException(MSG, cause);
-        if (!pe.getMessage().equals(MSG) || !pe.getCause().equals(cause)) {
-            throw new SecurityException("Test 11 failed");
-        }
-
-        SignatureException sige = new SignatureException(cause);
-        if (!sige.getCause().equals(cause)) {
-            throw new SecurityException("Test 12 failed");
-        }
-        sige = new SignatureException(MSG, cause);
-        if (!sige.getMessage().equals(MSG) || !sige.getCause().equals(cause)) {
-            throw new SecurityException("Test 12 failed");
-        }
-
-        CRLException crle = new CRLException(cause);
-        if (!crle.getCause().equals(cause)) {
-            throw new SecurityException("Test 13 failed");
-        }
-        crle = new CRLException(MSG, cause);
-        if (!crle.getMessage().equals(MSG) || !crle.getCause().equals(cause)) {
-            throw new SecurityException("Test 13 failed");
-        }
-
-        CertificateException ce = new CertificateException(cause);
-        if (!ce.getCause().equals(cause)) {
-            throw new SecurityException("Test 14 failed");
-        }
-        ce = new CertificateException(MSG, cause);
-        if (!ce.getMessage().equals(MSG) || !ce.getCause().equals(cause)) {
-            throw new SecurityException("Test 14 failed");
-        }
-
-        CertificateParsingException cpe =
-                new CertificateParsingException(cause);
-        if (!cpe.getCause().equals(cause)) {
-            throw new SecurityException("Test 15 failed");
-        }
-        cpe = new CertificateParsingException(MSG, cause);
-        if (!cpe.getMessage().equals(MSG) || !cpe.getCause().equals(cause)) {
-            throw new SecurityException("Test 15 failed");
-        }
-
-        CertificateEncodingException cee =
-                new CertificateEncodingException(cause);
-        if (!cee.getCause().equals(cause)) {
-            throw new SecurityException("Test 16 failed");
-        }
-        cee = new CertificateEncodingException(MSG, cause);
-        if (!cee.getMessage().equals(MSG) || !cee.getCause().equals(cause)) {
-            throw new SecurityException("Test 16 failed");
-        }
-
-        InvalidParameterException ipe =
-                new InvalidParameterException(cause);
-        if (!ipe.getCause().equals(cause)) {
-            throw new SecurityException("Test 17 failed");
-        }
-        ipe = new InvalidParameterException(MSG, cause);
-        if (!ipe.getMessage().equals(MSG) || !ipe.getCause().equals(cause)) {
-            throw new SecurityException("Test 17 failed");
-        }
-
-/*
-        SSLException ssle =
-                new SSLException(cause);
-        if (!ssle.getCause().equals(cause)) {
-            throw new SecurityException("Test 17 failed");
-        }
-        ssle =new SSLException(MSG, cause);
-        if (!ssle.getMessage().equals(MSG) || !ssle.getCause().equals(cause)) {
-            throw new SecurityException("Test 17 failed");
-        }
-*/
+        test(new SecurityException(cause), new SecurityException(MSG, cause));
+        test(new DigestException(cause), new DigestException(MSG, cause));
+        test(new GeneralSecurityException(cause), new GeneralSecurityException(MSG, cause));
+        test(new InvalidAlgorithmParameterException(cause),
+             new InvalidAlgorithmParameterException(MSG, cause));
+        test(new InvalidKeyException(cause), new InvalidKeyException(MSG, cause));
+        test(new InvalidKeySpecException(cause), new InvalidKeySpecException(MSG, cause));
+        test(new InvalidParameterException(cause), new InvalidParameterException(MSG, cause));
+        test(new KeyException(cause), new KeyException(MSG, cause));
+        test(new KeyManagementException(cause), new KeyManagementException(MSG, cause));
+        test(new KeyStoreException(cause), new KeyStoreException(MSG, cause));
+        test(new NoSuchAlgorithmException(cause), new NoSuchAlgorithmException(MSG, cause));
+        test(new ProviderException(cause), new ProviderException(MSG, cause));
+        test(new SignatureException(cause), new SignatureException(MSG, cause));
+        test(new CRLException(cause), new CRLException(MSG, cause));
+        test(new CertificateException(cause), new CertificateException(MSG, cause));
+        test(new CertificateParsingException(cause), new CertificateParsingException(MSG, cause));
+        test(new CertificateEncodingException(cause), new CertificateEncodingException(MSG, cause));
+        test(new CertPathBuilderException(cause), new CertPathBuilderException(MSG, cause));
     }
 }

--- a/test/jdk/java/security/Exceptions/ChainingConstructors.java
+++ b/test/jdk/java/security/Exceptions/ChainingConstructors.java
@@ -23,8 +23,8 @@
 
 /*
  * @test
- * @bug 4496095
- * @summary Add constructors for exception chaining to java.security Exceptions
+ * @bug 4496095 8296406
+ * @summary Test constructors for exception chaining of security-related exceptions
  */
 
 import java.security.*;
@@ -67,5 +67,6 @@ public class ChainingConstructors {
         test(new CertificateParsingException(cause), new CertificateParsingException(MSG, cause));
         test(new CertificateEncodingException(cause), new CertificateEncodingException(MSG, cause));
         test(new CertPathBuilderException(cause), new CertPathBuilderException(MSG, cause));
+        test(new SSLException(cause), new SSLException(MSG, cause));
     }
 }


### PR DESCRIPTION
The java/security/Exceptions/ChainingConstructors jdk jtreg test shows quite a lot of code duplication. The test code can be simplified e.g. by using generics. Additionally the test failure output was improved and a test for the constructors of CertPathBuilderException was added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296406](https://bugs.openjdk.org/browse/JDK-8296406): ChainingConstructors jtreg test reduce code duplication


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11016/head:pull/11016` \
`$ git checkout pull/11016`

Update a local copy of the PR: \
`$ git checkout pull/11016` \
`$ git pull https://git.openjdk.org/jdk pull/11016/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11016`

View PR using the GUI difftool: \
`$ git pr show -t 11016`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11016.diff">https://git.openjdk.org/jdk/pull/11016.diff</a>

</details>
