### PR TITLE
8296953: Fix a typo in exception documentation

### DIFF
--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnection.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -363,7 +363,7 @@ public interface RMIConnection extends Closeable, Remote {
      * @throws InstanceNotFoundException The MBean specified is not
      * registered in the MBean server.
      * @throws MBeanRegistrationException The preDeregister
-     * ((<code>MBeanRegistration</code> interface) method of the MBean
+     * (<code>MBeanRegistration</code> interface) method of the MBean
      * has thrown an exception.
      * @throws RuntimeOperationsException Wraps a
      * <code>java.lang.IllegalArgumentException</code>: The object

--- a/src/java.management/share/classes/javax/management/MBeanServerConnection.java
+++ b/src/java.management/share/classes/javax/management/MBeanServerConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -354,7 +354,7 @@ public interface MBeanServerConnection {
      * @exception InstanceNotFoundException The MBean specified is not
      * registered in the MBean server.
      * @exception MBeanRegistrationException The preDeregister
-     * ((<CODE>MBeanRegistration</CODE> interface) method of the MBean
+     * (<CODE>MBeanRegistration</CODE> interface) method of the MBean
      * has thrown an exception.
      * @exception RuntimeMBeanException If the <CODE>postDeregister</CODE>
      * (<CODE>MBeanRegistration</CODE> interface) method of the MBean throws a


### PR DESCRIPTION
Please review this trivial documentation change that fixes a typo accidentally found while comparing javadoc output for an unrelated change in jdk.javadoc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296953](https://bugs.openjdk.org/browse/JDK-8296953): Fix a typo in exception documentation


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11140/head:pull/11140` \
`$ git checkout pull/11140`

Update a local copy of the PR: \
`$ git checkout pull/11140` \
`$ git pull https://git.openjdk.org/jdk pull/11140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11140`

View PR using the GUI difftool: \
`$ git pr show -t 11140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11140.diff">https://git.openjdk.org/jdk/pull/11140.diff</a>

</details>
