### PR TITLE
8296156: [macos] Resize DMG windows and background to fit additional DMG contents

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/DMGsetup.scpt
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/DMGsetup.scpt
@@ -21,6 +21,9 @@ tell application "Finder"
 
   set allTheFiles to the name of every item of theWindow
   set xpos to 120
+  set ypos to 290
+  set i to 1
+  set j to 0
   repeat with theFile in allTheFiles
     set theFilePath to POSIX path of theFile
     set appFilePath to POSIX path of "/DEPLOY_TARGET"
@@ -31,12 +34,34 @@ tell application "Finder"
       -- Position application or runtime
       set position of item theFile of theWindow to {120, 130}
     else
-      -- Position all other items in a second row.
-      set position of item theFile of theWindow to {xpos, 290}
-      set xpos to xpos + 150
+      -- Position all other items in rows by 3 item
+      set position of item theFile of theWindow to {xpos, ypos}
+      set xpos to xpos + 135
+      if (i mod 3) is equal to 0
+        set i to 1
+        set ypos to ypos + 150
+        set xpos to 120
+      else
+        set i to i + 1
+      end if
+      set j to j + 1
     end if
   end repeat
 
+  -- Reduce icon size to 96 if we have additional content
+  if j is not equal to 0
+    set icon size of theViewOptions to 96
+  end if
+
+  -- Resize window to fit 1 or 2 extra raws with additional content
+  -- 6 additional content will be displayed to user without scrolling
+  -- for anything more then 6 scrolling will be required
+  if j is greater than 0 and j is less than or equal to 3
+    set the bounds of theWindow to {400, 100, 920, 525}
+  end if
+  if j is greater than 3
+    set the bounds of theWindow to {400, 100, 920, 673}
+  end if
 
   update theDisk without registering applications
   delay 5


### PR DESCRIPTION
Additional DMG content will be arranged in raws with 3 items per raw. DMG windows will be resized to show one or two raws without any scrolling required. To see any additional content after two raws (7 or more items) user will need to use vertical scroll bar. See JBS for screen shots.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296156](https://bugs.openjdk.org/browse/JDK-8296156): [macos] Resize DMG windows and background to fit additional DMG contents


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11068/head:pull/11068` \
`$ git checkout pull/11068`

Update a local copy of the PR: \
`$ git checkout pull/11068` \
`$ git pull https://git.openjdk.org/jdk pull/11068/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11068`

View PR using the GUI difftool: \
`$ git pr show -t 11068`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11068.diff">https://git.openjdk.org/jdk/pull/11068.diff</a>

</details>
