### PR TITLE
8294924: JvmtiExport::post_exception_throw() doesn't deal well with concurrent stack processing

### DIFF
--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -60,6 +60,7 @@
 #include "runtime/javaCalls.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/jniHandles.inline.hpp"
+#include "runtime/keepStackGCProcessed.hpp" 
 #include "runtime/objectMonitor.hpp"
 #include "runtime/objectMonitor.inline.hpp"
 #include "runtime/os.hpp"
@@ -1964,6 +1965,7 @@ void JvmtiExport::post_exception_throw(JavaThread *thread, Method* method, addre
   HandleMark hm(thread);
   methodHandle mh(thread, method);
   Handle exception_handle(thread, exception);
+  KeepStackGCProcessedMark ksgcpm(thread);
 
   JvmtiThreadState *state = thread->jvmti_thread_state();
   if (state == NULL) {

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -60,7 +60,7 @@
 #include "runtime/javaCalls.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/jniHandles.inline.hpp"
-#include "runtime/keepStackGCProcessed.hpp" 
+#include "runtime/keepStackGCProcessed.hpp"
 #include "runtime/objectMonitor.hpp"
 #include "runtime/objectMonitor.inline.hpp"
 #include "runtime/os.hpp"

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -1965,6 +1965,10 @@ void JvmtiExport::post_exception_throw(JavaThread *thread, Method* method, addre
   HandleMark hm(thread);
   methodHandle mh(thread, method);
   Handle exception_handle(thread, exception);
+  // The KeepStackGCProcessedMark below keeps the target thread and its stack fully
+  // GC processed across this scope. This is needed because there is a stack walk
+  // below with safepoint polls inside of it. After such safepoints, we have to
+  // ensure the stack is sufficiently processed.
   KeepStackGCProcessedMark ksgcpm(thread);
 
   JvmtiThreadState *state = thread->jvmti_thread_state();


### PR DESCRIPTION
There is a stack walk in JvmtiExport::post_exception_throw() that has safepoints in it. This trips up the stack watermark code. This patch adds a RAII object to JvmtiExport::post_exception_throw() that keeps the thread and its stack fully processed throughout the function.
Testing: tier1-7 of ZGC tests on linux x86_64 debug and manual testing of the test that failed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294924](https://bugs.openjdk.org/browse/JDK-8294924): JvmtiExport::post_exception_throw() doesn't deal well with concurrent stack processing


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**) ⚠️ Review applies to [6aabc24b](https://git.openjdk.org/jdk/pull/11238/files/6aabc24bb3ac1d1763fd61d71f71881c1cc8109e)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11238/head:pull/11238` \
`$ git checkout pull/11238`

Update a local copy of the PR: \
`$ git checkout pull/11238` \
`$ git pull https://git.openjdk.org/jdk pull/11238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11238`

View PR using the GUI difftool: \
`$ git pr show -t 11238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11238.diff">https://git.openjdk.org/jdk/pull/11238.diff</a>

</details>
