### PR TITLE
JDK-8297184: Test runtime/ErrorHandling/TestSigInfoInHsErrFile.java is failing

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
@@ -69,7 +69,7 @@ public class TestSigInfoInHsErrFile {
 
     // Crash address: see VMError::_segfault_address - carefully choosen to give us a SEGV_MAPERR
     String crashAddress = Platform.isAix() ? "0x0*1400" : "0x0*400";
-    patterns.add(Pattern.compile("siginfo: si_signo: \\d+ \\(SIGSEGV\\), si_code: \\d+ \\(SEGV_MAPERR\\), si_addr: " + crashAddress + ".*"));
+    patterns.add(Pattern.compile("siginfo: si_signo: \\d+ \\(SIGSEGV\\), si_code: \\d+ \\(SEGV_.*\\), si_addr: " + crashAddress + ".*"));
 
     HsErrFileUtils.checkHsErrFileContent(f, patterns.toArray(new Pattern[] {}), true);
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
@@ -67,7 +67,7 @@ public class TestSigInfoInHsErrFile {
     patterns.add(Pattern.compile("# *Problematic frame.*"));
     patterns.add(Pattern.compile("# .*VMError::controlled_crash.*"));
 
-    // Crash address: see VMError::_segfault_address - carefully choosen to give us a SEGV_MAPERR
+    // Crash address: see VMError::_segfault_address
     String crashAddress = Platform.isAix() ? "0x0*1400" : "0x0*400";
     patterns.add(Pattern.compile("siginfo: si_signo: \\d+ \\(SIGSEGV\\), si_code: \\d+ \\(SEGV_.*\\), si_addr: " + crashAddress + ".*"));
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
@@ -31,18 +31,7 @@
  * @requires os.family != "windows"
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver TestSigInfoInHsErrFile segv
- */
-
-/*
- * @test fpe
- * @summary Test that for a given crash situation we see the correct siginfo in the hs-err file
- * @library /test/lib
- * @requires vm.debug
- * @requires os.family != "windows"
- * @modules java.base/jdk.internal.misc
- *          java.management
- * @run driver TestSigInfoInHsErrFile fpe
+ * @run driver TestSigInfoInHsErrFile
  */
 
 import jdk.test.lib.Platform;
@@ -55,48 +44,6 @@ import java.util.regex.Pattern;
 public class TestSigInfoInHsErrFile {
 
   public static void main(String[] args) throws Exception {
-    if (args.length != 1) {
-      throw new IllegalArgumentException("missing argument");
-    } else if (args[0].equals("segv")) {
-      testWithSEGV();
-    } else if (args[0].equals("fpe")) {
-      testWithFPE();
-    } else {
-      throw new IllegalArgumentException("unknown argument");
-    }
-  }
-
-  static void testWithFPE() throws Exception {
-
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-            "-XX:+UnlockDiagnosticVMOptions",
-            "-Xmx100M",
-            "-XX:-CreateCoredumpOnCrash",
-            "-XX:ErrorHandlerTest=15",
-            "-version");
-
-    OutputAnalyzer output = new OutputAnalyzer(pb.start());
-    output.shouldNotHaveExitValue(0);
-
-    // we should have crashed with a SIGFPE
-    output.shouldMatch("#.+SIGFPE.*");
-
-    // extract hs-err file
-    File f = HsErrFileUtils.openHsErrFileFromOutput(output);
-
-    ArrayList<Pattern> patterns = new ArrayList<>();
-    patterns.add(Pattern.compile("# A fatal error has been detected.*"));
-    patterns.add(Pattern.compile("# *SIGFPE.*"));
-    patterns.add(Pattern.compile("# *Problematic frame.*"));
-    patterns.add(Pattern.compile("# .*VMError::controlled_crash.*"));
-
-    patterns.add(Pattern.compile("siginfo: si_signo: \\d+ \\(SIGFPE\\), si_code: \\d+ \\(FPE_INTDIV\\).*"));
-
-    HsErrFileUtils.checkHsErrFileContent(f, patterns.toArray(new Pattern[] {}), true);
-
-  }
-
-  static void testWithSEGV() throws Exception {
 
     ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
         "-XX:+UnlockDiagnosticVMOptions",
@@ -108,7 +55,7 @@ public class TestSigInfoInHsErrFile {
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldNotHaveExitValue(0);
 
-    // we should have crashed with a SIGFPE
+    // we should have crashed with a SIGSEGV
     output.shouldMatch("#.+SIGSEGV.*");
 
     // extract hs-err file
@@ -120,7 +67,7 @@ public class TestSigInfoInHsErrFile {
     patterns.add(Pattern.compile("# *Problematic frame.*"));
     patterns.add(Pattern.compile("# .*VMError::controlled_crash.*"));
 
-    // Crash address: see VMError::_segfault_address
+    // Crash address: see VMError::_segfault_address - carefully choosen to give us a SEGV_MAPERR
     String crashAddress = Platform.isAix() ? "0x0*1400" : "0x0*400";
     patterns.add(Pattern.compile("siginfo: si_signo: \\d+ \\(SIGSEGV\\), si_code: \\d+ \\(SEGV_MAPERR\\), si_addr: " + crashAddress + ".*"));
 


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8296906 added a new test that artificially crashes the VM with a known signal/code/crashaddress and checks that we see those informations precisely in the hs-err file. It did this for SIGSEGV and SIGFPE.

SIGFPE, however, is problematic. We fall back to pthread_kill() if we cannot trigger a real FPE fault. In that case the code will be SI_KILL and the sending frame will be pthread_kill(). 

Since we cannot guarantee that a real signal is sent, I opted for just removing the part of the test that tests FPE. The other part, testing SIGSEGV, is enough to cover what the test should cover.

*update*

I also added a fix for the second error mode we see, where we don't crash with SIGSEGV SEGV_MAPERR but SIGSEGV ACCERR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297184](https://bugs.openjdk.org/browse/JDK-8297184): Test runtime/ErrorHandling/TestSigInfoInHsErrFile.java is failing


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11202/head:pull/11202` \
`$ git checkout pull/11202`

Update a local copy of the PR: \
`$ git checkout pull/11202` \
`$ git pull https://git.openjdk.org/jdk pull/11202/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11202`

View PR using the GUI difftool: \
`$ git pr show -t 11202`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11202.diff">https://git.openjdk.org/jdk/pull/11202.diff</a>

</details>
