### PR TITLE
JDK-8296906: VMError::controlled_crash crashes with wrong code and address

### DIFF
--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2017, 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2017, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -187,9 +187,8 @@ public:
 
   DEBUG_ONLY(static void controlled_crash(int how);)
 
-  // Address which is guaranteed to generate a fault on read, for test purposes,
-  // which is not NULL and contains bits in every word.
-  static const intptr_t segfault_address = LP64_ONLY(0xABC0000000000ABCULL) NOT_LP64(0x00000ABC);
+  // Non-NULL address guaranteed to generate a SEGV mapping error on read, for test purposes.
+  static constexpr intptr_t segfault_address = (1 * K) AIX_ONLY(+ (4 * K));
 
   // Max value for the ErrorLogPrintCodeLimit flag.
   static const int max_error_log_print_code = 10;

--- a/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
@@ -91,7 +91,7 @@ public class HsErrFileUtils {
 
         if (currentPattern < patterns.length) {
             throw new RuntimeException("hs-err file incomplete (found " + currentPattern + " matching pattern, " +
-                                       "first missing pattern: " +  patterns[currentPattern] + ")");
+                                       "first missing pattern: " + patterns[currentPattern] + ")");
         }
 
         if (!lastLine.equals("END.")) {

--- a/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
@@ -32,7 +32,7 @@ public class HsErrFileUtils {
     /**
      * Given the output of a java VM that crashed, extract the name of the hs-err file from the output
      */
-    static public String extractHsErrFileNameFromOutput(OutputAnalyzer output) {
+    public static String extractHsErrFileNameFromOutput(OutputAnalyzer output) {
         output.shouldMatch("# A fatal error has been detected.*");
 
         // extract hs-err file

--- a/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
@@ -50,7 +50,7 @@ public class HsErrFileUtils {
      * @param output
      * @return
      */
-    static public File openHsErrFileFromOutput(OutputAnalyzer output) {
+    public static File openHsErrFileFromOutput(OutputAnalyzer output) {
         String name = extractHsErrFileNameFromOutput(output);
         File f = new File(name);
         if (!f.exists()) {
@@ -63,7 +63,7 @@ public class HsErrFileUtils {
      * Given an open hs-err file, read it line by line and check for pattern. Pattern
      * need to appear in order, but not necessarily uninterrupted.
      */
-    static public void checkHsErrFileContent(File f, Pattern[] patterns, boolean verbose) throws IOException {
+    public static void checkHsErrFileContent(File f, Pattern[] patterns, boolean verbose) throws IOException {
 
         FileInputStream fis = new FileInputStream(f);
         BufferedReader br = new BufferedReader(new InputStreamReader(fis));

--- a/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
@@ -1,0 +1,81 @@
+import jdk.test.lib.process.OutputAnalyzer;
+
+import java.io.*;
+import java.util.regex.Pattern;
+
+public class HsErrFileUtils {
+
+    /**
+     * Given the output of a java VM that crashed, extract the name of the hs-err file from the output
+     */
+    static public String extractHsErrFileNameFromOutput(OutputAnalyzer output) {
+        output.shouldMatch("# A fatal error has been detected.*");
+
+        // extract hs-err file
+        String hs_err_file = output.firstMatch("# *(\\S*hs_err_pid\\d+\\.log)", 1);
+        if (hs_err_file == null) {
+            throw new RuntimeException("Did not find hs-err file in output.\n");
+        }
+
+        return hs_err_file;
+    }
+
+    /**
+     * Given the output of a java VM that crashed, extract the name of the hs-err file from the output,
+     * open that file and return its File.
+     * @param output
+     * @return
+     */
+    static public File openHsErrFileFromOutput(OutputAnalyzer output) {
+        String name = extractHsErrFileNameFromOutput(output);
+        File f = new File(name);
+        if (!f.exists()) {
+            throw new RuntimeException("Cannot find hs-err file at " + f.getAbsolutePath());
+        }
+        return f;
+    }
+
+    /**
+     * Given an open hs-err file, read it line by line and check for pattern. Pattern
+     * need to appear in order, but not necessarily uninterrupted.
+     */
+    static public void checkHsErrFileContent(File f, Pattern[] patterns, boolean verbose) throws IOException {
+
+        FileInputStream fis = new FileInputStream(f);
+        BufferedReader br = new BufferedReader(new InputStreamReader(fis));
+        String line = null;
+
+        int currentPattern = 0;
+
+        String lastLine = null;
+        while ((line = br.readLine()) != null) {
+            if (verbose) {
+                System.out.println(line);
+            }
+            if (currentPattern < patterns.length) {
+                if (patterns[currentPattern].matcher(line).matches()) {
+                    if (!verbose) {
+                        System.out.println(line);
+                    }
+                    System.out.println("^^^ Match " + currentPattern + ": matches " + patterns[currentPattern] + "^^^");
+                    currentPattern ++;
+                }
+            }
+            lastLine = line;
+        }
+        br.close();
+
+        if (currentPattern < patterns.length) {
+            throw new RuntimeException("hs-err file incomplete (found " + currentPattern + " matching pattern, " +
+                                       "first missing pattern: " +  patterns[currentPattern] + ")");
+        }
+
+        if (!lastLine.equals("END.")) {
+            throw new RuntimeException("hs-err file incomplete (missing END marker.)");
+        }
+
+        System.out.println("Found all expected pattern in hs-err file at " + f.getAbsolutePath());
+
+    }
+
+}

--- a/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 import jdk.test.lib.process.OutputAnalyzer;
 
 import java.io.*;

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+ * @test segv
+ * @summary Test that for a given crash situation we see the correct siginfo in the hs-err file
+ * @library /test/lib
+ * @requires vm.debug
+ * @requires os.family != "windows"
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver TestSigInfoInHsErrFile segv
+ */
+
+/*
+ * @test fpe
+ * @summary Test that for a given crash situation we see the correct siginfo in the hs-err file
+ * @library /test/lib
+ * @requires vm.debug
+ * @requires os.family != "windows"
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver TestSigInfoInHsErrFile fpe
+ */
+
+import jdk.test.lib.Platform;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+
+public class TestSigInfoInHsErrFile {
+
+  public static void main(String[] args) throws Exception {
+    if (args.length != 1) {
+      throw new IllegalArgumentException("missing argument");
+    } else if (args[0].equals("segv")) {
+      testWithSEGV();
+    } else if (args[0].equals("fpe")) {
+      testWithFPE();
+    } else {
+      throw new IllegalArgumentException("unknown argument");
+    }
+  }
+
+  static void testWithFPE() throws Exception {
+
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-Xmx100M",
+            "-XX:-CreateCoredumpOnCrash",
+            "-XX:ErrorHandlerTest=15",
+            "-version");
+
+    OutputAnalyzer output = new OutputAnalyzer(pb.start());
+    output.shouldNotHaveExitValue(0);
+
+    // we should have crashed with a SIGFPE
+    output.shouldMatch("#.+SIGFPE.*");
+
+    // extract hs-err file
+    File f = HsErrFileUtils.openHsErrFileFromOutput(output);
+
+    ArrayList<Pattern> patterns = new ArrayList<>();
+    patterns.add(Pattern.compile("# A fatal error has been detected.*"));
+    patterns.add(Pattern.compile("# *SIGFPE.*"));
+    patterns.add(Pattern.compile("# *Problematic frame.*"));
+    patterns.add(Pattern.compile("# .*VMError::controlled_crash.*"));
+
+    patterns.add(Pattern.compile("siginfo: si_signo: \\d+ \\(SIGFPE\\), si_code: \\d+ \\(FPE_INTDIV\\).*"));
+
+    HsErrFileUtils.checkHsErrFileContent(f, patterns.toArray(new Pattern[] {}), true);
+
+  }
+
+  static void testWithSEGV() throws Exception {
+
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+        "-XX:+UnlockDiagnosticVMOptions",
+        "-Xmx100M",
+        "-XX:-CreateCoredumpOnCrash",
+        "-XX:ErrorHandlerTest=14",
+        "-version");
+
+    OutputAnalyzer output = new OutputAnalyzer(pb.start());
+    output.shouldNotHaveExitValue(0);
+
+    // we should have crashed with a SIGFPE
+    output.shouldMatch("#.+SIGSEGV.*");
+
+    // extract hs-err file
+    File f = HsErrFileUtils.openHsErrFileFromOutput(output);
+
+    ArrayList<Pattern> patterns = new ArrayList<>();
+    patterns.add(Pattern.compile("# A fatal error has been detected.*"));
+    patterns.add(Pattern.compile("# *SIGSEGV.*"));
+    patterns.add(Pattern.compile("# *Problematic frame.*"));
+    patterns.add(Pattern.compile("# .*VMError::controlled_crash.*"));
+
+    if (!Platform.isAix()) {
+      // Crash address is, for all non-AIX platforms, at 1K (0x400). See VMError::_segfault_address
+      patterns.add(Pattern.compile("siginfo: si_signo: \\d+ \\(SIGSEGV\\), si_code: \\d+ \\(SEGV_MAPERR\\), si_addr: 0x0*400"));
+    } else {
+      patterns.add(Pattern.compile("siginfo: si_signo: \\d+ \\(SIGSEGV\\).*"));
+    }
+
+    HsErrFileUtils.checkHsErrFileContent(f, patterns.toArray(new Pattern[] {}), true);
+
+  }
+
+}
+
+

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,11 +48,7 @@
 import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
-
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.regex.Pattern;
 
@@ -123,12 +120,9 @@ public class TestSigInfoInHsErrFile {
     patterns.add(Pattern.compile("# *Problematic frame.*"));
     patterns.add(Pattern.compile("# .*VMError::controlled_crash.*"));
 
-    if (!Platform.isAix()) {
-      // Crash address is, for all non-AIX platforms, at 1K (0x400). See VMError::_segfault_address
-      patterns.add(Pattern.compile("siginfo: si_signo: \\d+ \\(SIGSEGV\\), si_code: \\d+ \\(SEGV_MAPERR\\), si_addr: 0x0*400"));
-    } else {
-      patterns.add(Pattern.compile("siginfo: si_signo: \\d+ \\(SIGSEGV\\).*"));
-    }
+    // Crash address: see VMError::_segfault_address
+    String crashAddress = Platform.isAix() ? "0x0*1400" : "0x0*400";
+    patterns.add(Pattern.compile("siginfo: si_signo: \\d+ \\(SIGSEGV\\), si_code: \\d+ \\(SEGV_MAPERR\\), si_addr: " + crashAddress + ".*"));
 
     HsErrFileUtils.checkHsErrFileContent(f, patterns.toArray(new Pattern[] {}), true);
 


### PR DESCRIPTION
We have VMError::controlled_crash() in debug builds, whose job is to trigger clearly defined faults to test VM error reporting. VMError::controlled_crash(14) (the numbers don't mean anything and probably should be replaced with clear enums) is to crash with a SIGSEGV + SEGV_MAPERR mapping error at a well-known crash address. But this does not work on Linux, where it generates a SIGSEGV with SI_KERNEL instead. We never noticed since it had not been used in tests so far.

The reason for SI_KERNEL was that the crash address we use (0xABC0000000000ABC) was outside the user-space address range on Linux. This patch redefines the crash address to a value that really generates a SIGSEGV + SEGV_MAPERR on all our platforms. That's one line; the rest is a new regression test that checks that signal info is printed correctly in hs-err files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296906](https://bugs.openjdk.org/browse/JDK-8296906): VMError::controlled_crash crashes with wrong code and address


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [a72d834a](https://git.openjdk.org/jdk/pull/11122/files/a72d834ace3b49975651dca92591e75adb0e628f)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**) ⚠️ Review applies to [33b758ca](https://git.openjdk.org/jdk/pull/11122/files/33b758ca6a62cf24af1164d7f37bad5d3c4ab56b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11122/head:pull/11122` \
`$ git checkout pull/11122`

Update a local copy of the PR: \
`$ git checkout pull/11122` \
`$ git pull https://git.openjdk.org/jdk pull/11122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11122`

View PR using the GUI difftool: \
`$ git pr show -t 11122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11122.diff">https://git.openjdk.org/jdk/pull/11122.diff</a>

</details>
