### PR TITLE
8296675: Exclude linux-aarch64 in NSS tests

### DIFF
--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -700,6 +700,8 @@ public abstract class PKCS11Test {
         osMap.put("Linux-arm-32", new String[] {
                 "/usr/lib/arm-linux-gnueabi/nss/",
                 "/usr/lib/arm-linux-gnueabihf/nss/" });
+        // Exclude linux-aarch64 at the moment until the following bug is fixed:
+        // 8296631: NSS tests failing on OL9 linux-aarch64 hosts
 //        osMap.put("Linux-aarch64-64", new String[] {
 //                "/usr/lib/aarch64-linux-gnu/",
 //                "/usr/lib/aarch64-linux-gnu/nss/",

--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -700,10 +700,10 @@ public abstract class PKCS11Test {
         osMap.put("Linux-arm-32", new String[] {
                 "/usr/lib/arm-linux-gnueabi/nss/",
                 "/usr/lib/arm-linux-gnueabihf/nss/" });
-        osMap.put("Linux-aarch64-64", new String[] {
-                "/usr/lib/aarch64-linux-gnu/",
-                "/usr/lib/aarch64-linux-gnu/nss/",
-                "/usr/lib64/" });
+//        osMap.put("Linux-aarch64-64", new String[] {
+//                "/usr/lib/aarch64-linux-gnu/",
+//                "/usr/lib/aarch64-linux-gnu/nss/",
+//                "/usr/lib64/" });
         return osMap;
     }
 


### PR DESCRIPTION
The NSS tests do not work fine on linux-aarch64 now. Disable them at the moment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296675](https://bugs.openjdk.org/browse/JDK-8296675): Exclude linux-aarch64 in NSS tests


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to [4126608e](https://git.openjdk.org/jdk/pull/11063/files/4126608eb32776961ff8f16f99bdd9652ab49cdc)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11063/head:pull/11063` \
`$ git checkout pull/11063`

Update a local copy of the PR: \
`$ git checkout pull/11063` \
`$ git pull https://git.openjdk.org/jdk pull/11063/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11063`

View PR using the GUI difftool: \
`$ git pr show -t 11063`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11063.diff">https://git.openjdk.org/jdk/pull/11063.diff</a>

</details>
