### PR TITLE
8282404: DrawStringWithInfiniteXform.java failed with "RuntimeException: drawString with InfiniteXform transform takes long time"

### DIFF
--- a/test/jdk/java/awt/FontClass/DrawStringWithInfiniteXform.java
+++ b/test/jdk/java/awt/FontClass/DrawStringWithInfiniteXform.java
@@ -41,14 +41,15 @@ public class DrawStringWithInfiniteXform {
 
     class ScheduleTask extends TimerTask {
         public void run() {
-        System.out.println("Task running at " + System.currentTimeMillis());
-        System.out.flush();
+            System.out.println("Task running at " + System.currentTimeMillis());
+            System.out.flush();
             synchronized(DrawStringWithInfiniteXform.class) {
-               System.out.println("Checking done at " + System.currentTimeMillis());
+               System.out.println(
+                   "Checking done at " + System.currentTimeMillis());
                System.out.flush();
                 if (!done) {
-                    throw new
-                    RuntimeException("drawString with InfiniteXform transform takes long time");
+                    throw new RuntimeException(
+                       "drawString with InfiniteXform transform takes long time");
                 }
             }
         }
@@ -67,10 +68,12 @@ public class DrawStringWithInfiniteXform {
         System.out.println("start at " + System.currentTimeMillis());
         System.out.flush();
         float[] vals = new float[6];
-        for (int i=0;i<6;i++) vals[i]=Float.POSITIVE_INFINITY;
+        for (int i=0; i<6; i++) {
+            vals[i] = Float.POSITIVE_INFINITY;
+        }
         AffineTransform nanTX = new AffineTransform(vals);
 
-        BufferedImage bi = new BufferedImage(1,1,BufferedImage.TYPE_INT_RGB);
+        BufferedImage bi = new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB);
         Graphics2D g2d = bi.createGraphics();
 
         g2d.rotate(Float.POSITIVE_INFINITY);

--- a/test/jdk/java/awt/FontClass/DrawStringWithInfiniteXform.java
+++ b/test/jdk/java/awt/FontClass/DrawStringWithInfiniteXform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,13 +24,13 @@
  * @test
  * @bug 8023213
  * @summary Font/Text APIs should not crash/takes long time
- *          if transform includes INIFINITY
+ *          if transform includes INFINITY
  * @run main DrawStringWithInfiniteXform
  */
-import java.awt.*;
-import java.awt.font.*;
-import java.awt.geom.*;
-import java.awt.image.*;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -41,15 +41,21 @@ public class DrawStringWithInfiniteXform {
 
     class ScheduleTask extends TimerTask {
         public void run() {
-            if (!done) {
-                throw new
-                RuntimeException("drawString with InfiniteXform transform takes long time");
+        System.out.println("Task running at " + System.currentTimeMillis());
+        System.out.flush();
+            synchronized(DrawStringWithInfiniteXform.class) {
+               System.out.println("Checking done at " + System.currentTimeMillis());
+               System.out.flush();
+                if (!done) {
+                    throw new
+                    RuntimeException("drawString with InfiniteXform transform takes long time");
+                }
             }
         }
     }
     public DrawStringWithInfiniteXform() {
         timer = new Timer();
-        timer.schedule(new ScheduleTask(), 20000);
+        timer.schedule(new ScheduleTask(), 30000);
     }
 
     public static void main(String [] args) {
@@ -58,6 +64,8 @@ public class DrawStringWithInfiniteXform {
     }
 
     private void start() {
+        System.out.println("start at " + System.currentTimeMillis());
+        System.out.flush();
         float[] vals = new float[6];
         for (int i=0;i<6;i++) vals[i]=Float.POSITIVE_INFINITY;
         AffineTransform nanTX = new AffineTransform(vals);
@@ -73,8 +81,12 @@ public class DrawStringWithInfiniteXform {
             g2d.setFont(xfiniteFont);
             g2d.drawString("abc", 20, 20);
         }
-        done = true;
-        timer.cancel();
+        System.out.println("Loop done at " + System.currentTimeMillis());
+        System.out.flush();
+        synchronized (DrawStringWithInfiniteXform.class) {
+            done = true;
+            timer.cancel();
+        }
         System.out.println("Test passed");
     }
 }

--- a/test/jdk/java/awt/FontClass/DrawStringWithInfiniteXform.java
+++ b/test/jdk/java/awt/FontClass/DrawStringWithInfiniteXform.java
@@ -43,7 +43,7 @@ public class DrawStringWithInfiniteXform {
         public void run() {
             System.out.println("Task running at " + System.currentTimeMillis());
             System.out.flush();
-            synchronized(DrawStringWithInfiniteXform.class) {
+            synchronized (DrawStringWithInfiniteXform.class) {
                System.out.println(
                    "Checking done at " + System.currentTimeMillis());
                System.out.flush();


### PR DESCRIPTION
This test is not problem listed and has failed only once since (SFAIK) it was last updated a year ago so
this is just another small attempt to remove instability by increasing timeout, being really insistent about
making sure the "done=true" is propagated and adding some extra timing logging to help analyse any failures

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282404](https://bugs.openjdk.org/browse/JDK-8282404): DrawStringWithInfiniteXform.java failed with "RuntimeException: drawString with InfiniteXform transform takes long time"


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**) ⚠️ Review applies to [7becd787](https://git.openjdk.org/jdk/pull/11179/files/7becd787da4fc106081b5b6415140fc981dba59b)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**) ⚠️ Review applies to [7becd787](https://git.openjdk.org/jdk/pull/11179/files/7becd787da4fc106081b5b6415140fc981dba59b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11179/head:pull/11179` \
`$ git checkout pull/11179`

Update a local copy of the PR: \
`$ git checkout pull/11179` \
`$ git pull https://git.openjdk.org/jdk pull/11179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11179`

View PR using the GUI difftool: \
`$ git pr show -t 11179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11179.diff">https://git.openjdk.org/jdk/pull/11179.diff</a>

</details>
