### PR TITLE
8296786: Limit VM modes for com/sun/jdi/JdbLastErrorTest.java

### DIFF
--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -30,6 +30,4 @@
 java/lang/invoke/MethodHandles/CatchExceptionTest.java 8146623 generic-all
 java/lang/ref/ReferenceEnqueue.java 8284236 generic-all
 
-com/sun/jdi/JdbLastErrorTest.java 8293829 windows-x64
-
 java/lang/Float/Binary16Conversion.java 8295351 generic-x64

--- a/test/jdk/com/sun/jdi/JdbLastErrorTest.java
+++ b/test/jdk/com/sun/jdi/JdbLastErrorTest.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8292302
  * @summary Test persistence of native last error value under jdb (Windows)
- * @requires (os.family == "windows")
+ * @requires (os.family == "windows") & (vm.compMode != "Xcomp") & (vm.compMode != "Xint")
  * @library /test/lib
  * @run compile --release 20 --enable-preview JdbLastErrorTest.java
  * @run main/othervm --enable-preview JdbLastErrorTest


### PR DESCRIPTION
This is a (trivial) change of the @requires statement in a test: 
don't run in -Xcomp or -Xint modes, where the interaction of Windows' native GetLastError and Panama direct native access are known not to work well together.

Remove test/jdk/ProblemList-Xcomp.txt entry for this test.

Running jtreg directly (which would ignore problemlist) will now skip this test if e.g. those modes are given using -vmoption

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296786](https://bugs.openjdk.org/browse/JDK-8296786): Limit VM modes for com/sun/jdi/JdbLastErrorTest.java


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11136/head:pull/11136` \
`$ git checkout pull/11136`

Update a local copy of the PR: \
`$ git checkout pull/11136` \
`$ git pull https://git.openjdk.org/jdk pull/11136/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11136`

View PR using the GUI difftool: \
`$ git pr show -t 11136`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11136.diff">https://git.openjdk.org/jdk/pull/11136.diff</a>

</details>
