### PR TITLE
JDK-8296931: NMT tests slowed down considerably by JDK-8242181

### DIFF
--- a/src/hotspot/share/utilities/nativeCallStack.cpp
+++ b/src/hotspot/share/utilities/nativeCallStack.cpp
@@ -80,7 +80,6 @@ void NativeCallStack::print_on(outputStream* out, int indent) const {
   address pc;
   char    buf[1024];
   int     offset;
-  int     line_no;
   if (is_empty()) {
     for (int index = 0; index < indent; index ++) out->print(" ");
     out->print("[BOOTSTRAP]");
@@ -96,9 +95,10 @@ void NativeCallStack::print_on(outputStream* out, int indent) const {
         out->print("[" PTR_FORMAT "]", p2i(pc));
       }
 
-      if (Decoder::get_source_info(pc, buf, sizeof(buf), &line_no, frame != 0)) {
-        out->print("  (%s:%d)", buf, line_no);
-      }
+      // Note: we deliberately omit printing source information here. NativeCallStack::print_on()
+      // can be called thousands of times as part of NMT detail reporting, and source printing
+      // can slow down reporting by a factor of 5 or more depending on platform (see JDK-8296931).
+
       out->cr();
     }
   }


### PR DESCRIPTION
We noticed that NMT tests on our slower PPC machines started failing.

The reason is that NMT detail reports have become 2-5x slower. This is caused by us now parsing the dwarf debug information to extract source information for each PC in each call stack. That is nice but costly.

The slowdown is not limited to PPC, it affects all Elf platforms. On my Linux x64 box, runtime/NMT/VirtualAllocCommitMerge.java increased from 20 to 90 seconds.

---

This patch simply removes source info from NMT call stacks. They are not that important for pinpointing leaks and such. I considered more involved solutions, like making them optional via an argument to the NMT report command, but decided against it. The added benefit would be small, not worth much complexity.

With this patch, on my box with -conc 4 all NMT together are about 2.5 x faster (2m56 -> 1m09).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296931](https://bugs.openjdk.org/browse/JDK-8296931): NMT tests slowed down considerably by JDK-8242181


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11135/head:pull/11135` \
`$ git checkout pull/11135`

Update a local copy of the PR: \
`$ git checkout pull/11135` \
`$ git pull https://git.openjdk.org/jdk pull/11135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11135`

View PR using the GUI difftool: \
`$ git pr show -t 11135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11135.diff">https://git.openjdk.org/jdk/pull/11135.diff</a>

</details>
