### PR TITLE
7132279: (ch) SeekableByteChannel operation may throw Non{Readable,Writable}ChannelException

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -380,6 +380,7 @@ public abstract class FileChannel
      * @throws  ClosedChannelException      {@inheritDoc}
      * @throws  AsynchronousCloseException  {@inheritDoc}
      * @throws  ClosedByInterruptException  {@inheritDoc}
+     * @throws  NonReadableChannelException {@inheritDoc}
      */
     public abstract int read(ByteBuffer dst) throws IOException;
 
@@ -395,6 +396,7 @@ public abstract class FileChannel
      * @throws  ClosedChannelException      {@inheritDoc}
      * @throws  AsynchronousCloseException  {@inheritDoc}
      * @throws  ClosedByInterruptException  {@inheritDoc}
+     * @throws  NonReadableChannelException {@inheritDoc}
      */
     public abstract long read(ByteBuffer[] dsts, int offset, int length)
         throws IOException;
@@ -410,6 +412,7 @@ public abstract class FileChannel
      * @throws  ClosedChannelException      {@inheritDoc}
      * @throws  AsynchronousCloseException  {@inheritDoc}
      * @throws  ClosedByInterruptException  {@inheritDoc}
+     * @throws  NonReadableChannelException {@inheritDoc}
      */
     public final long read(ByteBuffer[] dsts) throws IOException {
         return read(dsts, 0, dsts.length);
@@ -426,12 +429,10 @@ public abstract class FileChannel
      * behaves exactly as specified by the {@link WritableByteChannel}
      * interface. </p>
      *
-     * @throws  NonWritableChannelException
-     *          If this channel was not opened for writing
-     *
      * @throws  ClosedChannelException      {@inheritDoc}
      * @throws  AsynchronousCloseException  {@inheritDoc}
      * @throws  ClosedByInterruptException  {@inheritDoc}
+     * @throws  NonWritableChannelException {@inheritDoc}
      */
     public abstract int write(ByteBuffer src) throws IOException;
 
@@ -447,12 +448,10 @@ public abstract class FileChannel
      * behaves exactly as specified in the {@link GatheringByteChannel}
      * interface.  </p>
      *
-     * @throws  NonWritableChannelException
-     *          If this channel was not opened for writing
-     *
      * @throws  ClosedChannelException      {@inheritDoc}
      * @throws  AsynchronousCloseException  {@inheritDoc}
      * @throws  ClosedByInterruptException  {@inheritDoc}
+     * @throws  NonWritableChannelException {@inheritDoc}
      */
     public abstract long write(ByteBuffer[] srcs, int offset, int length)
         throws IOException;
@@ -468,12 +467,10 @@ public abstract class FileChannel
      * behaves exactly as specified in the {@link GatheringByteChannel}
      * interface.  </p>
      *
-     * @throws  NonWritableChannelException
-     *          If this channel was not opened for writing
-     *
      * @throws  ClosedChannelException      {@inheritDoc}
      * @throws  AsynchronousCloseException  {@inheritDoc}
      * @throws  ClosedByInterruptException  {@inheritDoc}
+     * @throws  NonWritableChannelException {@inheritDoc}
      */
     public final long write(ByteBuffer[] srcs) throws IOException {
         return write(srcs, 0, srcs.length);

--- a/src/java.base/share/classes/java/nio/channels/SeekableByteChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/SeekableByteChannel.java
@@ -64,6 +64,7 @@ public interface SeekableByteChannel
      * @throws  ClosedChannelException      {@inheritDoc}
      * @throws  AsynchronousCloseException  {@inheritDoc}
      * @throws  ClosedByInterruptException  {@inheritDoc}
+     * @throws  NonReadableChannelException {@inheritDoc}
      */
     @Override
     int read(ByteBuffer dst) throws IOException;
@@ -83,6 +84,7 @@ public interface SeekableByteChannel
      * @throws  ClosedChannelException      {@inheritDoc}
      * @throws  AsynchronousCloseException  {@inheritDoc}
      * @throws  ClosedByInterruptException  {@inheritDoc}
+     * @throws  NonWritableChannelException {@inheritDoc}
      */
     @Override
     int write(ByteBuffer src) throws IOException;


### PR DESCRIPTION
Fix the specifications of the `read` and `write` methods in `SeekableByteChannel` and `FileChannel` to indicate that a `NonReadableChannelException` or `NonWritableChannelException`, respectively.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-7132279](https://bugs.openjdk.org/browse/JDK-7132279): (ch) SeekableByteChannel operation may throw Non{Readable,Writable}ChannelException
 * [JDK-8297054](https://bugs.openjdk.org/browse/JDK-8297054): (ch) SeekableByteChannel operation may throw Non{Readable,Writable}ChannelException (**CSR**)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11141/head:pull/11141` \
`$ git checkout pull/11141`

Update a local copy of the PR: \
`$ git checkout pull/11141` \
`$ git pull https://git.openjdk.org/jdk pull/11141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11141`

View PR using the GUI difftool: \
`$ git pr show -t 11141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11141.diff">https://git.openjdk.org/jdk/pull/11141.diff</a>

</details>
