### PR TITLE
8297134: Add a @sealedGraph tag to InetAddress

### DIFF
--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -223,6 +223,7 @@ import static java.net.spi.InetAddressResolver.LookupPolicy.IPV6_FIRST;
  * @see     java.net.InetAddress#getByName(java.lang.String)
  * @see     java.net.InetAddress#getLocalHost()
  * @since 1.0
+ * @sealedGraph
  */
 public sealed class InetAddress implements Serializable permits Inet4Address, Inet6Address {
 


### PR DESCRIPTION
This PR proposes to opt in for graphic rendering of the sealed hierarchy of the `InetAddress` class.

Rendering capability was added via https://bugs.openjdk.org/browse/JDK-8295653

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297134](https://bugs.openjdk.org/browse/JDK-8297134): Add a @sealedGraph tag to InetAddress


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Aleksei Efimov](https://openjdk.org/census#aefimov) (@AlekseiEfimov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11184/head:pull/11184` \
`$ git checkout pull/11184`

Update a local copy of the PR: \
`$ git checkout pull/11184` \
`$ git pull https://git.openjdk.org/jdk pull/11184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11184`

View PR using the GUI difftool: \
`$ git pr show -t 11184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11184.diff">https://git.openjdk.org/jdk/pull/11184.diff</a>

</details>
