### PR TITLE
8297303: ProblemList java/awt/Mouse/EnterExitEvents/DragWindowTest.java on macosx-all

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -673,6 +673,8 @@ java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64
 java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 macosx-aarch64
 javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8274106 macosx-aarch64
 
+java/awt/Mouse/EnterExitEvents/DragWindowTest.java 8297296 macosx-all
+
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8293001 linux-all
 sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java 8265770 macosx-all
 


### PR DESCRIPTION
A trivial fix to ProblemList java/awt/Mouse/EnterExitEvents/DragWindowTest.java on macosx-all

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297303](https://bugs.openjdk.org/browse/JDK-8297303): ProblemList java/awt/Mouse/EnterExitEvents/DragWindowTest.java on macosx-all


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11252/head:pull/11252` \
`$ git checkout pull/11252`

Update a local copy of the PR: \
`$ git checkout pull/11252` \
`$ git pull https://git.openjdk.org/jdk pull/11252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11252`

View PR using the GUI difftool: \
`$ git pr show -t 11252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11252.diff">https://git.openjdk.org/jdk/pull/11252.diff</a>

</details>
