### PR TITLE
8290313: Produce warning when user specified java.io.tmpdir directory doesn't exist

### DIFF
--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -35,7 +35,7 @@ import java.nio.file.Path;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
-import sun.security.action.GetPropertyAction;
+import jdk.internal.util.StaticProperty;
 
 /**
  * An abstract representation of file and directory pathnames.
@@ -1984,8 +1984,8 @@ public class File
         private TempDirectory() { }
 
         // temporary directory location
-        private static final File tmpdir = new File(
-                GetPropertyAction.privilegedGetProperty("java.io.tmpdir"));
+        private static final File tmpdir = new File(StaticProperty.javaIoTmpDir());
+
         static File location() {
             return tmpdir;
         }

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2245,8 +2245,8 @@ public final class System {
         Unsafe.getUnsafe().ensureClassInitialized(StringConcatFactory.class);
 
         // Emit a warning if java.io.tmpdir is set via the command line to a directory that doesn't exist
-        if (SystemProps.checkIfWarningRequired()) {
-            System.err.println("WARNING: java.io.tmpdir location does not exist");
+        if (SystemProps.checkIoTmpdir()) {
+            System.err.println("WARNING: java.io.tmpdir directory does not exist");
         }
 
         String smProp = System.getProperty("java.security.manager");

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2244,6 +2244,9 @@ public final class System {
         // SecurityManager
         Unsafe.getUnsafe().ensureClassInitialized(StringConcatFactory.class);
 
+        // print out warning message if java.io.tmpdir is set through command line with non-existing folder
+        SystemProps.checkIoTmpdir();
+
         String smProp = System.getProperty("java.security.manager");
         boolean needWarning = false;
         if (smProp != null) {

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2244,8 +2244,9 @@ public final class System {
         // SecurityManager
         Unsafe.getUnsafe().ensureClassInitialized(StringConcatFactory.class);
 
-        // Emit a warning if java.io.tmpdir is set via the command line to a directory that doesn't exist
-        if (SystemProps.checkIoTmpdir()) {
+        // Emit a warning if java.io.tmpdir is set via the command line
+        // to a directory that doesn't exist
+        if (SystemProps.isBadIoTmpdir()) {
             System.err.println("WARNING: java.io.tmpdir directory does not exist");
         }
 

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2244,8 +2244,10 @@ public final class System {
         // SecurityManager
         Unsafe.getUnsafe().ensureClassInitialized(StringConcatFactory.class);
 
-        // print out warning message if java.io.tmpdir is set through command line with non-existing folder
-        SystemProps.checkIoTmpdir();
+        // Emit a warning if java.io.tmpdir is set via the command line to a directory that doesn't exist
+        if (SystemProps.checkIfWarningRequired()) {
+            System.err.println("WARNING: java.io.tmpdir location does not exist");
+        }
 
         String smProp = System.getProperty("java.security.manager");
         boolean needWarning = false;

--- a/src/java.base/share/classes/jdk/internal/util/SystemProps.java
+++ b/src/java.base/share/classes/jdk/internal/util/SystemProps.java
@@ -49,7 +49,7 @@ public final class SystemProps {
      *
      * @return a boolean value
      */
