### PR TITLE
8296954: G1: Enable parallel scanning for heap region remset

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.hpp
@@ -378,6 +378,8 @@ public:
   // Clear the entire contents of this remembered set.
   void clear();
 
+  void reset_table_scanner();
+
   // Iterate over the container, calling a method on every card or card range contained
   // in the card container.
   // For every container, first calls

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -916,6 +916,9 @@ void G1RemSet::assert_scan_top_is_null(uint hrm_index) {
 void G1RemSet::prepare_region_for_scan(HeapRegion* r) {
   uint hrm_index = r->hrm_index();
 
+  // we call prepare_remset_for_scan unconditionally because optional evacuation doesn't not call this method again.
+  r->prepare_remset_for_scan();
+
   // Only update non-collection set old regions, others must have already been set
   // to NULL (don't scan) in the initialization.
   if (r->in_collection_set()) {
@@ -1358,7 +1361,7 @@ public:
         G1ClearBitmapClosure clear(g1h);
         G1CombinedClosure combined(&merge, &clear);
 
-        g1h->collection_set_iterate_increment_from(&combined, &_hr_claimer, worker_id);
+        g1h->collection_set_iterate_increment_from(&combined, nullptr, worker_id);
         stats = merge.stats();
       }
 

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -916,7 +916,6 @@ void G1RemSet::assert_scan_top_is_null(uint hrm_index) {
 void G1RemSet::prepare_region_for_scan(HeapRegion* r) {
   uint hrm_index = r->hrm_index();
 
-  // we call prepare_remset_for_scan unconditionally because optional evacuation doesn't not call this method again.
   r->prepare_remset_for_scan();
 
   // Only update non-collection set old regions, others must have already been set

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -220,6 +220,10 @@ void HeapRegion::clear_humongous() {
   _humongous_start_region = NULL;
 }
 
+void HeapRegion::prepare_remset_for_scan() {
+  return _rem_set->reset_table_scanner();
+}
+
 HeapRegion::HeapRegion(uint hrm_index,
                        G1BlockOffsetTable* bot,
                        MemRegion mr,

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -457,6 +457,8 @@ public:
 
   inline bool in_collection_set() const;
 
+  void prepare_remset_for_scan();
+
   // Methods used by the HeapRegionSetBase class and subclasses.
 
   // Getter and setter for the next and prev fields used to link regions into

--- a/src/hotspot/share/gc/g1/heapRegionRemSet.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.cpp
@@ -83,6 +83,10 @@ void HeapRegionRemSet::clear_locked(bool only_cardset) {
   assert(occupied() == 0, "Should be clear.");
 }
 
+void HeapRegionRemSet::reset_table_scanner() {
+  _card_set.reset_table_scanner();
+}
+
 G1MonotonicArenaMemoryStats HeapRegionRemSet::card_set_memory_stats() const {
   return _card_set_mm.memory_stats();
 }

--- a/src/hotspot/share/gc/g1/heapRegionRemSet.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.hpp
@@ -122,6 +122,8 @@ public:
   void clear(bool only_cardset = false);
   void clear_locked(bool only_cardset = false);
 
+  void reset_table_scanner();
+
   G1MonotonicArenaMemoryStats card_set_memory_stats() const;
 
   // The actual # of bytes this hr_remset takes up. Also includes the code

--- a/src/hotspot/share/utilities/concurrentHashTableTasks.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTableTasks.inline.hpp
@@ -56,6 +56,7 @@ public:
 
     void set(size_t claim_size, InternalTable* table) {
       assert(table != nullptr, "precondition");
+      _next = 0;
       _limit = table->_size;
       _size  = MIN2(claim_size, _limit);
     }


### PR DESCRIPTION
Hi all, 

Please review this change that allows parallel scanning of a heap region's remembered set.  More balanced work load distribution in cases where are cards are unevenly distributed among remembered sets.

Testing: Tier 1-3

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296954](https://bugs.openjdk.org/browse/JDK-8296954): G1: Enable parallel scanning for heap region remset


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [b0891932](https://git.openjdk.org/jdk/pull/11173/files/b0891932f7e5f94090f4855e98fc66b0b148b134)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11173/head:pull/11173` \
`$ git checkout pull/11173`

Update a local copy of the PR: \
`$ git checkout pull/11173` \
`$ git pull https://git.openjdk.org/jdk pull/11173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11173`

View PR using the GUI difftool: \
`$ git pr show -t 11173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11173.diff">https://git.openjdk.org/jdk/pull/11173.diff</a>

</details>
