### PR TITLE
8297186: G1 triggers unnecessary full GCs when heap utilization is low

### DIFF
--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -212,7 +212,7 @@ private:
   // If no parameters are passed, predict pending cards and the RS length using
   // the prediction model.
   void update_young_length_bounds();
-  void update_young_length_bounds(size_t pending_cards, size_t rs_length);
+  void update_young_length_bounds(size_t pending_cards, size_t rs_length, bool after_gc);
 
   // Calculate and return the minimum desired eden length based on the MMU target.
   uint calculate_desired_eden_length_by_mmu() const;
@@ -242,7 +242,7 @@ private:
   // available free regions into account.
   uint calculate_young_desired_length(size_t pending_cards, size_t rs_length) const;
   // Limit the given desired young length to available free regions.
-  uint calculate_young_target_length(uint desired_young_length) const;
+  uint calculate_young_target_length(uint desired_young_length, bool after_gc) const;
   // The GCLocker might cause us to need more regions than the target. Calculate
   // the maximum number of regions to use in that case.
   uint calculate_young_max_length(uint target_young_length) const;

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -210,10 +210,10 @@ private:
 
   // Updates the internal young gen maximum and target and desired lengths.
   // If no parameters are passed, predict pending cards and the RS length using
-  // the prediction model. Request one eden region when not revising young length
-  // at mutator time.
+  // the prediction model. If after_gc is set, make sure that there is one eden region
+  // available (if there is enough space) to guarantee some progress.
   void update_young_length_bounds();
-  void update_young_length_bounds(size_t pending_cards, size_t rs_length, bool need_one_eden_region);
+  void update_young_length_bounds(size_t pending_cards, size_t rs_length, bool after_gc);
 
   // Calculate and return the minimum desired eden length based on the MMU target.
   uint calculate_desired_eden_length_by_mmu() const;
@@ -241,7 +241,7 @@ private:
 
   // Calculate desired young length based on current situation without taking actually
   // available free regions into account.
-  uint calculate_young_desired_length(size_t pending_cards, size_t rs_length, bool need_one_eden_region) const;
+  uint calculate_young_desired_length(size_t pending_cards, size_t rs_length, bool after_gc) const;
   // Limit the given desired young length to available free regions.
   uint calculate_young_target_length(uint desired_young_length) const;
   // The GCLocker might cause us to need more regions than the target. Calculate

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -210,9 +210,10 @@ private:
 
   // Updates the internal young gen maximum and target and desired lengths.
   // If no parameters are passed, predict pending cards and the RS length using
-  // the prediction model.
+  // the prediction model. Request one eden region when not revising young length
+  // at mutator time.
   void update_young_length_bounds();
-  void update_young_length_bounds(size_t pending_cards, size_t rs_length, bool after_gc);
+  void update_young_length_bounds(size_t pending_cards, size_t rs_length, bool need_one_eden_region);
 
   // Calculate and return the minimum desired eden length based on the MMU target.
   uint calculate_desired_eden_length_by_mmu() const;
@@ -240,9 +241,9 @@ private:
 
   // Calculate desired young length based on current situation without taking actually
   // available free regions into account.
-  uint calculate_young_desired_length(size_t pending_cards, size_t rs_length) const;
+  uint calculate_young_desired_length(size_t pending_cards, size_t rs_length, bool need_one_eden_region) const;
   // Limit the given desired young length to available free regions.
-  uint calculate_young_target_length(uint desired_young_length, bool after_gc) const;
+  uint calculate_young_target_length(uint desired_young_length) const;
   // The GCLocker might cause us to need more regions than the target. Calculate
   // the maximum number of regions to use in that case.
   uint calculate_young_max_length(uint target_young_length) const;

