### PR TITLE
8191406: [hidpi] sun/java2d/SunGraphics2D/DrawImageBilinear.java test fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -226,6 +226,7 @@ sun/java2d/DirectX/MultiPaintEventTest/MultiPaintEventTest.java 8284825 windows-
 sun/java2d/DirectX/OverriddenInsetsTest/OverriddenInsetsTest.java 8196102 generic-all
 sun/java2d/DirectX/RenderingToCachedGraphicsTest/RenderingToCachedGraphicsTest.java 8196180 windows-all,macosx-all
 sun/java2d/SunGraphics2D/EmptyClipRenderingTest.java 8144029 macosx-all,linux-all
+sun/java2d/SunGraphics2D/DrawImageBilinear.java 8297175 linux-all
 sun/java2d/SunGraphics2D/PolyVertTest.java 6986565 generic-all
 sun/java2d/SunGraphics2D/SimplePrimQuality.java 6992007 generic-all
 sun/java2d/SunGraphics2D/SourceClippingBlitTest/SourceClippingBlitTest.java 8196185 generic-all

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -226,7 +226,6 @@ sun/java2d/DirectX/MultiPaintEventTest/MultiPaintEventTest.java 8284825 windows-
 sun/java2d/DirectX/OverriddenInsetsTest/OverriddenInsetsTest.java 8196102 generic-all
 sun/java2d/DirectX/RenderingToCachedGraphicsTest/RenderingToCachedGraphicsTest.java 8196180 windows-all,macosx-all
 sun/java2d/SunGraphics2D/EmptyClipRenderingTest.java 8144029 macosx-all,linux-all
-sun/java2d/SunGraphics2D/DrawImageBilinear.java 8191406 generic-all
 sun/java2d/SunGraphics2D/PolyVertTest.java 6986565 generic-all
 sun/java2d/SunGraphics2D/SimplePrimQuality.java 6992007 generic-all
 sun/java2d/SunGraphics2D/SourceClippingBlitTest/SourceClippingBlitTest.java 8196185 generic-all

