### PR TITLE
8297168: Provide a bulk OopHandle release mechanism with the ServiceThread

### DIFF
--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -600,10 +600,7 @@ JavaThread::JavaThread(ThreadFunction entry_point, size_t stack_sz) : JavaThread
 JavaThread::~JavaThread() {
 
   // Ask ServiceThread to release the OopHandles
-  ServiceThread::add_oop_handle_release(_threadObj);
-  ServiceThread::add_oop_handle_release(_vthread);
-  ServiceThread::add_oop_handle_release(_jvmti_vthread);
-  ServiceThread::add_oop_handle_release(_extentLocalCache);
+  ServiceThread::add_oop_handle_release_for(this);
 
   // Return the sleep event to the free list
   ParkEvent::Release(_SleepEvent);

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -599,8 +599,8 @@ JavaThread::JavaThread(ThreadFunction entry_point, size_t stack_sz) : JavaThread
 
 JavaThread::~JavaThread() {
 
-  // Ask ServiceThread to release the OopHandles
-  ServiceThread::add_oop_handle_release_for(this);
+  // Enqueue OopHandles for release by the service thread.
+  add_oop_handles_for_release();
 
   // Return the sleep event to the free list
   ParkEvent::Release(_SleepEvent);
@@ -2069,4 +2069,58 @@ void JavaThread::vm_exit_on_osthread_failure(JavaThread* thread) {
     vm_exit_during_initialization("java.lang.OutOfMemoryError",
                                   os::native_thread_creation_failed_msg());
   }
+}
+
+// Deferred OopHandle release support.
+
+class OopHandleList : public CHeapObj<mtInternal> {
+  static const int _count = 4;
+  OopHandle _handles[_count];
+  OopHandleList* _next;
+  int _index;
+ public:
+  OopHandleList(OopHandleList* next) : _next(next), _index(0) {}
+  void add(OopHandle h) {
+    assert(_index < _count, "too many additions");
+    _handles[_index++] = h;
+  }
+  ~OopHandleList() {
+    assert(_index == _count, "usage error");
+    for (int i = 0; i < _index; i++) {
+      _handles[i].release(JavaThread::thread_oop_storage());
+    }
+  }
+  OopHandleList* next() const { return _next; }
+};
+
+OopHandleList* JavaThread::_oop_handle_list = nullptr;
+
+// Called by the ServiceThread to do the work of releasing
+// the OopHandles.
+void JavaThread::release_oop_handles() {
+  OopHandleList* list;
+  {
+    MutexLocker ml(Service_lock, Mutex::_no_safepoint_check_flag);
+    list = _oop_handle_list;
+    _oop_handle_list = nullptr;
+  }
+  assert(!SafepointSynchronize::is_at_safepoint(), "cannot be called at a safepoint");
+
+  while (list != nullptr) {
+    OopHandleList* l = list;
+    list = l->next();
+    delete l;
+  }
+}
+
+// Add our OopHandles for later release.
+void JavaThread::add_oop_handles_for_release() {
+  MutexLocker ml(Service_lock, Mutex::_no_safepoint_check_flag);
+  OopHandleList* new_head = new OopHandleList(_oop_handle_list);
+  new_head->add(_threadObj);
+  new_head->add(_vthread);
+  new_head->add(_jvmti_vthread);
+  new_head->add(_extentLocalCache);
+  _oop_handle_list = new_head;
+  Service_lock->notify_all();
 }

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -86,6 +86,10 @@ class JavaThread: public Thread {
   bool           _in_asgct;                      // Is set when this JavaThread is handling ASGCT call
   bool           _on_thread_list;                // Is set when this JavaThread is added to the Threads list
 
+  // All references to Java objects managed via OopHandles. These
+  // have to be released by the ServiceThread after the JavaThread has
+  // terminated. If you add/remove an OopHandle be sure to update the
+  // ServiceThread code to match.
   OopHandle      _threadObj;                     // The Java level thread object
   OopHandle      _vthread; // the value returned by Thread.currentThread(): the virtual thread, if mounted, otherwise _threadObj
   OopHandle      _jvmti_vthread;

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -59,6 +59,7 @@ class JvmtiSampledObjectAllocEventCollector;
 class JvmtiThreadState;
 
 class Metadata;
+class OopHandleList;
 class OopStorage;
 class OSThread;
 
@@ -81,15 +82,14 @@ class JavaThread: public Thread {
   friend class HandshakeState;
   friend class Continuation;
   friend class Threads;
-  friend class ServiceThread; // for OopHandle access
+  friend class ServiceThread; // for deferred OopHandle release access
  private:
   bool           _in_asgct;                      // Is set when this JavaThread is handling ASGCT call
   bool           _on_thread_list;                // Is set when this JavaThread is added to the Threads list
 
   // All references to Java objects managed via OopHandles. These
   // have to be released by the ServiceThread after the JavaThread has
-  // terminated. If you add/remove an OopHandle be sure to update the
-  // ServiceThread code to match.
+  // terminated - see add_oop_handles_for_release().
   OopHandle      _threadObj;                     // The Java level thread object
   OopHandle      _vthread; // the value returned by Thread.currentThread(): the virtual thread, if mounted, otherwise _threadObj
   OopHandle      _jvmti_vthread;
@@ -1174,6 +1174,20 @@ public:
   // AsyncGetCallTrace support
   inline bool in_asgct(void) {return _in_asgct;}
   inline void set_in_asgct(bool value) {_in_asgct = value;}
+
+  // Deferred OopHandle release support
+ private:
+  // List of OopHandles to be released - guarded by the Service_lock.
+  static OopHandleList* _oop_handle_list;
+  // Add our OopHandles to the list for the service thread to release.
+  void add_oop_handles_for_release();
+  // Called by the ServiceThread to release the OopHandles.
+  static void release_oop_handles();
+  // Called by the ServiceThread to poll if there are any OopHandles to release.
+  // Called when holding the Service_lock.
+  static bool has_oop_handles_to_release() {
+    return _oop_handle_list != nullptr;
+  }
 };
 
 inline JavaThread* JavaThread::current_or_null() {

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -81,9 +81,11 @@ class JavaThread: public Thread {
   friend class HandshakeState;
   friend class Continuation;
   friend class Threads;
+  friend class ServiceThread; // for OopHandle access
  private:
   bool           _in_asgct;                      // Is set when this JavaThread is handling ASGCT call
   bool           _on_thread_list;                // Is set when this JavaThread is added to the Threads list
+
   OopHandle      _threadObj;                     // The Java level thread object
   OopHandle      _vthread; // the value returned by Thread.currentThread(): the virtual thread, if mounted, otherwise _threadObj
   OopHandle      _jvmti_vthread;

--- a/src/hotspot/share/runtime/serviceThread.cpp
+++ b/src/hotspot/share/runtime/serviceThread.cpp
@@ -59,45 +59,6 @@ JvmtiDeferredEvent* ServiceThread::_jvmti_event = NULL;
 // to add this field to the per-JavaThread event queue.  TODO: fix this sometime later
 JvmtiDeferredEventQueue ServiceThread::_jvmti_service_queue;
 
-// Defer releasing JavaThread OopHandles to the ServiceThread
-class OopHandleList : public CHeapObj<mtInternal> {
-  static const int _count = 4;  // Need to keep in sync with JavaThread
-  OopHandle _handles[_count];
-  OopHandleList* _next;
-  int _index;
- public:
-  OopHandleList(OopHandleList* next) : _next(next), _index(0) {}
-  void add(OopHandle h) {
-    assert(_index < _count, "too many additions");
-    _handles[_index++] = h;
-  }
-  ~OopHandleList() {
-    assert(_index == _count, "usage error");
-    for (int i = 0; i < _index; i++) {
-      _handles[i].release(JavaThread::thread_oop_storage());
-    }
-  }
-  OopHandleList* next() const { return _next; }
-};
-
-static OopHandleList* _oop_handle_list = NULL;
-
-static void release_oop_handles() {
-  OopHandleList* list;
-  {
-    MutexLocker ml(Service_lock, Mutex::_no_safepoint_check_flag);
-    list = _oop_handle_list;
-    _oop_handle_list = NULL;
-  }
-  assert(!SafepointSynchronize::is_at_safepoint(), "cannot be called at a safepoint");
-
-  while (list != NULL) {
-    OopHandleList* l = list;
-    list = l->next();
-    delete l;
-  }
-}
-
 void ServiceThread::initialize() {
   EXCEPTION_MARK;
 
@@ -161,7 +122,7 @@ void ServiceThread::service_thread_entry(JavaThread* jt, TRAPS) {
               (thread_id_table_work = ThreadIdTable::has_work()) |
               (protection_domain_table_work = ProtectionDomainCacheTable::has_work()) |
               (oopstorage_work = OopStorage::has_cleanup_work_and_reset()) |
-              (oop_handles_to_release = (_oop_handle_list != NULL)) |
+              (oop_handles_to_release = JavaThread::has_oop_handles_to_release()) |
               (cldg_cleanup_work = ClassLoaderDataGraph::should_clean_metaspaces_and_reset()) |
               (jvmti_tagmap_work = JvmtiTagMap::has_object_free_events_and_reset())
              ) == 0) {
@@ -224,7 +185,7 @@ void ServiceThread::service_thread_entry(JavaThread* jt, TRAPS) {
     }
 
     if (oop_handles_to_release) {
-      release_oop_handles();
+      JavaThread::release_oop_handles();
     }
 
     if (cldg_cleanup_work) {
@@ -269,15 +230,4 @@ void ServiceThread::nmethods_do(CodeBlobClosure* cf) {
     MutexLocker ml(Service_lock, Mutex::_no_safepoint_check_flag);
     _jvmti_service_queue.nmethods_do(cf);
   }
-}
-
-void ServiceThread::add_oop_handle_release_for(JavaThread* jt) {
-  MutexLocker ml(Service_lock, Mutex::_no_safepoint_check_flag);
-  OopHandleList* new_head = new OopHandleList(_oop_handle_list);
-  new_head->add(jt->_threadObj);
-  new_head->add(jt->_vthread);
-  new_head->add(jt->_jvmti_vthread);
-  new_head->add(jt->_extentLocalCache);
-  _oop_handle_list = new_head;
-  Service_lock->notify_all();
 }

--- a/src/hotspot/share/runtime/serviceThread.cpp
+++ b/src/hotspot/share/runtime/serviceThread.cpp
@@ -73,7 +73,7 @@ class OopHandleList : public CHeapObj<mtInternal> {
   }
   ~OopHandleList() {
     assert(_index == _count, "usage error");
-    for (int i = 0; i < _count; i++) {
+    for (int i = 0; i < _index; i++) {
       _handles[i].release(JavaThread::thread_oop_storage());
     }
   }

--- a/src/hotspot/share/runtime/serviceThread.hpp
+++ b/src/hotspot/share/runtime/serviceThread.hpp
@@ -52,8 +52,6 @@ class ServiceThread : public JavaThread {
 
   // Add event to the service thread event queue.
   static void enqueue_deferred_event(JvmtiDeferredEvent* event);
-  // Add jt's OopHandles to the service thread OopHandle queue to be released.
-  static void add_oop_handle_release_for(JavaThread* jt);
 
   // GC support
   void oops_do_no_frames(OopClosure* f, CodeBlobClosure* cf);

--- a/src/hotspot/share/runtime/serviceThread.hpp
+++ b/src/hotspot/share/runtime/serviceThread.hpp
@@ -52,7 +52,8 @@ class ServiceThread : public JavaThread {
 
   // Add event to the service thread event queue.
   static void enqueue_deferred_event(JvmtiDeferredEvent* event);
-  static void add_oop_handle_release(OopHandle handle);
+  // Add jt's OopHandles to the service thread OopHandle queue to be released.
+  static void add_oop_handle_release_for(JavaThread* jt);
 
   // GC support
   void oops_do_no_frames(OopClosure* f, CodeBlobClosure* cf);


### PR DESCRIPTION
When a `JavaThread` terminates it has to release all `OopHandles` that it uses. This can't be done by the thread itself due to timing issues, so it is handed-off to the `ServiceThread` to do it - ref [JDK-8244997](https://bugs.openjdk.org/browse/JDK-8244997).

Initially there was only one `OopHandle` to handle - that of the `threadObj`, but since Loom there are another 3 `OopHandles` to process. The existing logic does the hand-off one `OopHandle` at a time but that is a potential synchronization bottleneck because each hand-off acquires the `ServiceLock`, enqueues the `OopHandle`, issues a notify to (potentially) wakeup the `ServiceThread` and then releases the `ServiceLock`. This can lead to high contention on the `ServiceLock` and also bad scheduling interactions with the `ServiceThread`.

This PR contains two commits. The first simply changes the API so that we pass the target `JavaThread` so that all 4  `OopHandles` can be extracted in one call. The second commit looks at streamlining things further by consolidating  into a single `OopHandleList` instance.

As `ServiceThread is a subclass of `JavaThread` I wasn't concerned about it having detailed knowledge of the JavaThread implementation.

Testing:
  - tiers 1-3
  - checked still no memory leak (ref [JDK-8296463](https://bugs.openjdk.org/browse/JDK-8296463))

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297168](https://bugs.openjdk.org/browse/JDK-8297168): Provide a bulk OopHandle release mechanism with the ServiceThread


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11254/head:pull/11254` \
`$ git checkout pull/11254`

Update a local copy of the PR: \
`$ git checkout pull/11254` \
`$ git pull https://git.openjdk.org/jdk pull/11254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11254`

View PR using the GUI difftool: \
`$ git pr show -t 11254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11254.diff">https://git.openjdk.org/jdk/pull/11254.diff</a>

</details>
