### PR TITLE
8296515: RISC-V: Small refactoring for MaxReductionV/MinReductionV/AddReductionV node implementation

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1690,9 +1690,11 @@ bool C2_MacroAssembler::in_scratch_emit_size() {
   return MacroAssembler::in_scratch_emit_size();
 }
 
-void C2_MacroAssembler::reduce_operation(Register dst, VectorRegister tmp,
-                                         Register src1, VectorRegister src2,
-                                         BasicType bt, REDUCTION_OP op) {
+void C2_MacroAssembler::rvv_reduce_integral(Register dst, VectorRegister tmp,
+                                            Register src1, VectorRegister src2,
+                                            BasicType bt, REDUCTION_OP op) {
+  assert(bt == T_BYTE || bt == T_SHORT || bt == T_INT || bt == T_LONG, "unsupported element type");
+
   Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
   vsetvli(t0, x0, sew);
 
@@ -1710,6 +1712,12 @@ void C2_MacroAssembler::reduce_operation(Register dst, VectorRegister tmp,
       break;
     case REDUCTION_OP::XOR:
       vredxor_vs(tmp, src2, tmp);
+      break;
+    case REDUCTION_OP::MAX:
+      vredmax_vs(tmp, src2, tmp);
+      break;
+    case REDUCTION_OP::MIN:
+      vredmin_vs(tmp, src2, tmp);
       break;
     default:
       ShouldNotReachHere();

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1692,7 +1692,7 @@ bool C2_MacroAssembler::in_scratch_emit_size() {
 
 void C2_MacroAssembler::rvv_reduce_integral(Register dst, VectorRegister tmp,
                                             Register src1, VectorRegister src2,
-                                            BasicType bt, REDUCTION_OP op) {
+                                            BasicType bt, int opc) {
   assert(bt == T_BYTE || bt == T_SHORT || bt == T_INT || bt == T_LONG, "unsupported element type");
 
   Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
@@ -1700,23 +1700,24 @@ void C2_MacroAssembler::rvv_reduce_integral(Register dst, VectorRegister tmp,
 
   vmv_s_x(tmp, src1);
 
-  switch (op) {
-    case REDUCTION_OP::ADD:
+  switch (opc) {
+    case Op_AddReductionVI:
+    case Op_AddReductionVL:
       vredsum_vs(tmp, src2, tmp);
       break;
-    case REDUCTION_OP::AND:
+    case Op_AndReductionV:
       vredand_vs(tmp, src2, tmp);
       break;
-    case REDUCTION_OP::OR:
+    case Op_OrReductionV:
       vredor_vs(tmp, src2, tmp);
       break;
-    case REDUCTION_OP::XOR:
+    case Op_XorReductionV:
       vredxor_vs(tmp, src2, tmp);
       break;
-    case REDUCTION_OP::MAX:
+    case Op_MaxReductionV:
       vredmax_vs(tmp, src2, tmp);
       break;
-    case REDUCTION_OP::MIN:
+    case Op_MinReductionV:
       vredmin_vs(tmp, src2, tmp);
       break;
     default:

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -195,8 +195,8 @@
                          VectorRegister tmp1, VectorRegister tmp2,
                          bool is_double, bool is_min);
 
- void reduce_operation(Register dst, VectorRegister tmp,
-                       Register src1, VectorRegister src2,
-                       BasicType bt, REDUCTION_OP op);
+ void rvv_reduce_integral(Register dst, VectorRegister tmp,
+                          Register src1, VectorRegister src2,
+                          BasicType bt, REDUCTION_OP op);
 
 #endif // CPU_RISCV_C2_MACROASSEMBLER_RISCV_HPP

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -197,6 +197,6 @@
 
  void rvv_reduce_integral(Register dst, VectorRegister tmp,
                           Register src1, VectorRegister src2,
-                          BasicType bt, REDUCTION_OP op);
+                          BasicType bt, int opc);
 
 #endif // CPU_RISCV_C2_MACROASSEMBLER_RISCV_HPP

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1300,7 +1300,4 @@ class SkipIfEqual {
    ~SkipIfEqual();
 };
 
-// reduction related operations
-enum REDUCTION_OP {ADD, AND, OR, XOR, MAX, MIN};
-
 #endif // CPU_RISCV_MACROASSEMBLER_RISCV_HPP

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1301,6 +1301,6 @@ class SkipIfEqual {
 };
 
 // reduction related operations
-enum REDUCTION_OP {ADD, AND, OR, XOR};
+enum REDUCTION_OP {ADD, AND, OR, XOR, MAX, MIN};
 
 #endif // CPU_RISCV_MACROASSEMBLER_RISCV_HPP

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -819,7 +819,7 @@ instruct reduce_andI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::AND);
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
   %}
   ins_pipe(pipe_slow);
 %}
@@ -835,7 +835,7 @@ instruct reduce_andL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::AND);
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
   %}
   ins_pipe(pipe_slow);
 %}
