### PR TITLE
[PATCH] Cleanup char/codepoint to String conversion

### DIFF
--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -3112,19 +3112,19 @@ public final class Formatter implements Closeable, Flushable {
             } else if (arg instanceof Byte) {
                 byte i = (Byte) arg;
                 if (Character.isValidCodePoint(i))
-                    s = new String(Character.toChars(i));
+                    s = Character.toString(i);
                 else
                     throw new IllegalFormatCodePointException(i);
             } else if (arg instanceof Short) {
                 short i = (Short) arg;
                 if (Character.isValidCodePoint(i))
-                    s = new String(Character.toChars(i));
+                    s = Character.toString(i);
                 else
                     throw new IllegalFormatCodePointException(i);
             } else if (arg instanceof Integer) {
                 int i = (Integer) arg;
                 if (Character.isValidCodePoint(i))
-                    s = new String(Character.toChars(i));
+                    s = Character.toString(i);
                 else
                     throw new IllegalFormatCodePointException(i);
             } else {

--- a/src/java.desktop/share/classes/javax/swing/text/html/parser/Parser.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/parser/Parser.java
@@ -29,11 +29,7 @@ import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.html.HTML;
 import javax.swing.text.ChangedCharSetException;
 import java.io.*;
-import java.util.Hashtable;
-import java.util.Properties;
 import java.util.Vector;
-import java.util.Enumeration;
-import java.net.URL;
 
 /**
  * A simple DTD-driven HTML parser. The parser reads an
@@ -1514,8 +1510,7 @@ class Parser implements DTDConstants {
                         }
                     }
                 } else {
-                    char[] str = {(char)ch};
-                    error("invalid.tagchar", new String(str), elem.getName());
+                    error("invalid.tagchar", String.valueOf((char)ch), elem.getName());
                     ch = readCh();
                     continue;
                 }
@@ -1534,8 +1529,7 @@ class Parser implements DTDConstants {
                 error("attvalerr");
                 return;
             } else {
-                char[] str = {(char)ch};
-                error("invalid.tagchar", new String(str), elem.getName());
+                error("invalid.tagchar", String.valueOf((char)ch), elem.getName());
                 if (!strict) {
                     ch = readCh();
                     continue;

--- a/src/java.desktop/share/classes/javax/swing/text/rtf/RTFParser.java
+++ b/src/java.desktop/share/classes/javax/swing/text/rtf/RTFParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -191,10 +191,8 @@ abstract class RTFParser extends AbstractFilter
           break;
         }
         if (!Character.isLetter(ch)) {
-          char[] newstring = new char[1];
-          newstring[0] = ch;
-          if (!handleKeyword(new String(newstring))) {
-            warning("Unknown keyword: " + newstring + " (" + (byte)ch + ")");
+          if (!handleKeyword(String.valueOf(ch))) {
+            warning("Unknown keyword: " + ch + " (" + (byte)ch + ")");
           }
           state = S_text;
           pendingKeyword = null;


### PR DESCRIPTION
1.
Method `java.lang.Character#toString(int)` was introduced in Java 11 to simplify construction of String from single code point.
There are 3 places in `java.util.Formatter.FormatSpecifier#printCharacter` which could use this method instead of manual conversion int -> char[] -> String.

2.
We can use `java.lang.String#valueOf(char)` method to convert `char` to `String` directly, without intermediate array creation.
It was proved to be faster in [JDK-8263552](https://github.com/openjdk/jdk/pull/2660).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11064/head:pull/11064` \
`$ git checkout pull/11064`

Update a local copy of the PR: \
`$ git checkout pull/11064` \
`$ git pull https://git.openjdk.org/jdk pull/11064/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11064`

View PR using the GUI difftool: \
`$ git pr show -t 11064`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11064.diff">https://git.openjdk.org/jdk/pull/11064.diff</a>

</details>
