### PR TITLE
8296900: CertificateValidity fields are not optional

### DIFF
--- a/src/java.base/share/classes/sun/security/x509/CertificateValidity.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateValidity.java
@@ -27,6 +27,7 @@ package sun.security.x509;
 import java.io.IOException;
 import java.security.cert.*;
 import java.util.Date;
+import java.util.Objects;
 
 import sun.security.util.*;
 
@@ -46,8 +47,8 @@ public class CertificateValidity implements DerEncoder {
     static final long YR_2050 = 2524608000000L;
 
     // Private data members
-    private Date        notBefore;
-    private Date        notAfter;
+    private final Date        notBefore;
+    private final Date        notAfter;
 
     // Returns the first time the certificate is valid.
     public Date getNotBefore() {
@@ -59,8 +60,27 @@ public class CertificateValidity implements DerEncoder {
        return new Date(notAfter.getTime());
     }
 
-    // Construct the class from the DerValue
-    private void construct(DerValue derVal) throws IOException {
+    /**
+     * The constructor for this class for the specified interval.
+     *
+     * @param notBefore the date and time before which the certificate
+     *                   is not valid
+     * @param notAfter the date and time after which the certificate is
+     *                  not valid
+     */
+    public CertificateValidity(Date notBefore, Date notAfter) {
+        this.notBefore = Objects.requireNonNull(notBefore);
+        this.notAfter = Objects.requireNonNull(notAfter);
+    }
+
+    /**
+     * Create the object, decoding the values from the passed DER stream.
+     *
+     * @param in the DerInputStream to read the CertificateValidity from
+     * @exception IOException on decoding errors.
+     */
+    public CertificateValidity(DerInputStream in) throws IOException {
+        DerValue derVal = in.getDerValue();
         if (derVal.tag != DerValue.tag_Sequence) {
             throw new IOException("Invalid encoded CertificateValidity, " +
                                   "starting sequence tag missing.");
@@ -92,40 +112,9 @@ public class CertificateValidity implements DerEncoder {
     }
 
     /**
-     * Default constructor for the class.
-     */
-    public CertificateValidity() { }
-
-    /**
-     * The default constructor for this class for the specified interval.
-     *
-     * @param notBefore the date and time before which the certificate
-     *                   is not valid.
-     * @param notAfter the date and time after which the certificate is
-     *                  not valid.
-     */
-    public CertificateValidity(Date notBefore, Date notAfter) {
-        this.notBefore = notBefore;
-        this.notAfter = notAfter;
-    }
-
-    /**
-     * Create the object, decoding the values from the passed DER stream.
-     *
-     * @param in the DerInputStream to read the CertificateValidity from.
-     * @exception IOException on decoding errors.
-     */
-    public CertificateValidity(DerInputStream in) throws IOException {
-        DerValue derVal = in.getDerValue();
-        construct(derVal);
-    }
-
-    /**
      * Return the validity period as user readable string.
      */
     public String toString() {
-        if (notBefore == null || notAfter == null)
-            return "";
         return "Validity: [From: " + notBefore +
                ",\n               To: " + notAfter + ']';
     }
@@ -139,12 +128,6 @@ public class CertificateValidity implements DerEncoder {
     @Override
     public void encode(DerOutputStream out) throws IOException {
 
-        // in cases where default constructor is used check for
-        // null values
-        if (notBefore == null || notAfter == null) {
-            throw new IOException("CertificateValidity:" +
-                                  " null values to encode.\n");
-        }
         DerOutputStream pair = new DerOutputStream();
 
         if (notBefore.getTime() < YR_2050) {

--- a/test/jdk/sun/security/x509/CertificateValidity/NullName.java
+++ b/test/jdk/sun/security/x509/CertificateValidity/NullName.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8296900
+ * @summary CertificateValidity fields are not be optional
+ * @library /test/lib
+ * @modules java.base/sun.security.x509
+ */
+
+import jdk.test.lib.Utils;
+import sun.security.x509.CertificateValidity;
+
+import java.util.Date;
+
+public class NullName {
+
+    public static void main(String[] argv) throws Exception {
+        Date now = new Date();
+        Utils.runAndCheckException(
+                () -> new CertificateValidity(null, null),
+                NullPointerException.class);
+        Utils.runAndCheckException(
+                () -> new CertificateValidity(now, null),
+                NullPointerException.class);
+        Utils.runAndCheckException(
+                () -> new CertificateValidity(null, now),
+                NullPointerException.class);
+        new CertificateValidity(now, now);
+    }
+}


### PR DESCRIPTION
Make two fields inside `CertificateValidity` final.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296900](https://bugs.openjdk.org/browse/JDK-8296900): CertificateValidity fields are not optional


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11126/head:pull/11126` \
`$ git checkout pull/11126`

Update a local copy of the PR: \
`$ git checkout pull/11126` \
`$ git pull https://git.openjdk.org/jdk pull/11126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11126`

View PR using the GUI difftool: \
`$ git pr show -t 11126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11126.diff">https://git.openjdk.org/jdk/pull/11126.diff</a>

</details>
