### PR TITLE
8196018: java/awt/Scrollbar/ScrollbarMouseWheelTest/ScrollbarMouseWheelTest.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -190,7 +190,6 @@ java/awt/event/KeyEvent/KeyTyped/CtrlASCII.java 8252713 linux-all
 
 java/awt/dnd/URIListToFileListBetweenJVMsTest/URIListToFileListBetweenJVMsTest.java 8194947 generic-all
 java/awt/Frame/FramesGC/FramesGC.java 8079069 macosx-all
-java/awt/Scrollbar/ScrollbarMouseWheelTest/ScrollbarMouseWheelTest.java 8196018 windows-all,linux-all
 java/awt/TrayIcon/ActionCommand/ActionCommand.java 8150540 windows-all
 java/awt/TrayIcon/ActionEventMask/ActionEventMask.java 8150540,8295300 windows-all,linux-all
 java/awt/TrayIcon/ActionEventTest/ActionEventTest.java 8150540,8242801 windows-all,macosx-all

--- a/test/jdk/java/awt/Scrollbar/ScrollbarMouseWheelTest/ScrollbarMouseWheelTest.java
+++ b/test/jdk/java/awt/Scrollbar/ScrollbarMouseWheelTest/ScrollbarMouseWheelTest.java
@@ -32,8 +32,6 @@ import java.awt.Scrollbar;
 import java.awt.Toolkit;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
-import java.awt.event.WindowEvent;
-import java.awt.event.WindowListener;
 
 /**
  * @test
@@ -43,7 +41,7 @@ import java.awt.event.WindowListener;
  */
 
 public final class ScrollbarMouseWheelTest
-        implements MouseWheelListener, WindowListener {
+        implements MouseWheelListener {
 
     final static boolean isWindows =
             Toolkit.getDefaultToolkit().getClass()
@@ -61,14 +59,6 @@ public final class ScrollbarMouseWheelTest
     Scrollbar sb2;
     Panel pnl;
 
-    class Sema {
-        boolean flag;
-        boolean getVal() { return flag;}
-        void setVal(boolean b) { flag = b;}
-    }
-
-    Sema sema = new Sema();
-
     Robot robot;
 
     int sb1upevents, sb2upevents, pnlupevents;
@@ -85,15 +75,13 @@ public final class ScrollbarMouseWheelTest
         } catch (AWTException e) {
             System.out.println("Problem creating Robot.  FAIL.");
             throw new RuntimeException("Problem creating Robot.  FAIL.");
-
         }
 
-        robot.setAutoDelay(500);
+        robot.setAutoDelay(250);
         robot.setAutoWaitForIdle(true);
 
         // Show test Frame
         Frame frame = new Frame("ScrollbarMouseWheelTest");
-        frame.addWindowListener(this);
         pnl = new Panel();
         pnl.setLayout(new GridLayout(1, 2));
         pnl.addMouseWheelListener(this);
@@ -108,14 +96,8 @@ public final class ScrollbarMouseWheelTest
         frame.setVisible(true);
         frame.toFront();
 
-        // When Frame is active, start testing (handled in windowActivated())
-        while (true) {
-            synchronized (sema) {
-                if (sema.getVal()) {
-                    break;
-                }
-            }
-        }
+        robot.waitForIdle();
+        robot.delay(1000);
 
         // up on sb1
         testComp(sb1, true);
@@ -185,17 +167,4 @@ public final class ScrollbarMouseWheelTest
             System.out.println("weird wheel rotation");
         }
     }
-
-    public void windowActivated(WindowEvent we) {
-        synchronized (sema) {
-            sema.setVal(true);
-        }
-    }
-
-    public void windowClosed(WindowEvent we) {}
-    public void windowClosing(WindowEvent we) {}
-    public void windowDeactivated(WindowEvent we) {}
-    public void windowDeiconified(WindowEvent we) {}
-    public void windowIconified(WindowEvent we) {}
-    public void windowOpened(WindowEvent we) {}
 }// class ScrollbarMouseWheelTest

