### PR TITLE
8296479: Remove stray comment about POST_STRIP_CMD

### DIFF
--- a/make/autoconf/flags-other.m4
+++ b/make/autoconf/flags-other.m4
@@ -46,7 +46,6 @@ AC_DEFUN([FLAGS_SETUP_ARFLAGS],
 AC_DEFUN([FLAGS_SETUP_STRIPFLAGS],
 [
   ## Setup strip.
-  # FIXME: we should really only export STRIPFLAGS from here, not POST_STRIP_CMD.
   if test "x$STRIP" != x; then
     AC_MSG_CHECKING([how to run strip])
 
@@ -134,4 +133,3 @@ AC_DEFUN([FLAGS_SETUP_ASFLAGS_CPU_DEP],
 
   AC_SUBST($2JVM_ASFLAGS)
 ])
-


### PR DESCRIPTION
The variable POST_STRIP_CMD has been removed, but not all comments about it

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296479](https://bugs.openjdk.org/browse/JDK-8296479): Remove stray comment about POST_STRIP_CMD


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11021/head:pull/11021` \
`$ git checkout pull/11021`

Update a local copy of the PR: \
`$ git checkout pull/11021` \
`$ git pull https://git.openjdk.org/jdk pull/11021/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11021`

View PR using the GUI difftool: \
`$ git pr show -t 11021`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11021.diff">https://git.openjdk.org/jdk/pull/11021.diff</a>

</details>
