### PR TITLE
8297129: Inflater documentation refers to 'deflate' methods

### DIFF
--- a/src/java.base/share/classes/java/util/zip/Inflater.java
+++ b/src/java.base/share/classes/java/util/zip/Inflater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ import sun.nio.ch.DirectBuffer;
  * This class inflates sequences of ZLIB compressed bytes. The input byte
  * sequence is provided in either byte array or byte buffer, via one of the
  * {@code setInput()} methods. The output byte sequence is written to the
- * output byte array or byte buffer passed to the {@code deflate()} methods.
+ * output byte array or byte buffer passed to the {@code inflate()} methods.
  * <p>
  * The following code fragment demonstrates a trivial compression
  * and decompression of a string using {@code Deflater} and


### PR DESCRIPTION
Can I please get a review for this doc only change which fixes the javadoc of java.util.zip.Inflater class? As noted in https://bugs.openjdk.org/browse/JDK-8297129, there's a typo in the javadoc. This commit fixes that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297129](https://bugs.openjdk.org/browse/JDK-8297129): Inflater documentation refers to 'deflate' methods


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11232/head:pull/11232` \
`$ git checkout pull/11232`

Update a local copy of the PR: \
`$ git checkout pull/11232` \
`$ git pull https://git.openjdk.org/jdk pull/11232/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11232`

View PR using the GUI difftool: \
`$ git pr show -t 11232`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11232.diff">https://git.openjdk.org/jdk/pull/11232.diff</a>

</details>
