### PR TITLE
8296638: RISC-V: NegVI node emits wrong code when vector element basic type is T_BYTE/T_SHORT

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -761,9 +761,6 @@ instruct vmulD(vReg dst, vReg src1, vReg src2) %{
 // vector neg
 
 instruct vnegI(vReg dst, vReg src) %{
-  predicate(Matcher::vector_element_basic_type(n->in(1)) == T_BYTE ||
-            Matcher::vector_element_basic_type(n->in(1)) == T_SHORT ||
-            Matcher::vector_element_basic_type(n->in(1)) == T_INT);
   match(Set dst (NegVI src));
   ins_cost(VEC_COST);
   format %{ "vrsub.vx $dst, $src, $src\t#@vnegI" %}

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -814,7 +814,7 @@ instruct vnegD(vReg dst, vReg src) %{
 // vector and reduction
 
 instruct reduce_andI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
-  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE || 
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE ||
             Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (AndReductionV src1 src2));
@@ -850,7 +850,7 @@ instruct reduce_andL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
 // vector or reduction
 
 instruct reduce_orI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
-  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE || 
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE ||
             Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (OrReductionV src1 src2));
@@ -886,7 +886,7 @@ instruct reduce_orL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
 // vector xor reduction
 
 instruct reduce_xorI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
-  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE || 
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE ||
             Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (XorReductionV src1 src2));
@@ -922,7 +922,7 @@ instruct reduce_xorL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
 // vector add reduction
 
 instruct reduce_addI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
-  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE || 
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE ||
             Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (AddReductionVI src1 src2));
@@ -992,7 +992,7 @@ instruct reduce_addD(fRegD src1_dst, vReg src2, vReg tmp) %{
 // vector integer max reduction
 
 instruct vreduce_maxI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
-  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE || 
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE ||
             Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (MaxReductionV src1 src2));
@@ -1024,7 +1024,7 @@ instruct vreduce_maxL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
 // vector integer min reduction
 
 instruct vreduce_minI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
-  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE || 
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE ||
             Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (MinReductionV src1 src2));

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -761,11 +761,16 @@ instruct vmulD(vReg dst, vReg src1, vReg src2) %{
 // vector neg
 
 instruct vnegI(vReg dst, vReg src) %{
+  predicate(Matcher::vector_element_basic_type(n->in(1)) == T_BYTE ||
+            Matcher::vector_element_basic_type(n->in(1)) == T_SHORT ||
+            Matcher::vector_element_basic_type(n->in(1)) == T_INT);
   match(Set dst (NegVI src));
   ins_cost(VEC_COST);
   format %{ "vrsub.vx $dst, $src, $src\t#@vnegI" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
+    __ vsetvli(t0, x0, sew);
     __ vneg_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);


### PR DESCRIPTION
Hi,

test/jdk/jdk/incubator/vector/Byte256VectorTests.java fails on riscv with the following error:
```
test Byte256VectorTests.negByte256VectorTests (byte [i * 5]): failure
java.lang.AssertionError: at index #2, input = 10 expected [-10] but found [-11]
```

Currently, `NegVI` can only handle the vector element basic type `T_INT` with`vsetvli(t0, x0, Assembler::e32)` but `T_SHORT/T_BYTE` can also be matched with `NegVI`, so these two types of tests are currently failing:
```
test/jdk/jdk/incubator/vector/Byte*VectorTests.java
test/jdk/jdk/incubator/vector/Short*VectorTests.java
```

Meanwhile, I removed some useless trailing whitespace.

Please take a look and have some reviews. Thanks a lot.

## Testing:

- test/jdk/jdk/incubator/vector (fastdebug/release with UseRVV on QEMU)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296638](https://bugs.openjdk.org/browse/JDK-8296638): RISC-V: NegVI node emits wrong code when vector element basic type is T_BYTE/T_SHORT


### Reviewers
 * [Gui Cao](https://openjdk.org/census#gcao) (@zifeihan - Author)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11074/head:pull/11074` \
`$ git checkout pull/11074`

Update a local copy of the PR: \
`$ git checkout pull/11074` \
`$ git pull https://git.openjdk.org/jdk pull/11074/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11074`

View PR using the GUI difftool: \
`$ git pr show -t 11074`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11074.diff">https://git.openjdk.org/jdk/pull/11074.diff</a>

</details>
