### PR TITLE
8227257: javax/swing/JFileChooser/4847375/bug4847375.java fails with AssertionError

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
@@ -1437,7 +1437,7 @@ final class Win32ShellFolder2 extends ShellFolder {
                     }
                 }
             }
-            if (retVal.getWidth(null) != w) {
+            if ((retVal != null) && (retVal.getWidth(null) != w)) {
                 BufferedImage newVariant = new BufferedImage(w, w, BufferedImage.TYPE_INT_ARGB);
                 Graphics2D g2d = newVariant.createGraphics();
                 g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);


### PR DESCRIPTION
Observation found when _JFileChooser_ is instantiated in _WindowsLookAndFeel_ which invokes _getSystemIcon()_ from WindowsFileChooserUI class. Could not find the exact root cause so predicting it to be an issue with icons not loaded where _resolutionVariants_ map is empty in _public Image getResolutionVariant(double width, double height) _. Hence proposing a null check before accessing _getWidth()_. Fix is tested in CI system.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8227257](https://bugs.openjdk.org/browse/JDK-8227257): javax/swing/JFileChooser/4847375/bug4847375.java fails with AssertionError


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11079/head:pull/11079` \
`$ git checkout pull/11079`

Update a local copy of the PR: \
`$ git checkout pull/11079` \
`$ git pull https://git.openjdk.org/jdk pull/11079/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11079`

View PR using the GUI difftool: \
`$ git pr show -t 11079`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11079.diff">https://git.openjdk.org/jdk/pull/11079.diff</a>

</details>
