### PR TITLE
JDK-8296969: C1: PrintC1Statistics is broken after JDK-8292878

### DIFF
--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -3447,7 +3447,7 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
 
 #ifndef PRODUCT
   if (PrintC1Statistics) {
-    __ incrementl(ExternalAddress(Runtime1::arraycopy_count_address(basic_type)));
+    __ incrementl(ExternalAddress(Runtime1::arraycopy_count_address(basic_type)), rscratch1);
   }
 #endif
 

--- a/test/hotspot/jtreg/compiler/c1/TestPrintC1Statistics.java
+++ b/test/hotspot/jtreg/compiler/c1/TestPrintC1Statistics.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Checks that -XX:+PrintC1Statistics works
+ * @bug 8296969
+ * @requires vm.debug == true & vm.compiler1.enabled
+ * @library /test/lib
+ * @run main/othervm -XX:+Verbose compiler.c1.TestPrintC1Statistics
+ */
+
+package compiler.c1;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestPrintC1Statistics {
+    public static void main(String[] args) throws Exception {
+        List<String> options = new ArrayList<String>();
+        options.add("-XX:+PrintC1Statistics");
+        options.add("--version");
+
+        OutputAnalyzer oa = ProcessTools.executeTestJvm(options);
+
+        oa.shouldHaveExitValue(0).shouldContain("C1 Runtime statistics");
+    }
+ }


### PR DESCRIPTION
Issue is coming from https://bugs.openjdk.org/browse/JDK-8292878. This PR adds the `rscratch1` argument to the affected `incrementl` call.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296969](https://bugs.openjdk.org/browse/JDK-8296969): C1: PrintC1Statistics is broken after JDK-8292878


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [7a2c075b](https://git.openjdk.org/jdk/pull/11170/files/7a2c075b210735354ea1d6c7c0be9a418b60b9b7)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Xin Liu](https://openjdk.org/census#xliu) (@navyxliu - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11170/head:pull/11170` \
`$ git checkout pull/11170`

Update a local copy of the PR: \
`$ git checkout pull/11170` \
`$ git pull https://git.openjdk.org/jdk pull/11170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11170`

View PR using the GUI difftool: \
`$ git pr show -t 11170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11170.diff">https://git.openjdk.org/jdk/pull/11170.diff</a>

</details>
