### PR TITLE
8296958: [JVMCI] add API for retrieving ConstantValue attributes

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -576,6 +576,16 @@ C2V_VMENTRY_NULL(jobject, lookupClass, (JNIEnv* env, jobject, jclass mirror))
   return JVMCIENV->get_jobject(result);
 C2V_END
 
+C2V_VMENTRY_NULL(jobject, getUncachedStringInPool, (JNIEnv* env, jobject, ARGUMENT_PAIR(cp), jint index))
+  constantPoolHandle cp(THREAD, UNPACK_PAIR(ConstantPool, cp));
+  constantTag tag = cp->tag_at(index);
+  if (!tag.is_string()) {
+    JVMCI_THROW_MSG_NULL(IllegalArgumentException, err_msg("Unexpected constant pool tag at index %d: %d", index, tag.value()));
+  }
+  oop obj = cp->uncached_string_at(index, CHECK_NULL);
+  return JVMCIENV->get_jobject(JVMCIENV->get_object_constant(obj));
+C2V_END
+
 C2V_VMENTRY_NULL(jobject, resolvePossiblyCachedConstantInPool, (JNIEnv* env, jobject, ARGUMENT_PAIR(cp), jint index))
   constantPoolHandle cp(THREAD, UNPACK_PAIR(ConstantPool, cp));
   oop obj = cp->resolve_possibly_cached_constant_at(index, CHECK_NULL);
@@ -2834,6 +2844,7 @@ JNINativeMethod CompilerToVM::methods[] = {
   {CC "lookupMethodInPool",                           CC "(" HS_CONSTANT_POOL2 "IB" HS_METHOD2 ")" HS_METHOD,                               FN_PTR(lookupMethodInPool)},
   {CC "constantPoolRemapInstructionOperandFromCache", CC "(" HS_CONSTANT_POOL2 "I)I",                                                       FN_PTR(constantPoolRemapInstructionOperandFromCache)},
   {CC "resolveBootstrapMethod",                       CC "(" HS_CONSTANT_POOL2 "I)[" OBJECT,                                                FN_PTR(resolveBootstrapMethod)},
+  {CC "getUncachedStringInPool",                      CC "(" HS_CONSTANT_POOL2 "I)" JAVACONSTANT,                                           FN_PTR(getUncachedStringInPool)},
   {CC "resolvePossiblyCachedConstantInPool",          CC "(" HS_CONSTANT_POOL2 "I)" JAVACONSTANT,                                           FN_PTR(resolvePossiblyCachedConstantInPool)},
   {CC "resolveTypeInPool",                            CC "(" HS_CONSTANT_POOL2 "I)" HS_KLASS,                                               FN_PTR(resolveTypeInPool)},
   {CC "resolveFieldInPool",                           CC "(" HS_CONSTANT_POOL2 "I" HS_METHOD2 "B[I)" HS_KLASS,                              FN_PTR(resolveFieldInPool)},

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -174,6 +174,7 @@
                                                                                                                                      \
   nonstatic_field(JavaThread,                  _threadObj,                                    OopHandle)                             \
   nonstatic_field(JavaThread,                  _vthread,                                      OopHandle)                             \
+  nonstatic_field(JavaThread,                  _extentLocalCache,                             OopHandle)                             \
   nonstatic_field(JavaThread,                  _anchor,                                       JavaFrameAnchor)                       \
   nonstatic_field(JavaThread,                  _vm_result,                                    oop)                                   \
   nonstatic_field(JavaThread,                  _stack_overflow_state._stack_overflow_limit,   address)                               \

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -252,6 +252,18 @@ final class CompilerToVM {
     native HotSpotResolvedJavaType lookupClass(Class<?> javaClass);
 
     /**
+     * Resolves the entry at index {@code cpi} in {@code constantPool} to an interned String object.
+     *
+     * The behavior of this method is undefined if {@code cpi} does not denote an
+     * {@code JVM_CONSTANT_String}.
+     */
+    JavaConstant getUncachedStringInPool(HotSpotConstantPool constantPool, int cpi) {
+        return getUncachedStringInPool(constantPool, constantPool.getConstantPoolPointer(), cpi);
+    }
+
+    private native JavaConstant getUncachedStringInPool(HotSpotConstantPool constantPool, long constantPoolPointer, int cpi);
+
+    /**
      * Resolves the entry at index {@code cpi} in {@code constantPool} to an object, looking in the
      * constant pool cache first.
      *

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotConstantPool.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotConstantPool.java
@@ -619,6 +619,27 @@ public final class HotSpotConstantPool implements ConstantPool, MetaspaceHandleO
         }
     }
 
+    /**
+     * Gets the {@link JavaConstant} for the {@code ConstantValue} attribute of a field.
+     */
+    JavaConstant getStaticFieldConstantValue(int cpi) {
+        final JvmConstant tag = getTagAt(cpi);
+        switch (tag.name) {
+            case "Integer":
+                return JavaConstant.forInt(getIntAt(cpi));
+            case "Long":
+                return JavaConstant.forLong(getLongAt(cpi));
+            case "Float":
+                return JavaConstant.forFloat(getFloatAt(cpi));
+            case "Double":
+                return JavaConstant.forDouble(getDoubleAt(cpi));
+            case "String":
+                return compilerToVM().getUncachedStringInPool(this, cpi);
+            default:
+                throw new IllegalArgumentException("Illegal entry for a ConstantValue attribute:" + tag);
+        }
+    }
+
     @Override
     public Object lookupConstant(int cpi) {
         assert cpi != 0;

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedJavaFieldImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedJavaFieldImpl.java
@@ -214,4 +214,9 @@ class HotSpotResolvedJavaFieldImpl implements HotSpotResolvedJavaField {
         }
         return runtime().reflection.getFieldAnnotation(this, annotationClass);
     }
+
+    @Override
+    public JavaConstant getConstantValue() {
+        return holder.createFieldInfo(index).getConstantValue();
+    }
 }

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedObjectTypeImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedObjectTypeImpl.java
@@ -689,6 +689,10 @@ final class HotSpotResolvedObjectTypeImpl extends HotSpotResolvedJavaType implem
             return readFieldSlot(config().fieldInfoSignatureIndexOffset);
         }
 
