### PR TITLE
8148041: Test java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick fails on Ubuntu with mouseReleased event after double click on title bar

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -430,7 +430,6 @@ java/awt/SplashScreen/MultiResolutionSplash/unix/UnixMultiResolutionSplashTest.j
 java/awt/Robot/AcceptExtraMouseButtons/AcceptExtraMouseButtons.java 7107528 linux-all,macosx-all
 java/awt/Mouse/MouseDragEvent/MouseDraggedTest.java 8080676 linux-all
 java/awt/Mouse/MouseModifiersUnitTest/MouseModifiersInKeyEvent.java 8157147 linux-all,windows-all,macosx-all
-java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick.java 8148041 linux-all
 java/awt/Toolkit/DesktopProperties/rfe4758438.java 8193547 linux-all
 java/awt/Toolkit/ToolkitPropertyTest/ToolkitPropertyTest_Enable.java 6847163
 java/awt/xembed/server/RunTestXEmbed.java 7034201 linux-all

--- a/test/jdk/java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick.java
+++ b/test/jdk/java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick.java
@@ -83,15 +83,24 @@ public class TitleBarDoubleClick implements MouseListener,
         );
         robot.waitForIdle();
 
-        System.out.println("1st press:   currentTimeMillis: " + System.currentTimeMillis());
+        System.out.println("1st press:   currentTimeMillis: "
+                + System.currentTimeMillis());
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-        System.out.println("1st release: currentTimeMillis: " + System.currentTimeMillis());
+
+        System.out.println("1st release: currentTimeMillis: "
+                + System.currentTimeMillis());
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-        System.out.println("2nd press:   currentTimeMillis: " + System.currentTimeMillis());
+
+        System.out.println("2nd press:   currentTimeMillis: "
+                + System.currentTimeMillis());
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-        System.out.println("2nd release: currentTimeMillis: " + System.currentTimeMillis());
+
+        System.out.println("2nd release: currentTimeMillis: "
+                + System.currentTimeMillis());
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-        System.out.println("done:        currentTimeMillis: " + System.currentTimeMillis());
+
+        System.out.println("done:        currentTimeMillis: "
+                + System.currentTimeMillis());
 
         robot.waitForIdle();
         robot.delay(500);
@@ -110,16 +119,16 @@ public class TitleBarDoubleClick implements MouseListener,
 
     public void mouseEntered(MouseEvent e) {}
     public void mouseExited(MouseEvent e) {}
-    public void mousePressed(MouseEvent e) {fail(e);}
-    public void mouseReleased(MouseEvent e) {fail(e);}
-    public void mouseClicked(MouseEvent e) {fail(e);}
+    public void mousePressed(MouseEvent e) { fail(e); }
+    public void mouseReleased(MouseEvent e) { fail(e); }
+    public void mouseClicked(MouseEvent e) { fail(e); }
 
-    public void windowActivated(WindowEvent  e) {}
-    public void windowClosed(WindowEvent  e) {}
-    public void windowClosing(WindowEvent  e) {}
-    public void windowDeactivated(WindowEvent  e) {}
-    public void windowDeiconified(WindowEvent  e) {}
-    public void windowIconified(WindowEvent  e) {}
-    public void windowOpened(WindowEvent  e) {}
+    public void windowActivated(WindowEvent e) {}
+    public void windowClosed(WindowEvent e) {}
+    public void windowClosing(WindowEvent e) {}
+    public void windowDeactivated(WindowEvent e) {}
+    public void windowDeiconified(WindowEvent e) {}
+    public void windowIconified(WindowEvent e) {}
+    public void windowOpened(WindowEvent e) {}
 
 }// class TitleBarDoubleClick

--- a/test/jdk/java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick.java
+++ b/test/jdk/java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick.java
@@ -26,14 +26,19 @@
   @key headful
   @bug 4664415
   @summary Test that double clicking the titlebar does not send RELEASE/CLICKED
-  @library    ../../regtesthelpers
-  @build      Util
   @run main TitleBarDoubleClick
 */
 