@@ -853,7 +853,7 @@ instruct reduce_orI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::OR);
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
   %}
   ins_pipe(pipe_slow);
 %}
@@ -869,7 +869,7 @@ instruct reduce_orL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::OR);
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
   %}
   ins_pipe(pipe_slow);
 %}
@@ -887,7 +887,7 @@ instruct reduce_xorI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::XOR);
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
   %}
   ins_pipe(pipe_slow);
 %}
@@ -903,7 +903,7 @@ instruct reduce_xorL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::XOR);
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
   %}
   ins_pipe(pipe_slow);
 %}
@@ -923,7 +923,7 @@ instruct reduce_addI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::ADD);
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
   %}
   ins_pipe(pipe_slow);
 %}
@@ -939,7 +939,7 @@ instruct reduce_addL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::ADD);
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
   %}
   ins_pipe(pipe_slow);
 %}
@@ -991,7 +991,7 @@ instruct vreduce_maxI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::MAX);
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1005,7 +1005,7 @@ instruct vreduce_maxL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::MAX);
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1023,7 +1023,7 @@ instruct vreduce_minI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::MIN);
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1037,7 +1037,7 @@ instruct vreduce_minL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::MIN);
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -818,8 +818,8 @@ instruct reduce_andI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
             "vmv.x.s $dst, $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
-    __ reduce_operation($dst$$Register, as_VectorRegister($tmp$$reg),
-                        $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::AND);
+    __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::AND);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -834,8 +834,8 @@ instruct reduce_andL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
             "vmv.x.s $dst, $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
-    __ reduce_operation($dst$$Register, as_VectorRegister($tmp$$reg),
-                        $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::AND);
+    __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::AND);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -852,8 +852,8 @@ instruct reduce_orI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
             "vmv.x.s $dst, $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
-    __ reduce_operation($dst$$Register, as_VectorRegister($tmp$$reg),
-                        $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::OR);
+    __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::OR);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -868,8 +868,8 @@ instruct reduce_orL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
             "vmv.x.s $dst, $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
-    __ reduce_operation($dst$$Register, as_VectorRegister($tmp$$reg),
-                        $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::OR);
+    __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::OR);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -886,8 +886,8 @@ instruct reduce_xorI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
             "vmv.x.s $dst, $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
-    __ reduce_operation($dst$$Register, as_VectorRegister($tmp$$reg),
-                        $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::XOR);
+    __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::XOR);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -902,82 +902,44 @@ instruct reduce_xorL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
             "vmv.x.s $dst, $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
-    __ reduce_operation($dst$$Register, as_VectorRegister($tmp$$reg),
-                        $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::XOR);
+    __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::XOR);
   %}
   ins_pipe(pipe_slow);
 %}
 
 // vector add reduction
 
