### PR TITLE
JDK-8297000 [jib] Add more friendly warning for proxy issues

### DIFF
--- a/bin/jib.sh
+++ b/bin/jib.sh
@@ -129,13 +129,9 @@ install_jib() {
         fi
     fi
     # Want to check the filetype using file, to see if we got served a HTML error page.
-    # In order to support solaris, we don't use any fancy flags to file.
-    # file will prepend the filename, so we need to remove it before testing the output.
-    PREFIX="${installed_jib_script}.gz: "
-    FILEOUTPUT=`file ${installed_jib_script}.gz`
-    # ${X:${#Y}} gives X without the first ${#Y} characters, and ${#Y} is length of Y.
-    FILEOUTPUT=${FILEOUTPUT:${#PREFIX}}
-    if [[ "$FILEOUTPUT" != *"gzip compressed data"* ]]; then
+	# This is sensitive to the filename containing a specific string, but good enough.
+	file ${installed_jib_script}.gz | grep "gzip compressed data" > /dev/null
+	if [ $? -ne 0 ]; then 
         echo "Warning: ${installed_jib_script}.gz is not a gzip file."
         echo "If you are behind a proxy you may need to configure exceptions using no_proxy."
         echo "The download URL was: ${jib_url}"

--- a/bin/jib.sh
+++ b/bin/jib.sh
@@ -129,9 +129,9 @@ install_jib() {
         fi
     fi
     # Want to check the filetype using file, to see if we got served a HTML error page.
-	# This is sensitive to the filename containing a specific string, but good enough.
-	file ${installed_jib_script}.gz | grep "gzip compressed data" > /dev/null
-	if [ $? -ne 0 ]; then 
+    # This is sensitive to the filename containing a specific string, but good enough.
+    file ${installed_jib_script}.gz | grep "gzip compressed data" > /dev/null
+    if [ $? -ne 0 ]; then 
         echo "Warning: ${installed_jib_script}.gz is not a gzip file."
         echo "If you are behind a proxy you may need to configure exceptions using no_proxy."
         echo "The download URL was: ${jib_url}"

--- a/bin/jib.sh
+++ b/bin/jib.sh
@@ -128,6 +128,19 @@ install_jib() {
             exit 1
         fi
     fi
+    # Want to check the filetype using file, to see if we got served a HTML error page.
+    # In order to support solaris, we don't use any fancy flags to file.
+    # file will prepend the filename, so we need to remove it before testing the output.
+    PREFIX="${installed_jib_script}.gz: "
+    FILEOUTPUT=`file ${installed_jib_script}.gz`
+    # ${X:${#Y}} gives X without the first ${#Y} characters, and ${#Y} is length of Y.
+    FILEOUTPUT=${FILEOUTPUT:${#PREFIX}}
+    if [[ "$FILEOUTPUT" != *"gzip compressed data"* ]]; then
+        echo "Warning: ${installed_jib_script}.gz is not a gzip file."
+        echo "If you are behind a proxy you may need to configure exceptions using no_proxy."
+        echo "The download URL was: ${jib_url}"
+        exit 1
+    fi
     echo "Extracting JIB bootstrap script"
     rm -f "${installed_jib_script}"
     gunzip "${installed_jib_script}.gz"


### PR DESCRIPTION
When jib tries to download itself behind a proxy, sometimes it can get a different file than it expected. This can result in cryptic errors that are hard to troubleshoot. Let's handle this a little more gracefully by detecting it in the bootstrapper and printing an error.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297000](https://bugs.openjdk.org/browse/JDK-8297000): [jib] Add more friendly warning for proxy issues


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11159/head:pull/11159` \
`$ git checkout pull/11159`

Update a local copy of the PR: \
`$ git checkout pull/11159` \
`$ git pull https://git.openjdk.org/jdk pull/11159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11159`

View PR using the GUI difftool: \
`$ git pr show -t 11159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11159.diff">https://git.openjdk.org/jdk/pull/11159.diff</a>

</details>
