### PR TITLE
JDK-8296743: Tighten Class.getModifiers spec for array classes

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -1308,7 +1308,7 @@ public final class Class<T> implements java.io.Serializable,
      * If this {@code Class} object represents a primitive type or
      * void, its {@code public}, {@code abstract}, and {@code final}
      * modifiers are always {@code true}.
-     * For class objects representing void, primitive types, and
+     * For {@code Class} objects representing void, primitive types, and
      * arrays, the values of other modifiers are {@code false} other
      * than as specified above.
      *
@@ -1333,17 +1333,19 @@ public final class Class<T> implements java.io.Serializable,
      * {@return an unmodifiable set of the {@linkplain AccessFlag access
      * flags} for this class, possibly empty}
      *
-     * <p> If the underlying class is an array class, then its
-     * {@code PUBLIC}, {@code PRIVATE} and {@code PROTECTED}
-     * access flags are the same as those of its component type.  If this
-     * {@code Class} object represents a primitive type or void, the
-     * {@code PUBLIC} access flag is present, and the
-     * {@code PROTECTED} and {@code PRIVATE} access flags are always
-     * absent. If this {@code Class} object represents an array class, a
-     * primitive type or void, then the {@code FINAL} access flag is always
-     * present and the interface access flag is always
-     * absent. The values of its other access flags are not determined
-     * by this specification.
+     * <p> If the underlying class is an array class:
+     * <ul>
+     * <li> its {@code PUBLIC}, {@code PRIVATE} and {@code PROTECTED}
+     *      access flags are the same as those of its component type
+     * <li> its {@code FINAL} and {@code ABSTRACT} flags are present
+     * <li> its {@code INTERFACE} flag is absent, even when the
+     *      component type is an interface
+     * </ul>
+     *  If this {@code Class} object represents a primitive type or
+     *  void, the flags are {@code PUBLIC}, {@code ABSTRACT}, and
+     *  {@code FINAL}.
+     * For {@code Class} objects representing void, primitive types, and
+     * arrays, access flags are absent other than as specified above.
      *
      * @see #getModifiers()
      * @jvms 4.1 The ClassFile Structure

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -1296,17 +1296,21 @@ public final class Class<T> implements java.io.Serializable,
      * {@code abstract} and {@code interface}; they should be decoded
      * using the methods of class {@code Modifier}.
      *
-     * <p> If the underlying class is an array class, then its
-     * {@code public}, {@code private} and {@code protected}
-     * modifiers are the same as those of its component type.  If this
-     * {@code Class} object represents a primitive type or void, its
-     * {@code public} modifier is always {@code true}, and its
-     * {@code protected} and {@code private} modifiers are always
-     * {@code false}. If this {@code Class} object represents an array class, a
-     * primitive type or void, then its {@code final} modifier is always
-     * {@code true} and its interface modifier is always
-     * {@code false}. The values of its other modifiers are not determined
-     * by this specification.
+     * <p> If the underlying class is an array class:
+     * <ul>
+     * <li> its {@code public}, {@code private} and {@code protected}
+     *      modifiers are the same as those of its component type
+     * <li> its {@code final} modifier is always
+     *      {@code true}
+     * <li> its interface modifier is always {@code false}, event when
+     *      the component type is an interface
+     * </ul>
+     * If this {@code Class} object represents a primitive type or
+     * void, its {@code public}, {@code abstract}, and {@code final}
+     * modifiers are always {@code true}.
+     * For class objects representing void, primitive types, and
+     * arrays, the values of other modifiers are {@code false} other
+     * than as specified above.
      *
      * <p> The modifier encodings are defined in section {@jvms 4.1}
      * of <cite>The Java Virtual Machine Specification</cite>.
@@ -1320,6 +1324,7 @@ public final class Class<T> implements java.io.Serializable,
      * @since 1.1
      * @jls 8.1.1 Class Modifiers
      * @jls 9.1.1. Interface Modifiers
+     * @jvms 4.1 The {@code ClassFile} Structure
      */
     @IntrinsicCandidate
     public native int getModifiers();

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -1300,7 +1300,7 @@ public final class Class<T> implements java.io.Serializable,
      * <ul>
      * <li> its {@code public}, {@code private} and {@code protected}
      *      modifiers are the same as those of its component type
-     * <li> its {@code final} and {@code abstract} modifiers are always
+     * <li> its {@code abstract} and {@code final} modifiers are always
      *      {@code true}
      * <li> its interface modifier is always {@code false}, even when
      *      the component type is an interface
@@ -1337,13 +1337,13 @@ public final class Class<T> implements java.io.Serializable,
      * <ul>
      * <li> its {@code PUBLIC}, {@code PRIVATE} and {@code PROTECTED}
      *      access flags are the same as those of its component type
-     * <li> its {@code FINAL} and {@code ABSTRACT} flags are present
+     * <li> its {@code ABSTRACT} and {@code FINAL} flags are present
      * <li> its {@code INTERFACE} flag is absent, even when the
      *      component type is an interface
      * </ul>
