### PR TITLE
8296970: Remove sysThreadAvailableStackWithSlack from hotspot-symbols

### DIFF
--- a/make/data/hotspot-symbols/symbols-aix
+++ b/make/data/hotspot-symbols/symbols-aix
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -24,4 +24,3 @@
 JVM_handle_aix_signal
 numa_error
 numa_warn
-sysThreadAvailableStackWithSlack

--- a/make/data/hotspot-symbols/symbols-linux
+++ b/make/data/hotspot-symbols/symbols-linux
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -25,4 +25,3 @@ JVM_handle_linux_signal
 JVM_IsUseContainerSupport
 numa_error
 numa_warn
-sysThreadAvailableStackWithSlack


### PR DESCRIPTION
Hi all,

Could anyone review this cleanup to remove dead symbol "sysThreadAvailableStackWithSlack"? See https://bugs.openjdk.org/browse/JDK-8296970 for more details.

-Man

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296970](https://bugs.openjdk.org/browse/JDK-8296970): Remove sysThreadAvailableStackWithSlack from hotspot-symbols


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11156/head:pull/11156` \
`$ git checkout pull/11156`

Update a local copy of the PR: \
`$ git checkout pull/11156` \
`$ git pull https://git.openjdk.org/jdk pull/11156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11156`

View PR using the GUI difftool: \
`$ git pr show -t 11156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11156.diff">https://git.openjdk.org/jdk/pull/11156.diff</a>

</details>
