### PR TITLE
8296746: NativePRNG SecureRandom doesn't scale with threads

### DIFF
--- a/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
+++ b/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
@@ -191,7 +191,7 @@ public final class NativePRNG extends SecureRandomSpi {
                     return ThreadLocal.withInitial(() -> {
                         try {
                             return new RandomIO(seedFile, nextFile);
-                        } catch (Exception e)  {
+                        } catch (Exception e) {
                             return null;
                         }
                     });

--- a/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
+++ b/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
@@ -247,9 +247,6 @@ public final class NativePRNG extends SecureRandomSpi {
 
        // private static final ThreadLocal<RandomIO> INSTANCE = new ThreadLocal<> ();
         private static final ThreadLocal<RandomIO> INSTANCE = initIO(Variant.BLOCKING);
-        static {
-//          initIO(Variant.BLOCKING);
-        }
 
         // return whether this is available
         static boolean isAvailable() {
@@ -299,10 +296,6 @@ public final class NativePRNG extends SecureRandomSpi {
         private static final long serialVersionUID = -1102062982994105487L;
 
         private static final ThreadLocal<RandomIO> INSTANCE = initIO(Variant.NONBLOCKING);
-
-        static {
-          //initIO(Variant.NONBLOCKING);
-        }
 
         // return whether this is available
         static boolean isAvailable() {

--- a/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
+++ b/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
@@ -89,20 +89,8 @@ public final class NativePRNG extends SecureRandomSpi {
         MIXED, BLOCKING, NONBLOCKING
     }
 
-    // singleton instance or null if not available
-    // private static final RandomIO INSTANCE = initIO(Variant.MIXED);
-    // private static final ThreadLocal<RandomIO> INSTANCE = new ThreadLocal<>();
+    // ThreadLocal instance or null if not available
     private static final ThreadLocal<RandomIO> INSTANCE = initIO(Variant.MIXED);
-
-    static {
-     System.out.println("******INIT*****");
-//      initIO(Variant.MIXED);
-      if (INSTANCE.get() == null) {
-        System.out.println("******INIT NOT AVAILABLE*****");
-      } else {
-        System.out.println("******INIT SUCCESS*****");
-      }
-    }
 
     /**
      * Get the System egd source (if defined).  We only allow "file:"
@@ -213,11 +201,6 @@ public final class NativePRNG extends SecureRandomSpi {
 
     // return whether the NativePRNG is available
     static boolean isAvailable() {
-        if (INSTANCE.get() == null) {
-          System.out.println("****** NOT AVAILABLE*****");
-        } else {
-          System.out.println("****** YES AVAILABLE*****");
-        }
         return INSTANCE.get() != null;
     }
 
@@ -226,8 +209,6 @@ public final class NativePRNG extends SecureRandomSpi {
         super();
         if (INSTANCE.get() == null) {
             throw new AssertionError("NativePRNG not available");
-        } else {
-          System.out.println("****** YES AVAILABLE1*****");
         }
     }
 
@@ -317,7 +298,6 @@ public final class NativePRNG extends SecureRandomSpi {
     public static final class NonBlocking extends SecureRandomSpi {
         private static final long serialVersionUID = -1102062982994105487L;
 
-        //private static final ThreadLocal<RandomIO> INSTANCE = new ThreadLocal<>();
         private static final ThreadLocal<RandomIO> INSTANCE = initIO(Variant.NONBLOCKING);
 
         static {


### PR DESCRIPTION
NativePRNG SecureRandom doesn’t scale with number of threads. The performance starts dropping as we increase the number of threads. Even going from 1 thread to 2 threads shows significant drop. The bottleneck is the singleton RandomIO instance. Making the RandomIO ThreadLocal helps in removing this bottleneck.

Here are the jmh  thrpt ops/s data for SecureRandomBench.nextBytes, algorithm=NativePRNGNonBlocking, datasize=64, notshared:

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/xbzhang/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/xbzhang/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{color:black;
	text-align:right;
	vertical-align:middle;}
-->

</head>

<body link="#0563C1" vlink="#954F72">



#threads | singleton RandomIO | ThreadLocal RandomIO
-- | -- | --
1 | 1269133 | 1279088
2 | 862923 | 1362066
3 | 819734 | 1630522
4 | 809128 | 1614500
5 | 821514 | 1594965
6 | 808795 | 1545045
7 | 783050 | 1499388
8 | 787236 | 1470004



</body>

</html>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296746](https://bugs.openjdk.org/browse/JDK-8296746): NativePRNG SecureRandom doesn't scale with threads


### Contributors
 * Sandhya Viswanathan `<sviswanathan@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11069/head:pull/11069` \
`$ git checkout pull/11069`

Update a local copy of the PR: \
`$ git checkout pull/11069` \
`$ git pull https://git.openjdk.org/jdk pull/11069/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11069`

View PR using the GUI difftool: \
`$ git pr show -t 11069`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11069.diff">https://git.openjdk.org/jdk/pull/11069.diff</a>

</details>
