### PR TITLE
8296399: crlNumExtVal might be null inside X509CRLSelector::match

### DIFF
--- a/src/java.base/share/classes/java/security/cert/X509CRLSelector.java
+++ b/src/java.base/share/classes/java/security/cert/X509CRLSelector.java
@@ -623,6 +623,7 @@ public class X509CRLSelector implements CRLSelector {
                 if (debug != null) {
                     debug.println("X509CRLSelector.match: no CRLNumber");
                 }
+                return false;
             }
             BigInteger crlNum;
             try {

--- a/test/jdk/java/security/cert/X509CRLSelector/CRLNumberMissing.java
+++ b/test/jdk/java/security/cert/X509CRLSelector/CRLNumberMissing.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.Asserts;
+import sun.security.x509.CRLExtensions;
+import sun.security.x509.CRLNumberExtension;
+import sun.security.x509.X500Name;
+import sun.security.x509.X509CRLImpl;
+
+import java.math.BigInteger;
+import java.security.KeyPairGenerator;
+import java.security.cert.X509CRLSelector;
+import java.util.Date;
+
+/**
+ * @test
+ * @bug 8296399
+ * @summary crlNumExtVal might be null inside X509CRLSelector::match
+ * @library /test/lib
+ * @modules java.base/sun.security.x509
+ */
+
+public class CRLNumberMissing {
+
+    public static void main(String[] args) throws Exception {
+
+        var pk = KeyPairGenerator.getInstance("Ed25519")
+                .generateKeyPair().getPrivate();
+
+        var crlWithoutNum = X509CRLImpl.signNew(
+                new X509CRLImpl.TBSCertList(
+                        new X500Name("CN=CRL"), new Date(), new Date()),
+                pk, "Ed25519");
+
+        var exts = new CRLExtensions();
+        exts.setExtension("CRLNumber", new CRLNumberExtension(1));
+        var crlWithNum = X509CRLImpl.signNew(
+                new X509CRLImpl.TBSCertList(
+                        new X500Name("CN=CRL"), new Date(), new Date(),
+                        null, exts),
+                pk, "Ed25519");
+
+        var sel = new X509CRLSelector();
+        Asserts.assertTrue(sel.match(crlWithNum));
+        Asserts.assertTrue(sel.match(crlWithoutNum));
+
+        sel = new X509CRLSelector();
+        sel.setMinCRLNumber(BigInteger.ZERO);
+        Asserts.assertTrue(sel.match(crlWithNum));
+        Asserts.assertFalse(sel.match(crlWithoutNum));
+
+        sel = new X509CRLSelector();
+        sel.setMinCRLNumber(BigInteger.TWO);
+        Asserts.assertFalse(sel.match(crlWithNum));
+        Asserts.assertFalse(sel.match(crlWithoutNum));
+    }
+}

--- a/test/jdk/java/security/cert/X509CRLSelector/CRLNumberMissing.java
+++ b/test/jdk/java/security/cert/X509CRLSelector/CRLNumberMissing.java
@@ -47,14 +47,14 @@ public class CRLNumberMissing {
         var pk = KeyPairGenerator.getInstance("Ed25519")
                 .generateKeyPair().getPrivate();
 
-        var crlWithoutNum = X509CRLImpl.signNew(
+        var crlWithoutNum = X509CRLImpl.newSigned(
                 new X509CRLImpl.TBSCertList(
                         new X500Name("CN=CRL"), new Date(), new Date()),
                 pk, "Ed25519");
 
         var exts = new CRLExtensions();
         exts.setExtension("CRLNumber", new CRLNumberExtension(1));
-        var crlWithNum = X509CRLImpl.signNew(
+        var crlWithNum = X509CRLImpl.newSigned(
                 new X509CRLImpl.TBSCertList(
                         new X500Name("CN=CRL"), new Date(), new Date(),
                         null, exts),


### PR DESCRIPTION
When `X509CRLSelector ` requires a CRL number extension but a CRL does not have it, the CRL should not be selected.

Note: the test uses a new internal API introduced in https://github.com/openjdk/jdk/pull/11151.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296399](https://bugs.openjdk.org/browse/JDK-8296399): crlNumExtVal might be null inside X509CRLSelector::match


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11215/head:pull/11215` \
`$ git checkout pull/11215`

Update a local copy of the PR: \
`$ git checkout pull/11215` \
`$ git pull https://git.openjdk.org/jdk pull/11215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11215`

View PR using the GUI difftool: \
`$ git pr show -t 11215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11215.diff">https://git.openjdk.org/jdk/pull/11215.diff</a>

</details>
