### PR TITLE
8297006: JFR: AbstractEventStream should not hold thread instance

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/AbstractEventStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/AbstractEventStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,6 @@ public abstract class AbstractEventStream implements EventStream {
     private final StreamConfiguration streamConfiguration = new StreamConfiguration();
     private final List<Configuration> configurations;
     private final ParserState parserState = new ParserState();
-    private volatile Thread thread;
     private Dispatcher dispatcher;
     private boolean daemon = false;
 
@@ -214,14 +213,13 @@ public abstract class AbstractEventStream implements EventStream {
     public final void startAsync(long startNanos) {
         startInternal(startNanos);
         Runnable r = () -> run(accessControllerContext);
-        thread = SecuritySupport.createThreadWitNoPermissions(nextThreadName(), r);
+        Thread thread = SecuritySupport.createThreadWitNoPermissions(nextThreadName(), r);
         SecuritySupport.setDaemonThread(thread, daemon);
         thread.start();
     }
 
     public final void start(long startNanos) {
         startInternal(startNanos);
-        thread = Thread.currentThread();
         run(accessControllerContext);
     }
 


### PR DESCRIPTION
Could I have a review of a PR that removes an unnecessary reference to a thread. This could potentially become a memory leak.

Testing: test/jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297006](https://bugs.openjdk.org/browse/JDK-8297006): JFR: AbstractEventStream should not hold thread instance


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11166/head:pull/11166` \
`$ git checkout pull/11166`

Update a local copy of the PR: \
`$ git checkout pull/11166` \
`$ git pull https://git.openjdk.org/jdk pull/11166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11166`

View PR using the GUI difftool: \
`$ git pr show -t 11166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11166.diff">https://git.openjdk.org/jdk/pull/11166.diff</a>

</details>
