### PR TITLE
8297074: Use enhanced-for cycle instead of Enumeration in javax.crypto

### DIFF
--- a/src/java.base/share/classes/javax/crypto/CryptoPermission.java
+++ b/src/java.base/share/classes/javax/crypto/CryptoPermission.java
@@ -506,10 +506,8 @@ final class CryptoPermissionCollection extends PermissionCollection
         if (!(permission instanceof CryptoPermission cp))
             return false;
 
-        Enumeration<Permission> e = permissions.elements();
-
-        while (e.hasMoreElements()) {
-            CryptoPermission x = (CryptoPermission) e.nextElement();
+        for (Permission p : permissions) {
+            CryptoPermission x = (CryptoPermission) p;
             if (x.implies(cp)) {
                 return true;
             }

--- a/src/java.base/share/classes/javax/crypto/CryptoPermissions.java
+++ b/src/java.base/share/classes/javax/crypto/CryptoPermissions.java
@@ -229,12 +229,9 @@ implements Serializable {
         // For each algorithm in this CryptoPermissions,
         // find out if there is anything we should add into
         // ret.
-        Enumeration<String> thisKeys = this.perms.keys();
-        while (thisKeys.hasMoreElements()) {
-            String alg = thisKeys.nextElement();
-
-            PermissionCollection thisPc = this.perms.get(alg);
-            PermissionCollection thatPc = other.perms.get(alg);
+        for (var entry : perms.entrySet()) {
+            PermissionCollection thisPc = entry.getValue();
+            PermissionCollection thatPc = other.perms.get(entry.getKey());
 
             CryptoPermission[] partialResult;
 
@@ -270,15 +267,14 @@ implements Serializable {
         maxKeySize =
             ((CryptoPermission)
                     thisWildcard.elements().nextElement()).getMaxKeySize();
-        Enumeration<String> thatKeys = other.perms.keys();
-        while (thatKeys.hasMoreElements()) {
-            String alg = thatKeys.nextElement();
+        for (var entry : other.perms.entrySet()) {
+            String alg = entry.getKey();
 
             if (this.perms.containsKey(alg)) {
                 continue;
             }
 
-            PermissionCollection thatPc = other.perms.get(alg);
+            PermissionCollection thatPc = entry.getValue();
 
             CryptoPermission[] partialResult;
 

--- a/src/java.base/share/classes/javax/crypto/CryptoPermissions.java
+++ b/src/java.base/share/classes/javax/crypto/CryptoPermissions.java
@@ -229,9 +229,9 @@ implements Serializable {
         // For each algorithm in this CryptoPermissions,
         // find out if there is anything we should add into
         // ret.
-        for (var entry : perms.entrySet()) {
-            PermissionCollection thisPc = entry.getValue();
-            PermissionCollection thatPc = other.perms.get(entry.getKey());
+        for (String alg : this.perms.keySet()) {
+            PermissionCollection thisPc = this.perms.get(alg);
+            PermissionCollection thatPc = other.perms.get(alg);
 
             CryptoPermission[] partialResult;
 
@@ -267,14 +267,13 @@ implements Serializable {
         maxKeySize =
             ((CryptoPermission)
                     thisWildcard.elements().nextElement()).getMaxKeySize();
-        for (var entry : other.perms.entrySet()) {
-            String alg = entry.getKey();
+        for (String alg : other.perms.keySet()) {
 
             if (this.perms.containsKey(alg)) {
                 continue;
             }
 
-            PermissionCollection thatPc = entry.getValue();
+            PermissionCollection thatPc = other.perms.get(alg);
 
             CryptoPermission[] partialResult;
 

--- a/src/java.base/share/classes/javax/crypto/CryptoPolicyParser.java
+++ b/src/java.base/share/classes/javax/crypto/CryptoPolicyParser.java
@@ -472,10 +472,7 @@ final class CryptoPolicyParser {
         ArrayList<CryptoPermission> result = new ArrayList<>();
 
         for (GrantEntry ge : grantEntries) {
-            Enumeration<CryptoPermissionEntry> permEnum =
-                    ge.permissionElements();
-            while (permEnum.hasMoreElements()) {
-                CryptoPermissionEntry pe = permEnum.nextElement();
+            for (CryptoPermissionEntry pe : ge.permissionEntries) {
                 if (pe.cryptoPermission.equals(
                                         "javax.crypto.CryptoAllPermission")) {
                     result.add(CryptoAllPermission.INSTANCE);
@@ -575,24 +572,6 @@ final class CryptoPolicyParser {
         {
             permissionEntries.addElement(pe);
         }
-
-        boolean remove(CryptoPermissionEntry pe)
-        {
-            return permissionEntries.removeElement(pe);
-        }
-
-        boolean contains(CryptoPermissionEntry pe)
-        {
-            return permissionEntries.contains(pe);
-        }
-
-        /**
-         * Enumerate all the permission entries in this {@code GrantEntry}.
-         */
-        Enumeration<CryptoPermissionEntry> permissionElements(){
-            return permissionEntries.elements();
-        }
-
     }
 
     /**

--- a/src/java.base/share/classes/javax/crypto/CryptoPolicyParser.java
+++ b/src/java.base/share/classes/javax/crypto/CryptoPolicyParser.java
@@ -471,9 +471,7 @@ final class CryptoPolicyParser {
     CryptoPermission[] getPermissions() {
         ArrayList<CryptoPermission> result = new ArrayList<>();
 
-        Enumeration<GrantEntry> grantEnum = grantEntries.elements();
-        while (grantEnum.hasMoreElements()) {
-            GrantEntry ge = grantEnum.nextElement();
+        for (GrantEntry ge : grantEntries) {
             Enumeration<CryptoPermissionEntry> permEnum =
                     ge.permissionElements();
             while (permEnum.hasMoreElements()) {


### PR DESCRIPTION
java.util.Enumeration is a legacy interface from java 1.0.
There are a few places with cycles which use it to iterate over collections. We can replace this manual cycle with enchanced-for, which is shorter and easier to read.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297074](https://bugs.openjdk.org/browse/JDK-8297074): Use enhanced-for cycle instead of Enumeration in javax.crypto


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)
 * [Bradford Wetmore](https://openjdk.org/census#wetmore) (@bradfordwetmore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11022/head:pull/11022` \
`$ git checkout pull/11022`

Update a local copy of the PR: \
`$ git checkout pull/11022` \
`$ git pull https://git.openjdk.org/jdk pull/11022/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11022`

View PR using the GUI difftool: \
`$ git pr show -t 11022`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11022.diff">https://git.openjdk.org/jdk/pull/11022.diff</a>

</details>
