### PR TITLE
8296301: Interpreter(RISC-V): Implement -XX:+PrintBytecodeHistogram and -XX:+PrintBytecodePairHistogram options

### DIFF
--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -1735,18 +1735,35 @@ address TemplateInterpreterGenerator::generate_trace_code(TosState state) {
 }
 
 void TemplateInterpreterGenerator::count_bytecode() {
-  __ push_reg(t0);
-  __ push_reg(x10);
-  __ mv(x10, (address) &BytecodeCounter::_counter_value);
-  __ mv(t0, 1);
-  __ amoadd_d(zr, x10, t0, Assembler::aqrl);
-  __ pop_reg(x10);
-  __ pop_reg(t0);
+  __ mv(x7, (address) &BytecodeCounter::_counter_value);
+  __ atomic_addalw(noreg, 1, x7);
 }
 
-void TemplateInterpreterGenerator::histogram_bytecode(Template* t) { ; }
+void TemplateInterpreterGenerator::histogram_bytecode(Template* t) {
+  __ mv(x7, (address) &BytecodeHistogram::_counters[t->bytecode()]);
+  __ atomic_addalw(noreg, 1, x7);
+}
 
-void TemplateInterpreterGenerator::histogram_bytecode_pair(Template* t) { ; }
+void TemplateInterpreterGenerator::histogram_bytecode_pair(Template* t) {
+  // Calculate new index for counter:
+  //   _index = (_index >> log2_number_of_codes) |
+  //            (bytecode << log2_number_of_codes);
+  Register index_addr = t1;
+  Register index = t0;
+  __ mv(index_addr, (address) &BytecodePairHistogram::_index);
+  __ lw(index, index_addr);
+  __ mv(x7, ((int)t->bytecode()) << BytecodePairHistogram::log2_number_of_codes);
+  __ srli(index, index, BytecodePairHistogram::log2_number_of_codes);
+  __ orrw(index, x7, index);
+  __ sw(index, index_addr);
+  // Bump bucket contents:
+  //   _counters[_index] ++;
+  Register counter_addr = t1;
+  __ mv(x7, (address) &BytecodePairHistogram::_counters);
+  __ slli(index, index, LogBytesPerInt);
+  __ add(counter_addr, x7, index);
+  __ atomic_addalw(noreg, 1, counter_addr);
+ }
 
 void TemplateInterpreterGenerator::trace_bytecode(Template* t) {
   // Call a little run-time stub to avoid blow-up for each bytecode.

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -1736,12 +1736,12 @@ address TemplateInterpreterGenerator::generate_trace_code(TosState state) {
 
 void TemplateInterpreterGenerator::count_bytecode() {
   __ mv(x7, (address) &BytecodeCounter::_counter_value);
-  __ atomic_addalw(noreg, 1, x7);
+  __ atomic_addw(noreg, 1, x7);
 }
 
 void TemplateInterpreterGenerator::histogram_bytecode(Template* t) {
   __ mv(x7, (address) &BytecodeHistogram::_counters[t->bytecode()]);
-  __ atomic_addalw(noreg, 1, x7);
+  __ atomic_addw(noreg, 1, x7);
 }
 
 void TemplateInterpreterGenerator::histogram_bytecode_pair(Template* t) {
@@ -1762,7 +1762,7 @@ void TemplateInterpreterGenerator::histogram_bytecode_pair(Template* t) {
   __ mv(x7, (address) &BytecodePairHistogram::_counters);
   __ slli(index, index, LogBytesPerInt);
   __ add(counter_addr, x7, index);
-  __ atomic_addalw(noreg, 1, counter_addr);
+  __ atomic_addw(noreg, 1, counter_addr);
  }
 
 void TemplateInterpreterGenerator::trace_bytecode(Template* t) {


### PR DESCRIPTION
In this patch, count_bytecode() is modified by using "x7" as temporary register. Also implement histogram_bytecode() and histogram_bytecode_pair(), which can be enabled on debug mode by setting the options PrintBytecodeHistogram and PrintBytecodePairHistogram.

The following is the output when PrintBytecodeHistogram or PrintBytecodePairHistogram is TRUE.
```
$ java -XX:+PrintBytecodeHistogram --version|head -n 20
openjdk 20 2022-11-09
OpenJDK Runtime Environment (fastdebug build 20)
OpenJDK 64-Bit Server VM (fastdebug build 20, mixed mode)

Histogram of 8101142 executed bytecodes:

  absolute  relative  code    name
----------------------------------------------------------------------
    634592     7.83%    dc    fast_aload_0
    471840     5.82%    b6    invokevirtual
    376275     4.64%    2b    aload_1
    358520     4.43%    e0    fast_iload
    332267     4.10%    de    fast_aaccess_0
    270189     3.34%    a7    goto
    249831     3.08%    19    aload
    223361     2.76%    b9    invokeinterface
    215666     2.66%    1c    iload_2
    194877     2.41%    b8    invokestatic
    192212     2.37%    2c    aload_2
    185826     2.29%    1b    iload_1

$ java -XX:+PrintBytecodePairHistogram --version|head -n 20
openjdk 20 2022-11-09
OpenJDK Runtime Environment (fastdebug build 20)
OpenJDK 64-Bit Server VM (fastdebug build 20, mixed mode)

Histogram of 7627721 executed bytecode pairs:

  absolute  relative    codes    1st bytecode        2nd bytecode
----------------------------------------------------------------------
    102673    1.346%    84 a7    iinc                goto
     85429    1.120%    dc 2b    fast_aload_0        aload_1
     84394    1.106%    dc b6    fast_aload_0        invokevirtual
     73131    0.959%    b7 dc    invokespecial       fast_aload_0
     64605    0.847%    2b b6    aload_1             invokevirtual
     64086    0.840%    dc b9    fast_aload_0        invokeinterface
     63663    0.835%    b6 dc    invokevirtual       fast_aload_0
     59946    0.786%    b6 de    invokevirtual       fast_aaccess_0
     56631    0.742%    36 e0    istore              fast_iload
     51261    0.672%    b9 de    invokeinterface     fast_aaccess_0
     49556    0.650%    3a 19    astore              aload
     49106    0.644%    a7 e0    goto                fast_iload
```
The items in column "relative" are equal to percentages of bytecodes in the result of the TraceBytecodes option(counting bytecodes manually).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296301](https://bugs.openjdk.org/browse/JDK-8296301): Interpreter(RISC-V): Implement -XX:+PrintBytecodeHistogram and -XX:+PrintBytecodePairHistogram options


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author) ⚠️ Review applies to [753a384d](https://git.openjdk.org/jdk/pull/11051/files/753a384ddd6209b0bbfe2c3fd768761f110113c4)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11051/head:pull/11051` \
`$ git checkout pull/11051`

Update a local copy of the PR: \
`$ git checkout pull/11051` \
`$ git pull https://git.openjdk.org/jdk pull/11051/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11051`

View PR using the GUI difftool: \
`$ git pr show -t 11051`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11051.diff">https://git.openjdk.org/jdk/pull/11051.diff</a>

</details>
