### PR TITLE
8297682: Use Collections.emptyIterator where applicable

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -189,8 +189,7 @@ abstract class UnixFileSystem
                         sm.checkRead(rootDirectory.toString());
                     return allowedList.iterator();
                 } catch (SecurityException x) {
-                    List<Path> disallowed = Collections.emptyList();
-                    return disallowed.iterator();
+                    return Collections.emptyIterator(); //disallowed
                 }
             }
         };

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
@@ -383,8 +383,7 @@ public class JavacProcessingEnvironment implements ProcessingEnvironment, Closea
             handleException(key, e);
         }
 
-        java.util.List<Processor> pl = Collections.emptyList();
-        return pl.iterator();
+        return Collections.emptyIterator();
     }
 
     /**


### PR DESCRIPTION
Instead of `Collections.emptyList().iterator()` we can use `Collections.emptyIterator()` method.
Actual implementation of `java.util.Collections.EmptyList#iterator` does exactly this - just calls `emptyIterator` method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297682](https://bugs.openjdk.org/browse/JDK-8297682): Use Collections.emptyIterator where applicable


### Reviewers
 * [Sergey Tsypanov](https://openjdk.org/census#stsypanov) (@stsypanov - Author)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11025/head:pull/11025` \
`$ git checkout pull/11025`

Update a local copy of the PR: \
`$ git checkout pull/11025` \
`$ git pull https://git.openjdk.org/jdk pull/11025/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11025`

View PR using the GUI difftool: \
`$ git pr show -t 11025`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11025.diff">https://git.openjdk.org/jdk/pull/11025.diff</a>

</details>
