### PR TITLE
8296429: Remove os::supports_sse

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -854,9 +854,6 @@ void VM_Version::get_processor_features() {
     _data_cache_line_flush_size = _cpuid_info.std_cpuid1_ebx.bits.clflush_size * 8;
   }
 #endif
-  // If the OS doesn't support SSE, we can't use this feature even if the HW does
-  if (!os::supports_sse())
-    _features &= ~(CPU_SSE|CPU_SSE2|CPU_SSE3|CPU_SSSE3|CPU_SSE4A|CPU_SSE4_1|CPU_SSE4_2);
 
   if (UseSSE < 4) {
     _features &= ~CPU_SSE4_1;

--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -636,13 +636,6 @@ void os::Bsd::init_thread_fpu_state(void) {
 #endif // !AMD64
 }
 
-
-// Check that the bsd kernel version is 2.4 or higher since earlier
-// versions do not support SSE without patches.
-bool os::supports_sse() {
-  return true;
-}
-
 juint os::cpu_microcode_revision() {
   juint result = 0;
   char data[8];

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -443,24 +443,6 @@ void os::Linux::set_fpu_control_word(int fpu_control) {
 #endif // !AMD64
 }
 
-// Check that the linux kernel version is 2.4 or higher since earlier
-// versions do not support SSE without patches.
-bool os::supports_sse() {
-#ifdef AMD64
-  return true;
-#else
-  struct utsname uts;
-  if( uname(&uts) != 0 ) return false; // uname fails?
-  char *minor_string;
-  int major = strtol(uts.release,&minor_string,10);
-  int minor = strtol(minor_string+1,NULL,10);
-  bool result = (major > 2 || (major==2 && minor >= 4));
-  log_info(os)("OS version is %d.%d, which %s support SSE/SSE2",
-               major,minor, result ? "DOES" : "does NOT");
-  return result;
-#endif // AMD64
-}
-
 juint os::cpu_microcode_revision() {
   // Note: this code runs on startup, and therefore should not be slow,
   // see JDK-8283200.

--- a/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.cpp
@@ -275,10 +275,6 @@ void os::print_register_info(outputStream *st, const void *context) {
 void os::setup_fpu() {
 }
 
-bool os::supports_sse() {
-  return true;
-}
-
 #ifndef PRODUCT
 void os::verify_stack_alignment() {
   assert(((intptr_t)os::current_stack_pointer() & (StackAlignmentInBytes-1)) == 0, "incorrect stack alignment");

--- a/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
+++ b/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
@@ -565,7 +565,3 @@ int os::extra_bang_size_in_bytes() {
   // JDK-8050147 requires the full cache line bang for x86.
   return VM_Version::L1_line_size();
 }
-
-bool os::supports_sse() {
-  return true;
-}

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -947,7 +947,6 @@ class os: AllStatic {
   inline static bool zero_page_read_protected();
 
   static void setup_fpu();
-  static bool supports_sse();
   static juint cpu_microcode_revision();
 
   static inline jlong rdtsc();


### PR DESCRIPTION
os::supports_sse only exists to be backwards compatible with linux kernels older than 2.4, which may not have SSE support. Since support for 2.2.x kernels ended in 2004 I think we can safely clean this out.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296429](https://bugs.openjdk.org/browse/JDK-8296429): Remove os::supports_sse


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11164/head:pull/11164` \
`$ git checkout pull/11164`

Update a local copy of the PR: \
`$ git checkout pull/11164` \
`$ git pull https://git.openjdk.org/jdk pull/11164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11164`

View PR using the GUI difftool: \
`$ git pr show -t 11164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11164.diff">https://git.openjdk.org/jdk/pull/11164.diff</a>

</details>
