### PR TITLE
8297348: make CONF=xxx should match if xxx is an exact match

### DIFF
--- a/make/InitSupport.gmk
+++ b/make/InitSupport.gmk
@@ -204,6 +204,15 @@ ifeq ($(HAS_SPEC),)
           # Otherwise select those that contain the given CONF string
           matching_confs := $$(strip $$(foreach var, $$(all_confs), \
               $$(if $$(findstring $$(CONF), $$(var)), $$(var))))
+          ifneq ($$(filter $$(CONF), $$(matching_confs)), )
+            # If we found an exact match, use that
+            matching_confs := $$(CONF)
+            # Don't repeat this output on make restarts caused by including
+            # generated files.
+            ifeq ($$(MAKE_RESTARTS),)
+              $$(info Using exact match for CONF=$$(CONF) (other matches are possible))
+            endif
+          endif
         endif
         ifeq ($$(matching_confs),)
           $$(info Error: No configurations found matching CONF=$$(CONF).)


### PR DESCRIPTION
A typical use case for multiple configurations is that you have a release configuration (say `linux-x64`) and a debug configuration (say `linux-x64-debug`). You can now easily select the debug configuration with `CONF=debug`, or both configurations with `CONF=`, but there is no way to select just the release configuration. Instead, workarounds using `SPEC` or `CONF_NAME` (which always does an exact match) is needed.

Instead, we should modify the behavior of `CONF` slightly, so if it gets an exact match, it should behave like `CONF_NAME` and select just that configurations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297348](https://bugs.openjdk.org/browse/JDK-8297348): make CONF=xxx should match if xxx is an exact match


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11269/head:pull/11269` \
`$ git checkout pull/11269`

Update a local copy of the PR: \
`$ git checkout pull/11269` \
`$ git pull https://git.openjdk.org/jdk pull/11269/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11269`

View PR using the GUI difftool: \
`$ git pr show -t 11269`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11269.diff">https://git.openjdk.org/jdk/pull/11269.diff</a>

</details>
