### PR TITLE
8292317: Missing null check for Iterator.forEachRemaining implementations

### DIFF
--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1714,6 +1714,7 @@ public class Collections {
                         throw new UnsupportedOperationException();
                     }
                     public void forEachRemaining(Consumer<? super Map.Entry<K, V>> action) {
+                        Objects.requireNonNull(action);
                         i.forEachRemaining(entryConsumer(action));
                     }
                 };
@@ -3878,6 +3879,7 @@ public class Collections {
                     }
 
                     public void forEachRemaining(Consumer<? super Entry<K, V>> action) {
+                        Objects.requireNonNull(action);
                         i.forEachRemaining(
                             e -> action.accept(checkedEntry(e, valueType)));
                     }

--- a/test/jdk/java/util/Collections/DelegatingIteratorForEachRemaining.java
+++ b/test/jdk/java/util/Collections/DelegatingIteratorForEachRemaining.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 Google Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -194,5 +195,42 @@ public class DelegatingIteratorForEachRemaining {
         Set<Map.Entry<String, Object>> entrySet = map().entrySet();
         Class clazz = entrySet.iterator().next().getClass();
         assertThrowingIterator(Collections.checkedSet(entrySet, clazz).iterator());
+    }
+
+    /**
+     * Calls Collections.unmodifiableMap().entrySet().iterator().forEachRemaining() by passing
+     * that method a {@code null} action and expects that call to fail with a
+     * {@code NullPointerException}. Additionally, the test verifies that the such a (failed) call
+     * doesn't advance the iterator to the next entry.
+     */
+    @Test
+    public void testUnmodifiableForEachRemainingNPE() {
+        final Map<String, String> singleEntryMap = Collections.singletonMap("foo", "bar");
+        final Iterator<Map.Entry<String, String>> it = Collections.unmodifiableMap(singleEntryMap)
+                .entrySet().iterator();
+        Assert.assertTrue("Iterator unexpectedly doesn't have any entry", it.hasNext());
+        // pass null "action" and expect it to fail with NPE
+        Assert.assertThrows(NullPointerException.class, () -> it.forEachRemaining(null));
+        // verify the iterator didn't advance
+        Assert.assertTrue("Iterator unexpectedly doesn't have any entry", it.hasNext());
+    }
+
+    /**
+     * Calls Collections.checkedMap().entrySet().iterator().forEachRemaining() by passing
+     * that method a {@code null} action and expects that call to fail with a
+     * {@code NullPointerException}. Additionally, the test verifies that the such a (failed) call
+     * doesn't advance the iterator to the next entry.
+     */
+    @Test
+    public void testCheckedMapForEachRemainingNPE() {
+        final Map<String, String> checkedMap = Collections.checkedMap(new HashMap<>(), String.class,
+                String.class);
+        checkedMap.put("hello", "world");
+        final Iterator<Map.Entry<String, String>> it = checkedMap.entrySet().iterator();
+        Assert.assertTrue("Iterator unexpectedly doesn't have any entry", it.hasNext());
+        // pass null "action" and expect it to fail with NPE
+        Assert.assertThrows(NullPointerException.class, () -> it.forEachRemaining(null));
+        // verify the iterator didn't advance
+        Assert.assertTrue("Iterator unexpectedly doesn't have any entry", it.hasNext());
     }
 }

