### PR TITLE
8296821: compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java fails after JDK-8262901

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -46,7 +46,6 @@
 compiler/ciReplay/TestSAServer.java 8029528 generic-all
 compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java 8225370 generic-all
 compiler/jvmci/compilerToVM/GetFlagValueTest.java 8204459 generic-all
-compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java 8296821 generic-all
 compiler/tiered/LevelTransitionTest.java 8067651 generic-all
 
 compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java 8190680 generic-all

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java
@@ -159,7 +159,13 @@ public class NativeCallTest extends CodeInstallationTest {
                 asm.emitCallPrologue(cc, values);
                 asm.emitCall(addr);
                 asm.emitCallEpilogue(cc);
-                asm.emitFloatRet(((RegisterValue) cc.getReturn()).getRegister());
+                if (returnClazz == float.class) {
+                    asm.emitFloatRet(((RegisterValue) cc.getReturn()).getRegister());
+                } else if (returnClazz == int.class) {
+                    asm.emitIntRet(((RegisterValue) cc.getReturn()).getRegister());
+                } else {
+                    assert false : "Unimplemented return type: " + returnClazz;
+                }
             }, getMethod(name, types), values);
         } catch (Throwable e) {
             e.printStackTrace();

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/amd64/AMD64TestAssembler.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/amd64/AMD64TestAssembler.java
@@ -403,8 +403,7 @@ public class AMD64TestAssembler extends TestAssembler {
 
     @Override
     public void emitCallPrologue(CallingConvention cc, Object... prim) {
-        emitGrowStack(cc.getStackSize());
-        frameSize += cc.getStackSize();
+        growFrame(cc.getStackSize());
         AllocatableValue[] args = cc.getArguments();
         // Do the emission in reverse, this avoids register collisons of xmm0 - which is used a
         // scratch register when putting arguments on the stack.
@@ -427,7 +426,6 @@ public class AMD64TestAssembler extends TestAssembler {
 
     @Override
     public void emitCallEpilogue(CallingConvention cc) {
-        emitGrowStack(-cc.getStackSize());
-        frameSize -= cc.getStackSize();
+        growFrame(-cc.getStackSize());
     }
 }


### PR DESCRIPTION
This is a fix for a bug in the test that was added by [JDK-8262901](https://bugs.openjdk.org/browse/JDK-8262901).
The root cause of the issue was because the test returns 'int' while 'float' was expected. 

In addition the stack growth considering 16 bytes alignment in AMD64TestAssembler is fixed (similar to AArch64TestAssembler).

Tested on macOS x64 / AArch64, Linux x64 / AArch64 as follow:
` $JTREG_HOME/bin/jtreg -ea -jdk:$BUILD_HOME -nativepath:$NATIVE_PATH ./test/hotspot/jtreg/compiler/jvmci/`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296821](https://bugs.openjdk.org/browse/JDK-8296821): compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java fails after JDK-8262901


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11114/head:pull/11114` \
`$ git checkout pull/11114`

Update a local copy of the PR: \
`$ git checkout pull/11114` \
`$ git pull https://git.openjdk.org/jdk pull/11114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11114`

View PR using the GUI difftool: \
`$ git pr show -t 11114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11114.diff">https://git.openjdk.org/jdk/pull/11114.diff</a>

</details>
