### PR TITLE
8297342: make LOG=debug is too verbose

### DIFF
--- a/make/common/MakeBase.gmk
+++ b/make/common/MakeBase.gmk
@@ -219,7 +219,7 @@ define NamedParamsMacroTemplate
   $(foreach i,$(PARAM_SEQUENCE), $(if $(strip $($i)),\
     $(strip $1)_$(strip $(call EscapeHash, $(call DoubleDollar, $($i))))$(NEWLINE)))
   # Debug print all named parameter names and values
-  $(if $(findstring $(LOG_LEVEL),debug trace), \
+  $(if $(findstring $(LOG_LEVEL), trace), \
     $(info $0 $(strip $1) $(foreach i,$(PARAM_SEQUENCE), \
       $(if $(strip $($i)),$(NEWLINE) $(strip [$i] $(if $(filter $(LOG_LEVEL), trace), \
         $($i), $(wordlist 1, 20, $($(i))) $(if $(word 21, $($(i))), ...)))))))


### PR DESCRIPTION
The `debug` level of make logging is not really useful, since it spits out a full expansion of all named param macro arguments and their values. 

With the NamedParamsMacroTemplate being stable for years, this is seldom useful, and the massive amount of logs drown out everything else.

We should move this debugging to the `trace` level.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297342](https://bugs.openjdk.org/browse/JDK-8297342): make LOG=debug is too verbose


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11264/head:pull/11264` \
`$ git checkout pull/11264`

Update a local copy of the PR: \
`$ git checkout pull/11264` \
`$ git pull https://git.openjdk.org/jdk pull/11264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11264`

View PR using the GUI difftool: \
`$ git pr show -t 11264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11264.diff">https://git.openjdk.org/jdk/pull/11264.diff</a>

</details>
