### PR TITLE
8297333: Parallel: Remove unused methods in PCIterateMarkAndPushClosure

### DIFF
--- a/src/hotspot/share/gc/parallel/psCompactionManager.hpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.hpp
@@ -182,10 +182,6 @@ class ParCompactionManager : public CHeapObj<mtGC> {
   // Check mark and maybe push on marking stack.
   template <typename T> inline void mark_and_push(T* p);
 
-  inline void follow_klass(Klass* klass);
-
-  void follow_class_loader(ClassLoaderData* klass);
-
   // Access function for compaction managers
   static ParCompactionManager* gc_thread_compaction_manager(uint index);
 

--- a/src/hotspot/share/gc/parallel/psCompactionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.inline.hpp
@@ -61,9 +61,6 @@ public:
   template <typename T> void do_oop_nv(T* p)      { _compaction_manager->mark_and_push(p); }
   virtual void do_oop(oop* p)                     { do_oop_nv(p); }
   virtual void do_oop(narrowOop* p)               { do_oop_nv(p); }
-
-  void do_klass_nv(Klass* k)                      { _compaction_manager->follow_klass(k); }
-  void do_cld_nv(ClassLoaderData* cld)            { _compaction_manager->follow_class_loader(cld); }
 };
 
 inline bool ParCompactionManager::steal(int queue_num, oop& t) {
@@ -119,11 +116,6 @@ inline void ParCompactionManager::mark_and_push(T* p) {
   }
 }
 
-inline void ParCompactionManager::follow_klass(Klass* klass) {
-  oop holder = klass->class_loader_data()->holder_no_keepalive();
-  mark_and_push(&holder);
-}
-
 inline void ParCompactionManager::FollowStackClosure::do_void() {
   _compaction_manager->follow_marking_stacks();
   if (_terminator != nullptr) {
@@ -166,11 +158,6 @@ inline void ParCompactionManager::update_contents(oop obj) {
     PCAdjustPointerClosure apc(this);
     obj->oop_iterate(&apc);
   }
-}
-
-inline void ParCompactionManager::follow_class_loader(ClassLoaderData* cld) {
-  PCMarkAndPushClosure mark_and_push_closure(this);
-  cld->oops_do(&mark_and_push_closure, true);
 }
 
 inline void ParCompactionManager::follow_contents(oop obj) {


### PR DESCRIPTION
Trivial change of removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297333](https://bugs.openjdk.org/browse/JDK-8297333): Parallel: Remove unused methods in PCIterateMarkAndPushClosure


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11261/head:pull/11261` \
`$ git checkout pull/11261`

Update a local copy of the PR: \
`$ git checkout pull/11261` \
`$ git pull https://git.openjdk.org/jdk pull/11261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11261`

View PR using the GUI difftool: \
`$ git pr show -t 11261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11261.diff">https://git.openjdk.org/jdk/pull/11261.diff</a>

</details>
