### PR TITLE
8296243: [IR Framework] Fix issues with IRNode.ALLOC* regexes

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -167,27 +167,25 @@ public class IRNode {
 
     public static final String ALLOC = PREFIX + "ALLOC" + POSTFIX;
     static {
-        String idealIndependentRegex = START + "Allocate" + MID + END;
-        String optoRegex = "(.*precise .*\\R((.*(?i:mov|xorl|nop|spill).*|\\s*|.*LGHI.*)\\R)*.*(?i:call,static).*wrapper for: _new_instance_Java" + END;
-        allocNodes(ALLOC, idealIndependentRegex, optoRegex);
+        String optoRegex = "(.*precise .*\\R((.*(?i:mov|xorl|nop|spill).*|\\s*)\\R)*.*(?i:call,static).*wrapper for: _new_instance_Java" + END;
+        allocNodes(ALLOC, "Allocate", optoRegex);
     }
 
     public static final String ALLOC_OF = COMPOSITE_PREFIX + "ALLOC_OF" + POSTFIX;
     static {
-        String regex = "(.*precise .*" + IS_REPLACED + ":.*\\R((.*(?i:mov|xorl|nop|spill).*|\\s*|.*LGHI.*)\\R)*.*(?i:call,static).*wrapper for: _new_instance_Java" + END;
+        String regex = "(.*precise .*" + IS_REPLACED + ":.*\\R((.*(?i:mov|xorl|nop|spill).*|\\s*)\\R)*.*(?i:call,static).*wrapper for: _new_instance_Java" + END;
         optoOnly(ALLOC_OF, regex);
     }
 
     public static final String ALLOC_ARRAY = PREFIX + "ALLOC_ARRAY" + POSTFIX;
     static {
-        String idealIndependentRegex = START + "AllocateArray" + MID + END;
-        String optoRegex = "(.*precise \\[.*\\R((.*(?i:mov|xor|nop|spill).*|\\s*|.*LGHI.*)\\R)*.*(?i:call,static).*wrapper for: _new_array_Java" + END;
-        allocNodes(ALLOC_ARRAY, idealIndependentRegex, optoRegex);
+        String optoRegex = "(.*precise \\[.*\\R((.*(?i:mov|xor|nop|spill).*|\\s*|.*(LGHI|LI).*)\\R)*.*(?i:call,static).*wrapper for: _new_array_Java" + END;
+        allocNodes(ALLOC_ARRAY, "AllocateArray", optoRegex);
     }
 
     public static final String ALLOC_ARRAY_OF = COMPOSITE_PREFIX + "ALLOC_ARRAY_OF" + POSTFIX;
     static {
-        String regex = "(.*precise \\[.*" + IS_REPLACED + ":.*\\R((.*(?i:mov|xorl|nop|spill).*|\\s*|.*LGHI.*)\\R)*.*(?i:call,static).*wrapper for: _new_array_Java" + END;
+        String regex = "(.*precise \\[.*" + IS_REPLACED + ":.*\\R((.*(?i:mov|xorl|nop|spill).*|\\s*|.*(LGHI|LI).*)\\R)*.*(?i:call,static).*wrapper for: _new_array_Java" + END;
         optoOnly(ALLOC_ARRAY_OF, regex);
     }
 
@@ -1182,10 +1180,11 @@ public class IRNode {
         IR_NODE_MAPPINGS.put(irNodePlaceholder, new RegexTypeEntry(RegexType.IDEAL_INDEPENDENT, regex));
     }
 
-    private static void allocNodes(String irNode, String idealRegex, String optoRegex) {
+    private static void allocNodes(String irNode, String irNodeName, String optoRegex) {
+        String idealIndependentRegex = START + irNodeName + "\\b" + MID + END;
         Map<PhaseInterval, String> intervalToRegexMap = new HashMap<>();
         intervalToRegexMap.put(new PhaseInterval(CompilePhase.BEFORE_REMOVEUSELESS, CompilePhase.PHASEIDEALLOOP_ITERATIONS),
-                               idealRegex);
+                               idealIndependentRegex);
         intervalToRegexMap.put(new PhaseInterval(CompilePhase.PRINT_OPTO_ASSEMBLY), optoRegex);
         MultiPhaseRangeEntry entry = new MultiPhaseRangeEntry(CompilePhase.PRINT_OPTO_ASSEMBLY, intervalToRegexMap);
         IR_NODE_MAPPINGS.put(irNode, entry);

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java
@@ -245,7 +245,7 @@ class Basics {
         obj = new Object();
         obj2 = new Object[1];
     }
-    
+
     @Test
     @IR(counts = {IRNode.ALLOC, "2", IRNode.ALLOC_ARRAY, "2"}, // works for all phases
         phase = {CompilePhase.BEFORE_REMOVEUSELESS, CompilePhase.CCP1, CompilePhase.PRINT_OPTO_ASSEMBLY, CompilePhase.DEFAULT})

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java
@@ -245,6 +245,7 @@ class Basics {
         obj = new Object();
         obj2 = new Object[1];
     }
+    
     @Test
     @IR(counts = {IRNode.ALLOC, "2", IRNode.ALLOC_ARRAY, "2"}, // works for all phases
         phase = {CompilePhase.BEFORE_REMOVEUSELESS, CompilePhase.CCP1, CompilePhase.PRINT_OPTO_ASSEMBLY, CompilePhase.DEFAULT})

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java
@@ -104,6 +104,8 @@ class Basics {
     long l;
     Object obj;
     Object obj2;
+    Object obj3;
+    Object obj4;
 
     @Test
     @IR(failOn = IRNode.STORE, phase = {CompilePhase.DEFAULT, CompilePhase.PRINT_IDEAL})
@@ -242,6 +244,15 @@ class Basics {
     public void alloc() {
         obj = new Object();
         obj2 = new Object[1];
+    }
+    @Test
+    @IR(counts = {IRNode.ALLOC, "2", IRNode.ALLOC_ARRAY, "2"}, // works for all phases
+        phase = {CompilePhase.BEFORE_REMOVEUSELESS, CompilePhase.CCP1, CompilePhase.PRINT_OPTO_ASSEMBLY, CompilePhase.DEFAULT})
+    public void alloc2() {
+        obj = new Object();
+        obj2 = new Object[1];
+        obj3 = new Object();
+        obj4 = new Object[2];
     }
 }
 


### PR DESCRIPTION
There are currently two problems with `IRNode.ALLOC*` regexes:
1. On PPC64, we do not account for an `LI` instruction which matches the array size. As a result, we could miss some array allocations with the `ALLOC_ARRAY*` regexes:
```
2e4     LD      R3, offset, R3   // load ptr precise [java/lang/Object:
0x0000200058006e40 *: :Constant:exact * from TOC (lo)
2e8     STD     R17, [R1_SP + #104+0]    // spill copy
2ec     LI      R4, #1    <------- we only look for LGHI here which is specific to s390 while LI is used for PPC64
2f0     CALL,static 0x00002000177cd300   // ==>  wrapper for: _new_array_Java
```
This was revealed by a new test added by [JDK-8280378](https://bugs.openjdk.org/browse/JDK-8280378) but was already a problem before this change.

2. The newly added `IRNode.ALLOC*` regexes in JDK-8280378 which can be matched on the independent ideal compile phases by using the name of the IR node "Allocate" also matches "AllocateArray" (substring match). This is unexpected. I've changed this by matching "Allocate" exactly.

I've additionally removed the matching of `LI` and `LGHI` for the `ALLOC` regexes on normal objects as we do not have an array size. I think it's safe to remove these (might need some additional testing on PPC64/s390).

Thanks @TheRealMDoerr for helping to test the initial fix on PPC64!

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296243](https://bugs.openjdk.org/browse/JDK-8296243): [IR Framework] Fix issues with IRNode.ALLOC* regexes


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [c36e645b](https://git.openjdk.org/jdk/pull/11037/files/c36e645b6c0b62f5ef01b52e3a7a56383ae4d3a7)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [0d28220f](https://git.openjdk.org/jdk/pull/11037/files/0d28220fe507a8f261fd7a07916b0added30025c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11037/head:pull/11037` \
`$ git checkout pull/11037`

Update a local copy of the PR: \
`$ git checkout pull/11037` \
`$ git pull https://git.openjdk.org/jdk pull/11037/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11037`

View PR using the GUI difftool: \
`$ git pr show -t 11037`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11037.diff">https://git.openjdk.org/jdk/pull/11037.diff</a>

</details>
