### PR TITLE
8297154: Improve safepoint cleanup logging

### DIFF
--- a/src/hotspot/share/runtime/safepoint.hpp
+++ b/src/hotspot/share/runtime/safepoint.hpp
@@ -259,6 +259,7 @@ private:
 
   static VM_Operation::VMOp_Type _current_type;
   static jlong     _max_sync_time;
+  static jlong     _max_cleanup_time;
   static jlong     _max_vmop_time;
   static uint64_t  _op_count[VM_Operation::VMOp_Terminating];
 


### PR DESCRIPTION
When backporting [JDK-8280784](https://bugs.openjdk.org/browse/JDK-8280784), I realized that safepoint cleanup logging added by [JDK-8219436](https://bugs.openjdk.org/browse/JDK-8219436) is misleading. `-Xlog:safepoint` output includes "cleanup" time into "Reaching safepoint", which users can arguably expect to be only the time-to-safepoint. With large reported "Reaching safepoint" time, users would chase a safepoint polling / scheduling problem, rather than suspect the safepoint cleanup costs. I was confused about this myself, and only reading the safepoint timing code made the picture more clear.

It can be observed if you enable both `-Xlog:safepoint` and `-Xlog:safepoint+stats` and run this on busy machine:

```
$ build/linux-x86_64-server-fastdebug/images/jdk/bin/java -XX:+SafepointALot -XX:GuaranteedSafepointInterval=1000 [1.647s][info][safepoint,stats] VM Operation                 [ threads: total initial_running ][ time:       sync    cleanup       vmop      total ] page_trap_count
[1.647s][info][safepoint,stats] Cleanup                      [             15               1 ][            26541     240544      30371     297456 ]               0
[1.647s][info][safepoint      ] Safepoint "Cleanup", Time since last: 1499772987 ns, Reaching safepoint: 267085 ns, At safepoint: 30371 ns, Total: 297456 ns
```

Note how "sync" takes only 26541 ns, "cleanup" takes 240544 ns, yet "Reaching safepoint" reports the sums of both.

To fix this, I propose we report "Cleanup" times separately. This changes the logging statement. If we want to keep the logging statement intact, we can move "cleanup" to "At safepoint" costs, which would be slightly less confusing. This is what we do with `RuntimeService::record_safepoint_end` anyway: management layer clearly separates "sync" and "safepoint" time, and "cleanup" more clearly belongs to "safepoint" time here.

While we are at it, we can also track and report max cleanup time.

Example output after:

```
[1.099s][info][safepoint,stats] VM Operation                 [ threads: total initial_running ][ time:       sync    cleanup       vmop      total ] page_trap_count
[1.099s][info][safepoint,stats] Cleanup                      [             15               1 ][            77391     124662       5420     207473 ]               0
[1.099s][info][safepoint      ] Safepoint "Cleanup", Time since last: 1013526788 ns, Reaching safepoint: 77391 ns, Cleanup: 124662 ns, At safepoint: 5420 ns, Total: 207473 ns
```

Additional testing:
 - [x] Eyeballing the safepoint logs
 - [x] Linux x86_64 fastdebug `tier1`, `tier2`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297154](https://bugs.openjdk.org/browse/JDK-8297154): Improve safepoint cleanup logging


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - Committer)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11194/head:pull/11194` \
`$ git checkout pull/11194`

Update a local copy of the PR: \
`$ git checkout pull/11194` \
`$ git pull https://git.openjdk.org/jdk pull/11194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11194`

View PR using the GUI difftool: \
`$ git pr show -t 11194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11194.diff">https://git.openjdk.org/jdk/pull/11194.diff</a>

</details>
