### PR TITLE
8286575: Document how properties in java.security are parsed

### DIFF
--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -25,8 +25,9 @@
 #
 # If this properties file fails to load, the JDK implementation will throw
 # an unspecified error when initializing the java.security.Security class.
-# Properties in this file are typically parsed only once. Any modification
-# would require an application restart to reflect changes.
+# Properties in this file are typically parsed only once. If any of the
+# properties are modified, applications should be restarted to ensure the
+# changes are properly reflected.
 
 # In this file, various security properties are set for use by
 # java.security classes. This is where users can statically register

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -25,6 +25,8 @@
 #
 # If this properties file fails to load, the JDK implementation will throw
 # an unspecified error when initializing the java.security.Security class.
+# Properties in this file are typically parsed only once. Any modification
+# would require an application restart to reflect changes.
 
 # In this file, various security properties are set for use by
 # java.security classes. This is where users can statically register


### PR DESCRIPTION
A doc edit to indicate that modifications of values in java.security conf file would require a JVM restart in order for such changes to be detected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286575](https://bugs.openjdk.org/browse/JDK-8286575): Document how properties in java.security are parsed


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11208/head:pull/11208` \
`$ git checkout pull/11208`

Update a local copy of the PR: \
`$ git checkout pull/11208` \
`$ git pull https://git.openjdk.org/jdk pull/11208/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11208`

View PR using the GUI difftool: \
`$ git pr show -t 11208`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11208.diff">https://git.openjdk.org/jdk/pull/11208.diff</a>

</details>
