### PR TITLE
8295315: [REDO] 8276687 Remove support for JDK 1.4.1 PerfData shared memory files

### DIFF
--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/LocalVmManager.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/LocalVmManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,6 @@ import java.io.*;
 public class LocalVmManager {
     private FilenameFilter userDirFilter;
     private FilenameFilter userDirFileFilter;
-    private FilenameFilter oldtmpFileFilter;
 
     /**
      * Creates a LocalVmManager instance for the local system.
@@ -53,7 +52,7 @@ public class LocalVmManager {
      * has appropriate permissions.
      */
     public LocalVmManager() {
-        // 1.4.2 and later: The files are in {tmpdir}/hsperfdata_{any_user_name}/[0-9]+
+        // The files are in {tmpdir}/hsperfdata_{any_user_name}/[0-9]+
         Pattern userDirPattern = Pattern.compile(PerfDataFile.userDirNamePattern);
         userDirFilter = new FilenameFilter() {
             public boolean accept(File dir, String name) {
@@ -65,15 +64,6 @@ public class LocalVmManager {
         userDirFileFilter = new FilenameFilter() {
             public boolean accept(File dir, String name) {
                 return userDirFilePattern.matcher(name).matches();
-            }
-        };
-
-        // 1.4.1 (or earlier?): the files are stored directly under {tmpdir}/ with
-        // the following pattern.
-        Pattern oldtmpFilePattern = Pattern.compile(PerfDataFile.tmpFileNamePattern);
-        oldtmpFileFilter = new FilenameFilter() {
-            public boolean accept(File dir, String name) {
-                return oldtmpFilePattern.matcher(name).matches();
             }
         };
     }
@@ -100,7 +90,7 @@ public class LocalVmManager {
             }
 
 
-            // 1.4.2 and later: Look for the files {tmpdir}/hsperfdata_{any_user_name}/[0-9]+
+            // Look for the files {tmpdir}/hsperfdata_{any_user_name}/[0-9]+
             // that are readable by the current user.
             File[] dirs = tmpdir.listFiles(userDirFilter);
             for (File subDir : dirs) {
@@ -121,20 +111,6 @@ public class LocalVmManager {
                     }
                 }
             }
-
-            // look for any 1.4.1 files that are readable by the current user.
-            File[] files = tmpdir.listFiles(oldtmpFileFilter);
-            if (files != null) {
-                for (File file : files) {
-                    if (file.isFile() && file.canRead()) {
-                        int vmid = PerfDataFile.getLocalVmId(file);
-                        if (vmid != -1) {
-                            jvmSet.add(vmid);
-                        }
-                    }
-                }
-            }
-
         }
         return jvmSet;
     }

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/PerfDataBuffer.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/PerfDataBuffer.java
@@ -61,33 +61,8 @@ public class PerfDataBuffer extends AbstractPerfDataBuffer {
      */
     public PerfDataBuffer(VmIdentifier vmid) throws MonitorException {
         try {
-            // Try 1.4.2 and later first
             ByteBuffer bb = perf.attach(vmid.getLocalVmId());
             createPerfDataBuffer(bb, vmid.getLocalVmId());
-
-        } catch (IllegalArgumentException e) {
-            // now try 1.4.1 by attempting to directly map the files.
-            try {
-                String filename = PerfDataFile.getTempDirectory()
-                                  + PerfDataFile.dirNamePrefix
-                                  + Integer.toString(vmid.getLocalVmId());
-
-                File f = new File(filename);
-
-                FileChannel fc = new RandomAccessFile(f, "r").getChannel();
-                ByteBuffer bb = fc.map(FileChannel.MapMode.READ_ONLY, 0L,
-                                       (int)fc.size());
-                fc.close();
-                createPerfDataBuffer(bb, vmid.getLocalVmId());
-
-            } catch (FileNotFoundException e2) {
-                // re-throw the exception from the 1.4.2 attach method
-                throw new MonitorException(vmid.getLocalVmId() + " not found",
-                                           e);
-            } catch (IOException e2) {
-                throw new MonitorException("Could not map 1.4.1 file for "
-                                           + vmid.getLocalVmId(), e2);
-            }
         } catch (IOException e) {
             throw new MonitorException("Could not attach to "
                                        + vmid.getLocalVmId(), e);

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/PerfDataBuffer.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/PerfDataBuffer.java
@@ -63,7 +63,7 @@ public class PerfDataBuffer extends AbstractPerfDataBuffer {
         try {
             ByteBuffer bb = perf.attach(vmid.getLocalVmId());
             createPerfDataBuffer(bb, vmid.getLocalVmId());
-        } catch (IOException e) {
+        } catch (IOException | IllegalArgumentException e) {
             throw new MonitorException("Could not attach to "
                                        + vmid.getLocalVmId(), e);
         }

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/PerfDataFile.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/PerfDataFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,19 +64,10 @@ public class PerfDataFile {
      * The file name pattern for PerfData shared memory files.
      * <p>
      * This pattern must be kept in synch with the file name pattern
-     * used by the 1.4.2 and later HotSpot JVM.
+     * used by the 1.4.2 and later HotSpot JVM. Earlier versions are
+     * no longer supported.
      */
     public static final String fileNamePattern = "^[0-9]+$";
-
-    /**
-     * The file name pattern for 1.4.1 PerfData shared memory files.
-     * <p>
-     * This pattern must be kept in synch with the file name pattern
-     * used by the 1.4.1 HotSpot JVM.
-     */
-    public static final String tmpFileNamePattern =
-            "^hsperfdata_[0-9]+(_[1-2]+)?$";
-
 
     /**
      * Platform Specific methods for looking up temporary directories
@@ -97,24 +88,10 @@ public class PerfDataFile {
      */
     public static int getLocalVmId(File file) {
         try {
-            // try 1.4.2 and later format first
             return(platSupport.getLocalVmId(file));
         } catch (NumberFormatException e) { }
 
-        // now try the 1.4.1 format
-        String name = file.getName();
-        if (name.startsWith(dirNamePrefix)) {
-            int first = name.indexOf('_');
-            int last = name.lastIndexOf('_');
-            try {
-                if (first == last) {
-                    return Integer.parseInt(name.substring(first + 1));
-                } else {
-                    return Integer.parseInt(name.substring(first + 1, last));
-                }
-            } catch (NumberFormatException e) { }
-        }
-        throw new IllegalArgumentException("file name does not match pattern");
+        throw new IllegalArgumentException("Cannot convert '" + file + "' to VM id");
     }
 
     /**


### PR DESCRIPTION
Here's redo for https://github.com/openjdk/jdk/pull/10687. This PR has two commits:
- 739b79afb1965b625b2002187ac3fd43f385a639 is the same as in the original PR
- 78455c024ec5c00f1a0ce6c0e13df477c3063fe1 fixes the bug in the original PR.

I have run tiers 1 - 4 so hopefully I got it right this time :-)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295315](https://bugs.openjdk.org/browse/JDK-8295315): [REDO] 8276687 Remove support for JDK 1.4.1 PerfData shared memory files


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11094/head:pull/11094` \
`$ git checkout pull/11094`

Update a local copy of the PR: \
`$ git checkout pull/11094` \
`$ git pull https://git.openjdk.org/jdk pull/11094/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11094`

View PR using the GUI difftool: \
`$ git pr show -t 11094`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11094.diff">https://git.openjdk.org/jdk/pull/11094.diff</a>

</details>