-instruct reduce_addB(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
-  predicate(n->in(2)->bottom_type()->is_vect()->element_basic_type() == T_BYTE);
-  match(Set dst (AddReductionVI src1 src2));
-  effect(TEMP tmp);
-  ins_cost(VEC_COST);
-  format %{ "vmv.s.x $tmp, $src1\t#@reduce_addB\n\t"
-            "vredsum.vs $tmp, $src2, $tmp\n\t"
-            "vmv.x.s  $dst, $tmp" %}
-  ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e8);
-    __ vmv_s_x(as_VectorRegister($tmp$$reg), $src1$$Register);
-    __ vredsum_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg),
-                  as_VectorRegister($tmp$$reg));
-    __ vmv_x_s($dst$$Register, as_VectorRegister($tmp$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct reduce_addS(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
-  predicate(n->in(2)->bottom_type()->is_vect()->element_basic_type() == T_SHORT);
-  match(Set dst (AddReductionVI src1 src2));
-  effect(TEMP tmp);
-  ins_cost(VEC_COST);
-  format %{ "vmv.s.x $tmp, $src1\t#@reduce_addS\n\t"
-            "vredsum.vs $tmp, $src2, $tmp\n\t"
-            "vmv.x.s  $dst, $tmp" %}
-  ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e16);
-    __ vmv_s_x(as_VectorRegister($tmp$$reg), $src1$$Register);
-    __ vredsum_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg),
-                  as_VectorRegister($tmp$$reg));
-    __ vmv_x_s($dst$$Register, as_VectorRegister($tmp$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
 instruct reduce_addI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
-  predicate(n->in(2)->bottom_type()->is_vect()->element_basic_type() == T_INT);
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE || 
+            Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
+            Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (AddReductionVI src1 src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
   format %{ "vmv.s.x $tmp, $src1\t#@reduce_addI\n\t"
             "vredsum.vs $tmp, $src2, $tmp\n\t"
-            "vmv.x.s  $dst, $tmp" %}
+            "vmv.x.s $dst, $tmp" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
-    __ vmv_s_x(as_VectorRegister($tmp$$reg), $src1$$Register);
-    __ vredsum_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg),
-                  as_VectorRegister($tmp$$reg));
-    __ vmv_x_s($dst$$Register, as_VectorRegister($tmp$$reg));
+    BasicType bt = Matcher::vector_element_basic_type(this, $src2);
+    __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::ADD);
   %}
   ins_pipe(pipe_slow);
 %}
 
 instruct reduce_addL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
-  predicate(n->in(2)->bottom_type()->is_vect()->element_basic_type() == T_LONG);
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (AddReductionVL src1 src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
   format %{ "vmv.s.x $tmp, $src1\t#@reduce_addL\n\t"
             "vredsum.vs $tmp, $src2, $tmp\n\t"
-            "vmv.x.s  $dst, $tmp" %}
+            "vmv.x.s $dst, $tmp" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
-    __ vmv_s_x(as_VectorRegister($tmp$$reg), $src1$$Register);
-    __ vredsum_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg),
-                  as_VectorRegister($tmp$$reg));
-    __ vmv_x_s($dst$$Register, as_VectorRegister($tmp$$reg));
+    BasicType bt = Matcher::vector_element_basic_type(this, $src2);
+    __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::ADD);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1017,135 +979,65 @@ instruct reduce_addD(fRegD src1_dst, vReg src2, vReg tmp) %{
 %}
 
 // vector integer max reduction
