### PR TITLE
8295788: C2 compilation hits "assert((mode == ControlAroundStripMined && use == sfpt) || !use->is_reachable_from_root()) failed: missed a node"

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -2165,17 +2165,19 @@ static void clone_outer_loop_helper(Node* n, const IdealLoopTree *loop, const Id
     if (!u->is_CFG() && (!check_old_new || old_new[u->_idx] == NULL)) {
       Node* c = phase->get_ctrl(u);
       IdealLoopTree* u_loop = phase->get_loop(c);
-      assert(!loop->is_member(u_loop), "can be in outer loop or out of both loops only");
-      if (outer_loop->is_member(u_loop)) {
-        wq.push(u);
-      } else {
-        // nodes pinned with control in the outer loop but not referenced from the safepoint must be moved out of
-        // the outer loop too
-        Node* u_c = u->in(0);
-        if (u_c != NULL) {
-          IdealLoopTree* u_c_loop = phase->get_loop(u_c);
-          if (outer_loop->is_member(u_c_loop) && !loop->is_member(u_c_loop)) {
-            wq.push(u);
+      assert(!loop->is_member(u_loop) || !loop->_body.contains(u), "can be in outer loop or out of both loops only");
+      if (!loop->is_member(u_loop)) {
+        if (outer_loop->is_member(u_loop)) {
+          wq.push(u);
+        } else {
+          // nodes pinned with control in the outer loop but not referenced from the safepoint must be moved out of
+          // the outer loop too
+          Node* u_c = u->in(0);
+          if (u_c != NULL) {
+            IdealLoopTree* u_c_loop = phase->get_loop(u_c);
+            if (outer_loop->is_member(u_c_loop) && !loop->is_member(u_c_loop)) {
+              wq.push(u);
+            }
           }
         }
       }
@@ -2294,6 +2296,11 @@ void PhaseIdealLoop::clone_outer_loop(LoopNode* head, CloneLoopMode mode, IdealL
     Unique_Node_List wq;
     for (uint i = 0; i < extra_data_nodes.size(); i++) {
       Node* old = extra_data_nodes.at(i);
+      clone_outer_loop_helper(old, loop, outer_loop, old_new, wq, this, true);
+    }
+
+    for (uint i = 0; i < loop->_body.size(); i++) {
+      Node* old = loop->_body.at(i);
       clone_outer_loop_helper(old, loop, outer_loop, old_new, wq, this, true);
     }
 

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestUseFromInnerInOuterUnusedBySfpt.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestUseFromInnerInOuterUnusedBySfpt.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8295788
+ * @summary C2 compilation hits "assert((mode == ControlAroundStripMined && use == sfpt) || !use->is_reachable_from_root()) failed: missed a node"
+ *
+ * @run main/othervm -Xcomp -XX:CompileOnly=TestUseFromInnerInOuterUnusedBySfpt TestUseFromInnerInOuterUnusedBySfpt
+ *
+ */
+
+public class TestUseFromInnerInOuterUnusedBySfpt {
+
+    public static final int N = 400;
+
+    public static void dMeth(long l, int i5, int i6) {
+
+        int i7=14, i8=-14, i9=7476, i11=0;
+        long lArr[]=new long[N];
+
+        for (i7 = 3; i7 < 177; i7++) {
+            lArr[i7 + 1] >>= l;
+            l -= i8;
+            i6 = (int)l;
+        }
+        for (i9 = 15; i9 < 356; i9 += 3) {
+            i11 = 14;
+            do {
+                i5 |= i6;
+            } while (--i11 > 0);
+        }
+    }
+
+    public static void main(String[] strArr) {
+        TestUseFromInnerInOuterUnusedBySfpt _instance = new TestUseFromInnerInOuterUnusedBySfpt();
+        for (int i = 0; i < 10; i++ ) {
+            _instance.dMeth(-12L, -50242, 20);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestUseFromInnerInOuterUnusedBySfpt.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestUseFromInnerInOuterUnusedBySfpt.java
@@ -54,7 +54,7 @@ public class TestUseFromInnerInOuterUnusedBySfpt {
 
     public static void main(String[] strArr) {
         TestUseFromInnerInOuterUnusedBySfpt _instance = new TestUseFromInnerInOuterUnusedBySfpt();
-        for (int i = 0; i < 10; i++ ) {
+        for (int i = 0; i < 10; i++) {
             _instance.dMeth(-12L, -50242, 20);
         }
     }


### PR DESCRIPTION
This failure is similar to previous failures with loop strip mining: a
node is encountered that has control set in the outer strip mined loop
but is not reachable from the safepoint. There's already logic in loop
cloning to find those and fix their control to be outside the
loop. Usually a node ends up in the outer loop because some of its
inputs is in the outer loop. The current logic to catch nodes that are
erroneously assigned control in the outer loop is to start from
safepoint's inputs and look for uses with incorrect control. That
doesn't work in this case because: 1) the node is created by
IdealLoopTree::reassociate in the outer loop because its inputs are
indeed there 2) but a pass of split if updates the control to be
inside the inner loop.

To fix this, I propose reusing the existing clone_outer_loop_helper()
but apply it to the loop body as well. I had to tweak that method
because I ran into cases of dead nodes still reachable from a node in
the loop body but removed from the _body list by
IdealLoopTree::DCE_loop_body() (and as a result not cloned).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295788](https://bugs.openjdk.org/browse/JDK-8295788): C2 compilation hits "assert((mode == ControlAroundStripMined && use == sfpt) || !use->is_reachable_from_root()) failed: missed a node"


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [32271652](https://git.openjdk.org/jdk/pull/11162/files/322716529b18b5fbfcac34956cdb5bb633a2df3d)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11162/head:pull/11162` \
`$ git checkout pull/11162`

Update a local copy of the PR: \
`$ git checkout pull/11162` \
`$ git pull https://git.openjdk.org/jdk pull/11162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11162`

View PR using the GUI difftool: \
`$ git pr show -t 11162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11162.diff">https://git.openjdk.org/jdk/pull/11162.diff</a>

</details>
