### PR TITLE
8297145: Add a @sealedGraph tag to ConstantDesc

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/ConstantDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ConstantDesc.java
@@ -74,6 +74,7 @@ import java.lang.invoke.VarHandle.VarHandleDesc;
  * @jvms 4.4 The Constant Pool
  *
  * @since 12
+ * @sealedGraph
  */
 public sealed interface ConstantDesc
         permits ClassDesc,


### PR DESCRIPTION
This PR proposes to opt in for graphic rendering of the sealed hierarchy of the ConstantDesc class.

Rendering capability was added via https://bugs.openjdk.org/browse/JDK-8295653


Here is how it would look like:

<img width="561" alt="ConstantDesc_SH" src="https://user-images.githubusercontent.com/7457876/202216017-ec996722-2956-4b0a-adb5-538bce12c135.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297145](https://bugs.openjdk.org/browse/JDK-8297145): Add a @sealedGraph tag to ConstantDesc


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11187/head:pull/11187` \
`$ git checkout pull/11187`

Update a local copy of the PR: \
`$ git checkout pull/11187` \
`$ git pull https://git.openjdk.org/jdk pull/11187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11187`

View PR using the GUI difftool: \
`$ git pr show -t 11187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11187.diff">https://git.openjdk.org/jdk/pull/11187.diff</a>

</details>
