### PR TITLE
8297293: Add java/nio/channels/FileChannel/FileExtensionAndMap.java to ProblemList

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -555,6 +555,8 @@ java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc6
 
 java/nio/channels/DatagramChannel/ManySourcesAndTargets.java    8264385 macosx-aarch64
 
+java/nio/channels/FileChannel/FileExtensionAndMap.java          8297292 generic-all
+
 ############################################################################
 
 # jdk_rmi


### PR DESCRIPTION
java/nio/channels/FileChannel/FileExtensionAndMap.java was excluded for a long time because it required too many resources. It was re-enabled recently via JDK-8249693 but it's back causing problems again add adding up to 40 minutes to jdk/:tier2_part2. I'd like to exclude it again until the test can be re-written.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297293](https://bugs.openjdk.org/browse/JDK-8297293): Add java/nio/channels/FileChannel/FileExtensionAndMap.java to ProblemList


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11247/head:pull/11247` \
`$ git checkout pull/11247`

Update a local copy of the PR: \
`$ git checkout pull/11247` \
`$ git pull https://git.openjdk.org/jdk pull/11247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11247`

View PR using the GUI difftool: \
`$ git pr show -t 11247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11247.diff">https://git.openjdk.org/jdk/pull/11247.diff</a>

</details>
