### PR TITLE
8296741: Illegal X400Address and EDIPartyName should not be created

### DIFF
--- a/src/java.base/share/classes/sun/security/x509/EDIPartyName.java
+++ b/src/java.base/share/classes/sun/security/x509/EDIPartyName.java
@@ -26,6 +26,8 @@
 package sun.security.x509;
 
 import java.io.IOException;
+import java.util.Objects;
+
 import sun.security.util.*;
 
 /**
@@ -61,7 +63,7 @@ public class EDIPartyName implements GeneralNameInterface {
      */
     public EDIPartyName(String assignerName, String partyName) {
         this.assigner = assignerName;
-        this.party = partyName;
+        this.party = Objects.requireNonNull(partyName);
     }
 
     /**
@@ -70,7 +72,7 @@ public class EDIPartyName implements GeneralNameInterface {
      * @param partyName the name of the EDI party.
      */
     public EDIPartyName(String partyName) {
-        this.party = partyName;
+        this(null, partyName);
     }
 
     /**
@@ -106,6 +108,9 @@ public class EDIPartyName implements GeneralNameInterface {
                 party = opt.getAsString();
             }
         }
+        if (party == null) {
+            throw new IOException("party cannot be missing");
+        }
     }
 
     /**
@@ -132,9 +137,6 @@ public class EDIPartyName implements GeneralNameInterface {
             tagged.write(DerValue.createTag(DerValue.TAG_CONTEXT,
                                  false, TAG_ASSIGNER), tmp2);
         }
-        if (party == null)
-            throw  new IOException("Cannot have null partyName");
-
         // XXX - shd check is chars fit into PrintableString
         tmp.putPrintableString(party);
         tagged.write(DerValue.createTag(DerValue.TAG_CONTEXT,

--- a/src/java.base/share/classes/sun/security/x509/GeneralSubtrees.java
+++ b/src/java.base/share/classes/sun/security/x509/GeneralSubtrees.java
@@ -253,7 +253,7 @@ public class GeneralSubtrees implements Cloneable {
                 newName = new GeneralName(new DNSName(""));
                 break;
             case GeneralNameInterface.NAME_X400:
-                newName = new GeneralName(new X400Address((byte[])null));
+                newName = new GeneralName(new X400Address(null));
                 break;
             case GeneralNameInterface.NAME_DIRECTORY:
                 newName = new GeneralName(new X500Name(""));

--- a/src/java.base/share/classes/sun/security/x509/X400Address.java
+++ b/src/java.base/share/classes/sun/security/x509/X400Address.java
@@ -335,16 +335,13 @@ import sun.security.util.DerOutputStream;
 public class X400Address implements GeneralNameInterface {
 
     // Private data members
-    byte[] nameValue;
+    DerValue derValue;
 
     /**
      * Create the X400Address object from the specified byte array
      *
      * @param value value of the name as a byte array
      */
-    public X400Address(byte[] value) {
-        nameValue = value;
-    }
 
     /**
      * Create the X400Address object from the passed encoded Der value.
@@ -353,7 +350,7 @@ public class X400Address implements GeneralNameInterface {
      * @exception IOException on error.
      */
     public X400Address(DerValue derValue) throws IOException {
-        nameValue = derValue.toByteArray();
+        this.derValue = derValue;
     }
 
     /**
@@ -369,8 +366,8 @@ public class X400Address implements GeneralNameInterface {
      * @param out the DER stream to encode the X400Address to.
      * @exception IOException on encoding errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
-        DerValue derValue = new DerValue(nameValue);
         out.putDerValue(derValue);
     }
 

--- a/test/jdk/sun/security/x509/EDIPartyName/NullName.java
+++ b/test/jdk/sun/security/x509/EDIPartyName/NullName.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8296741
+ * @summary Illegal X400Address and EDIPartyName should not be created
+ * @library /test/lib
+ * @modules java.base/sun.security.x509
+ */
+
+import jdk.test.lib.Utils;
+import sun.security.x509.EDIPartyName;
+
+public class NullName {
+
+    public static void main(String[] argv) throws Exception {
+        Utils.runAndCheckException(
+                () -> new EDIPartyName((String)null),
+                NullPointerException.class);
+        Utils.runAndCheckException(
+                () -> new EDIPartyName(null, null),
+                NullPointerException.class);
+        Utils.runAndCheckException(
+                () -> new EDIPartyName("hello", null),
+                NullPointerException.class);
+        new EDIPartyName(null, "hello");
+    }
+}


### PR DESCRIPTION
`EDIPartyName` should not have a null `partyName`.

Inside `X400Name` it should be a `DerValue` instead of arbitrary byte array. Note: in `GeneralSubtrees.java`, an `X400Name` is created with a null content. This would lead to an NPE anyway. A future fix might be needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296741](https://bugs.openjdk.org/browse/JDK-8296741): Illegal X400Address and EDIPartyName should not be created


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11071/head:pull/11071` \
`$ git checkout pull/11071`

Update a local copy of the PR: \
`$ git checkout pull/11071` \
`$ git pull https://git.openjdk.org/jdk pull/11071/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11071`

View PR using the GUI difftool: \
`$ git pr show -t 11071`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11071.diff">https://git.openjdk.org/jdk/pull/11071.diff</a>

</details>
