### PR TITLE
8297150: Add a @sealedGraph tag to Reference

### DIFF
--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -41,6 +41,7 @@ import jdk.internal.ref.Cleaner;
  *
  * @author   Mark Reinhold
  * @since    1.2
+ * @sealedGraph
  */
 
 public abstract sealed class Reference<T>


### PR DESCRIPTION
This PR proposes to opt in for graphic rendering of the sealed hierarchy of the `Reference` class.

Rendering capability was added via https://bugs.openjdk.org/browse/JDK-8295653

Here is how it would look like:

<img width="449" alt="Reference_SH" src="https://user-images.githubusercontent.com/7457876/202243138-7f2a799a-dc67-4c4e-9322-c18bf05d73e7.png">
