### PR TITLE
8296736: Some PKCS9Attribute can be created but cannot be encoded

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
@@ -378,13 +378,19 @@ public class PKCS9Attribute implements DerEncoder {
         this.oid = oid;
         index = indexOf(oid, PKCS9_OIDS, 1);
         Class<?> clazz = index == -1 ? BYTE_ARRAY_CLASS: VALUE_CLASSES[index];
-        if (clazz == null || !clazz.isInstance(value)) {
+        if (clazz == null) {
+            throw new IllegalArgumentException(
+                    "No value class supported " +
+                            " for attribute " + oid +
+                            " constructing PKCS9Attribute");
+        }
+        if (!clazz.isInstance(value)) {
                 throw new IllegalArgumentException(
                            "Wrong value class " +
                            " for attribute " + oid +
                            " constructing PKCS9Attribute; was " +
                            value.getClass().toString() + ", should be " +
-                           clazz);
+                           clazz.toString());
         }
         this.value = value;
     }

--- a/src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
@@ -597,20 +597,20 @@ public class PKCS9Attribute implements DerEncoder {
             break;
 
         case 9:     // extended-certificate attribute -- not supported
-            throw new IOException("PKCS9 extended-certificate " +
+            throw new IllegalArgumentException("PKCS9 extended-certificate " +
                                   "attribute not supported.");
             // break unnecessary
         case 10:    // issuerAndserialNumber attribute -- not supported
-            throw new IOException("PKCS9 IssuerAndSerialNumber " +
+            throw new IllegalArgumentException("PKCS9 IssuerAndSerialNumber " +
                                   "attribute not supported.");
             // break unnecessary
         case 11:    // RSA DSI proprietary
         case 12:    // RSA DSI proprietary
-            throw new IOException("PKCS9 RSA DSI attributes " +
+            throw new IllegalArgumentException("PKCS9 RSA DSI attributes " +
                                   "11 and 12, not supported.");
             // break unnecessary
         case 13:    // S/MIME unused attribute
-            throw new IOException("PKCS9 attribute #13 not supported.");
+            throw new IllegalArgumentException("PKCS9 attribute #13 not supported.");
             // break unnecessary
 
         case 14:     // ExtensionRequest
@@ -622,14 +622,17 @@ public class PKCS9Attribute implements DerEncoder {
             }
             break;
         case 15:    // SMIMECapability
-            throw new IOException("PKCS9 attribute #15 not supported.");
+            throw new IllegalArgumentException("PKCS9 attribute #15 not supported.");
             // break unnecessary
 
         case 16:    // SigningCertificate
-            throw new IOException(
-                "PKCS9 SigningCertificate attribute not supported.");
-            // break unnecessary
-
+            {
+                DerOutputStream temp2 = new DerOutputStream();
+                SigningCertificateInfo info = (SigningCertificateInfo)value;
+                temp2.writeBytes(info.toByteArray());
+                temp.write(DerValue.tag_Set, temp2.toByteArray());
+            }
+            break;
         case 17:    // SignatureTimestampToken
         case 18:    // CMSAlgorithmProtection
             temp.write(DerValue.tag_Set, (byte[])value);

--- a/src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
@@ -378,13 +378,13 @@ public class PKCS9Attribute implements DerEncoder {
         this.oid = oid;
         index = indexOf(oid, PKCS9_OIDS, 1);
         Class<?> clazz = index == -1 ? BYTE_ARRAY_CLASS: VALUE_CLASSES[index];
-        if (!clazz.isInstance(value)) {
+        if (clazz == null || !clazz.isInstance(value)) {
                 throw new IllegalArgumentException(
                            "Wrong value class " +
                            " for attribute " + oid +
                            " constructing PKCS9Attribute; was " +
                            value.getClass().toString() + ", should be " +
-                           clazz.toString());
+                           clazz);
         }
         this.value = value;
     }

--- a/src/java.base/share/classes/sun/security/pkcs/SigningCertificateInfo.java
+++ b/src/java.base/share/classes/sun/security/pkcs/SigningCertificateInfo.java
@@ -79,20 +79,21 @@ import sun.security.x509.SerialNumber;
  * @since 1.5
  * @author Vincent Ryan
  */
-public class SigningCertificateInfo {
+class SigningCertificateInfo {
 
     private byte[] ber;
     private ESSCertId[] certId = null;
 
-    public SigningCertificateInfo(byte[] ber) throws IOException {
+    SigningCertificateInfo(byte[] ber) throws IOException {
         parse(ber);
         this.ber = ber;
     }
 
-    public byte[] toByteArray() {
+    byte[] toByteArray() {
         return ber;
     }
 
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("[\n");
@@ -105,7 +106,7 @@ public class SigningCertificateInfo {
         return sb.toString();
     }
 
-    public void parse(byte[] bytes) throws IOException {
+    private void parse(byte[] bytes) throws IOException {
 
         // Parse signingCertificate
         DerValue derValue = new DerValue(bytes);
@@ -128,45 +129,46 @@ public class SigningCertificateInfo {
             }
         }
     }
-}
 
-class ESSCertId {
+    static class ESSCertId {
 
-    private static volatile HexDumpEncoder hexDumper;
+        private static volatile HexDumpEncoder hexDumper;
 
-    private final byte[] certHash;
-    private final GeneralNames issuer;
-    private final SerialNumber serialNumber;
+        private final byte[] certHash;
+        private final GeneralNames issuer;
+        private final SerialNumber serialNumber;
 
-    ESSCertId(DerValue certId) throws IOException {
-        // Parse certHash
-        certHash = certId.data.getDerValue().toByteArray();
+        ESSCertId(DerValue certId) throws IOException {
+            // Parse certHash
+            certHash = certId.data.getDerValue().toByteArray();
 
-        // Parse issuerSerial, if present
-        if (certId.data.available() > 0) {
-            DerValue issuerSerial = certId.data.getDerValue();
-            // Parse issuer
-            issuer = new GeneralNames(issuerSerial.data.getDerValue());
-            // Parse serialNumber
-            serialNumber = new SerialNumber(issuerSerial.data.getDerValue());
-        } else {
-            issuer = null;
-            serialNumber = null;
+            // Parse issuerSerial, if present
+            if (certId.data.available() > 0) {
+                DerValue issuerSerial = certId.data.getDerValue();
+                // Parse issuer
+                issuer = new GeneralNames(issuerSerial.data.getDerValue());
+                // Parse serialNumber
+                serialNumber = new SerialNumber(issuerSerial.data.getDerValue());
+            } else {
+                issuer = null;
+                serialNumber = null;
+            }
         }
-    }
 
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("[\n\tCertificate hash (SHA-1):\n");
-        if (hexDumper == null) {
-            hexDumper = new HexDumpEncoder();
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("[\n\tCertificate hash (SHA-1):\n");
+            if (hexDumper == null) {
+                hexDumper = new HexDumpEncoder();
+            }
+            sb.append(hexDumper.encode(certHash));
+            if (issuer != null && serialNumber != null) {
+                sb.append("\n\tIssuer: " + issuer + "\n");
+                sb.append("\t" + serialNumber);
+            }
+            sb.append("\n]");
+            return sb.toString();
         }
-        sb.append(hexDumper.encode(certHash));
-        if (issuer != null && serialNumber != null) {
-            sb.append("\n\tIssuer: " + issuer + "\n");
-            sb.append("\t" + serialNumber);
-        }
-        sb.append("\n]");
-        return sb.toString();
     }
 }

--- a/src/java.base/share/classes/sun/security/pkcs/SigningCertificateInfo.java
+++ b/src/java.base/share/classes/sun/security/pkcs/SigningCertificateInfo.java
@@ -81,10 +81,16 @@ import sun.security.x509.SerialNumber;
  */
 public class SigningCertificateInfo {
 
+    private byte[] ber;
     private ESSCertId[] certId = null;
 
     public SigningCertificateInfo(byte[] ber) throws IOException {
         parse(ber);
+        this.ber = ber;
+    }
+
+    public byte[] toByteArray() {
+        return ber;
     }
 
     public String toString() {

--- a/test/jdk/sun/security/pkcs/pkcs9/PKCS9AttrTypeTests.java
+++ b/test/jdk/sun/security/pkcs/pkcs9/PKCS9AttrTypeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8239950
+ * @bug 8239950 8296736
  * @summary Update PKCS9 Attributes to PKCS#9 v2.0 Encodings
  * @library /test/lib
  * @modules java.base/sun.security.pkcs
@@ -33,6 +33,7 @@
 import java.io.IOException;
 import java.util.*;
 import sun.security.pkcs.PKCS9Attribute;
+import sun.security.util.DerOutputStream;
 import sun.security.util.DerValue;
 import jdk.test.lib.Utils;
 
@@ -123,6 +124,9 @@ public class PKCS9AttrTypeTests {
                 put("signingTime as GeneralizedTime",
                     "301e06092a864886f70d010905311118" +
                     "0f32303530303533313132303030305a");
+
+                put("SigningCertificateInfo",
+                    "3018060b2a864886f70d010910020c3109300730053003040100");
             }};
 
     static final Map<String, String> TEST_INPUT_BAD =
@@ -166,6 +170,11 @@ public class PKCS9AttrTypeTests {
                 // a DerValue object to be consumed by PKCS9Attribute.
                 PKCS9Attribute p9Attr = new PKCS9Attribute(
                         new DerValue(Utils.toByteArray(entry.getValue())));
+
+                // Encoding is supported
+                DerOutputStream dos = new DerOutputStream();
+                p9Attr.encode(dos);
+
                 System.out.println("PASS");
                 System.out.println("---------------");
                 System.out.println(p9Attr);

--- a/test/jdk/sun/security/pkcs/pkcs9/PKCS9AttrTypeTests.java
+++ b/test/jdk/sun/security/pkcs/pkcs9/PKCS9AttrTypeTests.java
@@ -166,10 +166,15 @@ public class PKCS9AttrTypeTests {
             try {
                 System.out.print("Test - " + entry.getKey() + ": ");
 
-                // Decode each Base64 test vector into DER and place into
+                // Decode each HEX test vector into DER and place into
                 // a DerValue object to be consumed by PKCS9Attribute.
                 PKCS9Attribute p9Attr = new PKCS9Attribute(
                         new DerValue(Utils.toByteArray(entry.getValue())));
+
+                // There is a value inside
+                if (p9Attr.getValue() == null) {
+                    throw new IOException("Empty attribute");
+                }
 
                 // Encoding is supported
                 DerOutputStream dos = new DerOutputStream();


### PR DESCRIPTION
One `PKCS9Attribute` can be created but cannot be encoded. Since the `SigningCertificateInfo::parse` method has not fully parsed the data (`PolicyInformation` is left out), this code change add the encoding itself as a field to the `SigningCertificateInfo` class so we can encode it.

After this change, unsupported `PKCSAttribute` object simply cannot be created. The `new(DerValue)` constructor rejects them (type 9-13, 15) in a `switch` block, and the `new(ObjectIdentifier, Object)` constructor rejects them because `VALUE_CLASSES` for them are null.

In the `encode()` method, we now throw `IllegalArgumentException` for these types and they will not happen.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296736](https://bugs.openjdk.org/browse/JDK-8296736): Some PKCS9Attribute can be created but cannot be encoded


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**) ⚠️ Review applies to [8765c136](https://git.openjdk.org/jdk/pull/11070/files/8765c136254f81437b5ae56689f87a81cd93c18d)
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**) ⚠️ Review applies to [efc69f01](https://git.openjdk.org/jdk/pull/11070/files/efc69f014d4260796394c466a581ca05f77751ff)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11070/head:pull/11070` \
`$ git checkout pull/11070`

Update a local copy of the PR: \
`$ git checkout pull/11070` \
`$ git pull https://git.openjdk.org/jdk pull/11070/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11070`

View PR using the GUI difftool: \
`$ git pr show -t 11070`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11070.diff">https://git.openjdk.org/jdk/pull/11070.diff</a>

</details>
