### PR TITLE
8296771: RISC-V: C2: assert(false) failed: bad AD file

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -3265,6 +3265,7 @@ operand iRegP()
   match(RegP);
   match(iRegPNoSp);
   match(iRegP_R10);
+  match(iRegP_R15);
   match(javaThread_RegP);
   op_cost(0);
   format %{ %}


### PR DESCRIPTION
The backend encounters the same assertion failure as [JDK-8295414](https://bugs.openjdk.org/browse/JDK-8295414). This patch is a similar fix.

Same, `partialSubtypeCheck` uses `iRegP_R15` as a result while its use `iRegP`  doesn't match the `iRegP_R15`, causing this failure.

The details are in the JBS issue [JDK-8296771](https://bugs.openjdk.org/browse/JDK-8296771).

Tested the failed `compiler/types/TestSubTypeCheckMacroTrichotomy.java`, and a hotspot tier1 is running now.

Thanks,
Xiaolin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296771](https://bugs.openjdk.org/browse/JDK-8296771): RISC-V: C2: assert(false) failed: bad AD file


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11085/head:pull/11085` \
`$ git checkout pull/11085`

Update a local copy of the PR: \
`$ git checkout pull/11085` \
`$ git pull https://git.openjdk.org/jdk pull/11085/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11085`

View PR using the GUI difftool: \
`$ git pr show -t 11085`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11085.diff">https://git.openjdk.org/jdk/pull/11085.diff</a>

</details>
