### PR TITLE
8296670: G1: Remove unused G1GCPhaseTimes::record_preserve_cm_referents_time_ms

### DIFF
--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
@@ -185,7 +185,6 @@ void G1GCPhaseTimes::reset() {
   _recorded_prepare_heap_roots_time_ms = 0.0;
   _recorded_young_cset_choice_time_ms = 0.0;
   _recorded_non_young_cset_choice_time_ms = 0.0;
-  _recorded_preserve_cm_referents_time_ms = 0.0;
   _recorded_start_new_cset_time_ms = 0.0;
   _recorded_serial_free_cset_time_ms = 0.0;
   _recorded_total_rebuild_freelist_time_ms = 0.0;
@@ -463,7 +462,6 @@ double G1GCPhaseTimes::print_evacuate_initial_collection_set() const {
 
 double G1GCPhaseTimes::print_post_evacuate_collection_set(bool evacuation_failed) const {
   const double sum_ms = _cur_collection_nmethod_list_cleanup_time_ms +
-                        _recorded_preserve_cm_referents_time_ms +
                         _cur_ref_proc_time_ms +
                         (_weak_phase_times.total_time_sec() * MILLIUNITS) +
                         _cur_post_evacuate_cleanup_1_time_ms +

--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.hpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.hpp
@@ -200,8 +200,6 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
   double _recorded_young_cset_choice_time_ms;
   double _recorded_non_young_cset_choice_time_ms;
 
-  double _recorded_preserve_cm_referents_time_ms;
-
   double _recorded_start_new_cset_time_ms;
 
   double _recorded_serial_free_cset_time_ms;
@@ -354,10 +352,6 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
 
   void record_non_young_cset_choice_time_ms(double time_ms) {
     _recorded_non_young_cset_choice_time_ms = time_ms;
-  }
-
-  void record_preserve_cm_referents_time_ms(double time_ms) {
-    _recorded_preserve_cm_referents_time_ms = time_ms;
   }
 
   void record_start_new_cset_time_ms(double time_ms) {


### PR DESCRIPTION
Trivial change of removing effectively dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296670](https://bugs.openjdk.org/browse/JDK-8296670): G1: Remove unused G1GCPhaseTimes::record_preserve_cm_referents_time_ms


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11061/head:pull/11061` \
`$ git checkout pull/11061`

Update a local copy of the PR: \
`$ git checkout pull/11061` \
`$ git pull https://git.openjdk.org/jdk pull/11061/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11061`

View PR using the GUI difftool: \
`$ git pr show -t 11061`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11061.diff">https://git.openjdk.org/jdk/pull/11061.diff</a>

</details>
