### PR TITLE
8296630: Fix SkipIfEqual on AArch64 and RISC-V

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -3976,10 +3976,10 @@ SkipIfEqual::SkipIfEqual(
   uint64_t offset;
   _masm->adrp(rscratch1, ExternalAddress((address)flag_addr), offset);
   _masm->ldrb(rscratch1, Address(rscratch1, offset));
-  if (!value) {
-    _masm->cbzw(rscratch1, _label);
-  } else {
+  if (value) {
     _masm->cbnzw(rscratch1, _label);
+  } else {
+    _masm->cbzw(rscratch1, _label);
   }
 }
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -3976,7 +3976,11 @@ SkipIfEqual::SkipIfEqual(
   uint64_t offset;
   _masm->adrp(rscratch1, ExternalAddress((address)flag_addr), offset);
   _masm->ldrb(rscratch1, Address(rscratch1, offset));
-  _masm->cbzw(rscratch1, _label);
+  if (!value) {
+    _masm->cbzw(rscratch1, _label);
+  } else {
+    _masm->cbnzw(rscratch1, _label);
+  }
 }
 
 SkipIfEqual::~SkipIfEqual() {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2060,10 +2060,10 @@ SkipIfEqual::SkipIfEqual(MacroAssembler* masm, const bool* flag_addr, bool value
     _masm->la_patchable(t0, target, offset);
     _masm->lbu(t0, Address(t0, offset));
   });
-  if (!value) {
-    _masm->beqz(t0, _label);
-  } else {
+  if (value) {
     _masm->bnez(t0, _label);
+  } else {
+    _masm->beqz(t0, _label);
   }
 }
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2060,7 +2060,11 @@ SkipIfEqual::SkipIfEqual(MacroAssembler* masm, const bool* flag_addr, bool value
     _masm->la_patchable(t0, target, offset);
     _masm->lbu(t0, Address(t0, offset));
   });
-  _masm->beqz(t0, _label);
+  if (!value) {
+    _masm->beqz(t0, _label);
+  } else {
+    _masm->bnez(t0, _label);
+  }
 }
 
 SkipIfEqual::~SkipIfEqual() {


### PR DESCRIPTION
SkipIfEqual was supposed to load a flag value from some memory, compare it with a input boolean value, and jump to a specific label they a equals. The implementation on x86 and s390 platforms meets expectations, and ppc uses SkipIfEqualZero. However, on AArch64 and RISC-V platforms, the input argument "value" is not used, and jumping-if-equal-zero is generated only. That's not correct, but works well since only false passed on all call sites so far.

AArch64 tier1, riscv hotspot & jdk tier1 have been tested.
Additional cases with dtrace tested on AArch64:
test/hotspot/jtreg/serviceability/dtrace/DTraceOptionsTest.java
test/hotspot/jtreg/compiler/runtime/Test8168712.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296630](https://bugs.openjdk.org/browse/JDK-8296630): Fix SkipIfEqual on AArch64 and RISC-V


### Reviewers
 * [Nick Gasson](https://openjdk.org/census#ngasson) (@nick-arm - **Reviewer**) ⚠️ Review applies to [f927182d](https://git.openjdk.org/jdk/pull/11076/files/f927182dca253078a210a189a188324327d558b6)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) ⚠️ Review applies to [f927182d](https://git.openjdk.org/jdk/pull/11076/files/f927182dca253078a210a189a188324327d558b6)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Author) ⚠️ Review applies to [f927182d](https://git.openjdk.org/jdk/pull/11076/files/f927182dca253078a210a189a188324327d558b6)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11076/head:pull/11076` \
`$ git checkout pull/11076`

Update a local copy of the PR: \
`$ git checkout pull/11076` \
`$ git pull https://git.openjdk.org/jdk pull/11076/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11076`

View PR using the GUI difftool: \
`$ git pr show -t 11076`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11076.diff">https://git.openjdk.org/jdk/pull/11076.diff</a>

</details>
