### PR TITLE
8296818: Enhance JMH tests java/security/Signatures.java

### DIFF
--- a/test/micro/org/openjdk/bench/java/security/Signatures.java
+++ b/test/micro/org/openjdk/bench/java/security/Signatures.java
@@ -149,7 +149,7 @@ public class Signatures {
     }
 
     public static class RSASSAPSS extends Signatures {
-        @Param({"SHA256withRSASSA-PSS", "SHA3846withRSASSA-PSS", "SHA512withRSASSA-PSS"})
+        @Param({"SHA256", "SHA3846", "SHA512"})
         private String algorithm;
 
         @Setup
@@ -158,24 +158,24 @@ public class Signatures {
             (new Random(System.nanoTime())).nextBytes(message);
 
             int keyLength = switch (algorithm) {
-               case "SHA256withRSASSA-PSS" -> 2048;
-               case "SHA3846withRSASSA-PSS" -> 3072;
-               case "SHA512withRSASSA-PSS" -> 4096;
+               case "SHA256" -> 2048;
+               case "SHA384" -> 3072;
+               case "SHA512" -> 4096;
                default -> throw new RuntimeException();
             };
 
             PSSParameterSpec spec = switch (algorithm) {
-               case "SHA256withRSASSA-PSS" ->
+               case "SHA256" ->
                        new PSSParameterSpec(
                                "SHA-256", "MGF1",
                                MGF1ParameterSpec.SHA256,
                                32, PSSParameterSpec.TRAILER_FIELD_BC);
-               case "SHA3846withRSASSA-PSS" ->
+               case "SHA384" ->
                        new PSSParameterSpec(
                                "SHA-384", "MGF1",
                                MGF1ParameterSpec.SHA384,
                                48, PSSParameterSpec.TRAILER_FIELD_BC);
-               case "SHA512withRSASSA-PSS" ->
+               case "SHA512" ->
                         new PSSParameterSpec(
                                "SHA-512", "MGF1",
                                MGF1ParameterSpec.SHA512,

--- a/test/micro/org/openjdk/bench/java/security/Signatures.java
+++ b/test/micro/org/openjdk/bench/java/security/Signatures.java
@@ -99,6 +99,30 @@ public class Signatures {
         }
     }
 
+    public static class DSA extends Signatures {
+        @Param({"SHA256withDSA", "SHA384withDSA", "SHA512withDSA"})
+        private String algorithm;
+
+        @Setup
+        public void setup() throws Exception {
+            message = new byte[messageLength];
+            (new Random(System.nanoTime())).nextBytes(message);
+
+            int keyLength = switch (algorithm) {
+                case "SHA256withDSA" -> 2048;
+                case "SHA384withDSA" -> 3072;
+                default -> throw new RuntimeException();
+            };
+
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance("DSA");
+            kpg.initialize(keyLength);
+            KeyPair kp = kpg.generateKeyPair();
+
+            signer = Signature.getInstance(algorithm);
+            signer.initSign(kp.getPrivate());
+        }
+    }
+
     public static class RSA extends Signatures {
         @Param({"SHA256withRSA", "SHA384withRSA", "SHA512withRSA"})
         private String algorithm;
@@ -110,7 +134,7 @@ public class Signatures {
 
             int keyLength = switch (algorithm) {
                 case "SHA256withRSA" -> 2048;
-                case "SHA384withRSA" -> 3027;
+                case "SHA384withRSA" -> 3072;
                 case "SHA512withRSA" -> 4096;
                 default -> throw new RuntimeException();
             };
@@ -135,7 +159,7 @@ public class Signatures {
 
             int keyLength = switch (algorithm) {
                case "SHA256withRSASSA-PSS" -> 2048;
-               case "SHA3846withRSASSA-PSS" -> 3027;
+               case "SHA3846withRSASSA-PSS" -> 3072;
                case "SHA512withRSASSA-PSS" -> 4096;
                default -> throw new RuntimeException();
             };

--- a/test/micro/org/openjdk/bench/java/security/Signatures.java
+++ b/test/micro/org/openjdk/bench/java/security/Signatures.java
@@ -25,8 +25,7 @@ package org.openjdk.bench.java.security;
 import org.openjdk.jmh.annotations.*;
 
 import java.security.*;
-import java.security.spec.ECGenParameterSpec;
-import java.security.spec.NamedParameterSpec;
+import java.security.spec.*;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
@@ -37,53 +36,38 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 5, time = 1)
 @Fork(jvmArgsAppend = {"-Xms1024m", "-Xmx1024m", "-Xmn768m", "-XX:+UseParallelGC"}, value = 3)
 public class Signatures {
-    private Signature signer;
+    private static Signature signer;
 
     @Param({"64", "512", "2048", "16384"})
-    private int messageLength;
+    private static int messageLength;
 
-    @Param({"secp256r1", "secp384r1", "secp521r1", "Ed25519", "Ed448"})
-    private String curveName;
+    @Param({"secp256r1", "secp384r1", "secp521r1"})
+    private String algorithm;
 
-    private byte[] message;
-
-    record CurveSpec(String curveName, String signName) {
-        // blank
-    }
+    private static byte[] message;
 
     @Setup
     public void setup() throws Exception {
         message = new byte[messageLength];
         (new Random(System.nanoTime())).nextBytes(message);
 
-        String signName = switch (curveName) {
+        String signName = switch (algorithm) {
             case "secp256r1" -> "SHA256withECDSA";
             case "secp384r1" -> "SHA384withECDSA";
             case "secp521r1" -> "SHA512withECDSA";
-            case "Ed25519" -> "Ed25519";
-            case "Ed448" -> "Ed448";
             default -> throw new RuntimeException();
         };
 
-        KeyPair kp;
-        if (curveName.startsWith("secp")) {
-            AlgorithmParameters params =
-                    AlgorithmParameters.getInstance("EC", "SunEC");
-            params.init(new ECGenParameterSpec(curveName));
-            ECGenParameterSpec ecParams =
-                    params.getParameterSpec(ECGenParameterSpec.class);
+        AlgorithmParameters params =
+                AlgorithmParameters.getInstance("EC", "SunEC");
+        params.init(new ECGenParameterSpec(algorithm));
+        ECGenParameterSpec ecParams =
+                params.getParameterSpec(ECGenParameterSpec.class);
 
-            KeyPairGenerator kpg =
-                    KeyPairGenerator.getInstance("EC", "SunEC");
-            kpg.initialize(ecParams);
-            kp = kpg.generateKeyPair();
-        } else {
-            KeyPairGenerator kpg =
-                    KeyPairGenerator.getInstance(curveName, "SunEC");
-            NamedParameterSpec spec = new NamedParameterSpec(curveName);
-            kpg.initialize(spec);
-            kp = kpg.generateKeyPair();
-        }
+        KeyPairGenerator kpg =
+                KeyPairGenerator.getInstance("EC", "SunEC");
+        kpg.initialize(ecParams);
+        KeyPair kp = kpg.generateKeyPair();
 
         signer = Signature.getInstance(signName, "SunEC");
         signer.initSign(kp.getPrivate());
@@ -93,6 +77,96 @@ public class Signatures {
     public byte[] sign() throws SignatureException {
         signer.update(message);
         return signer.sign();
+    }
+
+    public static class EdDSA extends Signatures {
+        @Param({"Ed25519", "Ed448"})
+        private String algorithm;
+
+        @Setup
+        public void setup() throws Exception {
+            message = new byte[messageLength];
+            (new Random(System.nanoTime())).nextBytes(message);
+
+            KeyPairGenerator kpg =
+                    KeyPairGenerator.getInstance(algorithm, "SunEC");
+            NamedParameterSpec spec = new NamedParameterSpec(algorithm);
+            kpg.initialize(spec);
+            KeyPair kp = kpg.generateKeyPair();
+
+            signer = Signature.getInstance(algorithm, "SunEC");
+            signer.initSign(kp.getPrivate());
+        }
+    }
+
+    public static class RSA extends Signatures {
+        @Param({"SHA256withRSA", "SHA384withRSA", "SHA512withRSA"})
+        private String algorithm;
+
+        @Setup
+        public void setup() throws Exception {
+            message = new byte[messageLength];
+            (new Random(System.nanoTime())).nextBytes(message);
+
+            int keyLength = switch (algorithm) {
+                case "SHA256withRSA" -> 2048;
+                case "SHA384withRSA" -> 3027;
+                case "SHA512withRSA" -> 4096;
+                default -> throw new RuntimeException();
+            };
+
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+            kpg.initialize(keyLength);
+            KeyPair kp = kpg.generateKeyPair();
+
+            signer = Signature.getInstance(algorithm);
+            signer.initSign(kp.getPrivate());
+        }
+    }
+
+    public static class RSASSAPSS extends Signatures {
+        @Param({"SHA256withRSASSA-PSS", "SHA3846withRSASSA-PSS", "SHA512withRSASSA-PSS"})
+        private String algorithm;
+
+        @Setup
+        public void setup() throws Exception {
+            message = new byte[messageLength];
+            (new Random(System.nanoTime())).nextBytes(message);
+
+            int keyLength = switch (algorithm) {
+               case "SHA256withRSASSA-PSS" -> 2048;
+               case "SHA3846withRSASSA-PSS" -> 3027;
+               case "SHA512withRSASSA-PSS" -> 4096;
+               default -> throw new RuntimeException();
+            };
+
+            PSSParameterSpec spec = switch (algorithm) {
+               case "SHA256withRSASSA-PSS" ->
+                       new PSSParameterSpec(
+                               "SHA-256", "MGF1",
+                               MGF1ParameterSpec.SHA256,
+                               32, PSSParameterSpec.TRAILER_FIELD_BC);
+               case "SHA3846withRSASSA-PSS" ->
+                       new PSSParameterSpec(
+                               "SHA-384", "MGF1",
+                               MGF1ParameterSpec.SHA384,
+                               48, PSSParameterSpec.TRAILER_FIELD_BC);
+               case "SHA512withRSASSA-PSS" ->
+                        new PSSParameterSpec(
+                               "SHA-512", "MGF1",
+                               MGF1ParameterSpec.SHA512,
+                               64, PSSParameterSpec.TRAILER_FIELD_BC);
+               default -> throw new RuntimeException();
+            };
+
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSASSA-PSS");
+            kpg.initialize(keyLength);
+            KeyPair kp = kpg.generateKeyPair();
+
+            signer = Signature.getInstance("RSASSA-PSS");
+            signer.setParameter(spec);
+            signer.initSign(kp.getPrivate());
+        }
     }
 }
 

--- a/test/micro/org/openjdk/bench/java/security/Signatures.java
+++ b/test/micro/org/openjdk/bench/java/security/Signatures.java
@@ -111,6 +111,7 @@ public class Signatures {
             int keyLength = switch (algorithm) {
                 case "SHA256withDSA" -> 2048;
                 case "SHA384withDSA" -> 3072;
+                case "SHA512withDSA" -> 3072;
                 default -> throw new RuntimeException();
             };
 
@@ -149,7 +150,7 @@ public class Signatures {
     }
 
     public static class RSASSAPSS extends Signatures {
-        @Param({"SHA256", "SHA3846", "SHA512"})
+        @Param({"SHA256", "SHA384", "SHA512"})
         private String algorithm;
 
         @Setup


### PR DESCRIPTION
Hi,

May I get the micro benchmarking enhancement reviewed?

Benchmark cases for RSA(SSA-PSS)/DSA are added in the PR.  Here is the benchmarking number on a Linux X86_64 platform.
```
Benchmark                            (algorithm)  (messageLength)   Mode  Cnt     Score    Error  Units
Signatures.DSA.sign                SHA256withDSA               64  thrpt   15  2076.114 ±  6.269  ops/s
Signatures.DSA.sign                SHA256withDSA              512  thrpt   15  2080.330 ±  4.204  ops/s
Signatures.DSA.sign                SHA256withDSA             2048  thrpt   15  2074.546 ± 11.596  ops/s
Signatures.DSA.sign                SHA256withDSA            16384  thrpt   15  2029.887 ±  6.255  ops/s
Signatures.DSA.sign                SHA384withDSA               64  thrpt   15   882.339 ±  3.343  ops/s
Signatures.DSA.sign                SHA384withDSA              512  thrpt   15   881.690 ±  2.792  ops/s
Signatures.DSA.sign                SHA384withDSA             2048  thrpt   15   876.370 ±  5.779  ops/s
Signatures.DSA.sign                SHA384withDSA            16384  thrpt   15   860.463 ±  3.286  ops/s
Signatures.EdDSA.sign                    Ed25519               64  thrpt   15  1198.668 ±  4.347  ops/s
Signatures.EdDSA.sign                    Ed25519              512  thrpt   15  1199.107 ±  2.645  ops/s
Signatures.EdDSA.sign                    Ed25519             2048  thrpt   15  1191.952 ±  7.202  ops/s
Signatures.EdDSA.sign                    Ed25519            16384  thrpt   15  1112.078 ±  5.449  ops/s
Signatures.EdDSA.sign                      Ed448               64  thrpt   15   329.802 ±  5.474  ops/s
Signatures.EdDSA.sign                      Ed448              512  thrpt   15   328.258 ±  1.725  ops/s
Signatures.EdDSA.sign                      Ed448             2048  thrpt   15   322.206 ±  5.911  ops/s
Signatures.EdDSA.sign                      Ed448            16384  thrpt   15   317.814 ±  2.339  ops/s
Signatures.RSA.sign                SHA256withRSA               64  thrpt   15   834.704 ±  6.869  ops/s
Signatures.RSA.sign                SHA256withRSA              512  thrpt   15   838.794 ±  2.995  ops/s
Signatures.RSA.sign                SHA256withRSA             2048  thrpt   15   832.343 ±  3.781  ops/s
Signatures.RSA.sign                SHA256withRSA            16384  thrpt   15   833.405 ±  3.750  ops/s
Signatures.RSA.sign                SHA384withRSA               64  thrpt   15   279.930 ±  1.384  ops/s
Signatures.RSA.sign                SHA384withRSA              512  thrpt   15   280.822 ±  1.189  ops/s
Signatures.RSA.sign                SHA384withRSA             2048  thrpt   15   278.644 ±  1.608  ops/s
Signatures.RSA.sign                SHA384withRSA            16384  thrpt   15   277.631 ±  1.266  ops/s
Signatures.RSA.sign                SHA512withRSA               64  thrpt   15   126.927 ±  0.790  ops/s
Signatures.RSA.sign                SHA512withRSA              512  thrpt   15   126.572 ±  0.506  ops/s
Signatures.RSA.sign                SHA512withRSA             2048  thrpt   15   127.159 ±  0.619  ops/s
Signatures.RSA.sign                SHA512withRSA            16384  thrpt   15   126.104 ±  0.262  ops/s
Signatures.RSASSAPSS.sign   SHA256withRSASSA-PSS               64  thrpt   15   832.804 ±  4.243  ops/s
Signatures.RSASSAPSS.sign   SHA256withRSASSA-PSS              512  thrpt   15   828.386 ± 10.118  ops/s
Signatures.RSASSAPSS.sign   SHA256withRSASSA-PSS             2048  thrpt   15   831.469 ±  4.792  ops/s
Signatures.RSASSAPSS.sign   SHA256withRSASSA-PSS            16384  thrpt   15   826.325 ±  2.698  ops/s
Signatures.RSASSAPSS.sign  SHA3846withRSASSA-PSS               64  thrpt   15   276.043 ±  1.594  ops/s
Signatures.RSASSAPSS.sign  SHA3846withRSASSA-PSS              512  thrpt   15   278.548 ±  2.011  ops/s
Signatures.RSASSAPSS.sign  SHA3846withRSASSA-PSS             2048  thrpt   15   276.393 ±  2.155  ops/s
Signatures.RSASSAPSS.sign  SHA3846withRSASSA-PSS            16384  thrpt   15   274.924 ±  1.520  ops/s
Signatures.RSASSAPSS.sign   SHA512withRSASSA-PSS               64  thrpt   15   126.004 ±  0.413  ops/s
Signatures.RSASSAPSS.sign   SHA512withRSASSA-PSS              512  thrpt   15   127.211 ±  0.312  ops/s
Signatures.RSASSAPSS.sign   SHA512withRSASSA-PSS             2048  thrpt   15   127.200 ±  0.338  ops/s
Signatures.RSASSAPSS.sign   SHA512withRSASSA-PSS            16384  thrpt   15   126.327 ±  0.520  ops/s
Signatures.sign                        secp256r1               64  thrpt   15  1523.564 ± 22.411  ops/s
Signatures.sign                        secp256r1              512  thrpt   15  1529.083 ±  5.903  ops/s
Signatures.sign                        secp256r1             2048  thrpt   15  1530.112 ±  7.832  ops/s
Signatures.sign                        secp256r1            16384  thrpt   15  1500.652 ±  1.936  ops/s
Signatures.sign                        secp384r1               64  thrpt   15   642.752 ± 11.175  ops/s
Signatures.sign                        secp384r1              512  thrpt   15   645.279 ±  3.632  ops/s
Signatures.sign                        secp384r1             2048  thrpt   15   632.866 ±  4.137  ops/s
Signatures.sign                        secp384r1            16384  thrpt   15   624.020 ±  6.282  ops/s
Signatures.sign                        secp521r1               64  thrpt   15   319.333 ±  1.587  ops/s
Signatures.sign                        secp521r1              512  thrpt   15   320.025 ±  0.890  ops/s
Signatures.sign                        secp521r1             2048  thrpt   15   309.922 ±  9.569  ops/s
Signatures.sign                        secp521r1            16384  thrpt   15   317.070 ±  0.930  ops/s
```
Thanks,
Xuelei

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296818](https://bugs.openjdk.org/browse/JDK-8296818): Enhance JMH tests java/security/Signatures.java


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11131/head:pull/11131` \
`$ git checkout pull/11131`

Update a local copy of the PR: \
`$ git checkout pull/11131` \
`$ git pull https://git.openjdk.org/jdk pull/11131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11131`

View PR using the GUI difftool: \
`$ git pr show -t 11131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11131.diff">https://git.openjdk.org/jdk/pull/11131.diff</a>

</details>
