### PR TITLE
8296742: Illegal X509 Extension should not be created

### DIFF
--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -1582,7 +1582,11 @@ public final class Main {
             int d = id.indexOf(':');
             if (d >= 0) {
                 CRLExtensions ext = new CRLExtensions();
-                ext.setExtension("Reason", new CRLReasonCodeExtension(Integer.parseInt(id.substring(d+1))));
+                int code = Integer.parseInt(id.substring(d+1));
+                if (code == 0) {
+                    throw new Exception("Reason code cannot be 0");
+                }
+                ext.setExtension("Reason", new CRLReasonCodeExtension(code));
                 badCerts[i] = new X509CRLEntryImpl(new BigInteger(id.substring(0, d)),
                         firstDate, ext);
             } else {
@@ -4631,6 +4635,9 @@ public final class Main {
                     continue;
                 }
                 int exttype = oneOf(name, extSupported);
+                if (exttype != -1 && value != null && value.isEmpty()) {
+                    throw new Exception(rb.getString("Illegal.value.") + extstr);
+                }
                 switch (exttype) {
                     case 0:     // BC
                         int pathLen = -1;

--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -1583,8 +1583,8 @@ public final class Main {
             if (d >= 0) {
                 CRLExtensions ext = new CRLExtensions();
                 int code = Integer.parseInt(id.substring(d+1));
-                if (code == 0) {
-                    throw new Exception("Reason code cannot be 0");
+                if (code <= 0) {
+                    throw new Exception("Reason code must be positive");
                 }
                 ext.setExtension("Reason", new CRLReasonCodeExtension(code));
                 badCerts[i] = new X509CRLEntryImpl(new BigInteger(id.substring(0, d)),

--- a/src/java.base/share/classes/sun/security/x509/AuthorityInfoAccessExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/AuthorityInfoAccessExtension.java
@@ -74,7 +74,8 @@ public class AuthorityInfoAccessExtension extends Extension {
      * Create an AuthorityInfoAccessExtension from a List of
      * AccessDescription; the criticality is set to false.
      *
-     * @param accessDescriptions the List of AccessDescription
+     * @param accessDescriptions the List of AccessDescription,
+     *                           cannot be null or empty.
      * @throws IOException on error
      */
     public AuthorityInfoAccessExtension(

--- a/src/java.base/share/classes/sun/security/x509/AuthorityInfoAccessExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/AuthorityInfoAccessExtension.java
@@ -79,6 +79,9 @@ public class AuthorityInfoAccessExtension extends Extension {
      */
     public AuthorityInfoAccessExtension(
             List<AccessDescription> accessDescriptions) throws IOException {
+        if (accessDescriptions == null || accessDescriptions.isEmpty()) {
+            throw new IllegalArgumentException("accessDescriptions is null or empty");
+        }
         this.extensionId = PKIXExtensions.AuthInfoAccess_Id;
         this.critical = false;
         this.accessDescriptions = accessDescriptions;

--- a/src/java.base/share/classes/sun/security/x509/AuthorityKeyIdentifierExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/AuthorityKeyIdentifierExtension.java
@@ -111,7 +111,7 @@ public class AuthorityKeyIdentifierExtension extends Extension {
     public AuthorityKeyIdentifierExtension(KeyIdentifier kid, GeneralNames names,
                                            SerialNumber sn)
             throws IOException {
-        if (kid == null && names == null && serialNum == null) {
+        if (kid == null && names == null && sn == null) {
             throw new IllegalArgumentException(
                     "AuthorityKeyIdentifierExtension cannot be empty");
         }

--- a/src/java.base/share/classes/sun/security/x509/AuthorityKeyIdentifierExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/AuthorityKeyIdentifierExtension.java
@@ -99,8 +99,8 @@ public class AuthorityKeyIdentifierExtension extends Extension {
     }
 
     /**
-     * The default constructor for this extension.  Null parameters make
-     * the element optional (not present).
+     * The default constructor for this extension. At least one parameter
+     * must be non null. Null parameters make the element optional (not present).
      *
      * @param kid the KeyIdentifier associated with this extension.
      * @param names the GeneralNames associated with this extension

--- a/src/java.base/share/classes/sun/security/x509/AuthorityKeyIdentifierExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/AuthorityKeyIdentifierExtension.java
@@ -110,7 +110,11 @@ public class AuthorityKeyIdentifierExtension extends Extension {
      */
     public AuthorityKeyIdentifierExtension(KeyIdentifier kid, GeneralNames names,
                                            SerialNumber sn)
-    throws IOException {
+            throws IOException {
+        if (kid == null && names == null && serialNum == null) {
+            throw new IllegalArgumentException(
+                    "AuthorityKeyIdentifierExtension cannot be empty");
+        }
         this.id = kid;
         this.names = names;
         this.serialNum = sn;

--- a/src/java.base/share/classes/sun/security/x509/CRLDistributionPointsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CRLDistributionPointsExtension.java
@@ -120,8 +120,13 @@ public class CRLDistributionPointsExtension extends Extension {
      * Creates the extension (also called by the subclass).
      */
     protected CRLDistributionPointsExtension(ObjectIdentifier extensionId,
-        boolean isCritical, List<DistributionPoint> distributionPoints,
+            boolean isCritical, List<DistributionPoint> distributionPoints,
             String extensionName) throws IOException {
+
+        if (distributionPoints == null || distributionPoints.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "distribution points cannot be null or empty");
+        }
 
         this.extensionId = extensionId;
         this.critical = isCritical;

--- a/src/java.base/share/classes/sun/security/x509/CRLDistributionPointsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CRLDistributionPointsExtension.java
@@ -106,7 +106,8 @@ public class CRLDistributionPointsExtension extends Extension {
      * DistributionPoint.
      *
      * @param isCritical the criticality setting.
-     * @param distributionPoints the list of distribution points
+     * @param distributionPoints the list of distribution points,
+     *                           cannot be null or empty.
      * @throws IOException on error
      */
     public CRLDistributionPointsExtension(boolean isCritical,

--- a/src/java.base/share/classes/sun/security/x509/CRLNumberExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CRLNumberExtension.java
@@ -91,6 +91,9 @@ public class CRLNumberExtension extends Extension {
         boolean isCritical, BigInteger crlNum, String extensionName,
         String extensionLabel) throws IOException {
 
+        if (crlNumber == null) {
+            throw new IllegalArgumentException("CRL number cannot be null");
+        }
         this.extensionId = extensionId;
         this.critical = isCritical;
         this.crlNumber = crlNum;

--- a/src/java.base/share/classes/sun/security/x509/CRLNumberExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CRLNumberExtension.java
@@ -91,7 +91,7 @@ public class CRLNumberExtension extends Extension {
         boolean isCritical, BigInteger crlNum, String extensionName,
         String extensionLabel) throws IOException {
 
-        if (crlNumber == null) {
+        if (crlNum == null) {
             throw new IllegalArgumentException("CRL number cannot be null");
         }
         this.extensionId = extensionId;

--- a/src/java.base/share/classes/sun/security/x509/CRLNumberExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CRLNumberExtension.java
@@ -78,7 +78,7 @@ public class CRLNumberExtension extends Extension {
      * Create a CRLNumberExtension with the BigInteger value .
      * The criticality is set to false.
      *
-     * @param crlNum the value to be set for the extension.
+     * @param crlNum the value to be set for the extension, cannot be null
      */
     public CRLNumberExtension(BigInteger crlNum) throws IOException {
         this(PKIXExtensions.CRLNumber_Id, false, crlNum, NAME, LABEL);

--- a/src/java.base/share/classes/sun/security/x509/CRLReasonCodeExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CRLReasonCodeExtension.java
@@ -69,7 +69,7 @@ public class CRLReasonCodeExtension extends Extension {
      * Create a CRLReasonCodeExtension with the passed in reason.
      *
      * @param critical true if the extension is to be treated as critical.
-     * @param reason the enumerated value for the reason code.
+     * @param reason the enumerated value for the reason code, cannot be null.
      */
     public CRLReasonCodeExtension(boolean critical, int reason)
             throws IOException {

--- a/src/java.base/share/classes/sun/security/x509/CRLReasonCodeExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CRLReasonCodeExtension.java
@@ -69,12 +69,12 @@ public class CRLReasonCodeExtension extends Extension {
      * Create a CRLReasonCodeExtension with the passed in reason.
      *
      * @param critical true if the extension is to be treated as critical.
-     * @param reason the enumerated value for the reason code, cannot be null.
+     * @param reason the enumerated value for the reason code, must be positive.
      */
     public CRLReasonCodeExtension(boolean critical, int reason)
             throws IOException {
-        if (reason == 0) {
-            throw new IllegalArgumentException("reason code cannot be 0");
+        if (reason <= 0) {
+            throw new IllegalArgumentException("reason code must be positive");
         }
         this.extensionId = PKIXExtensions.ReasonCode_Id;
         this.critical = critical;

--- a/src/java.base/share/classes/sun/security/x509/CRLReasonCodeExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CRLReasonCodeExtension.java
@@ -72,7 +72,10 @@ public class CRLReasonCodeExtension extends Extension {
      * @param reason the enumerated value for the reason code.
      */
     public CRLReasonCodeExtension(boolean critical, int reason)
-    throws IOException {
+            throws IOException {
+        if (reason == 0) {
+            throw new IllegalArgumentException("reason code cannot be 0");
+        }
         this.extensionId = PKIXExtensions.ReasonCode_Id;
         this.critical = critical;
         this.reasonCode = reason;

--- a/src/java.base/share/classes/sun/security/x509/CertificateIssuerExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateIssuerExtension.java
@@ -84,6 +84,9 @@ public class CertificateIssuerExtension extends Extension {
      * @throws IOException on error
      */
     public CertificateIssuerExtension(GeneralNames issuer) throws IOException {
+        if (issuer == null || issuer.isEmpty()) {
+            throw new IllegalArgumentException("issuer cannot be null or empty");
+        }
         this.extensionId = PKIXExtensions.CertificateIssuer_Id;
         this.critical = true;
         this.names = issuer;

--- a/src/java.base/share/classes/sun/security/x509/CertificateIssuerExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateIssuerExtension.java
@@ -80,7 +80,7 @@ public class CertificateIssuerExtension extends Extension {
      * Create a CertificateIssuerExtension containing the specified issuer name.
      * Criticality is automatically set to true.
      *
-     * @param issuer the certificate issuer
+     * @param issuer the certificate issuer, cannot be null or empty.
      * @throws IOException on error
      */
     public CertificateIssuerExtension(GeneralNames issuer) throws IOException {

--- a/src/java.base/share/classes/sun/security/x509/CertificatePoliciesExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificatePoliciesExtension.java
@@ -106,7 +106,7 @@ public class CertificatePoliciesExtension extends Extension {
      * a List of PolicyInformation with specified criticality.
      *
      * @param critical true if the extension is to be treated as critical.
-     * @param certPolicies the List of PolicyInformation.
+     * @param certPolicies the List of PolicyInformation, cannot be null or empty.
      */
     public CertificatePoliciesExtension(Boolean critical,
             List<PolicyInformation> certPolicies) throws IOException {

--- a/src/java.base/share/classes/sun/security/x509/CertificatePoliciesExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificatePoliciesExtension.java
@@ -110,6 +110,10 @@ public class CertificatePoliciesExtension extends Extension {
      */
     public CertificatePoliciesExtension(Boolean critical,
             List<PolicyInformation> certPolicies) throws IOException {
+        if (certPolicies == null || certPolicies.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "certificate policies cannot be null or empty");
+        }
         this.certPolicies = certPolicies;
         this.extensionId = PKIXExtensions.CertificatePolicies_Id;
         this.critical = critical.booleanValue();

--- a/src/java.base/share/classes/sun/security/x509/CertificatePolicyId.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificatePolicyId.java
@@ -26,6 +26,8 @@
 package sun.security.x509;
 
 import java.io.IOException;
+import java.util.Objects;
+
 import sun.security.util.*;
 
 
@@ -44,7 +46,7 @@ public class CertificatePolicyId {
      * @param id the ObjectIdentifier for the policy id.
      */
     public CertificatePolicyId(ObjectIdentifier id) {
-        this.id = id;
+        this.id = Objects.requireNonNull(id);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertificatePolicyMap.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificatePolicyMap.java
@@ -26,6 +26,7 @@
 package sun.security.x509;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import sun.security.util.*;
 
@@ -47,8 +48,8 @@ public class CertificatePolicyMap {
      */
     public CertificatePolicyMap(CertificatePolicyId issuer,
                                 CertificatePolicyId subject) {
-        this.issuerDomain = issuer;
-        this.subjectDomain = subject;
+        this.issuerDomain = Objects.requireNonNull(issuer);
+        this.subjectDomain = Objects.requireNonNull(subject);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/ExtendedKeyUsageExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/ExtendedKeyUsageExtension.java
@@ -121,7 +121,11 @@ public class ExtendedKeyUsageExtension extends Extension {
      * @param keyUsages the Vector of KeyUsages (ObjectIdentifiers)
      */
     public ExtendedKeyUsageExtension(Boolean critical, Vector<ObjectIdentifier> keyUsages)
-    throws IOException {
+            throws IOException {
+        if (keyUsages == null || keyUsages.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "key usages cannot be null or empty");
+        }
         this.keyUsages = keyUsages;
         this.extensionId = PKIXExtensions.ExtendedKeyUsage_Id;
         this.critical = critical.booleanValue();

--- a/src/java.base/share/classes/sun/security/x509/ExtendedKeyUsageExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/ExtendedKeyUsageExtension.java
@@ -118,7 +118,8 @@ public class ExtendedKeyUsageExtension extends Extension {
      * a Vector of KeyUsages with specified criticality.
      *
      * @param critical true if the extension is to be treated as critical.
-     * @param keyUsages the Vector of KeyUsages (ObjectIdentifiers)
+     * @param keyUsages the Vector of KeyUsages (ObjectIdentifiers),
+     *                  cannot be null or empty.
      */
     public ExtendedKeyUsageExtension(Boolean critical, Vector<ObjectIdentifier> keyUsages)
             throws IOException {

--- a/src/java.base/share/classes/sun/security/x509/Extension.java
+++ b/src/java.base/share/classes/sun/security/x509/Extension.java
@@ -28,6 +28,8 @@ package sun.security.x509;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
+import java.util.Objects;
+
 import sun.security.util.*;
 
 /**
@@ -172,10 +174,10 @@ public class Extension implements java.security.cert.Extension, DerEncoder {
     @Override
     public void encode(DerOutputStream out) throws IOException {
 
-        if (extensionId == null)
-            throw new IOException("Null OID to encode for the extension!");
-        if (extensionValue == null)
-            throw new IOException("No value to encode for the extension!");
+        Objects.requireNonNull(extensionId,
+                "Null OID to encode for the extension!");
+        Objects.requireNonNull(extensionValue,
+                "No value to encode for the extension!");
 
         DerOutputStream dos = new DerOutputStream();
 

--- a/src/java.base/share/classes/sun/security/x509/Extension.java
+++ b/src/java.base/share/classes/sun/security/x509/Extension.java
@@ -175,9 +175,9 @@ public class Extension implements java.security.cert.Extension, DerEncoder {
     public void encode(DerOutputStream out) throws IOException {
 
         Objects.requireNonNull(extensionId,
-                "Null OID to encode for the extension!");
+                "No OID to encode for the extension");
         Objects.requireNonNull(extensionValue,
-                "No value to encode for the extension!");
+                "No value to encode for the extension");
 
         DerOutputStream dos = new DerOutputStream();
 

--- a/src/java.base/share/classes/sun/security/x509/GeneralSubtree.java
+++ b/src/java.base/share/classes/sun/security/x509/GeneralSubtree.java
@@ -26,6 +26,7 @@
 package sun.security.x509;
 
 import java.io.*;
+import java.util.Objects;
 
 import sun.security.util.*;
 
@@ -61,7 +62,7 @@ public class GeneralSubtree {
      * @param max the maximum BaseDistance
      */
     public GeneralSubtree(GeneralName name, int min, int max) {
-        this.name = name;
+        this.name = Objects.requireNonNull(name);
         this.minimum = min;
         this.maximum = max;
     }

--- a/src/java.base/share/classes/sun/security/x509/InhibitAnyPolicyExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/InhibitAnyPolicyExtension.java
@@ -83,7 +83,7 @@ public class InhibitAnyPolicyExtension extends Extension {
      */
     public InhibitAnyPolicyExtension(int skipCerts) throws IOException {
         if (skipCerts < -1)
-            throw new IOException("Invalid value for skipCerts");
+            throw new IllegalArgumentException("Invalid value for skipCerts");
         if (skipCerts == -1)
             this.skipCerts = Integer.MAX_VALUE;
         else

--- a/src/java.base/share/classes/sun/security/x509/InvalidityDateExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/InvalidityDateExtension.java
@@ -88,7 +88,7 @@ public class InvalidityDateExtension extends Extension {
      * Create a InvalidityDateExtension with the passed in date.
      *
      * @param critical true if the extension is to be treated as critical.
-     * @param date the invalidity date
+     * @param date the invalidity date, cannot be null.
      */
     public InvalidityDateExtension(boolean critical, Date date)
             throws IOException {

--- a/src/java.base/share/classes/sun/security/x509/InvalidityDateExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/InvalidityDateExtension.java
@@ -91,7 +91,10 @@ public class InvalidityDateExtension extends Extension {
      * @param date the invalidity date
      */
     public InvalidityDateExtension(boolean critical, Date date)
-    throws IOException {
+            throws IOException {
+        if (date == null) {
+            throw new IllegalArgumentException("date cannot be null");
+        }
         this.extensionId = PKIXExtensions.InvalidityDate_Id;
         this.critical = critical;
         this.date = date;

--- a/src/java.base/share/classes/sun/security/x509/IssuerAlternativeNameExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/IssuerAlternativeNameExtension.java
@@ -84,7 +84,7 @@ public class IssuerAlternativeNameExtension extends Extension {
     public IssuerAlternativeNameExtension(Boolean critical, GeneralNames names)
             throws IOException {
         if (names == null || names.isEmpty()) {
-            throw new IllegalArgumentException("names should not be empty");
+            throw new IllegalArgumentException("names cannot be null or empty");
         }
         this.names = names;
         this.extensionId = PKIXExtensions.IssuerAlternativeName_Id;

--- a/src/java.base/share/classes/sun/security/x509/IssuerAlternativeNameExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/IssuerAlternativeNameExtension.java
@@ -69,11 +69,8 @@ public class IssuerAlternativeNameExtension extends Extension {
      * @exception IOException on error.
      */
     public IssuerAlternativeNameExtension(GeneralNames names)
-    throws IOException {
-        this.names = names;
-        this.extensionId = PKIXExtensions.IssuerAlternativeName_Id;
-        this.critical = false;
-        encodeThis();
+            throws IOException {
+        this(false, names);
     }
 
     /**
@@ -85,20 +82,14 @@ public class IssuerAlternativeNameExtension extends Extension {
      * @exception IOException on error.
      */
     public IssuerAlternativeNameExtension(Boolean critical, GeneralNames names)
-    throws IOException {
+            throws IOException {
+        if (names == null || names.isEmpty()) {
+            throw new IllegalArgumentException("names should not be empty");
+        }
         this.names = names;
         this.extensionId = PKIXExtensions.IssuerAlternativeName_Id;
         this.critical = critical.booleanValue();
         encodeThis();
-    }
-
-    /**
-     * Create a default IssuerAlternativeNameExtension.
-     */
-    public IssuerAlternativeNameExtension() {
-        extensionId = PKIXExtensions.IssuerAlternativeName_Id;
-        critical = false;
-        names = new GeneralNames();
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/IssuerAlternativeNameExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/IssuerAlternativeNameExtension.java
@@ -78,7 +78,7 @@ public class IssuerAlternativeNameExtension extends Extension {
      * and GeneralNames.
      *
      * @param critical true if the extension is to be treated as critical.
-     * @param names the GeneralNames for the issuer.
+     * @param names the GeneralNames for the issuer, cannot be null or empty.
      * @exception IOException on error.
      */
     public IssuerAlternativeNameExtension(Boolean critical, GeneralNames names)

--- a/src/java.base/share/classes/sun/security/x509/IssuingDistributionPointExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/IssuingDistributionPointExtension.java
@@ -119,6 +119,14 @@ public class IssuingDistributionPointExtension extends Extension {
         boolean hasOnlyAttributeCerts, boolean isIndirectCRL)
             throws IOException {
 
+        if (distributionPoint == null &&
+                revocationReasons == null &&
+                !hasOnlyUserCerts &&
+                !hasOnlyCACerts &&
+                !hasOnlyAttributeCerts &&
+                !isIndirectCRL) {
+            throw new IllegalArgumentException("elements cannot be empty");
+        }
         if ((hasOnlyUserCerts && (hasOnlyCACerts || hasOnlyAttributeCerts)) ||
             (hasOnlyCACerts && (hasOnlyUserCerts || hasOnlyAttributeCerts)) ||
             (hasOnlyAttributeCerts && (hasOnlyUserCerts || hasOnlyCACerts))) {

--- a/src/java.base/share/classes/sun/security/x509/IssuingDistributionPointExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/IssuingDistributionPointExtension.java
@@ -110,7 +110,8 @@ public class IssuingDistributionPointExtension extends Extension {
      *        issuer CRL entry extension.
      * @throws IllegalArgumentException if more than one of
      *        <code>hasOnlyUserCerts</code>, <code>hasOnlyCACerts</code>,
-     *        <code>hasOnlyAttributeCerts</code> is set to <code>true</code>.
+     *        <code>hasOnlyAttributeCerts</code> is set to <code>true</code>,
+     *        or all arguments are either <code>null</code> or <code>false</code>.
      * @throws IOException on encoding error.
      */
     public IssuingDistributionPointExtension(

--- a/src/java.base/share/classes/sun/security/x509/NameConstraintsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/NameConstraintsExtension.java
@@ -136,7 +136,11 @@ public class NameConstraintsExtension extends Extension
      */
     public NameConstraintsExtension(GeneralSubtrees permitted,
                                     GeneralSubtrees excluded)
-    throws IOException {
+            throws IOException {
+        if (permitted == null && excluded == null) {
+            throw new IllegalArgumentException(
+                    "permitted and exclude cannot be all null");
+        }
         this.permitted = permitted;
         this.excluded = excluded;
 
@@ -280,6 +284,8 @@ public class NameConstraintsExtension extends Extension
             return;
         }
 
+        boolean updated = false;
+
         /*
          * If excludedSubtrees is present in the certificate, set the
          * excluded subtrees state variable to the union of its previous
@@ -288,12 +294,15 @@ public class NameConstraintsExtension extends Extension
 
         GeneralSubtrees newExcluded = newConstraints.getExcludedSubtrees();
         if (excluded == null) {
-            excluded = (newExcluded != null) ?
-                        (GeneralSubtrees)newExcluded.clone() : null;
+            if (newExcluded != null) {
+                excluded = (GeneralSubtrees) newExcluded.clone();
+                updated = true;
+            }
         } else {
             if (newExcluded != null) {
                 // Merge new excluded with current excluded (union)
                 excluded.union(newExcluded);
+                updated = true;
             }
         }
 
@@ -305,8 +314,10 @@ public class NameConstraintsExtension extends Extension
 
         GeneralSubtrees newPermitted = newConstraints.getPermittedSubtrees();
         if (permitted == null) {
-            permitted = (newPermitted != null) ?
-                        (GeneralSubtrees)newPermitted.clone() : null;
+            if (newPermitted != null) {
+                permitted = (GeneralSubtrees) newPermitted.clone();
+                updated = true;
+            }
         } else {
             if (newPermitted != null) {
                 // Merge new permitted with current permitted (intersection)
@@ -319,6 +330,7 @@ public class NameConstraintsExtension extends Extension
                     } else {
                         excluded = (GeneralSubtrees)newExcluded.clone();
                     }
+                    updated = true;
                 }
             }
         }
@@ -329,12 +341,14 @@ public class NameConstraintsExtension extends Extension
         // less space.
         if (permitted != null) {
             permitted.reduce(excluded);
+            updated = true;
         }
 
         // The NameConstraints have been changed, so re-encode them.  Methods in
         // this class assume that the encodings have already been done.
-        encodeThis();
-
+        if (updated) {
+            encodeThis();
+        }
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/NameConstraintsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/NameConstraintsExtension.java
@@ -139,7 +139,7 @@ public class NameConstraintsExtension extends Extension
             throws IOException {
         if (permitted == null && excluded == null) {
             throw new IllegalArgumentException(
-                    "permitted and exclude cannot both be null");
+                    "permitted and excluded cannot both be null");
         }
         this.permitted = permitted;
         this.excluded = excluded;

--- a/src/java.base/share/classes/sun/security/x509/NameConstraintsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/NameConstraintsExtension.java
@@ -127,8 +127,8 @@ public class NameConstraintsExtension extends Extension
     }
 
     /**
-     * The default constructor for this class. Both parameters
-     * are optional and can be set to null.  The extension criticality
+     * The default constructor for this class. Both parameters are optional
+     * but at least one should be non null.  The extension criticality
      * is set to true.
      *
      * @param permitted the permitted GeneralSubtrees (null for optional).
@@ -139,7 +139,7 @@ public class NameConstraintsExtension extends Extension
             throws IOException {
         if (permitted == null && excluded == null) {
             throw new IllegalArgumentException(
-                    "permitted and exclude cannot be all null");
+                    "permitted and exclude cannot both be null");
         }
         this.permitted = permitted;
         this.excluded = excluded;

--- a/src/java.base/share/classes/sun/security/x509/PolicyConstraintsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/PolicyConstraintsExtension.java
@@ -102,7 +102,7 @@ public class PolicyConstraintsExtension extends Extension {
     /**
      * Create a PolicyConstraintsExtension object with specified
      * criticality and both require explicit policy and inhibit
-     * policy mapping.
+     * policy mapping. At least one should be provided (not -1).
      *
      * @param critical true if the extension is to be treated as critical.
      * @param require require explicit policy (-1 for optional).
@@ -112,7 +112,7 @@ public class PolicyConstraintsExtension extends Extension {
             throws IOException {
         if (require == -1 && inhibit == -1) {
             throw new IllegalArgumentException(
-                    "require and inhibit cannot be all -1");
+                    "require and inhibit cannot both be -1");
         }
         this.require = require;
         this.inhibit = inhibit;

--- a/src/java.base/share/classes/sun/security/x509/PolicyConstraintsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/PolicyConstraintsExtension.java
@@ -109,7 +109,11 @@ public class PolicyConstraintsExtension extends Extension {
      * @param inhibit inhibit policy mapping (-1 for optional).
      */
     public PolicyConstraintsExtension(Boolean critical, int require, int inhibit)
-    throws IOException {
+            throws IOException {
+        if (require == -1 && inhibit == -1) {
+            throw new IllegalArgumentException(
+                    "require and inhibit cannot be all -1");
+        }
         this.require = require;
         this.inhibit = inhibit;
         this.extensionId = PKIXExtensions.PolicyConstraints_Id;

--- a/src/java.base/share/classes/sun/security/x509/PolicyInformation.java
+++ b/src/java.base/share/classes/sun/security/x509/PolicyInformation.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.security.cert.PolicyQualifierInfo;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import sun.security.util.DerValue;
@@ -87,7 +88,7 @@ public class PolicyInformation {
         }
         this.policyQualifiers =
                 new LinkedHashSet<>(policyQualifiers);
-        this.policyIdentifier = policyIdentifier;
+        this.policyIdentifier = Objects.requireNonNull(policyIdentifier);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/PolicyMappingsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/PolicyMappingsExtension.java
@@ -75,7 +75,7 @@ public class PolicyMappingsExtension extends Extension {
     /**
      * Create a PolicyMappings with the List of CertificatePolicyMap.
      *
-     * @param maps the List of CertificatePolicyMap.
+     * @param maps the List of CertificatePolicyMap, cannot be null or empty.
      */
     public PolicyMappingsExtension(List<CertificatePolicyMap> maps)
             throws IOException {

--- a/src/java.base/share/classes/sun/security/x509/PolicyMappingsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/PolicyMappingsExtension.java
@@ -79,19 +79,13 @@ public class PolicyMappingsExtension extends Extension {
      */
     public PolicyMappingsExtension(List<CertificatePolicyMap> maps)
             throws IOException {
+        if (maps == null || maps.isEmpty()) {
+            throw new IllegalArgumentException("maps cannot be null or empty");
+        }
         this.maps = maps;
         this.extensionId = PKIXExtensions.PolicyMappings_Id;
         this.critical = true;
         encodeThis();
-    }
-
-    /**
-     * Create a default PolicyMappingsExtension.
-     */
-    public PolicyMappingsExtension() {
-        extensionId = PKIXExtensions.PolicyMappings_Id;
-        critical = true;
-        maps = Collections.emptyList();
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/PrivateKeyUsageExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/PrivateKeyUsageExtension.java
@@ -101,7 +101,11 @@ public class PrivateKeyUsageExtension extends Extension {
      *         should not be used.
      */
     public PrivateKeyUsageExtension(Date notBefore, Date notAfter)
-    throws IOException {
+            throws IOException {
+        if (notBefore == null && notAfter == null) {
+            throw new IllegalArgumentException(
+                    "notBefore and notAfter cannot be all null");
+        }
         this.notBefore = notBefore;
         this.notAfter = notAfter;
 

--- a/src/java.base/share/classes/sun/security/x509/PrivateKeyUsageExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/PrivateKeyUsageExtension.java
@@ -93,10 +93,11 @@ public class PrivateKeyUsageExtension extends Extension {
     }
 
     /**
-     * The default constructor for PrivateKeyUsageExtension.
+     * The default constructor for PrivateKeyUsageExtension. At least one
+     * of the arguments must be non null.
      *
      * @param notBefore the date/time before which the private key
-     *         should not be used.
+     *         should not be used
      * @param notAfter the date/time after which the private key
      *         should not be used.
      */
@@ -104,7 +105,7 @@ public class PrivateKeyUsageExtension extends Extension {
             throws IOException {
         if (notBefore == null && notAfter == null) {
             throw new IllegalArgumentException(
-                    "notBefore and notAfter cannot be all null");
+                    "notBefore and notAfter cannot both be null");
         }
         this.notBefore = notBefore;
         this.notAfter = notAfter;

--- a/src/java.base/share/classes/sun/security/x509/SubjectAlternativeNameExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/SubjectAlternativeNameExtension.java
@@ -84,7 +84,7 @@ public class SubjectAlternativeNameExtension extends Extension {
      * criticality and GeneralNames.
      *
      * @param critical true if the extension is to be treated as critical.
-     * @param names the GeneralNames for the subject.
+     * @param names the GeneralNames for the subject, cannot be null or empty.
      * @exception IOException on error.
      */
     public SubjectAlternativeNameExtension(Boolean critical, GeneralNames names)

--- a/src/java.base/share/classes/sun/security/x509/SubjectAlternativeNameExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/SubjectAlternativeNameExtension.java
@@ -88,21 +88,14 @@ public class SubjectAlternativeNameExtension extends Extension {
      * @exception IOException on error.
      */
     public SubjectAlternativeNameExtension(Boolean critical, GeneralNames names)
-    throws IOException {
+            throws IOException {
+        if (names == null || names.isEmpty()) {
+            throw new IllegalArgumentException("names cannot be null or empty");
+        }
         this.names = names;
         this.extensionId = PKIXExtensions.SubjectAlternativeName_Id;
         this.critical = critical.booleanValue();
         encodeThis();
-    }
-
-    /**
-     * Create a default SubjectAlternativeNameExtension. The extension
-     * is marked non-critical.
-     */
-    public SubjectAlternativeNameExtension() {
-        extensionId = PKIXExtensions.SubjectAlternativeName_Id;
-        critical = false;
-        names = new GeneralNames();
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/SubjectInfoAccessExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/SubjectInfoAccessExtension.java
@@ -86,7 +86,7 @@ public class SubjectInfoAccessExtension extends Extension {
             List<AccessDescription> accessDescriptions) throws IOException {
         if (accessDescriptions == null || accessDescriptions.isEmpty()) {
             throw new IllegalArgumentException(
-                    "AccessDescription cannot be null or empty");
+                    "accessDescriptions cannot be null or empty");
         }
         this.extensionId = PKIXExtensions.SubjectInfoAccess_Id;
         this.critical = false;

--- a/src/java.base/share/classes/sun/security/x509/SubjectInfoAccessExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/SubjectInfoAccessExtension.java
@@ -78,7 +78,8 @@ public class SubjectInfoAccessExtension extends Extension {
      * Create an SubjectInfoAccessExtension from a List of
      * AccessDescription; the criticality is set to false.
      *
-     * @param accessDescriptions the List of AccessDescription
+     * @param accessDescriptions the List of AccessDescription,
+     *                           cannot be null or empty.
      * @throws IOException on error
      */
     public SubjectInfoAccessExtension(

--- a/src/java.base/share/classes/sun/security/x509/SubjectInfoAccessExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/SubjectInfoAccessExtension.java
@@ -83,6 +83,10 @@ public class SubjectInfoAccessExtension extends Extension {
      */
     public SubjectInfoAccessExtension(
             List<AccessDescription> accessDescriptions) throws IOException {
+        if (accessDescriptions == null || accessDescriptions.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "AccessDescription cannot be null or empty");
+        }
         this.extensionId = PKIXExtensions.SubjectInfoAccess_Id;
         this.critical = false;
         this.accessDescriptions = accessDescriptions;

--- a/src/java.base/share/classes/sun/security/x509/SubjectKeyIdentifierExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/SubjectKeyIdentifierExtension.java
@@ -73,7 +73,7 @@ public class SubjectKeyIdentifierExtension extends Extension {
      * @param octetString the octet string identifying the key identifier.
      */
     public SubjectKeyIdentifierExtension(byte[] octetString)
-    throws IOException {
+            throws IOException {
         id = new KeyIdentifier(octetString);
 
         this.extensionId = PKIXExtensions.SubjectKey_Id;

--- a/test/jdk/sun/security/x509/Extensions/DefaultCriticality.java
+++ b/test/jdk/sun/security/x509/Extensions/DefaultCriticality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,22 +25,30 @@
  * @test
  * @summary Change default criticality of policy mappings and policy constraints
             certificate extensions
- * @bug 8059916
+ * @bug 8059916 8296742
  * @modules java.base/sun.security.x509
+ *          java.base/sun.security.util
  */
 
+import sun.security.util.ObjectIdentifier;
+import sun.security.x509.CertificatePolicyId;
+import sun.security.x509.CertificatePolicyMap;
 import sun.security.x509.PolicyConstraintsExtension;
 import sun.security.x509.PolicyMappingsExtension;
 
+import java.util.List;
+
 public class DefaultCriticality {
     public static void main(String [] args) throws Exception {
-        PolicyConstraintsExtension pce = new PolicyConstraintsExtension(-1,-1);
+        PolicyConstraintsExtension pce = new PolicyConstraintsExtension(1, 1);
         if (!pce.isCritical()) {
             throw new Exception("PolicyConstraintsExtension should be " +
                                 "critical by default");
         }
 
-        PolicyMappingsExtension pme = new PolicyMappingsExtension();
+        CertificatePolicyId id = new CertificatePolicyId(ObjectIdentifier.of("1.2.3.4"));
+        PolicyMappingsExtension pme = new PolicyMappingsExtension(List.of(
+                new CertificatePolicyMap(id, id)));
         if (!pme.isCritical()) {
             throw new Exception("PolicyMappingsExtension should be " +
                                 "critical by default");

--- a/test/jdk/sun/security/x509/Extensions/DefaultCriticality.java
+++ b/test/jdk/sun/security/x509/Extensions/DefaultCriticality.java
@@ -25,7 +25,7 @@
  * @test
  * @summary Change default criticality of policy mappings and policy constraints
             certificate extensions
- * @bug 8059916 8296742
+ * @bug 8059916
  * @modules java.base/sun.security.x509
  *          java.base/sun.security.util
  */

--- a/test/jdk/sun/security/x509/Extensions/IllegalExtensions.java
+++ b/test/jdk/sun/security/x509/Extensions/IllegalExtensions.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8296742
+ * @summary Illegal X509 Extension should not be created
+ * @modules java.base/sun.security.util
+ *          java.base/sun.security.x509
+ * @library /test/lib
+ */
+
+import jdk.test.lib.Utils;
+import sun.security.util.ObjectIdentifier;
+import sun.security.x509.*;
+
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Vector;
+
+public class IllegalExtensions {
+
+    public static void main(String [] args) throws Exception {
+
+        var oid = ObjectIdentifier.of("1.2.3.4");
+        var emptyNames = new GeneralNames();
+        var name = new GeneralName(new X500Name("CN=one"));
+        var names = new GeneralNames();
+        names.add(name);
+
+        var ad = new AccessDescription(AccessDescription.Ad_CAISSUERS_Id, name);
+        new AuthorityInfoAccessExtension(List.of(ad));
+        Utils.runAndCheckException(() -> new AuthorityInfoAccessExtension(List.of()), IllegalArgumentException.class);
+        Utils.runAndCheckException(() -> new AuthorityInfoAccessExtension(null), IllegalArgumentException.class);
+
+        var kid = new KeyIdentifier(new byte[32]);
+        var sn = new SerialNumber(0);
+        new AuthorityKeyIdentifierExtension(kid, null, null);
+        new AuthorityKeyIdentifierExtension(null, names, null);
+        new AuthorityKeyIdentifierExtension(null, null, sn);
+        Utils.runAndCheckException(() -> new AuthorityKeyIdentifierExtension(null, null, null), IllegalArgumentException.class);
+
+        new CertificateIssuerExtension(names);
+        Utils.runAndCheckException(() -> new CertificateIssuerExtension(null), IllegalArgumentException.class);
+        Utils.runAndCheckException(() -> new CertificateIssuerExtension(emptyNames), IllegalArgumentException.class);
+
+        var pi = new PolicyInformation(new CertificatePolicyId(oid), Collections.emptySet());
+        new CertificatePoliciesExtension(List.of(pi));
+        Utils.runAndCheckException(() -> new CertificatePoliciesExtension(null), IllegalArgumentException.class);
+        Utils.runAndCheckException(() -> new CertificatePoliciesExtension(List.of()), IllegalArgumentException.class);
+
+        var dp = new DistributionPoint(names, null, null);
+        new CRLDistributionPointsExtension(List.of(dp));
+        Utils.runAndCheckException(() -> new CRLDistributionPointsExtension(List.of()), IllegalArgumentException.class);
+        Utils.runAndCheckException(() -> new CRLDistributionPointsExtension(null), IllegalArgumentException.class);
+
+        new CRLNumberExtension(0);
+        new CRLNumberExtension(BigInteger.ONE);
+        Utils.runAndCheckException(() -> new CRLNumberExtension(null), IllegalArgumentException.class);
+
+        new CRLReasonCodeExtension(1);
+        Utils.runAndCheckException(() -> new CRLReasonCodeExtension(0), IllegalArgumentException.class);
+
+        new ExtendedKeyUsageExtension(new Vector<>(List.of(oid)));
+        Utils.runAndCheckException(() -> new ExtendedKeyUsageExtension(null), IllegalArgumentException.class);
+        Utils.runAndCheckException(() -> new ExtendedKeyUsageExtension(new Vector<>()), IllegalArgumentException.class);
+
+        new InhibitAnyPolicyExtension(0);
+        new InhibitAnyPolicyExtension(-1);
+        Utils.runAndCheckException(() -> new InhibitAnyPolicyExtension(-2), IllegalArgumentException.class);
+
+        new InvalidityDateExtension(new Date());
+        Utils.runAndCheckException(() -> new InvalidityDateExtension(null), IllegalArgumentException.class);
+
+        new IssuerAlternativeNameExtension(names);
+        Utils.runAndCheckException(() -> new IssuerAlternativeNameExtension(null), IllegalArgumentException.class);
+        Utils.runAndCheckException(() -> new IssuerAlternativeNameExtension(emptyNames), IllegalArgumentException.class);
+
+        var dpn = new DistributionPointName(names);
+        var rf = new ReasonFlags(new boolean[1]);
+        new IssuingDistributionPointExtension(dpn, null, false, false, false, false);
+        new IssuingDistributionPointExtension(null, rf, false, false, false, false);
+        new IssuingDistributionPointExtension(null, null, true, false, false, false);
+        new IssuingDistributionPointExtension(null, null, false, true, false, false);
+        new IssuingDistributionPointExtension(null, null, false, false, true, false);
+        new IssuingDistributionPointExtension(null, null, false, false, false, true);
+        Utils.runAndCheckException(() -> new IssuingDistributionPointExtension(null, null, false, false, false, false), IllegalArgumentException.class);
+
+        var gss = new GeneralSubtrees();
+        new NameConstraintsExtension(gss, null);
+        new NameConstraintsExtension((GeneralSubtrees) null, gss);
+        Utils.runAndCheckException(() -> new NameConstraintsExtension((GeneralSubtrees) null, null), IllegalArgumentException.class);
+
+        new PolicyConstraintsExtension(0, 0);
+        new PolicyConstraintsExtension(-1, 0);
+        new PolicyConstraintsExtension(0, -1);
+        Utils.runAndCheckException(() -> new PolicyConstraintsExtension(-1, -1), IllegalArgumentException.class);
+
+        var cpi = new CertificatePolicyId(oid);
+        var cpm = new CertificatePolicyMap(cpi, cpi);
+        new PolicyMappingsExtension(List.of(cpm));
+        Utils.runAndCheckException(() -> new PolicyMappingsExtension(List.of()), IllegalArgumentException.class);
+        Utils.runAndCheckException(() -> new PolicyMappingsExtension(null), IllegalArgumentException.class);
+
+        new PrivateKeyUsageExtension(new Date(), new Date());
+        new PrivateKeyUsageExtension(new Date(), null);
+        new PrivateKeyUsageExtension((Date) null, new Date());
+        Utils.runAndCheckException(() -> new PrivateKeyUsageExtension((Date) null, null), IllegalArgumentException.class);
+
+        new SubjectAlternativeNameExtension(names);
+        Utils.runAndCheckException(() -> new SubjectAlternativeNameExtension(null), IllegalArgumentException.class);
+        Utils.runAndCheckException(() -> new SubjectAlternativeNameExtension(emptyNames), IllegalArgumentException.class);
+
+        new SubjectInfoAccessExtension(List.of(ad));
+        Utils.runAndCheckException(() -> new SubjectInfoAccessExtension(List.of()), IllegalArgumentException.class);
+        Utils.runAndCheckException(() -> new SubjectInfoAccessExtension(null), IllegalArgumentException.class);
+    }
+}

--- a/test/jdk/sun/security/x509/Extensions/IllegalExtensions.java
+++ b/test/jdk/sun/security/x509/Extensions/IllegalExtensions.java
@@ -82,6 +82,7 @@ public class IllegalExtensions {
 
         new CRLReasonCodeExtension(1);
         Utils.runAndCheckException(() -> new CRLReasonCodeExtension(0), IllegalArgumentException.class);
+        Utils.runAndCheckException(() -> new CRLReasonCodeExtension(-1), IllegalArgumentException.class);
 
         new ExtendedKeyUsageExtension(new Vector<>(List.of(oid)));
         Utils.runAndCheckException(() -> new ExtendedKeyUsageExtension(null), IllegalArgumentException.class);

--- a/test/jdk/sun/security/x509/X509CertImpl/V3Certificate.java
+++ b/test/jdk/sun/security/x509/X509CertImpl/V3Certificate.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8049237 8242151 8296742
+ * @bug 8049237 8242151
  * @modules java.base/sun.security.x509
  *          java.base/sun.security.util
  *          jdk.crypto.ec

--- a/test/jdk/sun/security/x509/X509CertImpl/V3Certificate.java
+++ b/test/jdk/sun/security/x509/X509CertImpl/V3Certificate.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8049237 8242151
+ * @bug 8049237 8242151 8296742
  * @modules java.base/sun.security.x509
  *          java.base/sun.security.util
  *          jdk.crypto.ec
@@ -155,21 +155,19 @@ public class V3Certificate {
                 new OIDName(ObjectIdentifier.of("1.2.3.4"));
         GeneralName oid = new GeneralName(oidInf);
 
-        SubjectAlternativeNameExtension subjectName
-                = new SubjectAlternativeNameExtension();
-        IssuerAlternativeNameExtension issuerName
-                = new IssuerAlternativeNameExtension();
 
-        GeneralNames subjectNames = subjectName.getNames();
-
-        GeneralNames issuerNames = issuerName.getNames();
-
+        GeneralNames subjectNames = new GeneralNames();
         subjectNames.add(mail);
         subjectNames.add(dns);
         subjectNames.add(uri);
+        SubjectAlternativeNameExtension subjectName
+                = new SubjectAlternativeNameExtension(subjectNames);
 
+        GeneralNames issuerNames = new GeneralNames();
         issuerNames.add(ip);
         issuerNames.add(oid);
+        IssuerAlternativeNameExtension issuerName
+                = new IssuerAlternativeNameExtension(issuerNames);
 
         cal.set(2000, 11, 15, 12, 30, 30);
         lastDate = cal.getTime();


### PR DESCRIPTION
Inside JDK we support a lot of X.509 certificate extensions. Almost every extension has a rule about what is legal or not. For example, the names in `SubjectAlternativeNameExtension` cannot be missing or empty. Usually, a rule is enforced in the `encode()` method, where the extension value is assigned null for illegal extension and the method throws an `IOException`. However, before the `encode()` method is called, the illegal extension can always be created successfully, whether from a constructor using extension components (For example, `new SubjectAlternativeNameExtension(names)`) or using the encoded value (for example, `new SubjectAlternativeNameExtension(derEncoding)`).

This code change tries to prevent illegal extensions from being created right from the beginning but the solution is not complete. Precisely, for constructors using extension components, new checks are added to ensure the correct components are provided and the extension can be encoded correctly. Fortunately, most of these conditions are already met inside JDK calls to them. The only exception is inside the `keytool -gencrl` command where the reason code of a revoked certificate could be zero. This has been fixed in this code change. There are some constructors having no arguments at all. These are useless and also removed.

On the other hand, constructors using the encoded value are complicated. Some of them check for legal values, some do not. However, since the encoding is read from the argument and already stored inside the object, there is no need to calculate the encoding in the `encode()` method and this method always succeed.

In short, while we cannot ensure the extensions created are perfectly legal, we ensure their `encode()` methods are always able to find a non-null extension value to write out.

More fine comments in the code change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296742](https://bugs.openjdk.org/browse/JDK-8296742): Illegal X509 Extension should not be created


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**) ⚠️ Review applies to [b76ce017](https://git.openjdk.org/jdk/pull/11137/files/b76ce01772f0a95fe41a9868135eb9130b2639fd)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11137/head:pull/11137` \
`$ git checkout pull/11137`

Update a local copy of the PR: \
`$ git checkout pull/11137` \
`$ git pull https://git.openjdk.org/jdk pull/11137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11137`

View PR using the GUI difftool: \
`$ git pr show -t 11137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11137.diff">https://git.openjdk.org/jdk/pull/11137.diff</a>

</details>
