### PR TITLE
8296820: Add implementation note to SSLContext.getInstance noting subsequent behavior if protocol is disabled

### DIFF
--- a/src/java.base/share/classes/javax/net/ssl/SSLContext.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLContext.java
@@ -163,13 +163,13 @@ public class SSLContext {
      * {@link Security#getProviders() Security.getProviders()}.
      *
      * <p>
-     * In the JDK Reference Implementation, a protocol can be disabled by
+     * In the JDK Reference implementation, a protocol can be disabled by
      * adding it to the {@code jdk.tls.disabledAlgorithms} security property.
      * If the specified protocol is disabled, the {@code getInstance} method
      * will still return an {@code SSLContext} if there is a configured
-     * provider that implements the protocol. However, subsequent operations
-     * that attempt to use the specified protocol will fail with an
-     * {@code SSLHandshakeException}.
+     * provider that implements the protocol. However, if the selected provider
+     * is the SunJSSE provider, subsequent operations that attempt to use the
+     * specified protocol will fail with an {@code SSLHandshakeException}.
      *
      * @param protocol the standard name of the requested protocol.
      *          See the SSLContext section in the <a href=
@@ -213,9 +213,9 @@ public class SSLContext {
      * adding it to the {@code jdk.tls.disabledAlgorithms} security property.
      * If the specified protocol is disabled, the {@code getInstance} method
      * will still return an {@code SSLContext} if the specified provider
-     * implements the protocol. However, subsequent operations that attempt
-     * to use the specified protocol will fail with an
-     * {@code SSLHandshakeException}.
+     * implements the protocol. However, if the specified provider is "SunJSSE",
+     * subsequent operations that attempt to use the specified protocol will
+     * fail with an {@code SSLHandshakeException}.
      *
      * @param protocol the standard name of the requested protocol.
      *          See the SSLContext section in the <a href=
@@ -270,9 +270,9 @@ public class SSLContext {
      * adding it to the {@code jdk.tls.disabledAlgorithms} security property.
      * If the specified protocol is disabled, the {@code getInstance} method
      * will still return an {@code SSLContext} if the specified provider
-     * implements the protocol. However, subsequent operations* that attempt
-     * to use the specified protocol will fail with an
-     * {@code SSLHandshakeException}.
+     * implements the protocol. However, if the specified provider is the
+     * SunJSSE provider, subsequent operations that attempt to use the
+     * specified protocol will fail with an {@code SSLHandshakeException}.
      *
      * @param provider an instance of the provider.
      *

--- a/src/java.base/share/classes/javax/net/ssl/SSLContext.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLContext.java
@@ -162,6 +162,15 @@ public class SSLContext {
      * may be different from the order of providers returned by
      * {@link Security#getProviders() Security.getProviders()}.
      *
+     * <p>
+     * In the JDK Reference Implementation, a protocol can be disabled by
+     * adding it to the {@code jdk.tls.disabledAlgorithms} security property.
+     * If the specified protocol is disabled, the {@code getInstance} method
+     * will still return an {@code SSLContext} if there is a configured
+     * provider that implements the protocol. However, subsequent operations
+     * that attempt to use the specified protocol will fail with an
+     * {@code SSLHandshakeException}.
+     *
      * @param protocol the standard name of the requested protocol.
      *          See the SSLContext section in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#sslcontext-algorithms">
@@ -198,6 +207,15 @@ public class SSLContext {
      *
      * <p> Note that the list of registered providers may be retrieved via
      * the {@link Security#getProviders() Security.getProviders()} method.
+     *
+     * @implNote
+     * In the JDK Reference Implementation, a protocol can be disabled by
+     * adding it to the {@code jdk.tls.disabledAlgorithms} security property.
+     * If the specified protocol is disabled, the {@code getInstance} method
+     * will still return an {@code SSLContext} if the specified provider
+     * implements the protocol. However, subsequent operations that attempt
+     * to use the specified protocol will fail with an
+     * {@code SSLHandshakeException}.
      *
      * @param protocol the standard name of the requested protocol.
      *          See the SSLContext section in the <a href=
@@ -246,6 +264,15 @@ public class SSLContext {
      * "{@docRoot}/../specs/security/standard-names.html#sslcontext-algorithms">
      *          Java Security Standard Algorithm Names Specification</a>
      *          for information about standard protocol names.
+     *
+     * @implNote
+     * In the JDK Reference Implementation, a protocol can be disabled by
+     * adding it to the {@code jdk.tls.disabledAlgorithms} security property.
+     * If the specified protocol is disabled, the {@code getInstance} method
+     * will still return an {@code SSLContext} if the specified provider
+     * implements the protocol. However, subsequent operations* that attempt
+     * to use the specified protocol will fail with an
+     * {@code SSLHandshakeException}.
      *
      * @param provider an instance of the provider.
      *


### PR DESCRIPTION
Please review this PR to add an implementation note to the`SSLContext.getInstance` methods to document the behavior when a protocol is disabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296820](https://bugs.openjdk.org/browse/JDK-8296820): Add implementation note to SSLContext.getInstance noting subsequent behavior if protocol is disabled


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11172/head:pull/11172` \
`$ git checkout pull/11172`

Update a local copy of the PR: \
`$ git checkout pull/11172` \
`$ git pull https://git.openjdk.org/jdk pull/11172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11172`

View PR using the GUI difftool: \
`$ git pr show -t 11172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11172.diff">https://git.openjdk.org/jdk/pull/11172.diff</a>

</details>