--- a/test/jdk/sun/java2d/SunGraphics2D/DrawImageBilinear.java
+++ b/test/jdk/sun/java2d/SunGraphics2D/DrawImageBilinear.java
@@ -145,10 +145,6 @@ public class DrawImageBilinear extends Canvas {
     public static void main(String[] args) throws Exception {
         try {
             EventQueue.invokeAndWait(() -> createAndShowGUI());
-        } catch (Exception ex) {
-            ex.printStackTrace();
-        }
-        try {
             GraphicsConfiguration gc = frame.getGraphicsConfiguration();
             if (gc.getColorModel() instanceof IndexColorModel) {
                 System.out.println("IndexColorModel detected: " +
@@ -181,7 +177,9 @@ public class DrawImageBilinear extends Canvas {
             testRegion(capture, new Rectangle(80, 10, 40, 40));
             testRegion(capture, new Rectangle(150, 10, 40, 40));
         } finally {
-            frame.dispose();
+            if (frame != null) {
+                frame.dispose();
+            }
         }
     }
 }

--- a/test/jdk/sun/java2d/SunGraphics2D/DrawImageBilinear.java
+++ b/test/jdk/sun/java2d/SunGraphics2D/DrawImageBilinear.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,16 +25,16 @@
  * @key headful
  * @bug 5009033 6603000 6666362 8159142 8198613
  * @summary Verifies that images transformed with bilinear filtering do not
- * leave artifacts at the edges.
+ *          leave artifacts at the edges.
  * @run main/othervm -Dsun.java2d.uiScale=2.5 DrawImageBilinear
  * @run main/othervm -Dsun.java2d.uiScale=2.5 -Dsun.java2d.d3d=false DrawImageBilinear
- * @author campbelc
  */
 
+import javax.imageio.ImageIO;
 import java.awt.Canvas;
 import java.awt.Color;
-import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.EventQueue;
 import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -47,6 +47,8 @@ import java.awt.Toolkit;
 import java.awt.image.BufferedImage;
 import java.awt.image.IndexColorModel;
 import java.awt.image.VolatileImage;
+import java.io.File;
+import java.io.IOException;
 
 public class DrawImageBilinear extends Canvas {
 
@@ -55,28 +57,13 @@ public class DrawImageBilinear extends Canvas {
     private static boolean done;
     private BufferedImage bimg1, bimg2;
     private VolatileImage vimg;
-    private static volatile BufferedImage capture;
-    private static void doCapture(Component test) {
-        try {
-            Thread.sleep(2000);
-        } catch (InterruptedException ex) {}
-        // Grab the screen region
-        try {
-            Robot robot = new Robot();
-            Point pt1 = test.getLocationOnScreen();
-            Rectangle rect =
-                new Rectangle(pt1.x, pt1.y, test.getWidth(), test.getHeight());
-            capture = robot.createScreenCapture(rect);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
+    private static BufferedImage capture;
+    private static DrawImageBilinear test;
+    private static Frame frame;
 
     private void renderPattern(Graphics g) {
         g.setColor(Color.red);
         g.fillRect(0, 0, SIZE, SIZE);
-        //g.setColor(Color.green);
-        //g.drawRect(0, 0, SIZE-1, SIZE-1);
         g.dispose();
     }
 
@@ -108,26 +95,17 @@ public class DrawImageBilinear extends Canvas {
 
             // second time will be a texture->surface blit
             g2d.drawImage(bimg2, 80, 10, 40, 40, null);
-            if (!skipOglTextureTest) {
-                g2d.drawImage(bimg2, 80, 10, 40, 40, null);
-            }
+            g2d.drawImage(bimg2, 80, 10, 40, 40, null);
 
             // third time will be a pbuffer->surface blit
-            if (vimg.validate(getGraphicsConfiguration()) != VolatileImage.IMAGE_OK) {
+            if (vimg.validate(getGraphicsConfiguration()) !=
+                VolatileImage.IMAGE_OK) {
                 renderPattern(vimg.createGraphics());
             }
             g2d.drawImage(vimg, 150, 10, 40, 40, null);
 
             Toolkit.getDefaultToolkit().sync();
         } while (vimg.contentsLost());
-
-        synchronized (this) {
-            if (!done) {
-                doCapture(this);
-                done = true;
-            }
-            notifyAll();
-        }
     }
 
     public Dimension getPreferredSize() {
@@ -146,6 +124,11 @@ public class DrawImageBilinear extends Canvas {
             for (int x = x1; x < x2; x++) {
                 int actual = bi.getRGB(x, y);
                 if ((actual != 0xfffe0000) && (actual != 0xffff0000)) {
+                    try {
+                        String name = "DrawImageBilinear.png";
+                        ImageIO.write(capture, "png", new File(name));
+                        System.out.println("Screen shot file: " + name);
+                    } catch (IOException ex) {}
                     throw new RuntimeException("Test failed at x="+x+" y="+y+
                                                " (expected=0xffff0000"+
                                                " actual=0x"+
@@ -156,63 +139,62 @@ public class DrawImageBilinear extends Canvas {
         }
     }
 
-    private static boolean skipOglTextureTest = false;
-
-    public static void main(String[] args) {
-        boolean show = false;
-        for (String arg : args) {
-            if ("-show".equals(arg)) {
-                show = true;
-            }
-        }
-
-        String arch = System.getProperty("os.arch");
-        boolean isOglEnabled = Boolean.getBoolean("sun.java2d.opengl");
-        skipOglTextureTest = false;
-        System.out.println("Skip OpenGL texture test: " + skipOglTextureTest);
-
-        DrawImageBilinear test = new DrawImageBilinear();
-        Frame frame = new Frame();
+    private static void createAndShowGUI() {
+        test = new DrawImageBilinear();
+        frame = new Frame();
         frame.add(test);
+        frame.setUndecorated(true);
+        frame.setAlwaysOnTop(true);
+        frame.setLocationRelativeTo(null);
         frame.pack();
         frame.setVisible(true);
+    }
 
-        // Wait until the component's been painted
-        synchronized (test) {
-            while (!done) {
-                try {
-                    test.wait();
-                } catch (InterruptedException e) {
-                    throw new RuntimeException("Failed: Interrupted");
-                }
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> createAndShowGUI());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+        try {
+            GraphicsConfiguration gc = frame.getGraphicsConfiguration();
+            if (gc.getColorModel() instanceof IndexColorModel) {
+                System.out.println("IndexColorModel detected: " +
+                                   "test considered PASSED");
+                return;
             }
-        }
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
+            robot.mouseMove(0,0);
+            robot.waitForIdle();
+            Point pt1 = frame.getLocationOnScreen();
+            Rectangle rect =
+                new Rectangle(pt1.x, pt1.y,
+                    frame.getWidth(), frame.getHeight());
+            capture = robot.createScreenCapture(rect);
+            robot.waitForIdle();
+            if (capture == null) {
+                throw new RuntimeException("Failed: capture is null");
+            }
 
-        GraphicsConfiguration gc = frame.getGraphicsConfiguration();
-        if (gc.getColorModel() instanceof IndexColorModel) {
-            System.out.println("IndexColorModel detected: " +
-                               "test considered PASSED");
+            // Test background color
+            int pixel = capture.getRGB(5, 5);
+            if (pixel != 0xffffffff) {
+                try {
+                    String name = "DrawImageBilinear.png";
+                    ImageIO.write(capture, "png", new File(name));
+                    System.out.println("Screen shot file: " + name);
+                } catch (IOException ex) {}
+                throw new RuntimeException("Failed: Incorrect color for " +
+                                           "background");
+            }
+
+            // Test pixels
+            testRegion(capture, new Rectangle(10, 10, 40, 40));
+            testRegion(capture, new Rectangle(80, 10, 40, 40));
+            testRegion(capture, new Rectangle(150, 10, 40, 40));
+        } finally {
             frame.dispose();
-            return;
         }
-
-        if (!show) {
-            frame.dispose();
-        }
-        if (capture == null) {
-            throw new RuntimeException("Failed: capture is null");
-        }
-
-        // Test background color
-        int pixel = capture.getRGB(5, 5);
-        if (pixel != 0xffffffff) {
-            throw new RuntimeException("Failed: Incorrect color for " +
-                                       "background");
-        }
-
-        // Test pixels
-        testRegion(capture, new Rectangle(10, 10, 40, 40));
-        testRegion(capture, new Rectangle(80, 10, 40, 40));
-        testRegion(capture, new Rectangle(150, 10, 40, 40));
     }
 }

--- a/test/jdk/sun/java2d/SunGraphics2D/DrawImageBilinear.java
+++ b/test/jdk/sun/java2d/SunGraphics2D/DrawImageBilinear.java
@@ -30,7 +30,6 @@
  * @run main/othervm -Dsun.java2d.uiScale=2.5 -Dsun.java2d.d3d=false DrawImageBilinear
  */
 
-import javax.imageio.ImageIO;
 import java.awt.Canvas;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -47,8 +46,6 @@ import java.awt.Toolkit;
 import java.awt.image.BufferedImage;
 import java.awt.image.IndexColorModel;
 import java.awt.image.VolatileImage;
-import java.io.File;
-import java.io.IOException;
 
 public class DrawImageBilinear extends Canvas {
 
@@ -137,11 +134,6 @@ public class DrawImageBilinear extends Canvas {
                     Math.abs(red - standardRed) > tolerance ||
                     Math.abs(green - standardGreen) > tolerance ||
                     Math.abs(blue - standardBlue) > tolerance) {
-                    try {
-                        String name = "DrawImageBilinear.png";
-                        ImageIO.write(capture, "png", new File(name));
-                        System.out.println("Screen shot file: " + name);
-                    } catch (IOException ex) {}
                     throw new RuntimeException("Test failed at x="+x+" y="+y+
                                                " (expected=0xffff0000"+
                                                " actual=0x"+
@@ -194,11 +186,6 @@ public class DrawImageBilinear extends Canvas {
             // Test background color
             int pixel = capture.getRGB(5, 5);
             if (pixel != 0xffffffff) {
-                try {
-                    String name = "DrawImageBilinear.png";
-                    ImageIO.write(capture, "png", new File(name));
-                    System.out.println("Screen shot file: " + name);
-                } catch (IOException ex) {}
                 throw new RuntimeException("Failed: Incorrect color for " +
                                            "background");
             }
@@ -208,11 +195,6 @@ public class DrawImageBilinear extends Canvas {
             testRegion(capture, new Rectangle(80, 10, 40, 40));
             testRegion(capture, new Rectangle(150, 10, 40, 40));
         } finally {
-            try {
-                String name = "DrawImageBilinear.png";
-                ImageIO.write(capture, "png", new File(name));
-                System.out.println("Screen shot file: " + name);
-            } catch (IOException ex) {}
             frame.dispose();
         }
     }

--- a/test/jdk/sun/java2d/SunGraphics2D/DrawImageBilinear.java
+++ b/test/jdk/sun/java2d/SunGraphics2D/DrawImageBilinear.java
@@ -50,7 +50,6 @@ import java.awt.image.VolatileImage;
 public class DrawImageBilinear extends Canvas {
 
     private static final int SIZE = 5;
-    private static final int tolerance = 5;
 
     private static boolean done;
     private BufferedImage bimg1, bimg2;
@@ -121,19 +120,7 @@ public class DrawImageBilinear extends Canvas {
         for (int y = y1; y < y2; y++) {
             for (int x = x1; x < x2; x++) {
                 int actual = bi.getRGB(x, y);
-                int expected = Color.RED.getRGB();
-                int alpha = (actual >> 24) & 0xFF;
-                int red = (actual >> 16) & 0xFF;
-                int green = (actual >> 8) & 0xFF;
-                int blue = (actual) & 0xFF;
-                int standardAlpha = (expected >> 24) & 0xFF;
-                int standardRed = (expected >> 16) & 0xFF;
-                int standardGreen = (expected >> 8) & 0xFF;
-                int standardBlue = (expected) & 0xFF;
-                if (Math.abs(alpha - standardAlpha) > tolerance ||
-                    Math.abs(red - standardRed) > tolerance ||
-                    Math.abs(green - standardGreen) > tolerance ||
-                    Math.abs(blue - standardBlue) > tolerance) {
+                if ((actual != 0xfffe0000) && (actual != 0xffff0000)) {
                     throw new RuntimeException("Test failed at x="+x+" y="+y+
                                                " (expected=0xffff0000"+
                                                " actual=0x"+
@@ -148,7 +135,6 @@ public class DrawImageBilinear extends Canvas {
         test = new DrawImageBilinear();
         frame = new Frame();
         frame.add(test);
-        frame.setBackground(Color.WHITE);
         frame.setUndecorated(true);
         frame.setAlwaysOnTop(true);
         frame.setLocationRelativeTo(null);

--- a/test/jdk/sun/java2d/SunGraphics2D/DrawImageBilinear.java
+++ b/test/jdk/sun/java2d/SunGraphics2D/DrawImageBilinear.java
@@ -53,6 +53,7 @@ import java.io.IOException;
 public class DrawImageBilinear extends Canvas {
 
     private static final int SIZE = 5;
+    private static final int tolerance = 5;
 
     private static boolean done;
     private BufferedImage bimg1, bimg2;
@@ -123,7 +124,19 @@ public class DrawImageBilinear extends Canvas {
         for (int y = y1; y < y2; y++) {
             for (int x = x1; x < x2; x++) {
                 int actual = bi.getRGB(x, y);
-                if ((actual != 0xfffe0000) && (actual != 0xffff0000)) {
+                int expected = Color.RED.getRGB();
+                int alpha = (actual >> 24) & 0xFF;
+                int red = (actual >> 16) & 0xFF;
+                int green = (actual >> 8) & 0xFF;
+                int blue = (actual) & 0xFF;
+                int standardAlpha = (expected >> 24) & 0xFF;
+                int standardRed = (expected >> 16) & 0xFF;
+                int standardGreen = (expected >> 8) & 0xFF;
+                int standardBlue = (expected) & 0xFF;
+                if (Math.abs(alpha - standardAlpha) > tolerance ||
+                    Math.abs(red - standardRed) > tolerance ||
+                    Math.abs(green - standardGreen) > tolerance ||
+                    Math.abs(blue - standardBlue) > tolerance) {
                     try {
                         String name = "DrawImageBilinear.png";
                         ImageIO.write(capture, "png", new File(name));
@@ -143,6 +156,7 @@ public class DrawImageBilinear extends Canvas {
         test = new DrawImageBilinear();
         frame = new Frame();
         frame.add(test);
+        frame.setBackground(Color.WHITE);
         frame.setUndecorated(true);
         frame.setAlwaysOnTop(true);
         frame.setLocationRelativeTo(null);
@@ -194,6 +208,11 @@ public class DrawImageBilinear extends Canvas {
             testRegion(capture, new Rectangle(80, 10, 40, 40));
             testRegion(capture, new Rectangle(150, 10, 40, 40));
         } finally {
+            try {
+                String name = "DrawImageBilinear.png";
+                ImageIO.write(capture, "png", new File(name));
+                System.out.println("Screen shot file: " + name);
+            } catch (IOException ex) {}
             frame.dispose();
         }
     }


### PR DESCRIPTION
This test was failing because of timing or color difference issues.
Updated test to:

1) Use EDT for UI drawing instead of manual synchronisation
2) Use Robot.waitForIdle before screen capture
3) Increase color tolerance delta from 1 to 5
4) Use undecorated frame and explicitly set background color and move the frame to top
5) Cleanup to remove not needed flags and java options

After these changes test passes on all platforms in CI except Linux. For Linux it looks like product issue so i have raised : https://bugs.openjdk.org/browse/JDK-8297175

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8191406](https://bugs.openjdk.org/browse/JDK-8191406): [hidpi] sun/java2d/SunGraphics2D/DrawImageBilinear.java test fails


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11201/head:pull/11201` \
`$ git checkout pull/11201`

Update a local copy of the PR: \
`$ git checkout pull/11201` \
`$ git pull https://git.openjdk.org/jdk pull/11201/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11201`

View PR using the GUI difftool: \
`$ git pr show -t 11201`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11201.diff">https://git.openjdk.org/jdk/pull/11201.diff</a>

</details>
