### PR TITLE
JDK-8296945: PublicMethodsTest is slow due to dependency verification with debug builds

### DIFF
--- a/test/jdk/java/lang/reflect/PublicMethods/PublicMethodsTest.java
+++ b/test/jdk/java/lang/reflect/PublicMethods/PublicMethodsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ import static java.util.stream.Collectors.toMap;
  * @modules jdk.compiler
  *          jdk.zipfs
  * @summary Nearly exhaustive test of Class.getMethod() and Class.getMethods()
- * @run main PublicMethodsTest
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies PublicMethodsTest
  */
 public class PublicMethodsTest {
 


### PR DESCRIPTION
As discussed in https://bugs.openjdk.org/browse/JDK-8296945 , let us switch off VerifyDependencies  in this test because of slow machines when (fast)debug builds are used, the test sometimes times out after the [JDK-8266074](https://bugs.openjdk.org/browse/JDK-8266074) Vtable-based CHA implementation  implementation came in.
Same has been done for other tests with similar issues, see 8268227: java/foreign/TestUpcall.java still times out  .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296945](https://bugs.openjdk.org/browse/JDK-8296945): PublicMethodsTest is slow due to dependency verification with debug builds


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11234/head:pull/11234` \
`$ git checkout pull/11234`

Update a local copy of the PR: \
`$ git checkout pull/11234` \
`$ git pull https://git.openjdk.org/jdk pull/11234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11234`

View PR using the GUI difftool: \
`$ git pr show -t 11234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11234.diff">https://git.openjdk.org/jdk/pull/11234.diff</a>

</details>
