### PR TITLE
JDK-8296764 NMT: reduce loads in os::malloc

### DIFF
--- a/src/hotspot/share/services/memTracker.cpp
+++ b/src/hotspot/share/services/memTracker.cpp
@@ -47,7 +47,7 @@
 #include <windows.h>
 #endif
 
-volatile NMT_TrackingLevel MemTracker::_tracking_level = NMT_unknown;
+NMT_TrackingLevel MemTracker::_tracking_level = NMT_unknown;
 
 MemBaseline MemTracker::_baseline;
 

--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -231,10 +231,7 @@ class MemTracker : AllStatic {
 
  private:
   // Tracking level
-  static volatile NMT_TrackingLevel   _tracking_level;
-  // If NMT option value passed by launcher through environment
-  // variable is valid
-  static bool                         _is_nmt_env_valid;
+  static NMT_TrackingLevel   _tracking_level;
   // Stored baseline
   static MemBaseline      _baseline;
   // Query lock

--- a/src/hotspot/share/services/nmtPreInit.cpp
+++ b/src/hotspot/share/services/nmtPreInit.cpp
@@ -159,7 +159,6 @@ void NMTPreInitAllocationTable::verify() const {
 // --------- NMTPreinit --------------
 
 NMTPreInitAllocationTable* NMTPreInit::_table = NULL;
-bool NMTPreInit::_nmt_was_initialized = false;
 
 // Some statistics
 unsigned NMTPreInit::_num_mallocs_pre = 0;
@@ -180,8 +179,7 @@ void* NMTPreInit::do_os_malloc(size_t size) {
 // Switches from NMT pre-init state to NMT post-init state;
 //  in post-init, no modifications to the lookup table are possible.
 void NMTPreInit::pre_to_post() {
-  assert(_nmt_was_initialized == false, "just once");
-  _nmt_was_initialized = true;
+  assert(MemTracker::is_initialized() == false, "just once");
   DEBUG_ONLY(verify();)
 }
 

--- a/src/hotspot/share/services/nmtPreInit.cpp
+++ b/src/hotspot/share/services/nmtPreInit.cpp
@@ -179,7 +179,7 @@ void* NMTPreInit::do_os_malloc(size_t size) {
 // Switches from NMT pre-init state to NMT post-init state;
 //  in post-init, no modifications to the lookup table are possible.
 void NMTPreInit::pre_to_post() {
-  assert(MemTracker::is_initialized() == false, "just once");
+  assert(!MemTracker::is_initialized(), "just once");
   DEBUG_ONLY(verify();)
 }
 

--- a/src/hotspot/share/services/nmtPreInit.hpp
+++ b/src/hotspot/share/services/nmtPreInit.hpp
@@ -30,6 +30,7 @@
 #ifdef ASSERT
 #include "runtime/atomic.hpp"
 #endif
+#include "services/memTracker.hpp" // for MemTracker::is_initialized()
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
@@ -217,7 +218,6 @@ public:
 class NMTPreInit : public AllStatic {
 
   static NMTPreInitAllocationTable* _table;
-  static bool _nmt_was_initialized;
 
   // Some statistics
   static unsigned _num_mallocs_pre;           // Number of pre-init mallocs
@@ -227,7 +227,7 @@ class NMTPreInit : public AllStatic {
   static void create_table();
 
   static void add_to_map(NMTPreInitAllocation* a) {
-    assert(!_nmt_was_initialized, "lookup map cannot be modified after NMT initialization");
+    assert(!MemTracker::is_initialized(), "lookup map cannot be modified after NMT initialization");
     // Only on add, we create the table on demand. Only needed on add, since everything should start
     // with a call to os::malloc().
     if (_table == NULL) {
@@ -242,7 +242,7 @@ class NMTPreInit : public AllStatic {
   }
 
   static NMTPreInitAllocation* find_and_remove_in_map(void* p) {
-    assert(!_nmt_was_initialized, "lookup map cannot be modified after NMT initialization");
+    assert(!MemTracker::is_initialized(), "lookup map cannot be modified after NMT initialization");
     assert(_table != NULL, "stray allocation?");
     return _table->find_and_remove(p);
   }
@@ -256,15 +256,12 @@ public:
   //  in post-init, no modifications to the lookup table are possible.
   static void pre_to_post();
 
-  // Returns true if we are still in pre-init phase, false if post-init
-  static bool in_preinit_phase()  { return _nmt_was_initialized == false; }
-
   // Called from os::malloc.
   // Returns true if allocation was handled here; in that case,
   // *rc contains the return address.
   static bool handle_malloc(void** rc, size_t size) {
     size = MAX2((size_t)1, size);         // malloc(0)
-    if (!_nmt_was_initialized) {
+    if (!MemTracker::is_initialized()) {
       // pre-NMT-init:
       // Allocate entry and add address to lookup table
       NMTPreInitAllocation* a = NMTPreInitAllocation::do_alloc(size);
@@ -284,7 +281,7 @@ public:
       return handle_malloc(rc, new_size);
     }
     new_size = MAX2((size_t)1, new_size); // realloc(.., 0)
-    if (!_nmt_was_initialized) {
+    if (!MemTracker::is_initialized()) {
       // pre-NMT-init:
       // - the address must already be in the lookup table
       // - find the old entry, remove from table, reallocate, add to table
@@ -323,7 +320,7 @@ public:
     if (p == NULL) { // free(NULL)
       return true;
     }
-    if (!_nmt_was_initialized) {
+    if (!MemTracker::is_initialized()) {
       // pre-NMT-init:
       // - the allocation must be in the hash map, since all allocations went through
       //   NMTPreInit::handle_malloc()

--- a/src/hotspot/share/services/nmtPreInit.hpp
+++ b/src/hotspot/share/services/nmtPreInit.hpp
@@ -30,7 +30,7 @@
 #ifdef ASSERT
 #include "runtime/atomic.hpp"
 #endif
-#include "services/memTracker.hpp" // for MemTracker::is_initialized()
+#include "services/memTracker.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"

--- a/test/hotspot/gtest/nmt/test_nmtpreinit.cpp
+++ b/test/hotspot/gtest/nmt/test_nmtpreinit.cpp
@@ -113,7 +113,7 @@ public:
     log_state();
   }
   void test_post() {
-    assert(!MemTracker::is_initialized() == false,
+    assert(MemTracker::is_initialized(),
            "This should be run in post-init phase (from inside a TEST_VM test)");
     LOG("corner cases, post-init (%d)", os::current_process_id());
     log_state();
@@ -127,7 +127,7 @@ public:
     log_state();
   }
   void free_all() {
-    assert(!MemTracker::is_initialized() == false,
+    assert(MemTracker::is_initialized(),
            "This should be run in post-init phase (from inside a TEST_VM test)");
     LOG("corner cases, free-all (%d)", os::current_process_id());
     log_state();

--- a/test/hotspot/gtest/nmt/test_nmtpreinit.cpp
+++ b/test/hotspot/gtest/nmt/test_nmtpreinit.cpp
@@ -25,6 +25,7 @@
 #include "precompiled.hpp"
 #include "memory/allocation.hpp"
 #include "runtime/os.hpp"
+#include "services/memTracker.hpp"
 #include "services/nmtPreInit.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/ostream.hpp"
@@ -74,7 +75,7 @@ public:
   }
   void test_pre() {
     // Note that this part will run every time a gtestlauncher execs (so, for every TEST_OTHER_VM).
-    assert(NMTPreInit::in_preinit_phase(),
+    assert(!MemTracker::is_initialized(),
            "This should be run in pre-init phase (as part of C++ dyn. initialization)");
     LOG("corner cases, pre-init (%d)", os::current_process_id());
     log_state();
@@ -112,7 +113,7 @@ public:
     log_state();
   }
   void test_post() {
-    assert(NMTPreInit::in_preinit_phase() == false,
+    assert(!MemTracker::is_initialized() == false,
            "This should be run in post-init phase (from inside a TEST_VM test)");
     LOG("corner cases, post-init (%d)", os::current_process_id());
     log_state();
@@ -126,7 +127,7 @@ public:
     log_state();
   }
   void free_all() {
-    assert(NMTPreInit::in_preinit_phase() == false,
+    assert(!MemTracker::is_initialized() == false,
            "This should be run in post-init phase (from inside a TEST_VM test)");
     LOG("corner cases, free-all (%d)", os::current_process_id());
     log_state();


### PR DESCRIPTION
We read the NMT level at every ps::malloc/realloc/free etc, even if NMT is off. That is unavoidable. But we also read a second variable that shadows the NMT level `_nmt_was_initialized`. That state is synonymous with NMT level "unknown," so there is no need for this second load.

Furthermore, NMT level is volatile. That had been necessary in older times since we used to shut down NMT on resource exhaustion. But since [JDK-8256844](https://bugs.openjdk.org/browse/JDK-8256844), NMT level is fixed at initialization, so we can remove the volatile specifier.

Patch 
- removes `_nmt_was_initialized` and redirects it to `MemTracker::is_initialized()`, which gets inlined to a load of NMT level. 
- makes NMT level non-volatile
- removes _is_nmt_env_valid, which had been dead code

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296764](https://bugs.openjdk.org/browse/JDK-8296764): NMT: reduce loads in os::malloc


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**) ⚠️ Review applies to [9d5cac2c](https://git.openjdk.org/jdk/pull/11080/files/9d5cac2c0659413c54fa7f36aa3f8b382c3bc1fb)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11080/head:pull/11080` \
`$ git checkout pull/11080`

Update a local copy of the PR: \
`$ git checkout pull/11080` \
`$ git pull https://git.openjdk.org/jdk pull/11080/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11080`

View PR using the GUI difftool: \
`$ git pr show -t 11080`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11080.diff">https://git.openjdk.org/jdk/pull/11080.diff</a>

</details>
