### PR TITLE
8296872: gtest is built with the build-jdk

### DIFF
--- a/make/hotspot/lib/CompileLibraries.gmk
+++ b/make/hotspot/lib/CompileLibraries.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,9 @@ include HotspotCommon.gmk
 include lib/CompileJvm.gmk
 
 ifneq ($(GTEST_FRAMEWORK_SRC), )
-  include lib/CompileGtest.gmk
+  ifneq ($(CREATING_BUILDJDK), true)
+    include lib/CompileGtest.gmk
+  endif
 endif
 
 include CopyToExplodedJdk.gmk


### PR DESCRIPTION
The build-jdk is a JDK built on the current sources that can execute on the build platform. This is needed when cross-compiling, in addition to the boot-jdk (which runs on the build platform, but is an older version of the JDK), and is different from the JDK resulting from the build (which can only execute on the target platform).

If we do not supply a pre-built build-jdk, the build system creates a new, on the fly, before starting the compilation proper. 

This build-jdk includes gtest for hotspot, if available. This is just a waste of resources (and actually triggered a bug; which is how it was discovered).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296872](https://bugs.openjdk.org/browse/JDK-8296872): gtest is built with the build-jdk


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)


### Contributors
 * Mikael Vidstedt `<mikael@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11106/head:pull/11106` \
`$ git checkout pull/11106`

Update a local copy of the PR: \
`$ git checkout pull/11106` \
`$ git pull https://git.openjdk.org/jdk pull/11106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11106`

View PR using the GUI difftool: \
`$ git pr show -t 11106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11106.diff">https://git.openjdk.org/jdk/pull/11106.diff</a>

</details>
