### PR TITLE
8297209: Serial: Refactor GenCollectedHeap::full_process_roots

### DIFF
--- a/src/hotspot/share/gc/serial/genMarkSweep.cpp
+++ b/src/hotspot/share/gc/serial/genMarkSweep.cpp
@@ -188,8 +188,6 @@ void GenMarkSweep::mark_sweep_phase1(bool clear_all_softrefs) {
 
     gch->full_process_roots(false, // not the adjust phase
                             GenCollectedHeap::SO_None,
-                            ClassUnloading, // only strong roots if ClassUnloading
-                                            // is enabled
                             &follow_root_closure,
                             &follow_cld_closure);
   }
@@ -264,15 +262,10 @@ void GenMarkSweep::mark_sweep_phase3() {
   // Need new claim bits for the pointer adjustment tracing.
   ClassLoaderDataGraph::clear_claimed_marks();
 
-  {
-    StrongRootsScope srs(0);
-
-    gch->full_process_roots(true,  // this is the adjust phase
-                            GenCollectedHeap::SO_AllCodeCache,
-                            false, // all roots
-                            &adjust_pointer_closure,
-                            &adjust_cld_closure);
-  }
+  gch->full_process_roots(true,  // this is the adjust phase
+                          GenCollectedHeap::SO_AllCodeCache,
+                          &adjust_pointer_closure,
+                          &adjust_cld_closure);
 
   gch->gen_process_weak_roots(&adjust_pointer_closure);
 

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -789,23 +789,6 @@ void GenCollectedHeap::process_roots(ScanningOption so,
   DEBUG_ONLY(ScavengableNMethods::asserted_non_scavengable_nmethods_do(&assert_code_is_non_scavengable));
 }
 
-void GenCollectedHeap::full_process_roots(bool is_adjust_phase,
-                                          ScanningOption so,
-                                          OopClosure* root_closure,
-                                          CLDClosure* cld_closure) {
-  // Called from either the marking phase or the adjust phase.
-  const bool is_marking_phase = !is_adjust_phase;
-
-  if (is_marking_phase) {
-    CLDClosure* weak_cld_closure = ClassUnloading ? NULL : cld_closure;
-    MarkingCodeBlobClosure mark_code_closure(root_closure, !CodeBlobToOopClosure::FixRelocations, true);
-    process_roots(so, root_closure, cld_closure, weak_cld_closure, &mark_code_closure);
-  } else {
-    CodeBlobToOopClosure code_closure(root_closure, CodeBlobToOopClosure::FixRelocations);
-    process_roots(so, root_closure, cld_closure, cld_closure, &code_closure);
-  }
-}
-
 void GenCollectedHeap::gen_process_weak_roots(OopClosure* root_closure) {
   WeakProcessor::oops_do(root_closure);
 }

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -791,16 +791,19 @@ void GenCollectedHeap::process_roots(ScanningOption so,
 
 void GenCollectedHeap::full_process_roots(bool is_adjust_phase,
                                           ScanningOption so,
-                                          bool only_strong_roots,
                                           OopClosure* root_closure,
                                           CLDClosure* cld_closure) {
   // Called from either the marking phase or the adjust phase.
   const bool is_marking_phase = !is_adjust_phase;
 
-  MarkingCodeBlobClosure mark_code_closure(root_closure, is_adjust_phase, is_marking_phase);
-  CLDClosure* weak_cld_closure = only_strong_roots ? NULL : cld_closure;
-
-  process_roots(so, root_closure, cld_closure, weak_cld_closure, &mark_code_closure);
+  if (is_marking_phase) {
+    CLDClosure* weak_cld_closure = ClassUnloading ? NULL : cld_closure;
+    MarkingCodeBlobClosure mark_code_closure(root_closure, !CodeBlobToOopClosure::FixRelocations, true);
+    process_roots(so, root_closure, cld_closure, weak_cld_closure, &mark_code_closure);
+  } else {
+    CodeBlobToOopClosure code_closure(root_closure, CodeBlobToOopClosure::FixRelocations);
+    process_roots(so, root_closure, cld_closure, cld_closure, &code_closure);
+  }
 }
 
 void GenCollectedHeap::gen_process_weak_roots(OopClosure* root_closure) {

--- a/src/hotspot/share/gc/shared/genCollectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.hpp
@@ -338,7 +338,6 @@ public:
  public:
   void full_process_roots(bool is_adjust_phase,
                           ScanningOption so,
-                          bool only_strong_roots,
                           OopClosure* root_closure,
                           CLDClosure* cld_closure);
 

--- a/src/hotspot/share/gc/shared/genCollectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.hpp
@@ -326,20 +326,16 @@ public:
   };
 
  protected:
+  virtual void gc_prologue(bool full);
+  virtual void gc_epilogue(bool full);
+
+ public:
+  // Apply closures on various roots in Young GC or marking/adjust phases of Full GC.
   void process_roots(ScanningOption so,
                      OopClosure* strong_roots,
                      CLDClosure* strong_cld_closure,
                      CLDClosure* weak_cld_closure,
                      CodeBlobToOopClosure* code_roots);
-
-  virtual void gc_prologue(bool full);
-  virtual void gc_epilogue(bool full);
-
- public:
-  void full_process_roots(bool is_adjust_phase,
-                          ScanningOption so,
-                          OopClosure* root_closure,
-                          CLDClosure* cld_closure);
 
   // Apply "root_closure" to all the weak roots of the system.
   // These include JNI weak roots, string table,


### PR DESCRIPTION
Simple change of replacing `MarkingCodeBlobClosure` with `CodeBlobToOopClosure` in the adjust-phase of Full GC.

Test: tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297209](https://bugs.openjdk.org/browse/JDK-8297209): Serial: Refactor GenCollectedHeap::full_process_roots


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11210/head:pull/11210` \
`$ git checkout pull/11210`

Update a local copy of the PR: \
`$ git checkout pull/11210` \
`$ git pull https://git.openjdk.org/jdk pull/11210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11210`

View PR using the GUI difftool: \
`$ git pr show -t 11210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11210.diff">https://git.openjdk.org/jdk/pull/11210.diff</a>

</details>
