### PR TITLE
8296923: JFR: jfr --version should return System.getProperty("java version")

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Version.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Version.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ final class Version extends Command {
 
     @Override
     public void execute(Deque<String> options) {
-        System.out.println("1.0");
+        System.out.println(System.getProperty("java.version"));
     }
 
     @Override


### PR DESCRIPTION
Could I have a review of a PR that changes the version of the jfr tool to that of the JDK.  

Testing: test/jdk/jdk/jfr/

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296923](https://bugs.openjdk.org/browse/JDK-8296923): JFR: jfr --version should return System.getProperty("java version")


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11132/head:pull/11132` \
`$ git checkout pull/11132`

Update a local copy of the PR: \
`$ git checkout pull/11132` \
`$ git pull https://git.openjdk.org/jdk pull/11132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11132`

View PR using the GUI difftool: \
`$ git pr show -t 11132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11132.diff">https://git.openjdk.org/jdk/pull/11132.diff</a>

</details>
