### PR TITLE
8296733: JFR: File Read event for RandomAccessFile::write(byte[]) is incorrect

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/RandomAccessFileInstrumentor.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/RandomAccessFileInstrumentor.java
@@ -153,7 +153,7 @@ final class RandomAccessFileInstrumentor {
             write(b);
             bytesWritten = b.length;
         } finally {
-            long duration = EventConfiguration.timestamp();
+            long duration = EventConfiguration.timestamp() - start;
             if (eventConfiguration.shouldCommit(duration)) {
                 FileWriteEvent.commit(start, duration, path, bytesWritten);
             }


### PR DESCRIPTION
The jdk.FileRead event emits an incorrect duration. This could lead to flooded buffers when using the default configuration.

Testing:  test/jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296733](https://bugs.openjdk.org/browse/JDK-8296733): JFR: File Read event for RandomAccessFile::write(byte[]) is incorrect


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11075/head:pull/11075` \
`$ git checkout pull/11075`

Update a local copy of the PR: \
`$ git checkout pull/11075` \
`$ git pull https://git.openjdk.org/jdk pull/11075/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11075`

View PR using the GUI difftool: \
`$ git pr show -t 11075`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11075.diff">https://git.openjdk.org/jdk/pull/11075.diff</a>

</details>
