### PR TITLE
8296957: One more cast in SAFE_SIZE_NEW_ARRAY2

### DIFF
--- a/src/java.desktop/share/native/common/awt/utility/sizecalc.h
+++ b/src/java.desktop/share/native/common/awt/utility/sizecalc.h
@@ -91,7 +91,7 @@
     (IS_SAFE_SIZE_MUL(sizeof(type), (n)) ? (new type[(size_t)(n)]) : throw std::bad_alloc())
 
 #define SAFE_SIZE_NEW_ARRAY2(type, n, m) \
-    (IS_SAFE_SIZE_MUL((m), (n)) && IS_SAFE_SIZE_MUL(sizeof(type), (n) * (m)) ? \
+    (IS_SAFE_SIZE_MUL((m), (n)) && IS_SAFE_SIZE_MUL(sizeof(type), (size_t)(n) * (size_t)(m)) ? \
      (new type[(size_t)(n) * (size_t)(m)]) : throw std::bad_alloc())
 
 /*


### PR DESCRIPTION
Implementation of SAFE_SIZE_NEW_ARRAY2 in the `sizecalc.h` missed one cast to the size_t

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296957](https://bugs.openjdk.org/browse/JDK-8296957): One more cast in SAFE_SIZE_NEW_ARRAY2


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11253/head:pull/11253` \
`$ git checkout pull/11253`

Update a local copy of the PR: \
`$ git checkout pull/11253` \
`$ git pull https://git.openjdk.org/jdk pull/11253/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11253`

View PR using the GUI difftool: \
`$ git pr show -t 11253`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11253.diff">https://git.openjdk.org/jdk/pull/11253.diff</a>

</details>
