### PR TITLE
8296615: use of undeclared identifier 'IPV6_DONTFRAG'

### DIFF
--- a/src/jdk.net/macosx/native/libextnet/MacOSXSocketOptions.c
+++ b/src/jdk.net/macosx/native/libextnet/MacOSXSocketOptions.c
@@ -38,6 +38,10 @@
 #define IP_DONTFRAG             28
 #endif
 
+#ifndef IPV6_DONTFRAG
+#define IPV6_DONTFRAG           62
+#endif
+
 #include "jni_util.h"
 
 /*


### PR DESCRIPTION
Hi,

May I have this update in jdk.net reviewed?

While build on MacOX, I run into the following issues:
/Users/xueleifan/workspace/jdk-dev/src/jdk.net/macosx/native/libextnet/MacOSXSocketOptions.c:207:43: error: use of undeclared identifier 'IPV6_DONTFRAG'
        rv = setsockopt(fd, IPPROTO_IPV6, IPV6_DONTFRAG, &value, sizeof(value));

It looks like the IPV6_DONTFRAG defined in netinet6/in6.h is somehow filtered out for MacOSXSocketOptions.c.  The option could add back as what was did for IP_DONTFRAG.  The value for IPV6_DONTFRAG is copied from netinet6/in6.h.  Hopefully, it is a safe value to use.

Thanks,
Xuelei

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296615](https://bugs.openjdk.org/browse/JDK-8296615): use of undeclared identifier 'IPV6_DONTFRAG'


### Reviewers
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11047/head:pull/11047` \
`$ git checkout pull/11047`

Update a local copy of the PR: \
`$ git checkout pull/11047` \
`$ git pull https://git.openjdk.org/jdk pull/11047/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11047`

View PR using the GUI difftool: \
`$ git pr show -t 11047`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11047.diff">https://git.openjdk.org/jdk/pull/11047.diff</a>

</details>
