### PR TITLE
8297194: Add a @sealedGraph tag to Buffer

### DIFF
--- a/src/java.base/share/classes/java/nio/Buffer.java
+++ b/src/java.base/share/classes/java/nio/Buffer.java
@@ -190,6 +190,7 @@ import java.util.Spliterator;
  * @author Mark Reinhold
  * @author JSR-51 Expert Group
  * @since 1.4
+ * @sealedGraph
  */
 
 public abstract sealed class Buffer


### PR DESCRIPTION
This PR proposes to opt in for graphic rendering of the sealed hierarchy of the `Buffer` class.

Rendering capability was added via https://bugs.openjdk.org/browse/JDK-8295653

Here is how it would look like:

<img width="475" alt="Buffer_SH" src="https://user-images.githubusercontent.com/7457876/202420742-4d379512-1d8c-4b32-8d17-d2e70faa3a8f.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297194](https://bugs.openjdk.org/browse/JDK-8297194): Add a @sealedGraph tag to Buffer


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11206/head:pull/11206` \
`$ git checkout pull/11206`

Update a local copy of the PR: \
`$ git checkout pull/11206` \
`$ git pull https://git.openjdk.org/jdk pull/11206/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11206`

View PR using the GUI difftool: \
`$ git pr show -t 11206`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11206.diff">https://git.openjdk.org/jdk/pull/11206.diff</a>

</details>
