### PR TITLE
8293584: CodeCache::old_nmethods_do incorrectly filters is_unloading nmethods

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1306,6 +1306,9 @@ void CodeCache::old_nmethods_do(MetadataClosure* f) {
   if (old_compiled_method_table != NULL) {
     length = old_compiled_method_table->length();
     for (int i = 0; i < length; i++) {
+      // Walk all methods saved on the last pass.  Concurrent class unloading may
+      // also be looking at this method's metadata, so don't delete it yet if
+      // it is marked as unloaded.
       old_compiled_method_table->at(i)->metadata_do(f);
     }
   }

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1306,11 +1306,7 @@ void CodeCache::old_nmethods_do(MetadataClosure* f) {
   if (old_compiled_method_table != NULL) {
     length = old_compiled_method_table->length();
     for (int i = 0; i < length; i++) {
-      CompiledMethod* cm = old_compiled_method_table->at(i);
-      // Only walk !is_unloading nmethods, the other ones will get removed by the GC.
-      if (!cm->is_unloading()) {
-        old_compiled_method_table->at(i)->metadata_do(f);
-      }
+      old_compiled_method_table->at(i)->metadata_do(f);
     }
   }
   log_debug(redefine, class, nmethod)("Walked %d nmethods for mark_on_stack", length);


### PR DESCRIPTION
I fixed the code to also include is_unloading nmethods.  I couldn't write a dedicated test for this.
Tested with tier1-4,6.  Also tried to reproduce another redefinition bug with this change, which didn't reproduce, but not caused by this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293584](https://bugs.openjdk.org/browse/JDK-8293584): CodeCache::old_nmethods_do incorrectly filters is_unloading nmethods


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to [de0a72c9](https://git.openjdk.org/jdk/pull/11243/files/de0a72c9baa42ed265ffd2493af5323b7644c299)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11243/head:pull/11243` \
`$ git checkout pull/11243`

Update a local copy of the PR: \
`$ git checkout pull/11243` \
`$ git pull https://git.openjdk.org/jdk pull/11243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11243`

View PR using the GUI difftool: \
`$ git pr show -t 11243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11243.diff">https://git.openjdk.org/jdk/pull/11243.diff</a>

</details>
