### PR TITLE
JDK-8296913: Correct enable preview idiom in JdbLastErrorTest.java

### DIFF
--- a/test/jdk/com/sun/jdi/JdbLastErrorTest.java
+++ b/test/jdk/com/sun/jdi/JdbLastErrorTest.java
@@ -27,7 +27,7 @@
  * @summary Test persistence of native last error value under jdb (Windows)
  * @requires (os.family == "windows")
  * @library /test/lib
- * @run compile --release 20 --enable-preview JdbLastErrorTest.java
+ * @run compile --release ${jdk.version} --enable-preview JdbLastErrorTest.java
  * @run main/othervm --enable-preview JdbLastErrorTest
  */
 

--- a/test/jdk/com/sun/jdi/JdbLastErrorTest.java
+++ b/test/jdk/com/sun/jdi/JdbLastErrorTest.java
@@ -28,6 +28,7 @@
  * @requires (os.family == "windows")
  * @library /test/lib
  * @enablePreview
+ * @run main/othervm JdbLastErrorTest
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/jdk/com/sun/jdi/JdbLastErrorTest.java
+++ b/test/jdk/com/sun/jdi/JdbLastErrorTest.java
@@ -27,8 +27,7 @@
  * @summary Test persistence of native last error value under jdb (Windows)
  * @requires (os.family == "windows")
  * @library /test/lib
- * @run compile --release ${jdk.version} --enable-preview JdbLastErrorTest.java
- * @run main/othervm --enable-preview JdbLastErrorTest
+ * @enablePreview
  */
 
 import jdk.test.lib.process.OutputAnalyzer;


### PR DESCRIPTION
Update the compile command in JdbLastErrorTest.java so that it doesn't need to be modified with each new JDK release to keep using preview features.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296913](https://bugs.openjdk.org/browse/JDK-8296913): Correct enable preview idiom in JdbLastErrorTest.java


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [7a8d00b4](https://git.openjdk.org/jdk/pull/11139/files/7a8d00b41b506005c0f001e3f42daf391c09445c)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to [7a8d00b4](https://git.openjdk.org/jdk/pull/11139/files/7a8d00b41b506005c0f001e3f42daf391c09445c)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [7a8d00b4](https://git.openjdk.org/jdk/pull/11139/files/7a8d00b41b506005c0f001e3f42daf391c09445c)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [7a8d00b4](https://git.openjdk.org/jdk/pull/11139/files/7a8d00b41b506005c0f001e3f42daf391c09445c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11139/head:pull/11139` \
`$ git checkout pull/11139`

Update a local copy of the PR: \
`$ git checkout pull/11139` \
`$ git pull https://git.openjdk.org/jdk pull/11139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11139`

View PR using the GUI difftool: \
`$ git pr show -t 11139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11139.diff">https://git.openjdk.org/jdk/pull/11139.diff</a>

</details>
