### PR TITLE
8296196: Class.getEnumConstants() throws undocumented ClassCastException and NullPointerException

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -3934,7 +3934,8 @@ public final class Class<T> implements java.io.Serializable,
             // These can happen when users concoct enum-like classes
             // that don't comply with the enum spec.
             catch (InvocationTargetException | NoSuchMethodException |
-                   IllegalAccessException ex) { return null; }
+                   IllegalAccessException | NullPointerException |
+                   ClassCastException ex) { return null; }
         }
         return constants;
     }

--- a/test/jdk/java/lang/Class/getEnumConstants/BadEnum1.jasm
+++ b/test/jdk/java/lang/Class/getEnumConstants/BadEnum1.jasm
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+super final enum class BadEnum1 extends java/lang/Enum
+version 52:0
+{
+    public Method values:"()[LBadEnum1;"
+    stack 1
+    {
+        iconst_0;
+        anewarray BadEnum1;
+        areturn;
+    }
+}

--- a/test/jdk/java/lang/Class/getEnumConstants/BadEnum2.jasm
+++ b/test/jdk/java/lang/Class/getEnumConstants/BadEnum2.jasm
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+super final enum class BadEnum2
+extends java/lang/Enum
+version 52:0
+{
+    public static Method values:"()Ljava/lang/Object;"
+    stack 2
+    {
+        new class java/lang/Object;
+        dup;
+        invokespecial Method java/lang/Object."<init>":"()V";
+        areturn;
+    }
+}

--- a/test/jdk/java/lang/Class/getEnumConstants/BadEnumTest.java
+++ b/test/jdk/java/lang/Class/getEnumConstants/BadEnumTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8296196
+ * @summary Test getEnumConstants on bad Enums
+ * @build BadEnum1 BadEnum2
+ * @run junit BadEnumTest
+ */
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BadEnumTest {
+
+    @Test
+    void testBadEnum1() {
+        assertNull(BadEnum1.class.getEnumConstants(), "Expected BadEnum1.class.getEnumConstants() to return null");
+    }
+
+    @Test
+    void testBadEnum2() {
+        assertNull(BadEnum2.class.getEnumConstants(), "Expected BadEnum2.class.getEnumConstants() to return null");
+    }
+}


### PR DESCRIPTION
When `Class.getEnumConstants()` is called on a bad enum class where `values()` is an instance method, or returns a non‑array, then it throws `NullPointerException` or `ClassCastException` respectively. 

This patch fixes `Class.getEnumConstants()` method to handle above mentioned bad enums and adds relevant tests.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296196](https://bugs.openjdk.org/browse/JDK-8296196): Class.getEnumConstants() throws undocumented ClassCastException and NullPointerException


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11056/head:pull/11056` \
`$ git checkout pull/11056`

Update a local copy of the PR: \
`$ git checkout pull/11056` \
`$ git pull https://git.openjdk.org/jdk pull/11056/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11056`

View PR using the GUI difftool: \
`$ git pr show -t 11056`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11056.diff">https://git.openjdk.org/jdk/pull/11056.diff</a>

</details>
