### PR TITLE
8296470: Refactor VMError::report STEP macro to improve readability

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -529,8 +529,9 @@ void VMError::clear_step_start_time() {
 void VMError::report(outputStream* st, bool _verbose) {
 
 # define BEGIN if (_current_step == 0) { _current_step = __LINE__;
-# define STEP(s) } if (_current_step < __LINE__) { _current_step = __LINE__; _current_step_info = s; \
+# define STEP_IF(s,cond) } if (_current_step < __LINE__ && (cond)) { _current_step = __LINE__; _current_step_info = s; \
   record_step_start_time(); _step_did_timeout = false;
+# define STEP(s) STEP_IF(s, true)
 # define END clear_step_start_time(); }
 
   // don't allocate large buffer on stack
@@ -541,7 +542,6 @@ void VMError::report(outputStream* st, bool _verbose) {
   BEGIN
 
   STEP("printing fatal error message")
-
     st->print_cr("#");
     if (should_report_bug(_id)) {
       st->print_cr("# A fatal error has been detected by the Java Runtime Environment:");
@@ -558,166 +558,146 @@ void VMError::report(outputStream* st, bool _verbose) {
 
   // test secondary error handling. Test it twice, to test that resetting
   // error handler after a secondary crash works.
-  STEP("test secondary crash 1")
-    if (_verbose && TestCrashInErrorHandler == TEST_SECONDARY_CRASH) {
-      st->print_cr("Will crash now (TestCrashInErrorHandler=%u)...",
-        TestCrashInErrorHandler);
-      controlled_crash(TestCrashInErrorHandler);
-    }
+  STEP_IF("test secondary crash 1", _verbose && TestCrashInErrorHandler == TEST_SECONDARY_CRASH)
+    st->print_cr("Will crash now (TestCrashInErrorHandler=%u)...",
+      TestCrashInErrorHandler);
+    controlled_crash(TestCrashInErrorHandler);
 
-  STEP("test secondary crash 2")
-    if (_verbose && TestCrashInErrorHandler == TEST_SECONDARY_CRASH) {
-      st->print_cr("Will crash now (TestCrashInErrorHandler=%u)...",
-        TestCrashInErrorHandler);
-      controlled_crash(TestCrashInErrorHandler);
-    }
+  STEP_IF("test secondary crash 2", _verbose && TestCrashInErrorHandler == TEST_SECONDARY_CRASH)
+    st->print_cr("Will crash now (TestCrashInErrorHandler=%u)...",
+      TestCrashInErrorHandler);
+    controlled_crash(TestCrashInErrorHandler);
 
-  STEP("test missing ResourceMark does not crash")
-    if (_verbose && TestCrashInErrorHandler == TEST_RESOURCE_MARK_CRASH) {
-      stringStream message;
-      message.print("This is a message with no ResourceMark");
-      tty->print_cr("%s", message.as_string());
-    }
+  STEP_IF("test missing ResourceMark does not crash", _verbose && TestCrashInErrorHandler == TEST_RESOURCE_MARK_CRASH)
+    stringStream message;
+    message.print("This is a message with no ResourceMark");
+    tty->print_cr("%s", message.as_string());
 
   // TestUnresponsiveErrorHandler: We want to test both step timeouts and global timeout.
   // Step to global timeout ratio is 4:1, so in order to be absolutely sure we hit the
   // global timeout, let's execute the timeout step five times.
   // See corresponding test in test/runtime/ErrorHandling/TimeoutInErrorHandlingTest.java
-  STEP("setup for test unresponsive error reporting step")
-    if (_verbose && TestUnresponsiveErrorHandler) {
-      // We record reporting_start_time for this test here because we
-      // care about the time spent executing TIMEOUT_TEST_STEP and not
-      // about the time it took us to get here.
-      tty->print_cr("Recording reporting_start_time for TestUnresponsiveErrorHandler.");
-      record_reporting_start_time();
-    }
+  STEP_IF("setup for test unresponsive error reporting step", _verbose && TestUnresponsiveErrorHandler)
+    // We record reporting_start_time for this test here because we
+    // care about the time spent executing TIMEOUT_TEST_STEP and not
+    // about the time it took us to get here.
+    tty->print_cr("Recording reporting_start_time for TestUnresponsiveErrorHandler.");
+    record_reporting_start_time();
 
-  #define TIMEOUT_TEST_STEP STEP("test unresponsive error reporting step") \
-    if (_verbose && TestUnresponsiveErrorHandler) { os::infinite_sleep(); }
+  #define TIMEOUT_TEST_STEP STEP_IF("test unresponsive error reporting step", _verbose && TestUnresponsiveErrorHandler) \
+    os::infinite_sleep();
   TIMEOUT_TEST_STEP
   TIMEOUT_TEST_STEP
   TIMEOUT_TEST_STEP
   TIMEOUT_TEST_STEP
   TIMEOUT_TEST_STEP
 
-  STEP("test safefetch in error handler")
+  STEP_IF("test safefetch in error handler", _verbose && TestSafeFetchInErrorHandler)
     // test whether it is safe to use SafeFetch32 in Crash Handler. Test twice
     // to test that resetting the signal handler works correctly.
-    if (_verbose && TestSafeFetchInErrorHandler) {
-      st->print_cr("Will test SafeFetch...");
-      int* const invalid_pointer = (int*)segfault_address;
-      const int x = 0x76543210;
-      int i1 = SafeFetch32(invalid_pointer, x);
-      int i2 = SafeFetch32(invalid_pointer, x);
-      if (i1 == x && i2 == x) {
-        st->print_cr("SafeFetch OK."); // Correctly deflected and returned default pattern
-      } else {
-        st->print_cr("??");
-      }
+    st->print_cr("Will test SafeFetch...");
+    int* const invalid_pointer = (int*)segfault_address;
+    const int x = 0x76543210;
+    int i1 = SafeFetch32(invalid_pointer, x);
+    int i2 = SafeFetch32(invalid_pointer, x);
+    if (i1 == x && i2 == x) {
+      st->print_cr("SafeFetch OK."); // Correctly deflected and returned default pattern
+    } else {
+      st->print_cr("??");
     }
 #endif // ASSERT
 
   STEP("printing type of error")
-
-     switch(static_cast<unsigned int>(_id)) {
-       case OOM_MALLOC_ERROR:
-       case OOM_MMAP_ERROR:
-       case OOM_MPROTECT_ERROR:
-         if (_size) {
-           st->print("# Native memory allocation ");
-           st->print((_id == (int)OOM_MALLOC_ERROR) ? "(malloc) failed to allocate " :
-                     (_id == (int)OOM_MMAP_ERROR)   ? "(mmap) failed to map " :
-                                                      "(mprotect) failed to protect ");
-           jio_snprintf(buf, sizeof(buf), SIZE_FORMAT, _size);
-           st->print("%s", buf);
-           st->print(" bytes");
-           if (strlen(_detail_msg) > 0) {
-             st->print(" for ");
-             st->print("%s", _detail_msg);
-           }
-           st->cr();
-         } else {
-           if (strlen(_detail_msg) > 0) {
-             st->print("# ");
-             st->print_cr("%s", _detail_msg);
-           }
-         }
-         // In error file give some solutions
-         if (_verbose) {
-           print_oom_reasons(st);
-         } else {
-           return;  // that's enough for the screen
-         }
-         break;
-       case INTERNAL_ERROR:
-       default:
-         break;
-     }
+    switch(static_cast<unsigned int>(_id)) {
+      case OOM_MALLOC_ERROR:
+      case OOM_MMAP_ERROR:
+      case OOM_MPROTECT_ERROR:
+        if (_size) {
+          st->print("# Native memory allocation ");
+          st->print((_id == (int)OOM_MALLOC_ERROR) ? "(malloc) failed to allocate " :
+                    (_id == (int)OOM_MMAP_ERROR)   ? "(mmap) failed to map " :
+                                                    "(mprotect) failed to protect ");
+          jio_snprintf(buf, sizeof(buf), SIZE_FORMAT, _size);
+          st->print("%s", buf);
+          st->print(" bytes");
+          if (strlen(_detail_msg) > 0) {
+            st->print(" for ");
+            st->print("%s", _detail_msg);
+          }
+          st->cr();
+        } else {
+          if (strlen(_detail_msg) > 0) {
+            st->print("# ");
+            st->print_cr("%s", _detail_msg);
+          }
+        }
+        // In error file give some solutions
+        if (_verbose) {
+          print_oom_reasons(st);
+        } else {
+          return;  // that's enough for the screen
+        }
+        break;
+      case INTERNAL_ERROR:
+      default:
+        break;
+    }
 
   STEP("printing exception/signal name")
-
-     st->print_cr("#");
-     st->print("#  ");
-     // Is it an OS exception/signal?
-     if (os::exception_name(_id, buf, sizeof(buf))) {
-       st->print("%s", buf);
-       st->print(" (0x%x)", _id);                // signal number
-       st->print(" at pc=" PTR_FORMAT, p2i(_pc));
-       if (_siginfo != NULL && os::signal_sent_by_kill(_siginfo)) {
-         st->print(" (sent by kill)");
-       }
-     } else {
-       if (should_report_bug(_id)) {
-         st->print("Internal Error");
-       } else {
-         st->print("Out of Memory Error");
-       }
-       if (_filename != NULL && _lineno > 0) {
+    st->print_cr("#");
+    st->print("#  ");
+    // Is it an OS exception/signal?
+    if (os::exception_name(_id, buf, sizeof(buf))) {
+      st->print("%s", buf);
+      st->print(" (0x%x)", _id);                // signal number
+      st->print(" at pc=" PTR_FORMAT, p2i(_pc));
+      if (_siginfo != NULL && os::signal_sent_by_kill(_siginfo)) {
+        st->print(" (sent by kill)");
+      }
+    } else {
+      if (should_report_bug(_id)) {
+        st->print("Internal Error");
+      } else {
+        st->print("Out of Memory Error");
+      }
+      if (_filename != NULL && _lineno > 0) {
 #ifdef PRODUCT
-         // In product mode chop off pathname
-         const char *file = get_filename_only();
+        // In product mode chop off pathname
+        const char *file = get_filename_only();
 #else
-         const char *file = _filename;
+        const char *file = _filename;
 #endif
-         st->print(" (%s:%d)", file, _lineno);
-       } else {
-         st->print(" (0x%x)", _id);
-       }
-     }
+        st->print(" (%s:%d)", file, _lineno);
+      } else {
+        st->print(" (0x%x)", _id);
+      }
+    }
 
   STEP("printing current thread and pid")
+    // process id, thread id
+    st->print(", pid=%d", os::current_process_id());
+    st->print(", tid=" UINTX_FORMAT, os::current_thread_id());
+    st->cr();
 
-     // process id, thread id
-     st->print(", pid=%d", os::current_process_id());
-     st->print(", tid=" UINTX_FORMAT, os::current_thread_id());
-     st->cr();
-
-  STEP("printing error message")
-
-     if (should_report_bug(_id)) {  // already printed the message.
-       // error message
-       if (strlen(_detail_msg) > 0) {
-         st->print_cr("#  %s: %s", _message ? _message : "Error", _detail_msg);
-       } else if (_message) {
-         st->print_cr("#  Error: %s", _message);
-       }
-     }
+  STEP_IF("printing error message", should_report_bug(_id)) // already printed the message.
+    // error message
+    if (strlen(_detail_msg) > 0) {
+      st->print_cr("#  %s: %s", _message ? _message : "Error", _detail_msg);
+    } else if (_message) {
+      st->print_cr("#  Error: %s", _message);
+    }
 
   STEP("printing Java version string")
+    report_vm_version(st, buf, sizeof(buf));
 
-     report_vm_version(st, buf, sizeof(buf));
-
-  STEP("printing problematic frame")
-
-     // Print current frame if we have a context (i.e. it's a crash)
-     if (_context) {
-       st->print_cr("# Problematic frame:");
-       st->print("# ");
-       frame fr = os::fetch_frame_from_context(_context);
-       fr.print_on_error(st, buf, sizeof(buf));
-       st->cr();
-       st->print_cr("#");
-     }
+  STEP_IF("printing problematic frame", _context)
+    // Print current frame if we have a context (i.e. it's a crash)
+    st->print_cr("# Problematic frame:");
+    st->print("# ");
+    frame fr = os::fetch_frame_from_context(_context);
+    fr.print_on_error(st, buf, sizeof(buf));
+    st->cr();
+    st->print_cr("#");
 
   STEP("printing core file information")
     st->print("# ");
@@ -736,503 +716,369 @@ void VMError::report(outputStream* st, bool _verbose) {
   JFR_ONLY(STEP("printing jfr information"))
   JFR_ONLY(Jfr::on_vm_error_report(st);)
 
-  STEP("printing bug submit message")
+  STEP_IF("printing bug submit message", should_submit_bug_report(_id) && _verbose)
+    print_bug_submit_message(st, _thread);
 
-     if (should_submit_bug_report(_id) && _verbose) {
-       print_bug_submit_message(st, _thread);
-     }
+  STEP_IF("printing summary", _verbose)
+    st->cr();
+    st->print_cr("---------------  S U M M A R Y ------------");
+    st->cr();
 
-  STEP("printing summary")
+  STEP_IF("printing VM option summary", _verbose)
+    // VM options
+    Arguments::print_summary_on(st);
+    st->cr();
 
-     if (_verbose) {
-       st->cr();
-       st->print_cr("---------------  S U M M A R Y ------------");
-       st->cr();
-     }
+  STEP_IF("printing summary machine and OS info", _verbose)
+    os::print_summary_info(st, buf, sizeof(buf));
 
-  STEP("printing VM option summary")
+  STEP_IF("printing date and time", _verbose)
+    os::print_date_and_time(st, buf, sizeof(buf));
 
-     if (_verbose) {
-       // VM options
-       Arguments::print_summary_on(st);
-       st->cr();
-     }
+  STEP_IF("printing thread", _verbose)
+    st->cr();
+    st->print_cr("---------------  T H R E A D  ---------------");
+    st->cr();
 
-  STEP("printing summary machine and OS info")
+  STEP_IF("printing current thread", _verbose)
+    // current thread
+    if (_thread) {
+      st->print("Current thread (" PTR_FORMAT "):  ", p2i(_thread));
+      _thread->print_on_error(st, buf, sizeof(buf));
+      st->cr();
+    } else {
+      st->print_cr("Current thread is native thread");
+    }
+    st->cr();
 
-     if (_verbose) {
-       os::print_summary_info(st, buf, sizeof(buf));
-     }
+  STEP_IF("printing current compile task", _verbose && _thread && _thread->is_Compiler_thread())
+    CompilerThread* t = (CompilerThread*)_thread;
+    if (t->task()) {
+        st->cr();
+        st->print_cr("Current CompileTask:");
+        t->task()->print_line_on_error(st, buf, sizeof(buf));
+        st->cr();
+    }
 
-  STEP("printing date and time")
+  STEP_IF("printing stack bounds", _verbose)
+    st->print("Stack: ");
 
-     if (_verbose) {
-       os::print_date_and_time(st, buf, sizeof(buf));
-     }
+    address stack_top;
+    size_t stack_size;
 
-  STEP("printing thread")
+    if (_thread) {
+      stack_top = _thread->stack_base();
+      stack_size = _thread->stack_size();
+    } else {
+      stack_top = os::current_stack_base();
+      stack_size = os::current_stack_size();
+    }
 
-     if (_verbose) {
-       st->cr();
-       st->print_cr("---------------  T H R E A D  ---------------");
-       st->cr();
-     }
+    address stack_bottom = stack_top - stack_size;
+    st->print("[" PTR_FORMAT "," PTR_FORMAT "]", p2i(stack_bottom), p2i(stack_top));
 
-  STEP("printing current thread")
+    frame fr = _context ? os::fetch_frame_from_context(_context)
+                        : os::current_frame();
 
-     // current thread
-     if (_verbose) {
-       if (_thread) {
-         st->print("Current thread (" PTR_FORMAT "):  ", p2i(_thread));
-         _thread->print_on_error(st, buf, sizeof(buf));
-         st->cr();
-       } else {
-         st->print_cr("Current thread is native thread");
-       }
-       st->cr();
-     }
+    if (fr.sp()) {
+      st->print(",  sp=" PTR_FORMAT, p2i(fr.sp()));
+      size_t free_stack_size = pointer_delta(fr.sp(), stack_bottom, 1024);
+      st->print(",  free space=" SIZE_FORMAT "k", free_stack_size);
+    }
 
-  STEP("printing current compile task")
+    st->cr();
 
-     if (_verbose && _thread && _thread->is_Compiler_thread()) {
-        CompilerThread* t = (CompilerThread*)_thread;
-        if (t->task()) {
-           st->cr();
-           st->print_cr("Current CompileTask:");
-           t->task()->print_line_on_error(st, buf, sizeof(buf));
-           st->cr();
-        }
-     }
+  STEP_IF("printing native stack (with source info)", _verbose)
+    if (os::platform_print_native_stack(st, _context, buf, sizeof(buf))) {
+      // We have printed the native stack in platform-specific code
+      // Windows/x64 needs special handling.
+    } else {
+      frame fr = _context ? os::fetch_frame_from_context(_context)
+                          : os::current_frame();
 
-  STEP("printing stack bounds")
+      print_native_stack(st, fr, _thread, true, buf, sizeof(buf));
+      _print_native_stack_used = true;
+    }
+    print_native_stack_succeeded = true;
 
-     if (_verbose) {
-       st->print("Stack: ");
+  STEP_IF("retry printing native stack (no source info)", _verbose && !print_native_stack_succeeded)
+    st->cr();
+    st->print_cr("Retrying call stack printing without source information...");
+    frame fr = _context ? os::fetch_frame_from_context(_context) : os::current_frame();
+    print_native_stack(st, fr, _thread, false, buf, sizeof(buf));
+    _print_native_stack_used = true;
 
-       address stack_top;
-       size_t stack_size;
+  STEP_IF("printing Java stack", _verbose && _thread && _thread->is_Java_thread())
+    if (_verbose && _thread && _thread->is_Java_thread()) {
+      print_stack_trace(st, JavaThread::cast(_thread), buf, sizeof(buf));
+    }
 
-       if (_thread) {
-          stack_top = _thread->stack_base();
-          stack_size = _thread->stack_size();
-       } else {
-          stack_top = os::current_stack_base();
-          stack_size = os::current_stack_size();
-       }
+  STEP_IF("printing target Java thread stack", _verbose && _thread && (_thread->is_Named_thread()))
+    // printing Java thread stack trace if it is involved in GC crash
+    Thread* thread = ((NamedThread *)_thread)->processed_thread();
+    if (thread != NULL && thread->is_Java_thread()) {
+      JavaThread* jt = JavaThread::cast(thread);
+      st->print_cr("JavaThread " PTR_FORMAT " (nid = %d) was being processed", p2i(jt), jt->osthread()->thread_id());
+      print_stack_trace(st, jt, buf, sizeof(buf), true);
+    }
 
-       address stack_bottom = stack_top - stack_size;
-       st->print("[" PTR_FORMAT "," PTR_FORMAT "]", p2i(stack_bottom), p2i(stack_top));
+  STEP_IF("printing siginfo", _verbose && _siginfo)
+    // signal no, signal code, address that caused the fault
+    st->cr();
+    os::print_siginfo(st, _siginfo);
+    st->cr();
 
-       frame fr = _context ? os::fetch_frame_from_context(_context)
-                           : os::current_frame();
+  STEP_IF("CDS archive access warning", _verbose && _siginfo)
+    // Print an explicit hint if we crashed on access to the CDS archive.
+    check_failing_cds_access(st, _siginfo);
+    st->cr();
 
-       if (fr.sp()) {
-         st->print(",  sp=" PTR_FORMAT, p2i(fr.sp()));
-         size_t free_stack_size = pointer_delta(fr.sp(), stack_bottom, 1024);
-         st->print(",  free space=" SIZE_FORMAT "k", free_stack_size);
-       }
+  STEP_IF("printing registers", _verbose && _context)
+    // printing registers
+    os::print_context(st, _context);
+    st->cr();
 
-       st->cr();
-     }
+  STEP_IF("printing register info", _verbose && _context && _thread && Universe::is_fully_initialized())
+    // decode register contents if possible
+    ResourceMark rm(_thread);
+    os::print_register_info(st, _context);
+    st->cr();
 
-  STEP("printing native stack (with source info)")
-
-   if (_verbose) {
-     if (os::platform_print_native_stack(st, _context, buf, sizeof(buf))) {
-       // We have printed the native stack in platform-specific code
-       // Windows/x64 needs special handling.
-     } else {
-       frame fr = _context ? os::fetch_frame_from_context(_context)
-                           : os::current_frame();
-
-       print_native_stack(st, fr, _thread, true, buf, sizeof(buf));
-       _print_native_stack_used = true;
-     }
-     print_native_stack_succeeded = true;
-   }
-
-  STEP("retry printing native stack (no source info)")
-
-   if (_verbose && !print_native_stack_succeeded) {
-     st->cr();
-     st->print_cr("Retrying call stack printing without source information...");
-     frame fr = _context ? os::fetch_frame_from_context(_context) : os::current_frame();
-     print_native_stack(st, fr, _thread, false, buf, sizeof(buf));
-     _print_native_stack_used = true;
-   }
-
-  STEP("printing Java stack")
-
-     if (_verbose && _thread && _thread->is_Java_thread()) {
-       print_stack_trace(st, JavaThread::cast(_thread), buf, sizeof(buf));
-     }
-
-  STEP("printing target Java thread stack")
-
-     // printing Java thread stack trace if it is involved in GC crash
-     if (_verbose && _thread && (_thread->is_Named_thread())) {
-       Thread* thread = ((NamedThread *)_thread)->processed_thread();
-       if (thread != NULL && thread->is_Java_thread()) {
-         JavaThread* jt = JavaThread::cast(thread);
-         st->print_cr("JavaThread " PTR_FORMAT " (nid = %d) was being processed", p2i(jt), jt->osthread()->thread_id());
-         print_stack_trace(st, jt, buf, sizeof(buf), true);
-       }
-     }
-
-  STEP("printing siginfo")
-
-     // signal no, signal code, address that caused the fault
-     if (_verbose && _siginfo) {
-       st->cr();
-       os::print_siginfo(st, _siginfo);
-       st->cr();
-     }
-
-  STEP("CDS archive access warning")
-
-     // Print an explicit hint if we crashed on access to the CDS archive.
-     if (_verbose && _siginfo) {
-       check_failing_cds_access(st, _siginfo);
-       st->cr();
-     }
-
-  STEP("printing registers")
-
-     // printing registers
-     if (_verbose && _context) {
-       os::print_context(st, _context);
-       st->cr();
-     }
-
-  STEP("printing register info")
-
-     // decode register contents if possible
-     if (_verbose && _context && _thread && Universe::is_fully_initialized()) {
-       ResourceMark rm(_thread);
-       os::print_register_info(st, _context);
-       st->cr();
-     }
 
   STEP("printing top of stack, instructions near pc")
 
-     // printing top of stack, instructions near pc
-     if (_verbose && _context) {
-       os::print_tos_pc(st, _context);
-       st->cr();
-     }
+  STEP_IF("printing top of stack, instructions near pc", _verbose && _context)
+    // printing top of stack, instructions near pc
+    os::print_tos_pc(st, _context);
+    st->cr();
 
-  STEP("inspecting top of stack")
-
-     // decode stack contents if possible
-     if (_verbose && _context && _thread && Universe::is_fully_initialized()) {
-       frame fr = os::fetch_frame_from_context(_context);
-       const int slots = 8;
-       const intptr_t *start = fr.sp();
-       const intptr_t *end = start + slots;
-       if (is_aligned(start, sizeof(intptr_t)) && os::is_readable_range(start, end)) {
-         st->print_cr("Stack slot to memory mapping:");
-         for (int i = 0; i < slots; ++i) {
-           st->print("stack at sp + %d slots: ", i);
-           ResourceMark rm(_thread);
-           os::print_location(st, *(start + i));
-         }
-       }
-       st->cr();
-     }
+  STEP_IF("inspecting top of stack", _verbose && _context && _thread && Universe::is_fully_initialized())
+    // decode stack contents if possible
+    frame fr = os::fetch_frame_from_context(_context);
+    const int slots = 8;
+    const intptr_t *start = fr.sp();
+    const intptr_t *end = start + slots;
+    if (is_aligned(start, sizeof(intptr_t)) && os::is_readable_range(start, end)) {
+      st->print_cr("Stack slot to memory mapping:");
+      for (int i = 0; i < slots; ++i) {
+        st->print("stack at sp + %d slots: ", i);
+        ResourceMark rm(_thread);
+        os::print_location(st, *(start + i));
+      }
+    }
+    st->cr();
 
   STEP("printing code blobs if possible")
 
-     if (_verbose) {
-       const int printed_capacity = max_error_log_print_code;
-       address printed[printed_capacity];
-       printed[0] = nullptr;
-       int printed_len = 0;
-       // Even though ErrorLogPrintCodeLimit is ranged checked
-       // during argument parsing, there's no way to prevent it
-       // subsequently (i.e., after parsing) being set to a
-       // value outside the range.
-       int limit = MIN2(ErrorLogPrintCodeLimit, printed_capacity);
-       if (limit > 0) {
-         // Scan the native stack
-         if (!_print_native_stack_used) {
-           // Only try to print code of the crashing frame since
-           // the native stack cannot be walked with next_frame.
-           if (print_code(st, _thread, _pc, true, printed, printed_capacity)) {
-             printed_len++;
-           }
-         } else {
-           frame fr = _context ? os::fetch_frame_from_context(_context)
-                               : os::current_frame();
-           while (printed_len < limit && fr.pc() != nullptr) {
-             if (print_code(st, _thread, fr.pc(), fr.pc() == _pc, printed, printed_capacity)) {
-               printed_len++;
-             }
-             fr = next_frame(fr, _thread);
-           }
-         }
-
-         // Scan the Java stack
-         if (_thread != nullptr && _thread->is_Java_thread()) {
-           JavaThread* jt = JavaThread::cast(_thread);
-           if (jt->has_last_Java_frame()) {
-             for (StackFrameStream sfs(jt, true /* update */, true /* process_frames */); printed_len < limit && !sfs.is_done(); sfs.next()) {
-               address pc = sfs.current()->pc();
-               if (print_code(st, _thread, pc, pc == _pc, printed, printed_capacity)) {
-                 printed_len++;
-               }
-             }
-           }
-         }
-       }
-     }
-
-  STEP("printing VM operation")
-
-     if (_verbose && _thread && _thread->is_VM_thread()) {
-        VMThread* t = (VMThread*)_thread;
-        VM_Operation* op = t->vm_operation();
-        if (op) {
-          op->print_on_error(st);
-          st->cr();
-          st->cr();
+  STEP_IF("printing code blobs if possible", _verbose)
+    const int printed_capacity = max_error_log_print_code;
+    address printed[printed_capacity];
+    printed[0] = nullptr;
+    int printed_len = 0;
+    // Even though ErrorLogPrintCodeLimit is ranged checked
+    // during argument parsing, there's no way to prevent it
+    // subsequently (i.e., after parsing) being set to a
+    // value outside the range.
+    int limit = MIN2(ErrorLogPrintCodeLimit, printed_capacity);
+    if (limit > 0) {
+      // Scan the native stack
+      if (!_print_native_stack_used) {
+        // Only try to print code of the crashing frame since
+        // the native stack cannot be walked with next_frame.
+        if (print_code(st, _thread, _pc, true, printed, printed_capacity)) {
+          printed_len++;
         }
-     }
+      } else {
+        frame fr = _context ? os::fetch_frame_from_context(_context)
+                            : os::current_frame();
+        while (printed_len < limit && fr.pc() != nullptr) {
+          if (print_code(st, _thread, fr.pc(), fr.pc() == _pc, printed, printed_capacity)) {
+            printed_len++;
+          }
+          fr = next_frame(fr, _thread);
+        }
+      }
+
+      // Scan the Java stack
+      if (_thread != nullptr && _thread->is_Java_thread()) {
+        JavaThread* jt = JavaThread::cast(_thread);
+        if (jt->has_last_Java_frame()) {
+          for (StackFrameStream sfs(jt, true /* update */, true /* process_frames */); printed_len < limit && !sfs.is_done(); sfs.next()) {
+            address pc = sfs.current()->pc();
+            if (print_code(st, _thread, pc, pc == _pc, printed, printed_capacity)) {
+              printed_len++;
+            }
+          }
+        }
+      }
+    }
+
+  STEP_IF("printing VM operation", _verbose && _thread && _thread->is_VM_thread())
+    VMThread* t = (VMThread*)_thread;
+    VM_Operation* op = t->vm_operation();
+    if (op) {
+      op->print_on_error(st);
+      st->cr();
+      st->cr();
+    }
 
   STEP("printing process")
 
-     if (_verbose) {
-       st->cr();
-       st->print_cr("---------------  P R O C E S S  ---------------");
-       st->cr();
-     }
+  STEP_IF("printing process", _verbose)
+    st->cr();
+    st->print_cr("---------------  P R O C E S S  ---------------");
+    st->cr();
 
-  STEP("printing user info")
+  STEP_IF("printing user info", ExtensiveErrorReports && _verbose)
+    os::print_user_info(st);
 
-     if (ExtensiveErrorReports && _verbose) {
-       os::print_user_info(st);
-     }
+  STEP_IF("printing all threads", _verbose && _thread)
+    // all threads
+    Threads::print_on_error(st, _thread, buf, sizeof(buf));
+    st->cr();
 
-  STEP("printing all threads")
+  STEP_IF("printing VM state", _verbose)
+    // Safepoint state
+    st->print("VM state: ");
 
-     // all threads
-     if (_verbose && _thread) {
-       Threads::print_on_error(st, _thread, buf, sizeof(buf));
-       st->cr();
-     }
+    if (SafepointSynchronize::is_synchronizing()) st->print("synchronizing");
+    else if (SafepointSynchronize::is_at_safepoint()) st->print("at safepoint");
+    else st->print("not at safepoint");
 
-  STEP("printing VM state")
+    // Also see if error occurred during initialization or shutdown
+    if (!Universe::is_fully_initialized()) {
+      st->print(" (not fully initialized)");
+    } else if (VM_Exit::vm_exited()) {
+      st->print(" (shutting down)");
+    } else {
+      st->print(" (normal execution)");
+    }
+    st->cr();
+    st->cr();
 
-     if (_verbose) {
-       // Safepoint state
-       st->print("VM state: ");
+  STEP_IF("printing owned locks on error", _verbose)
+    // mutexes/monitors that currently have an owner
+    print_owned_locks_on_error(st);
+    st->cr();
 
-       if (SafepointSynchronize::is_synchronizing()) st->print("synchronizing");
-       else if (SafepointSynchronize::is_at_safepoint()) st->print("at safepoint");
-       else st->print("not at safepoint");
-
-       // Also see if error occurred during initialization or shutdown
-       if (!Universe::is_fully_initialized()) {
-         st->print(" (not fully initialized)");
-       } else if (VM_Exit::vm_exited()) {
-         st->print(" (shutting down)");
-       } else {
-         st->print(" (normal execution)");
-       }
-       st->cr();
-       st->cr();
-     }
-
-  STEP("printing owned locks on error")
-
-     // mutexes/monitors that currently have an owner
-     if (_verbose) {
-       print_owned_locks_on_error(st);
-       st->cr();
-     }
-
-  STEP("printing number of OutOfMemoryError and StackOverflow exceptions")
-
-     if (_verbose && Exceptions::has_exception_counts()) {
-       st->print_cr("OutOfMemory and StackOverflow Exception counts:");
-       Exceptions::print_exception_counts_on_error(st);
-       st->cr();
-     }
+  STEP_IF("printing number of OutOfMemoryError and StackOverflow exceptions", _verbose && Exceptions::has_exception_counts())
+    st->print_cr("OutOfMemory and StackOverflow Exception counts:");
+    Exceptions::print_exception_counts_on_error(st);
+    st->cr();
 
 #ifdef _LP64
-  STEP("printing compressed oops mode")
+  STEP_IF("printing compressed oops mode", _verbose && UseCompressedOops)
+    CompressedOops::print_mode(st);
+    st->cr();
 
-     if (_verbose && UseCompressedOops) {
-       CompressedOops::print_mode(st);
-       st->cr();
-     }
-
-  STEP("printing compressed klass pointers mode")
-
-     if (_verbose && UseCompressedClassPointers) {
-       CDS_ONLY(MetaspaceShared::print_on(st);)
-       Metaspace::print_compressed_class_space(st);
-       CompressedKlassPointers::print_mode(st);
-       st->cr();
-     }
+  STEP_IF("printing compressed klass pointers mode", _verbose && UseCompressedClassPointers)
+    CDS_ONLY(MetaspaceShared::print_on(st);)
+    Metaspace::print_compressed_class_space(st);
+    CompressedKlassPointers::print_mode(st);
+    st->cr();
 #endif
 
-  STEP("printing heap information")
+  STEP_IF("printing heap information", _verbose)
+    GCLogPrecious::print_on_error(st);
 
-     if (_verbose) {
-       GCLogPrecious::print_on_error(st);
-
-       if (Universe::heap() != NULL) {
-         Universe::heap()->print_on_error(st);
-         st->cr();
-       }
-
-       if (Universe::is_fully_initialized()) {
-         st->print_cr("Polling page: " PTR_FORMAT, p2i(SafepointMechanism::get_polling_page()));
-         st->cr();
-       }
-     }
-
-  STEP("printing metaspace information")
-
-     if (_verbose && Universe::is_fully_initialized()) {
-       st->print_cr("Metaspace:");
-       MetaspaceUtils::print_basic_report(st, 0);
-     }
-
-  STEP("printing code cache information")
-
-     if (_verbose && Universe::is_fully_initialized()) {
-       // print code cache information before vm abort
-       CodeCache::print_summary(st);
-       st->cr();
-     }
-
-  STEP("printing ring buffers")
-
-     if (_verbose) {
-       Events::print_all(st);
-       st->cr();
-     }
-
-  STEP("printing dynamic libraries")
-
-     if (_verbose) {
-       // dynamic libraries, or memory map
-       os::print_dll_info(st);
-       st->cr();
-     }
-
-  STEP("printing native decoder state")
-
-     if (_verbose) {
-       Decoder::print_state_on(st);
-       st->cr();
-     }
-
-  STEP("printing VM options")
-
-     if (_verbose) {
-       // VM options
-       Arguments::print_on(st);
-       st->cr();
-     }
-
-  STEP("printing flags")
-
-    if (_verbose) {
-      JVMFlag::printFlags(
-        st,
-        true, // with comments
-        false, // no ranges
-        true); // skip defaults
+    if (Universe::heap() != NULL) {
+      Universe::heap()->print_on_error(st);
       st->cr();
     }
 
-  STEP("printing warning if internal testing API used")
-
-     if (WhiteBox::used()) {
-       st->print_cr("Unsupported internal testing APIs have been used.");
-       st->cr();
-     }
-
-  STEP("printing log configuration")
-    if (_verbose){
-      st->print_cr("Logging:");
-      LogConfiguration::describe_current_configuration(st);
+    if (Universe::is_fully_initialized()) {
+      st->print_cr("Polling page: " PTR_FORMAT, p2i(SafepointMechanism::get_polling_page()));
       st->cr();
     }
 
-  STEP("printing all environment variables")
+  STEP_IF("printing metaspace information", _verbose && Universe::is_fully_initialized())
+    st->print_cr("Metaspace:");
+    MetaspaceUtils::print_basic_report(st, 0);
 
-     if (_verbose) {
-       os::print_environment_variables(st, env_list);
-       st->cr();
-     }
+  STEP_IF("printing code cache information", _verbose && Universe::is_fully_initialized())
+    // print code cache information before vm abort
+    CodeCache::print_summary(st);
+    st->cr();
 
-  STEP("printing locale settings")
+  STEP_IF("printing ring buffers", _verbose)
+    Events::print_all(st);
+    st->cr();
 
-     if (_verbose) {
-       os::print_active_locale(st);
-       st->cr();
-     }
+  STEP_IF("printing dynamic libraries", _verbose)
+    // dynamic libraries, or memory map
+    os::print_dll_info(st);
+    st->cr();
 
-  STEP("printing signal handlers")
+  STEP_IF("printing native decoder state", _verbose)
+    Decoder::print_state_on(st);
+    st->cr();
 
-     if (_verbose) {
-       os::print_signal_handlers(st, buf, sizeof(buf));
-       st->cr();
-     }
+  STEP_IF("printing VM options", _verbose)
+    // VM options
+    Arguments::print_on(st);
+    st->cr();
 
-  STEP("Native Memory Tracking")
-     if (_verbose) {
-       MemTracker::error_report(st);
-     }
+  STEP_IF("printing flags", _verbose)
+    JVMFlag::printFlags(
+      st,
+      true, // with comments
+      false, // no ranges
+      true); // skip defaults
+    st->cr();
 
-  STEP("printing system")
+  STEP_IF("printing warning if internal testing API used", WhiteBox::used())
+    st->print_cr("Unsupported internal testing APIs have been used.");
+    st->cr();
 
-     if (_verbose) {
-       st->cr();
-       st->print_cr("---------------  S Y S T E M  ---------------");
-       st->cr();
-     }
+  STEP_IF("printing log configuration", _verbose)
+    st->print_cr("Logging:");
+    LogConfiguration::describe_current_configuration(st);
+    st->cr();
 
-  STEP("printing OS information")
+  STEP_IF("printing all environment variables", _verbose)
+    os::print_environment_variables(st, env_list);
+    st->cr();
 
-     if (_verbose) {
-       os::print_os_info(st);
-       st->cr();
-     }
+  STEP_IF("printing locale settings", _verbose)
+    os::print_active_locale(st);
+    st->cr();
 
-  STEP("printing CPU info")
-     if (_verbose) {
-       os::print_cpu_info(st, buf, sizeof(buf));
-       st->cr();
-     }
+  STEP_IF("printing signal handlers", _verbose)
+    os::print_signal_handlers(st, buf, sizeof(buf));
+    st->cr();
 
-  STEP("printing memory info")
+  STEP_IF("Native Memory Tracking", _verbose)
+    MemTracker::error_report(st);
 
-     if (_verbose) {
-       os::print_memory_info(st);
-       st->cr();
-     }
+  STEP_IF("printing system", _verbose)
+    st->cr();
+    st->print_cr("---------------  S Y S T E M  ---------------");
+    st->cr();
 
-  STEP("printing internal vm info")
+  STEP_IF("printing OS information", _verbose)
+    os::print_os_info(st);
+    st->cr();
 
-     if (_verbose) {
-       st->print_cr("vm_info: %s", VM_Version::internal_vm_info_string());
-       st->cr();
-     }
+  STEP_IF("printing CPU info", _verbose)
+    os::print_cpu_info(st, buf, sizeof(buf));
+    st->cr();
+
+  STEP_IF("printing memory info", _verbose)
+    os::print_memory_info(st);
+    st->cr();
+
+  STEP_IF("printing internal vm info", _verbose)
+    st->print_cr("vm_info: %s", VM_Version::internal_vm_info_string());
+    st->cr();
 
   // print a defined marker to show that error handling finished correctly.
-  STEP("printing end marker")
-
-     if (_verbose) {
-       st->print_cr("END.");
-     }
+  STEP_IF("printing end marker", _verbose)
+    st->print_cr("END.");
 
   END
 
 # undef BEGIN
+# undef STEP_IF
 # undef STEP
 # undef END
 }

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -583,7 +583,8 @@ void VMError::report(outputStream* st, bool _verbose) {
       TestCrashInErrorHandler);
     controlled_crash(TestCrashInErrorHandler);
 
-  STEP_IF("test missing ResourceMark does not crash", _verbose && TestCrashInErrorHandler == TEST_RESOURCE_MARK_CRASH)
+  STEP_IF("test missing ResourceMark does not crash",
+      _verbose && TestCrashInErrorHandler == TEST_RESOURCE_MARK_CRASH)
     stringStream message;
     message.print("This is a message with no ResourceMark");
     tty->print_cr("%s", message.as_string());
@@ -592,14 +593,16 @@ void VMError::report(outputStream* st, bool _verbose) {
   // Step to global timeout ratio is 4:1, so in order to be absolutely sure we hit the
   // global timeout, let's execute the timeout step five times.
   // See corresponding test in test/runtime/ErrorHandling/TimeoutInErrorHandlingTest.java
-  STEP_IF("setup for test unresponsive error reporting step", _verbose && TestUnresponsiveErrorHandler)
+  STEP_IF("setup for test unresponsive error reporting step",
+      _verbose && TestUnresponsiveErrorHandler)
     // We record reporting_start_time for this test here because we
     // care about the time spent executing TIMEOUT_TEST_STEP and not
     // about the time it took us to get here.
     tty->print_cr("Recording reporting_start_time for TestUnresponsiveErrorHandler.");
     record_reporting_start_time();
 
-  #define TIMEOUT_TEST_STEP STEP_IF("test unresponsive error reporting step", _verbose && TestUnresponsiveErrorHandler) \
+  #define TIMEOUT_TEST_STEP STEP_IF("test unresponsive error reporting step", \
+      _verbose && TestUnresponsiveErrorHandler) \
     os::infinite_sleep();
   TIMEOUT_TEST_STEP
   TIMEOUT_TEST_STEP
@@ -853,7 +856,8 @@ void VMError::report(outputStream* st, bool _verbose) {
     os::print_context(st, _context);
     st->cr();
 
-  STEP_IF("printing register info", _verbose && _context && _thread && Universe::is_fully_initialized())
+  STEP_IF("printing register info",
+      _verbose && _context && _thread && Universe::is_fully_initialized())
     // decode register contents if possible
     ResourceMark rm(_thread);
     os::print_register_info(st, _context);
@@ -867,7 +871,8 @@ void VMError::report(outputStream* st, bool _verbose) {
     os::print_tos_pc(st, _context);
     st->cr();
 
-  STEP_IF("inspecting top of stack", _verbose && _context && _thread && Universe::is_fully_initialized())
+  STEP_IF("inspecting top of stack",
+      _verbose && _context && _thread && Universe::is_fully_initialized())
     // decode stack contents if possible
     frame fr = os::fetch_frame_from_context(_context);
     const int slots = 8;
@@ -976,7 +981,8 @@ void VMError::report(outputStream* st, bool _verbose) {
     print_owned_locks_on_error(st);
     st->cr();
 
-  STEP_IF("printing number of OutOfMemoryError and StackOverflow exceptions", _verbose && Exceptions::has_exception_counts())
+  STEP_IF("printing number of OutOfMemoryError and StackOverflow exceptions",
+      _verbose && Exceptions::has_exception_counts())
     st->print_cr("OutOfMemory and StackOverflow Exception counts:");
     Exceptions::print_exception_counts_on_error(st);
     st->cr();

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -583,15 +583,6 @@ void VMError::report(outputStream* st, bool _verbose) {
       TestCrashInErrorHandler);
     controlled_crash(TestCrashInErrorHandler);
 
-  STEP_IF("test secondary crash in step condition",
-    _verbose && TestCrashInErrorHandler == TEST_SECONDARY_CRASH &&
-    [&](){
-      st->print_cr("Will crash now (TestCrashInErrorHandler=%u)...",
-        TestCrashInErrorHandler);
-      controlled_crash(TestCrashInErrorHandler);
-      return true;
-    }())
-
   STEP_IF("test missing ResourceMark does not crash", _verbose && TestCrashInErrorHandler == TEST_RESOURCE_MARK_CRASH)
     stringStream message;
     message.print("This is a message with no ResourceMark");

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -528,11 +528,26 @@ void VMError::clear_step_start_time() {
 // segment.
 void VMError::report(outputStream* st, bool _verbose) {
 
-# define BEGIN if (_current_step == 0) { _current_step = __LINE__;
-# define STEP_IF(s,cond) } if (_current_step < __LINE__ && (cond)) { _current_step = __LINE__; _current_step_info = s; \
-  record_step_start_time(); _step_did_timeout = false;
+# define BEGIN                                             \
+  if (_current_step == 0) {                                \
+    _current_step = __LINE__;                              \
+    {
+      // [Begin logic]
+# define STEP_IF(s,cond)                                   \
+    }                                                      \
+  }                                                        \
+  if (_current_step < __LINE__) {                          \
+    _current_step = __LINE__;                              \
+    _current_step_info = s;                                \
+    record_step_start_time();                              \
+    _step_did_timeout = false;                             \
+    if ((cond)) {
+      // [Step logic]
 # define STEP(s) STEP_IF(s, true)
-# define END clear_step_start_time(); }
+# define END                                               \
+    }                                                      \
+    clear_step_start_time();                               \
+  }
 
   // don't allocate large buffer on stack
   static char buf[O_BUFLEN];
@@ -567,6 +582,15 @@ void VMError::report(outputStream* st, bool _verbose) {
     st->print_cr("Will crash now (TestCrashInErrorHandler=%u)...",
       TestCrashInErrorHandler);
     controlled_crash(TestCrashInErrorHandler);
+
+  STEP_IF("test secondary crash in step condition",
+    _verbose && TestCrashInErrorHandler == TEST_SECONDARY_CRASH &&
+    [&](){
+      st->print_cr("Will crash now (TestCrashInErrorHandler=%u)...",
+        TestCrashInErrorHandler);
+      controlled_crash(TestCrashInErrorHandler);
+      return true;
+    }())
 
   STEP_IF("test missing ResourceMark does not crash", _verbose && TestCrashInErrorHandler == TEST_RESOURCE_MARK_CRASH)
     stringStream message;

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -708,7 +708,7 @@ void VMError::report(outputStream* st, bool _verbose) {
   STEP("printing Java version string")
     report_vm_version(st, buf, sizeof(buf));
 
-  STEP_IF("printing problematic frame", _context)
+  STEP_IF("printing problematic frame", _context != nullptr)
     // Print current frame if we have a context (i.e. it's a crash)
     st->print_cr("# Problematic frame:");
     st->print("# ");
@@ -769,7 +769,8 @@ void VMError::report(outputStream* st, bool _verbose) {
     }
     st->cr();
 
-  STEP_IF("printing current compile task", _verbose && _thread && _thread->is_Compiler_thread())
+  STEP_IF("printing current compile task",
+      _verbose && _thread != nullptr && _thread->is_Compiler_thread())
     CompilerThread* t = (CompilerThread*)_thread;
     if (t->task()) {
         st->cr();
@@ -831,7 +832,8 @@ void VMError::report(outputStream* st, bool _verbose) {
       print_stack_trace(st, JavaThread::cast(_thread), buf, sizeof(buf));
     }
 
-  STEP_IF("printing target Java thread stack", _verbose && _thread && (_thread->is_Named_thread()))
+  STEP_IF("printing target Java thread stack",
+      _verbose && _thread != nullptr && (_thread->is_Named_thread()))
     // printing Java thread stack trace if it is involved in GC crash
     Thread* thread = ((NamedThread *)_thread)->processed_thread();
     if (thread != NULL && thread->is_Java_thread()) {
@@ -840,24 +842,24 @@ void VMError::report(outputStream* st, bool _verbose) {
       print_stack_trace(st, jt, buf, sizeof(buf), true);
     }
 
-  STEP_IF("printing siginfo", _verbose && _siginfo)
+  STEP_IF("printing siginfo", _verbose && _siginfo != nullptr)
     // signal no, signal code, address that caused the fault
     st->cr();
     os::print_siginfo(st, _siginfo);
     st->cr();
 
-  STEP_IF("CDS archive access warning", _verbose && _siginfo)
+  STEP_IF("CDS archive access warning", _verbose && _siginfo != nullptr)
     // Print an explicit hint if we crashed on access to the CDS archive.
     check_failing_cds_access(st, _siginfo);
     st->cr();
 
-  STEP_IF("printing registers", _verbose && _context)
+  STEP_IF("printing registers", _verbose && _context != nullptr)
     // printing registers
     os::print_context(st, _context);
     st->cr();
 
   STEP_IF("printing register info",
-      _verbose && _context && _thread && Universe::is_fully_initialized())
+      _verbose && _context != nullptr && _thread != nullptr && Universe::is_fully_initialized())
     // decode register contents if possible
     ResourceMark rm(_thread);
     os::print_register_info(st, _context);
@@ -872,7 +874,7 @@ void VMError::report(outputStream* st, bool _verbose) {
     st->cr();
 
   STEP_IF("inspecting top of stack",
-      _verbose && _context && _thread && Universe::is_fully_initialized())
+      _verbose && _context != nullptr && _thread != nullptr && Universe::is_fully_initialized())
     // decode stack contents if possible
     frame fr = os::fetch_frame_from_context(_context);
     const int slots = 8;
@@ -933,7 +935,7 @@ void VMError::report(outputStream* st, bool _verbose) {
       }
     }
 
-  STEP_IF("printing VM operation", _verbose && _thread && _thread->is_VM_thread())
+  STEP_IF("printing VM operation", _verbose && _thread != nullptr && _thread->is_VM_thread())
     VMThread* t = (VMThread*)_thread;
     VM_Operation* op = t->vm_operation();
     if (op) {

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -533,6 +533,7 @@ void VMError::report(outputStream* st, bool _verbose) {
     _current_step = __LINE__;                              \
     {
       // [Begin logic]
+
 # define STEP_IF(s,cond)                                   \
     }                                                      \
   }                                                        \
@@ -543,7 +544,9 @@ void VMError::report(outputStream* st, bool _verbose) {
     _step_did_timeout = false;                             \
     if ((cond)) {
       // [Step logic]
+
 # define STEP(s) STEP_IF(s, true)
+
 # define END                                               \
     }                                                      \
     clear_step_start_time();                               \

--- a/test/hotspot/jtreg/runtime/ErrorHandling/SecondaryErrorTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/SecondaryErrorTest.java
@@ -90,6 +90,8 @@ public class SecondaryErrorTest {
         Pattern.compile("\\[error occurred during error reporting \\(test secondary crash 1\\).*\\]"),
         Pattern.compile("Will crash now \\(TestCrashInErrorHandler=14\\)..."),
         Pattern.compile("\\[error occurred during error reporting \\(test secondary crash 2\\).*\\]"),
+        Pattern.compile("Will crash now \\(TestCrashInErrorHandler=14\\)..."),
+        Pattern.compile("\\[error occurred during error reporting \\(test secondary crash in step condition\\).*\\]"),
     };
     int currentPattern = 0;
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/SecondaryErrorTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/SecondaryErrorTest.java
@@ -90,8 +90,6 @@ public class SecondaryErrorTest {
         Pattern.compile("\\[error occurred during error reporting \\(test secondary crash 1\\).*\\]"),
         Pattern.compile("Will crash now \\(TestCrashInErrorHandler=14\\)..."),
         Pattern.compile("\\[error occurred during error reporting \\(test secondary crash 2\\).*\\]"),
-        Pattern.compile("Will crash now \\(TestCrashInErrorHandler=14\\)..."),
-        Pattern.compile("\\[error occurred during error reporting \\(test secondary crash in step condition\\).*\\]"),
     };
     int currentPattern = 0;
 


### PR DESCRIPTION
Refactor the STEP macro in VMError::report to improve readability.
Right now the macro contains multiple statements on one line and the non-conventional control flow is even harder to understand.

This enhancement aims to do two things:
 1. It splits the macro into multiple lines with indentations which makes the structure of the C++ code generated by the preprocessor clearer.
  2. Separates the internal step logic from the decision logic which decides if a step should be taken with a STEP_IF(step_name_str, condition) macro

Testing: tier 1 + GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296470](https://bugs.openjdk.org/browse/JDK-8296470): Refactor VMError::report STEP macro to improve readability


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [b483c21c](https://git.openjdk.org/jdk/pull/11018/files/b483c21c37584161e96d48a5f5ed9d62bca3e276)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [b483c21c](https://git.openjdk.org/jdk/pull/11018/files/b483c21c37584161e96d48a5f5ed9d62bca3e276)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11018/head:pull/11018` \
`$ git checkout pull/11018`

Update a local copy of the PR: \
`$ git checkout pull/11018` \
`$ git pull https://git.openjdk.org/jdk pull/11018/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11018`

View PR using the GUI difftool: \
`$ git pr show -t 11018`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11018.diff">https://git.openjdk.org/jdk/pull/11018.diff</a>

</details>