-import java.awt.*;
-import java.awt.event.*;
-import test.java.awt.regtesthelpers.Util;
+import java.awt.AWTError;
+import java.awt.AWTException;
+import java.awt.Frame;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowListener;
 
 public class TitleBarDoubleClick implements MouseListener,
  WindowListener
@@ -45,14 +50,13 @@ public class TitleBarDoubleClick implements MouseListener,
     Frame frame;
     Robot robot;
 
-    public static void main(final String[] args) {
+    public static void main(final String[] args) throws AWTException {
         TitleBarDoubleClick app = new TitleBarDoubleClick();
         app.start();
     }
 
-    public void start ()
-    {
-            robot = Util.createRobot();
+    public void start () throws AWTException {
+            robot = new Robot();
             robot.setAutoDelay(100);
             robot.mouseMove(BOUNDS.x + (BOUNDS.width / 2),
                             BOUNDS.y + (BOUNDS.height/ 2));
@@ -79,16 +83,16 @@ public class TitleBarDoubleClick implements MouseListener,
             // Util.waitForIdle(robot) seem always hangs here.
             // Need to use it instead robot.delay() when the bug become fixed.
             System.out.println("1st press:   currentTimeMillis: " + System.currentTimeMillis());
-            robot.mousePress(InputEvent.BUTTON1_MASK);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.delay(50);
             System.out.println("1st release: currentTimeMillis: " + System.currentTimeMillis());
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.delay(50);
             System.out.println("2nd press:   currentTimeMillis: " + System.currentTimeMillis());
-            robot.mousePress(InputEvent.BUTTON1_MASK);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.delay(50);
             System.out.println("2nd release: currentTimeMillis: " + System.currentTimeMillis());
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             System.out.println("done:        currentTimeMillis: " + System.currentTimeMillis());
     }
 

--- a/test/jdk/java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick.java
+++ b/test/jdk/java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
 
 public class TitleBarDoubleClick implements MouseListener,
- WindowListener
+        WindowListener
 {
     //Declare things used in the test, like buttons and labels here
     private final static Rectangle BOUNDS = new Rectangle(300, 300, 300, 300);
@@ -50,63 +50,71 @@ public class TitleBarDoubleClick implements MouseListener,
     Frame frame;
     Robot robot;
 
+    private volatile boolean failed = false;
+
     public static void main(final String[] args) throws AWTException {
-        TitleBarDoubleClick app = new TitleBarDoubleClick();
-        app.start();
+        new TitleBarDoubleClick().doTest();
     }
 
-    public void start () throws AWTException {
-            robot = new Robot();
-            robot.setAutoDelay(100);
-            robot.mouseMove(BOUNDS.x + (BOUNDS.width / 2),
-                            BOUNDS.y + (BOUNDS.height/ 2));
+    public TitleBarDoubleClick() throws AWTException {
+        robot = new Robot();
+        robot.setAutoDelay(100);
 
-            frame = new Frame("TitleBarDoubleClick");
-            frame.setBounds(BOUNDS);
-            frame.addMouseListener(this);
-            frame.addWindowListener(this);
-            frame.setVisible(true);
-    }// start()
+        robot.mouseMove(
+                BOUNDS.x + (BOUNDS.width / 2),
+                BOUNDS.y + (BOUNDS.height/ 2)
+        );
 
-    // Move the mouse into the title bar and double click to maximize the
-    // Frame
-    static boolean hasRun = false;
+        frame = new Frame("TitleBarDoubleClick");
+        frame.setBounds(BOUNDS);
+        frame.addMouseListener(this);
+        frame.addWindowListener(this);
+        frame.setVisible(true);
 
-    private void doTest() {
-        if (hasRun) return;
-        hasRun = true;
+        robot.waitForIdle();
+        robot.delay(1000);
+    }
 
+    public void doTest() throws AWTException {
         System.out.println("doing test");
-            robot.mouseMove(BOUNDS.x + (BOUNDS.width / 2),
-                            BOUNDS.y + TITLE_BAR_OFFSET);
-            robot.delay(50);
-            // Util.waitForIdle(robot) seem always hangs here.
-            // Need to use it instead robot.delay() when the bug become fixed.
-            System.out.println("1st press:   currentTimeMillis: " + System.currentTimeMillis());
-            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-            robot.delay(50);
-            System.out.println("1st release: currentTimeMillis: " + System.currentTimeMillis());
-            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-            robot.delay(50);
-            System.out.println("2nd press:   currentTimeMillis: " + System.currentTimeMillis());
-            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-            robot.delay(50);
-            System.out.println("2nd release: currentTimeMillis: " + System.currentTimeMillis());
-            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-            System.out.println("done:        currentTimeMillis: " + System.currentTimeMillis());
+        robot.mouseMove(
+                BOUNDS.x + (BOUNDS.width / 2),
+                BOUNDS.y + TITLE_BAR_OFFSET
+        );
+        robot.waitForIdle();
+
+        System.out.println("1st press:   currentTimeMillis: " + System.currentTimeMillis());
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        System.out.println("1st release: currentTimeMillis: " + System.currentTimeMillis());
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        System.out.println("2nd press:   currentTimeMillis: " + System.currentTimeMillis());
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        System.out.println("2nd release: currentTimeMillis: " + System.currentTimeMillis());
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        System.out.println("done:        currentTimeMillis: " + System.currentTimeMillis());
+
+        robot.waitForIdle();
+        robot.delay(500);
+
+        frame.dispose();
+
+        if (failed) {
+            throw new AWTError("Test failed");
+        }
     }
 
-    private void fail() {
-        throw new AWTError("Test failed");
+    private void fail(MouseEvent e) {
+        System.err.println("Failed: " + e);
+        failed = true;
     }
 
     public void mouseEntered(MouseEvent e) {}
     public void mouseExited(MouseEvent e) {}
-    public void mousePressed(MouseEvent e) {fail();}
-    public void mouseReleased(MouseEvent e) {fail();}
-    public void mouseClicked(MouseEvent e) {fail();}
+    public void mousePressed(MouseEvent e) {fail(e);}
+    public void mouseReleased(MouseEvent e) {fail(e);}
+    public void mouseClicked(MouseEvent e) {fail(e);}
 
-    public void windowActivated(WindowEvent  e) {doTest();}
+    public void windowActivated(WindowEvent  e) {}
     public void windowClosed(WindowEvent  e) {}
     public void windowClosing(WindowEvent  e) {}
     public void windowDeactivated(WindowEvent  e) {}


### PR DESCRIPTION
This test was problem listed with ["some tests that leave windows open on the desktop" reason](https://github.com/openjdk/jdk/commit/fd8df3adf13f5df8f5f95482b8e0a70bc519f39f)

The main issue with the test is that it may pass, but in fact the actual test was not even performed. <br>`jtreg` kills the test window after exiting main and ends the test before it double clicks on window's title(actual test starts from `windowActivated` event).

So the test was refactored and stabilized:
* robot invocation moved from EDT to main thread.
* throwing test exception is performed only after frame is disposed
* extra delay added after showing window.

Old Ubuntu 16.04 and macOS 10.10.5 failures is no longer reproducible on modern systems.

CI testing looks good.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8148041](https://bugs.openjdk.org/browse/JDK-8148041): Test java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick fails on Ubuntu with  mouseReleased event after double click on title bar


### Reviewers
 * @kiraka42 (no known github.com user name / role) ⚠️ Review applies to [59642367](https://git.openjdk.org/jdk/pull/11150/files/5964236759f438081b24ecc2f7e71715bcb7b3d6)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11150/head:pull/11150` \
`$ git checkout pull/11150`

Update a local copy of the PR: \
`$ git checkout pull/11150` \
`$ git pull https://git.openjdk.org/jdk pull/11150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11150`

View PR using the GUI difftool: \
`$ git pr show -t 11150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11150.diff">https://git.openjdk.org/jdk/pull/11150.diff</a>

</details>