-     *  If this {@code Class} object represents a primitive type or
-     *  void, the flags are {@code PUBLIC}, {@code ABSTRACT}, and
-     *  {@code FINAL}.
+     * If this {@code Class} object represents a primitive type or
+     * void, the flags are {@code PUBLIC}, {@code ABSTRACT}, and
+     * {@code FINAL}.
      * For {@code Class} objects representing void, primitive types, and
      * arrays, access flags are absent other than as specified above.
      *

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -1300,9 +1300,9 @@ public final class Class<T> implements java.io.Serializable,
      * <ul>
      * <li> its {@code public}, {@code private} and {@code protected}
      *      modifiers are the same as those of its component type
-     * <li> its {@code final} modifier is always
+     * <li> its {@code final} and {@code abstract} modifiers are always
      *      {@code true}
-     * <li> its interface modifier is always {@code false}, event when
+     * <li> its interface modifier is always {@code false}, even when
      *      the component type is an interface
      * </ul>
      * If this {@code Class} object represents a primitive type or

--- a/test/jdk/java/lang/Class/getModifiers/TestPrimitiveAndArrayModifiers.java
+++ b/test/jdk/java/lang/Class/getModifiers/TestPrimitiveAndArrayModifiers.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.reflect.Modifier;
+import java.lang.annotation.*;
+
+/*
+ * @test
+ * @bug 8296743
+ * @summary Verify array classes and primitives have expected modifiers
+ */
+@ExpectedModifiers(Modifier.PUBLIC | Modifier.FINAL | Modifier.ABSTRACT)
+public class TestPrimitiveAndArrayModifiers {
+
+    /*
+     * Relevant excerpt of the Class.getModifiers() specification:
+     * <p> If the underlying class is an array class:
+     * <ul>
+     * <li> its {@code public}, {@code private} and {@code protected}
+     *      modifiers are the same as those of its component type
+     * <li> its {@code final} modifier is always
+     *      {@code true}
+     * <li> its interface modifier is always {@code false}, event when
+     *      the component type is an interface
+     * </ul>
+     */
+
+    public static void main(String... args) throws Exception {
+        testPrimitives();
+        testArrays();
+    }
+
+    private static void testArrays() {
+        Class<?>[] testCases = {
+            TestPrimitiveAndArrayModifiers.class,
+
+            PackagePrivateClass.class,
+            ProtectedClass.class,
+            PrivateClass.class,
+
+            PublicInterface.class,
+            PackagePrivateInterface.class,
+            ProtectedInterface.class,
+            PrivateInterface.class,
+        };
+
+        for(var testCase : testCases) {
+            int expectedModifiers =
+                testCase.getAnnotation(ExpectedModifiers.class).value();
+            Class<?> arrayClass = testCase.arrayType();
+            int actualModifiers = arrayClass.getModifiers();
+            if (expectedModifiers != actualModifiers) {
+                System.out.println("Expected " + Modifier.toString(expectedModifiers) +
+                                   ", but got " + Modifier.toString(actualModifiers));
+                throw new RuntimeException();
+            }
+        }
+    }
+
+    @ExpectedModifiers(Modifier.FINAL | Modifier.ABSTRACT)
+    class PackagePrivateClass {}
+
+    @ExpectedModifiers(Modifier.FINAL | Modifier.ABSTRACT | Modifier.PROTECTED)
+    protected class ProtectedClass {}
+
+    @ExpectedModifiers(Modifier.FINAL | Modifier.ABSTRACT | Modifier.PRIVATE)
+    private class  PrivateClass {}
+
+    @ExpectedModifiers(Modifier.FINAL | Modifier.ABSTRACT | Modifier.PUBLIC)
+    public interface PublicInterface {}
+
+    @ExpectedModifiers(Modifier.FINAL | Modifier.ABSTRACT)
+    interface PackagePrivateInterface {}
+
+    @ExpectedModifiers(Modifier.FINAL | Modifier.ABSTRACT | Modifier.PROTECTED)
+    protected interface ProtectedInterface {}
+
+    @ExpectedModifiers(Modifier.FINAL | Modifier.ABSTRACT | Modifier.PRIVATE)
+    private interface PrivateInterface {}
+
+    /*
+     * Relevant excerpt of the Class.getModifiers() specification:
+     *
+     * If this {@code Class} object represents a primitive type or
+     * void, its {@code public}, {@code abstract}, and {@code final}
+     * modifiers are always {@code true}.
+     */
+    private static void testPrimitives() {
+        Class<?>[] testCases = {
+            void.class,
+            boolean.class,
+            byte.class,
+            short.class,
+            char.class,
+            int.class,
+            float.class,
+            long.class,
+            double.class,
+        };
+
+        for(var testCase : testCases) {
+            int actualModifiers = testCase.getModifiers();
+            if ((Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL) !=
+                actualModifiers) {
+                System.out.println("Bad modifiers " + Modifier.toString(actualModifiers) +
+                                   " on primitive type " + testCase);
+                throw new RuntimeException();
+            }
+        }
+    }
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface ExpectedModifiers {
+    int value() default 0;
+}

--- a/test/jdk/java/lang/Class/getModifiers/TestPrimitiveAndArrayModifiers.java
+++ b/test/jdk/java/lang/Class/getModifiers/TestPrimitiveAndArrayModifiers.java
@@ -38,9 +38,9 @@ public class TestPrimitiveAndArrayModifiers {
      * <ul>
      * <li> its {@code public}, {@code private} and {@code protected}
      *      modifiers are the same as those of its component type
-     * <li> its {@code final} modifier is always
+     * <li> its {@code final} and {@code abstract} modifiers are always
      *      {@code true}
-     * <li> its interface modifier is always {@code false}, event when
+     * <li> its interface modifier is always {@code false}, even when
      *      the component type is an interface
      * </ul>
      */
@@ -70,9 +70,9 @@ public class TestPrimitiveAndArrayModifiers {
             Class<?> arrayClass = testCase.arrayType();
             int actualModifiers = arrayClass.getModifiers();
             if (expectedModifiers != actualModifiers) {
-                System.out.println("Expected " + Modifier.toString(expectedModifiers) +
-                                   ", but got " + Modifier.toString(actualModifiers));
-                throw new RuntimeException();
+                throw new RuntimeException("Expected " + Modifier.toString(expectedModifiers) +
+                                           "on " + testCase.getCanonicalName() +
+                                           ", but got " + Modifier.toString(actualModifiers));
             }
         }
     }
@@ -122,9 +122,9 @@ public class TestPrimitiveAndArrayModifiers {
             int actualModifiers = testCase.getModifiers();
             if ((Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL) !=
                 actualModifiers) {
-                System.out.println("Bad modifiers " + Modifier.toString(actualModifiers) +
-                                   " on primitive type " + testCase);
-                throw new RuntimeException();
+                throw new RuntimeException("Bad modifiers " +
+                                           Modifier.toString(actualModifiers) +
+                                           " on primitive type " + testCase);
             }
         }
     }

