### PR TITLE
8283238: make/scripts/compare.sh should show the diff when classlist does not match

### DIFF
--- a/make/InitSupport.gmk
+++ b/make/InitSupport.gmk
@@ -426,10 +426,10 @@ else # $(HAS_SPEC)=true
         # Compare first and second build. Ignore any error code from compare.sh.
 	$(ECHO) "Comparing between comparison rebuild (this/new) and baseline (other/old)"
 	$(if $(COMPARE_BUILD_COMP_DIR), \
-	  +(cd $(COMPARE_BUILD_OUTPUTDIR) && ./compare.sh $(COMPARE_BUILD_COMP_OPTS) \
+	  +(cd $(COMPARE_BUILD_OUTPUTDIR) && ./compare.sh -vv $(COMPARE_BUILD_COMP_OPTS) \
 	      -2dirs $(COMPARE_BUILD_OUTPUTDIR)/$(COMPARE_BUILD_COMP_DIR) \
 	      $(OUTPUTDIR)/$(COMPARE_BUILD_COMP_DIR) $(COMPARE_BUILD_IGNORE_RESULT)), \
-	  +(cd $(COMPARE_BUILD_OUTPUTDIR) && ./compare.sh $(COMPARE_BUILD_COMP_OPTS) \
+	  +(cd $(COMPARE_BUILD_OUTPUTDIR) && ./compare.sh -vv $(COMPARE_BUILD_COMP_OPTS) \
 	      -o $(OUTPUTDIR) $(COMPARE_BUILD_IGNORE_RESULT)) \
 	)
   endef


### PR DESCRIPTION
Please review this change for enabling verbose (-vv) when running the compare.sh script so that the diff between files will be available in the build stdout file. This is for troubleshooting the two bugs ([JDK-8283220](https://bugs.openjdk.org/browse/JDK-8283220), [JDK-8295951](https://bugs.openjdk.org/browse/JDK-8295951)) which happened intermittently.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283238](https://bugs.openjdk.org/browse/JDK-8283238): make/scripts/compare.sh should show the diff when classlist does not match


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11192/head:pull/11192` \
`$ git checkout pull/11192`

Update a local copy of the PR: \
`$ git checkout pull/11192` \
`$ git pull https://git.openjdk.org/jdk pull/11192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11192`

View PR using the GUI difftool: \
`$ git pr show -t 11192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11192.diff">https://git.openjdk.org/jdk/pull/11192.diff</a>

</details>
