### PR TITLE
8297132: BACKOUT JDK-8296889: Race condition when cancelling a request

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Exchange.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Exchange.java
@@ -209,11 +209,6 @@ class Http1Exchange<T> extends ExchangeImpl<T> {
         }
 
         @Override
-        public void onSubscribed() {
-            exchange.registerResponseSubscriber(this);
-        }
-
-        @Override
         protected void complete(Throwable t) {
             try {
                 exchange.unregisterResponseSubscriber(this);
@@ -464,6 +459,7 @@ class Http1Exchange<T> extends ExchangeImpl<T> {
         BodySubscriber<T> subscriber = handler.apply(response);
         Http1ResponseBodySubscriber<T> bs =
                 new Http1ResponseBodySubscriber<T>(subscriber, this);
+        registerResponseSubscriber(bs);
         return bs;
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -344,6 +344,7 @@ class Stream<T> extends ExchangeImpl<T> {
     Http2StreamResponseSubscriber<T> createResponseSubscriber(BodyHandler<T> handler, ResponseInfo response) {
         Http2StreamResponseSubscriber<T> subscriber =
                 new Http2StreamResponseSubscriber<>(handler.apply(response));
+        registerResponseSubscriber(subscriber);
         return subscriber;
     }
 
@@ -1543,21 +1544,16 @@ class Stream<T> extends ExchangeImpl<T> {
         }
 
         @Override
-        public void onSubscribed() {
-            registerResponseSubscriber(this);
-        }
-
-        @Override
         protected void complete(Throwable t) {
             try {
-                unregisterResponseSubscriber(this);
+                Stream.this.unregisterResponseSubscriber(this);
             } finally {
                 super.complete(t);
             }
         }
         @Override
         protected void onCancel() {
-            unregisterResponseSubscriber(this);
+            Stream.this.unregisterResponseSubscriber(this);
         }
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/HttpBodySubscriberWrapper.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/HttpBodySubscriberWrapper.java
@@ -128,15 +128,6 @@ public class HttpBodySubscriberWrapper<T> implements TrustedSubscriber<T> {
     protected void onCancel() { }
 
     /**
-     * Called right after the userSubscriber::onSubscribe is called.
-     * @apiNote
-     * This method may be used by subclasses to perform cleanup
-     * related actions after a subscription has been succesfully
-     * accepted.
-     */
-    protected void onSubscribed() { }
-
-    /**
      * Complete the subscriber, either normally or exceptionally
      * ensure that the subscriber is completed only once.
      * @param t a throwable, or {@code null}
@@ -178,9 +169,8 @@ public class HttpBodySubscriberWrapper<T> implements TrustedSubscriber<T> {
     public void onSubscribe(Flow.Subscription subscription) {
         // race condition with propagateError: we need to wait until
         // subscription is finished before calling onError;
-        boolean onSubscribed;
         synchronized (this) {
-            if ((onSubscribed = subscribed.compareAndSet(false, true))) {
+            if (subscribed.compareAndSet(false, true)) {
                 SubscriptionWrapper wrapped = new SubscriptionWrapper(subscription);
                 userSubscriber.onSubscribe(this.subscription = wrapped);
             } else {
@@ -191,7 +181,6 @@ public class HttpBodySubscriberWrapper<T> implements TrustedSubscriber<T> {
                 assert completed.get();
             }
         }
-        if (onSubscribed) onSubscribed();
     }
 
     @Override

--- a/test/jdk/java/net/httpclient/CancelRequestTest.java
+++ b/test/jdk/java/net/httpclient/CancelRequestTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8245462 8229822 8254786 8296889
+ * @bug 8245462 8229822 8254786
  * @summary Tests cancelling the request.
  * @library /test/lib http2/server
  * @key randomness


### PR DESCRIPTION
This fix for [JDK-8296889](https://bugs.openjdk.org/browse/JDK-8296889) is causing trouble with the CancelStreamedBodyTest. Let's back it out until a better solution is found.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297132](https://bugs.openjdk.org/browse/JDK-8297132): BACKOUT JDK-8296889: Race condition when cancelling a request


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - Committer)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11182/head:pull/11182` \
`$ git checkout pull/11182`

Update a local copy of the PR: \
`$ git checkout pull/11182` \
`$ git pull https://git.openjdk.org/jdk pull/11182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11182`

View PR using the GUI difftool: \
`$ git pr show -t 11182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11182.diff">https://git.openjdk.org/jdk/pull/11182.diff</a>

</details>
