### PR TITLE
8022403: sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -224,7 +224,6 @@ java/awt/print/Headless/HeadlessPrinterJob.java 8196088 windows-all
 sun/awt/datatransfer/SuplementaryCharactersTransferTest.java 8011371 generic-all
 sun/awt/shell/ShellFolderMemoryLeak.java 8197794 windows-all
 sun/java2d/DirectX/MultiPaintEventTest/MultiPaintEventTest.java 8284825 windows-all
-//sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java 8022403 generic-all
 sun/java2d/DirectX/OverriddenInsetsTest/OverriddenInsetsTest.java 8196102 generic-all
 sun/java2d/DirectX/RenderingToCachedGraphicsTest/RenderingToCachedGraphicsTest.java 8196180 windows-all,macosx-all
 sun/java2d/SunGraphics2D/EmptyClipRenderingTest.java 8144029 macosx-all,linux-all

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -224,7 +224,7 @@ java/awt/print/Headless/HeadlessPrinterJob.java 8196088 windows-all
 sun/awt/datatransfer/SuplementaryCharactersTransferTest.java 8011371 generic-all
 sun/awt/shell/ShellFolderMemoryLeak.java 8197794 windows-all
 sun/java2d/DirectX/MultiPaintEventTest/MultiPaintEventTest.java 8284825 windows-all
-sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java 8022403 generic-all
+//sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java 8022403 generic-all
 sun/java2d/DirectX/OverriddenInsetsTest/OverriddenInsetsTest.java 8196102 generic-all
 sun/java2d/DirectX/RenderingToCachedGraphicsTest/RenderingToCachedGraphicsTest.java 8196180 windows-all,macosx-all
 sun/java2d/SunGraphics2D/EmptyClipRenderingTest.java 8144029 macosx-all,linux-all

--- a/test/jdk/sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java
+++ b/test/jdk/sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java
@@ -92,7 +92,6 @@ public class OnScreenRenderingResizeTest {
                     createAndShowGUI();
                 }
             });
-            // wait for Vista's effects to complete
             Thread.sleep(2000);
         } catch (Exception ex) {
             ex.printStackTrace();

--- a/test/jdk/sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java
+++ b/test/jdk/sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java
@@ -27,6 +27,7 @@
  * @summary Tests that resizing a window to which a tight loop is rendering
  *          doesn't produce artifacts or crashes
  * @run main/othervm OnScreenRenderingResizeTest
+ * @run main/othervm -Dsun.java2d.d3d=false OnScreenRenderingResizeTest
  */
 
 import java.awt.AWTException;

--- a/test/jdk/sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java
+++ b/test/jdk/sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java
@@ -38,6 +38,7 @@ import java.awt.GraphicsConfiguration;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Robot;
+import java.awt.EventQueue;
 import java.awt.image.BufferedImage;
 import java.awt.image.VolatileImage;
 import java.io.File;
@@ -79,7 +80,6 @@ public class OnScreenRenderingResizeTest {
         frame.setUndecorated(true);
         frame.setAlwaysOnTop(true);
         frame.pack();
-        frame.setVisible(true);
 
         GraphicsConfiguration gc = frame.getGraphicsConfiguration();
         Rectangle gcBounds = gc.getBounds();
@@ -97,6 +97,18 @@ public class OnScreenRenderingResizeTest {
         Graphics g = output.getGraphics();
         g.setColor(renderColor);
         g.fillRect(0, 0, IMAGE_W, IMAGE_H);
+
+        try {
+            EventQueue.invokeAndWait(new Runnable() {
+                public void run() {
+                    frame.setVisible(true);
+                }
+            });
+            // wait for Vista's effects to complete
+            Thread.sleep(2000);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
 
         int maxW = gcBounds.width / 2;
         int maxH = gcBounds.height / 2;


### PR DESCRIPTION
This test was failing because of color difference on boundaries. Updated test case to not check edges and added color tolerance.

Also updated test to:
1) Use standard GraphicsConfiguration bounds for image instead of constant numbers.
2) Use waitForIdle before screen capture and added auto delay
3) Move mouse pointer away from rendering content (In my local Mac it failed every time when mouse pointer was present over test frame)
4) Remove usage of insets as it is undecorated and remove windows closing listener
5) Dispose frame when test fails

With these changes test is not failing in CI with multiple runs on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8022403](https://bugs.openjdk.org/browse/JDK-8022403): sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java fails


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [283685d7](https://git.openjdk.org/jdk/pull/11158/files/283685d7728b5b2975838c53c47aa3ce39bd8faf)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11158/head:pull/11158` \
`$ git checkout pull/11158`

Update a local copy of the PR: \
`$ git checkout pull/11158` \
`$ git pull https://git.openjdk.org/jdk pull/11158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11158`

View PR using the GUI difftool: \
`$ git pr show -t 11158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11158.diff">https://git.openjdk.org/jdk/pull/11158.diff</a>

</details>
