### PR TITLE
8297142: jdk/jfr/event/runtime/TestShutdown.java fails on Linux ppc64le and Linux aarch64

### DIFF
--- a/test/jdk/jdk/jfr/event/runtime/TestShutdownEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestShutdownEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,6 +92,7 @@ public class TestShutdownEvent {
         ProcessBuilder pb = ProcessTools.createTestJvm(
                                 "-Xlog:jfr=debug",
                                 "-XX:-CreateCoredumpOnCrash",
+                                "-XX:-TieredCompilation",
                                 "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
                                 "-XX:StartFlightRecording:filename=./dumped.jfr,dumponexit=true,settings=default",
                                 "jdk.jfr.event.runtime.TestShutdownEvent$TestMain",


### PR DESCRIPTION
This fails for the same reason as in https://bugs.openjdk.org/browse/JDK-8293166 while testing the dump on crash feature of JFR. Disabling tiered compilation avoids triggering this error.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297142](https://bugs.openjdk.org/browse/JDK-8297142): jdk/jfr/event/runtime/TestShutdown.java fails on Linux ppc64le and Linux aarch64


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11203/head:pull/11203` \
`$ git checkout pull/11203`

Update a local copy of the PR: \
`$ git checkout pull/11203` \
`$ git pull https://git.openjdk.org/jdk pull/11203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11203`

View PR using the GUI difftool: \
`$ git pr show -t 11203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11203.diff">https://git.openjdk.org/jdk/pull/11203.diff</a>

</details>
