### PR TITLE
8297350: Update JMH devkit to 1.36

### DIFF
--- a/make/devkit/createJMHBundle.sh
+++ b/make/devkit/createJMHBundle.sh
@@ -26,7 +26,7 @@
 # Create a bundle in the build directory, containing what's needed to
 # build and run JMH microbenchmarks from the OpenJDK build.
 
-JMH_VERSION=1.35
+JMH_VERSION=1.36
 COMMONS_MATH3_VERSION=3.2
 JOPT_SIMPLE_VERSION=5.0.4
 


### PR DESCRIPTION
JMH 1.36 was released, so we can bump the devkit too.

Additional testing:
 - [x] Ad-hoc benchmarks with newly generated devkit

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297350](https://bugs.openjdk.org/browse/JDK-8297350): Update JMH devkit to 1.36


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11271/head:pull/11271` \
`$ git checkout pull/11271`

Update a local copy of the PR: \
`$ git checkout pull/11271` \
`$ git pull https://git.openjdk.org/jdk pull/11271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11271`

View PR using the GUI difftool: \
`$ git pr show -t 11271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11271.diff">https://git.openjdk.org/jdk/pull/11271.diff</a>

</details>
