### PR TITLE
8296324: JVMTI GetStackTrace truncates vthread stack trace for agents loaded into running VM

### DIFF
--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -384,7 +384,7 @@ JvmtiExport::get_jvmti_interface(JavaVM *jvm, void **penv, jint version) {
     // Virtual threads support. There is a performance impact when VTMS transitions are enabled.
     if (!java_lang_VirtualThread ::notify_jvmti_events()) {
       java_lang_VirtualThread::set_notify_jvmti_events(true);
-      if (Thread::current_or_null() != NULL) { // need this for attached threads only 
+      if (Thread::current_or_null() != NULL) { // need this for attached threads only
         ThreadInVMfromNative tiv(JavaThread::current());
         java_lang_VirtualThread::init_static_notify_jvmti_events();
       }

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -382,7 +382,13 @@ JvmtiExport::get_jvmti_interface(JavaVM *jvm, void **penv, jint version) {
   }
   if (Continuations::enabled()) {
     // Virtual threads support. There is a performance impact when VTMS transitions are enabled.
-    java_lang_VirtualThread::set_notify_jvmti_events(true);
+    if (!java_lang_VirtualThread ::notify_jvmti_events()) {
+      java_lang_VirtualThread::set_notify_jvmti_events(true);
+      if (Thread::current_or_null() != NULL) { // need this for attached threads only 
+        ThreadInVMfromNative tiv(JavaThread::current());
+        java_lang_VirtualThread::init_static_notify_jvmti_events();
+      }
+    }
   }
 
   if (JvmtiEnv::get_phase() == JVMTI_PHASE_LIVE) {

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -382,12 +382,10 @@ JvmtiExport::get_jvmti_interface(JavaVM *jvm, void **penv, jint version) {
   }
   if (Continuations::enabled()) {
     // Virtual threads support. There is a performance impact when VTMS transitions are enabled.
-    if (!java_lang_VirtualThread ::notify_jvmti_events()) {
-      java_lang_VirtualThread::set_notify_jvmti_events(true);
-      if (Thread::current_or_null() != NULL) { // need this for attached threads only
-        ThreadInVMfromNative tiv(JavaThread::current());
-        java_lang_VirtualThread::init_static_notify_jvmti_events();
-      }
+    java_lang_VirtualThread::set_notify_jvmti_events(true);
+    if (JvmtiEnv::get_phase() == JVMTI_PHASE_LIVE) {
+      ThreadInVMfromNative __tiv(JavaThread::current());
+      java_lang_VirtualThread::init_static_notify_jvmti_events();
     }
   }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VirtualStackTraceTest/VirtualStackTraceTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VirtualStackTraceTest/VirtualStackTraceTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Verifies JVMTI GetStackTrace does not truncate virtual thread stack trace with agent attach
+ * @requires vm.continuations
+ * @enablePreview
+ * @run main/othervm/native -Djdk.attach.allowAttachSelf=true VirtualStackTraceTest
+ */
+
+import com.sun.tools.attach.VirtualMachine;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+public class VirtualStackTraceTest {
+    private static final String AGENT_LIB = "VirtualStackTraceTest";
+
+    public static native String[] getStackTrace();
+
+    public static void main(String[] args) throws Exception {
+        VirtualMachine vm = VirtualMachine.attach(String.valueOf(ProcessHandle.current().pid()));
+        vm.loadAgentLibrary(AGENT_LIB);
+        VirtualStackTraceTest t = new VirtualStackTraceTest();
+        t.runTest();
+    }
+
+    void runTest() throws Exception {
+        Thread thr = Thread.ofVirtual().name("VT").start(VirtualStackTraceTest::test);
+        thr.join();
+    }
+
+    private static void test() {
+        work();
+    }
+
+    private static void work() {
+        inner();
+    }
+
+    private static void inner() {
+        checkCurrentThread();
+    }
+
+    private static void checkCurrentThread() {
+        System.out.println("Stack trace for " + Thread.currentThread() + ": ");
+        var javaStackTrace = Arrays.stream(Thread.currentThread().getStackTrace()).map(StackTraceElement::getMethodName).toList();
+        var jvmtiStackTrace = List.of(getStackTrace());
+
+        System.out.println("JVMTI: " + jvmtiStackTrace);
+        System.out.println("Java : " + javaStackTrace);
+
+        if (!Objects.equals(jvmtiStackTrace, javaStackTrace)) {
+            throw new RuntimeException("VirtualStackTraceTest failed: stack traces do not match");
+        }
+    }
+}

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VirtualStackTraceTest/VirtualStackTraceTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VirtualStackTraceTest/VirtualStackTraceTest.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @summary Verifies JVMTI GetStackTrace does not truncate virtual thread stack trace with agent attach
+ * @requires vm.jvmti
  * @requires vm.continuations
  * @enablePreview
  * @run main/othervm/native -Djdk.attach.allowAttachSelf=true VirtualStackTraceTest

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VirtualStackTraceTest/libVirtualStackTraceTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VirtualStackTraceTest/libVirtualStackTraceTest.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <cstdlib>
+#include <cstring>
+#include <jvmti.h>
+#include "jvmti_common.h"
+
+extern "C" {
+
+const int MAX_COUNT = 50;
+static jvmtiEnv *jvmti;
+
+JNIEXPORT jobjectArray JNICALL
+Java_VirtualStackTraceTest_getStackTrace(JNIEnv* jni, jclass clazz) {
+  jvmtiError err;
+  jint count = 0;
+  jint skipped = 0;
+
+  jobject visibleFrames[MAX_COUNT];
+  jvmtiFrameInfo frameInfo[MAX_COUNT];
+
+  err = jvmti->GetStackTrace(NULL, 0, MAX_COUNT, frameInfo, &count);
+  check_jvmti_status(jni, err, "event handler: error in JVMTI GetStackTrace call");
+
+  for (int idx = 0; idx < count; idx++) {
+    jclass declaringClass = NULL;
+    char *clasSignature = NULL;
+    char *methodName = NULL;
+
+    err = jvmti->GetMethodDeclaringClass(frameInfo[idx].method, &declaringClass);
+    check_jvmti_status(jni, err, "event handler: error in JVMTI GetMethodDeclaringClass call");
+
+    err = jvmti->GetClassSignature(declaringClass, &clasSignature, NULL);
+    check_jvmti_status(jni, err, "event handler: error in JVMTI GetClassSignature call");
+
+    err = jvmti->GetMethodName(frameInfo[idx].method, &methodName, NULL, NULL);
+    check_jvmti_status(jni, err, "event handler: error in JVMTI GetMethodName call");
+
+    if (strchr(clasSignature, '.')) {
+      skipped++;
+      continue;
+    }
+    visibleFrames[idx - skipped] = jni->NewStringUTF(methodName);
+
+    jvmti->Deallocate(reinterpret_cast<unsigned char*>(methodName));
+    jvmti->Deallocate(reinterpret_cast<unsigned char*>(clasSignature));
+  }
+  jobjectArray methodNames = jni->NewObjectArray(count - skipped, jni->FindClass("java/lang/String"), NULL);
+  for (int idx = 0; idx < count - skipped; idx++) {
+    jni->SetObjectArrayElement(methodNames, idx, visibleFrames[idx]);
+  }
+  print_stack_trace(jvmti, jni, NULL);
+
+  return methodNames;
+}
+
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+  LOG("Agent_OnLoad started\n");
+  if (jvm->GetEnv((void **) (&jvmti), JVMTI_VERSION) != JNI_OK) {
+    return JNI_ERR;
+  }
+  return JNI_OK;
+}
+
+JNIEXPORT jint JNICALL
+Agent_OnAttach(JavaVM *jvm, char *options, void *reserved) {
+  LOG("Agent_OnAttach started\n");
+  if (jvm->GetEnv((void **) (&jvmti), JVMTI_VERSION) != JNI_OK) {
+    return JNI_ERR;
+  }
+  return JNI_OK;
+}
+
+} // extern "C"


### PR DESCRIPTION
The `VirtualThread` static field `notifyJvmtiEvents` is not set correctly in cases JVMTI agents are loaded into running VM. It is because an extra call to java_lang_VirtualThread::init_static_notify_jvmti_events() is needed.
This function is called once at the VM initialization, so this extra call is not necessary for agent loaded at startup.

Testing:
New test is added: `test/hotspot/jtreg/serviceability/jvmti/vthread/VirtualStackTraceTest`
This test is failed without fix and passed with it.
TBD: run all JVMTI and JDI test in mach5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296324](https://bugs.openjdk.org/browse/JDK-8296324): JVMTI GetStackTrace truncates vthread stack trace for agents loaded into running VM


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11204/head:pull/11204` \
`$ git checkout pull/11204`

Update a local copy of the PR: \
`$ git checkout pull/11204` \
`$ git pull https://git.openjdk.org/jdk pull/11204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11204`

View PR using the GUI difftool: \
`$ git pr show -t 11204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11204.diff">https://git.openjdk.org/jdk/pull/11204.diff</a>

</details>
