### PR TITLE
8297148: Add a @sealedGraph tag to CallSite

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/CallSite.java
+++ b/src/java.base/share/classes/java/lang/invoke/CallSite.java
@@ -83,6 +83,7 @@ private static CallSite bootstrapDynamic(MethodHandles.Lookup caller, String nam
 }</pre></blockquote>
  * @author John Rose, JSR 292 EG
  * @since 1.7
+ * @sealedGraph
  */
 public
 abstract sealed class CallSite permits ConstantCallSite, MutableCallSite, VolatileCallSite {


### PR DESCRIPTION
This PR proposes to opt in for graphic rendering of the sealed hierarchy of the CallSite class.

Rendering capability was added via https://bugs.openjdk.org/browse/JDK-8295653

Here is how it would look like:

<img width="479" alt="CallSite_SH" src="https://user-images.githubusercontent.com/7457876/202234105-8029ade2-4feb-456c-a010-b80122195f0f.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297148](https://bugs.openjdk.org/browse/JDK-8297148): Add a @sealedGraph tag to CallSite


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11190/head:pull/11190` \
`$ git checkout pull/11190`

Update a local copy of the PR: \
`$ git checkout pull/11190` \
`$ git pull https://git.openjdk.org/jdk pull/11190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11190`

View PR using the GUI difftool: \
`$ git pr show -t 11190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11190.diff">https://git.openjdk.org/jdk/pull/11190.diff</a>

</details>
