### PR TITLE
8294583: JShell: NPE in switch with non existing record pattern

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTaskImpl.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTaskImpl.java
@@ -401,7 +401,11 @@ public class JavacTaskImpl extends BasicJavacTask {
         final ListBuffer<Element> results = new ListBuffer<>();
         try {
             if (classes == null) {
-                handleFlowResults(compiler.flow(compiler.attribute(compiler.todo)), results);
+                Queue<Env<AttrContext>> attribute = compiler.attribute(compiler.todo);
+
+                if (compiler.errorCount() == 0) {
+                    handleFlowResults(compiler.flow(attribute), results);
+                }
             } else {
                 Filter f = new Filter() {
                     @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTaskImpl.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTaskImpl.java
@@ -401,11 +401,7 @@ public class JavacTaskImpl extends BasicJavacTask {
         final ListBuffer<Element> results = new ListBuffer<>();
         try {
             if (classes == null) {
-                Queue<Env<AttrContext>> attribute = compiler.attribute(compiler.todo);
-
-                if (compiler.errorCount() == 0) {
-                    handleFlowResults(compiler.flow(attribute), results);
-                }
+                handleFlowResults(compiler.flow(compiler.attribute(compiler.todo)), results);
             } else {
                 Filter f = new Filter() {
                     @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4183,6 +4183,7 @@ public class Attr extends JCTree.Visitor {
             expectedRecordTypes = Stream.generate(() -> Type.noType)
                                 .limit(tree.nested.size())
                                 .collect(List.collector());
+            tree.record = syms.errSymbol;
         }
         ListBuffer<BindingSymbol> outBindings = new ListBuffer<>();
         List<Type> recordTypes = expectedRecordTypes;

--- a/test/langtools/jdk/jshell/Test8294583.java
+++ b/test/langtools/jdk/jshell/Test8294583.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/jshell/Test8294583.java
+++ b/test/langtools/jdk/jshell/Test8294583.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8294583
+ * @summary JShell: NPE in switch with non existing record pattern
+ * @build KullaTesting TestingInputStream
+ * @run testng Test8294583
+ */
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+
+@Test
+public class Test8294583 extends KullaTesting {
+
+    public void test() {
+        assertEvalFail("switch (new Object()) {\n" +
+                        "   case Foo() -> {}\n" +
+                        "};");
+    }
+
+    @org.testng.annotations.BeforeMethod
+    public void setUp() {
+        super.setUp(bc -> bc.compilerOptions("--source", System.getProperty("java.specification.version"), "--enable-preview").remoteVMOptions("--enable-preview"));
+    }
+}


### PR DESCRIPTION
This fixes a situation where attribution errors are not short circuiting the compilation of an expression, e.g., in case of a declaration missing in the JShell evaluation of a switch expression.

Now there are two options:

1. handle this in `handleSwitch` (specific to switches, and avoid the `NPE` raised according to the JBS description)
2. handle this centrally in the corresponding task that is used in two places: 1) JShell evaluation and 2) `tools.javac.combo`.

I adopted the second option. Any thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294583](https://bugs.openjdk.org/browse/JDK-8294583): JShell: NPE in switch with non existing record pattern


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**) ⚠️ Review applies to [696c03ed](https://git.openjdk.org/jdk/pull/11251/files/696c03ed1c7f00f00ad664c63e2f4d4b2c642a2d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11251/head:pull/11251` \
`$ git checkout pull/11251`

Update a local copy of the PR: \
`$ git checkout pull/11251` \
`$ git pull https://git.openjdk.org/jdk pull/11251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11251`

View PR using the GUI difftool: \
`$ git pr show -t 11251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11251.diff">https://git.openjdk.org/jdk/pull/11251.diff</a>

</details>
