### PR TITLE
8296171: Compiler incorrectly rejects code with variadic method references

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -3111,7 +3111,8 @@ public class Resolve {
         boundSearchResolveContext.methodCheck = methodCheck;
         Symbol boundSym = lookupMethod(boundEnv, env.tree.pos(),
                 site.tsym, boundSearchResolveContext, boundLookupHelper);
-        ReferenceLookupResult boundRes = new ReferenceLookupResult(boundSym, boundSearchResolveContext);
+        boolean isStaticSelector = TreeInfo.isStaticSelector(referenceTree.expr, names);
+        ReferenceLookupResult boundRes = new ReferenceLookupResult(boundSym, boundSearchResolveContext, isStaticSelector);
         if (dumpMethodReferenceSearchResults) {
             dumpMethodReferenceSearchResults(referenceTree, boundSearchResolveContext, boundSym, true);
         }
@@ -3127,7 +3128,7 @@ public class Resolve {
             unboundSearchResolveContext.methodCheck = methodCheck;
             unboundSym = lookupMethod(unboundEnv, env.tree.pos(),
                     site.tsym, unboundSearchResolveContext, unboundLookupHelper);
-            unboundRes = new ReferenceLookupResult(unboundSym, unboundSearchResolveContext);
+            unboundRes = new ReferenceLookupResult(unboundSym, unboundSearchResolveContext, isStaticSelector);
             if (dumpMethodReferenceSearchResults) {
                 dumpMethodReferenceSearchResults(referenceTree, unboundSearchResolveContext, unboundSym, false);
             }
@@ -3238,8 +3239,8 @@ public class Resolve {
         /** The lookup result. */
         Symbol sym;
 
-        ReferenceLookupResult(Symbol sym, MethodResolutionContext resolutionContext) {
-            this(sym, staticKind(sym, resolutionContext));
+        ReferenceLookupResult(Symbol sym, MethodResolutionContext resolutionContext, boolean isStaticSelector) {
+            this(sym, staticKind(sym, resolutionContext, isStaticSelector));
         }
 
         private ReferenceLookupResult(Symbol sym, StaticKind staticKind) {
@@ -3247,17 +3248,17 @@ public class Resolve {
             this.sym = sym;
         }
 
-        private static StaticKind staticKind(Symbol sym, MethodResolutionContext resolutionContext) {
-            switch (sym.kind) {
-                case MTH:
-                case AMBIGUOUS:
-                    return resolutionContext.candidates.stream()
-                            .filter(c -> c.isApplicable() && c.step == resolutionContext.step)
-                            .map(c -> StaticKind.from(c.sym))
-                            .reduce(StaticKind::reduce)
-                            .orElse(StaticKind.UNDEFINED);
-                default:
-                    return StaticKind.UNDEFINED;
+        private static StaticKind staticKind(Symbol sym, MethodResolutionContext resolutionContext, boolean isStaticSelector) {
+            if (sym.kind == MTH && !isStaticSelector) {
+                return StaticKind.from(sym);
+            } else if (sym.kind == MTH || sym.kind == AMBIGUOUS) {
+                return resolutionContext.candidates.stream()
+                        .filter(c -> c.isApplicable() && c.step == resolutionContext.step)
+                        .map(c -> StaticKind.from(c.sym))
+                        .reduce(StaticKind::reduce)
+                        .orElse(StaticKind.UNDEFINED);
+            } else {
+                return StaticKind.UNDEFINED;
             }
         }
 

--- a/test/langtools/tools/javac/lambda/methodReference/BoundUnboundSearchTest.java
+++ b/test/langtools/tools/javac/lambda/methodReference/BoundUnboundSearchTest.java
@@ -132,5 +132,25 @@ public class BoundUnboundSearchTest extends CompilationTestCase {
                 }
                 """
         );
+
+        assertOK(
+                getDiagConsumer(0, -1),
+                """
+                import java.util.function.*;
+                
+                interface Intf {
+                    Object apply(String... args);
+                }
+                                
+                public class Test {
+                    public static Object foo(Object o) { return "bar"; }
+                    public final Object foo(Object... o) { return "foo"; }
+                                
+                    public void test() {
+                        Intf f = this::foo;
+                    }
+                }
+                """
+        );
     }
 }

--- a/test/langtools/tools/javac/lambda/methodReference/BoundUnboundSearchTest.java
+++ b/test/langtools/tools/javac/lambda/methodReference/BoundUnboundSearchTest.java
@@ -137,15 +137,15 @@ public class BoundUnboundSearchTest extends CompilationTestCase {
                 getDiagConsumer(0, -1),
                 """
                 import java.util.function.*;
-                
+
                 interface Intf {
                     Object apply(String... args);
                 }
-                                
+
                 public class Test {
                     public static Object foo(Object o) { return "bar"; }
                     public final Object foo(Object... o) { return "foo"; }
-                                
+
                     public void test() {
                         Intf f = this::foo;
                     }


### PR DESCRIPTION
Please review this PR that is syncing javac with the spec. Javac is rejecting this code:

```
import java.util.function.*;
interface Intf {
    Object apply(String... args);
}
                
public class Test {
    public static Object foo(Object o) { return "bar"; }
    public final Object foo(Object... o) { return "foo"; }
                
    public void test() {
        Intf f = this::foo;
    }
}
```

javac indicates that the method reference is invalid when according to the spec the second `foo` method should be selected by the compiler. The related section of the spec can be found at section `15.13.1 Compile-Time Declaration of a Method Reference`: 

```
  – For all other forms of method reference expression, one search for a most
  specific applicable method is performed. The search is as specified in
  §15.12.2.2 through §15.12.2.5, with the clarifications below.
  The method reference is treated as if it were an invocation with argument
  expressions of types P 1 , ..., P n ; the type arguments, if any, are given by the
  method reference expression.
  If the search results in an error as specified in §15.12.2.2 through §15.12.2.5,
  or if the most specific applicable method is static , there is no compile-time
  declaration.
  Otherwise, the compile-time declaration is the most specific applicable
  method.
```


Actually the method search is correct but later on javac is seeing that both methods are applicable and given that they have different staticness, it is making wrong assumptions down the road.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296171](https://bugs.openjdk.org/browse/JDK-8296171): Compiler incorrectly rejects code with variadic method references


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [1cd68fe4](https://git.openjdk.org/jdk/pull/11093/files/1cd68fe4954d44bc335c8bf7cce96902e5d71b3d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11093/head:pull/11093` \
`$ git checkout pull/11093`

Update a local copy of the PR: \
`$ git checkout pull/11093` \
`$ git pull https://git.openjdk.org/jdk pull/11093/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11093`

View PR using the GUI difftool: \
`$ git pr show -t 11093`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11093.diff">https://git.openjdk.org/jdk/pull/11093.diff</a>

</details>
