### PR TITLE
8297289: problem list runtime/vthread/RedefineClass.java and TestObjectAllocationSampleEvent.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -97,6 +97,8 @@ runtime/os/TestTracePageSizes.java#G1 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
+runtime/vthread/RedefineClass.java 8297286 generic-all
+runtime/vthread/TestObjectAllocationSampleEvent.java 8297286 generic-all
 
 applications/jcstress/copy.java 8229852 linux-all
 


### PR DESCRIPTION
A trivial fix to ProblemList two tests:
  runtime/vthread/RedefineClass.java
  runtime/vthread/TestObjectAllocationSampleEvent.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297289](https://bugs.openjdk.org/browse/JDK-8297289): problem list runtime/vthread/RedefineClass.java and TestObjectAllocationSampleEvent.java


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11245/head:pull/11245` \
`$ git checkout pull/11245`

Update a local copy of the PR: \
`$ git checkout pull/11245` \
`$ git pull https://git.openjdk.org/jdk pull/11245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11245`

View PR using the GUI difftool: \
`$ git pr show -t 11245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11245.diff">https://git.openjdk.org/jdk/pull/11245.diff</a>

</details>
