### PR TITLE
8297211: Expensive fillInStackTrace operation in HttpURLConnection.getOutputStream0 when no content-length in response

### DIFF
--- a/src/java.base/share/classes/java/net/URLConnection.java
+++ b/src/java.base/share/classes/java/net/URLConnection.java
@@ -623,8 +623,7 @@ public abstract class URLConnection {
         if (value != null) {
             try {
                 return Integer.parseInt(value);
-            } catch (NumberFormatException e) {
-            }
+            } catch (NumberFormatException e) { }
         }
         return Default;
     }
@@ -649,8 +648,7 @@ public abstract class URLConnection {
         if (value != null) {
             try {
                 return Long.parseLong(value);
-            } catch (NumberFormatException e) {
-            }
+            } catch (NumberFormatException e) { }
         }
         return Default;
     }
@@ -677,7 +675,7 @@ public abstract class URLConnection {
         if (value != null) {
             try {
                 return Date.parse(value);
-            } catch (NumberFormatException e) { }
+            } catch (Exception e) { }
         }
         return Default;
     }

--- a/src/java.base/share/classes/java/net/URLConnection.java
+++ b/src/java.base/share/classes/java/net/URLConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -619,10 +619,13 @@ public abstract class URLConnection {
      *          missing or malformed.
      */
     public int getHeaderFieldInt(String name, int Default) {
-        String value = getHeaderField(name);
-        try {
-            return Integer.parseInt(value);
-        } catch (Exception e) { }
+        final String value = getHeaderField(name);
+        if (value != null) {
+            try {
+                return Integer.parseInt(value);
+            } catch (NumberFormatException e) {
+            }
+        }
         return Default;
     }
 
@@ -642,10 +645,13 @@ public abstract class URLConnection {
      * @since 1.7
      */
     public long getHeaderFieldLong(String name, long Default) {
-        String value = getHeaderField(name);
-        try {
-            return Long.parseLong(value);
-        } catch (Exception e) { }
+        final String value = getHeaderField(name);
+        if (value != null) {
+            try {
+                return Long.parseLong(value);
+            } catch (NumberFormatException e) {
+            }
+        }
         return Default;
     }
 
@@ -667,10 +673,12 @@ public abstract class URLConnection {
      */
     @SuppressWarnings("deprecation")
     public long getHeaderFieldDate(String name, long Default) {
-        String value = getHeaderField(name);
-        try {
-            return Date.parse(value);
-        } catch (Exception e) { }
+        final String value = getHeaderField(name);
+        if (value != null) {
+            try {
+                return Date.parse(value);
+            } catch (NumberFormatException e) { }
+        }
         return Default;
     }
 

--- a/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
@@ -1936,9 +1936,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
                 if (contentLengthVal != null) {
                     try {
                         cl = Long.parseLong(contentLengthVal);
-                    } catch (NumberFormatException nfe) {
-                        // ignore
-                    }
+                    } catch (NumberFormatException nfe) { }
                 }
 
                 if (method.equals("HEAD") || cl == 0 ||

--- a/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
@@ -1932,9 +1932,14 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
                     continue;
                 }
 
-                try {
-                    cl = Long.parseLong(responses.findValue("content-length"));
-                } catch (Exception exc) { };
+                final String contentLengthVal = responses.findValue("content-length");
+                if (contentLengthVal != null) {
+                    try {
+                        cl = Long.parseLong(contentLengthVal);
+                    } catch (NumberFormatException nfe) {
+                        // ignore
+                    }
+                }
 
                 if (method.equals("HEAD") || cl == 0 ||
                     respCode == HTTP_NOT_MODIFIED ||


### PR DESCRIPTION
Can I please get a review for this small change which addresses https://bugs.openjdk.org/browse/JDK-8297211? 
The change checks if the `content-length` header value is present before parsing it into a `Long` value. The commit also now catches the more specific `NumberFormatException` instead of a general `Exception`. Given the context of the code, I believe this change in the exception type in the catch block should be fine.

No new test has been introduced given the nature of this change. I have triggered existing tests to verify no unexpected regressions show up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297211](https://bugs.openjdk.org/browse/JDK-8297211): Expensive fillInStackTrace operation in HttpURLConnection.getOutputStream0 when no content-length in response


### Reviewers
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11258/head:pull/11258` \
`$ git checkout pull/11258`

Update a local copy of the PR: \
`$ git checkout pull/11258` \
`$ git pull https://git.openjdk.org/jdk pull/11258/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11258`

View PR using the GUI difftool: \
`$ git pr show -t 11258`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11258.diff">https://git.openjdk.org/jdk/pull/11258.diff</a>

</details>
