### PR TITLE
8296671: [JFR] jdk.ContainerConfiguration event should include host total memory

### DIFF
--- a/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
@@ -63,6 +63,7 @@
 
 #ifdef LINUX
 #include "osContainer_linux.hpp"
+#include "os_linux.hpp"
 #endif
 
 #define NO_TRANSITION(result_type, header) extern "C" { result_type JNICALL header {
@@ -389,5 +390,15 @@ JVM_ENTRY_NO_ENV(jboolean, jfr_is_containerized(JNIEnv* env, jobject jvm))
   return OSContainer::is_containerized();
 #else
   return false;
+#endif
+JVM_END
+
+JVM_ENTRY_NO_ENV(jlong, jfr_host_total_memory(JNIEnv* env, jobject jvm))
+#ifdef LINUX
+  // We want the host memory, not the container limit.
+  // os::physical_memory() would return the container limit.
+  return os::Linux::physical_memory();
+#else
+  return os::physical_memory();
 #endif
 JVM_END

--- a/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
@@ -160,6 +160,8 @@ jboolean JNICALL jfr_is_class_instrumented(JNIEnv* env, jobject jvm, jclass claz
 
 jboolean JNICALL jfr_is_containerized(JNIEnv* env, jobject jvm);
 
+jlong JNICALL jfr_host_total_memory(JNIEnv* env, jobject jvm);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/hotspot/share/jfr/jni/jfrJniMethodRegistration.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethodRegistration.cpp
@@ -94,7 +94,8 @@ JfrJniMethodRegistration::JfrJniMethodRegistration(JNIEnv* env) {
       (char*)"getTypeId", (char*)"(Ljava/lang/String;)J", (void*)jfr_get_type_id_from_string,
       (char*)"isExcluded", (char*)"(Ljava/lang/Class;)Z", (void*)jfr_is_class_excluded,
       (char*)"isInstrumented", (char*)"(Ljava/lang/Class;)Z", (void*) jfr_is_class_instrumented,
-      (char*)"isContainerized", (char*)"()Z", (void*) jfr_is_containerized
+      (char*)"isContainerized", (char*)"()Z", (void*) jfr_is_containerized,
+      (char*)"hostTotalMemory", (char*)"()J", (void*) jfr_host_total_memory
     };
 
     const size_t method_array_length = sizeof(method) / sizeof(JNINativeMethod);

--- a/src/jdk.jfr/share/classes/jdk/jfr/events/ContainerConfigurationEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/ContainerConfigurationEvent.java
@@ -75,4 +75,9 @@ public final class ContainerConfigurationEvent extends AbstractJDKEvent {
     @Description("Maximum amount of physical memory and swap space, in bytes, that can be allocated in the container")
     @DataAmount
     public long swapMemoryLimit;
+
+    @Label("Container Host Total Memory")
+    @Description("Total memory of the host running the container")
+    @DataAmount
+    public long hostTotalMemory;
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
@@ -635,4 +635,10 @@ public final class JVM {
      * can't be emitted anyway.
      */
     public native boolean isContainerized();
+
+    /**
+     * Returns the total amount of memory of the host system whether or not this
+     * JVM runs in a container.
+     */
+    public native long hostTotalMemory();
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/JDKEvents.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/JDKEvents.java
@@ -221,6 +221,7 @@ public final class JDKEvents {
             t.memorySoftLimit = containerMetrics.getMemorySoftLimit();
             t.memoryLimit = containerMetrics.getMemoryLimit();
             t.swapMemoryLimit = containerMetrics.getMemoryAndSwapLimit();
+            t.hostTotalMemory = JVM.getJVM().hostTotalMemory();
             t.commit();
         }
     }


### PR DESCRIPTION
Please review this addition to the jdk.ContainerConfigration event which adds information
about the container host. Specifically, the total amount of memory of the host system.

Testing:
- [x] New test case (passed, fails before)
- [x] JFR tests. Passed.

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296671](https://bugs.openjdk.org/browse/JDK-8296671): [JFR] jdk.ContainerConfiguration event should include host total memory


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11143/head:pull/11143` \
`$ git checkout pull/11143`

Update a local copy of the PR: \
`$ git checkout pull/11143` \
`$ git pull https://git.openjdk.org/jdk pull/11143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11143`

View PR using the GUI difftool: \
`$ git pr show -t 11143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11143.diff">https://git.openjdk.org/jdk/pull/11143.diff</a>

</details>