--- a/test/jdk/java/util/Collections/DelegatingIteratorForEachRemaining.java
+++ b/test/jdk/java/util/Collections/DelegatingIteratorForEachRemaining.java
@@ -200,37 +200,25 @@ public class DelegatingIteratorForEachRemaining {
     /**
      * Calls Collections.unmodifiableMap().entrySet().iterator().forEachRemaining() by passing
      * that method a {@code null} action and expects that call to fail with a
-     * {@code NullPointerException}. Additionally, the test verifies that the such a (failed) call
-     * doesn't advance the iterator to the next entry.
+     * {@code NullPointerException}.
      */
     @Test
     public void testUnmodifiableForEachRemainingNPE() {
-        final Map<String, String> singleEntryMap = Collections.singletonMap("foo", "bar");
-        final Iterator<Map.Entry<String, String>> it = Collections.unmodifiableMap(singleEntryMap)
-                .entrySet().iterator();
-        Assert.assertTrue("Iterator unexpectedly doesn't have any entry", it.hasNext());
-        // pass null "action" and expect it to fail with NPE
+        final Iterator<?> it = Collections.unmodifiableMap(Map.of()).entrySet().iterator();
+        // pass null action and expect a NPE
         Assert.assertThrows(NullPointerException.class, () -> it.forEachRemaining(null));
-        // verify the iterator didn't advance
-        Assert.assertTrue("Iterator unexpectedly doesn't have any entry", it.hasNext());
     }
 
     /**
      * Calls Collections.checkedMap().entrySet().iterator().forEachRemaining() by passing
      * that method a {@code null} action and expects that call to fail with a
-     * {@code NullPointerException}. Additionally, the test verifies that the such a (failed) call
-     * doesn't advance the iterator to the next entry.
+     * {@code NullPointerException}.
      */
     @Test
     public void testCheckedMapForEachRemainingNPE() {
-        final Map<String, String> checkedMap = Collections.checkedMap(new HashMap<>(), String.class,
-                String.class);
-        checkedMap.put("hello", "world");
-        final Iterator<Map.Entry<String, String>> it = checkedMap.entrySet().iterator();
-        Assert.assertTrue("Iterator unexpectedly doesn't have any entry", it.hasNext());
+        final Iterator<?> it = Collections.checkedMap(Map.of(), String.class,
+                String.class).entrySet().iterator();
         // pass null "action" and expect it to fail with NPE
         Assert.assertThrows(NullPointerException.class, () -> it.forEachRemaining(null));
-        // verify the iterator didn't advance
-        Assert.assertTrue("Iterator unexpectedly doesn't have any entry", it.hasNext());
     }
 }


### PR DESCRIPTION
Can I please get a review of this change which proposes to fix https://bugs.openjdk.org/browse/JDK-8292317?

The `java.util.Iterator` has a `forEachRemaining(Consumer<? super E> action)` method. As per its contract, the implementations are expected to throw a `NullPointerException` if the passed `action` is `null`.

`java.util.Collections` has a couple of places where it wraps the passed `action` into another and passes that wrapped `action` to the underlying `java.util.Iterator`'s default `forEachRemaining` implementation which is:

```
Objects.requireNonNull(action);
  while (hasNext())
      action.accept(next());
```
Since the passed `action` is now a non-null wrapper, the implementation goes ahead and advances the iterator to the next entry and invokes on the non-null `action` to carry out its action. That non-null wrapper action then calls the `null` user passed action and runs into an expected `NullPointerException`. However, at this point the iterator has already advanced and that is what the bug is.

The commit in this PR introduces a trivial null check on the `action` very early in the call even before wrapping such an `action`. This prevents any further logic to execute if `action` is null.

New test methods have been added to the existing test class `test/jdk/java/util/Collections/DelegatingIteratorForEachRemaining.java`. This test class was introduced in https://bugs.openjdk.org/browse/JDK-8205184 where this delegation logic was added for the `forEachRemaining` methods. These new test methods reproduce the failure and verify the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292317](https://bugs.openjdk.org/browse/JDK-8292317): Missing null check for Iterator.forEachRemaining implementations


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - **Reviewer**) ⚠️ Review applies to [b58984ec](https://git.openjdk.org/jdk/pull/11154/files/b58984eca7a067fd0b849a04eaf2af758d302262)
 * [Stuart Marks](https://openjdk.org/census#smarks) (@stuart-marks - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11154/head:pull/11154` \
`$ git checkout pull/11154`

Update a local copy of the PR: \
`$ git checkout pull/11154` \
`$ git pull https://git.openjdk.org/jdk pull/11154/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11154`

View PR using the GUI difftool: \
`$ git pr show -t 11154`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11154.diff">https://git.openjdk.org/jdk/pull/11154.diff</a>

</details>
