### PR TITLE
8296960: [JVMCI] list HotSpotConstantPool.loadReferencedType to ConstantPool

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotConstantPool.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotConstantPool.java
@@ -815,6 +815,7 @@ public final class HotSpotConstantPool implements ConstantPool, MetaspaceHandleO
         loadReferencedType(cpi, opcode, true /* initialize */);
     }
 
+    @Override
     @SuppressWarnings("fallthrough")
     public void loadReferencedType(int cpi, int opcode, boolean initialize) {
         int index;

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/ConstantPool.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/ConstantPool.java
@@ -50,6 +50,24 @@ public interface ConstantPool {
     void loadReferencedType(int cpi, int opcode);
 
     /**
+     * Ensures that the type referenced by the specified constant pool entry is loaded. This can be
+     * used to compile time resolve a type. It works for field, method, or type constant pool
+     * entries.
+     *
+     * @param cpi the index of the constant pool entry that references the type
+     * @param opcode the opcode of the instruction that references the type
+     * @param initialize if {@code true}, the referenced type is either guaranteed to be initialized
+     *            upon return or an initialization exception is thrown
+     */
+    default void loadReferencedType(int cpi, int opcode, boolean initialize) {
+        if (initialize) {
+            loadReferencedType(cpi, opcode);
+        } else {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /**
      * Looks up the type referenced by the constant pool entry at {@code cpi} as referenced by the
      * {@code opcode} bytecode instruction.
      *


### PR DESCRIPTION
`HotSpotConstantPool.loadReferencedType(int cpi, int opcode, boolean initialize)` allows loading a type without triggering class initialization. This PR lifts this method up to `ConstantPool` so that this functionality can be used without depending on HotSpot-specific JVMCI classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296960](https://bugs.openjdk.org/browse/JDK-8296960): [JVMCI] list HotSpotConstantPool.loadReferencedType to ConstantPool


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11145/head:pull/11145` \
`$ git checkout pull/11145`

Update a local copy of the PR: \
`$ git checkout pull/11145` \
`$ git pull https://git.openjdk.org/jdk pull/11145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11145`

View PR using the GUI difftool: \
`$ git pr show -t 11145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11145.diff">https://git.openjdk.org/jdk/pull/11145.diff</a>

</details>
