### PR TITLE
8252713: jtreg time out of CtrlASCII.java seems to hang the Xserver.

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -186,7 +186,6 @@ java/awt/Focus/6981400/Test1.java 8029675 windows-all,macosx-all
 java/awt/Focus/6981400/Test3.java 8173264 generic-all
 java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java 8169476 windows-all,macosx-all
 java/awt/event/KeyEvent/KeyChar/KeyCharTest.java 8169474,8224055 macosx-all,windows-all
-java/awt/event/KeyEvent/KeyTyped/CtrlASCII.java 8252713 linux-all
 
 java/awt/dnd/URIListToFileListBetweenJVMsTest/URIListToFileListBetweenJVMsTest.java 8194947 generic-all
 java/awt/Frame/FramesGC/FramesGC.java 8079069 macosx-all

--- a/test/jdk/java/awt/event/KeyEvent/KeyTyped/CtrlASCII.java
+++ b/test/jdk/java/awt/event/KeyEvent/KeyTyped/CtrlASCII.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,19 @@
   @test
   @key headful
   @bug  6497426
-  @summary ests that pressing of Ctrl+ascii mostly fires KEY_TYPED with a Unicode control symbols
+  @summary Tests that pressing of Ctrl+ascii mostly fires KEY_TYPED with a Unicode control symbols
   @run main CtrlASCII
  */
 
-import java.awt.*;
-import java.awt.event.*;
-import java.util.*;
+import java.awt.BorderLayout;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.TextField;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.util.HashMap;
 
 //
 // In this test, a key listener for KEY_TYPED checks if a character typed has
@@ -51,7 +57,7 @@ public class CtrlASCII extends Frame implements KeyListener
     TextField tf;
     Robot robot;
 