-instruct vreduce_maxB(iRegINoSp dst, iRegI src1, vReg src2, vReg tmp) %{
-  predicate(n->in(2)->bottom_type()->is_vect()->element_basic_type() == T_BYTE);
-  match(Set dst (MaxReductionV src1 src2));
-  ins_cost(VEC_COST);
-  effect(TEMP tmp);
-  format %{ "vreduce_maxB $dst, $src1, $src2, $tmp" %}
-  ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e8);
-    __ vredmax_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg), as_VectorRegister($src2$$reg));
-    __ vmv_x_s($dst$$Register, as_VectorRegister($tmp$$reg));
-    Label Ldone;
-    __ ble(as_Register($src1$$reg), as_Register($dst$$reg), Ldone);
-    __ mv(as_Register($dst$$reg), as_Register($src1$$reg));
-    __ bind(Ldone);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vreduce_maxS(iRegINoSp dst, iRegI src1, vReg src2, vReg tmp) %{
-  predicate(n->in(2)->bottom_type()->is_vect()->element_basic_type() == T_SHORT);
-  match(Set dst (MaxReductionV src1 src2));
-  ins_cost(VEC_COST);
-  effect(TEMP tmp);
-  format %{ "vreduce_maxS $dst, $src1, $src2, $tmp" %}
-  ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e16);
-    __ vredmax_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg), as_VectorRegister($src2$$reg));
-    __ vmv_x_s($dst$$Register, as_VectorRegister($tmp$$reg));
-    Label Ldone;
-    __ ble(as_Register($src1$$reg), as_Register($dst$$reg), Ldone);
-    __ mv(as_Register($dst$$reg), as_Register($src1$$reg));
-    __ bind(Ldone);
-  %}
-  ins_pipe(pipe_slow);
-%}
 
 instruct vreduce_maxI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
-  predicate(n->in(2)->bottom_type()->is_vect()->element_basic_type() == T_INT);
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE || 
+            Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
+            Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (MaxReductionV src1 src2));
   ins_cost(VEC_COST);
   effect(TEMP tmp);
   format %{ "vreduce_maxI $dst, $src1, $src2, $tmp" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
-    __ vmv_s_x(as_VectorRegister($tmp$$reg), $src1$$Register);
-    __ vredmax_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg));
-    __ vmv_x_s($dst$$Register, as_VectorRegister($tmp$$reg));
+    BasicType bt = Matcher::vector_element_basic_type(this, $src2);
+    __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::MAX);
   %}
   ins_pipe(pipe_slow);
 %}
 
 instruct vreduce_maxL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
-  predicate(n->in(2)->bottom_type()->is_vect()->element_basic_type() == T_LONG);
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (MaxReductionV src1 src2));
   ins_cost(VEC_COST);
   effect(TEMP tmp);
   format %{ "vreduce_maxL $dst, $src1, $src2, $tmp" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
-    __ vmv_s_x(as_VectorRegister($tmp$$reg), $src1$$Register);
-    __ vredmax_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg));
-    __ vmv_x_s($dst$$Register, as_VectorRegister($tmp$$reg));
+    BasicType bt = Matcher::vector_element_basic_type(this, $src2);
+    __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::MAX);
   %}
   ins_pipe(pipe_slow);
 %}
 
 // vector integer min reduction
-instruct vreduce_minB(iRegINoSp dst, iRegI src1, vReg src2, vReg tmp) %{
-  predicate(n->in(2)->bottom_type()->is_vect()->element_basic_type() == T_BYTE);
-  match(Set dst (MinReductionV src1 src2));
-  ins_cost(VEC_COST);
-  effect(TEMP tmp);
-  format %{ "vreduce_minB $dst, $src1, $src2, $tmp" %}
-  ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e8);
-    __ vredmin_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg), as_VectorRegister($src2$$reg));
-    __ vmv_x_s($dst$$Register, as_VectorRegister($tmp$$reg));
-    Label Ldone;
-    __ bge(as_Register($src1$$reg), as_Register($dst$$reg), Ldone);
-    __ mv(as_Register($dst$$reg), as_Register($src1$$reg));
-    __ bind(Ldone);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vreduce_minS(iRegINoSp dst, iRegI src1, vReg src2, vReg tmp) %{
-  predicate(n->in(2)->bottom_type()->is_vect()->element_basic_type() == T_SHORT);
-  match(Set dst (MinReductionV src1 src2));
-  ins_cost(VEC_COST);
-  effect(TEMP tmp);
-  format %{ "vreduce_minS $dst, $src1, $src2, $tmp" %}
-  ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e16);
-    __ vredmin_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg), as_VectorRegister($src2$$reg));
-    __ vmv_x_s($dst$$Register, as_VectorRegister($tmp$$reg));
-    Label Ldone;
-    __ bge(as_Register($src1$$reg), as_Register($dst$$reg), Ldone);
-    __ mv(as_Register($dst$$reg), as_Register($src1$$reg));
-    __ bind(Ldone);
-  %}
-  ins_pipe(pipe_slow);
-%}
 
 instruct vreduce_minI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
