### PR TITLE
8291991: Adjust the "shared class paths mismatch" message if class path logging is enabled

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -136,15 +136,8 @@ void FileMapInfo::fail_continue_impl(LogLevelType level, const char *msg, va_lis
     if (RequireSharedSpaces) {
       fail_exit(msg, ap_copy);
     } else {
-      // LogMessage::vwrite, which makes a copy of the va_list, must be called before
-      // LogStream::vprint_cr.
       LogMessage(cds) lm;
       lm.vwrite(level, msg, ap_copy);
-      if (log_is_enabled(Info, cds)) {
-        LogStream ls(Log(cds)::info());
-        ls.print("UseSharedSpaces: ");
-        ls.vprint_cr(msg, ap_copy);
-      }
     }
   }
   va_end(ap_copy);

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1117,10 +1117,15 @@ bool FileMapInfo::validate_shared_path_table() {
     assert(shared_path(0)->is_modules_image(), "first shared_path must be the modules image");
   } else {
     if (!validate_boot_class_paths() || !validate_app_class_paths(shared_app_paths_len)) {
-      const char* mismatch_msg = "shared class paths mismatch (hint: enable -Xlog:class+path=info to diagnose the failure)";
-      fail_continue("%s", mismatch_msg);
+      const char* mismatch_msg = "shared class paths mismatch";
+      const char* hint_msg = "(hint: enable -Xlog:class+path=info to diagnose the failure)";
+      if (log_is_enabled(Info, class, path)) {
+        fail_continue("%s", mismatch_msg);
+      } else {
+        fail_continue("%s %s", mismatch_msg, hint_msg);
+      }
       if (!log_is_enabled(Info, cds) && !log_is_enabled(Info, class, path)) {
-        log_warning(cds)("%s", mismatch_msg);
+        log_warning(cds)("%s %s", mismatch_msg, hint_msg);
       }
       return false;
     }

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -123,24 +123,21 @@ void FileMapInfo::fail_continue(LogLevelType level, const char *msg, ...) {
 }
 
 void FileMapInfo::fail_continue_impl(LogLevelType level, const char *msg, va_list ap) {
-  va_list ap_copy;
-  va_copy(ap_copy, ap);
   if (PrintSharedArchiveAndExit && _validating_shared_path_table) {
     // If we are doing PrintSharedArchiveAndExit and some of the classpath entries
     // do not validate, we can still continue "limping" to validate the remaining
     // entries. No need to quit.
     tty->print("[");
-    tty->vprint(msg, ap_copy);
+    tty->vprint(msg, ap);
     tty->print_cr("]");
   } else {
     if (RequireSharedSpaces) {
-      fail_exit(msg, ap_copy);
+      fail_exit(msg, ap);
     } else {
       LogMessage(cds) lm;
-      lm.vwrite(level, msg, ap_copy);
+      lm.vwrite(level, msg, ap);
     }
   }
-  va_end(ap_copy);
 }
 
 // Fill in the fileMapInfo structure with data about this VM instance.

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -27,6 +27,7 @@
 
 #include "cds/metaspaceShared.hpp"
 #include "include/cds.h"
+#include "logging/logLevel.hpp"
 #include "oops/array.hpp"
 #include "oops/compressedOops.hpp"
 #include "utilities/align.hpp"
@@ -481,6 +482,8 @@ public:
   // Errors.
   static void fail_stop(const char *msg, ...) ATTRIBUTE_PRINTF(1, 2);
   static void fail_continue(const char *msg, ...) ATTRIBUTE_PRINTF(1, 2);
+  static void fail_continue(LogLevelType level, const char *msg, ...) ATTRIBUTE_PRINTF(2, 3);
+  static void fail_continue_impl(LogLevelType level, const char *msg, va_list ap) ATTRIBUTE_PRINTF(2, 0);
   static bool memory_mapping_failed() {
     CDS_ONLY(return _memory_mapping_failed;)
     NOT_CDS(return false;)

--- a/test/hotspot/jtreg/runtime/cds/appcds/MismatchedPathTriggerMemoryRelease.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/MismatchedPathTriggerMemoryRelease.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,8 +35,8 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 public class MismatchedPathTriggerMemoryRelease {
     private static String ERR_MSGS[] = {
-        "UseSharedSpaces: shared class paths mismatch (hint: enable -Xlog:class+path=info to diagnose the failure)",
-        "UseSharedSpaces: Unable to map shared spaces"};
+        "shared class paths mismatch (hint: enable -Xlog:class+path=info to diagnose the failure)",
+        "Unable to map shared spaces"};
     private static String RELEASE_SPACE_MATCH = "Released shared space .* 0(x|X)[0-9a-fA-F]+$";
     private static String OS_RELEASE_MSG = "os::release_memory failed";
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/SharedArchiveConsistency.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/SharedArchiveConsistency.java
@@ -60,7 +60,7 @@ public class SharedArchiveConsistency {
 
     public static int num_regions = shared_region_name.length;
     public static String[] matchMessages = {
-        "UseSharedSpaces: Header checksum verification failed.",
+        "Header checksum verification failed.",
         "The shared archive file has an incorrect header size.",
         "Unable to use shared archive",
         "An error has occurred while processing the shared archive file.",

--- a/test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
@@ -41,7 +41,8 @@ public class WrongClasspath {
   public static void main(String[] args) throws Exception {
     String appJar = JarBuilder.getOrCreateHelloJar();
     String unableToUseMsg = "Unable to use shared archive";
-    String mismatchMsg = "shared class paths mismatch (hint: enable -Xlog:class+path=info to diagnose the failure)";
+    String mismatchMsg = "shared class paths mismatch";
+    String hintMsg = "(hint: enable -Xlog:class+path=info to diagnose the failure)";
 
     // Dump an archive with a specified JAR file in -classpath
     TestCommon.testDump(appJar, TestCommon.list("Hello"));
@@ -51,12 +52,24 @@ public class WrongClasspath {
         /* "-cp", appJar, */ // <- uncomment this and the execution should succeed
         "-Xlog:cds",
         "Hello")
-        .assertAbnormalExit(unableToUseMsg, mismatchMsg);
+        .assertAbnormalExit(unableToUseMsg, mismatchMsg, hintMsg);
 
     // Run with -Xshare:auto and without CDS logging enabled, the mismatch message
     // should still be there.
     OutputAnalyzer output = TestCommon.execAuto("Hello");
-    output.shouldContain(mismatchMsg);
+    output.shouldContain(mismatchMsg)
+          .shouldContain(hintMsg);
+
+    // Run with -Xshare:on and -Xlog:class+path=info, the mismatchMsg should
+    // be there, the hintMsg should NOT be there.
+    TestCommon.run(
+        "-Xlog:class+path=info",
+        "Hello")
+        .assertAbnormalExit( out -> {
+            out.shouldContain(unableToUseMsg)
+               .shouldContain(mismatchMsg)
+               .shouldNotContain(hintMsg);
+        });
 
     // Dump CDS archive with 2 jars: -cp hello.jar:jar2.jar
     // Run with 2 jars but the second jar doesn't exist: -cp hello.jarjar2.jarx
@@ -66,7 +79,7 @@ public class WrongClasspath {
     TestCommon.testDump(jars, TestCommon.list("Hello", "pkg/C2"));
     TestCommon.run(
         "-cp", jars + "x", "Hello")
-        .assertAbnormalExit(unableToUseMsg, mismatchMsg);
+        .assertAbnormalExit(unableToUseMsg, mismatchMsg, hintMsg);
 
     // modify the timestamp of the jar2
     (new File(jar2.toString())).setLastModified(System.currentTimeMillis() + 2000);

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java
@@ -336,8 +336,8 @@ public class TestAutoCreateSharedArchive extends DynamicArchiveTestBase {
                 output.shouldHaveExitValue(0)
                       .shouldContain(HELLO_WORLD)
                       .shouldContain("The shared archive file version " + hex(version2) + " does not match the required version " + hex(currentCDSVersion))
-                      .shouldContain("UseSharedSpaces: The shared archive file has the wrong version")
-                      .shouldContain("UseSharedSpaces: Initialize dynamic archive failed")
+                      .shouldContain("The shared archive file has the wrong version")
+                      .shouldContain("Initialize dynamic archive failed")
                       .shouldContain("Dumping shared data to file");
             });
         ft2 = Files.getLastModifiedTime(Paths.get(modVersion));
@@ -400,7 +400,7 @@ public class TestAutoCreateSharedArchive extends DynamicArchiveTestBase {
             .assertNormalExit(output -> {
                 output.shouldHaveExitValue(0);
                 if (verifyOn) {
-                    output.shouldContain("UseSharedSpaces: Header checksum verification failed")
+                    output.shouldContain("Header checksum verification failed")
                           .shouldContain("Unable to use shared archive: invalid archive")
                           .shouldNotContain("Dumping shared data to file");
                 } else {
@@ -605,7 +605,7 @@ public class TestAutoCreateSharedArchive extends DynamicArchiveTestBase {
             .assertNormalExit(output -> {
                 output.shouldHaveExitValue(0);
                 if (verifyOn) {
-                    output.shouldContain("UseSharedSpaces: Header checksum verification failed");
+                    output.shouldContain("Header checksum verification failed");
                 }
                 output.shouldContain(HELLO_WORLD)
                       .shouldContain("Dumping shared data to file");
@@ -634,7 +634,7 @@ public class TestAutoCreateSharedArchive extends DynamicArchiveTestBase {
                 output.shouldHaveExitValue(0)
                       .shouldContain(HELLO_WORLD);
                 if (verifyOn) {
-                    output.shouldContain("UseSharedSpaces: Header checksum verification failed");
+                    output.shouldContain("Header checksum verification failed");
                 }
                 output.shouldContain("Unable to map shared spaces")
                       .shouldNotContain("Dumping shared data to file");

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java
@@ -112,8 +112,8 @@ public class TestAutoCreateSharedArchiveNoDefaultArchive {
                                                          "-version");
             TestCommon.executeAndLog(pb, "show-version")
                       .shouldHaveExitValue(0)
-                      .shouldContain("UseSharedSpaces: Initialize static archive failed")
-                      .shouldContain("UseSharedSpaces: Unable to map shared spaces")
+                      .shouldContain("Initialize static archive failed")
+                      .shouldContain("Unable to map shared spaces")
                       .shouldNotContain("sharing");
         }
         // delete existing jsa file
@@ -132,8 +132,8 @@ public class TestAutoCreateSharedArchiveNoDefaultArchive {
                                                          mainClass);
             TestCommon.executeAndLog(pb, "no-default-archive")
                       .shouldHaveExitValue(0)
-                      .shouldContain("UseSharedSpaces: Initialize static archive failed")
-                      .shouldContain("UseSharedSpaces: Unable to map shared spaces")
+                      .shouldContain("Initialize static archive failed")
+                      .shouldContain("Unable to map shared spaces")
                       .shouldNotContain("Dumping shared data to file");
             if (jsaFile.exists()) {
                 throw new RuntimeException("Archive file " + jsaFileName + " should not be created at exit");

--- a/test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClasses.java
+++ b/test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClasses.java
@@ -184,12 +184,12 @@ public class ReplaceCriticalClasses {
         final boolean expectShared = shared.equals("-shared");
         CDSTestUtils.run(opts).assertNormalExit(out -> {
                 if (expectDisable) {
-                    out.shouldContain("UseSharedSpaces: CDS is disabled because early JVMTI ClassFileLoadHook is in use.");
+                    out.shouldContain("CDS is disabled because early JVMTI ClassFileLoadHook is in use.");
                     System.out.println("CDS disabled as expected");
                 }
                 if (checkSubgraph) {
                     if (expectShared) {
-                        if (!out.getOutput().contains("UseSharedSpaces: Unable to map at required address in java heap")) {
+                        if (!out.getOutput().contains("Unable to map at required address in java heap")) {
                             out.shouldContain(subgraphInit);
                             // If the subgraph is successfully initialized, the specified shared class must not be rewritten.
                             out.shouldNotContain("Rewriting done.");


### PR DESCRIPTION
Before this fix, with `-Xshare:on` and `-Xlog:class+path=info` and if there is a class path mismatch, the following error message will be displayed:

`shared class paths mismatch (hint: enable -Xlog:class+path=info to diagnose the failure)`

After this fix, only the first part of the error message will be displayed since the "hint" is repetitive if the user has specified `-Xlog:class+path=info.`

`shared class paths mismatch`

Passed tiers 1 and 2 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291991](https://bugs.openjdk.org/browse/JDK-8291991): Adjust the "shared class paths mismatch" message if class path logging is enabled


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11078/head:pull/11078` \
`$ git checkout pull/11078`

Update a local copy of the PR: \
`$ git checkout pull/11078` \
`$ git pull https://git.openjdk.org/jdk pull/11078/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11078`

View PR using the GUI difftool: \
`$ git pr show -t 11078`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11078.diff">https://git.openjdk.org/jdk/pull/11078.diff</a>

</details>
