### PR TITLE
8249693: java/nio/channels/FileChannel/FileExtensionAndMap.java uses @ignore w/o bug id

### DIFF
--- a/test/jdk/java/nio/channels/FileChannel/FileExtensionAndMap.java
+++ b/test/jdk/java/nio/channels/FileChannel/FileExtensionAndMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/channels/FileChannel/FileExtensionAndMap.java
+++ b/test/jdk/java/nio/channels/FileChannel/FileExtensionAndMap.java
@@ -25,6 +25,7 @@
  * @bug 8168628
  * @summary Test extending files to very large sizes without hitting a SIGBUS
  * @requires (os.family == "linux")
+ * @requires (sun.arch.data.model == "64")
  * @library /test/lib/
  * @run main/othervm/timeout=600 -Xms4g -Xmx4g FileExtensionAndMap
  * @run main/othervm/timeout=600 -Xms4g -Xmx4g FileExtensionAndMap true
@@ -143,7 +144,7 @@ public class FileExtensionAndMap {
         } else {
             for (Path p : List.of(destinationPath, tmpDir)) {
                 long usableDiskSpace = Files.getFileStore(p).getUsableSpace();
-                if(usableDiskSpace < totalDiskSpaceNeeded) {
+                if (usableDiskSpace < totalDiskSpaceNeeded) {
                     throw new SkippedException("Insufficient disk space on " + p
                             + ". Test requires: " + totalDiskSpaceNeeded
                             + ". Available on disk: " + usableDiskSpace);

--- a/test/jdk/java/nio/channels/FileChannel/FileExtensionAndMap.java
+++ b/test/jdk/java/nio/channels/FileChannel/FileExtensionAndMap.java
@@ -22,10 +22,10 @@
  */
 
 /* @test
- * @ignore This test has huge disk space requirements
  * @bug 8168628
  * @summary Test extending files to very large sizes without hitting a SIGBUS
  * @requires (os.family == "linux")
+ * @library /test/lib/
  * @run main/othervm/timeout=600 -Xms4g -Xmx4g FileExtensionAndMap
  * @run main/othervm/timeout=600 -Xms4g -Xmx4g FileExtensionAndMap true
  */
@@ -42,11 +42,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Semaphore;
 import java.util.stream.IntStream;
+import jtreg.SkippedException;
 
 public class FileExtensionAndMap {
 
@@ -56,6 +58,9 @@ public class FileExtensionAndMap {
     private static final String TMPDIR = System.getProperty("test.dir", ".");
 
     private static boolean useRaf = false;
+
+    private static final long FILESIZE = 3L * 1024L * 1024L * 1024L;
+    private static final int PARALLELISM = 3;
 
     public static void main(String args[]) throws Exception {
         if (args.length > 2) {
@@ -70,6 +75,7 @@ public class FileExtensionAndMap {
                 defaultFolder = args[1];
             }
         }
+
         final String targetFolder = defaultFolder;
         Path p = Paths.get(targetFolder);
         boolean targetExists = Files.exists(p);
@@ -77,10 +83,12 @@ public class FileExtensionAndMap {
             Files.createDirectory(p);
         }
 
+        checkRequiredDiskSpace(defaultFolder);
+
         System.out.printf("Using RandomAccessFile: %s; target folder: %s%n",
             useRaf, targetFolder);
 
-        ForkJoinPool fjPool = new ForkJoinPool(3);
+        ForkJoinPool fjPool = new ForkJoinPool(PARALLELISM);
         fjPool.submit(() -> {
             IntStream.range(0, 20).parallel().forEach((index) -> {
                 String fileName = "testBigFile_" + index + ".dat";
@@ -117,6 +125,29 @@ public class FileExtensionAndMap {
         }
     }
 
+    private static void checkRequiredDiskSpace(String destinationFolder) throws IOException {
+        Path destinationPath = Path.of(destinationFolder);
+        Path tmpDir = Path.of(TMPDIR);
+
+        long totalDiskSpaceNeeded = FILESIZE * PARALLELISM;
+
+        if (Files.getFileStore(tmpDir).name().equals(Files.getFileStore(destinationPath).name())) {
+            totalDiskSpaceNeeded *= 2; // writing and copying to same FS
+            long usableDiskSpace = Files.getFileStore(tmpDir).getUsableSpace();
+            if (usableDiskSpace < totalDiskSpaceNeeded) {
+                throw new SkippedException("Insufficient disk space on " + TMPDIR + ". Test requires: " + totalDiskSpaceNeeded + ". Available on disk: " + usableDiskSpace);
+            }
+
+        } else {
+            for (Path p : List.of(destinationPath, tmpDir)) {
+                long usableDiskSpace = Files.getFileStore(p).getUsableSpace();
+                if(usableDiskSpace < totalDiskSpaceNeeded) {
+                    throw new SkippedException("Insufficient disk space on " + p + ". Test requires: " + totalDiskSpaceNeeded + ". Available on disk: " + usableDiskSpace);
+                }
+            }
+        }
+    }
+
     private static void testFileCopy(Path source, Path target)
         throws IOException {
         Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
@@ -127,15 +158,15 @@ public class FileExtensionAndMap {
     private static void testCreateBigFile(Path segmentFile)
         throws IOException {
         final Semaphore concurrencySemaphore = new Semaphore(5);
-        long fileSize = 3L * 1024L * 1024L * 1024L;
+
         int blockSize = 10 * 1024 * 1024;
-        int loopCount = (int) Math.floorDiv(fileSize, blockSize);
+        int loopCount = (int) Math.floorDiv(FILESIZE, blockSize);
 
         String fileName = segmentFile.getFileName().toString();
         if (useRaf) {
             try (RandomAccessFile raf
                 = new RandomAccessFile(segmentFile.toFile(), "rw")) {
-                raf.setLength(fileSize);
+                raf.setLength(FILESIZE);
                 try (FileChannel fc = raf.getChannel()) {
                     for (int i = 0; i < loopCount; i++) {
                         final long startPosition = 1L * blockSize * i;

--- a/test/jdk/java/nio/channels/FileChannel/FileExtensionAndMap.java
+++ b/test/jdk/java/nio/channels/FileChannel/FileExtensionAndMap.java
@@ -131,18 +131,22 @@ public class FileExtensionAndMap {
 
         long totalDiskSpaceNeeded = FILESIZE * PARALLELISM;
 
-        if (Files.getFileStore(tmpDir).name().equals(Files.getFileStore(destinationPath).name())) {
+        if (Files.getFileStore(tmpDir).equals(Files.getFileStore(destinationPath))) {
             totalDiskSpaceNeeded *= 2; // writing and copying to same FS
             long usableDiskSpace = Files.getFileStore(tmpDir).getUsableSpace();
             if (usableDiskSpace < totalDiskSpaceNeeded) {
-                throw new SkippedException("Insufficient disk space on " + TMPDIR + ". Test requires: " + totalDiskSpaceNeeded + ". Available on disk: " + usableDiskSpace);
+                throw new SkippedException("Insufficient disk space on " + TMPDIR
+                        + ". Test requires: " + totalDiskSpaceNeeded
+                        + ". Available on disk: " + usableDiskSpace);
             }
 
         } else {
             for (Path p : List.of(destinationPath, tmpDir)) {
                 long usableDiskSpace = Files.getFileStore(p).getUsableSpace();
                 if(usableDiskSpace < totalDiskSpaceNeeded) {
-                    throw new SkippedException("Insufficient disk space on " + p + ". Test requires: " + totalDiskSpaceNeeded + ". Available on disk: " + usableDiskSpace);
+                    throw new SkippedException("Insufficient disk space on " + p
+                            + ". Test requires: " + totalDiskSpaceNeeded
+                            + ". Available on disk: " + usableDiskSpace);
                 }
             }
         }


### PR DESCRIPTION
Added a check that source and destination volumes have enough space to run the test.

This test will no longer be ignored.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8249693](https://bugs.openjdk.org/browse/JDK-8249693): java/nio/channels/FileChannel/FileExtensionAndMap.java uses @ignore w/o bug id


### Reviewers
 * [Rajan Halade](https://openjdk.org/census#rhalade) (@rhalade - **Reviewer**) ⚠️ Review applies to [be28f3e7](https://git.openjdk.org/jdk/pull/11028/files/be28f3e72779a8edad3740e2d9d57da43b9e315e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11028/head:pull/11028` \
`$ git checkout pull/11028`

Update a local copy of the PR: \
`$ git checkout pull/11028` \
`$ git pull https://git.openjdk.org/jdk pull/11028/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11028`

View PR using the GUI difftool: \
`$ git pr show -t 11028`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11028.diff">https://git.openjdk.org/jdk/pull/11028.diff</a>

</details>
