### PR TITLE
8295861: get rid of list argument in debug agent's removeNode() API

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -314,14 +314,14 @@ findRunningThread(jthread thread)
 
 /* Remove a ThreadNode from a ThreadList */
 static void
-removeNode(ThreadList *list, ThreadNode *node)
+removeNode(ThreadNode *node)
 {
     ThreadNode *prev;
     ThreadNode *next;
-
-    JDI_ASSERT(list == node->list);
+    ThreadList *list;
     prev = node->prev;
     next = node->next;
+    list = node->list;
     if ( prev != NULL ) {
         prev->next = next;
     }
@@ -491,7 +491,7 @@ static void
 removeThread(JNIEnv *env, ThreadNode *node)
 {
   JDI_ASSERT(node != NULL);
-  removeNode(node->list, node);
+  removeNode(node);
   clearThread(env, node);
 }
 
@@ -517,7 +517,7 @@ removeVThreads(JNIEnv *env)
     ThreadNode *node = list->first;
     while (node != NULL) {
         ThreadNode *temp = node->next;
-        removeNode(list, node);
+        removeNode(node);
         clearThread(env, node);
         node = temp;
     }
@@ -526,7 +526,7 @@ removeVThreads(JNIEnv *env)
 static void
 moveNode(ThreadList *source, ThreadList *dest, ThreadNode *node)
 {
-    removeNode(source, node);
+    removeNode(node);
     JDI_ASSERT(findThread(dest, node->thread) == NULL);
     addNode(dest, node);
 }


### PR DESCRIPTION
Get rid of `list` argument in debug agent's `removeNode()` API. The list is stored in the node, so no need to pass it in.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295861](https://bugs.openjdk.org/browse/JDK-8295861): get rid of list argument in debug agent's removeNode() API


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11101/head:pull/11101` \
`$ git checkout pull/11101`

Update a local copy of the PR: \
`$ git checkout pull/11101` \
`$ git pull https://git.openjdk.org/jdk pull/11101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11101`

View PR using the GUI difftool: \
`$ git pr show -t 11101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11101.diff">https://git.openjdk.org/jdk/pull/11101.diff</a>

</details>
