### PR TITLE
8296846: Minor cleanup of some dead code in Flow.java

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -2175,10 +2175,6 @@ public class Flow {
             Lint lintPrev = lint;
             lint = lint.augment(tree.sym);
             try {
-                if (tree.sym == null) {
-                    return;
-                }
-
                 JCClassDecl classDefPrev = classDef;
                 int firstadrPrev = firstadr;
                 int nextadrPrev = nextadr;
@@ -2265,15 +2261,6 @@ public class Flow {
             Lint lintPrev = lint;
             lint = lint.augment(tree.sym);
             try {
-                if (tree.body == null) {
-                    return;
-                }
-                /*  Ignore synthetic methods, except for translated lambda methods.
-                 */
-                if ((tree.sym.flags() & (SYNTHETIC | LAMBDA_METHOD)) == SYNTHETIC) {
-                    return;
-                }
-
                 final Bits initsPrev = new Bits(inits);
                 final Bits uninitsPrev = new Bits(uninits);
                 int nextadrPrev = nextadr;


### PR DESCRIPTION
This patch removes two bits of dead code that I ran across.

The only interesting bit is the second patch, which removes this check:
```java
                /*  Ignore synthetic methods, except for translated lambda methods.
                 */
                if ((tree.sym.flags() & (SYNTHETIC | LAMBDA_METHOD)) == SYNTHETIC) {
                    return;
                }
```
because it's always preceded by this more general check:
```java
             /*  MemberEnter can generate synthetic methods ignore them
              */
             if ((tree.sym.flags() & SYNTHETIC) != 0) {
                 return;
             }
```
and so can never match.

So the patch preserves the existing behavior, but the bit being removed there begs the question: was there some scenario where `tree.sym.flags()` could have both `SYNTHETIC` and `LAMBDA_METHOD` that we were supposed to be handling?

As it turns out, the `LAMBDA_METHOD` flag is only ever set by `LambdaToMethod`, but that class runs after this code (during flow analysis). So if there ever was any such scenario, it can no longer happen anyway.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296846](https://bugs.openjdk.org/browse/JDK-8296846): Minor cleanup of some dead code in Flow.java


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11112/head:pull/11112` \
`$ git checkout pull/11112`

Update a local copy of the PR: \
`$ git checkout pull/11112` \
`$ git pull https://git.openjdk.org/jdk pull/11112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11112`

View PR using the GUI difftool: \
`$ git pr show -t 11112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11112.diff">https://git.openjdk.org/jdk/pull/11112.diff</a>

</details>
