### PR TITLE
JDK-8245246: Deprecate -profile option in javac

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
@@ -82,7 +82,8 @@ javac.opt.J=\
 javac.opt.encoding=\
     Specify character encoding used by source files
 javac.opt.profile=\
-    Check that API used is available in the specified profile
+    Check that API used is available in the specified profile.\n\
+    This option is deprecated and may be removed in a future release.
 javac.opt.target=\
     Generate class files suitable for the specified Java SE release. Supported releases: {0}
 javac.opt.release=\
@@ -123,8 +124,6 @@ javac.opt.arg.encoding=\
     <encoding>
 javac.opt.arg.profile=\
     <profile>
-javac.opt.arg.release=\
-    <release>
 javac.opt.arg.release=\
     <release>
 javac.opt.arg.number=\


### PR DESCRIPTION
Please review a trivial update for javac, to note that the `-profile` option is deprecated and may be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8245246](https://bugs.openjdk.org/browse/JDK-8245246): Deprecate -profile option in javac
 * [JDK-8245393](https://bugs.openjdk.org/browse/JDK-8245393): Deprecate -profile option in javac (**CSR**)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11226/head:pull/11226` \
`$ git checkout pull/11226`

Update a local copy of the PR: \
`$ git checkout pull/11226` \
`$ git pull https://git.openjdk.org/jdk pull/11226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11226`

View PR using the GUI difftool: \
`$ git pr show -t 11226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11226.diff">https://git.openjdk.org/jdk/pull/11226.diff</a>

</details>