-    public static boolean checkIoTmpdir() {
+    public static boolean isBadIoTmpdir() {
         return customTmpdir != null && !(new File(customTmpdir).isDirectory());
     }
 

--- a/src/java.base/share/classes/jdk/internal/util/SystemProps.java
+++ b/src/java.base/share/classes/jdk/internal/util/SystemProps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package jdk.internal.util;
 import java.lang.annotation.Native;
 import java.util.HashMap;
 import java.util.Map;
+import java.io.File;
 
 /**
  * System Property initialization for internal use only
@@ -39,6 +40,16 @@ public final class SystemProps {
 
     // no instances
     private SystemProps() {}
+
+    // custom java.io.tmpdir from command line
+    private static String customTmpdir;
+
+    // Print warning message if temp directory is not valid
+    public static void checkIoTmpdir() {
+        if (customTmpdir != null && !(new File(customTmpdir).isDirectory())) {
+            System.err.println("WARNING: java.io.tmpdir location does not exist");
+        }
+    }
 
     /**
      * Create and initialize the system properties from the native properties
@@ -53,6 +64,9 @@ public final class SystemProps {
         // Initially, cmdProperties only includes -D and props from the VM
         Raw raw = new Raw();
         HashMap<String, String> props = raw.cmdProperties();
+
+        // java.io.tmpdir from command line
+        customTmpdir = props.get("java.io.tmpdir");
 
         String javaHome = props.get("java.home");
         assert javaHome != null : "java.home not set";
@@ -280,6 +294,7 @@ public final class SystemProps {
                     break;
                 }
             }
+
             return cmdProps;
         }
 

--- a/src/java.base/share/classes/jdk/internal/util/SystemProps.java
+++ b/src/java.base/share/classes/jdk/internal/util/SystemProps.java
@@ -67,8 +67,6 @@ public final class SystemProps {
         Raw raw = new Raw();
         HashMap<String, String> props = raw.cmdProperties();
 
-        customTmpdir = props.get("java.io.tmpdir");
-
         String javaHome = props.get("java.home");
         assert javaHome != null : "java.home not set";
 
@@ -110,6 +108,8 @@ public final class SystemProps {
         putIfAbsent(props, "line.separator", raw.propDefault(Raw._line_separator_NDX));
         putIfAbsent(props, "file.separator", raw.propDefault(Raw._file_separator_NDX));
         putIfAbsent(props, "path.separator", raw.propDefault(Raw._path_separator_NDX));
+
+        customTmpdir = props.get("java.io.tmpdir");
         putIfAbsent(props, "java.io.tmpdir", raw.propDefault(Raw._java_io_tmpdir_NDX));
         putIfAbsent(props, "http.proxyHost", raw.propDefault(Raw._http_proxyHost_NDX));
         putIfAbsent(props, "http.proxyPort", raw.propDefault(Raw._http_proxyPort_NDX));

--- a/src/java.base/share/classes/jdk/internal/util/SystemProps.java
+++ b/src/java.base/share/classes/jdk/internal/util/SystemProps.java
@@ -41,14 +41,16 @@ public final class SystemProps {
     // no instances
     private SystemProps() {}
 
-    // custom java.io.tmpdir from command line
+    // custom java.io.tmpdir via command line
     private static String customTmpdir;
 
-    // Print warning message if temp directory is not valid
-    public static void checkIoTmpdir() {
-        if (customTmpdir != null && !(new File(customTmpdir).isDirectory())) {
-            System.err.println("WARNING: java.io.tmpdir location does not exist");
-        }
+    /**
+     * check if warning for custom java.io.tmpdir is required
+     *
+     * @return a boolean value
+     */
+    public static boolean checkIfWarningRequired() {
+        return customTmpdir != null && !(new File(customTmpdir).isDirectory());
     }
 
     /**
@@ -65,7 +67,6 @@ public final class SystemProps {
         Raw raw = new Raw();
         HashMap<String, String> props = raw.cmdProperties();
 
-        // java.io.tmpdir from command line
         customTmpdir = props.get("java.io.tmpdir");
 
         String javaHome = props.get("java.home");

--- a/src/java.base/share/classes/jdk/internal/util/SystemProps.java
+++ b/src/java.base/share/classes/jdk/internal/util/SystemProps.java
@@ -294,7 +294,6 @@ public final class SystemProps {
                     break;
                 }
             }
-
             return cmdProps;
         }
 

--- a/src/java.base/share/classes/jdk/internal/util/SystemProps.java
+++ b/src/java.base/share/classes/jdk/internal/util/SystemProps.java
@@ -41,15 +41,15 @@ public final class SystemProps {
     // no instances
     private SystemProps() {}
 
-    // custom java.io.tmpdir via command line
+    // Custom java.io.tmpdir via command line.
     private static String customTmpdir;
 
     /**
-     * check if warning for custom java.io.tmpdir is required
+     * Check if warning for custom java.io.tmpdir is required.
      *
      * @return a boolean value
      */
-    public static boolean checkIfWarningRequired() {
+    public static boolean checkIoTmpdir() {
         return customTmpdir != null && !(new File(customTmpdir).isDirectory());
     }
 

--- a/test/jdk/java/io/File/TempDirDoesNotExist.java
+++ b/test/jdk/java/io/File/TempDirDoesNotExist.java
@@ -27,7 +27,6 @@
  * @summary Produce warning when user specified java.io.tmpdir directory doesn't exist
  */
 
-import jdk.test.lib.Platform;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 
@@ -45,9 +44,8 @@ public class TempDirDoesNotExist {
         String userDir = System.getProperty("user.home");
         String timeStamp = java.time.Instant.now().toString();
         String tempDir = Path.of(userDir,"non-existing-", timeStamp).toString();
-        System.out.println("args length:"+args.length);
+
         for (String arg : args) {
-            System.out.println("args value:" + arg);
             if (arg.equals("io")) {
                 try {
                     File.createTempFile("prefix", ".suffix");
@@ -112,6 +110,6 @@ public class TempDirDoesNotExist {
                 -> line.equalsIgnoreCase(ioWarningMsg)).collect(Collectors.toList());
         if (list.size() != 1 || originalOutput.getExitValue() != exitValue)
             throw new Exception("counter of messages is not one, but " + list.size()
-                    + "\n" + originalOutput.asLines().toString());
+                    + "\n" + originalOutput.asLines().toString() + "\n");
     }
 }

--- a/test/jdk/java/io/File/TempDirDoesNotExist.java
+++ b/test/jdk/java/io/File/TempDirDoesNotExist.java
@@ -37,7 +37,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class TempDirectoryNotExisting {
+public class TempDirDoesNotExist {
     final static String ioWarningMsg = "WARNING: java.io.tmpdir directory does not exist";
 
     public static void main(String... args) throws Exception {
@@ -60,17 +60,6 @@ public class TempDirectoryNotExisting {
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
-            } else if (arg.equals("io-nio")) {
-                try {
-                    File.createTempFile("prefix", ".suffix");
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-                try {
-                    Files.createTempFile("prefix", ".suffix");
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
             } else {
                 throw new Exception("unknown case: " + arg);
             }
@@ -78,33 +67,33 @@ public class TempDirectoryNotExisting {
 
         if (args.length == 0) {
             // standard test with default setting for java.io.tmpdir
-            testMessageNotExist(0, ioWarningMsg, "TempDirectoryNotExisting", "io");
-            testMessageNotExist(0, ioWarningMsg, "TempDirectoryNotExisting", "nio");
+            testMessageNotExist(0, ioWarningMsg, "TempDirDoesNotExist", "io");
+            testMessageNotExist(0, ioWarningMsg, "TempDirDoesNotExist", "nio");
 
             // valid custom java.io.tmpdir
             testMessageNotExist(0, ioWarningMsg, "-Djava.io.tmpdir=" + userDir,
-                    "TempDirectoryNotExisting", "io");
+                    "TempDirDoesNotExist", "io");
             testMessageNotExist(0, ioWarningMsg, "-Djava.io.tmpdir=" + userDir,
-                    "TempDirectoryNotExisting", "nio");
+                    "TempDirDoesNotExist", "nio");
 
             // invalid custom java.io.tmpdir
             testMessageExist(0, ioWarningMsg, "-Djava.io.tmpdir=" + tempDir,
-                    "TempDirectoryNotExisting", "io");
+                    "TempDirDoesNotExist", "io");
             testMessageExist(0, ioWarningMsg, "-Djava.io.tmpdir=" + tempDir,
-                    "TempDirectoryNotExisting", "nio");
+                    "TempDirDoesNotExist", "nio");
 
             // test with security manager
             testMessageExist(0, ioWarningMsg, "-Djava.io.tmpdir=" + tempDir
                             + " -Djava.security.manager",
-                    "TempDirectoryNotExisting", "io");
+                    "TempDirDoesNotExist", "io");
 
             testMessageExist(0, ioWarningMsg, "-Djava.io.tmpdir=" + tempDir
                             + " -Djava.security.manager",
-                    "TempDirectoryNotExisting", "nio");
+                    "TempDirDoesNotExist", "nio");
 
             // error message printed only once
             testMessageCounter(0, "-Djava.io.tmpdir=" + tempDir,
-                    "TempDirectoryNotExisting", "io-nio");
+                    "TempDirDoesNotExist", "io", "nio");
         }
     }
 

--- a/test/jdk/java/io/File/TempDirectoryNotExisting.java
+++ b/test/jdk/java/io/File/TempDirectoryNotExisting.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8290313
+ * @library /test/lib
+ * @summary Produce warning when user specified java.io.tmpdir directory doesn't exist
+ */
+
+import jdk.test.lib.Platform;
+import jdk.test.lib.process.ProcessTools;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class TempDirectoryNotExisting {
+    final static String ioWarningMsg = "WARNING: java.io.tmpdir location does not exist";
+
+    public static void main(String... args) throws Exception {
+
+        String userDir = System.getProperty("user.home");
+        String timeStamp = System.currentTimeMillis() + "";
+        String tempDir = Path.of(userDir,"non-existing-", timeStamp).toString();
+
+        if (args.length != 0) {
+            if (args[0].equals("io")) {
+                try {
+                    File.createTempFile("prefix", ".suffix");
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            } else {
+
+                if (args[0].equals("nio")) {
+                    try {
+                        Files.createTempFile("prefix", ".suffix");
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                } else {
+                    try {
+                        File.createTempFile("prefix", ".suffix");
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                    try {
+                        Files.createTempFile("prefix", ".suffix");
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        } else {
+
+            // standard test with default setting for java.io.tmpdir
+            testMessageNotExist(0, ioWarningMsg, "TempDirectoryNotExisting", "io");
+            testMessageNotExist(0, ioWarningMsg, "TempDirectoryNotExisting", "nio");
+
+            // valid custom java.io.tmpdir
+            testMessageNotExist(0, ioWarningMsg, "-Djava.io.tmpdir=" + userDir,
+                    "TempDirectoryNotExisting", "io");
+            testMessageNotExist(0, ioWarningMsg, "-Djava.io.tmpdir=" + userDir,
+                    "TempDirectoryNotExisting", "nio");
+
+            // invalid custom java.io.tmpdir
+            testMessageExist(0, ioWarningMsg, "-Djava.io.tmpdir=" + tempDir,
+                    "TempDirectoryNotExisting", "io");
+            testMessageExist(0, ioWarningMsg, "-Djava.io.tmpdir=" + tempDir,
+                    "TempDirectoryNotExisting", "nio");
+
+            // test with security manager
+            testMessageExist(0, ioWarningMsg, "-Djava.io.tmpdir=" + tempDir
+                            + " -Djava.security.manager",
+                    "TempDirectoryNotExisting", "io");
+
+            testMessageExist(0, ioWarningMsg, "-Djava.io.tmpdir=" + tempDir
+                            + " -Djava.security.manager",
+                    "TempDirectoryNotExisting", "nio");
+
+            // error message printed only once
+            testMessageCounter(0, "-Djava.io.tmpdir=" + tempDir,
+                    "TempDirectoryNotExisting", "io-nio");
+        }
+    }
+
+    private static void testMessageExist(int exitValue, String errorMsg, String... options) throws Exception {
+        ProcessTools.executeTestJvm(options).shouldContain(errorMsg)
+                .shouldHaveExitValue(exitValue);
+    }
+
+    private static void testMessageNotExist(int exitValue, String errorMsg,String... options) throws Exception {
+        ProcessTools.executeTestJvm(options).shouldNotContain(errorMsg).shouldHaveExitValue(exitValue);
+    }
+
+    private static void testMessageCounter(int exitValue,String... options) throws Exception {
+        List<String> list = ProcessTools.executeTestJvm(options).shouldHaveExitValue(exitValue)
+                .asLines().stream()
+                .filter(line -> line.equalsIgnoreCase(ioWarningMsg))
+                .collect(Collectors.toList());
+        if (list.size() != 1) throw new Exception("counter of messages is not one, but " + list.size());
+    }
+}


### PR DESCRIPTION
print warning message for java.io.tmpdir when it is set through the command line and the value is not good for creating file folder.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290313](https://bugs.openjdk.org/browse/JDK-8290313): Produce warning when user specified java.io.tmpdir directory doesn't exist


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to [38f8855b](https://git.openjdk.org/jdk/pull/11174/files/38f8855b4e482dc4e37b8aef4d506e8cc71cb660)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [38f8855b](https://git.openjdk.org/jdk/pull/11174/files/38f8855b4e482dc4e37b8aef4d506e8cc71cb660)
 * [Sean Coffey](https://openjdk.org/census#coffeys) (@coffeys - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11174/head:pull/11174` \
`$ git checkout pull/11174`

Update a local copy of the PR: \
`$ git checkout pull/11174` \
`$ git pull https://git.openjdk.org/jdk pull/11174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11174`

View PR using the GUI difftool: \
`$ git pr show -t 11174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11174.diff">https://git.openjdk.org/jdk/pull/11174.diff</a>

</details>
