### PR TITLE
8293856: AArch64: Remove clear_inst_mark from aarch64_enc_java_dynamic_call

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3670,7 +3670,6 @@ encode %{
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }
-    _masm.clear_inst_mark();
     __ post_call_nop();
     if (Compile::current()->max_vector_size() > 0) {
       __ reinitialize_ptrue();


### PR DESCRIPTION
1) After the fix of JDK-8287394, there is no need for clear_inst_mark after trampoline_call. See the discussion in [1].

2) MacroAssembler::ic_call has trampoline_call as the last call.

Hence, clear_inst_mark after MacroAssembler::ic_call can be removed. There is such a case in aarch64_enc_java_dynamic_call. We conduct the cleanup in this patch.

Testing: tier1~3 passed with no new failures on Linux/AArch64 platform.

[1] https://github.com/openjdk/jdk/pull/8564#discussion_r871062342

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293856](https://bugs.openjdk.org/browse/JDK-8293856): AArch64: Remove clear_inst_mark from aarch64_enc_java_dynamic_call


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Evgeny Astigeevich](https://openjdk.org/census#eastigeevich) (@eastig - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11200/head:pull/11200` \
`$ git checkout pull/11200`

Update a local copy of the PR: \
`$ git checkout pull/11200` \
`$ git pull https://git.openjdk.org/jdk pull/11200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11200`

View PR using the GUI difftool: \
`$ git pr show -t 11200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11200.diff">https://git.openjdk.org/jdk/pull/11200.diff</a>

</details>
