### PR TITLE
8296805: ctw build is broken

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/Makefile
+++ b/test/hotspot/jtreg/testlibrary/ctw/Makefile
@@ -47,7 +47,7 @@ LIB_FILES = $(shell find $(TESTLIBRARY_DIR)/jdk/test/lib/ \
     $(TESTLIBRARY_DIR)/jdk/test/lib/util \
     $(TESTLIBRARY_DIR)/jtreg \
     -maxdepth 1 -name '*.java')
-WB_SRC_FILES = $(shell find $(TESTLIBRARY_DIR)/sun/hotspot $(TESTLIBRARY_DIR)/jdk/test/whitebox -name '*.java')
+WB_SRC_FILES = $(shell find $(TESTLIBRARY_DIR)/jdk/test/lib/compiler $(TESTLIBRARY_DIR)/jdk/test/whitebox -name '*.java')
 EXPORTS=--add-exports java.base/jdk.internal.jimage=ALL-UNNAMED \
 	--add-exports java.base/jdk.internal.misc=ALL-UNNAMED \
 	--add-exports java.base/jdk.internal.reflect=ALL-UNNAMED \


### PR DESCRIPTION
I noticed the build for the ctw tool based on the WhiteBox API is
broken. This fixes it AFAICT.
