### PR TITLE
8178698: javax/sound/midi/Sequencer/MetaCallback.java failed with timeout

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -629,7 +629,6 @@ javax/sound/sampled/Clip/Drain/ClipDrain.java          7062792 generic-all
 javax/sound/sampled/Mixers/DisabledAssertionCrash.java 7067310 generic-all
 
 javax/sound/midi/Sequencer/Recording.java 8167580,8265485 linux-all,macosx-aarch64
-javax/sound/midi/Sequencer/MetaCallback.java 8178698 linux-all
 javax/sound/midi/Sequencer/Looping.java 8136897 generic-all
 
 ############################################################################

--- a/test/jdk/javax/sound/midi/Sequencer/MetaCallback.java
+++ b/test/jdk/javax/sound/midi/Sequencer/MetaCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/sound/midi/Sequencer/MetaCallback.java
+++ b/test/jdk/javax/sound/midi/Sequencer/MetaCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javax.sound.midi.Track;
  * @bug 4347135
  * @summary MIDI MetaMessage callback inconsistent
  * @key intermittent sound
- * @run main/othervm MetaCallback
+ * @run main/othervm/timeout=300 MetaCallback
  */
 public class MetaCallback implements MetaEventListener {
 

--- a/test/jdk/javax/sound/midi/Sequencer/MetaCallback.java
+++ b/test/jdk/javax/sound/midi/Sequencer/MetaCallback.java
@@ -31,6 +31,9 @@ import javax.sound.midi.Sequence;
 import javax.sound.midi.Sequencer;
 import javax.sound.midi.ShortMessage;
 import javax.sound.midi.Track;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * @test
@@ -61,6 +64,8 @@ public class MetaCallback implements MetaEventListener {
 
     int metaCount = 0;
     boolean finished = false;
+    // On M1 Mac sometimes system notifies listener about the same message twice
+    static List<MetaMessage> received = Collections.synchronizedList(new ArrayList<>());
 
     MetaCallback() throws Exception {
 
@@ -101,13 +106,17 @@ public class MetaCallback implements MetaEventListener {
         }
     }
     void start() {sequencer.start();}
-    void stop() {sequencer.stop();}
+    void stop() {
+        sequencer.stop();
+        sequencer.close();
+    }
 
     public void meta(MetaMessage msg) {
         System.out.println(""+metaCount+": got "+msg);
         if (msg.getType() == 0x2F) {
             finished = true;
-        } else if (msg.getData().length > 0 && msg.getType() == 1) {
+        } else if (msg.getData().length > 0 && msg.getType() == 1 && !received.contains(msg)) {
+            received.add(msg);
             metaCount++;
         }
     }

--- a/test/jdk/javax/sound/midi/Sequencer/MetaCallback.java
+++ b/test/jdk/javax/sound/midi/Sequencer/MetaCallback.java
@@ -40,7 +40,7 @@ import java.util.List;
  * @bug 4347135
  * @summary MIDI MetaMessage callback inconsistent
  * @key intermittent sound
- * @run main/othervm/timeout=300 MetaCallback
+ * @run main/othervm/timeout=120 MetaCallback
  */
 public class MetaCallback implements MetaEventListener {
 


### PR DESCRIPTION
On m1 mac sometimes (in very rare instance) it takes a long time to get the sequencer so increasing timeout helps with that.
Also on m1 mac sequencer got notified about the first MetaMessage twice. The reason is unclear but watching for that fixes the problem. Also on Linux sometimes process hangs indefinitely without finishing hold by the com.sun.media.sound.MediaDispatcher. Closing the sequencer at the end of the test helps with that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8178698](https://bugs.openjdk.org/browse/JDK-8178698): javax/sound/midi/Sequencer/MetaCallback.java failed with timeout


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [496e1eb5](https://git.openjdk.org/jdk/pull/11157/files/496e1eb5c6d21f53c9eb945f241c11b832489234)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**) ⚠️ Review applies to [791065fb](https://git.openjdk.org/jdk/pull/11157/files/791065fb7a1a4424f16446751c269a0ff718d5d7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11157/head:pull/11157` \
`$ git checkout pull/11157`

Update a local copy of the PR: \
`$ git checkout pull/11157` \
`$ git pull https://git.openjdk.org/jdk pull/11157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11157`

View PR using the GUI difftool: \
`$ git pr show -t 11157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11157.diff">https://git.openjdk.org/jdk/pull/11157.diff</a>

</details>
