### PR TITLE
8296620: Removed total_space_rs from MetaspaceShared::map_archives()

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -191,11 +191,9 @@ private:
   static char* reserve_address_space_for_archives(FileMapInfo* static_mapinfo,
                                                   FileMapInfo* dynamic_mapinfo,
                                                   bool use_archive_base_addr,
-                                                  ReservedSpace& total_space_rs,
                                                   ReservedSpace& archive_space_rs,
                                                   ReservedSpace& class_space_rs);
- static void release_reserved_spaces(ReservedSpace& total_space_rs,
-                                     ReservedSpace& archive_space_rs,
+ static void release_reserved_spaces(ReservedSpace& archive_space_rs,
                                      ReservedSpace& class_space_rs);
   static MapArchiveResult map_archive(FileMapInfo* mapinfo, char* mapped_base_address, ReservedSpace rs);
   static void unmap_archive(FileMapInfo* mapinfo);


### PR DESCRIPTION
The `total_space_rs` variable is passed around by several functions in the `MetaspaceShared` class. However, it's used only inside `MetaspaceShared::reserve_address_space_for_archives()`.

We should remove it from other functions and simplify the interfaces.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296620](https://bugs.openjdk.org/browse/JDK-8296620): Removed total_space_rs from MetaspaceShared::map_archives()


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11050/head:pull/11050` \
`$ git checkout pull/11050`

Update a local copy of the PR: \
`$ git checkout pull/11050` \
`$ git pull https://git.openjdk.org/jdk pull/11050/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11050`

View PR using the GUI difftool: \
`$ git pr show -t 11050`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11050.diff">https://git.openjdk.org/jdk/pull/11050.diff</a>

</details>