--- a/test/jdk/java/awt/Scrollbar/ScrollbarMouseWheelTest/ScrollbarMouseWheelTest.java
+++ b/test/jdk/java/awt/Scrollbar/ScrollbarMouseWheelTest/ScrollbarMouseWheelTest.java
@@ -21,8 +21,19 @@
  * questions.
  */
 
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.AWTException;
+import java.awt.Component;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.Scrollbar;
+import java.awt.Toolkit;
+import java.awt.event.MouseWheelEvent;
+import java.awt.event.MouseWheelListener;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowListener;
 
 /**
  * @test
@@ -34,23 +45,28 @@ import java.awt.event.*;
 public final class ScrollbarMouseWheelTest
         implements MouseWheelListener, WindowListener {
 
-    final static String tk = Toolkit.getDefaultToolkit().getClass().getName();
+    final static boolean isWindows =
+            Toolkit.getDefaultToolkit().getClass()
+                    .getName().equals("sun.awt.windows.WToolkit");
+
     final static int REPS = 5;
     // There is a bug on Windows: 4616935.
     // Wheel events comes to every component in the hierarchy so we should
     // check a platform.
     // There are two scrollbars within one Panel and both accept 5 clicks, so
     // Panel would accept 5*2 clicks on Windows.
-    final static int PANEL_REPS = tk.equals("sun.awt.windows.WToolkit")? REPS * 2: REPS;
+    final static int PANEL_REPS = isWindows ? REPS * 2: REPS;
 
     Scrollbar sb1;
     Scrollbar sb2;
     Panel pnl;
+
     class Sema {
         boolean flag;
         boolean getVal() { return flag;}
         void setVal(boolean b) { flag = b;}
     }
+
     Sema sema = new Sema();
 
     Robot robot;
@@ -100,6 +116,7 @@ public final class ScrollbarMouseWheelTest
                 }
             }
         }
+
         // up on sb1
         testComp(sb1, true);
         // down on sb1
@@ -108,7 +125,9 @@ public final class ScrollbarMouseWheelTest
         testComp(sb2, true);
         // down on sb2
         testComp(sb2, false);
+
         frame.dispose();
+
         System.out.println("Test done.");
         if (sb1upevents == REPS &&
                 sb2upevents == 0 &&

--- a/test/jdk/java/awt/Scrollbar/ScrollbarMouseWheelTest/ScrollbarMouseWheelTest.java
+++ b/test/jdk/java/awt/Scrollbar/ScrollbarMouseWheelTest/ScrollbarMouseWheelTest.java
@@ -61,8 +61,8 @@ public final class ScrollbarMouseWheelTest
 
     Robot robot;
 
-    int sb1upevents, sb2upevents, pnlupevents;
-    int sb1downevents, sb2downevents, pnldownevents;
+    volatile int sb1upevents, sb2upevents, pnlupevents;
+    volatile int sb1downevents, sb2downevents, pnldownevents;
 
     public static void main(final String[] args) {
         new ScrollbarMouseWheelTest().test();
@@ -107,6 +107,9 @@ public final class ScrollbarMouseWheelTest
         testComp(sb2, true);
         // down on sb2
         testComp(sb2, false);
+
+        robot.waitForIdle();
+        robot.delay(500);
 
         frame.dispose();
 

--- a/test/jdk/java/awt/Scrollbar/ScrollbarMouseWheelTest/ScrollbarMouseWheelTest.java
+++ b/test/jdk/java/awt/Scrollbar/ScrollbarMouseWheelTest/ScrollbarMouseWheelTest.java
@@ -108,7 +108,6 @@ public final class ScrollbarMouseWheelTest
         // down on sb2
         testComp(sb2, false);
 
-        robot.waitForIdle();
         robot.delay(500);
 
         frame.dispose();


### PR DESCRIPTION
The issue contains evaluation:
* the test is not failing on Windows
* it also fails on Linux(but provided stack trace with failure is from different test)

I rechecked the test and it does not fail on all platforms.

Test is stabilized:
* replaced synchronization on windowActivated event with standard `robot.waitForIdle(); robot.delay(1000);`
* Robot autoDelay decreased to 250 to make the test go faster. It it still a reasonable value.

CI testing looks good also.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8196018](https://bugs.openjdk.org/browse/JDK-8196018): java/awt/Scrollbar/ScrollbarMouseWheelTest/ScrollbarMouseWheelTest.java fails


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**) ⚠️ Review applies to [c2ada26e](https://git.openjdk.org/jdk/pull/11213/files/c2ada26e4200121b339f0f67a5df2da31604897c)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11213/head:pull/11213` \
`$ git checkout pull/11213`

Update a local copy of the PR: \
`$ git checkout pull/11213` \
`$ git pull https://git.openjdk.org/jdk pull/11213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11213`

View PR using the GUI difftool: \
`$ git pr show -t 11213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11213.diff">https://git.openjdk.org/jdk/pull/11213.diff</a>

</details>
