### PR TITLE
8297080: Remove com/sun/jdi/NashornPopFrameTest.java from the problem list

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -698,8 +698,6 @@ sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java 8265770 macosx-all
 
 com/sun/jdi/RepStep.java                                        8043571 generic-all
 
-com/sun/jdi/NashornPopFrameTest.java                            8225620 generic-all
-
 com/sun/jdi/InvokeHangTest.java                                 8218463 linux-all
 
 com/sun/jdi/AfterThreadDeathTest.java                           8232839 linux-all


### PR DESCRIPTION
The bug is closed (was specific to sparc) and the test no longer exists (Nashorn has been removed). 

I'd like to push this as a trivial change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297080](https://bugs.openjdk.org/browse/JDK-8297080): Remove com/sun/jdi/NashornPopFrameTest.java from the problem list


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11216/head:pull/11216` \
`$ git checkout pull/11216`

Update a local copy of the PR: \
`$ git checkout pull/11216` \
`$ git pull https://git.openjdk.org/jdk pull/11216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11216`

View PR using the GUI difftool: \
`$ git pr show -t 11216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11216.diff">https://git.openjdk.org/jdk/pull/11216.diff</a>

</details>