-  predicate(n->in(2)->bottom_type()->is_vect()->element_basic_type() == T_INT);
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE || 
+            Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
+            Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (MinReductionV src1 src2));
   ins_cost(VEC_COST);
   effect(TEMP tmp);
   format %{ "vreduce_minI $dst, $src1, $src2, $tmp" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
-    __ vmv_s_x(as_VectorRegister($tmp$$reg), $src1$$Register);
-    __ vredmin_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg));
-    __ vmv_x_s($dst$$Register, as_VectorRegister($tmp$$reg));
+    BasicType bt = Matcher::vector_element_basic_type(this, $src2);
+    __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::MIN);
   %}
   ins_pipe(pipe_slow);
 %}
 
 instruct vreduce_minL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
-  predicate(n->in(2)->bottom_type()->is_vect()->element_basic_type() == T_LONG);
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (MinReductionV src1 src2));
   ins_cost(VEC_COST);
   effect(TEMP tmp);
   format %{ "vreduce_minL $dst, $src1, $src2, $tmp" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
-    __ vmv_s_x(as_VectorRegister($tmp$$reg), $src1$$Register);
-    __ vredmin_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg));
-    __ vmv_x_s($dst$$Register, as_VectorRegister($tmp$$reg));
+    BasicType bt = Matcher::vector_element_basic_type(this, $src2);
+    __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt, REDUCTION_OP::MIN);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -809,7 +809,9 @@ instruct vnegD(vReg dst, vReg src) %{
 // vector and reduction
 
 instruct reduce_andI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
-  predicate(Matcher::vector_element_basic_type(n->in(2)) != T_LONG);
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE || 
+            Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
+            Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (AndReductionV src1 src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
@@ -843,7 +845,9 @@ instruct reduce_andL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
 // vector or reduction
 
 instruct reduce_orI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
-  predicate(Matcher::vector_element_basic_type(n->in(2)) != T_LONG);
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE || 
+            Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
+            Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (OrReductionV src1 src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
@@ -877,7 +881,9 @@ instruct reduce_orL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
 // vector xor reduction
 
 instruct reduce_xorI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
-  predicate(Matcher::vector_element_basic_type(n->in(2)) != T_LONG);
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE || 
+            Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
+            Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (XorReductionV src1 src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);


### PR DESCRIPTION
HI,

The MaxReductionV, MinReductionV, AddReductionV nodes currently implemented by riscv rvv can be implemented by calling shared functions, and the T_BYTE and T_SHORT types in the MaxReductionV and MinReductionV node implementations can also be implemented in the same way as the T_INT type.

Please take a look and have some reviews. Thanks a lot.

## Testing:
- hotspot and jdk tier1 on unmatched board without new failures
- test/jdk/jdk/incubator/vector/* with fastdebug on qemu

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296515](https://bugs.openjdk.org/browse/JDK-8296515): RISC-V: Small refactoring for MaxReductionV/MinReductionV/AddReductionV node implementation


### Reviewers
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Author)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Author)
 * [Yanhong Zhu](https://openjdk.org/census#yzhu) (@yhzhu20 - Author)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11036/head:pull/11036` \
`$ git checkout pull/11036`

Update a local copy of the PR: \
`$ git checkout pull/11036` \
`$ git pull https://git.openjdk.org/jdk pull/11036/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11036`

View PR using the GUI difftool: \
`$ git pr show -t 11036`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11036.diff">https://git.openjdk.org/jdk/pull/11036.diff</a>

</details>
