### PR TITLE
8296504: Memory leak in G1PLABAllocator::PLABData

### DIFF
--- a/src/hotspot/share/gc/g1/g1Allocator.cpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.cpp
@@ -309,6 +309,7 @@ G1PLABAllocator::PLABData::~PLABData() {
   for (uint node_index = 0; node_index < _num_alloc_buffers; node_index++) {
     delete _alloc_buffer[node_index];
   }
+  FREE_C_HEAP_ARRAY(PLAB*, _alloc_buffer);
 }
 
 void G1PLABAllocator::PLABData::initialize(uint num_alloc_buffers, size_t desired_plab_size, size_t tolerated_refills) {


### PR DESCRIPTION
Hi all,

Could anyone review this fix for a memory leak identified by colleague Justin King (jcking@google.com) using LeakSanitizer?
I'm sponsoring Justin for this change.

-Man

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296504](https://bugs.openjdk.org/browse/JDK-8296504): Memory leak in G1PLABAllocator::PLABData


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Contributors
 * Justin King `<jcking@google.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11032/head:pull/11032` \
`$ git checkout pull/11032`

Update a local copy of the PR: \
`$ git checkout pull/11032` \
`$ git pull https://git.openjdk.org/jdk pull/11032/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11032`

View PR using the GUI difftool: \
`$ git pr show -t 11032`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11032.diff">https://git.openjdk.org/jdk/pull/11032.diff</a>

</details>
