### PR TITLE
8293862: javax/swing/JFileChooser/8046391/bug8046391.java failed with 'Cannot invoke "java.awt.Image.getWidth(java.awt.image.ImageObserver)" because "retVal" is null'

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
@@ -1437,7 +1437,7 @@ final class Win32ShellFolder2 extends ShellFolder {
                     }
                 }
             }
-            if (retVal.getWidth(null) != w) {
+            if ((retVal != null) && (retVal.getWidth(null) != w)) {
                 BufferedImage newVariant = new BufferedImage(w, w, BufferedImage.TYPE_INT_ARGB);
                 Graphics2D g2d = newVariant.createGraphics();
                 g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);

--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
@@ -1399,11 +1399,13 @@ final class Win32ShellFolder2 extends ShellFolder {
         final Map<Integer, Image> resolutionVariants = new HashMap<>();
 
         public MultiResolutionIconImage(int baseSize, Map<Integer, Image> resolutionVariants) {
+            assert !resolutionVariants.containsValue(null) : "There are null icons in the MRI variants map";
             this.baseSize = baseSize;
             this.resolutionVariants.putAll(resolutionVariants);
         }
 
         public MultiResolutionIconImage(int baseSize, Image image) {
+            assert image != null : "Null icons are added into MRI variants map";
             this.baseSize = baseSize;
             this.resolutionVariants.put(baseSize, image);
         }
@@ -1441,7 +1443,7 @@ final class Win32ShellFolder2 extends ShellFolder {
                     }
                 }
             }
-            if ((retVal != null) && (retVal.getWidth(null) != w)) {
+            if (retVal.getWidth(null) != w) {
                 BufferedImage newVariant = new BufferedImage(w, w, BufferedImage.TYPE_INT_ARGB);
                 Graphics2D g2d = newVariant.createGraphics();
                 g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);

--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
@@ -1405,7 +1405,7 @@ final class Win32ShellFolder2 extends ShellFolder {
         }
 
         public MultiResolutionIconImage(int baseSize, Image image) {
-            assert image != null : "Null icons are added into MRI variants map";
+            assert image != null : "Null icon passed as the base image for MRI";
             this.baseSize = baseSize;
             this.resolutionVariants.put(baseSize, image);
         }

--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
@@ -1176,6 +1176,10 @@ final class Win32ShellFolder2 extends ShellFolder {
                     newIcon = makeIcon(hIcon);
                     disposeIcon(hIcon);
 
+                    if (newIcon == null) {
+                        return null;
+                    }
+
                     multiResolutionIcon.put(s, newIcon);
                     if (size < MIN_QUALITY_ICON || size > MAX_QUALITY_ICON) {
                         break;

--- a/test/jdk/javax/swing/JFileChooser/8046391/bug8046391.java
+++ b/test/jdk/javax/swing/JFileChooser/8046391/bug8046391.java
@@ -27,6 +27,7 @@
  * @requires (os.family == "windows")
  * @summary JFileChooser hangs if displayed in Windows L&F
  * @author Alexey Ivanov
+ * @key headful
  * @library /test/lib
  * @modules java.desktop/com.sun.java.swing.plaf.windows
  * @build jdk.test.lib.Platform


### PR DESCRIPTION
Observation found when JFileChooser is instantiated in WindowsLookAndFeel which invokes getSystemIcon() from WindowsFileChooserUI class. Could not find the exact root cause so predicting it to be an issue with icons not loaded where resolutionVariants map is empty in _public Image getResolutionVariant(double width, double height) _. Hence proposing a null check before accessing getWidth(). Fix is tested in CI system.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ 8293862 is used in problem lists: [test/jdk/ProblemList.txt]

### Issue
 * [JDK-8293862](https://bugs.openjdk.org/browse/JDK-8293862): javax/swing/JFileChooser/8046391/bug8046391.java failed with 'Cannot invoke "java.awt.Image.getWidth(java.awt.image.ImageObserver)" because "retVal" is null'


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11104/head:pull/11104` \
`$ git checkout pull/11104`

Update a local copy of the PR: \
`$ git checkout pull/11104` \
`$ git pull https://git.openjdk.org/jdk pull/11104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11104`

View PR using the GUI difftool: \
`$ git pr show -t 11104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11104.diff">https://git.openjdk.org/jdk/pull/11104.diff</a>

</details>
