### PR TITLE
8295214: Generational ZGC: Guard nmethods from cross modifying code

### DIFF
--- a/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
@@ -195,5 +195,6 @@ bool BarrierSetNMethod::nmethod_osr_entry_barrier(nmethod* nm) {
 
   assert(nm->is_osr_method(), "Should not reach here");
   log_trace(nmethod, barrier)("Running osr nmethod entry barrier: " PTR_FORMAT, p2i(nm));
+  OrderAccess::cross_modify_fence();
   return nmethod_entry_barrier(nm);
 }

--- a/src/hotspot/share/runtime/safepointMechanism.cpp
+++ b/src/hotspot/share/runtime/safepointMechanism.cpp
@@ -94,12 +94,31 @@ void SafepointMechanism::update_poll_values(JavaThread* thread) {
   assert(thread == Thread::current(), "Must be");
   assert(thread->thread_state() != _thread_blocked, "Must not be");
   assert(thread->thread_state() != _thread_in_native, "Must not be");
+
   for (;;) {
     bool armed = global_poll() || thread->handshake_state()->has_operation();
     uintptr_t stack_watermark = StackWatermarkSet::lowest_watermark(thread);
     uintptr_t poll_page = armed ? _poll_page_armed_value
                                 : _poll_page_disarmed_value;
     uintptr_t poll_word = compute_poll_word(armed, stack_watermark);
+    uintptr_t prev_poll_word = thread->poll_data()->get_polling_word();
+
+    if (prev_poll_word != poll_word ||
+        prev_poll_word == _poll_word_armed_value) {
+      // After updating the poll value, we allow entering new nmethods
+      // through stack unwinding. The nmethods might have been processed in
+      // a concurrent thread by the GC. So we need to run a cross modify
+      // fence to ensure patching becomes visible. We may also wake up from
+      // a safepoint that has patched code. This cross modify fence will
+      // ensure such paths can observe patched code.
+      // Note that while other threads may arm the thread-local poll of
+      // a thread, only the thread itself has permission to disarm its own
+      // poll value, in any way making it less restrictive. Therefore, whenever
+      // the frontier of what the mutator allows itself to do is increased,
+      // we will catch that here, and ensure a cross modifying fence is used.
+      OrderAccess::cross_modify_fence();
+    }
+
     thread->poll_data()->set_polling_page(poll_page);
     thread->poll_data()->set_polling_word(poll_word);
     OrderAccess::fence();
@@ -141,7 +160,6 @@ void SafepointMechanism::process(JavaThread *thread, bool allow_suspend, bool ch
   } while (need_rechecking);
 
   update_poll_values(thread);
-  OrderAccess::cross_modify_fence();
   assert(sp_before == thread->last_Java_sp(), "Anchor has changed");
 }
 

--- a/src/hotspot/share/runtime/safepointMechanism.cpp
+++ b/src/hotspot/share/runtime/safepointMechanism.cpp
@@ -105,7 +105,7 @@ void SafepointMechanism::update_poll_values(JavaThread* thread) {
 
     if (prev_poll_word != poll_word ||
         prev_poll_word == _poll_word_armed_value) {
-      // After updating the poll value, we allow entering new nmethods
+      // While updating the poll value, we allow entering new nmethods
       // through stack unwinding. The nmethods might have been processed in
       // a concurrent thread by the GC. So we need to run a cross modify
       // fence to ensure patching becomes visible. We may also wake up from

--- a/src/hotspot/share/runtime/safepointMechanism.inline.hpp
+++ b/src/hotspot/share/runtime/safepointMechanism.inline.hpp
@@ -78,10 +78,6 @@ bool SafepointMechanism::should_process(JavaThread* thread, bool allow_suspend) 
   // 2: We have a suspend or async exception handshake, which cannot be processed.
   // We update the poll value in case of a disarm, to reduce false positives.
   update_poll_values(thread);
-
-  // We are now about to avoid processing and thus no cross modify fence will be executed.
-  // In case a safepoint happened, while being blocked, we execute it here.
-  OrderAccess::cross_modify_fence();
   return false;
 }
 


### PR DESCRIPTION
Generational ZGC will need to patch nmethod instructions outside of safepoints, and guard entries into the nmethods with cross modifying code fences. This is mostly taken care of by nmethod entry barrier code. But there are a few entries that don't go through nmethod entry barriers that need fixing. In particular when entering an nmethod by returning through the stack watermark barrier. This patch ensures that whenever the stack watermark barrier exposes a new nmethod, we also ensure that a cross modify fence is executed, so that any concurrently updated instructions can be safely executed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295214](https://bugs.openjdk.org/browse/JDK-8295214): Generational ZGC: Guard nmethods from cross modifying code


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [b1910e26](https://git.openjdk.org/jdk/pull/11042/files/b1910e2660899da1bf548541455875cdc6feab75)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**) ⚠️ Review applies to [b1910e26](https://git.openjdk.org/jdk/pull/11042/files/b1910e2660899da1bf548541455875cdc6feab75)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11042/head:pull/11042` \
`$ git checkout pull/11042`

Update a local copy of the PR: \
`$ git checkout pull/11042` \
`$ git pull https://git.openjdk.org/jdk pull/11042/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11042`

View PR using the GUI difftool: \
`$ git pr show -t 11042`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11042.diff">https://git.openjdk.org/jdk/pull/11042.diff</a>

</details>
