### PR TITLE
8297217: Incorrect generation name in the heap verification log message with Serial GC

### DIFF
--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -1062,7 +1062,7 @@ void GenCollectedHeap::verify(VerifyOption option /* ignored */) {
   log_debug(gc, verify)("%s", _old_gen->name());
   _old_gen->verify();
 
-  log_debug(gc, verify)("%s", _old_gen->name());
+  log_debug(gc, verify)("%s", _young_gen->name());
   _young_gen->verify();
 
   log_debug(gc, verify)("RemSet");


### PR DESCRIPTION
Please review this trivial patch to fix the young generation name displayed in the log message during heap verification for Serial GC.

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297217](https://bugs.openjdk.org/browse/JDK-8297217): Incorrect generation name in the heap verification log message with Serial GC


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11219/head:pull/11219` \
`$ git checkout pull/11219`

Update a local copy of the PR: \
`$ git checkout pull/11219` \
`$ git pull https://git.openjdk.org/jdk pull/11219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11219`

View PR using the GUI difftool: \
`$ git pr show -t 11219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11219.diff">https://git.openjdk.org/jdk/pull/11219.diff</a>

</details>
