### PR TITLE
8297265: G1: Remove unnecessary null-check in RebuildCodeRootClosure::do_code_blob

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3398,12 +3398,10 @@ public:
     _g1h(g1h) {}
 
   void do_code_blob(CodeBlob* cb) {
-    nmethod* nm = (cb != NULL) ? cb->as_nmethod_or_null() : NULL;
-    if (nm == NULL) {
-      return;
+    nmethod* nm = cb->as_nmethod_or_null();
+    if (nm != NULL) {
+      _g1h->register_nmethod(nm);
     }
-
-    _g1h->register_nmethod(nm);
   }
 };
 


### PR DESCRIPTION
Simple change of removing an unnecessary check.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297265](https://bugs.openjdk.org/browse/JDK-8297265): G1: Remove unnecessary null-check in RebuildCodeRootClosure::do_code_blob


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11242/head:pull/11242` \
`$ git checkout pull/11242`

Update a local copy of the PR: \
`$ git checkout pull/11242` \
`$ git pull https://git.openjdk.org/jdk pull/11242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11242`

View PR using the GUI difftool: \
`$ git pr show -t 11242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11242.diff">https://git.openjdk.org/jdk/pull/11242.diff</a>

</details>
