### PR TITLE
8297241: Update sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java

### DIFF
--- a/test/jdk/sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java
+++ b/test/jdk/sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java
@@ -63,7 +63,10 @@ public class OnScreenRenderingResizeTest {
     private static Frame frame;
 
     private static void createAndShowGUI() {
-        frame = new Frame();
+        frame = new Frame() {
+            public void paint(Graphics g) {}
+            public void update(Graphics g) {}
+        };
         frame.setBackground(bgColor);
         frame.setUndecorated(true);
         frame.setAlwaysOnTop(true);
@@ -148,6 +151,9 @@ public class OnScreenRenderingResizeTest {
                         incH = -incH;
                     }
                     frame.setSize(w, h);
+                    if (robot != null) {
+                        robot.waitForIdle();
+                    }
                     cnt = 0;
                 }
                 // try to put the device into non-default state, for example,


### PR DESCRIPTION
This is follow up of https://github.com/openjdk/jdk/pull/11158#discussion_r1025574199

I have added empty paint() and update() methods back for the frame in this test.
Ran the test 20 times in our CI machines on all platforms. It failed once in Linux machine and image dump showed nothing was drawn.

Added robot.waitForIdle() after frame.resize() also so that system-triggered repaint can be finished after resize of the frame. With this update i don't see this test failing on all platforms in our CI even when run for 100 times.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8297241](https://bugs.openjdk.org/browse/JDK-8297241): Update sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java
 * [JDK-8297153](https://bugs.openjdk.org/browse/JDK-8297153): sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java fails again


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11237/head:pull/11237` \
`$ git checkout pull/11237`

Update a local copy of the PR: \
`$ git checkout pull/11237` \
`$ git pull https://git.openjdk.org/jdk pull/11237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11237`

View PR using the GUI difftool: \
`$ git pr show -t 11237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11237.diff">https://git.openjdk.org/jdk/pull/11237.diff</a>

</details>
