### PR TITLE
8296912: C2: CreateExNode::Identity fails with assert(i < _max) failed: oob: i=1, _max=1

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -2782,9 +2782,8 @@ Node* CreateExNode::Identity(PhaseGVN* phase) {
   // exception oop through.
   CallNode *call = in(1)->in(0)->as_Call();
 
-  return ( in(0)->is_CatchProj() && in(0)->in(0)->in(1) == in(1) )
-    ? this
-    : call->in(TypeFunc::Parms);
+  return (in(0)->is_CatchProj() && in(0)->in(0)->is_Catch() &&
+          in(0)->in(0)->in(1) == in(1)) ? this : call->in(TypeFunc::Parms);
 }
 
 //=============================================================================

--- a/test/hotspot/jtreg/compiler/c2/TestDeadDataLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/TestDeadDataLoop.java
@@ -23,17 +23,20 @@
 
 /*
  * @test
- * @bug 8284358
+ * @bug 8284358 8296912
  * @summary An unreachable loop is not removed, leading to a broken graph.
  * @requires vm.compiler2.enabled
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:StressSeed=1448005075
- *                   -XX:CompileCommand=compileonly,*TestDeadDataLoop::test* -XX:CompileCommand=dontinline,*TestDeadDataLoop::notInlined
+ *                   -XX:CompileCommand=compileonly,*TestDeadDataLoop::test* -XX:CompileCommand=dontinline,*TestDeadDataLoop::notInlined*
  *                   compiler.c2.TestDeadDataLoop
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:StressSeed=1922737097
- *                   -XX:CompileCommand=compileonly,*TestDeadDataLoop::test* -XX:CompileCommand=dontinline,*TestDeadDataLoop::notInlined
+ *                   -XX:CompileCommand=compileonly,*TestDeadDataLoop::test* -XX:CompileCommand=dontinline,*TestDeadDataLoop::notInlined*
+ *                   compiler.c2.TestDeadDataLoop
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:StressSeed=2472844645
+ *                   -XX:CompileCommand=compileonly,*TestDeadDataLoop::test* -XX:CompileCommand=dontinline,*TestDeadDataLoop::notInlined*
  *                   compiler.c2.TestDeadDataLoop
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN
- *                   -XX:CompileCommand=compileonly,*TestDeadDataLoop::test* -XX:CompileCommand=dontinline,*TestDeadDataLoop::notInlined
+ *                   -XX:CompileCommand=compileonly,*TestDeadDataLoop::test* -XX:CompileCommand=dontinline,*TestDeadDataLoop::notInlined*
  *                   compiler.c2.TestDeadDataLoop
  */
 
@@ -216,8 +219,27 @@ public class TestDeadDataLoop {
         }
     }
 
+    static long l;
+
+    static void test11(boolean never) {
+        float f = 1;
+        boolean b;
+        for (int i = 0; i < 5; ++i) {
+            b = (never || l < 0);
+            l = notInlined2();
+            if (!never) {
+                f += i;
+            }
+        }
+        l += f;
+    }
+
     public static boolean notInlined() {
         return false;
+    }
+
+    public static int notInlined2() {
+        return 42;
     }
 
     public static void main(String[] args) {
@@ -234,6 +256,7 @@ public class TestDeadDataLoop {
         test8();
         test9();
         test10();
+        test11(false);
     }
 }
 


### PR DESCRIPTION
The fix for [JDK-8284358](https://bugs.openjdk.org/browse/JDK-8284358) added code that aggressively removes dead subgraphs when detecting an unreachable Region by walking up the CFG and replacing all nodes by top (because they must be unreachable as well). In this case, we detect that `280 Region` is unreachable from root and replace `276 Catch` by top while walking up the CFG:

![Screenshot from 2022-11-16 12-53-56](https://user-images.githubusercontent.com/5312595/202174104-9437914a-cb38-401c-b0fd-d6ca849969b0.png)

Code in `CreateExNode::Identity` does not expect `292 CatchProj` to have a top input when processing `305 CreateEx`. The fix is to simply add a `in(0)->in(0)->is_Catch()` check.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296912](https://bugs.openjdk.org/browse/JDK-8296912): C2: CreateExNode::Identity fails with assert(i < _max) failed: oob: i=1, _max=1


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11181/head:pull/11181` \
`$ git checkout pull/11181`

Update a local copy of the PR: \
`$ git checkout pull/11181` \
`$ git pull https://git.openjdk.org/jdk pull/11181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11181`

View PR using the GUI difftool: \
`$ git pr show -t 11181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11181.diff">https://git.openjdk.org/jdk/pull/11181.diff</a>

</details>
