### PR TITLE
JDK-8297309: Memory leak in ShenandoahFullGC

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -66,6 +66,10 @@ ShenandoahFullGC::ShenandoahFullGC() :
   _gc_timer(ShenandoahHeap::heap()->gc_timer()),
   _preserved_marks(new PreservedMarksSet(true)) {}
 
+ShenandoahFullGC::~ShenandoahFullGC() {
+  delete _preserved_marks;
+}
+
 bool ShenandoahFullGC::collect(GCCause::Cause cause) {
   vmop_entry_full(cause);
   // Always success

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.hpp
@@ -66,6 +66,7 @@ private:
 
 public:
   ShenandoahFullGC();
+  ~ShenandoahFullGC();
   bool collect(GCCause::Cause cause);
 
 private:


### PR DESCRIPTION
Signed-off-by: Justin King <jcking@google.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297309](https://bugs.openjdk.org/browse/JDK-8297309): Memory leak in ShenandoahFullGC


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11255/head:pull/11255` \
`$ git checkout pull/11255`

Update a local copy of the PR: \
`$ git checkout pull/11255` \
`$ git pull https://git.openjdk.org/jdk pull/11255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11255`

View PR using the GUI difftool: \
`$ git pr show -t 11255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11255.diff">https://git.openjdk.org/jdk/pull/11255.diff</a>

</details>
