### PR TITLE
8297091: New langtools test jdk/javadoc/doclet/testValueTag/TestValueFormats.java fails on machines with unexpected number format

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testValueTag/TestValueFormats.java
+++ b/test/langtools/jdk/javadoc/doclet/testValueTag/TestValueFormats.java
@@ -86,7 +86,7 @@ public class TestValueFormats extends JavadocTester {
                 """
                     <h3>pi</h3>
                     <div class="member-signature"><span class="modifiers">public static final</span>&nbsp;<span class="return-type">double</span>&nbsp;<span class="element-name">pi</span></div>
-                    <div class="block">The value 3.1415926525 is  3.14.</div>""");
+                    <div class="block">The value 3.1415926525 is %5.2f.</div>""".formatted(3.14));
     }
 
     @Test


### PR DESCRIPTION
The new test langtools/jdk/javadoc/doclet/testValueTag/TestValueFormats.java assumes a number format with a decimal separator dot (.). This can be different in other locales.

This fixes the issue by expecting a number format that is calculated at runtime, with the locale settings the test runs in. Not sure if it is the correct way to fix, though.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297091](https://bugs.openjdk.org/browse/JDK-8297091): New langtools test jdk/javadoc/doclet/testValueTag/TestValueFormats.java fails on machines with unexpected number format


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11177/head:pull/11177` \
`$ git checkout pull/11177`

Update a local copy of the PR: \
`$ git checkout pull/11177` \
`$ git pull https://git.openjdk.org/jdk pull/11177/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11177`

View PR using the GUI difftool: \
`$ git pr show -t 11177`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11177.diff">https://git.openjdk.org/jdk/pull/11177.diff</a>

</details>
