### PR TITLE
8297195: AWTAccessor and SwingAccessor should avoid double racy reads from non-volatile fields

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/AWTAccessor.java
+++ b/src/java.desktop/share/classes/sun/awt/AWTAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -874,11 +874,12 @@ public final class AWTAccessor {
      * Retrieve the accessor object for the java.awt.Component class.
      */
     public static ComponentAccessor getComponentAccessor() {
-        if (componentAccessor == null) {
+        var access = componentAccessor;
+        if (access == null) {
             ensureClassInitialized(Component.class);
+            access = componentAccessor;
         }
-
-        return componentAccessor;
+        return access;
     }
 
     /*
@@ -892,11 +893,12 @@ public final class AWTAccessor {
      * Retrieve the accessor object for the java.awt.Container class.
      */
     public static ContainerAccessor getContainerAccessor() {
-        if (containerAccessor == null) {
+        var access = containerAccessor;
+        if (access == null) {
             ensureClassInitialized(Container.class);
+            access = containerAccessor;
         }
-
-        return containerAccessor;
+        return access;
     }
 
     /*
@@ -910,10 +912,12 @@ public final class AWTAccessor {
      * Retrieve the accessor object for the java.awt.Window class.
      */
     public static WindowAccessor getWindowAccessor() {
-        if (windowAccessor == null) {
+        var access = windowAccessor;
+        if (access == null) {
             ensureClassInitialized(Window.class);
+            access = windowAccessor;
         }
-        return windowAccessor;
+        return access;
     }
 
     /*
@@ -927,10 +931,12 @@ public final class AWTAccessor {
      * Retrieve the accessor object for the java.awt.AWTEvent class.
      */
     public static AWTEventAccessor getAWTEventAccessor() {
-        if (awtEventAccessor == null) {
+        var access = awtEventAccessor;
+        if (access == null) {
             ensureClassInitialized(AWTEvent.class);
+            access = awtEventAccessor;
         }
-        return awtEventAccessor;
+        return access;
     }
 
     /*
@@ -944,10 +950,12 @@ public final class AWTAccessor {
      * Retrieve the accessor object for the java.awt.event.InputEvent class.
      */
     public static InputEventAccessor getInputEventAccessor() {
-        if (inputEventAccessor == null) {
+        var access = inputEventAccessor;
+        if (access == null) {
             ensureClassInitialized(InputEvent.class);
+            access = inputEventAccessor;
         }
-        return inputEventAccessor;
+        return access;
     }
 
     /*
@@ -961,10 +969,12 @@ public final class AWTAccessor {
      * Retrieve the accessor object for the java.awt.event.MouseEvent class.
      */
     public static MouseEventAccessor getMouseEventAccessor() {
-        if (mouseEventAccessor == null) {
+        var access = mouseEventAccessor;
+        if (access == null) {
             ensureClassInitialized(MouseEvent.class);
+            access = mouseEventAccessor;
         }
-        return mouseEventAccessor;
+        return access;
     }
 
     /*
@@ -978,10 +988,12 @@ public final class AWTAccessor {
      * Retrieve the accessor object for the java.awt.Frame class.
      */
     public static FrameAccessor getFrameAccessor() {
-        if (frameAccessor == null) {
+        var access = frameAccessor;
+        if (access == null) {
             ensureClassInitialized(Frame.class);
+            access = frameAccessor;
         }
-        return frameAccessor;
+        return access;
     }
 
     /*
@@ -995,10 +1007,12 @@ public final class AWTAccessor {
      * Retrieve the accessor object for the java.awt.KeyboardFocusManager class.
      */
     public static KeyboardFocusManagerAccessor getKeyboardFocusManagerAccessor() {
-        if (kfmAccessor == null) {
+        var access = kfmAccessor;
+        if (access == null) {
             ensureClassInitialized(KeyboardFocusManager.class);
+            access = kfmAccessor;
         }
-        return kfmAccessor;
+        return access;
     }
 
     /*
@@ -1012,10 +1026,12 @@ public final class AWTAccessor {
      * Retrieve the accessor object for the java.awt.MenuComponent class.
      */
     public static MenuComponentAccessor getMenuComponentAccessor() {
-        if (menuComponentAccessor == null) {
+        var access = menuComponentAccessor;
+        if (access == null) {
             ensureClassInitialized(MenuComponent.class);
+            access = menuComponentAccessor;
         }
-        return menuComponentAccessor;
+        return access;
     }
 
     /*
@@ -1029,10 +1045,12 @@ public final class AWTAccessor {
      * Retrieve the accessor object for the java.awt.EventQueue class.
      */
     public static EventQueueAccessor getEventQueueAccessor() {
-        if (eventQueueAccessor == null) {
+        var access = eventQueueAccessor;
+        if (access == null) {
             ensureClassInitialized(EventQueue.class);
+            access = eventQueueAccessor;
         }
-        return eventQueueAccessor;
+        return access;
     }
 
     /*
@@ -1046,10 +1064,12 @@ public final class AWTAccessor {
      * Retrieve the accessor object for the java.awt.PopupMenu class.
      */
     public static PopupMenuAccessor getPopupMenuAccessor() {
-        if (popupMenuAccessor == null) {
+        var access = popupMenuAccessor;
+        if (access == null) {
             ensureClassInitialized(PopupMenu.class);
+            access = popupMenuAccessor;
         }
-        return popupMenuAccessor;
+        return access;
     }
 
     /*
@@ -1063,10 +1083,12 @@ public final class AWTAccessor {
      * Retrieve the accessor object for the java.awt.FileDialog class.
      */
     public static FileDialogAccessor getFileDialogAccessor() {
-        if (fileDialogAccessor == null) {
+        var access = fileDialogAccessor;
+        if (access == null) {
             ensureClassInitialized(FileDialog.class);
+            access = fileDialogAccessor;
         }
-        return fileDialogAccessor;
+        return access;
     }
 
     /*
@@ -1081,10 +1103,12 @@ public final class AWTAccessor {
      * class.
      */
     public static ScrollPaneAdjustableAccessor getScrollPaneAdjustableAccessor() {
-        if (scrollPaneAdjustableAccessor == null) {
+        var access = scrollPaneAdjustableAccessor;
+        if (access == null) {
             ensureClassInitialized(ScrollPaneAdjustable.class);
+            access = scrollPaneAdjustableAccessor;
         }
-        return scrollPaneAdjustableAccessor;
+        return access;
     }
 
     /**
@@ -1098,10 +1122,12 @@ public final class AWTAccessor {
      * Retrieve the accessor object for the java.awt.CheckboxMenuItem class.
      */
     public static CheckboxMenuItemAccessor getCheckboxMenuItemAccessor() {
-        if (checkboxMenuItemAccessor == null) {
+        var access = checkboxMenuItemAccessor;
+        if (access == null) {
             ensureClassInitialized(CheckboxMenuItemAccessor.class);
+            access = checkboxMenuItemAccessor;
         }
-        return checkboxMenuItemAccessor;
+        return access;
     }
 
     /**
@@ -1115,10 +1141,12 @@ public final class AWTAccessor {
      * Retrieve the accessor object for the java.awt.Cursor class.
      */
     public static CursorAccessor getCursorAccessor() {
-        if (cursorAccessor == null) {
+        var access = cursorAccessor;
+        if (access == null) {
             ensureClassInitialized(CursorAccessor.class);
+            access = cursorAccessor;
         }
-        return cursorAccessor;
+        return access;
     }
 
     /**
@@ -1132,10 +1160,12 @@ public final class AWTAccessor {
      * Retrieve the accessor object for the java.awt.MenuBar class.
      */
     public static MenuBarAccessor getMenuBarAccessor() {
-        if (menuBarAccessor == null) {
+        var access = menuBarAccessor;
+        if (access == null) {
             ensureClassInitialized(MenuBarAccessor.class);
+            access = menuBarAccessor;
         }
-        return menuBarAccessor;
+        return access;
     }
 
     /**
@@ -1149,10 +1179,12 @@ public final class AWTAccessor {
      * Retrieve the accessor object for the java.awt.MenuItem class.
      */
     public static MenuItemAccessor getMenuItemAccessor() {
-        if (menuItemAccessor == null) {
+        var access = menuItemAccessor;
+        if (access == null) {
             ensureClassInitialized(MenuItemAccessor.class);
+            access = menuItemAccessor;
         }
-        return menuItemAccessor;
+        return access;
     }
 
     /**
@@ -1166,10 +1198,12 @@ public final class AWTAccessor {
      * Retrieve the accessor object for the java.awt.Menu class.
      */
     public static MenuAccessor getMenuAccessor() {
-        if (menuAccessor == null) {
+        var access = menuAccessor;
+        if (access == null) {
             ensureClassInitialized(MenuAccessor.class);
+            access = menuAccessor;
         }
-        return menuAccessor;
+        return access;
     }
 
     /**
@@ -1183,10 +1217,12 @@ public final class AWTAccessor {
      * Retrieve the accessor object for the java.awt.event.KeyEvent class.
      */
     public static KeyEventAccessor getKeyEventAccessor() {
-        if (keyEventAccessor == null) {
+        var access = keyEventAccessor;
+        if (access == null) {
             ensureClassInitialized(KeyEventAccessor.class);
+            access = keyEventAccessor;
         }
-        return keyEventAccessor;
+        return access;
     }
 
     /**
@@ -1200,10 +1236,12 @@ public final class AWTAccessor {
      * Retrieve the accessor object for the javax.swing.ClientPropertyKey class.
      */
     public static ClientPropertyKeyAccessor getClientPropertyKeyAccessor() {
-        if (clientPropertyKeyAccessor == null) {
+        var access = clientPropertyKeyAccessor;
+        if (access == null) {
             ensureClassInitialized(ClientPropertyKeyAccessor.class);
+            access = clientPropertyKeyAccessor;
         }
-        return clientPropertyKeyAccessor;
+        return access;
     }
 
     /**
@@ -1217,10 +1255,12 @@ public final class AWTAccessor {
      * Retrieve the accessor object for the java.awt.SystemTray class.
      */
     public static SystemTrayAccessor getSystemTrayAccessor() {
-        if (systemTrayAccessor == null) {
+        var access = systemTrayAccessor;
+        if (access == null) {
             ensureClassInitialized(SystemTrayAccessor.class);
+            access = systemTrayAccessor;
         }
-        return systemTrayAccessor;
+        return access;
     }
 
     /**
@@ -1234,10 +1274,12 @@ public final class AWTAccessor {
      * Retrieve the accessor object for the java.awt.TrayIcon class.
      */
     public static TrayIconAccessor getTrayIconAccessor() {
-        if (trayIconAccessor == null) {
+        var access = trayIconAccessor;
+        if (access == null) {
             ensureClassInitialized(TrayIconAccessor.class);
+            access = trayIconAccessor;
         }
-        return trayIconAccessor;
+        return access;
     }
 
     /**
@@ -1251,10 +1293,12 @@ public final class AWTAccessor {
      * Retrieve the accessor object for the java.awt.DefaultKeyboardFocusManager class.
      */
     public static DefaultKeyboardFocusManagerAccessor getDefaultKeyboardFocusManagerAccessor() {
-        if (defaultKeyboardFocusManagerAccessor == null) {
+        var access = defaultKeyboardFocusManagerAccessor;
+        if (access == null) {
             ensureClassInitialized(DefaultKeyboardFocusManagerAccessor.class);
+            access = defaultKeyboardFocusManagerAccessor;
         }
-        return defaultKeyboardFocusManagerAccessor;
+        return access;
     }
     /*
      * Set an accessor object for the java.awt.SequencedEvent class.
@@ -1267,14 +1311,16 @@ public final class AWTAccessor {
      * Get the accessor object for the java.awt.SequencedEvent class.
      */
     public static SequencedEventAccessor getSequencedEventAccessor() {
-        if (sequencedEventAccessor == null) {
+        var acceess = sequencedEventAccessor;
+        if (acceess == null) {
             try {
                 ensureClassInitialized(
                         Class.forName("java.awt.SequencedEvent"));
             } catch (ClassNotFoundException ignore) {
             }
+            acceess = sequencedEventAccessor;
         }
-        return sequencedEventAccessor;
+        return acceess;
     }
 
     /*
@@ -1288,11 +1334,12 @@ public final class AWTAccessor {
      * Get the accessor object for the java.awt.Toolkit class.
      */
     public static ToolkitAccessor getToolkitAccessor() {
-        if (toolkitAccessor == null) {
+        var access = toolkitAccessor;
+        if (access == null) {
             ensureClassInitialized(Toolkit.class);
+            access = toolkitAccessor;
         }
-
-        return toolkitAccessor;
+        return access;
     }
 
     /*
@@ -1313,11 +1360,12 @@ public final class AWTAccessor {
      * Get the accessor object for the java.awt.SystemColor class.
      */
     public static SystemColorAccessor getSystemColorAccessor() {
-        if (systemColorAccessor == null) {
+        var access = systemColorAccessor;
+        if (access == null) {
             ensureClassInitialized(SystemColor.class);
+            access = systemColorAccessor;
         }
-
-        return systemColorAccessor;
+        return access;
     }
 
      /*
@@ -1331,10 +1379,12 @@ public final class AWTAccessor {
      * Get the accessor object for the javax.accessibility.AccessibleContext class.
      */
     public static AccessibleContextAccessor getAccessibleContextAccessor() {
-        if (accessibleContextAccessor == null) {
+        var access = accessibleContextAccessor;
+        if (access == null) {
             ensureClassInitialized(AccessibleContext.class);
+            access = accessibleContextAccessor;
         }
-        return accessibleContextAccessor;
+        return access;
     }
 
    /*
@@ -1348,10 +1398,12 @@ public final class AWTAccessor {
      * Get the accessor object for the javax.accessibility.AccessibleBundle class.
      */
     public static AccessibleBundleAccessor getAccessibleBundleAccessor() {
-        if (accessibleBundleAccessor == null) {
+        var access = accessibleBundleAccessor;
+        if (access == null) {
             ensureClassInitialized(AccessibleBundle.class);
+            access = accessibleBundleAccessor;
         }
-        return accessibleBundleAccessor;
+        return access;
     }
 
    /*
@@ -1365,10 +1417,12 @@ public final class AWTAccessor {
      * Get the accessor object for the java.awt.dnd.DragSourceContext class.
      */
     public static DragSourceContextAccessor getDragSourceContextAccessor() {
-        if (dragSourceContextAccessor == null) {
+        var access = dragSourceContextAccessor;
+        if (access == null) {
             ensureClassInitialized(DragSourceContext.class);
+            access = dragSourceContextAccessor;
         }
-        return dragSourceContextAccessor;
+        return access;
     }
 
     /*
@@ -1382,10 +1436,12 @@ public final class AWTAccessor {
      * Get the accessor object for the java.awt.dnd.DropTargetContext class.
      */
     public static DropTargetContextAccessor getDropTargetContextAccessor() {
-        if (dropTargetContextAccessor == null) {
+        var access = dropTargetContextAccessor;
+        if (access == null) {
             ensureClassInitialized(DropTargetContext.class);
+            access = dropTargetContextAccessor;
         }
-        return dropTargetContextAccessor;
+        return access;
     }
 
     /*

--- a/src/java.desktop/share/classes/sun/awt/AWTAccessor.java
+++ b/src/java.desktop/share/classes/sun/awt/AWTAccessor.java
@@ -1311,16 +1311,16 @@ public final class AWTAccessor {
      * Get the accessor object for the java.awt.SequencedEvent class.
      */
     public static SequencedEventAccessor getSequencedEventAccessor() {
-        var acceess = sequencedEventAccessor;
-        if (acceess == null) {
+        var access = sequencedEventAccessor;
+        if (access == null) {
             try {
                 ensureClassInitialized(
                         Class.forName("java.awt.SequencedEvent"));
             } catch (ClassNotFoundException ignore) {
             }
-            acceess = sequencedEventAccessor;
+            access = sequencedEventAccessor;
         }
-        return acceess;
+        return access;
     }
 
     /*

--- a/src/java.desktop/share/classes/sun/swing/SwingAccessor.java
+++ b/src/java.desktop/share/classes/sun/swing/SwingAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -138,11 +138,12 @@ public final class SwingAccessor {
      * Retrieve the accessor object for the javax.swing.JComponent class.
      */
     public static JComponentAccessor getJComponentAccessor() {
-        if (jComponentAccessor == null) {
+        var access = jComponentAccessor;
+        if (access == null) {
             ensureClassInitialized(JComponent.class);
+            access = jComponentAccessor;
         }
-
-        return jComponentAccessor;
+        return access;
     }
 
     /**
@@ -161,11 +162,12 @@ public final class SwingAccessor {
      * Retrieve the accessor object for the javax.swing.text.JTextComponent class.
      */
     public static JTextComponentAccessor getJTextComponentAccessor() {
-        if (jtextComponentAccessor == null) {
+        var access = jtextComponentAccessor;
+        if (access == null) {
             ensureClassInitialized(JTextComponent.class);
+            access = jtextComponentAccessor;
         }
-
-        return jtextComponentAccessor;
+        return access;
     }
 
     /**
@@ -184,10 +186,12 @@ public final class SwingAccessor {
      * Retrieve the accessor object for the JLightweightFrame class
      */
     public static JLightweightFrameAccessor getJLightweightFrameAccessor() {
-        if (jLightweightFrameAccessor == null) {
+        var access = jLightweightFrameAccessor;
+        if (access == null) {
             ensureClassInitialized(JLightweightFrame.class);
+            access = jLightweightFrameAccessor;
         }
-        return jLightweightFrameAccessor;
+        return access;
     }
 
     /**
@@ -206,10 +210,12 @@ public final class SwingAccessor {
      * Retrieve the accessor object for the JLightweightFrame class
      */
     public static UIDefaultsAccessor getUIDefaultsAccessor() {
-        if (uiDefaultsAccessor == null) {
+        var access = uiDefaultsAccessor;
+        if (access == null) {
             ensureClassInitialized(UIDefaults.class);
+            access = uiDefaultsAccessor;
         }
-        return uiDefaultsAccessor;
+        return access;
     }
 
     /**
@@ -228,10 +234,12 @@ public final class SwingAccessor {
      * Retrieve the accessor object for the RepaintManager class.
      */
     public static RepaintManagerAccessor getRepaintManagerAccessor() {
-        if (repaintManagerAccessor == null) {
+        var access = repaintManagerAccessor;
+        if (access == null) {
             ensureClassInitialized(RepaintManager.class);
+            access = repaintManagerAccessor;
         }
-        return repaintManagerAccessor;
+        return access;
     }
 
     /**
@@ -243,10 +251,12 @@ public final class SwingAccessor {
      * Retrieve the accessor object for the PopupFactory class.
      */
     public static PopupFactoryAccessor getPopupFactoryAccessor() {
-        if (popupFactoryAccessor == null) {
+        var access = popupFactoryAccessor;
+        if (access == null) {
             ensureClassInitialized(PopupFactory.class);
+            access = popupFactoryAccessor;
         }
-        return popupFactoryAccessor;
+        return access;
     }
 
     /**
@@ -265,10 +275,12 @@ public final class SwingAccessor {
      * Retrieve the accessor object for the KeyStroke class.
      */
     public static KeyStrokeAccessor getKeyStrokeAccessor() {
-        if (keyStrokeAccessor == null) {
+        var access = keyStrokeAccessor;
+        if (access == null) {
             ensureClassInitialized(KeyStroke.class);
+            access = keyStrokeAccessor;
         }
-        return keyStrokeAccessor;
+        return access;
     }
 
     /*


### PR DESCRIPTION
The patch applied to SharedSecrets by https://github.com/openjdk/jdk/pull/1914 is applied to the AWTAccessor and SwingAccessor. It prevents null to be returned by the some of methods. 

See also discussion in thread: https://mail.openjdk.java.net/pipermail/core-libs-dev/2020-December/072798.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297195](https://bugs.openjdk.org/browse/JDK-8297195): AWTAccessor and SwingAccessor should avoid double racy reads from non-volatile fields


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11205/head:pull/11205` \
`$ git checkout pull/11205`

Update a local copy of the PR: \
`$ git checkout pull/11205` \
`$ git pull https://git.openjdk.org/jdk pull/11205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11205`

View PR using the GUI difftool: \
`$ git pr show -t 11205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11205.diff">https://git.openjdk.org/jdk/pull/11205.diff</a>

</details>
