### PR TITLE
8296083: javax/swing/JTree/6263446/bug6263446.java fails intermittently on a VM

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -650,7 +650,6 @@ javax/swing/JWindow/ShapedAndTranslucentWindows/TranslucentJComboBox.java 802462
 # The next test below is an intermittent failure
 javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all
 javax/swing/JTree/4633594/JTreeFocusTest.java 7105441 macosx-all
-javax/swing/JTree/6263446/bug6263446.java 8296083 linux-all
 javax/swing/JSpinner/4788637/bug4788637.java 8296084 linux-all
 javax/swing/AbstractButton/6711682/bug6711682.java 8060765 windows-all,macosx-all
 javax/swing/JFileChooser/6396844/TwentyThousandTest.java 8198003 generic-all

--- a/test/jdk/javax/swing/JTree/6263446/bug6263446.java
+++ b/test/jdk/javax/swing/JTree/6263446/bug6263446.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import javax.swing.tree.*;
 
 public class bug6263446 {
 
-    private static final String FIRST = "AAAAAAAAAAA";
+    private static final String FIRST = "AAAAA";
     private static final String SECOND = "BB";
     private static final String ALL = FIRST + " " + SECOND;
     private static JTree tree;
@@ -62,46 +62,59 @@ public class bug6263446 {
         try {
             Point point = getClickPoint();
             robot.mouseMove(point.x, point.y);
+            robot.waitForIdle();
 
             // click count 3
             click(1);
+            robot.waitForIdle();
             assertNotEditing();
 
             click(2);
+            robot.waitForIdle();
             assertNotEditing();
 
             click(3);
+            robot.waitForIdle();
             assertEditing();
             cancelCellEditing();
             assertNotEditing();
 
             click(4);
+            robot.waitForIdle();
             checkSelectedText(FIRST);
 
             click(5);
+            robot.waitForIdle();
             checkSelectedText(ALL);
 
             // click count 4
             setClickCountToStart(4);
+            robot.waitForIdle();
 
             click(1);
+            robot.waitForIdle();
             assertNotEditing();
 
             click(2);
+            robot.waitForIdle();
             assertNotEditing();
 
             click(3);
+            robot.waitForIdle();
             assertNotEditing();
 
             click(4);
+            robot.waitForIdle();
             assertEditing();
             cancelCellEditing();
             assertNotEditing();
 
             click(5);
+            robot.waitForIdle();
             checkSelectedText(FIRST);
 
             click(6);
+            robot.waitForIdle();
             checkSelectedText(ALL);
 
             // start path editing
@@ -109,12 +122,15 @@ public class bug6263446 {
             assertEditing();
 
             click(1);
+            robot.waitForIdle();
             checkSelection(null);
 
             click(2);
+            robot.waitForIdle();
             checkSelection(FIRST);
 
             click(3);
+            robot.waitForIdle();
             checkSelection(ALL);
         } finally {
             if (frame != null) {
@@ -128,7 +144,6 @@ public class bug6263446 {
         for (int i = 0; i < times; i++) {
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-            robot.waitForIdle();
         }
     }
 
@@ -141,7 +156,7 @@ public class bug6263446 {
             public void run() {
                 Rectangle rect = tree.getRowBounds(0);
                 // UPDATE !!!
-                Point p = new Point(rect.x + rect.width / 2, rect.y + 2);
+                Point p = new Point(rect.x + rect.width/2, rect.y + rect.height/2);
                 SwingUtilities.convertPointToScreen(p, tree);
                 result[0] = p;
 
@@ -166,9 +181,11 @@ public class bug6263446 {
 
 
         frame.getContentPane().add(tree);
-        frame.pack();
+        frame.setAlwaysOnTop(true);
         frame.setLocationRelativeTo(null);
+        frame.pack();
         frame.setVisible(true);
+        frame.toFront();
     }
 
     private static void setClickCountToStart(final int clicks) throws Exception {
@@ -183,6 +200,7 @@ public class bug6263446 {
                     field.setAccessible(true);
                     DefaultCellEditor ce = (DefaultCellEditor) field.get(editor);
                     ce.setClickCountToStart(clicks);
+
                 } catch (IllegalAccessException e) {
                     throw new RuntimeException(e);
                 } catch (NoSuchFieldException e) {
@@ -248,7 +266,9 @@ public class bug6263446 {
     private static void checkSelectedText(String sel) throws Exception {
         assertEditing();
         checkSelection(sel);
+        robot.waitForIdle();
         cancelCellEditing();
+        robot.waitForIdle();
         assertNotEditing();
     }
 

--- a/test/jdk/javax/swing/JTree/6263446/bug6263446.java
+++ b/test/jdk/javax/swing/JTree/6263446/bug6263446.java
@@ -182,8 +182,8 @@ public class bug6263446 {
 
         frame.getContentPane().add(tree);
         frame.setAlwaysOnTop(true);
-        frame.setLocationRelativeTo(null);
         frame.pack();
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
         frame.toFront();
     }


### PR DESCRIPTION
Test intermittently fails in VM citing "Tree is not editing". Seems to be problem with mouse clicks not getting registered properly..
Similar test test/jdk/javax/swing/JTable/6263446/bug6263446.java is not affected, so made the test similar to it by using same safeguard using Robot.waitForIdle() and modifying clickpoint to tree cell midpoint.

Several iterations of the test pass in the OCI VM and all other physical platforms (link in JBS)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296083](https://bugs.openjdk.org/browse/JDK-8296083): javax/swing/JTree/6263446/bug6263446.java fails intermittently on a VM


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer) ⚠️ Review applies to [6a00a87c](https://git.openjdk.org/jdk/pull/11057/files/6a00a87cc005a1a14a79748950c913baf9305f2d)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11057/head:pull/11057` \
`$ git checkout pull/11057`

Update a local copy of the PR: \
`$ git checkout pull/11057` \
`$ git pull https://git.openjdk.org/jdk pull/11057/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11057`

View PR using the GUI difftool: \
`$ git pr show -t 11057`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11057.diff">https://git.openjdk.org/jdk/pull/11057.diff</a>

</details>