-    static void fillHash( boolean isMSWindows ) {
+    static void fillHash() {
         KEYCHAR_MAP.put((char) 0x20, KeyEvent.VK_SPACE);             /*32,x20*/ /*' ' */
         KEYCHAR_MAP.put((char) 0x21, KeyEvent.VK_EXCLAMATION_MARK);  /*33,x21*/ /*'!' fr*/
         KEYCHAR_MAP.put((char) 0x22, KeyEvent.VK_QUOTEDBL);          /*34,x22*/ /*'"' fr*/
@@ -157,6 +163,7 @@ public class CtrlASCII extends Frame implements KeyListener
 
 
     }
+
     public static void main(String[] args) {
         CtrlASCII test = new CtrlASCII();
         test.init();
@@ -165,9 +172,8 @@ public class CtrlASCII extends Frame implements KeyListener
 
     public void init()
     {
-        fillHash( false );
+        fillHash();
         this.setLayout (new BorderLayout ());
-
     }//End  init()
 
     public void start ()
@@ -200,7 +206,7 @@ public class CtrlASCII extends Frame implements KeyListener
             robot.mousePress( InputEvent.BUTTON1_DOWN_MASK );
             robot.mouseRelease( InputEvent.BUTTON1_DOWN_MASK );
 
-            KEYCHAR_MAP.forEach((k,v) -> punchCtrlKey(robot, v));
+            KEYCHAR_MAP.forEach((k,v) -> punchCtrlKey(v));
 
             robot.delay(500);
         } catch (Exception e) {
@@ -212,40 +218,37 @@ public class CtrlASCII extends Frame implements KeyListener
         System.out.println("Success\n");
 
     }// start()
-    public void punchCtrlKey( Robot ro, int keyCode ) {
-        ro.keyPress(KeyEvent.VK_CONTROL);
+
+    public void punchCtrlKey(int keyCode ) {
+        robot.keyPress(KeyEvent.VK_CONTROL);
         try {
-            ro.keyPress(keyCode);
-            ro.keyRelease(keyCode);
-        }catch(IllegalArgumentException iae) {
-            System.err.println("skip probably invalid keyCode "+keyCode);
+            robot.keyPress(keyCode);
+            robot.keyRelease(keyCode);
+        } catch (IllegalArgumentException iae) {
+            System.err.println("skip probably invalid keyCode " + keyCode);
         }
-        ro.keyRelease(KeyEvent.VK_CONTROL);
-        ro.delay(200);
+        robot.keyRelease(KeyEvent.VK_CONTROL);
+        robot.delay(200);
     }
-    public void keyPressed(KeyEvent evt)
-    {
+
+    public void keyPressed(KeyEvent evt) {
         //printKey(evt);
     }
 
-    public void keyTyped(KeyEvent evt)
-    {
+    public void keyTyped(KeyEvent evt) {
         printKey(evt);
         char keych = evt.getKeyChar();
         if( !KEYCHAR_MAP.containsKey( keych ) ) {
-            System.out.println("Unexpected keychar: "+keych);
             System.out.println("Unexpected keychar: "+keych);
             testFailed = true;
         }
     }
 
-    public void keyReleased(KeyEvent evt)
-    {
+    public void keyReleased(KeyEvent evt) {
         //printKey(evt);
     }
 
-    protected void printKey(KeyEvent evt)
-    {
+    protected void printKey(KeyEvent evt) {
         switch(evt.getID())
         {
           case KeyEvent.KEY_TYPED:
@@ -254,11 +257,9 @@ public class CtrlASCII extends Frame implements KeyListener
             break;
           default:
             System.out.println("Other Event ");
-            System.out.println("Other Event ");
             return;
         }
-        System.out.print(" 0x"+ Integer.toHexString(evt.getKeyChar()));
-        System.out.println    (" 0x"+ Integer.toHexString(evt.getKeyChar()));
+        System.out.println(" 0x" + Integer.toHexString(evt.getKeyChar()));
     }
 
 }// class CtrlASCII

--- a/test/jdk/java/awt/event/KeyEvent/KeyTyped/CtrlASCII.java
+++ b/test/jdk/java/awt/event/KeyEvent/KeyTyped/CtrlASCII.java
@@ -45,114 +45,115 @@ import java.util.*;
 public class CtrlASCII extends Frame implements KeyListener
 {
     // Declare things used in the test, like buttons and labels here
-    static Hashtable<Character, Integer> keycharHash = new Hashtable<Character, Integer>();
+    static final HashMap<Character, Integer> KEYCHAR_MAP = new HashMap<>();
     static boolean testFailed = false;
     //Frame frame;
     TextField tf;
     Robot robot;
 
     static void fillHash( boolean isMSWindows ) {
-        keycharHash.put(    (char)0x20         , KeyEvent.VK_SPACE        );                      /*32,x20*/ /*' ' */
-        keycharHash.put(    (char)0x21         , KeyEvent.VK_EXCLAMATION_MARK        );           /*33,x21*/ /*'!' fr*/
-        keycharHash.put(    (char)0x22         , KeyEvent.VK_QUOTEDBL        );                   /*34,x22*/ /*'"' fr*/
-        keycharHash.put(    (char)0x23         , KeyEvent.VK_NUMBER_SIGN        );                /*35,x23*/ /*'#' de*/
-        keycharHash.put(    (char)0x24         , KeyEvent.VK_DOLLAR        );                      /*36,x24*/ /*'$', de_CH*/
-        //keycharHash.put('%',                                  (char)0x25        );                                  /*37,x25*/ /*no VK, cannot test*/
-        keycharHash.put(    (char)0x26    , KeyEvent.VK_AMPERSAND        );                  /*38,x26*/ /*'&', fr*/
-        keycharHash.put(    (char)0x27    , KeyEvent.VK_QUOTE        );                      /*39,x27*/ /*''', fr*/
-        keycharHash.put(    (char)0x28    , KeyEvent.VK_LEFT_PARENTHESIS        );           /*40,x28*/ /*'(', fr*/
-        keycharHash.put(    (char)0x29    , KeyEvent.VK_RIGHT_PARENTHESIS        );           /*41,x29*/ /*')', fr*/
-        keycharHash.put(    (char)0x2a    , KeyEvent.VK_ASTERISK        );                    /*42,x2a*/ /*'*', fr*/
-        keycharHash.put(    (char)0x2b    , KeyEvent.VK_PLUS        );                        /*43,x2b*/ /*'+', de*/
-        keycharHash.put(    (char)0x2c    , KeyEvent.VK_COMMA        );                       /*44,x2c*/  /*','*/
-        keycharHash.put(    (char)0x2d    , KeyEvent.VK_MINUS        );                       /*45,x2d*/ /*'-'*/
-        keycharHash.put(    (char)0x2e    , KeyEvent.VK_PERIOD        );                      /*46,x2e*/ /*'.'*/
-        keycharHash.put(    (char)0x2f    , KeyEvent.VK_SLASH        );                       /*47,x2f*/ /*'/'*/
-        keycharHash.put(    (char)0x30    , KeyEvent.VK_0        );                           /*48,x30*/
-        keycharHash.put(    (char)0x31    , KeyEvent.VK_1        );                           /*49,x31*/
-        keycharHash.put(    (char)0x32    , KeyEvent.VK_2        );                           /*50,x32*/
-        keycharHash.put(    (char)0x33    , KeyEvent.VK_3        );                           /*51,x33*/
-        keycharHash.put(    (char)0x34    , KeyEvent.VK_4        );                           /*52,x34*/
-        keycharHash.put(    (char)0x35    , KeyEvent.VK_5        );                           /*53,x35*/
-        keycharHash.put(    (char)0x36    , KeyEvent.VK_6        );                           /*54,x36*/
-        keycharHash.put(    (char)0x37    , KeyEvent.VK_7        );                           /*55,x37*/
-        keycharHash.put(    (char)0x38    , KeyEvent.VK_8        );                           /*56,x38*/
-        keycharHash.put(    (char)0x39    , KeyEvent.VK_9        );                           /*57,x39*/
-        keycharHash.put(    (char)0x3a    , KeyEvent.VK_COLON        );                       /*58,x3a*/ /*':', fr*/
-        keycharHash.put(    (char)0x3b    , KeyEvent.VK_SEMICOLON        );                   /*59,x3b*/ /*';'*/
-        keycharHash.put(    (char)0x3c    , KeyEvent.VK_LESS        );                        /*60,x3c*/ /*'<' us 102*/
-        keycharHash.put(    (char)0x3d    , KeyEvent.VK_EQUALS        );                      /*61,x3d*/
-        keycharHash.put(    (char)0x3e    , KeyEvent.VK_GREATER        );                     /*62,x3e*/ /*'>' ?????? where???*/
-            // Javadoc says: "there is no keycode for the question mark because
-            // there is no keyboard for which it appears on the primary layer."
-            // Well, it's Lithuanian standard.
-        //keycharHash.put('?',                                 (char)0x3f        );                                   /*63,x3f*/ /*no VK, cannot test*/
-        keycharHash.put(    (char)0x40   , KeyEvent.VK_AT        );                          /*64,x40*/ /*'@' ?????? where???*/
-        keycharHash.put(    (char)0x1    , KeyEvent.VK_A        );                             /*65,x41*/
-        keycharHash.put(    (char)0x2    , KeyEvent.VK_B        );                            /*66,x42*/
-        keycharHash.put(    (char)0x3    , KeyEvent.VK_C        );                            /*67,x43*/
-        keycharHash.put(    (char)0x4    , KeyEvent.VK_D        );                            /*68,x44*/
-        keycharHash.put(    (char)0x5    , KeyEvent.VK_E        );                            /*69,x45*/
-        keycharHash.put(    (char)0x6    , KeyEvent.VK_F        );                            /*70,x46*/
-        keycharHash.put(    (char)0x7    , KeyEvent.VK_G        );                            /*71,x47*/
-        keycharHash.put(    (char)0x8    , KeyEvent.VK_H        );                            /*72,x48*/
-        keycharHash.put(    (char)0x9    , KeyEvent.VK_I        );                            /*73,x49*/
-        keycharHash.put(    (char)0xa    , KeyEvent.VK_J        );                            /*74,x4a*/
-        keycharHash.put(    (char)0xb    , KeyEvent.VK_K        );                            /*75,x4b*/
-        keycharHash.put(    (char)0xc    , KeyEvent.VK_L        );                            /*76,x4c*/
-        keycharHash.put(    (char)0xd    , KeyEvent.VK_M        );                            /*77,x4d*/
-        keycharHash.put(    (char)0xe    , KeyEvent.VK_N        );                            /*78,x4e*/
-        keycharHash.put(    (char)0xf    , KeyEvent.VK_O        );                            /*79,x4f*/
-        keycharHash.put(    (char)0x10   , KeyEvent.VK_P        );                           /*80,x50*/
-        keycharHash.put(    (char)0x11   , KeyEvent.VK_Q        );                           /*81,x51*/
-        keycharHash.put(    (char)0x12   , KeyEvent.VK_R        );                           /*82,x52*/
-        keycharHash.put(    (char)0x13   , KeyEvent.VK_S        );                           /*83,x53*/
-        keycharHash.put(    (char)0x14   , KeyEvent.VK_T        );                           /*84,x54*/
-        keycharHash.put(    (char)0x15   , KeyEvent.VK_U        );                           /*85,x55*/
-        keycharHash.put(    (char)0x16   , KeyEvent.VK_V        );                           /*86,x56*/
-        keycharHash.put(    (char)0x17   , KeyEvent.VK_W        );                           /*87,x57*/
-        keycharHash.put(    (char)0x18   , KeyEvent.VK_X        );                           /*88,x58*/
-        keycharHash.put(    (char)0x19   , KeyEvent.VK_Y        );                           /*89,x59*/
-        keycharHash.put(    (char)0x1a   , KeyEvent.VK_Z        );                           /*90,x5a*/
+        KEYCHAR_MAP.put((char) 0x20, KeyEvent.VK_SPACE);             /*32,x20*/ /*' ' */
+        KEYCHAR_MAP.put((char) 0x21, KeyEvent.VK_EXCLAMATION_MARK);  /*33,x21*/ /*'!' fr*/
+        KEYCHAR_MAP.put((char) 0x22, KeyEvent.VK_QUOTEDBL);          /*34,x22*/ /*'"' fr*/
+        KEYCHAR_MAP.put((char) 0x23, KeyEvent.VK_NUMBER_SIGN);       /*35,x23*/ /*'#' de*/
+        KEYCHAR_MAP.put((char) 0x24, KeyEvent.VK_DOLLAR);            /*36,x24*/ /*'$', de_CH*/
+        //keycharHash.put('%', (char)0x25 );                         /*37,x25*/ /*no VK, cannot test*/
+        KEYCHAR_MAP.put((char) 0x26, KeyEvent.VK_AMPERSAND);         /*38,x26*/ /*'&', fr*/
+        KEYCHAR_MAP.put((char) 0x27, KeyEvent.VK_QUOTE);             /*39,x27*/ /*''', fr*/
+        KEYCHAR_MAP.put((char) 0x28, KeyEvent.VK_LEFT_PARENTHESIS);  /*40,x28*/ /*'(', fr*/
+        KEYCHAR_MAP.put((char) 0x29, KeyEvent.VK_RIGHT_PARENTHESIS); /*41,x29*/ /*')', fr*/
+        KEYCHAR_MAP.put((char) 0x2a, KeyEvent.VK_ASTERISK);          /*42,x2a*/ /*'*', fr*/
+        KEYCHAR_MAP.put((char) 0x2b, KeyEvent.VK_PLUS);              /*43,x2b*/ /*'+', de*/
+        KEYCHAR_MAP.put((char) 0x2c, KeyEvent.VK_COMMA);             /*44,x2c*/  /*','*/
+        KEYCHAR_MAP.put((char) 0x2d, KeyEvent.VK_MINUS);             /*45,x2d*/ /*'-'*/
+        KEYCHAR_MAP.put((char) 0x2e, KeyEvent.VK_PERIOD);            /*46,x2e*/ /*'.'*/
+        KEYCHAR_MAP.put((char) 0x2f, KeyEvent.VK_SLASH);             /*47,x2f*/ /*'/'*/
+        KEYCHAR_MAP.put((char) 0x30, KeyEvent.VK_0);                 /*48,x30*/
+        KEYCHAR_MAP.put((char) 0x31, KeyEvent.VK_1);                 /*49,x31*/
+        KEYCHAR_MAP.put((char) 0x32, KeyEvent.VK_2);                 /*50,x32*/
+        KEYCHAR_MAP.put((char) 0x33, KeyEvent.VK_3);                 /*51,x33*/
+        KEYCHAR_MAP.put((char) 0x34, KeyEvent.VK_4);                 /*52,x34*/
+        KEYCHAR_MAP.put((char) 0x35, KeyEvent.VK_5);                 /*53,x35*/
+        KEYCHAR_MAP.put((char) 0x36, KeyEvent.VK_6);                 /*54,x36*/
+        KEYCHAR_MAP.put((char) 0x37, KeyEvent.VK_7);                 /*55,x37*/
+        KEYCHAR_MAP.put((char) 0x38, KeyEvent.VK_8);                 /*56,x38*/
+        KEYCHAR_MAP.put((char) 0x39, KeyEvent.VK_9);                 /*57,x39*/
+        KEYCHAR_MAP.put((char) 0x3a, KeyEvent.VK_COLON);             /*58,x3a*/ /*':', fr*/
+        KEYCHAR_MAP.put((char) 0x3b, KeyEvent.VK_SEMICOLON);         /*59,x3b*/ /*';'*/
+        KEYCHAR_MAP.put((char) 0x3c, KeyEvent.VK_LESS);              /*60,x3c*/ /*'<' us 102*/
+        KEYCHAR_MAP.put((char) 0x3d, KeyEvent.VK_EQUALS);            /*61,x3d*/
+        KEYCHAR_MAP.put((char) 0x3e, KeyEvent.VK_GREATER);           /*62,x3e*/ /*'>' ?????? where???*/
+        // Javadoc says: "there is no keycode for the question mark because
+        // there is no keyboard for which it appears on the primary layer."
+        // Well, it's Lithuanian standard.
+        //keycharHash.put('?', (char)0x3f);                          /*63,x3f*/ /*no VK, cannot test*/
+        KEYCHAR_MAP.put((char) 0x40, KeyEvent.VK_AT);                /*64,x40*/ /*'@' ?????? where???*/
+        KEYCHAR_MAP.put((char) 0x1, KeyEvent.VK_A);                  /*65,x41*/
+        KEYCHAR_MAP.put((char) 0x2, KeyEvent.VK_B);                  /*66,x42*/
+        KEYCHAR_MAP.put((char) 0x3, KeyEvent.VK_C);                  /*67,x43*/
+        KEYCHAR_MAP.put((char) 0x4, KeyEvent.VK_D);                  /*68,x44*/
+        KEYCHAR_MAP.put((char) 0x5, KeyEvent.VK_E);                  /*69,x45*/
+        KEYCHAR_MAP.put((char) 0x6, KeyEvent.VK_F);                  /*70,x46*/
+        KEYCHAR_MAP.put((char) 0x7, KeyEvent.VK_G);                  /*71,x47*/
+        KEYCHAR_MAP.put((char) 0x8, KeyEvent.VK_H);                  /*72,x48*/
+        KEYCHAR_MAP.put((char) 0x9, KeyEvent.VK_I);                  /*73,x49*/
+        KEYCHAR_MAP.put((char) 0xa, KeyEvent.VK_J);                  /*74,x4a*/
+        KEYCHAR_MAP.put((char) 0xb, KeyEvent.VK_K);                  /*75,x4b*/
+        KEYCHAR_MAP.put((char) 0xc, KeyEvent.VK_L);                  /*76,x4c*/
+        KEYCHAR_MAP.put((char) 0xd, KeyEvent.VK_M);                  /*77,x4d*/
+        KEYCHAR_MAP.put((char) 0xe, KeyEvent.VK_N);                  /*78,x4e*/
+        KEYCHAR_MAP.put((char) 0xf, KeyEvent.VK_O);                  /*79,x4f*/
+        KEYCHAR_MAP.put((char) 0x10, KeyEvent.VK_P);                 /*80,x50*/
+        KEYCHAR_MAP.put((char) 0x11, KeyEvent.VK_Q);                 /*81,x51*/
+        KEYCHAR_MAP.put((char) 0x12, KeyEvent.VK_R);                 /*82,x52*/
+        KEYCHAR_MAP.put((char) 0x13, KeyEvent.VK_S);                 /*83,x53*/
+        KEYCHAR_MAP.put((char) 0x14, KeyEvent.VK_T);                 /*84,x54*/
+        KEYCHAR_MAP.put((char) 0x15, KeyEvent.VK_U);                 /*85,x55*/
+        KEYCHAR_MAP.put((char) 0x16, KeyEvent.VK_V);                 /*86,x56*/
+        KEYCHAR_MAP.put((char) 0x17, KeyEvent.VK_W);                 /*87,x57*/
+        KEYCHAR_MAP.put((char) 0x18, KeyEvent.VK_X);                 /*88,x58*/
+        KEYCHAR_MAP.put((char) 0x19, KeyEvent.VK_Y);                 /*89,x59*/
+        KEYCHAR_MAP.put((char) 0x1a, KeyEvent.VK_Z);                 /*90,x5a*/
 
-        keycharHash.put(    (char)0x1b   , KeyEvent.VK_OPEN_BRACKET        );             /*91,x5b*/ /*'['*/
-        keycharHash.put(    (char)0x1c   , KeyEvent.VK_BACK_SLASH        );               /*92,x5c*/ /*'\'*/
-        keycharHash.put(    (char)0x1d   , KeyEvent.VK_CLOSE_BRACKET        );            /*93,x5d*/ /*']'*/
-        keycharHash.put(    (char)0x5e   , KeyEvent.VK_CIRCUMFLEX        );               /*94,x5e*/  /*'^' ?? nodead fr, de??*/
-        keycharHash.put(    (char)0x1f   , KeyEvent.VK_UNDERSCORE        );               /*95,x5f*/  /*'_' fr*/
-        keycharHash.put(    (char)0x60   , KeyEvent.VK_BACK_QUOTE        );               /*96,x60*/
+        KEYCHAR_MAP.put((char) 0x1b, KeyEvent.VK_OPEN_BRACKET);      /*91,x5b*/ /*'['*/
+        KEYCHAR_MAP.put((char) 0x1c, KeyEvent.VK_BACK_SLASH);        /*92,x5c*/ /*'\'*/
+        KEYCHAR_MAP.put((char) 0x1d, KeyEvent.VK_CLOSE_BRACKET);     /*93,x5d*/ /*']'*/
+        KEYCHAR_MAP.put((char) 0x5e, KeyEvent.VK_CIRCUMFLEX);        /*94,x5e*/  /*'^' ?? nodead fr, de??*/
+        KEYCHAR_MAP.put((char) 0x1f, KeyEvent.VK_UNDERSCORE);        /*95,x5f*/  /*'_' fr*/
+        KEYCHAR_MAP.put((char) 0x60, KeyEvent.VK_BACK_QUOTE);        /*96,x60*/
+
         /********* Same as uppercase*/
-        //keycharHash.put(  (char)0x1         , KeyEvent.VK_a        );/*97,x61*/
-        //keycharHash.put(  (char)0x2         , KeyEvent.VK_b        );/*98,x62*/
-        //keycharHash.put(  (char)0x3         , KeyEvent.VK_c        );/*99,x63*/
-        //keycharHash.put(  (char)0x4         , KeyEvent.VK_d        );/*100,x64*/
-        //keycharHash.put(  (char)0x5         , KeyEvent.VK_e        );/*101,x65*/
-        //keycharHash.put(  (char)0x6         , KeyEvent.VK_f        );/*102,x66*/
-        //keycharHash.put(  (char)0x7         , KeyEvent.VK_g        );/*103,x67*/
-        //keycharHash.put(  (char)0x8         , KeyEvent.VK_h        );/*104,x68*/
-        //keycharHash.put(  (char)0x9         , KeyEvent.VK_i        );/*105,x69*/
-        //keycharHash.put(  (char)0xa         , KeyEvent.VK_j        );/*106,x6a*/
-        //keycharHash.put(  (char)0xb         , KeyEvent.VK_k        );/*107,x6b*/
-        //keycharHash.put(  (char)0xc         , KeyEvent.VK_l        );/*108,x6c*/
-        //keycharHash.put(  (char)0xd         , KeyEvent.VK_m        );/*109,x6d*/
-        //keycharHash.put(  (char)0xe         , KeyEvent.VK_n        );/*110,x6e*/
-        //keycharHash.put(  (char)0xf         , KeyEvent.VK_o        );/*111,x6f*/
-        //keycharHash.put(  (char)0x10        , KeyEvent.VK_p        );/*112,x70*/
-        //keycharHash.put(  (char)0x11        , KeyEvent.VK_q        );/*113,x71*/
-        //keycharHash.put(  (char)0x12        , KeyEvent.VK_r        );/*114,x72*/
-        //keycharHash.put(  (char)0x13        , KeyEvent.VK_s        );/*115,x73*/
-        //keycharHash.put(  (char)0x14        , KeyEvent.VK_t        );/*116,x74*/
-        //keycharHash.put(  (char)0x15        , KeyEvent.VK_u        );/*117,x75*/
-        //keycharHash.put(  (char)0x16        , KeyEvent.VK_v        );/*118,x76*/
-        //keycharHash.put(  (char)0x17        , KeyEvent.VK_w        );/*119,x77*/
-        //keycharHash.put(  (char)0x18        , KeyEvent.VK_x        );/*120,x78*/
-        //keycharHash.put(  (char)0x19        , KeyEvent.VK_y        );/*121,x79*/
-        //keycharHash.put(  (char)0x1a        , KeyEvent.VK_z        );/*122,x7a*/
+        //keycharHash.put((char)0x1, KeyEvent.VK_a);                 /*97,x61*/
+        //keycharHash.put((char)0x2, KeyEvent.VK_b);                 /*98,x62*/
+        //keycharHash.put((char)0x3, KeyEvent.VK_c);                 /*99,x63*/
+        //keycharHash.put((char)0x4, KeyEvent.VK_d);                 /*100,x64*/
+        //keycharHash.put((char)0x5, KeyEvent.VK_e);                 /*101,x65*/
+        //keycharHash.put((char)0x6, KeyEvent.VK_f);                 /*102,x66*/
+        //keycharHash.put((char)0x7, KeyEvent.VK_g);                 /*103,x67*/
+        //keycharHash.put((char)0x8, KeyEvent.VK_h);                 /*104,x68*/
+        //keycharHash.put((char)0x9, KeyEvent.VK_i);                 /*105,x69*/
+        //keycharHash.put((char)0xa, KeyEvent.VK_j);                 /*106,x6a*/
+        //keycharHash.put((char)0xb, KeyEvent.VK_k);                 /*107,x6b*/
+        //keycharHash.put((char)0xc, KeyEvent.VK_l);                 /*108,x6c*/
+        //keycharHash.put((char)0xd, KeyEvent.VK_m);                 /*109,x6d*/
+        //keycharHash.put((char)0xe, KeyEvent.VK_n);                 /*110,x6e*/
+        //keycharHash.put((char)0xf, KeyEvent.VK_o);                 /*111,x6f*/
+        //keycharHash.put((char)0x10, KeyEvent.VK_p);                /*112,x70*/
+        //keycharHash.put((char)0x11, KeyEvent.VK_q);                /*113,x71*/
+        //keycharHash.put((char)0x12, KeyEvent.VK_r);                /*114,x72*/
+        //keycharHash.put((char)0x13, KeyEvent.VK_s);                /*115,x73*/
+        //keycharHash.put((char)0x14, KeyEvent.VK_t);                /*116,x74*/
+        //keycharHash.put((char)0x15, KeyEvent.VK_u);                /*117,x75*/
+        //keycharHash.put((char)0x16, KeyEvent.VK_v);                /*118,x76*/
+        //keycharHash.put((char)0x17, KeyEvent.VK_w);                /*119,x77*/
+        //keycharHash.put((char)0x18, KeyEvent.VK_x);                /*120,x78*/
+        //keycharHash.put((char)0x19, KeyEvent.VK_y);                /*121,x79*/
+        //keycharHash.put((char)0x1a, KeyEvent.VK_z);                /*122,x7a*/
 
-        keycharHash.put(    (char)0x7b      , KeyEvent.VK_BRACELEFT        );             /*123,x7b*/ /*'{' la (Latin American)*/
-        //keycharHash.put(  (char)0x1c        , KeyEvent.VK_|        );                   /*124,x7c*/ /* no VK, cannot test*/
-        keycharHash.put(    (char)0x7d      , KeyEvent.VK_BRACERIGHT        );            /*125,x7d*/ /*'}' la */
-        //keycharHash.put(  (char)0x1e        , KeyEvent.VK_~        );                   /*126,x7e*/ /* no VK, cannot test*/
+        KEYCHAR_MAP.put((char) 0x7b, KeyEvent.VK_BRACELEFT);         /*123,x7b*/ /*'{' la (Latin American)*/
+        //keycharHash.put(char) 0x1c, KeyEvent.VK_|);                /*124,x7c*/ /* no VK, cannot test*/
+        KEYCHAR_MAP.put((char) 0x7d, KeyEvent.VK_BRACERIGHT);        /*125,x7d*/ /*'}' la */
+        //keycharHash.put((char) 0x1e, KeyEvent.VK_~);               /*126,x7e*/ /* no VK, cannot test*/
 
 
     }
@@ -196,15 +197,11 @@ public class CtrlASCII extends Frame implements KeyListener
             Point pt = getLocationOnScreen();
             robot.mouseMove( pt.x+100, pt.y+100 );
             robot.delay(2000);
-            robot.mousePress( InputEvent.BUTTON1_MASK );
-            robot.mouseRelease( InputEvent.BUTTON1_MASK );
-            Enumeration<Integer> enuElem = keycharHash.elements();
+            robot.mousePress( InputEvent.BUTTON1_DOWN_MASK );
+            robot.mouseRelease( InputEvent.BUTTON1_DOWN_MASK );
 
-            int kc;
-            while( enuElem.hasMoreElements()) {
-                kc = enuElem.nextElement();
-                punchCtrlKey( robot, kc );
-            }
+            KEYCHAR_MAP.forEach((k,v) -> punchCtrlKey(robot, v));
+
             robot.delay(500);
         } catch (Exception e) {
             throw new RuntimeException("The test was not completed.\n\n" + e);
@@ -235,7 +232,7 @@ public class CtrlASCII extends Frame implements KeyListener
     {
         printKey(evt);
         char keych = evt.getKeyChar();
-        if( !keycharHash.containsKey( keych ) ) {
+        if( !KEYCHAR_MAP.containsKey( keych ) ) {
             System.out.println("Unexpected keychar: "+keych);
             System.out.println("Unexpected keychar: "+keych);
             testFailed = true;

--- a/test/jdk/java/awt/event/KeyEvent/KeyTyped/CtrlASCII.java
+++ b/test/jdk/java/awt/event/KeyEvent/KeyTyped/CtrlASCII.java
@@ -49,8 +49,7 @@ import java.util.HashMap;
 // produce a unicode character, so there will be no KEY_TYPED and no problem.
 // Test doesn't try to verify Ctrl+deadkey behavior.
 //
-public class CtrlASCII extends Frame implements KeyListener
-{
+public class CtrlASCII extends Frame implements KeyListener {
     // Declare things used in the test, like buttons and labels here
     static final HashMap<Character, Integer> KEYCHAR_MAP = new HashMap<>();
     static volatile boolean testFailed = false;
@@ -176,9 +175,9 @@ public class CtrlASCII extends Frame implements KeyListener
         robot.setAutoWaitForIdle(true);
         robot.setAutoDelay(100);
 
-        setLayout (new BorderLayout ());
+        setLayout(new BorderLayout());
 
-        setSize(400,300);
+        setSize(400, 300);
         setLocationRelativeTo(null);
         setVisible(true);
 
@@ -197,15 +196,15 @@ public class CtrlASCII extends Frame implements KeyListener
         robot.waitForIdle();
     }//End  init()
 
-    public void start () {
+    public void start() {
         try {
             Point pt = getLocationOnScreen();
-            robot.mouseMove( pt.x+100, pt.y+100 );
+            robot.mouseMove(pt.x + 100, pt.y + 100);
             robot.delay(1000);
-            robot.mousePress( InputEvent.BUTTON1_DOWN_MASK );
-            robot.mouseRelease( InputEvent.BUTTON1_DOWN_MASK );
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
 
-            KEYCHAR_MAP.forEach((k,v) -> punchCtrlKey(v));
+            KEYCHAR_MAP.forEach((k, v) -> punchCtrlKey(v));
 
             robot.delay(500);
         } catch (Exception e) {
@@ -244,8 +243,8 @@ public class CtrlASCII extends Frame implements KeyListener
     public void keyTyped(KeyEvent evt) {
         printKey(evt);
         char keych = evt.getKeyChar();
-        if( !KEYCHAR_MAP.containsKey( keych ) ) {
-            System.out.println("Unexpected keychar: "+keych);
+        if (!KEYCHAR_MAP.containsKey(keych)) {
+            System.out.println("Unexpected keychar: " + keych);
             testFailed = true;
         }
     }
@@ -255,15 +254,14 @@ public class CtrlASCII extends Frame implements KeyListener
     }
 
     protected void printKey(KeyEvent evt) {
-        switch(evt.getID())
-        {
-          case KeyEvent.KEY_TYPED:
-          case KeyEvent.KEY_PRESSED:
-          case KeyEvent.KEY_RELEASED:
-            break;
-          default:
-            System.out.println("Other Event ");
-            return;
+        switch (evt.getID()) {
+            case KeyEvent.KEY_TYPED:
+            case KeyEvent.KEY_PRESSED:
+            case KeyEvent.KEY_RELEASED:
+                break;
+            default:
+                System.out.println("Other Event ");
+                return;
         }
         System.out.println(" 0x" + Integer.toHexString(evt.getKeyChar()));
     }


### PR DESCRIPTION
This test needs more stabilization:

- The test can be easily hang by replacing <br> iteration on `keycharHash.elements()` with `keycharHash.forEach((k, v) -> punchCtrlKey(robot, v));` 
I do not see any reason why we need a synchronized `Hashtable`, so switched to `HashMap`
Looks like it might be a reason of original test hanging.
- `keyRelease`, `dispose` calls wrapped with finally block
- Just to be safe added timeout `@run main/timeout=600` ( none of the CI test runs took too long thought)

CI testing looks good on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8252713](https://bugs.openjdk.org/browse/JDK-8252713): jtreg time out of CtrlASCII.java seems to hang the Xserver.


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [e53dcead](https://git.openjdk.org/jdk/pull/11214/files/e53dceadac2b925103359c4cde0d0cf53fb19486)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11214/head:pull/11214` \
`$ git checkout pull/11214`

Update a local copy of the PR: \
`$ git checkout pull/11214` \
`$ git pull https://git.openjdk.org/jdk pull/11214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11214`

View PR using the GUI difftool: \
`$ git pr show -t 11214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11214.diff">https://git.openjdk.org/jdk/pull/11214.diff</a>

</details>
