### PR TITLE
8296910: Add EdDSA/XDH/RSASSA-PSS to KeyPairGeneratorBench.java

### DIFF
--- a/test/micro/org/openjdk/bench/javax/crypto/full/KeyPairGeneratorBench.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/full/KeyPairGeneratorBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,8 @@ public class KeyPairGeneratorBench extends CryptoBase {
     @Setup
     public void setup() throws NoSuchAlgorithmException {
         setupProvider();
-        generator = (prov == null) ? KeyPairGenerator.getInstance(algorithm) : KeyPairGenerator.getInstance(algorithm, prov);
+        generator = (prov == null) ? KeyPairGenerator.getInstance(algorithm)
+                                : KeyPairGenerator.getInstance(algorithm, prov);
         generator.initialize(keyLength);
     }
 
@@ -57,9 +58,17 @@ public class KeyPairGeneratorBench extends CryptoBase {
         @Param({"RSA"})
         private String algorithm;
 
-        @Param({"1024", "2048", "3072"})
+        @Param({"1024", "2048", "3072", "4096"})
         private int keyLength;
+    }
 
+    public static class RSASSAPSS extends KeyPairGeneratorBench {
+
+        @Param({"RSASSA-PSS"})
+        private String algorithm;
+
+        @Param({"1024", "2048", "3072", "4096"})
+        private int keyLength;
     }
 
     public static class EC extends KeyPairGeneratorBench {
@@ -69,7 +78,23 @@ public class KeyPairGeneratorBench extends CryptoBase {
 
         @Param({"256", "384", "521"})
         private int keyLength;
-
     }
 
+    public static class EdDSA extends KeyPairGeneratorBench {
+
+        @Param({"EdDSA"})
+        private String algorithm;
+
+        @Param({"255", "448"})
+        private int keyLength;
+    }
+
+    public static class XDH extends KeyPairGeneratorBench {
+
+        @Param({"XDH"})
+        private String algorithm;
+
+        @Param({"255", "448"})
+        private int keyLength;
+    }
 }


### PR DESCRIPTION
Hi,

May I have this update reviewed?

In the current key pair generation micro-benchmark, there is no cases for `EdDSA`, `XDH`, and `RSASSA-PSS`.  This PR is trying to add these algorithms.

BTW, here is the benchmarking data on a Linux x86_64 platform.  You can see how much the performance difference could be among key pair generation algorithms.

```
Benchmark                                                         (algorithm)  (keyLength)  (provider)   Mode  Cnt     Score    Error  Units
o.o.b.j.c.full.KeyPairGeneratorBench.EC.generateKeyPair                    EC          256              thrpt   40  1647.342 ±  8.548  ops/s
o.o.b.j.c.full.KeyPairGeneratorBench.EC.generateKeyPair                    EC          384              thrpt   40   698.990 ±  5.647  ops/s
o.o.b.j.c.full.KeyPairGeneratorBench.EC.generateKeyPair                    EC          521              thrpt   40   364.970 ±  5.556  ops/s
o.o.b.j.c.full.KeyPairGeneratorBench.EdDSA.generateKeyPair              EdDSA          255              thrpt   40  2400.202 ± 17.685  ops/s
o.o.b.j.c.full.KeyPairGeneratorBench.EdDSA.generateKeyPair              EdDSA          448              thrpt   40   680.304 ±  5.923  ops/s
o.o.b.j.c.full.KeyPairGeneratorBench.RSA.generateKeyPair                  RSA         1024              thrpt   40    69.614 ±  1.907  ops/s
o.o.b.j.c.full.KeyPairGeneratorBench.RSA.generateKeyPair                  RSA         2048              thrpt   40     9.192 ±  0.567  ops/s
o.o.b.j.c.full.KeyPairGeneratorBench.RSA.generateKeyPair                  RSA         3072              thrpt   40     2.352 ±  0.385  ops/s
o.o.b.j.c.full.KeyPairGeneratorBench.RSA.generateKeyPair                  RSA         4096              thrpt   40     0.815 ±  0.221  ops/s
o.o.b.j.c.full.KeyPairGeneratorBench.RSASSAPSS.generateKeyPair     RSASSA-PSS         1024              thrpt   40    70.022 ±  2.336  ops/s
o.o.b.j.c.full.KeyPairGeneratorBench.RSASSAPSS.generateKeyPair     RSASSA-PSS         2048              thrpt   40     9.260 ±  0.730  ops/s
o.o.b.j.c.full.KeyPairGeneratorBench.RSASSAPSS.generateKeyPair     RSASSA-PSS         3072              thrpt   40     2.305 ±  0.369  ops/s
o.o.b.j.c.full.KeyPairGeneratorBench.RSASSAPSS.generateKeyPair     RSASSA-PSS         4096              thrpt   40     0.902 ±  0.194  ops/s
o.o.b.j.c.full.KeyPairGeneratorBench.XDH.generateKeyPair                  XDH          255              thrpt   40  5061.279 ± 33.878  ops/s
o.o.b.j.c.full.KeyPairGeneratorBench.XDH.generateKeyPair                  XDH          448              thrpt   40  1404.786 ± 11.083  ops/s
o.o.b.j.c.full.KeyPairGeneratorBench.generateKeyPair                      DSA         1024              thrpt   40  9486.010 ± 20.242  ops/s
o.o.b.j.c.full.KeyPairGeneratorBench.generateKeyPair                      DSA         2048              thrpt   40  2174.506 ±  2.514  ops/s
o.o.b.j.c.full.KeyPairGeneratorBench.generateKeyPair            DiffieHellman         1024              thrpt   40  3532.067 ±  7.882  ops/s
o.o.b.j.c.full.KeyPairGeneratorBench.generateKeyPair            DiffieHellman         2048              thrpt   40   523.746 ±  0.704  ops/s
o.o.b.j.c.small.KeyPairGeneratorBench.generateKeyPair                     DSA         2048              thrpt   40  2171.807 ±  3.505  ops/s
o.o.b.j.c.small.KeyPairGeneratorBench.generateKeyPair                     RSA         2048              thrpt   40     9.549 ±  0.809  ops/s

```

Thanks,
Xuelei

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296910](https://bugs.openjdk.org/browse/JDK-8296910): Add EdDSA/XDH/RSASSA-PSS to KeyPairGeneratorBench.java


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11124/head:pull/11124` \
`$ git checkout pull/11124`

Update a local copy of the PR: \
`$ git checkout pull/11124` \
`$ git pull https://git.openjdk.org/jdk pull/11124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11124`

View PR using the GUI difftool: \
`$ git pr show -t 11124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11124.diff">https://git.openjdk.org/jdk/pull/11124.diff</a>

</details>
