### PR TITLE
8296602: RISC-V: improve performance of copy_memory stub

### DIFF
--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -881,7 +881,11 @@ class StubGenerator: public StubCodeGenerator {
   //
   /*
    * if (is_aligned) {
-   *   goto copy_8_bytes;
+   *   if (count >= 32)
+   *     goto copy_big;
+   *   if (count >= 8)
+   *     goto copy8;
+   *   goto copy_small;
    * }
    * bool is_backwards = step < 0;
    * int granularity = uabs(step);
@@ -1056,14 +1060,14 @@ class StubGenerator: public StubCodeGenerator {
       __ addi(src, src, wordSize*4);
       __ addi(dst, dst, wordSize*4);
     }
-    __ addi(tmp4, cnt, -(32+wordSize*4));
+    __ addi(tmp, cnt, -(32+wordSize*4));
     __ addi(cnt, cnt, -wordSize*4);
-    __ bgez(tmp4, copy32); // cnt >= 32, do next loop
+    __ bgez(tmp, copy32); // cnt >= 32, do next loop
 
     __ beqz(cnt, done); // if that's all - done
 
-    __ addi(tmp4, cnt, -8); // if not - copy the reminder
-    __ bltz(tmp4, copy_small); // cnt < 8, go to copy_small, else fall throught to copy8
+    __ addi(tmp, cnt, -8); // if not - copy the reminder
+    __ bltz(tmp, copy_small); // cnt < 8, go to copy_small, else fall throught to copy8
 
     __ bind(copy8);
     if (is_backwards) {
@@ -1076,9 +1080,9 @@ class StubGenerator: public StubCodeGenerator {
       __ addi(src, src, wordSize);
       __ addi(dst, dst, wordSize);
     }
-    __ addi(tmp4, cnt, -(8+wordSize));
+    __ addi(tmp, cnt, -(8+wordSize));
     __ addi(cnt, cnt, -wordSize);
-    __ bgez(tmp4, copy8); // cnt >= 8, do next loop
+    __ bgez(tmp, copy8); // cnt >= 8, do next loop
 
     __ beqz(cnt, done); // if that's all - done
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -899,9 +899,12 @@ class StubGenerator: public StubCodeGenerator {
    *
    * if ((dst % 8) == (src % 8)) {
    *   aligned;
-   *   goto copy8;
+   *   goto copy_big;
    * }
    *
+   * copy_big:
+   * if the amount to copy is more than (or equal to) 32 bytes goto copy32
+   *  else goto copy8
    * copy_small:
    *   load element one by one;
    * done;
@@ -962,10 +965,10 @@ class StubGenerator: public StubCodeGenerator {
     bool is_backwards = step < 0;
     int granularity = uabs(step);
 
-    const Register src = x30, dst = x31, cnt = x15, tmp3 = x16, tmp4 = x17;
+    const Register src = x30, dst = x31, cnt = x15, tmp3 = x16, tmp4 = x17, tmp5 = x14, tmp6 = x13;
 
     Label same_aligned;
-    Label copy8, copy_small, done;
+    Label copy_big, copy32, copy8, copy_small, done;
 
     copy_insn ld_arr = NULL, st_arr = NULL;
     switch (granularity) {
@@ -991,7 +994,7 @@ class StubGenerator: public StubCodeGenerator {
 
     __ beqz(count, done);
     __ slli(cnt, count, exact_log2(granularity));
-    if (is_backwards) {
+    if (is_backwards) { //find the start
       __ add(src, s, cnt);
       __ add(dst, d, cnt);
     } else {
@@ -1000,34 +1003,67 @@ class StubGenerator: public StubCodeGenerator {
     }
 
     if (is_aligned) {
+      __ addi(tmp, cnt, -32);
+      __ bgez(tmp, copy32);
       __ addi(tmp, cnt, -8);
       __ bgez(tmp, copy8);
       __ j(copy_small);
+    } else {
+      __ mv(tmp, 16);
+      __ blt(cnt, tmp, copy_small);
+
+      __ xorr(tmp, src, dst);
+      __ andi(tmp, tmp, 0b111);
+      __ bnez(tmp, copy_small);
+
+      __ bind(same_aligned);
+      __ andi(tmp, src, 0b111);
+      __ beqz(tmp, copy_big);
+      if (is_backwards) {
+        __ addi(src, src, step);
+        __ addi(dst, dst, step);
+      }
+      (_masm->*ld_arr)(tmp3, Address(src), t0);
+      (_masm->*st_arr)(tmp3, Address(dst), t0);
+      if (!is_backwards) {
+        __ addi(src, src, step);
+        __ addi(dst, dst, step);
+      }
+      __ addi(cnt, cnt, -granularity);
+      __ beqz(cnt, done);
+      __ j(same_aligned);
+
+      __ bind(copy_big);
+      __ mv(tmp, 32);
+      __ blt(cnt, tmp, copy8);
     }
-
-    __ mv(tmp, 16);
-    __ blt(cnt, tmp, copy_small);
-
-    __ xorr(tmp, src, dst);
-    __ andi(tmp, tmp, 0b111);
-    __ bnez(tmp, copy_small);
-
-    __ bind(same_aligned);
-    __ andi(tmp, src, 0b111);
-    __ beqz(tmp, copy8);
+    __ bind(copy32);
     if (is_backwards) {
-      __ addi(src, src, step);
-      __ addi(dst, dst, step);
+      __ addi(src, src, -wordSize*4);
+      __ addi(dst, dst, -wordSize*4);
     }
-    (_masm->*ld_arr)(tmp3, Address(src), t0);
-    (_masm->*st_arr)(tmp3, Address(dst), t0);
+    // we first load 32 bytes, then write it, so the direction here doesn't matter
+    __ ld(tmp3, Address(src));
+    __ ld(tmp4, Address(src, 8));
+    __ ld(tmp5, Address(src, 16));
+    __ ld(tmp6, Address(src, 24));
+    __ sd(tmp3, Address(dst));
+    __ sd(tmp4, Address(dst, 8));
+    __ sd(tmp5, Address(dst, 16));
+    __ sd(tmp6, Address(dst, 24));
+
     if (!is_backwards) {
-      __ addi(src, src, step);
-      __ addi(dst, dst, step);
+      __ addi(src, src, wordSize*4);
+      __ addi(dst, dst, wordSize*4);
     }
-    __ addi(cnt, cnt, -granularity);
-    __ beqz(cnt, done);
-    __ j(same_aligned);
+    __ addi(tmp4, cnt, -(32+wordSize*4));
+    __ addi(cnt, cnt, -wordSize*4);
+    __ bgez(tmp4, copy32); // cnt >= 32, do next loop
+
+    __ beqz(cnt, done); // if that's all - done
+
+    __ addi(tmp4, cnt, -8); // if not - copy the reminder
+    __ bltz(tmp4, copy_small); // cnt < 8, go to copy_small, else fall throught to copy8
 
     __ bind(copy8);
     if (is_backwards) {
@@ -1040,11 +1076,11 @@ class StubGenerator: public StubCodeGenerator {
       __ addi(src, src, wordSize);
       __ addi(dst, dst, wordSize);
     }
+    __ addi(tmp4, cnt, -(8+wordSize));
     __ addi(cnt, cnt, -wordSize);
-    __ addi(tmp4, cnt, -8);
     __ bgez(tmp4, copy8); // cnt >= 8, do next loop
 
-    __ beqz(cnt, done);
+    __ beqz(cnt, done); // if that's all - done
 
     __ bind(copy_small);
     if (is_backwards) {

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -882,7 +882,7 @@ class StubGenerator: public StubCodeGenerator {
   /*
    * if (is_aligned) {
    *   if (count >= 32)
-   *     goto copy_big;
+   *     goto copy32;
    *   if (count >= 8)
    *     goto copy8;
    *   goto copy_small;
@@ -1043,8 +1043,8 @@ class StubGenerator: public StubCodeGenerator {
     }
     __ bind(copy32);
     if (is_backwards) {
-      __ addi(src, src, -wordSize*4);
-      __ addi(dst, dst, -wordSize*4);
+      __ addi(src, src, -wordSize * 4);
+      __ addi(dst, dst, -wordSize * 4);
     }
     // we first load 32 bytes, then write it, so the direction here doesn't matter
     __ ld(tmp3, Address(src));
@@ -1057,11 +1057,11 @@ class StubGenerator: public StubCodeGenerator {
     __ sd(tmp6, Address(dst, 24));
 
     if (!is_backwards) {
-      __ addi(src, src, wordSize*4);
-      __ addi(dst, dst, wordSize*4);
+      __ addi(src, src, wordSize * 4);
+      __ addi(dst, dst, wordSize * 4);
     }
-    __ addi(tmp, cnt, -(32+wordSize*4));
-    __ addi(cnt, cnt, -wordSize*4);
+    __ addi(tmp, cnt, -(32 + wordSize * 4));
+    __ addi(cnt, cnt, -wordSize * 4);
     __ bgez(tmp, copy32); // cnt >= 32, do next loop
 
     __ beqz(cnt, done); // if that's all - done
@@ -1080,7 +1080,7 @@ class StubGenerator: public StubCodeGenerator {
       __ addi(src, src, wordSize);
       __ addi(dst, dst, wordSize);
     }
-    __ addi(tmp, cnt, -(8+wordSize));
+    __ addi(tmp, cnt, -(8 + wordSize));
     __ addi(cnt, cnt, -wordSize);
     __ bgez(tmp, copy8); // cnt >= 8, do next loop
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -994,7 +994,7 @@ class StubGenerator: public StubCodeGenerator {
 
     __ beqz(count, done);
     __ slli(cnt, count, exact_log2(granularity));
-    if (is_backwards) { //find the start
+    if (is_backwards) {
       __ add(src, s, cnt);
       __ add(dst, d, cnt);
     } else {


### PR DESCRIPTION
Please review this change to improve the performance of copy_memory stub on risc-v

This change has three parts
1) use copy32 if possible to do 4 ld and 4 st per loop cycle
2) don't produce precopy code if is_aligned is true, it's not executed.
3) in the end of loop8 and loop32, remove data dependency between two addi opcodes, to allow them to be scheduled simultaneously

testing: org.openjdk.bench.vm.compiler.ArrayCopyObject, hotspot_compiler_arraycopy, hotspot:tier1, hotspot:tier2 - all ok
hotspot:tier2 is on the way.

and for the benchmark results, using 
org.openjdk.bench.vm.compiler.ArrayCopyObject.conjoint_micro

thead rvb-ice c910
thead

Before ( copy8 only )
Benchmark            	   (size) Mode Cnt  Score  Error  Units
ArrayCopyObject.conjoint_micro    31 thrpt 25 6653.095 ± 251.565 ops/ms
ArrayCopyObject.conjoint_micro    63 thrpt 25 4933.970 ± 77.559 ops/ms
ArrayCopyObject.conjoint_micro   127 thrpt 25 3627.454 ± 34.589 ops/ms
ArrayCopyObject.conjoint_micro  2047 thrpt 25 368.249 ± 0.453  ops/ms
ArrayCopyObject.conjoint_micro  4095 thrpt 25 187.776 ± 0.306  ops/ms
ArrayCopyObject.conjoint_micro  8191 thrpt 25  94.477 ± 0.340   ops/ms

after ( with copy32 )
ArrayCopyObject.conjoint_micro    31 thrpt 25 7620.546 ± 69.756 ops/ms
ArrayCopyObject.conjoint_micro    63 thrpt 25 6677.978 ± 33.112 ops/ms
ArrayCopyObject.conjoint_micro   127 thrpt 25 5206.973 ± 22.612 ops/ms
ArrayCopyObject.conjoint_micro  2047 thrpt 25 653.655 ± 31.494 ops/ms
ArrayCopyObject.conjoint_micro  4095 thrpt 25 352.905 ± 7.390  ops/ms
ArrayCopyObject.conjoint_micro  8191 thrpt 25 165.127 ± 0.832  ops/ms 

after ( copy32 with dead code elimination and independent addis )
ArrayCopyObject.conjoint_micro      31  thrpt   25  7576.346 ?  94.487  ops/ms
ArrayCopyObject.conjoint_micro      63  thrpt   25  6475.730 ? 252.590  ops/ms
ArrayCopyObject.conjoint_micro     127  thrpt   25  5221.764 ?  20.415  ops/ms
ArrayCopyObject.conjoint_micro    2047  thrpt   25   691.847 ?   1.102  ops/ms
ArrayCopyObject.conjoint_micro    4095  thrpt   25   360.269 ?   1.091  ops/ms
ArrayCopyObject.conjoint_micro    8191  thrpt   25   179.733 ?   3.012  ops/ms

on hifive unmatched:

before:
Benchmark                       (size)   Mode  Cnt     Score     Error   Units
ArrayCopyObject.conjoint_micro      31  thrpt   25  5391.575 ± 152.984  ops/ms
ArrayCopyObject.conjoint_micro      63  thrpt   25  3700.946 ±  43.175  ops/ms
ArrayCopyObject.conjoint_micro     127  thrpt   25  2316.160 ±  24.734  ops/ms
ArrayCopyObject.conjoint_micro    2047  thrpt   25   188.616 ±   0.151  ops/ms
ArrayCopyObject.conjoint_micro    4095  thrpt   25    95.323 ±   0.053  ops/ms
ArrayCopyObject.conjoint_micro    8191  thrpt   25    46.935 ±   0.041  ops/ms

after:
Benchmark                       (size)   Mode  Cnt     Score     Error   Units
ArrayCopyObject.conjoint_micro      31  thrpt   25  6136.169 ± 330.409  ops/ms
ArrayCopyObject.conjoint_micro      63  thrpt   25  4924.020 ±  78.529  ops/ms
ArrayCopyObject.conjoint_micro     127  thrpt   25  3732.561 ±  89.606  ops/ms
ArrayCopyObject.conjoint_micro    2047  thrpt   25   431.103 ±   0.505  ops/ms
ArrayCopyObject.conjoint_micro    4095  thrpt   25   221.543 ±   0.363  ops/ms
ArrayCopyObject.conjoint_micro    8191  thrpt   25   100.586 ±   0.197  ops/ms

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296602](https://bugs.openjdk.org/browse/JDK-8296602): RISC-V: improve performance of copy_memory stub


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) ⚠️ Review applies to [cc91f7b6](https://git.openjdk.org/jdk/pull/11058/files/cc91f7b68cfe44cafa1cfe819b965775a5dee3af)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11058/head:pull/11058` \
`$ git checkout pull/11058`

Update a local copy of the PR: \
`$ git checkout pull/11058` \
`$ git pull https://git.openjdk.org/jdk pull/11058/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11058`

View PR using the GUI difftool: \
`$ git pr show -t 11058`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11058.diff">https://git.openjdk.org/jdk/pull/11058.diff</a>

</details>
