### PR TITLE
8296472: Remove ObjectLocker around appendToClassPathForInstrumentation call

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -715,9 +715,7 @@ JvmtiEnv::AddToSystemClassLoaderSearch(const char* segment) {
     }
     delete zip_entry;   // no longer needed
 
-    // lock the loader
-    Handle loader = Handle(THREAD, SystemDictionary::java_system_loader());
-    ObjectLocker ol(loader, THREAD);
+    Handle loader(THREAD, SystemDictionary::java_system_loader());
 
     // need the path as java.lang.String
     Handle path = java_lang_String::create_from_platform_dependent_str(segment, THREAD);

--- a/src/java.base/share/classes/jdk/internal/loader/ClassLoaders.java
+++ b/src/java.base/share/classes/jdk/internal/loader/ClassLoaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -197,10 +197,11 @@ public class ClassLoaders {
 
         /**
          * Called by the VM to support dynamic additions to the class path
+         * Locks the System ClassLoader to prevent concurrent changes.
          *
          * @see java.lang.instrument.Instrumentation#appendToSystemClassLoaderSearch
          */
-        void appendToClassPathForInstrumentation(String path) {
+        synchronized void appendToClassPathForInstrumentation(String path) {
             appendClassPath(path);
         }
 

--- a/src/java.base/share/classes/jdk/internal/loader/ClassLoaders.java
+++ b/src/java.base/share/classes/jdk/internal/loader/ClassLoaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -201,7 +201,7 @@ public class ClassLoaders {
          *
          * @see java.lang.instrument.Instrumentation#appendToSystemClassLoaderSearch
          */
-        synchronized void appendToClassPathForInstrumentation(String path) {
+        void appendToClassPathForInstrumentation(String path) {
             appendClassPath(path);
         }
 

--- a/src/java.base/share/classes/jdk/internal/loader/ClassLoaders.java
+++ b/src/java.base/share/classes/jdk/internal/loader/ClassLoaders.java
@@ -197,7 +197,6 @@ public class ClassLoaders {
 
         /**
          * Called by the VM to support dynamic additions to the class path
-         * Locks the System ClassLoader to prevent concurrent changes.
          *
          * @see java.lang.instrument.Instrumentation#appendToSystemClassLoaderSearch
          */


### PR DESCRIPTION
This patch moves the acquisition of the boot class loader lock out of the JVM and into the Java function.
Tested with tier1-4, and jvmti and jdi tests locally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8296472](https://bugs.openjdk.org/browse/JDK-8296472): Remove ObjectLocker around appendToClassPathForInstrumentation call
 * [JDK-8297169](https://bugs.openjdk.org/browse/JDK-8297169): Remove ObjectLocker around appendToClassPathForInstrumentation call (**CSR**)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11023/head:pull/11023` \
`$ git checkout pull/11023`

Update a local copy of the PR: \
`$ git checkout pull/11023` \
`$ git pull https://git.openjdk.org/jdk pull/11023/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11023`

View PR using the GUI difftool: \
`$ git pr show -t 11023`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11023.diff">https://git.openjdk.org/jdk/pull/11023.diff</a>

</details>
