### PR TITLE
8296292: Document the default behavior of '$' in regular expressions correctly

### DIFF
--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -484,11 +484,15 @@ import jdk.internal.util.regex.Grapheme;
  * <p> The regular expression {@code .} matches any character except a line
  * terminator unless the {@link #DOTALL} flag is specified.
  *
- * <p> By default, the regular expressions {@code ^} and {@code $} ignore
- * line terminators and only match at the beginning and the end, respectively,
- * of the entire input sequence. However, {@code $} also matches a final line
- * terminator not followed by any other input character, in addition to the end
- * of the input sequence itself. If {@link #MULTILINE} mode is activated then
+ * <p> If {@link #MULTILINE} mode is not activated, the regular expression
+ * {@code ^} ignores line terminators and only matches at the beginning of
+ * the entire input sequence. The regular expression {@code $} matches at the
+ * end of the entire input sequence, but also matches just before the last line
+ * terminator if this is not followed by any other input character. Other line
+ * terminators are ignored, including the last one if it is followed by other
+ * input characters.
+ *
+ * <p> If {@link #MULTILINE} mode is activated then
  * {@code ^} matches at the beginning of input and after any line terminator
  * except at the end of input. When in {@link #MULTILINE} mode {@code $}
  * matches just before a line terminator or the end of the input sequence.

--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -486,7 +486,9 @@ import jdk.internal.util.regex.Grapheme;
  *
  * <p> By default, the regular expressions {@code ^} and {@code $} ignore
  * line terminators and only match at the beginning and the end, respectively,
- * of the entire input sequence. If {@link #MULTILINE} mode is activated then
+ * of the entire input sequence. However, {@code $} also matches a final line
+ * terminator not followed by any other input character, in addition to the end
+ * of the input sequence itself. If {@link #MULTILINE} mode is activated then
  * {@code ^} matches at the beginning of input and after any line terminator
  * except at the end of input. When in {@link #MULTILINE} mode {@code $}
  * matches just before a line terminator or the end of the input sequence.


### PR DESCRIPTION
A small spec change to match established behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8296292](https://bugs.openjdk.org/browse/JDK-8296292): Document the default behavior of '$' in regular expressions correctly
 * [JDK-8296529](https://bugs.openjdk.org/browse/JDK-8296529): Document the default behavior of '$' in regular expressions correctly (**CSR**)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11038/head:pull/11038` \
`$ git checkout pull/11038`

Update a local copy of the PR: \
`$ git checkout pull/11038` \
`$ git pull https://git.openjdk.org/jdk pull/11038/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11038`

View PR using the GUI difftool: \
`$ git pr show -t 11038`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11038.diff">https://git.openjdk.org/jdk/pull/11038.diff</a>

</details>
