### PR TITLE
8296768: Use different explicit claim marks for CLDs in Parallel and Serial GC

### DIFF
--- a/src/hotspot/share/gc/parallel/psCompactionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.inline.hpp
@@ -52,11 +52,13 @@ public:
   virtual void do_oop(narrowOop* p)               { do_oop_nv(p); }
 };
 
-class PCIterateMarkAndPushClosure: public MetadataVisitingOopIterateClosure {
+class PCIterateMarkAndPushClosure: public ClaimMetadataVisitingOopIterateClosure {
 private:
   ParCompactionManager* _compaction_manager;
 public:
-  PCIterateMarkAndPushClosure(ParCompactionManager* cm, ReferenceProcessor* rp) : MetadataVisitingOopIterateClosure(rp), _compaction_manager(cm) { }
+  PCIterateMarkAndPushClosure(ParCompactionManager* cm, ReferenceProcessor* rp) :
+    ClaimMetadataVisitingOopIterateClosure(ClassLoaderData::_claim_stw_fullgc_mark, rp),
+    _compaction_manager(cm) { }
 
   template <typename T> void do_oop_nv(T* p)      { _compaction_manager->mark_and_push(p); }
   virtual void do_oop(oop* p)                     { do_oop_nv(p); }

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -988,6 +988,9 @@ void PSParallelCompact::pre_compact()
   DEBUG_ONLY(summary_data().verify_clear();)
 
   ParCompactionManager::reset_all_bitmap_query_caches();
+
+  // Need new claim bits before marking starts.
+  ClassLoaderDataGraph::clear_claimed_marks();
 }
 
 void PSParallelCompact::post_compact()
@@ -1965,7 +1968,7 @@ public:
     PCMarkAndPushClosure mark_and_push_closure(cm);
 
     {
-      CLDToOopClosure cld_closure(&mark_and_push_closure, ClassLoaderData::_claim_strong);
+      CLDToOopClosure cld_closure(&mark_and_push_closure, ClassLoaderData::_claim_stw_fullgc_mark);
       ClassLoaderDataGraph::always_strong_cld_do(&cld_closure);
 
       // Do the real work
@@ -2016,9 +2019,7 @@ void PSParallelCompact::marking_phase(ParallelOldTracer *gc_tracer) {
 
   uint active_gc_threads = ParallelScavengeHeap::heap()->workers().active_workers();
 
-  // Need new claim bits before marking starts.
-  ClassLoaderDataGraph::clear_claimed_marks();
-
+  ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_stw_fullgc_mark);
   {
     GCTraceTime(Debug, gc, phases) tm("Par Mark", &_gc_timer);
 
@@ -2094,8 +2095,8 @@ public:
     _sub_tasks(PSAdjustSubTask_num_elements),
     _weak_proc_task(nworkers),
     _nworkers(nworkers) {
-    // Need new claim bits when tracing through and adjusting pointers.
-    ClassLoaderDataGraph::clear_claimed_marks();
+
+    ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_stw_fullgc_adjust);
     if (nworkers > 1) {
       Threads::change_thread_claim_token();
     }
@@ -2114,7 +2115,7 @@ public:
     }
     _oop_storage_iter.oops_do(&adjust);
     {
-      CLDToOopClosure cld_closure(&adjust, ClassLoaderData::_claim_strong);
+      CLDToOopClosure cld_closure(&adjust, ClassLoaderData::_claim_stw_fullgc_adjust);
       ClassLoaderDataGraph::cld_do(&cld_closure);
     }
     {

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -988,9 +988,6 @@ void PSParallelCompact::pre_compact()
   DEBUG_ONLY(summary_data().verify_clear();)
 
   ParCompactionManager::reset_all_bitmap_query_caches();
-
-  // Need new claim bits before marking starts.
-  ClassLoaderDataGraph::clear_claimed_marks();
 }
 
 void PSParallelCompact::post_compact()
@@ -1035,6 +1032,9 @@ void PSParallelCompact::post_compact()
   // Delete metaspaces for unloaded class loaders and clean up loader_data graph
   ClassLoaderDataGraph::purge(/*at_safepoint*/true);
   DEBUG_ONLY(MetaspaceUtils::verify();)
+
+  // Need to clear claim bits for the next mark.
+  ClassLoaderDataGraph::clear_claimed_marks();
 
   heap->prune_scavengable_nmethods();
 

--- a/src/hotspot/share/gc/serial/genMarkSweep.cpp
+++ b/src/hotspot/share/gc/serial/genMarkSweep.cpp
@@ -83,9 +83,6 @@ void GenMarkSweep::invoke_at_safepoint(ReferenceProcessor* rp, bool clear_all_so
   // Increment the invocation count
   _total_invocations++;
 
-  // Need new claim bits before marking starts.
-  ClassLoaderDataGraph::clear_claimed_marks();
-
   // Capture used regions for each generation that will be
   // subject to collection, so that card table adjustments can
   // be made intelligently (see clear / invalidate further below).

--- a/src/hotspot/share/gc/serial/genMarkSweep.cpp
+++ b/src/hotspot/share/gc/serial/genMarkSweep.cpp
@@ -83,6 +83,9 @@ void GenMarkSweep::invoke_at_safepoint(ReferenceProcessor* rp, bool clear_all_so
   // Increment the invocation count
   _total_invocations++;
 
+  // Need new claim bits before marking starts.
+  ClassLoaderDataGraph::clear_claimed_marks();
+
   // Capture used regions for each generation that will be
   // subject to collection, so that card table adjustments can
   // be made intelligently (see clear / invalidate further below).
@@ -180,8 +183,7 @@ void GenMarkSweep::mark_sweep_phase1(bool clear_all_softrefs) {
 
   GenCollectedHeap* gch = GenCollectedHeap::heap();
 
-  // Need new claim bits before marking starts.
-  ClassLoaderDataGraph::clear_claimed_marks();
+  ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_stw_fullgc_mark);
 
   {
     StrongRootsScope srs(0);
@@ -261,8 +263,7 @@ void GenMarkSweep::mark_sweep_phase3() {
   // Adjust the pointers to reflect the new locations
   GCTraceTime(Info, gc, phases) tm("Phase 3: Adjust pointers", gc_timer());
 
-  // Need new claim bits for the pointer adjustment tracing.
-  ClassLoaderDataGraph::clear_claimed_marks();
+  ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_stw_fullgc_adjust);
 
   {
     StrongRootsScope srs(0);

--- a/src/hotspot/share/gc/serial/markSweep.cpp
+++ b/src/hotspot/share/gc/serial/markSweep.cpp
@@ -62,8 +62,8 @@ StringDedup::Requests*  MarkSweep::_string_dedup_requests = NULL;
 MarkSweep::FollowRootClosure  MarkSweep::follow_root_closure;
 
 MarkAndPushClosure MarkSweep::mark_and_push_closure;
-CLDToOopClosure    MarkSweep::follow_cld_closure(&mark_and_push_closure, ClassLoaderData::_claim_strong);
-CLDToOopClosure    MarkSweep::adjust_cld_closure(&adjust_pointer_closure, ClassLoaderData::_claim_strong);
+CLDToOopClosure    MarkSweep::follow_cld_closure(&mark_and_push_closure, ClassLoaderData::_claim_stw_fullgc_mark);
+CLDToOopClosure    MarkSweep::adjust_cld_closure(&adjust_pointer_closure, ClassLoaderData::_claim_stw_fullgc_adjust);
 
 template <class T> inline void MarkSweep::KeepAliveClosure::do_oop_work(T* p) {
   mark_and_push(p);

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -628,6 +628,10 @@ void GenCollectedHeap::do_collection(bool           full,
     // Delete metaspaces for unloaded class loaders and clean up loader_data graph
     ClassLoaderDataGraph::purge(/*at_safepoint*/true);
     DEBUG_ONLY(MetaspaceUtils::verify();)
+
+    // Need to clear claim bits for the next mark.
+    ClassLoaderDataGraph::clear_claimed_marks();
+
     // Resize the metaspace capacity after full collections
     MetaspaceGC::compute_new_size();
     update_full_collections_completed();


### PR DESCRIPTION
Hi all,

  please review this change that implements the same optimization as [JDK-8295871](https://bugs.openjdk.org/browse/JDK-8295871) to use different claim marks for different full gc phases for Parallel and Serial GC. For both collectors I decided to clear all marks before full gc, but that is arbitrary. If you want this could be done at the end to the same effect.

Testing: tier1-5 (with JDK-8295871)

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296768](https://bugs.openjdk.org/browse/JDK-8296768): Use different explicit claim marks for CLDs in Parallel and Serial GC


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11092/head:pull/11092` \
`$ git checkout pull/11092`

Update a local copy of the PR: \
`$ git checkout pull/11092` \
`$ git pull https://git.openjdk.org/jdk pull/11092/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11092`

View PR using the GUI difftool: \
`$ git pr show -t 11092`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11092.diff">https://git.openjdk.org/jdk/pull/11092.diff</a>

</details>
