### PR TITLE
JDK-8296665: IGV: Show dialog with stack trace for exceptions

### DIFF
--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
@@ -60,6 +60,10 @@ import org.openide.windows.WindowManager;
  */
 public final class OutlineTopComponent extends TopComponent implements ExplorerManager.Provider, ChangedListener<InputGraphProvider> {
 
+    static {
+        System.setProperty("netbeans.exception.report.min.level", "900");
+    }
+
     public static OutlineTopComponent instance;
     public static final String PREFERRED_ID = "OutlineTopComponent";
     private ExplorerManager manager;

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/OutlineTopComponent.java
@@ -60,10 +60,6 @@ import org.openide.windows.WindowManager;
  */
 public final class OutlineTopComponent extends TopComponent implements ExplorerManager.Provider, ChangedListener<InputGraphProvider> {
 
-    static {
-        System.setProperty("netbeans.exception.report.min.level", "900");
-    }
-
     public static OutlineTopComponent instance;
     public static final String PREFERRED_ID = "OutlineTopComponent";
     private ExplorerManager manager;

--- a/src/utils/IdealGraphVisualizer/application/src/main/resources/idealgraphvisualizer.conf
+++ b/src/utils/IdealGraphVisualizer/application/src/main/resources/idealgraphvisualizer.conf
@@ -21,4 +21,4 @@
 
 # Open/export modules still accessed by the NetBeans Platform.
 # All options must be passed in a single line for multi-platform support.
-default_options="-J--add-opens=java.base/java.net=ALL-UNNAMED -J--add-opens=java.desktop/javax.swing.plaf.synth=ALL-UNNAMED -J--add-opens=java.desktop/com.sun.java.swing.plaf.gtk=ALL-UNNAMED -J--add-opens=java.desktop/javax.swing=ALL-UNNAMED -J--add-exports=java.desktop/sun.awt=ALL-UNNAMED"
+default_options="-J-Dnetbeans.exception.report.min.level=1000 -J--add-opens=java.base/java.net=ALL-UNNAMED -J--add-opens=java.desktop/javax.swing.plaf.synth=ALL-UNNAMED -J--add-opens=java.desktop/com.sun.java.swing.plaf.gtk=ALL-UNNAMED -J--add-opens=java.desktop/javax.swing=ALL-UNNAMED -J--add-exports=java.desktop/sun.awt=ALL-UNNAMED"


### PR DESCRIPTION
Currently in IGV when an exception occurs a small red icon in the bottom right corner appears. The user often does not see this and if he sees it, usually not immediately when the error occurs:
<img width="447" alt="exception now" src="https://user-images.githubusercontent.com/71546117/200838912-1dab349d-ac60-49bf-8546-95455367ba7f.png">

The exception reporting level is changed to `1000` (Level.SEVERE) in IGV to show a dialog with the stack-trace. The user can still close it and continue the work: 
<img width="1529" alt="exception suggestion" src="https://user-images.githubusercontent.com/71546117/200838877-346ef916-72b2-435c-8425-e799663efee5.png">

To test insert something like the following somewhere in the codebase 
```java
try {
    int i=1/0;
} catch (Exception e) {
    throw new RuntimeException(e);
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296665](https://bugs.openjdk.org/browse/JDK-8296665): IGV: Show dialog with stack trace for exceptions


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11060/head:pull/11060` \
`$ git checkout pull/11060`

Update a local copy of the PR: \
`$ git checkout pull/11060` \
`$ git pull https://git.openjdk.org/jdk pull/11060/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11060`

View PR using the GUI difftool: \
`$ git pr show -t 11060`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11060.diff">https://git.openjdk.org/jdk/pull/11060.diff</a>

</details>