+        private int getConstantValueIndex() {
+            return readFieldSlot(config().fieldInfoConstantValueIndexOffset);
+        }
+
         public int getOffset() {
             HotSpotVMConfig config = config();
             final int lowPacked = readFieldSlot(config.fieldInfoLowPackedOffset);
@@ -722,6 +726,19 @@ final class HotSpotResolvedObjectTypeImpl extends HotSpotResolvedJavaType implem
         public String getSignature() {
             final int signatureIndex = getSignatureIndex();
             return isInternal() ? config().symbolAt(signatureIndex) : getConstantPool().lookupUtf8(signatureIndex);
+        }
+
+        /**
+         * Gets the {@link JavaConstant} for the {@code ConstantValue} attribute of this field.
+         *
+         * @return {@code null} if this field has no {@code ConstantValue} attribute
+         */
+        public JavaConstant getConstantValue() {
+            int cvIndex = getConstantValueIndex();
+            if (cvIndex == 0) {
+                return null;
+            }
+            return constantPool.getStaticFieldConstantValue(cvIndex);
         }
 
         public JavaType getType() {

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotVMConfig.java
@@ -119,6 +119,7 @@ class HotSpotVMConfig extends HotSpotVMConfigAccess {
     final int fieldInfoAccessFlagsOffset = getConstant("FieldInfo::access_flags_offset", Integer.class);
     final int fieldInfoNameIndexOffset = getConstant("FieldInfo::name_index_offset", Integer.class);
     final int fieldInfoSignatureIndexOffset = getConstant("FieldInfo::signature_index_offset", Integer.class);
+    final int fieldInfoConstantValueIndexOffset = getConstant("FieldInfo::initval_index_offset", Integer.class);
     final int fieldInfoLowPackedOffset = getConstant("FieldInfo::low_packed_offset", Integer.class);
     final int fieldInfoHighPackedOffset = getConstant("FieldInfo::high_packed_offset", Integer.class);
     final int fieldInfoFieldSlots = getConstant("FieldInfo::field_slots", Integer.class);

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/ResolvedJavaField.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/ResolvedJavaField.java
@@ -63,4 +63,15 @@ public interface ResolvedJavaField extends JavaField, ModifiersProvider, Annotat
      */
     @Override
     ResolvedJavaType getDeclaringClass();
+
+    /**
+     * Gets the value of the {@code ConstantValue} attribute ({@jvms 4.7.2}) associated with this
+     * field.
+     *
+     * @return {@code null} if this field has no {@code ConstantValue} attribute
+     * @throws UnsupportedOperationException if this operation is not supported
+     */
+    default JavaConstant getConstantValue() {
+        throw new UnsupportedOperationException();
+    }
 }


### PR DESCRIPTION
In order to properly initialize classes in a native image at run time, Native Image needs to capture the value of [`ConstantValue` attributes](https://docs.oracle.com/javase/specs/jvms/se19/html/jvms-4.html#jvms-4.7.2) at image build time. This PR adds `ResolvedJavaField.getConstantValue()` for this purpose.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296958](https://bugs.openjdk.org/browse/JDK-8296958): [JVMCI] add API for retrieving ConstantValue attributes


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11144/head:pull/11144` \
`$ git checkout pull/11144`

Update a local copy of the PR: \
`$ git checkout pull/11144` \
`$ git pull https://git.openjdk.org/jdk pull/11144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11144`

View PR using the GUI difftool: \
`$ git pr show -t 11144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11144.diff">https://git.openjdk.org/jdk/pull/11144.diff</a>

</details>
