### PR TITLE
8296961: [JVMCI] Access to j.l.r.Method/Constructor/Field for ResolvedJavaMethod/ResolvedJavaField

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJDKReflection.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJDKReflection.java
@@ -283,7 +283,7 @@ final class HotSpotJDKReflection extends HotSpotJVMCIReflection {
      * Gets a {@link Method} object corresponding to {@code method}. This method guarantees the same
      * {@link Method} object is returned if called twice on the same {@code method} value.
      */
-    private static Executable getMethod(HotSpotResolvedJavaMethodImpl method) {
+    static Executable getMethod(HotSpotResolvedJavaMethodImpl method) {
         assert !method.isClassInitializer() : method;
         if (method.toJavaCache == null) {
             synchronized (method) {
@@ -303,7 +303,7 @@ final class HotSpotJDKReflection extends HotSpotJVMCIReflection {
      * {@code f} and annotation class {@code a}, the same object is returned for each call to
      * {@code f.getAnnotation(a)}).
      */
-    private static Field getField(HotSpotResolvedJavaFieldImpl field) {
+    static Field getField(HotSpotResolvedJavaFieldImpl field) {
         HotSpotResolvedObjectTypeImpl declaringClass = field.getDeclaringClass();
         synchronized (declaringClass) {
             HashMap<HotSpotResolvedJavaFieldImpl, Field> cache = declaringClass.reflectionFieldCache;

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
@@ -35,6 +35,8 @@ import java.lang.invoke.CallSite;
 import java.lang.invoke.ConstantCallSite;
 import java.lang.invoke.MethodHandle;
 import java.lang.ref.WeakReference;
+import java.lang.reflect.Executable;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
@@ -60,6 +62,8 @@ import jdk.vm.ci.common.JVMCIError;
 import jdk.vm.ci.common.NativeImageReinitialize;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.JavaType;
+import jdk.vm.ci.meta.ResolvedJavaField;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaType;
 import jdk.vm.ci.meta.UnresolvedJavaType;
 import jdk.vm.ci.runtime.JVMCI;
@@ -769,7 +773,7 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
     }
 
     /**
-     * Get the {@link Class} corresponding to {@code type}.
+     * Gets the {@link Class} corresponding to {@code type}.
      *
      * @param type the type for which a {@link Class} is requested
      * @return the original Java class corresponding to {@code type} or {@code null} if this runtime
@@ -779,6 +783,36 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
     public Class<?> getMirror(ResolvedJavaType type) {
         if (type instanceof HotSpotResolvedJavaType && reflection instanceof HotSpotJDKReflection) {
             return ((HotSpotJDKReflection) reflection).getMirror((HotSpotResolvedJavaType) type);
+        }
+        return null;
+    }
+
+    /**
+     * Gets the {@link Executable} corresponding to {@code method}.
+     *
+     * @param method the method for which an {@link Executable} is requested
+     * @return the original Java method or constructor corresponding to {@code method} or
+     *         {@code null} if this runtime does not support mapping {@link ResolvedJavaMethod}
+     *         instances to {@link Executable} instances
+     */
+    public Executable getMirror(ResolvedJavaMethod method) {
+        if (method instanceof HotSpotResolvedJavaMethodImpl && reflection instanceof HotSpotJDKReflection) {
+            return HotSpotJDKReflection.getMethod((HotSpotResolvedJavaMethodImpl) method);
+        }
+        return null;
+    }
+
+    /**
+     * Gets the {@link Field} corresponding to {@code field}.
+     *
+     * @param field the field for which a {@link Field} is requested
+     * @return the original Java field corresponding to {@code field} or {@code null} if this
+     *         runtime does not support mapping {@link ResolvedJavaField} instances to {@link Field}
+     *         instances
+     */
+    public Field getMirror(ResolvedJavaField field) {
+        if (field instanceof HotSpotResolvedJavaFieldImpl && reflection instanceof HotSpotJDKReflection) {
+            return HotSpotJDKReflection.getField((HotSpotResolvedJavaFieldImpl) field);
         }
         return null;
     }


### PR DESCRIPTION
Native Image needs to convert `ResolvedJavaMethod` objects to `java.lang.reflect.Executable` objects and `ResolvedJavaField` objects to `java.lang.reflect.Field` objects. This is currently done by digging into JVMCI internals with reflection. Instead, this functionality should be exposed by public JVMCI API which is what this PR does.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296961](https://bugs.openjdk.org/browse/JDK-8296961): [JVMCI] Access to j.l.r.Method/Constructor/Field for ResolvedJavaMethod/ResolvedJavaField


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11146/head:pull/11146` \
`$ git checkout pull/11146`

Update a local copy of the PR: \
`$ git checkout pull/11146` \
`$ git pull https://git.openjdk.org/jdk pull/11146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11146`

View PR using the GUI difftool: \
`$ git pr show -t 11146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11146.diff">https://git.openjdk.org/jdk/pull/11146.diff</a>

</details>
