### PR TITLE
JDK-8297147: UnexpectedSourceImageSize test times out on slow machines when fastdebug is used

### DIFF
--- a/test/jdk/sun/java2d/cmm/ColorConvertOp/UnexpectedSourceImageSize.java
+++ b/test/jdk/sun/java2d/cmm/ColorConvertOp/UnexpectedSourceImageSize.java
@@ -44,6 +44,7 @@ import static java.awt.image.BufferedImage.TYPE_USHORT_GRAY;
  * @test
  * @bug 8264666
  * @summary No exception or errors should occur in ColorConvertOp.filter().
+ * @run main/othervm/timeout=600 UnexpectedSourceImageSize
  */
 public final class UnexpectedSourceImageSize {
 


### PR DESCRIPTION
The image related test UnexpectedSourceImageSize test introduced with https://bugs.openjdk.org/browse/JDK-8264666
sometimes times out on slow machines when fastdebug is used. This happens especially in 11 and 17; in 20 it seems to be a bit faster but we better change timeouts across releases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297147](https://bugs.openjdk.org/browse/JDK-8297147): UnexpectedSourceImageSize test times out on slow machines when fastdebug is used


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11240/head:pull/11240` \
`$ git checkout pull/11240`

Update a local copy of the PR: \
`$ git checkout pull/11240` \
`$ git pull https://git.openjdk.org/jdk pull/11240/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11240`

View PR using the GUI difftool: \
`$ git pr show -t 11240`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11240.diff">https://git.openjdk.org/jdk/pull/11240.diff</a>

</details>
