### PR TITLE
8298449: Unnecessary Vector usage in MetaData.ProxyPersistenceDelegate

### DIFF
--- a/src/java.desktop/share/classes/java/beans/MetaData.java
+++ b/src/java.desktop/share/classes/java/beans/MetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -155,9 +155,8 @@ static final class ProxyPersistenceDelegate extends PersistenceDelegate {
         // This unappealing hack is not required but makes the
         // representation of EventHandlers much more concise.
         java.lang.reflect.InvocationHandler ih = java.lang.reflect.Proxy.getInvocationHandler(p);
-        if (ih instanceof EventHandler) {
-            EventHandler eh = (EventHandler)ih;
-            Vector<Object> args = new Vector<>();
+        if (ih instanceof EventHandler eh) {
+            ArrayList<Object> args = new ArrayList<>();
             args.add(type.getInterfaces()[0]);
             args.add(eh.getTarget());
             args.add(eh.getAction());
@@ -165,7 +164,9 @@ static final class ProxyPersistenceDelegate extends PersistenceDelegate {
                 args.add(eh.getEventPropertyName());
             }
             if (eh.getListenerMethodName() != null) {
-                args.setSize(4);
+                if (args.size() == 3) {
+                    args.add(null);
+                }
                 args.add(eh.getListenerMethodName());
             }
             return new Expression(oldInstance,


### PR DESCRIPTION
`Vector<Object> args` is used only in single method and then it converted to `Object[]`.
So we can avoid usage of legacy synchronized `Vector` here and use `ArrayList` instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298449](https://bugs.openjdk.org/browse/JDK-8298449): Unnecessary Vector usage in MetaData.ProxyPersistenceDelegate


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11103/head:pull/11103` \
`$ git checkout pull/11103`

Update a local copy of the PR: \
`$ git checkout pull/11103` \
`$ git pull https://git.openjdk.org/jdk pull/11103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11103`

View PR using the GUI difftool: \
`$ git pr show -t 11103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11103.diff">https://git.openjdk.org/jdk/pull/11103.diff</a>

</details>
