### PR TITLE
JDK-8297047: IGV: graphContent not set when opening a new tab

### DIFF
--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorTopComponent.java
@@ -148,11 +148,7 @@ public final class EditorTopComponent extends TopComponent {
             setToolTipText(diagramViewModel.getGroup().getDisplayName());
         });
 
-        diagramViewModel.getGraphChangedEvent().addListener(model -> {
-            setDisplayName(model.getGraph().getDisplayName());
-            setToolTipText(model.getGroup().getDisplayName());
-            graphContent.set(Collections.singletonList(new EditorInputGraphProvider(this)), null);
-        });
+        diagramViewModel.getGraphChangedEvent().addListener(model -> graphChanged(model));
 
         cardLayout = new CardLayout();
         centerPanel = new JPanel();
@@ -244,6 +240,14 @@ public final class EditorTopComponent extends TopComponent {
         topPanel.add(toolbarPanel);
         topPanel.add(quickSearchToolbar);
         container.add(BorderLayout.NORTH, topPanel);
+
+        graphChanged(diagramViewModel);
+    }
+
+    private void graphChanged(DiagramViewModel model) {
+        setDisplayName(model.getGraph().getDisplayName());
+        setToolTipText(model.getGroup().getDisplayName());
+        graphContent.set(Collections.singletonList(new EditorInputGraphProvider(this)), null);
     }
 
     public DiagramViewModel getModel() {


### PR DESCRIPTION
Open any graph in IGV. The graph will be opened in a new tab as expected. But the tab has the name "graph" instead of the actual graph name. Further, the "Bytecode" and "Control Flow" windows are not updated with the current graph. 

The reason was that `graphContent` was not set when opening a new EditorTopComponent.

Before: 
![graph_not_updated](https://user-images.githubusercontent.com/71546117/201946772-727f1c57-d69e-4551-a560-14d18cfb2b63.png)

Now the title of tab and the "Control Flow" is updated:
![graph_updated](https://user-images.githubusercontent.com/71546117/201947659-a238d0a2-b064-4373-81dc-7fb3f0dea7ec.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297047](https://bugs.openjdk.org/browse/JDK-8297047): IGV: graphContent not set when opening a new tab


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11168/head:pull/11168` \
`$ git checkout pull/11168`

Update a local copy of the PR: \
`$ git checkout pull/11168` \
`$ git pull https://git.openjdk.org/jdk pull/11168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11168`

View PR using the GUI difftool: \
`$ git pr show -t 11168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11168.diff">https://git.openjdk.org/jdk/pull/11168.diff</a>

</details>
