### PR TITLE
8296773: G1: Factor out hash function for G1CardSet

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.hpp
@@ -414,18 +414,4 @@ public:
   G1CardSetHashTableValue(uint region_idx, ContainerPtr container) : _region_idx(region_idx), _num_occupied(0), _container(container) { }
 };
 
-class G1CardSetHashTableConfig : public StackObj {
-public:
-  using Value = G1CardSetHashTableValue;
-
-  static uintx get_hash(Value const& value, bool* is_dead) {
-    *is_dead = false;
-    return value._region_idx;
-  }
-  static void* allocate_node(void* context, size_t size, Value const& value);
-  static void free_node(void* context, void* memory, Value const& value);
-};
-
-using CardSetHash = ConcurrentHashTable<G1CardSetHashTableConfig, mtGCCardSet>;
-
 #endif // SHARE_GC_G1_G1CARDSET_HPP


### PR DESCRIPTION
Hi all,

  please review this refactoring that removes the inlining of the "hash" in `G1CardSet` to call a common function.
This makes experimenting with different hash functions much easier.

Testing: local compilation, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296773](https://bugs.openjdk.org/browse/JDK-8296773): G1: Factor out hash function for G1CardSet


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11087/head:pull/11087` \
`$ git checkout pull/11087`

Update a local copy of the PR: \
`$ git checkout pull/11087` \
`$ git pull https://git.openjdk.org/jdk pull/11087/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11087`

View PR using the GUI difftool: \
`$ git pr show -t 11087`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11087.diff">https://git.openjdk.org/jdk/pull/11087.diff</a>

</details>
