### PR TITLE
JDK-8297299 SequenceInputStream should not use Vector

### DIFF
--- a/src/java.base/share/classes/java/io/SequenceInputStream.java
+++ b/src/java.base/share/classes/java/io/SequenceInputStream.java
@@ -44,8 +44,8 @@ import java.util.Objects;
  * @since   1.0
  */
 public class SequenceInputStream extends InputStream {
-    Enumeration<? extends InputStream> e;
-    InputStream in;
+    private final Enumeration<? extends InputStream> e;
+    private InputStream in;
 
     /**
      * Initializes a newly created {@code SequenceInputStream}

--- a/src/java.base/share/classes/java/io/SequenceInputStream.java
+++ b/src/java.base/share/classes/java/io/SequenceInputStream.java
@@ -25,9 +25,9 @@
 
 package java.io;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -80,7 +80,10 @@ public class SequenceInputStream extends InputStream {
      * @param   s2   the second input stream to read.
      */
     public SequenceInputStream(InputStream s1, InputStream s2) {
-        e = Collections.enumeration(s2 == null ? List.of(s1) : List.of(s1, s2));
+        var list = new ArrayList<InputStream>(2);
+        list.add(s1);
+        list.add(s2);
+        e = Collections.enumeration(list);
         peekNextStream();
     }
 

--- a/src/java.base/share/classes/java/io/SequenceInputStream.java
+++ b/src/java.base/share/classes/java/io/SequenceInputStream.java
@@ -25,7 +25,7 @@
 
 package java.io;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Objects;
@@ -80,11 +80,7 @@ public class SequenceInputStream extends InputStream {
      * @param   s2   the second input stream to read.
      */
     public SequenceInputStream(InputStream s1, InputStream s2) {
-        var list = new ArrayList<InputStream>(2);
-        list.add(s1);
-        list.add(s2);
-        e = Collections.enumeration(list);
-        peekNextStream();
+        this(Collections.enumeration(Arrays.asList(s1, s2)));
     }
 
     /**

--- a/src/java.base/share/classes/java/io/SequenceInputStream.java
+++ b/src/java.base/share/classes/java/io/SequenceInputStream.java
@@ -80,7 +80,7 @@ public class SequenceInputStream extends InputStream {
      * @param   s2   the second input stream to read.
      */
     public SequenceInputStream(InputStream s1, InputStream s2) {
-        e = Collections.enumeration(List.of(s1, s2));
+        e = Collections.enumeration(s2 == null ? List.of(s1) : List.of(s1, s2));
         peekNextStream();
     }
 

--- a/src/java.base/share/classes/java/io/SequenceInputStream.java
+++ b/src/java.base/share/classes/java/io/SequenceInputStream.java
@@ -25,9 +25,10 @@
 
 package java.io;
 
+import java.util.Collections;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Objects;
-import java.util.Vector;
 
 /**
  * A {@code SequenceInputStream} represents
@@ -39,7 +40,7 @@ import java.util.Vector;
  * and so on, until end of file is reached
  * on the last of the contained input streams.
  *
- * @author  Author van Hoff
+ * @author  Arthur van Hoff
  * @since   1.0
  */
 public class SequenceInputStream extends InputStream {
@@ -79,10 +80,7 @@ public class SequenceInputStream extends InputStream {
      * @param   s2   the second input stream to read.
      */
     public SequenceInputStream(InputStream s1, InputStream s2) {
-        Vector<InputStream> v = new Vector<>(2);
-        v.addElement(s1);
-        v.addElement(s2);
-        e = v.elements();
+        e = Collections.enumeration(List.of(s1, s2));
         peekNextStream();
     }
 


### PR DESCRIPTION
There is no need to use a temporary Vector within the constructor of SynchronizedInputStream, as more efficient (non-synchronized) alternative code (like List.of) will do the same in possibly less time. While the optimization is not dramatic, it still makes sense to replace Vector unless synchronization is really needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297299](https://bugs.openjdk.org/browse/JDK-8297299): SequenceInputStream should not use Vector


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11249/head:pull/11249` \
`$ git checkout pull/11249`

Update a local copy of the PR: \
`$ git checkout pull/11249` \
`$ git pull https://git.openjdk.org/jdk pull/11249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11249`

View PR using the GUI difftool: \
`$ git pr show -t 11249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11249.diff">https://git.openjdk.org/jdk/pull/11249.diff</a>

</details>