--- a/test/hotspot/jtreg/gc/g1/TestOneEdenRegionAfterGC.java
+++ b/test/hotspot/jtreg/gc/g1/TestOneEdenRegionAfterGC.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package gc.g1;
+
+/*
+ * @test
+ * @bug 8297186
+ * @requires vm.gc.G1
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver gc.g1.TestOneEdenRegionAfterGC
+ * @summary Test that on a very small heap g1 with very little data (smaller than region size)
+ *          will use at least one eden region after gc to avoid full gcs.
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.whitebox.WhiteBox;
+
+public class TestOneEdenRegionAfterGC {
+  private static long YoungGenSize  = 32 * 1024 * 1024;
+
+  private static OutputAnalyzer run() throws Exception {
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+      "-Xbootclasspath/a:.",
+      "-XX:+UnlockDiagnosticVMOptions",
+      "-Xmn" + YoungGenSize,
+      "-Xmx512M",
+      "-Xms512M",
+      "-XX:G1HeapRegionSize=32M",
+      "-XX:+UseG1GC",
+      "-Xlog:gc,gc+ergo*=trace",
+      TestOneEdenRegionAfterGC.Allocate.class.getName(),
+      "" + YoungGenSize);
+    return new OutputAnalyzer(pb.start());
+  }
+
+  public static void main(String args[]) throws Exception {
+    OutputAnalyzer out = run();
+
+    out.shouldMatch(".*Pause Young \\(Normal\\).*");
+    out.shouldNotMatch(".*Pause Full.*");
+  }
+
+  public static class Allocate {
+    public static Object dummy;
+
+    public static void main(String [] args) throws Exception {
+      if (args.length != 1) {
+        throw new IllegalArgumentException("Usage: <YoungGenSize>");
+      }
+
+      long youngGenSize = Long.parseLong(args[0]);
+      triggerYoungGCs(youngGenSize);
+    }
+
+    public static void triggerYoungGCs(long youngGenSize) {
+      long approxAllocSize = 32 * 1024;
+      long numAllocations  = 2 * youngGenSize / approxAllocSize;
+
+      for (long i = 0; i < numAllocations; i++) {
+        dummy = new byte[(int)approxAllocSize];
+      }
+    }
+  }
+}
+

--- a/test/hotspot/jtreg/gc/g1/TestOneEdenRegionAfterGC.java
+++ b/test/hotspot/jtreg/gc/g1/TestOneEdenRegionAfterGC.java
@@ -28,8 +28,6 @@ package gc.g1;
  * @bug 8297186
  * @requires vm.gc.G1
  * @library /test/lib
- * @modules java.base/jdk.internal.misc
- *          java.management
  * @run driver gc.g1.TestOneEdenRegionAfterGC
  * @summary Test that on a very small heap g1 with very little data (smaller than region size)
  *          will use at least one eden region after gc to avoid full gcs.
@@ -37,15 +35,13 @@ package gc.g1;
 
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
-import jdk.test.whitebox.WhiteBox;
 
 public class TestOneEdenRegionAfterGC {
-  private static long YoungGenSize  = 32 * 1024 * 1024;
+  private static long YoungGenSize = 32 * 1024 * 1024;
 
   private static OutputAnalyzer run() throws Exception {
     ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
       "-Xbootclasspath/a:.",
-      "-XX:+UnlockDiagnosticVMOptions",
       "-Xmn" + YoungGenSize,
       "-Xmx512M",
       "-Xms512M",

--- a/test/hotspot/jtreg/runtime/cds/appcds/LotsOfClasses.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/LotsOfClasses.java
@@ -48,6 +48,7 @@ public class LotsOfClasses {
         opts.addSuffix("ALL-SYSTEM");
         opts.addSuffix("-Xlog:hashtables");
         opts.addSuffix("-Xmx500m");
+        opts.addSuffix("-XX:MetaspaceSize=500M"); // avoid heap fragmentation by avoiding metaspace-limit induced GCs
         opts.addSuffix("-Xlog:gc+region+cds");
         opts.addSuffix("-Xlog:cds=debug");  // test detailed metadata info printing
 


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that better enforces that after gc there is at least one eden region to allocate into?

That avoids the problem described in the PR.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297186](https://bugs.openjdk.org/browse/JDK-8297186): G1 triggers unnecessary full GCs when heap utilization is low


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11209/head:pull/11209` \
`$ git checkout pull/11209`

Update a local copy of the PR: \
`$ git checkout pull/11209` \
`$ git pull https://git.openjdk.org/jdk pull/11209/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11209`

View PR using the GUI difftool: \
`$ git pr show -t 11209`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11209.diff">https://git.openjdk.org/jdk/pull/11209.diff</a>

</details>
