### PR TITLE
8295886: Eliminate field maxThawingSize of StackChunk

### DIFF
--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -532,7 +532,6 @@
   template(during_unsafe_access_name,                 "during_unsafe_access")                     \
   template(checkIndex_name,                           "checkIndex")                               \
   template(jfr_epoch_name,                            "jfr_epoch")                                \
-  template(maxThawingSize_name,                       "maxThawingSize")                           \
                                                                                                   \
   /* name symbols needed by intrinsics */                                                         \
   VM_INTRINSICS_DO(VM_INTRINSIC_IGNORE, VM_SYMBOL_IGNORE, template, VM_SYMBOL_IGNORE, VM_ALIAS_IGNORE) \

--- a/src/hotspot/share/oops/instanceStackChunkKlass.cpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.cpp
@@ -244,8 +244,8 @@ void InstanceStackChunkKlass::print_chunk(const stackChunkOop c, bool verbose, o
   st->print_cr("       barriers: %d gc_mode: %d bitmap: %d parent: " PTR_FORMAT,
                c->requires_barriers(), c->is_gc_mode(), c->has_bitmap(), p2i(c->parent()));
   st->print_cr("       flags mixed: %d", c->has_mixed_frames());
-  st->print_cr("       size: %d argsize: %d max_size: %d sp: %d pc: " PTR_FORMAT,
-               c->stack_size(), c->argsize(), c->max_thawing_size(), c->sp(), p2i(c->pc()));
+  st->print_cr("       size: %d argsize: %d sp: %d pc: " PTR_FORMAT,
+               c->stack_size(), c->argsize(), c->sp(), p2i(c->pc()));
 
   if (verbose) {
     st->cr();

--- a/src/hotspot/share/oops/stackChunkOop.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.hpp
@@ -76,6 +76,8 @@ public:
 
   inline int stack_size() const;
 
+  inline int stack_used() const;
+
   inline int sp() const;
   inline void set_sp(int value);
 
@@ -89,9 +91,6 @@ public:
   inline uint8_t flags_acquire() const;
   inline void set_flags(uint8_t value);
   inline void release_set_flags(uint8_t value);
-
-  inline int max_thawing_size() const;
-  inline void set_max_thawing_size(int value);
 
   inline oop cont() const;
   template<typename P> inline oop cont() const;

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -57,6 +57,8 @@ inline void stackChunkOopDesc::set_parent_access(oop value)    { jdk_internal_vm
 
 inline int stackChunkOopDesc::stack_size() const        { return jdk_internal_vm_StackChunk::size(as_oop()); }
 
+inline int stackChunkOopDesc::stack_used() const        { return stack_size() - sp(); }
+
 inline int stackChunkOopDesc::sp() const                { return jdk_internal_vm_StackChunk::sp(as_oop()); }
 inline void stackChunkOopDesc::set_sp(int value)        { jdk_internal_vm_StackChunk::set_sp(this, value); }
 
@@ -77,12 +79,6 @@ inline void stackChunkOopDesc::release_set_flags(uint8_t value) {
 
 inline bool stackChunkOopDesc::try_set_flags(uint8_t prev_flags, uint8_t new_flags) {
   return jdk_internal_vm_StackChunk::try_set_flags(this, prev_flags, new_flags);
-}
-
-inline int stackChunkOopDesc::max_thawing_size() const          { return jdk_internal_vm_StackChunk::maxThawingSize(as_oop()); }
-inline void stackChunkOopDesc::set_max_thawing_size(int value)  {
-  assert(value >= 0, "size must be >= 0");
-  jdk_internal_vm_StackChunk::set_maxThawingSize(this, (jint)value);
 }
 
 inline oop stackChunkOopDesc::cont() const              { return UseCompressedOops ? cont<narrowOop>() : cont<oop>(); /* jdk_internal_vm_StackChunk::cont(as_oop()); */ }

--- a/src/hotspot/share/runtime/continuationJavaClasses.cpp
+++ b/src/hotspot/share/runtime/continuationJavaClasses.cpp
@@ -86,7 +86,6 @@ int jdk_internal_vm_StackChunk::_sp_offset;
 int jdk_internal_vm_StackChunk::_pc_offset;
 int jdk_internal_vm_StackChunk::_argsize_offset;
 int jdk_internal_vm_StackChunk::_flags_offset;
-int jdk_internal_vm_StackChunk::_maxThawingSize_offset;
 int jdk_internal_vm_StackChunk::_cont_offset;
 
 #define STACKCHUNK_FIELDS_DO(macro) \

--- a/src/hotspot/share/runtime/continuationJavaClasses.hpp
+++ b/src/hotspot/share/runtime/continuationJavaClasses.hpp
@@ -80,7 +80,6 @@ class jdk_internal_vm_Continuation: AllStatic {
   macro(jdk_internal_vm_StackChunk, cont,           continuation_signature, false) \
   macro(jdk_internal_vm_StackChunk, flags,          byte_signature,         false) \
   macro(jdk_internal_vm_StackChunk, pc,             intptr_signature,       false) \
-  macro(jdk_internal_vm_StackChunk, maxThawingSize, int_signature,          false) \
 
 class jdk_internal_vm_StackChunk: AllStatic {
   friend class JavaClasses;
@@ -91,7 +90,6 @@ class jdk_internal_vm_StackChunk: AllStatic {
   static int _pc_offset;
   static int _argsize_offset;
   static int _flags_offset;
-  static int _maxThawingSize_offset;
   static int _cont_offset;
 
 
@@ -127,9 +125,6 @@ class jdk_internal_vm_StackChunk: AllStatic {
   static inline uint8_t flags_acquire(oop chunk);
   static inline void release_set_flags(oop chunk, uint8_t value);
   static inline bool try_set_flags(oop chunk, uint8_t expected_value, uint8_t new_value);
-
-  static inline int maxThawingSize(oop chunk);
-  static inline void set_maxThawingSize(oop chunk, int value);
 
  // cont oop's processing is essential for the chunk's GC protocol
   static inline oop cont(oop chunk);

--- a/src/hotspot/share/runtime/continuationJavaClasses.inline.hpp
+++ b/src/hotspot/share/runtime/continuationJavaClasses.inline.hpp
@@ -187,16 +187,4 @@ inline bool jdk_internal_vm_StackChunk::try_set_flags(oop chunk, uint8_t expecte
   return Atomic::cmpxchg(chunk->field_addr<uint8_t>(_flags_offset), expected_value, new_value) == expected_value;
 }
 
-inline int jdk_internal_vm_StackChunk::maxThawingSize(oop chunk) {
-  return chunk->int_field(_maxThawingSize_offset);
-}
-
-inline void jdk_internal_vm_StackChunk::set_maxThawingSize(oop chunk, int value) {
-#ifdef ASSERT
-  jint old = maxThawingSize(chunk);
-  log_develop_trace(continuations)("%s max_size: %d -> %d", value >= old ? "add" : "sub", old, value);
-#endif
-  chunk->int_field_put(_maxThawingSize_offset, value);
-}
-
 #endif // SHARE_RUNTIME_CONTINUATIONJAVACLASSES_INLINE_HPP


### PR DESCRIPTION
Hi,

this pr simplifies continuations by removing the injected field `jdk.internal.vm.StackChunk::maxThawingSize` and the logic to compute and update its value.

Please refer to the the JBS item for an explanation why the field is redundant.

The change is split into 3 commits. The first is the actual removal of `maxThawingSize`. The second just moves code. The last one introduces the constant `ThawBase::max_num_frames_slow` which is used in the thawing size calculation and in an assertion check that not more frames are thawed on the slow path.

The change passed our CI testing: most JCK and JTREG tests, also in Xcomp mode, SPECjvm2008, SPECjbb2015, Renaissance Suite and SAP specific tests with fastdebug and release builds on the standard platforms plus PPC64. These tests do include hotspot_loom and jdk_loom JTREG tests which I've also run with TEST_VM_OPTS="-XX:+VerifyContinuations" on X86_64, PPC64, and AARCH64.

Thanks, Richard.