### PR TITLE
8297238: RISC-V: C2: Use Matcher::vector_element_basic_type when checking for vector element type in predicate

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -359,8 +359,8 @@ instruct vdivD(vReg dst, vReg src1, vReg src2) %{
 // vector integer max/min
 
 instruct vmax(vReg dst, vReg src1, vReg src2) %{
-  predicate(n->bottom_type()->is_vect()->element_basic_type() != T_FLOAT &&
-            n->bottom_type()->is_vect()->element_basic_type() != T_DOUBLE);
+  predicate(Matcher::vector_element_basic_type(n) != T_FLOAT &&
+            Matcher::vector_element_basic_type(n) != T_DOUBLE);
   match(Set dst (MaxV src1 src2));
   ins_cost(VEC_COST);
   format %{ "vmax.vv $dst, $src1, $src2\t#@vmax" %}
@@ -375,8 +375,8 @@ instruct vmax(vReg dst, vReg src1, vReg src2) %{
 %}
 
 instruct vmin(vReg dst, vReg src1, vReg src2) %{
-  predicate(n->bottom_type()->is_vect()->element_basic_type() != T_FLOAT &&
-            n->bottom_type()->is_vect()->element_basic_type() != T_DOUBLE);
+  predicate(Matcher::vector_element_basic_type(n) != T_FLOAT &&
+            Matcher::vector_element_basic_type(n) != T_DOUBLE);
   match(Set dst (MinV src1 src2));
   ins_cost(VEC_COST);
   format %{ "vmin.vv $dst, $src1, $src2\t#@vmin" %}
@@ -393,7 +393,7 @@ instruct vmin(vReg dst, vReg src1, vReg src2) %{
 // vector float-point max/min
 
 instruct vmaxF(vReg dst, vReg src1, vReg src2) %{
-  predicate(n->bottom_type()->is_vect()->element_basic_type() == T_FLOAT);
+  predicate(Matcher::vector_element_basic_type(n) == T_FLOAT);
   match(Set dst (MaxV src1 src2));
   effect(TEMP_DEF dst);
   ins_cost(VEC_COST);
@@ -407,7 +407,7 @@ instruct vmaxF(vReg dst, vReg src1, vReg src2) %{
 %}
 
 instruct vmaxD(vReg dst, vReg src1, vReg src2) %{
-  predicate(n->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE);
+  predicate(Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (MaxV src1 src2));
   effect(TEMP_DEF dst);
   ins_cost(VEC_COST);
@@ -421,7 +421,7 @@ instruct vmaxD(vReg dst, vReg src1, vReg src2) %{
 %}
 
 instruct vminF(vReg dst, vReg src1, vReg src2) %{
-  predicate(n->bottom_type()->is_vect()->element_basic_type() == T_FLOAT);
+  predicate(Matcher::vector_element_basic_type(n) == T_FLOAT);
   match(Set dst (MinV src1 src2));
   effect(TEMP_DEF dst);
   ins_cost(VEC_COST);
@@ -435,7 +435,7 @@ instruct vminF(vReg dst, vReg src1, vReg src2) %{
 %}
 
 instruct vminD(vReg dst, vReg src1, vReg src2) %{
-  predicate(n->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE);
+  predicate(Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (MinV src1 src2));
   effect(TEMP_DEF dst);
   ins_cost(VEC_COST);
@@ -1053,7 +1053,7 @@ instruct vreduce_minL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
 // vector float max reduction
 
 instruct vreduce_maxF(fRegF dst, fRegF src1, vReg src2, vReg tmp1, vReg tmp2) %{
-  predicate(n->in(2)->bottom_type()->is_vect()->element_basic_type() == T_FLOAT);
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_FLOAT);
   match(Set dst (MaxReductionV src1 src2));
   ins_cost(VEC_COST);
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
@@ -1068,7 +1068,7 @@ instruct vreduce_maxF(fRegF dst, fRegF src1, vReg src2, vReg tmp1, vReg tmp2) %{
 %}
 
 instruct vreduce_maxD(fRegD dst, fRegD src1, vReg src2, vReg tmp1, vReg tmp2) %{
-  predicate(n->in(2)->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE);
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_DOUBLE);
   match(Set dst (MaxReductionV src1 src2));
   ins_cost(VEC_COST);
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
@@ -1085,7 +1085,7 @@ instruct vreduce_maxD(fRegD dst, fRegD src1, vReg src2, vReg tmp1, vReg tmp2) %{
 // vector float min reduction
 
 instruct vreduce_minF(fRegF dst, fRegF src1, vReg src2, vReg tmp1, vReg tmp2) %{
-  predicate(n->in(2)->bottom_type()->is_vect()->element_basic_type() == T_FLOAT);
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_FLOAT);
   match(Set dst (MinReductionV src1 src2));
   ins_cost(VEC_COST);
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
@@ -1100,7 +1100,7 @@ instruct vreduce_minF(fRegF dst, fRegF src1, vReg src2, vReg tmp1, vReg tmp2) %{
 %}
 
 instruct vreduce_minD(fRegD dst, fRegD src1, vReg src2, vReg tmp1, vReg tmp2) %{
-  predicate(n->in(2)->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE);
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_DOUBLE);
   match(Set dst (MinReductionV src1 src2));
   ins_cost(VEC_COST);
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
@@ -1117,7 +1117,7 @@ instruct vreduce_minD(fRegD dst, fRegD src1, vReg src2, vReg tmp1, vReg tmp2) %{
 // vector Math.rint, floor, ceil
 
 instruct vroundD(vReg dst, vReg src, immI rmode) %{
-  predicate(n->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE);
+  predicate(Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (RoundDoubleModeV src rmode));
   format %{ "vroundD $dst, $src, $rmode" %}
   ins_encode %{
@@ -1672,7 +1672,7 @@ instruct vlslL_imm(vReg dst, vReg src, immI shift) %{
 %}
 
 instruct vshiftcntB(vReg dst, iRegIorL2I cnt) %{
-  predicate(n->bottom_type()->is_vect()->element_basic_type() == T_BYTE);
+  predicate(Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst (LShiftCntV cnt));
   match(Set dst (RShiftCntV cnt));
   format %{ "vmv.v.x $dst, $cnt\t#@vshiftcntB" %}
@@ -1684,8 +1684,8 @@ instruct vshiftcntB(vReg dst, iRegIorL2I cnt) %{
 %}
 
 instruct vshiftcntS(vReg dst, iRegIorL2I cnt) %{
-  predicate(n->bottom_type()->is_vect()->element_basic_type() == T_SHORT ||
-            n->bottom_type()->is_vect()->element_basic_type() == T_CHAR);
+  predicate(Matcher::vector_element_basic_type(n) == T_SHORT ||
+            Matcher::vector_element_basic_type(n) == T_CHAR);
   match(Set dst (LShiftCntV cnt));
   match(Set dst (RShiftCntV cnt));
   format %{ "vmv.v.x $dst, $cnt\t#@vshiftcntS" %}
@@ -1697,7 +1697,7 @@ instruct vshiftcntS(vReg dst, iRegIorL2I cnt) %{
 %}
 
 instruct vshiftcntI(vReg dst, iRegIorL2I cnt) %{
-  predicate(n->bottom_type()->is_vect()->element_basic_type() == T_INT);
+  predicate(Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst (LShiftCntV cnt));
   match(Set dst (RShiftCntV cnt));
   format %{ "vmv.v.x $dst, $cnt\t#@vshiftcntI" %}
@@ -1709,7 +1709,7 @@ instruct vshiftcntI(vReg dst, iRegIorL2I cnt) %{
 %}
 
 instruct vshiftcntL(vReg dst, iRegIorL2I cnt) %{
-  predicate(n->bottom_type()->is_vect()->element_basic_type() == T_LONG);
+  predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (LShiftCntV cnt));
   match(Set dst (RShiftCntV cnt));
   format %{ "vmv.v.x $dst, $cnt\t#@vshiftcntL" %}


### PR DESCRIPTION
Hi,

In the vector type predicate matching process of riscv, n->bottom_type()->is_vect()->element_basic_type() is used in some places to get the data type, and Matcher::vector_element_basic_type(n) is used in some places to get the data type, In fact, Matcher::vector_element_basic_type(n) is the function encapsulation form of n->bottom_type()->is_vect()->element_basic_type(), here Matcher::vector_element_basic_type(n) is used uniformly to get the data type.

Please take a look and have some reviews. Thanks a lot.

## Testing:
- hotspot and jdk tier1 without new failures (release with UseRVV on QEMU)
- test/jdk/jdk/incubator/vector/* (fastdebug/release with UseRVV on QEMU)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297238](https://bugs.openjdk.org/browse/JDK-8297238): RISC-V: C2: Use Matcher::vector_element_basic_type when checking for vector element type in predicate


### Reviewers
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Author)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11239/head:pull/11239` \
`$ git checkout pull/11239`

Update a local copy of the PR: \
`$ git checkout pull/11239` \
`$ git pull https://git.openjdk.org/jdk pull/11239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11239`

View PR using the GUI difftool: \
`$ git pr show -t 11239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11239.diff">https://git.openjdk.org/jdk/pull/11239.diff</a>

</details>