--- a/test/jdk/java/lang/reflect/AccessFlag/ClassAccessFlagTest.java
+++ b/test/jdk/java/lang/reflect/AccessFlag/ClassAccessFlagTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8266670 8291734
+ * @bug 8266670 8291734 8296743
  * @summary Test expected AccessFlag's on classes.
  */
 
@@ -98,23 +98,14 @@ public final class ClassAccessFlagTest {
             void.class // same access flag rules
         };
 
-        var mustBePresent = Set.of(AccessFlag.PUBLIC, AccessFlag.FINAL);
-        var mustBeAbsent = Set.of(AccessFlag.PRIVATE,
-                                  AccessFlag.PROTECTED,
-                                  AccessFlag.INTERFACE);
+        var expected = Set.of(AccessFlag.PUBLIC,
+                              AccessFlag.FINAL,
+                              AccessFlag.ABSTRACT);
 
         for(var primClass : primitives) {
-            // PUBLIC must be present, PROTECTED and PRIVATE must be
-            // absent.
-            // FINAL must be present, INTERFACE must be absent.
             var accessFlags = primClass.accessFlags();
-            if (!accessFlags.containsAll(mustBePresent)) {
-                throw new RuntimeException("Missing mandatory flags on " +
-                                           primClass);
-            }
-
-            if (containsAny(accessFlags, mustBeAbsent)) {
-                throw new RuntimeException("Unexpected flags present on " +
+            if (!accessFlags.equals(expected)) {
+                throw new RuntimeException("Unexpected flags on " +
                                            primClass);
             }
         }


### PR DESCRIPTION
Update the spec of Class.getModifiers to match long-standing behavior for primitive and array classes. Remove unneeded implementation flexibility with regard to setting other bit positions. This work was prompted to better support anticipated future Valhalla changes.

Please also review the CSR: https://bugs.openjdk.org/browse/JDK-8297237

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8296743](https://bugs.openjdk.org/browse/JDK-8296743): Tighten Class.getModifiers spec for array classes
 * [JDK-8297237](https://bugs.openjdk.org/browse/JDK-8297237): Tighten Class.getModifiers spec for array classes (**CSR**)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to [3321b086](https://git.openjdk.org/jdk/pull/11229/files/3321b08686ca19c94e8d245d5368425fef9c45a4)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to [375c260d](https://git.openjdk.org/jdk/pull/11229/files/375c260d3de576cc3558b294a9db16700cbebbb3)
 * [Dan Heidinga](https://openjdk.org/census#heidinga) (@DanHeidinga - no project role) ⚠️ Review applies to [375c260d](https://git.openjdk.org/jdk/pull/11229/files/375c260d3de576cc3558b294a9db16700cbebbb3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11229/head:pull/11229` \
`$ git checkout pull/11229`

Update a local copy of the PR: \
`$ git checkout pull/11229` \
`$ git pull https://git.openjdk.org/jdk pull/11229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11229`

View PR using the GUI difftool: \
`$ git pr show -t 11229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11229.diff">https://git.openjdk.org/jdk/pull/11229.diff</a>

</details>
