### PR TITLE
8296222: SwingEventMonitor - installListeners(Component , int ) - CELLEDITOR - bug

### DIFF
--- a/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/SwingEventMonitor.java
+++ b/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/SwingEventMonitor.java
@@ -987,7 +987,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
                 //
                 try {
                     getCellEditorMethod = c.getClass().getMethod(
-                        "getCellEditorMethod", nullClass);
+                        "getCellEditor", nullClass);
                     try {
                         Object o = getCellEditorMethod.invoke(c, nullArgs);
                         if (o != null && o instanceof CellEditor) {
@@ -1633,7 +1633,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
                 //
                 try {
                     getCellEditorMethod = c.getClass().getMethod(
-                        "getCellEditorMethod", nullClass);
+                        "getCellEditor", nullClass);
                     try {
                         Object o = getCellEditorMethod.invoke(c, nullArgs);
                         if (o != null && o instanceof CellEditor) {


### PR DESCRIPTION
It seems there was a typo inside function `installListeners(Component, int)` and `removeListeners(Component)` on case EventID.CELLEDITOR.

Changed the string from "getCellEditorMethod" to "getCellEditor" in `protected void installListeners(Component c, int eventID)` and `protected void removeListeners(Component c)` methods.

Didn't add any test case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296222](https://bugs.openjdk.org/browse/JDK-8296222): SwingEventMonitor - installListeners(Component , int ) - CELLEDITOR - bug


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - no project role)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11082/head:pull/11082` \
`$ git checkout pull/11082`

Update a local copy of the PR: \
`$ git checkout pull/11082` \
`$ git pull https://git.openjdk.org/jdk pull/11082/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11082`

View PR using the GUI difftool: \
`$ git pr show -t 11082`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11082.diff">https://git.openjdk.org/jdk/pull/11082.diff</a>

</details>
