### PR TITLE
8297173: usageTicks and totalTicks should be volatile to ensure that different threads get the latest ticks

### DIFF
--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -49,8 +49,8 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
     private ContainerCpuTicks processLoadTicks = new ProcessCpuTicks();
 
     private abstract class ContainerCpuTicks {
-        private volatile long usageTicks = 0;
-        private volatile long totalTicks = 0;
+        private volatile long usageTicks;
+        private volatile long totalTicks;
 
         private double getUsageDividesTotal(long usageTicks, long totalTicks) {
             // If cpu quota or cpu shares are in effect. Calculate the cpu load

--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -49,8 +49,8 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
     private ContainerCpuTicks processLoadTicks = new ProcessCpuTicks();
 
     private abstract class ContainerCpuTicks {
-        private long usageTicks = 0;
-        private long totalTicks = 0;
+        private volatile long usageTicks = 0;
+        private volatile long totalTicks = 0;
 
         private double getUsageDividesTotal(long usageTicks, long totalTicks) {
             // If cpu quota or cpu shares are in effect. Calculate the cpu load


### PR DESCRIPTION
As the title says, add the volatile modifier.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297173](https://bugs.openjdk.org/browse/JDK-8297173): usageTicks and totalTicks should be volatile to ensure that different threads get the latest ticks


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**) ⚠️ Review applies to [dd459966](https://git.openjdk.org/jdk/pull/11199/files/dd4599661ab209ef1a77c36be066a2af61304156)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11199/head:pull/11199` \
`$ git checkout pull/11199`

Update a local copy of the PR: \
`$ git checkout pull/11199` \
`$ git pull https://git.openjdk.org/jdk pull/11199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11199`

View PR using the GUI difftool: \
`$ git pr show -t 11199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11199.diff">https://git.openjdk.org/jdk/pull/11199.diff</a>

</details>
