### PR TITLE
8296463: Memory leak in JVM_StartThread with the integration of Virtual threads

### DIFF
--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -599,10 +599,11 @@ JavaThread::JavaThread(ThreadFunction entry_point, size_t stack_sz) : JavaThread
 
 JavaThread::~JavaThread() {
 
-  // Ask ServiceThread to release the threadObj OopHandle
+  // Ask ServiceThread to release the OopHandles
   ServiceThread::add_oop_handle_release(_threadObj);
   ServiceThread::add_oop_handle_release(_vthread);
   ServiceThread::add_oop_handle_release(_jvmti_vthread);
+  ServiceThread::add_oop_handle_release(_extentLocalCache);
 
   // Return the sleep event to the free list
   ParkEvent::Release(_SleepEvent);


### PR DESCRIPTION
Please review this simple fix that removes a memory leak. The _extentLocalCache OopHandle was not being released when a JavaThread was destroyed.

Testing:
 - manual leak checking with NMT
 -  tier1 (sanity)
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296463](https://bugs.openjdk.org/browse/JDK-8296463): Memory leak in JVM_StartThread with the integration of Virtual threads


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11198/head:pull/11198` \
`$ git checkout pull/11198`

Update a local copy of the PR: \
`$ git checkout pull/11198` \
`$ git pull https://git.openjdk.org/jdk pull/11198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11198`

View PR using the GUI difftool: \
`$ git pr show -t 11198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11198.diff">https://git.openjdk.org/jdk/pull/11198.diff</a>

</details>
