### PR TITLE
JDK-8294947: Use 64bit atomics in patch_verified_entry on x86_64

### DIFF
--- a/src/hotspot/cpu/x86/nativeInst_x86.cpp
+++ b/src/hotspot/cpu/x86/nativeInst_x86.cpp
@@ -561,7 +561,7 @@ void NativeJump::patch_verified_entry(address entry, address verified_entry, add
   *(int32_t*)verified_entry = *(int32_t *)code_buffer;
   // Invalidate.  Opteron requires a flush after every write.
   n_jump->wrote(0);
-#endif // AMD64
+#endif // _LP64
 
 }
 

--- a/src/hotspot/cpu/x86/nativeInst_x86.cpp
+++ b/src/hotspot/cpu/x86/nativeInst_x86.cpp
@@ -510,22 +510,21 @@ void NativeJump::check_verified_entry_alignment(address entry, address verified_
 //
 void NativeJump::patch_verified_entry(address entry, address verified_entry, address dest) {
   // complete jump instruction (to be inserted) is in code_buffer;
-#ifdef AMD64
-  unsigned char code_buffer[8];
+#ifdef _LP64
+  union {
+    jlong cb_long;
+    unsigned char code_buffer[8];
+  } u;
 
-  assert(sizeof(code_buffer)==sizeof(jlong), "sanity check");
+  u.cb_long = *(jlong *)verified_entry;
 
   intptr_t disp = (intptr_t)dest - ((intptr_t)verified_entry + 1 + 4);
   guarantee(disp == (intptr_t)(int32_t)disp, "must be 32-bit offset");
 
-  // save extra 3 bytes
-  *(jlong *) code_buffer = *(jlong *) verified_entry;
-  code_buffer[0] = instruction_code;
-  *(int32_t*)(code_buffer + 1) = (int32_t)disp;
+  u.code_buffer[0] = instruction_code;
+  *(int32_t*)(u.code_buffer + 1) = (int32_t)disp;
 
-  check_verified_entry_alignment(entry, verified_entry);
-
-  Atomic::store((jlong *) verified_entry, *(jlong *) code_buffer);
+  Atomic::store((jlong *) verified_entry, u.cb_long);
   ICache::invalidate_range(verified_entry, 8);
 
 #else


### PR DESCRIPTION
In the void NativeJump::patch_verified_entry() we atomically patch first 4 bytes, then atomically patch 5th byte, then atomically patch first 4 bytes again. But from CMC (cross-modified code) point of view it's better to patch atomically 8 bytes at once.

The patch was tested with hotspot jtreg tests in bare-metal and virtualized environments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294947](https://bugs.openjdk.org/browse/JDK-8294947): Use 64bit atomics in patch_verified_entry on x86_64


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11059/head:pull/11059` \
`$ git checkout pull/11059`

Update a local copy of the PR: \
`$ git checkout pull/11059` \
`$ git pull https://git.openjdk.org/jdk pull/11059/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11059`

View PR using the GUI difftool: \
`$ git pr show -t 11059`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11059.diff">https://git.openjdk.org/jdk/pull/11059.diff</a>

</details>
