### PR TITLE
8297083: Remove vmTestbase/nsk/jvmti/GetAllThreads/allthr001 from problem list

### DIFF
--- a/test/hotspot/jtreg/ProblemList-svc-vthread.txt
+++ b/test/hotspot/jtreg/ProblemList-svc-vthread.txt
@@ -32,11 +32,6 @@ serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java          826
 vmTestbase/nsk/jvmti/CompiledMethodUnload/compmethunload001/TestDescription.java
 
 ####
-## NSK JVMTI tests failing with wrapper
-
-vmTestbase/nsk/jvmti/GetAllThreads/allthr001/TestDescription.java 8284027 generic-all
-
-####
 ## Tests for functionality which currently is not supported for virtual threads
 
 vmTestbase/nsk/jvmti/GetCurrentThreadCpuTime/curthrcputime001/TestDescription.java


### PR DESCRIPTION
Remove vmTestbase/nsk/jvmti/GetAllThreads/allthr001 from vthread problem list. [JDK-8284027](https://bugs.openjdk.org/browse/JDK-8284027) has been fixed.

Ran test on all supported platforms with:

`JTREG_EXTRA_PROBLEM_LISTS=ProblemList-svc-vthread.txt JTREG_MAIN_WRAPPER=Virtual TEST_VM_OPTS=-Dmain.wrapper=Virtual`

I'd like to push this as a trivial change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297083](https://bugs.openjdk.org/browse/JDK-8297083): Remove vmTestbase/nsk/jvmti/GetAllThreads/allthr001 from problem list


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11220/head:pull/11220` \
`$ git checkout pull/11220`

Update a local copy of the PR: \
`$ git checkout pull/11220` \
`$ git pull https://git.openjdk.org/jdk pull/11220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11220`

View PR using the GUI difftool: \
`$ git pr show -t 11220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11220.diff">https://git.openjdk.org/jdk/pull/11220.diff</a>

</details>
