### PR TITLE
9074331 fixed printing page range for e.g. page 2 to 2 on macOS

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
@@ -612,7 +612,7 @@ JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_CPrinterJob_printLoop
 JNI_COCOA_ENTER(env);
     // Get the first page's PageFormat for setting things up (This introduces
     //  and is a facet of the same problem in Radar 2818593/2708932).
-    jobject page = (*env)->CallObjectMethod(env, jthis, jm_getPageFormat, 0); // AWT_THREADING Safe (!appKit)
+    jobject page = (*env)->CallObjectMethod(env, jthis, jm_getPageFormat, firstPage); // AWT_THREADING Safe (!appKit)
     CHECK_EXCEPTION();
     if (page != NULL) {
         jobject pageFormatArea = (*env)->CallObjectMethod(env, jthis, jm_getPageFormatArea, page); // AWT_THREADING Safe (!appKit)


### PR DESCRIPTION
When choosing on macOS a page range from printing e.g. "page 2 to 2" or "page 2 to 4" of a multipage document, the pages are not printed. This happens on swing as well as on JavaFX.

I already created a bug in bug database and got internal review ID : 9074331

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Integration blocker
&nbsp;⚠️ Failed to retrieve information on issue `9074331`. Please make sure it exists and is accessible.

### Issue
 * ⚠️ Failed to retrieve information on issue `9074331`.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11180/head:pull/11180` \
`$ git checkout pull/11180`

Update a local copy of the PR: \
`$ git checkout pull/11180` \
`$ git pull https://git.openjdk.org/jdk pull/11180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11180`

View PR using the GUI difftool: \
`$ git pr show -t 11180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11180.diff">https://git.openjdk.org/jdk/pull/11180.diff</a>

</details>
