### PR TITLE
Use enhanced-for cycle instead of Enumeration in sun.rmi.transport.Target

### DIFF
--- a/src/java.rmi/share/classes/sun/rmi/transport/Target.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/Target.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -360,9 +360,7 @@ public final class Target {
              */
             unpinImpl();
             DGCImpl dgc = DGCImpl.getDGCImpl();
-            Enumeration<VMID> enum_ = refSet.elements();
-            while (enum_.hasMoreElements()) {
-                VMID vmid = enum_.nextElement();
+            for (VMID vmid : refSet) {
                 dgc.unregisterTarget(vmid, this);
             }
             return true;


### PR DESCRIPTION
java.util.Enumeration is a legacy interface from java 1.0.
There is one place with cycles which use it to iterate over collections. We can replace this manual cycle with enchanced-for, which is shorter and easier to read.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11175/head:pull/11175` \
`$ git checkout pull/11175`

Update a local copy of the PR: \
`$ git checkout pull/11175` \
`$ git pull https://git.openjdk.org/jdk pull/11175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11175`

View PR using the GUI difftool: \
`$ git pr show -t 11175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11175.diff">https://git.openjdk.org/jdk/pull/11175.diff</a>

</details>
