### PR TITLE
8297347: Problem list compiler/debug/TestStress*.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -68,6 +68,9 @@ compiler/c2/Test8004741.java 8235801 generic-all
 
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-all
 
+compiler/debug/TestStressCM.java 8297343 generic-all
+compiler/debug/TestStressIGVNAndCCP.java 8297343 generic-all
+
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
Problem list tests until [JDK-8297343](https://bugs.openjdk.org/browse/JDK-8297343) is fixed.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297347](https://bugs.openjdk.org/browse/JDK-8297347): Problem list compiler/debug/TestStress*.java


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11267/head:pull/11267` \
`$ git checkout pull/11267`

Update a local copy of the PR: \
`$ git checkout pull/11267` \
`$ git pull https://git.openjdk.org/jdk pull/11267/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11267`

View PR using the GUI difftool: \
`$ git pr show -t 11267`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11267.diff">https://git.openjdk.org/jdk/pull/11267.diff</a>

</details>
