### PR TITLE
8297353: Regenerated checked-in html files with new pandoc

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -5,127 +5,230 @@
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
   <title>Building the JDK</title>
-  <style type="text/css">
-      code{white-space: pre-wrap;}
-      span.smallcaps{font-variant: small-caps;}
-      span.underline{text-decoration: underline;}
-      div.column{display: inline-block; vertical-align: top; width: 50%;}
+  <style>
+    code{white-space: pre-wrap;}
+    span.smallcaps{font-variant: small-caps;}
+    div.columns{display: flex; gap: min(4vw, 1.5em);}
+    div.column{flex: auto; overflow-x: auto;}
+    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+    ul.task-list{list-style: none;}
+    ul.task-list li input[type="checkbox"] {
+      width: 0.8em;
+      margin: 0 0.8em 0.2em -1.6em;
+      vertical-align: middle;
+    }
+    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
   </style>
   <link rel="stylesheet" href="../make/data/docs-resources/resources/jdk-default.css" />
+  <style type="text/css">pre, code, tt { color: #1d6ae5; }</style>
   <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
   <![endif]-->
-  <style type="text/css">pre, code, tt { color: #1d6ae5; }</style>
 </head>
 <body>
 <header id="title-block-header">
 <h1 class="title">Building the JDK</h1>
 </header>
-<nav id="TOC">
+<nav id="TOC" role="doc-toc">
 <ul>
-<li><a href="#tldr-instructions-for-the-impatient">TL;DR (Instructions for the Impatient)</a></li>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#getting-the-source-code">Getting the Source Code</a><ul>
-<li><a href="#special-considerations">Special Considerations</a></li>
+<li><a href="#tldr-instructions-for-the-impatient"
+id="toc-tldr-instructions-for-the-impatient">TL;DR (Instructions for the
+Impatient)</a></li>
+<li><a href="#introduction" id="toc-introduction">Introduction</a></li>
+<li><a href="#getting-the-source-code"
+id="toc-getting-the-source-code">Getting the Source Code</a>
+<ul>
+<li><a href="#special-considerations"
+id="toc-special-considerations">Special Considerations</a></li>
 </ul></li>
-<li><a href="#build-hardware-requirements">Build Hardware Requirements</a><ul>
-<li><a href="#building-on-x86">Building on x86</a></li>
-<li><a href="#building-on-aarch64">Building on aarch64</a></li>
-<li><a href="#building-on-32-bit-arm">Building on 32-bit arm</a></li>
+<li><a href="#build-hardware-requirements"
+id="toc-build-hardware-requirements">Build Hardware Requirements</a>
+<ul>
+<li><a href="#building-on-x86" id="toc-building-on-x86">Building on
+x86</a></li>
+<li><a href="#building-on-aarch64" id="toc-building-on-aarch64">Building
+on aarch64</a></li>
+<li><a href="#building-on-32-bit-arm"
+id="toc-building-on-32-bit-arm">Building on 32-bit arm</a></li>
 </ul></li>
-<li><a href="#operating-system-requirements">Operating System Requirements</a><ul>
-<li><a href="#windows">Windows</a></li>
-<li><a href="#macos">macOS</a></li>
-<li><a href="#linux">Linux</a></li>
-<li><a href="#aix">AIX</a></li>
+<li><a href="#operating-system-requirements"
+id="toc-operating-system-requirements">Operating System Requirements</a>
+<ul>
+<li><a href="#windows" id="toc-windows">Windows</a></li>
+<li><a href="#macos" id="toc-macos">macOS</a></li>
+<li><a href="#linux" id="toc-linux">Linux</a></li>
+<li><a href="#aix" id="toc-aix">AIX</a></li>
 </ul></li>
-<li><a href="#native-compiler-toolchain-requirements">Native Compiler (Toolchain) Requirements</a><ul>
-<li><a href="#gcc">gcc</a></li>
-<li><a href="#clang">clang</a></li>
-<li><a href="#apple-xcode">Apple Xcode</a></li>
-<li><a href="#microsoft-visual-studio">Microsoft Visual Studio</a></li>
-<li><a href="#ibm-xl-cc">IBM XL C/C++</a></li>
+<li><a href="#native-compiler-toolchain-requirements"
+id="toc-native-compiler-toolchain-requirements">Native Compiler
+(Toolchain) Requirements</a>
+<ul>
+<li><a href="#gcc" id="toc-gcc">gcc</a></li>
+<li><a href="#clang" id="toc-clang">clang</a></li>
+<li><a href="#apple-xcode" id="toc-apple-xcode">Apple Xcode</a></li>
+<li><a href="#microsoft-visual-studio"
+id="toc-microsoft-visual-studio">Microsoft Visual Studio</a></li>
+<li><a href="#ibm-xl-cc" id="toc-ibm-xl-cc">IBM XL C/C++</a></li>
 </ul></li>
-<li><a href="#boot-jdk-requirements">Boot JDK Requirements</a><ul>
-<li><a href="#getting-jdk-binaries">Getting JDK binaries</a></li>
+<li><a href="#boot-jdk-requirements" id="toc-boot-jdk-requirements">Boot
+JDK Requirements</a>
+<ul>
+<li><a href="#getting-jdk-binaries"
+id="toc-getting-jdk-binaries">Getting JDK binaries</a></li>
 </ul></li>
-<li><a href="#external-library-requirements">External Library Requirements</a><ul>
-<li><a href="#freetype">FreeType</a></li>
-<li><a href="#cups">CUPS</a></li>
-<li><a href="#x11">X11</a></li>
-<li><a href="#alsa">ALSA</a></li>
-<li><a href="#libffi">libffi</a></li>
+<li><a href="#external-library-requirements"
+id="toc-external-library-requirements">External Library Requirements</a>
+<ul>
+<li><a href="#freetype" id="toc-freetype">FreeType</a></li>
+<li><a href="#cups" id="toc-cups">CUPS</a></li>
+<li><a href="#x11" id="toc-x11">X11</a></li>
+<li><a href="#alsa" id="toc-alsa">ALSA</a></li>
+<li><a href="#libffi" id="toc-libffi">libffi</a></li>
 </ul></li>
-<li><a href="#build-tools-requirements">Build Tools Requirements</a><ul>
-<li><a href="#autoconf">Autoconf</a></li>
-<li><a href="#gnu-make">GNU Make</a></li>
-<li><a href="#gnu-bash">GNU Bash</a></li>
+<li><a href="#build-tools-requirements"
+id="toc-build-tools-requirements">Build Tools Requirements</a>
+<ul>
+<li><a href="#autoconf" id="toc-autoconf">Autoconf</a></li>
+<li><a href="#gnu-make" id="toc-gnu-make">GNU Make</a></li>
+<li><a href="#gnu-bash" id="toc-gnu-bash">GNU Bash</a></li>
 </ul></li>
-<li><a href="#running-configure">Running Configure</a><ul>
-<li><a href="#common-configure-arguments">Common Configure Arguments</a></li>
-<li><a href="#configure-control-variables">Configure Control Variables</a></li>
+<li><a href="#running-configure" id="toc-running-configure">Running
+Configure</a>
+<ul>
+<li><a href="#common-configure-arguments"
+id="toc-common-configure-arguments">Common Configure Arguments</a></li>
+<li><a href="#configure-control-variables"
+id="toc-configure-control-variables">Configure Control
+Variables</a></li>
 </ul></li>
-<li><a href="#running-make">Running Make</a><ul>
-<li><a href="#common-make-targets">Common Make Targets</a></li>
-<li><a href="#make-control-variables">Make Control Variables</a></li>
+<li><a href="#running-make" id="toc-running-make">Running Make</a>
+<ul>
+<li><a href="#common-make-targets" id="toc-common-make-targets">Common
+Make Targets</a></li>
+<li><a href="#make-control-variables"
+id="toc-make-control-variables">Make Control Variables</a></li>
 </ul></li>
-<li><a href="#running-tests">Running Tests</a></li>
-<li><a href="#signing">Signing</a><ul>
-<li><a href="#macos-1">macOS</a></li>
+<li><a href="#running-tests" id="toc-running-tests">Running
+Tests</a></li>
+<li><a href="#signing" id="toc-signing">Signing</a>
+<ul>
+<li><a href="#macos-1" id="toc-macos-1">macOS</a></li>
 </ul></li>
-<li><a href="#cross-compiling">Cross-compiling</a><ul>
-<li><a href="#cross-compiling-the-easy-way-with-openjdk-devkits">Cross compiling the easy way with OpenJDK devkits</a></li>
-<li><a href="#boot-jdk-and-build-jdk">Boot JDK and Build JDK</a></li>
-<li><a href="#specifying-the-target-platform">Specifying the Target Platform</a></li>
-<li><a href="#toolchain-considerations">Toolchain Considerations</a></li>
-<li><a href="#native-libraries">Native Libraries</a></li>
-<li><a href="#cross-compiling-with-debian-sysroots">Cross compiling with Debian sysroots</a></li>
-<li><a href="#building-for-armaarch64">Building for ARM/aarch64</a></li>
-<li><a href="#building-for-musl">Building for musl</a></li>
-<li><a href="#verifying-the-build">Verifying the Build</a></li>
+<li><a href="#cross-compiling"
+id="toc-cross-compiling">Cross-compiling</a>
+<ul>
+<li><a href="#cross-compiling-the-easy-way-with-openjdk-devkits"
+id="toc-cross-compiling-the-easy-way-with-openjdk-devkits">Cross
+compiling the easy way with OpenJDK devkits</a></li>
+<li><a href="#boot-jdk-and-build-jdk"
+id="toc-boot-jdk-and-build-jdk">Boot JDK and Build JDK</a></li>
+<li><a href="#specifying-the-target-platform"
+id="toc-specifying-the-target-platform">Specifying the Target
+Platform</a></li>
+<li><a href="#toolchain-considerations"
+id="toc-toolchain-considerations">Toolchain Considerations</a></li>
+<li><a href="#native-libraries" id="toc-native-libraries">Native
+Libraries</a></li>
+<li><a href="#cross-compiling-with-debian-sysroots"
+id="toc-cross-compiling-with-debian-sysroots">Cross compiling with
+Debian sysroots</a></li>
+<li><a href="#building-for-armaarch64"
+id="toc-building-for-armaarch64">Building for ARM/aarch64</a></li>
+<li><a href="#building-for-musl" id="toc-building-for-musl">Building for
+musl</a></li>
+<li><a href="#verifying-the-build"
+id="toc-verifying-the-build">Verifying the Build</a></li>
 </ul></li>
-<li><a href="#build-performance">Build Performance</a><ul>
-<li><a href="#disk-speed">Disk Speed</a></li>
-<li><a href="#virus-checking">Virus Checking</a></li>
-<li><a href="#ccache">Ccache</a></li>
-<li><a href="#precompiled-headers">Precompiled Headers</a></li>
-<li><a href="#icecc-icecream">Icecc / icecream</a></li>
-<li><a href="#using-the-javac-server">Using the javac server</a></li>
-<li><a href="#building-the-right-target">Building the Right Target</a></li>
+<li><a href="#build-performance" id="toc-build-performance">Build
+Performance</a>
+<ul>
+<li><a href="#disk-speed" id="toc-disk-speed">Disk Speed</a></li>
+<li><a href="#virus-checking" id="toc-virus-checking">Virus
+Checking</a></li>
+<li><a href="#ccache" id="toc-ccache">Ccache</a></li>
+<li><a href="#precompiled-headers"
+id="toc-precompiled-headers">Precompiled Headers</a></li>
+<li><a href="#icecc-icecream" id="toc-icecc-icecream">Icecc /
+icecream</a></li>
+<li><a href="#using-the-javac-server"
+id="toc-using-the-javac-server">Using the javac server</a></li>
+<li><a href="#building-the-right-target"
+id="toc-building-the-right-target">Building the Right Target</a></li>
 </ul></li>
-<li><a href="#troubleshooting">Troubleshooting</a><ul>
-<li><a href="#locating-the-source-of-the-error">Locating the Source of the Error</a></li>
-<li><a href="#fixing-unexpected-build-failures">Fixing Unexpected Build Failures</a></li>
-<li><a href="#specific-build-issues">Specific Build Issues</a></li>
-<li><a href="#getting-help">Getting Help</a></li>
+<li><a href="#troubleshooting"
+id="toc-troubleshooting">Troubleshooting</a>
+<ul>
+<li><a href="#locating-the-source-of-the-error"
+id="toc-locating-the-source-of-the-error">Locating the Source of the
+Error</a></li>
+<li><a href="#fixing-unexpected-build-failures"
+id="toc-fixing-unexpected-build-failures">Fixing Unexpected Build
+Failures</a></li>
+<li><a href="#specific-build-issues"
+id="toc-specific-build-issues">Specific Build Issues</a></li>
+<li><a href="#getting-help" id="toc-getting-help">Getting Help</a></li>
 </ul></li>
-<li><a href="#reproducible-builds">Reproducible Builds</a></li>
-<li><a href="#hints-and-suggestions-for-advanced-users">Hints and Suggestions for Advanced Users</a><ul>
-<li><a href="#bash-completion">Bash Completion</a></li>
-<li><a href="#using-multiple-configurations">Using Multiple Configurations</a></li>
-<li><a href="#handling-reconfigurations">Handling Reconfigurations</a></li>
-<li><a href="#using-fine-grained-make-targets">Using Fine-Grained Make Targets</a></li>
+<li><a href="#reproducible-builds"
+id="toc-reproducible-builds">Reproducible Builds</a></li>
+<li><a href="#hints-and-suggestions-for-advanced-users"
+id="toc-hints-and-suggestions-for-advanced-users">Hints and Suggestions
+for Advanced Users</a>
+<ul>
+<li><a href="#bash-completion" id="toc-bash-completion">Bash
+Completion</a></li>
+<li><a href="#using-multiple-configurations"
+id="toc-using-multiple-configurations">Using Multiple
+Configurations</a></li>
+<li><a href="#handling-reconfigurations"
+id="toc-handling-reconfigurations">Handling Reconfigurations</a></li>
+<li><a href="#using-fine-grained-make-targets"
+id="toc-using-fine-grained-make-targets">Using Fine-Grained Make
+Targets</a></li>
 </ul></li>
-<li><a href="#understanding-the-build-system">Understanding the Build System</a><ul>
-<li><a href="#configurations">Configurations</a></li>
-<li><a href="#build-output-structure">Build Output Structure</a></li>
-<li><a href="#fixpath">Fixpath</a></li>
-<li><a href="#native-debug-symbols">Native Debug Symbols</a></li>
-<li><a href="#autoconf-details">Autoconf Details</a></li>
-<li><a href="#developing-the-build-system-itself">Developing the Build System Itself</a></li>
+<li><a href="#understanding-the-build-system"
+id="toc-understanding-the-build-system">Understanding the Build
+System</a>
+<ul>
+<li><a href="#configurations"
+id="toc-configurations">Configurations</a></li>
+<li><a href="#build-output-structure"
+id="toc-build-output-structure">Build Output Structure</a></li>
+<li><a href="#fixpath" id="toc-fixpath">Fixpath</a></li>
+<li><a href="#native-debug-symbols" id="toc-native-debug-symbols">Native
+Debug Symbols</a></li>
+<li><a href="#autoconf-details" id="toc-autoconf-details">Autoconf
+Details</a></li>
+<li><a href="#developing-the-build-system-itself"
+id="toc-developing-the-build-system-itself">Developing the Build System
+Itself</a></li>
 </ul></li>
-<li><a href="#contributing-to-the-jdk">Contributing to the JDK</a></li>
-<li><a href="#editing-this-document">Editing this document</a></li>
+<li><a href="#contributing-to-the-jdk"
+id="toc-contributing-to-the-jdk">Contributing to the JDK</a></li>
+<li><a href="#editing-this-document"
+id="toc-editing-this-document">Editing this document</a></li>
 </ul>
 </nav>
-<h2 id="tldr-instructions-for-the-impatient">TL;DR (Instructions for the Impatient)</h2>
-<p>If you are eager to try out building the JDK, these simple steps works most of the time. They assume that you have installed Git (and Cygwin if running on Windows) and cloned the top-level JDK repository that you want to build.</p>
+<h2 id="tldr-instructions-for-the-impatient">TL;DR (Instructions for the
+Impatient)</h2>
+<p>If you are eager to try out building the JDK, these simple steps
+works most of the time. They assume that you have installed Git (and
+Cygwin if running on Windows) and cloned the top-level JDK repository
+that you want to build.</p>
 <ol type="1">
-<li><p><a href="#getting-the-source-code">Get the complete source code</a>:<br />
+<li><p><a href="#getting-the-source-code">Get the complete source
+code</a>:<br />
 <code>git clone https://git.openjdk.org/jdk/</code></p></li>
 <li><p><a href="#running-configure">Run configure</a>:<br />
 <code>bash configure</code></p>
-<p>If <code>configure</code> fails due to missing dependencies (to either the <a href="#native-compiler-toolchain-requirements">toolchain</a>, <a href="#build-tools-requirements">build tools</a>, <a href="#external-library-requirements">external libraries</a> or the <a href="#boot-jdk-requirements">boot JDK</a>), most of the time it prints a suggestion on how to resolve the situation on your platform. Follow the instructions, and try running <code>bash configure</code> again.</p></li>
+<p>If <code>configure</code> fails due to missing dependencies (to
+either the <a
+href="#native-compiler-toolchain-requirements">toolchain</a>, <a
+href="#build-tools-requirements">build tools</a>, <a
+href="#external-library-requirements">external libraries</a> or the <a
+href="#boot-jdk-requirements">boot JDK</a>), most of the time it prints
+a suggestion on how to resolve the situation on your platform. Follow
+the instructions, and try running <code>bash configure</code>
+again.</p></li>
 <li><p><a href="#running-make">Run make</a>:<br />
 <code>make images</code></p></li>
 <li><p>Verify your newly built JDK:<br />
@@ -133,48 +236,118 @@
 <li><p><a href="##running-tests">Run basic tests</a>:<br />
 <code>make run-test-tier1</code></p></li>
 </ol>
-<p>If any of these steps failed, or if you want to know more about build requirements or build functionality, please continue reading this document.</p>
+<p>If any of these steps failed, or if you want to know more about build
+requirements or build functionality, please continue reading this
+document.</p>
 <h2 id="introduction">Introduction</h2>
-<p>The JDK is a complex software project. Building it requires a certain amount of technical expertise, a fair number of dependencies on external software, and reasonably powerful hardware.</p>
-<p>If you just want to use the JDK and not build it yourself, this document is not for you. See for instance <a href="http://openjdk.org/install">OpenJDK installation</a> for some methods of installing a prebuilt JDK.</p>
+<p>The JDK is a complex software project. Building it requires a certain
+amount of technical expertise, a fair number of dependencies on external
+software, and reasonably powerful hardware.</p>
+<p>If you just want to use the JDK and not build it yourself, this
+document is not for you. See for instance <a
+href="http://openjdk.org/install">OpenJDK installation</a> for some
+methods of installing a prebuilt JDK.</p>
 <h2 id="getting-the-source-code">Getting the Source Code</h2>
-<p>Make sure you are getting the correct version. As of JDK 10, the source is no longer split into separate repositories so you only need to clone one single repository. At the <a href="https://git.openjdk.org/">OpenJDK Git site</a> you can see a list of all available repositories. If you want to build an older version, e.g. JDK 11, it is recommended that you get the <code>jdk11u</code> repo, which contains incremental updates, instead of the <code>jdk11</code> repo, which was frozen at JDK 11 GA.</p>
-<p>If you are new to Git, a good place to start is the book <a href="https://git-scm.com/book/en/v2">Pro Git</a>. The rest of this document assumes a working knowledge of Git.</p>
+<p>Make sure you are getting the correct version. As of JDK 10, the
+source is no longer split into separate repositories so you only need to
+clone one single repository. At the <a
+href="https://git.openjdk.org/">OpenJDK Git site</a> you can see a list
+of all available repositories. If you want to build an older version,
+e.g. JDK 11, it is recommended that you get the <code>jdk11u</code>
+repo, which contains incremental updates, instead of the
+<code>jdk11</code> repo, which was frozen at JDK 11 GA.</p>
+<p>If you are new to Git, a good place to start is the book <a
+href="https://git-scm.com/book/en/v2">Pro Git</a>. The rest of this
+document assumes a working knowledge of Git.</p>
 <h3 id="special-considerations">Special Considerations</h3>
-<p>For a smooth building experience, it is recommended that you follow these rules on where and how to check out the source code.</p>
+<p>For a smooth building experience, it is recommended that you follow
+these rules on where and how to check out the source code.</p>
 <ul>
-<li><p>Do not check out the source code in a path which contains spaces. Chances are the build will not work. This is most likely to be an issue on Windows systems.</p></li>
-<li><p>Do not check out the source code in a path which has a very long name or is nested many levels deep. Chances are you will hit an OS limitation during the build.</p></li>
-<li><p>Put the source code on a local disk, not a network share. If possible, use an SSD. The build process is very disk intensive, and having slow disk access will significantly increase build times. If you need to use a network share for the source code, see below for suggestions on how to keep the build artifacts on a local disk.</p></li>
-<li><p>On Windows, if using <a href="#cygwin">Cygwin</a>, extra care must be taken to make sure the environment is consistent. It is recommended that you follow this procedure:</p>
+<li><p>Do not check out the source code in a path which contains spaces.
+Chances are the build will not work. This is most likely to be an issue
+on Windows systems.</p></li>
+<li><p>Do not check out the source code in a path which has a very long
+name or is nested many levels deep. Chances are you will hit an OS
+limitation during the build.</p></li>
+<li><p>Put the source code on a local disk, not a network share. If
+possible, use an SSD. The build process is very disk intensive, and
+having slow disk access will significantly increase build times. If you
+need to use a network share for the source code, see below for
+suggestions on how to keep the build artifacts on a local disk.</p></li>
+<li><p>On Windows, if using <a href="#cygwin">Cygwin</a>, extra care
+must be taken to make sure the environment is consistent. It is
+recommended that you follow this procedure:</p>
 <ul>
-<li><p>Create the directory that is going to contain the top directory of the JDK clone by using the <code>mkdir</code> command in the Cygwin bash shell. That is, do <em>not</em> create it using Windows Explorer. This will ensure that it will have proper Cygwin attributes, and that it's children will inherit those attributes.</p></li>
-<li><p>Do not put the JDK clone in a path under your Cygwin home directory. This is especially important if your user name contains spaces and/or mixed upper and lower case letters.</p></li>
-<li><p>You need to install a git client. You have two choices, Cygwin git or Git for Windows. Unfortunately there are pros and cons with each choice.</p>
+<li><p>Create the directory that is going to contain the top directory
+of the JDK clone by using the <code>mkdir</code> command in the Cygwin
+bash shell. That is, do <em>not</em> create it using Windows Explorer.
+This will ensure that it will have proper Cygwin attributes, and that
+it's children will inherit those attributes.</p></li>
+<li><p>Do not put the JDK clone in a path under your Cygwin home
+directory. This is especially important if your user name contains
+spaces and/or mixed upper and lower case letters.</p></li>
+<li><p>You need to install a git client. You have two choices, Cygwin
+git or Git for Windows. Unfortunately there are pros and cons with each
+choice.</p>
 <ul>
-<li><p>The Cygwin <code>git</code> client has no line ending issues and understands Cygwin paths (which are used throughout the JDK build system). However, it does not currently work well with the Skara CLI tooling. Please see the <a href="https://wiki.openjdk.org/display/SKARA/Skara#Skara-Git">Skara wiki on Git clients</a> for up-to-date information about the Skara git client support.</p></li>
-<li><p>The <a href="https://gitforwindows.org">Git for Windows</a> client has issues with line endings, and do not understand Cygwin paths. It does work well with the Skara CLI tooling, however. To alleviate the line ending problems, make sure you set <code>core.autocrlf</code> to <code>false</code> (this is asked during installation).</p></li>
+<li><p>The Cygwin <code>git</code> client has no line ending issues and
+understands Cygwin paths (which are used throughout the JDK build
+system). However, it does not currently work well with the Skara CLI
+tooling. Please see the <a
+href="https://wiki.openjdk.org/display/SKARA/Skara#Skara-Git">Skara wiki
+on Git clients</a> for up-to-date information about the Skara git client
+support.</p></li>
+<li><p>The <a href="https://gitforwindows.org">Git for Windows</a>
+client has issues with line endings, and do not understand Cygwin paths.
+It does work well with the Skara CLI tooling, however. To alleviate the
+line ending problems, make sure you set <code>core.autocrlf</code> to
+<code>false</code> (this is asked during installation).</p></li>
 </ul></li>
 </ul>
-<p>Failure to follow this procedure might result in hard-to-debug build problems.</p></li>
+<p>Failure to follow this procedure might result in hard-to-debug build
+problems.</p></li>
 </ul>
 <h2 id="build-hardware-requirements">Build Hardware Requirements</h2>
-<p>The JDK is a massive project, and require machines ranging from decent to powerful to be able to build in a reasonable amount of time, or to be able to complete a build at all.</p>
-<p>We <em>strongly</em> recommend usage of an SSD disk for the build, since disk speed is one of the limiting factors for build performance.</p>
+<p>The JDK is a massive project, and require machines ranging from
+decent to powerful to be able to build in a reasonable amount of time,
+or to be able to complete a build at all.</p>
+<p>We <em>strongly</em> recommend usage of an SSD disk for the build,
+since disk speed is one of the limiting factors for build
+performance.</p>
 <h3 id="building-on-x86">Building on x86</h3>
-<p>At a minimum, a machine with 2-4 cores is advisable, as well as 2-4 GB of RAM. (The more cores to use, the more memory you need.) At least 6 GB of free disk space is required.</p>
-<p>Even for 32-bit builds, it is recommended to use a 64-bit build machine, and instead create a 32-bit target using <code>--with-target-bits=32</code>.</p>
+<p>At a minimum, a machine with 2-4 cores is advisable, as well as 2-4
+GB of RAM. (The more cores to use, the more memory you need.) At least 6
+GB of free disk space is required.</p>
+<p>Even for 32-bit builds, it is recommended to use a 64-bit build
+machine, and instead create a 32-bit target using
+<code>--with-target-bits=32</code>.</p>
 <h3 id="building-on-aarch64">Building on aarch64</h3>
-<p>At a minimum, a machine with 8 cores is advisable, as well as 8 GB of RAM. (The more cores to use, the more memory you need.) At least 6 GB of free disk space is required.</p>
-<p>If you do not have access to sufficiently powerful hardware, it is also possible to use <a href="#cross-compiling">cross-compiling</a>.</p>
+<p>At a minimum, a machine with 8 cores is advisable, as well as 8 GB of
+RAM. (The more cores to use, the more memory you need.) At least 6 GB of
+free disk space is required.</p>
+<p>If you do not have access to sufficiently powerful hardware, it is
+also possible to use <a href="#cross-compiling">cross-compiling</a>.</p>
 <h4 id="branch-protection">Branch Protection</h4>
-<p>In order to use Branch Protection features in the VM, <code>--enable-branch-protection</code> must be used. This option requires C++ compiler support (GCC 9.1.0+ or Clang 10+). The resulting build can be run on both machines with and without support for branch protection in hardware. Branch Protection is only supported for Linux targets.</p>
+<p>In order to use Branch Protection features in the VM,
+<code>--enable-branch-protection</code> must be used. This option
+requires C++ compiler support (GCC 9.1.0+ or Clang 10+). The resulting
+build can be run on both machines with and without support for branch
+protection in hardware. Branch Protection is only supported for Linux
+targets.</p>
 <h3 id="building-on-32-bit-arm">Building on 32-bit arm</h3>
-<p>This is not recommended. Instead, see the section on <a href="#cross-compiling">Cross-compiling</a>.</p>
-<h2 id="operating-system-requirements">Operating System Requirements</h2>
-<p>The mainline JDK project supports Linux, macOS, AIX and Windows. Support for other operating system, e.g. BSD, exists in separate &quot;port&quot; projects.</p>
-<p>In general, the JDK can be built on a wide range of versions of these operating systems, but the further you deviate from what is tested on a daily basis, the more likely you are to run into problems.</p>
-<p>This table lists the OS versions used by Oracle when building the JDK. Such information is always subject to change, but this table is up to date at the time of writing.</p>
+<p>This is not recommended. Instead, see the section on <a
+href="#cross-compiling">Cross-compiling</a>.</p>
+<h2 id="operating-system-requirements">Operating System
+Requirements</h2>
+<p>The mainline JDK project supports Linux, macOS, AIX and Windows.
+Support for other operating system, e.g. BSD, exists in separate "port"
+projects.</p>
+<p>In general, the JDK can be built on a wide range of versions of these
+operating systems, but the further you deviate from what is tested on a
+daily basis, the more likely you are to run into problems.</p>
+<p>This table lists the OS versions used by Oracle when building the
+JDK. Such information is always subject to change, but this table is up
+to date at the time of writing.</p>
 <table>
 <thead>
 <tr class="header">
@@ -197,49 +370,128 @@
 </tr>
 </tbody>
 </table>
-<p>The double version numbers for Linux are due to the hybrid model used at Oracle, where header files and external libraries from an older version are used when building on a more modern version of the OS.</p>
-<p>The Build Group has a wiki page with <a href="https://wiki.openjdk.org/display/Build/Supported+Build+Platforms">Supported Build Platforms</a>. From time to time, this is updated by contributors to list successes or failures of building on different platforms.</p>
+<p>The double version numbers for Linux are due to the hybrid model used
+at Oracle, where header files and external libraries from an older
+version are used when building on a more modern version of the OS.</p>
+<p>The Build Group has a wiki page with <a
+href="https://wiki.openjdk.org/display/Build/Supported+Build+Platforms">Supported
+Build Platforms</a>. From time to time, this is updated by contributors
+to list successes or failures of building on different platforms.</p>
 <h3 id="windows">Windows</h3>
-<p>Windows XP is not a supported platform, but all newer Windows should be able to build the JDK.</p>
-<p>On Windows, it is important that you pay attention to the instructions in the <a href="#special-considerations">Special Considerations</a>.</p>
-<p>Windows is the only non-POSIX OS supported by the JDK, and as such, requires some extra care. A POSIX support layer is required to build on Windows. Currently, the only supported such layers are Cygwin, Windows Subsystem for Linux (WSL), and MSYS2. (MSYS is no longer supported due to an outdated bash; While OpenJDK can be built with MSYS2, support for it is still experimental, so build failures and unusual errors are not uncommon.)</p>
-<p>Internally in the build system, all paths are represented as Unix-style paths, e.g. <code>/cygdrive/c/git/jdk/Makefile</code> rather than <code>C:\git\jdk\Makefile</code>. This rule also applies to input to the build system, e.g. in arguments to <code>configure</code>. So, use <code>--with-msvcr-dll=/cygdrive/c/msvcr100.dll</code> rather than <code>--with-msvcr-dll=c:\msvcr100.dll</code>. For details on this conversion, see the section on <a href="#fixpath">Fixpath</a>.</p>
+<p>Windows XP is not a supported platform, but all newer Windows should
+be able to build the JDK.</p>
+<p>On Windows, it is important that you pay attention to the
+instructions in the <a href="#special-considerations">Special
+Considerations</a>.</p>
+<p>Windows is the only non-POSIX OS supported by the JDK, and as such,
+requires some extra care. A POSIX support layer is required to build on
+Windows. Currently, the only supported such layers are Cygwin, Windows
+Subsystem for Linux (WSL), and MSYS2. (MSYS is no longer supported due
+to an outdated bash; While OpenJDK can be built with MSYS2, support for
+it is still experimental, so build failures and unusual errors are not
+uncommon.)</p>
+<p>Internally in the build system, all paths are represented as
+Unix-style paths, e.g. <code>/cygdrive/c/git/jdk/Makefile</code> rather
+than <code>C:\git\jdk\Makefile</code>. This rule also applies to input
+to the build system, e.g. in arguments to <code>configure</code>. So,
+use <code>--with-msvcr-dll=/cygdrive/c/msvcr100.dll</code> rather than
+<code>--with-msvcr-dll=c:\msvcr100.dll</code>. For details on this
+conversion, see the section on <a href="#fixpath">Fixpath</a>.</p>
 <h4 id="cygwin">Cygwin</h4>
-<p>A functioning <a href="http://www.cygwin.com/">Cygwin</a> environment is required for building the JDK on Windows. If you have a 64-bit OS, we strongly recommend using the 64-bit version of Cygwin.</p>
-<p><strong>Note:</strong> Cygwin has a model of continuously updating all packages without any easy way to install or revert to a specific version of a package. This means that whenever you add or update a package in Cygwin, you might (inadvertently) update tools that are used by the JDK build process, and that can cause unexpected build problems.</p>
-<p>The JDK requires GNU Make 4.0 or greater in Cygwin. This is usually not a problem, since Cygwin currently only distributes GNU Make at a version above 4.0.</p>
-<p>Apart from the basic Cygwin installation, the following packages must also be installed:</p>
+<p>A functioning <a href="http://www.cygwin.com/">Cygwin</a> environment
+is required for building the JDK on Windows. If you have a 64-bit OS, we
+strongly recommend using the 64-bit version of Cygwin.</p>
+<p><strong>Note:</strong> Cygwin has a model of continuously updating
+all packages without any easy way to install or revert to a specific
+version of a package. This means that whenever you add or update a
+package in Cygwin, you might (inadvertently) update tools that are used
+by the JDK build process, and that can cause unexpected build
+problems.</p>
+<p>The JDK requires GNU Make 4.0 or greater in Cygwin. This is usually
+not a problem, since Cygwin currently only distributes GNU Make at a
+version above 4.0.</p>
+<p>Apart from the basic Cygwin installation, the following packages must
+also be installed:</p>
 <ul>
 <li><code>autoconf</code></li>
 <li><code>make</code></li>
 <li><code>zip</code></li>
 <li><code>unzip</code></li>
 </ul>
-<p>Often, you can install these packages using the following command line:</p>
+<p>Often, you can install these packages using the following command
+line:</p>
 <pre><code>&lt;path to Cygwin setup&gt;/setup-x86_64 -q -P autoconf -P make -P unzip -P zip</code></pre>
-<p>Unfortunately, Cygwin can be unreliable in certain circumstances. If you experience build tool crashes or strange issues when building on Windows, please check the Cygwin FAQ on the <a href="https://cygwin.com/faq/faq.html#faq.using.bloda">&quot;BLODA&quot; list</a> and the section on <a href="https://cygwin.com/faq/faq.html#faq.using.fixing-fork-failures">fork() failures</a>.</p>
-<h4 id="windows-subsystem-for-linux-wsl">Windows Subsystem for Linux (WSL)</h4>
-<p>Windows 10 1809 or newer is supported due to a dependency on the wslpath utility and support for environment variable sharing through WSLENV. Version 1803 can work but intermittent build failures have been observed.</p>
-<p>It's possible to build both Windows and Linux binaries from WSL. To build Windows binaries, you must use a Windows boot JDK (located in a Windows-accessible directory). To build Linux binaries, you must use a Linux boot JDK. The default behavior is to build for Windows. To build for Linux, pass <code>--build=x86_64-unknown-linux-gnu --openjdk-target=x86_64-unknown-linux-gnu</code> to <code>configure</code>.</p>
-<p>If building Windows binaries, the source code must be located in a Windows- accessible directory. This is because Windows executables (such as Visual Studio and the boot JDK) must be able to access the source code. Also, the drive where the source is stored must be mounted as case-insensitive by changing either /etc/fstab or /etc/wsl.conf in WSL. Individual directories may be corrected using the fsutil tool in case the source was cloned before changing the mount options.</p>
-<p>Note that while it's possible to build on WSL, testing is still not fully supported.</p>
+<p>Unfortunately, Cygwin can be unreliable in certain circumstances. If
+you experience build tool crashes or strange issues when building on
+Windows, please check the Cygwin FAQ on the <a
+href="https://cygwin.com/faq/faq.html#faq.using.bloda">"BLODA" list</a>
+and the section on <a
+href="https://cygwin.com/faq/faq.html#faq.using.fixing-fork-failures">fork()
+failures</a>.</p>
+<h4 id="windows-subsystem-for-linux-wsl">Windows Subsystem for Linux
+(WSL)</h4>
+<p>Windows 10 1809 or newer is supported due to a dependency on the
+wslpath utility and support for environment variable sharing through
+WSLENV. Version 1803 can work but intermittent build failures have been
+observed.</p>
+<p>It's possible to build both Windows and Linux binaries from WSL. To
+build Windows binaries, you must use a Windows boot JDK (located in a
+Windows-accessible directory). To build Linux binaries, you must use a
+Linux boot JDK. The default behavior is to build for Windows. To build
+for Linux, pass
+<code>--build=x86_64-unknown-linux-gnu --openjdk-target=x86_64-unknown-linux-gnu</code>
+to <code>configure</code>.</p>
+<p>If building Windows binaries, the source code must be located in a
+Windows- accessible directory. This is because Windows executables (such
+as Visual Studio and the boot JDK) must be able to access the source
+code. Also, the drive where the source is stored must be mounted as
+case-insensitive by changing either /etc/fstab or /etc/wsl.conf in WSL.
+Individual directories may be corrected using the fsutil tool in case
+the source was cloned before changing the mount options.</p>
+<p>Note that while it's possible to build on WSL, testing is still not
+fully supported.</p>
 <h3 id="macos">macOS</h3>
-<p>Apple is using a quite aggressive scheme of pushing OS updates, and coupling these updates with required updates of Xcode. Unfortunately, this makes it difficult for a project such as the JDK to keep pace with a continuously updated machine running macOS. See the section on <a href="#apple-xcode">Apple Xcode</a> on some strategies to deal with this.</p>
-<p>It is recommended that you use at least Mac OS X 10.13 (High Sierra). At the time of writing, the JDK has been successfully compiled on macOS 10.12 (Sierra).</p>
-<p>The standard macOS environment contains the basic tooling needed to build, but for external libraries a package manager is recommended. The JDK uses <a href="https://brew.sh/">homebrew</a> in the examples, but feel free to use whatever manager you want (or none).</p>
+<p>Apple is using a quite aggressive scheme of pushing OS updates, and
+coupling these updates with required updates of Xcode. Unfortunately,
+this makes it difficult for a project such as the JDK to keep pace with
+a continuously updated machine running macOS. See the section on <a
+href="#apple-xcode">Apple Xcode</a> on some strategies to deal with
+this.</p>
+<p>It is recommended that you use at least Mac OS X 10.13 (High Sierra).
+At the time of writing, the JDK has been successfully compiled on macOS
+10.12 (Sierra).</p>
+<p>The standard macOS environment contains the basic tooling needed to
+build, but for external libraries a package manager is recommended. The
+JDK uses <a href="https://brew.sh/">homebrew</a> in the examples, but
+feel free to use whatever manager you want (or none).</p>
 <h3 id="linux">Linux</h3>
-<p>It is often not much problem to build the JDK on Linux. The only general advice is to try to use the compilers, external libraries and header files as provided by your distribution.</p>
-<p>The basic tooling is provided as part of the core operating system, but you will most likely need to install developer packages.</p>
+<p>It is often not much problem to build the JDK on Linux. The only
+general advice is to try to use the compilers, external libraries and
+header files as provided by your distribution.</p>
+<p>The basic tooling is provided as part of the core operating system,
+but you will most likely need to install developer packages.</p>
 <p>For apt-based distributions (Debian, Ubuntu, etc), try this:</p>
 <pre><code>sudo apt-get install build-essential</code></pre>
 <p>For rpm-based distributions (Fedora, Red Hat, etc), try this:</p>
 <pre><code>sudo yum groupinstall &quot;Development Tools&quot;</code></pre>
-<p>For Alpine Linux, aside from basic tooling, install the GNU versions of some programs:</p>
+<p>For Alpine Linux, aside from basic tooling, install the GNU versions
+of some programs:</p>
 <pre><code>sudo apk add build-base bash grep zip</code></pre>
 <h3 id="aix">AIX</h3>
-<p>Please consult the AIX section of the <a href="https://wiki.openjdk.org/display/Build/Supported+Build+Platforms">Supported Build Platforms</a> OpenJDK Build Wiki page for details about which versions of AIX are supported.</p>
-<h2 id="native-compiler-toolchain-requirements">Native Compiler (Toolchain) Requirements</h2>
-<p>Large portions of the JDK consists of native code, that needs to be compiled to be able to run on the target platform. In theory, toolchain and operating system should be independent factors, but in practice there's more or less a one-to-one correlation between target operating system and toolchain. There are ongoing efforts to loosen this strict coupling between compiler and operating system (see <a href="https://bugs.openjdk.org/browse/JDK-8288293">JDK-8288293</a>) but it will likely be a very long time before this goal can be realized.</p>
+<p>Please consult the AIX section of the <a
+href="https://wiki.openjdk.org/display/Build/Supported+Build+Platforms">Supported
+Build Platforms</a> OpenJDK Build Wiki page for details about which
+versions of AIX are supported.</p>
+<h2 id="native-compiler-toolchain-requirements">Native Compiler
+(Toolchain) Requirements</h2>
+<p>Large portions of the JDK consists of native code, that needs to be
+compiled to be able to run on the target platform. In theory, toolchain
+and operating system should be independent factors, but in practice
+there's more or less a one-to-one correlation between target operating
+system and toolchain. There are ongoing efforts to loosen this strict
+coupling between compiler and operating system (see <a
+href="https://bugs.openjdk.org/browse/JDK-8288293">JDK-8288293</a>) but
+it will likely be a very long time before this goal can be realized.</p>
 <table>
 <thead>
 <tr class="header">
@@ -266,7 +518,12 @@
 </tr>
 </tbody>
 </table>
-<p>Please see the individual sections on the toolchains for version recommendations. As a reference, these versions of the toolchains are used, at the time of writing, by Oracle for the daily builds of the JDK. It should be possible to compile the JDK with both older and newer versions, but the closer you stay to this list, the more likely you are to compile successfully without issues.</p>
+<p>Please see the individual sections on the toolchains for version
+recommendations. As a reference, these versions of the toolchains are
+used, at the time of writing, by Oracle for the daily builds of the JDK.
+It should be possible to compile the JDK with both older and newer
+versions, but the closer you stay to this list, the more likely you are
+to compile successfully without issues.</p>
 <table>
 <thead>
 <tr class="header">
@@ -285,225 +542,528 @@
 </tr>
 <tr class="odd">
 <td style="text-align: left;">Windows</td>
-<td style="text-align: left;">Microsoft Visual Studio 2022 update 17.1.0</td>
+<td style="text-align: left;">Microsoft Visual Studio 2022 update
+17.1.0</td>
 </tr>
 </tbody>
 </table>
-<p>All compilers are expected to be able to compile to the C99 language standard, as some C99 features are used in the source code. Microsoft Visual Studio doesn't fully support C99 so in practice shared code is limited to using C99 features that it does support.</p>
+<p>All compilers are expected to be able to compile to the C99 language
+standard, as some C99 features are used in the source code. Microsoft
+Visual Studio doesn't fully support C99 so in practice shared code is
+limited to using C99 features that it does support.</p>
 <h3 id="gcc">gcc</h3>
-<p>The minimum accepted version of gcc is 5.0. Older versions will generate a warning by <code>configure</code> and are unlikely to work.</p>
-<p>The JDK is currently known to be able to compile with at least version 11.2 of gcc.</p>
+<p>The minimum accepted version of gcc is 5.0. Older versions will
+generate a warning by <code>configure</code> and are unlikely to
+work.</p>
+<p>The JDK is currently known to be able to compile with at least
+version 11.2 of gcc.</p>
 <p>In general, any version between these two should be usable.</p>
 <h3 id="clang">clang</h3>
-<p>The minimum accepted version of clang is 3.5. Older versions will not be accepted by <code>configure</code>.</p>
-<p>To use clang instead of gcc on Linux, use <code>--with-toolchain-type=clang</code>.</p>
+<p>The minimum accepted version of clang is 3.5. Older versions will not
+be accepted by <code>configure</code>.</p>
+<p>To use clang instead of gcc on Linux, use
+<code>--with-toolchain-type=clang</code>.</p>
 <h3 id="apple-xcode">Apple Xcode</h3>
 <p>The oldest supported version of Xcode is 8.</p>
-<p>You will need the Xcode command lines developers tools to be able to build the JDK. (Actually, <em>only</em> the command lines tools are needed, not the IDE.) The simplest way to install these is to run:</p>
+<p>You will need the Xcode command lines developers tools to be able to
+build the JDK. (Actually, <em>only</em> the command lines tools are
+needed, not the IDE.) The simplest way to install these is to run:</p>
 <pre><code>xcode-select --install</code></pre>
-<p>It is advisable to keep an older version of Xcode for building the JDK when updating Xcode. This <a href="http://iosdevelopertips.com/xcode/install-multiple-versions-of-xcode.html">blog page</a> has good suggestions on managing multiple Xcode versions. To use a specific version of Xcode, use <code>xcode-select -s</code> before running <code>configure</code>, or use <code>--with-toolchain-path</code> to point to the version of Xcode to use, e.g. <code>configure --with-toolchain-path=/Applications/Xcode8.app/Contents/Developer/usr/bin</code></p>
-<p>If you have recently (inadvertently) updated your OS and/or Xcode version, and the JDK can no longer be built, please see the section on <a href="#problems-with-the-build-environment">Problems with the Build Environment</a>, and <a href="#getting-help">Getting Help</a> to find out if there are any recent, non-merged patches available for this update.</p>
+<p>It is advisable to keep an older version of Xcode for building the
+JDK when updating Xcode. This <a
+href="http://iosdevelopertips.com/xcode/install-multiple-versions-of-xcode.html">blog
+page</a> has good suggestions on managing multiple Xcode versions. To
+use a specific version of Xcode, use <code>xcode-select -s</code> before
+running <code>configure</code>, or use
+<code>--with-toolchain-path</code> to point to the version of Xcode to
+use, e.g.
+<code>configure --with-toolchain-path=/Applications/Xcode8.app/Contents/Developer/usr/bin</code></p>
+<p>If you have recently (inadvertently) updated your OS and/or Xcode
+version, and the JDK can no longer be built, please see the section on
+<a href="#problems-with-the-build-environment">Problems with the Build
+Environment</a>, and <a href="#getting-help">Getting Help</a> to find
+out if there are any recent, non-merged patches available for this
+update.</p>
 <h3 id="microsoft-visual-studio">Microsoft Visual Studio</h3>
-<p>The minimum accepted version is Visual Studio 2019 version 16.8. (Note that this version is often presented as &quot;MSVC 14.28&quot;, and reported by cl.exe as 19.28.) Older versions will not be accepted by <code>configure</code> and will not work. The maximum accepted version of Visual Studio is 2022.</p>
-<p>If you have multiple versions of Visual Studio installed, <code>configure</code> will by default pick the latest. You can request a specific version to be used by setting <code>--with-toolchain-version</code>, e.g. <code>--with-toolchain-version=2022</code>.</p>
-<p>If you have Visual Studio installed but <code>configure</code> fails to detect it, it may be because of <a href="#spaces-in-path">spaces in path</a>.</p>
+<p>The minimum accepted version is Visual Studio 2019 version 16.8.
+(Note that this version is often presented as "MSVC 14.28", and reported
+by cl.exe as 19.28.) Older versions will not be accepted by
+<code>configure</code> and will not work. The maximum accepted version
+of Visual Studio is 2022.</p>
+<p>If you have multiple versions of Visual Studio installed,
+<code>configure</code> will by default pick the latest. You can request
+a specific version to be used by setting
+<code>--with-toolchain-version</code>, e.g.
+<code>--with-toolchain-version=2022</code>.</p>
+<p>If you have Visual Studio installed but <code>configure</code> fails
+to detect it, it may be because of <a href="#spaces-in-path">spaces in
+path</a>.</p>
 <h3 id="ibm-xl-cc">IBM XL C/C++</h3>
-<p>Please consult the AIX section of the <a href="https://wiki.openjdk.org/display/Build/Supported+Build+Platforms">Supported Build Platforms</a> OpenJDK Build Wiki page for details about which versions of XLC are supported.</p>
+<p>Please consult the AIX section of the <a
+href="https://wiki.openjdk.org/display/Build/Supported+Build+Platforms">Supported
+Build Platforms</a> OpenJDK Build Wiki page for details about which
+versions of XLC are supported.</p>
 <h2 id="boot-jdk-requirements">Boot JDK Requirements</h2>
-<p>Paradoxically, building the JDK requires a pre-existing JDK. This is called the &quot;boot JDK&quot;. The boot JDK does not, however, have to be a JDK built directly from the source code available in the OpenJDK Community. If you are porting the JDK to a new platform, chances are that there already exists another JDK for that platform that is usable as boot JDK.</p>
-<p>The rule of thumb is that the boot JDK for building JDK major version <em>N</em> should be a JDK of major version <em>N-1</em>, so for building JDK 9 a JDK 8 would be suitable as boot JDK. However, the JDK should be able to &quot;build itself&quot;, so an up-to-date build of the current JDK source is an acceptable alternative. If you are following the <em>N-1</em> rule, make sure you've got the latest update version, since JDK 8 GA might not be able to build JDK 9 on all platforms.</p>
-<p>Early in the release cycle, version <em>N-1</em> may not yet have been released. In that case, the preferred boot JDK will be version <em>N-2</em> until version <em>N-1</em> is available.</p>
-<p>If the boot JDK is not automatically detected, or the wrong JDK is picked, use <code>--with-boot-jdk</code> to point to the JDK to use.</p>
+<p>Paradoxically, building the JDK requires a pre-existing JDK. This is
+called the "boot JDK". The boot JDK does not, however, have to be a JDK
+built directly from the source code available in the OpenJDK Community.
+If you are porting the JDK to a new platform, chances are that there
+already exists another JDK for that platform that is usable as boot
+JDK.</p>
+<p>The rule of thumb is that the boot JDK for building JDK major version
+<em>N</em> should be a JDK of major version <em>N-1</em>, so for
+building JDK 9 a JDK 8 would be suitable as boot JDK. However, the JDK
+should be able to "build itself", so an up-to-date build of the current
+JDK source is an acceptable alternative. If you are following the
+<em>N-1</em> rule, make sure you've got the latest update version, since
+JDK 8 GA might not be able to build JDK 9 on all platforms.</p>
+<p>Early in the release cycle, version <em>N-1</em> may not yet have
+been released. In that case, the preferred boot JDK will be version
+<em>N-2</em> until version <em>N-1</em> is available.</p>
+<p>If the boot JDK is not automatically detected, or the wrong JDK is
+picked, use <code>--with-boot-jdk</code> to point to the JDK to use.</p>
 <h3 id="getting-jdk-binaries">Getting JDK binaries</h3>
-<p>JDK binaries for Linux, Windows and macOS can be downloaded from <a href="http://jdk.java.net">jdk.java.net</a>. An alternative is to download the <a href="http://www.oracle.com/technetwork/java/javase/downloads">Oracle JDK</a>. Another is the <a href="https://adoptopenjdk.net/">Adopt OpenJDK Project</a>, which publishes experimental prebuilt binaries for various platforms.</p>
-<p>On Linux you can also get a JDK from the Linux distribution. On apt-based distros (like Debian and Ubuntu), <code>sudo apt-get install openjdk-&lt;VERSION&gt;-jdk</code> is typically enough to install a JDK &lt;VERSION&gt;. On rpm-based distros (like Fedora and Red Hat), try <code>sudo yum install java-&lt;VERSION&gt;-openjdk-devel</code>.</p>
-<h2 id="external-library-requirements">External Library Requirements</h2>
-<p>Different platforms require different external libraries. In general, libraries are not optional - that is, they are either required or not used.</p>
-<p>If a required library is not detected by <code>configure</code>, you need to provide the path to it. There are two forms of the <code>configure</code> arguments to point to an external library: <code>--with-&lt;LIB&gt;=&lt;path&gt;</code> or <code>--with-&lt;LIB&gt;-include=&lt;path to include&gt; --with-&lt;LIB&gt;-lib=&lt;path to lib&gt;</code>. The first variant is more concise, but require the include files and library files to reside in a default hierarchy under this directory. In most cases, it works fine.</p>
-<p>As a fallback, the second version allows you to point to the include directory and the lib directory separately.</p>
+<p>JDK binaries for Linux, Windows and macOS can be downloaded from <a
+href="http://jdk.java.net">jdk.java.net</a>. An alternative is to
+download the <a
+href="http://www.oracle.com/technetwork/java/javase/downloads">Oracle
+JDK</a>. Another is the <a href="https://adoptopenjdk.net/">Adopt
+OpenJDK Project</a>, which publishes experimental prebuilt binaries for
+various platforms.</p>
+<p>On Linux you can also get a JDK from the Linux distribution. On
+apt-based distros (like Debian and Ubuntu),
+<code>sudo apt-get install openjdk-&lt;VERSION&gt;-jdk</code> is
+typically enough to install a JDK &lt;VERSION&gt;. On rpm-based distros
+(like Fedora and Red Hat), try
+<code>sudo yum install java-&lt;VERSION&gt;-openjdk-devel</code>.</p>
+<h2 id="external-library-requirements">External Library
+Requirements</h2>
+<p>Different platforms require different external libraries. In general,
+libraries are not optional - that is, they are either required or not
+used.</p>
+<p>If a required library is not detected by <code>configure</code>, you
+need to provide the path to it. There are two forms of the
+<code>configure</code> arguments to point to an external library:
+<code>--with-&lt;LIB&gt;=&lt;path&gt;</code> or
+<code>--with-&lt;LIB&gt;-include=&lt;path to include&gt; --with-&lt;LIB&gt;-lib=&lt;path to lib&gt;</code>.
+The first variant is more concise, but require the include files and
+library files to reside in a default hierarchy under this directory. In
+most cases, it works fine.</p>
+<p>As a fallback, the second version allows you to point to the include
+directory and the lib directory separately.</p>
 <h3 id="freetype">FreeType</h3>
-<p>FreeType2 from <a href="http://www.freetype.org/">The FreeType Project</a> is not required on any platform. The exception is on Unix-based platforms when configuring such that the build artifacts will reference a system installed library, rather than bundling the JDK's own copy.</p>
+<p>FreeType2 from <a href="http://www.freetype.org/">The FreeType
+Project</a> is not required on any platform. The exception is on
+Unix-based platforms when configuring such that the build artifacts will
+reference a system installed library, rather than bundling the JDK's own
+copy.</p>
 <ul>
-<li>To install on an apt-based Linux, try running <code>sudo apt-get install libfreetype6-dev</code>.</li>
-<li>To install on an rpm-based Linux, try running <code>sudo yum install freetype-devel</code>.</li>
-<li>To install on Alpine Linux, try running <code>sudo apk add freetype-dev</code>.</li>
-<li>To install on macOS, try running <code>brew install freetype</code>.</li>
+<li>To install on an apt-based Linux, try running
+<code>sudo apt-get install     libfreetype6-dev</code>.</li>
+<li>To install on an rpm-based Linux, try running
+<code>sudo yum install     freetype-devel</code>.</li>
+<li>To install on Alpine Linux, try running
+<code>sudo apk add freetype-dev</code>.</li>
+<li>To install on macOS, try running
+<code>brew install freetype</code>.</li>
 </ul>
-<p>Use <code>--with-freetype-include=&lt;path&gt;</code> and <code>--with-freetype-lib=&lt;path&gt;</code> if <code>configure</code> does not automatically locate the platform FreeType files.</p>
+<p>Use <code>--with-freetype-include=&lt;path&gt;</code> and
+<code>--with-freetype-lib=&lt;path&gt;</code> if <code>configure</code>
+does not automatically locate the platform FreeType files.</p>
 <h3 id="cups">CUPS</h3>
-<p>CUPS, <a href="http://www.cups.org">Common UNIX Printing System</a> header files are required on all platforms, except Windows. Often these files are provided by your operating system.</p>
+<p>CUPS, <a href="http://www.cups.org">Common UNIX Printing System</a>
+header files are required on all platforms, except Windows. Often these
+files are provided by your operating system.</p>
 <ul>
-<li>To install on an apt-based Linux, try running <code>sudo apt-get install libcups2-dev</code>.</li>
-<li>To install on an rpm-based Linux, try running <code>sudo yum install cups-devel</code>.</li>
-<li>To install on Alpine Linux, try running <code>sudo apk add cups-dev</code>.</li>
+<li>To install on an apt-based Linux, try running
+<code>sudo apt-get install     libcups2-dev</code>.</li>
+<li>To install on an rpm-based Linux, try running
+<code>sudo yum install     cups-devel</code>.</li>
+<li>To install on Alpine Linux, try running
+<code>sudo apk add cups-dev</code>.</li>
 </ul>
-<p>Use <code>--with-cups=&lt;path&gt;</code> if <code>configure</code> does not properly locate your CUPS files.</p>
+<p>Use <code>--with-cups=&lt;path&gt;</code> if <code>configure</code>
+does not properly locate your CUPS files.</p>
 <h3 id="x11">X11</h3>
-<p>Certain <a href="http://www.x.org/">X11</a> libraries and include files are required on Linux.</p>
+<p>Certain <a href="http://www.x.org/">X11</a> libraries and include
+files are required on Linux.</p>
 <ul>
-<li>To install on an apt-based Linux, try running <code>sudo apt-get install libx11-dev libxext-dev libxrender-dev libxrandr-dev libxtst-dev libxt-dev</code>.</li>
-<li>To install on an rpm-based Linux, try running <code>sudo yum install libXtst-devel libXt-devel libXrender-devel libXrandr-devel libXi-devel</code>.</li>
-<li>To install on Alpine Linux, try running <code>sudo apk add libx11-dev libxext-dev libxrender-dev libxrandr-dev libxtst-dev libxt-dev</code>.</li>
+<li>To install on an apt-based Linux, try running
+<code>sudo apt-get install     libx11-dev libxext-dev libxrender-dev libxrandr-dev libxtst-dev libxt-dev</code>.</li>
+<li>To install on an rpm-based Linux, try running
+<code>sudo yum install     libXtst-devel libXt-devel libXrender-devel libXrandr-devel libXi-devel</code>.</li>
+<li>To install on Alpine Linux, try running
+<code>sudo apk add libx11-dev     libxext-dev libxrender-dev libxrandr-dev libxtst-dev libxt-dev</code>.</li>
 </ul>
-<p>Use <code>--with-x=&lt;path&gt;</code> if <code>configure</code> does not properly locate your X11 files.</p>
+<p>Use <code>--with-x=&lt;path&gt;</code> if <code>configure</code> does
+not properly locate your X11 files.</p>
 <h3 id="alsa">ALSA</h3>
-<p>ALSA, <a href="https://www.alsa-project.org/">Advanced Linux Sound Architecture</a> is required on Linux. At least version 0.9.1 of ALSA is required.</p>
+<p>ALSA, <a href="https://www.alsa-project.org/">Advanced Linux Sound
+Architecture</a> is required on Linux. At least version 0.9.1 of ALSA is
+required.</p>
 <ul>
-<li>To install on an apt-based Linux, try running <code>sudo apt-get install libasound2-dev</code>.</li>
-<li>To install on an rpm-based Linux, try running <code>sudo yum install alsa-lib-devel</code>.</li>
-<li>To install on Alpine Linux, try running <code>sudo apk add alsa-lib-dev</code>.</li>
+<li>To install on an apt-based Linux, try running
+<code>sudo apt-get install     libasound2-dev</code>.</li>
+<li>To install on an rpm-based Linux, try running
+<code>sudo yum install     alsa-lib-devel</code>.</li>
+<li>To install on Alpine Linux, try running
+<code>sudo apk add alsa-lib-dev</code>.</li>
 </ul>
-<p>Use <code>--with-alsa=&lt;path&gt;</code> if <code>configure</code> does not properly locate your ALSA files.</p>
+<p>Use <code>--with-alsa=&lt;path&gt;</code> if <code>configure</code>
+does not properly locate your ALSA files.</p>
 <h3 id="libffi">libffi</h3>
-<p>libffi, the <a href="http://sourceware.org/libffi">Portable Foreign Function Interface Library</a> is required when building the Zero version of Hotspot.</p>
+<p>libffi, the <a href="http://sourceware.org/libffi">Portable Foreign
+Function Interface Library</a> is required when building the Zero
+version of Hotspot.</p>
 <ul>
-<li>To install on an apt-based Linux, try running <code>sudo apt-get install libffi-dev</code>.</li>
-<li>To install on an rpm-based Linux, try running <code>sudo yum install libffi-devel</code>.</li>
-<li>To install on Alpine Linux, try running <code>sudo apk add libffi-dev</code>.</li>
+<li>To install on an apt-based Linux, try running
+<code>sudo apt-get install     libffi-dev</code>.</li>
+<li>To install on an rpm-based Linux, try running
+<code>sudo yum install     libffi-devel</code>.</li>
+<li>To install on Alpine Linux, try running
+<code>sudo apk add libffi-dev</code>.</li>
 </ul>
-<p>Use <code>--with-libffi=&lt;path&gt;</code> if <code>configure</code> does not properly locate your libffi files.</p>
+<p>Use <code>--with-libffi=&lt;path&gt;</code> if <code>configure</code>
+does not properly locate your libffi files.</p>
 <h2 id="build-tools-requirements">Build Tools Requirements</h2>
 <h3 id="autoconf">Autoconf</h3>
-<p>The JDK requires <a href="http://www.gnu.org/software/autoconf">Autoconf</a> on all platforms. At least version 2.69 is required.</p>
+<p>The JDK requires <a
+href="http://www.gnu.org/software/autoconf">Autoconf</a> on all
+platforms. At least version 2.69 is required.</p>
 <ul>
-<li>To install on an apt-based Linux, try running <code>sudo apt-get install autoconf</code>.</li>
-<li>To install on an rpm-based Linux, try running <code>sudo yum install autoconf</code>.</li>
-<li>To install on Alpine Linux, try running <code>sudo apk add autoconf</code>.</li>
-<li>To install on macOS, try running <code>brew install autoconf</code>.</li>
-<li>To install on Windows, try running <code>&lt;path to Cygwin setup&gt;/setup-x86_64 -q -P autoconf</code>.</li>
+<li>To install on an apt-based Linux, try running
+<code>sudo apt-get install     autoconf</code>.</li>
+<li>To install on an rpm-based Linux, try running
+<code>sudo yum install     autoconf</code>.</li>
+<li>To install on Alpine Linux, try running
+<code>sudo apk add autoconf</code>.</li>
+<li>To install on macOS, try running
+<code>brew install autoconf</code>.</li>
+<li>To install on Windows, try running
+<code>&lt;path to Cygwin setup&gt;/setup-x86_64 -q     -P autoconf</code>.</li>
 </ul>
-<p>If <code>configure</code> has problems locating your installation of autoconf, you can specify it using the <code>AUTOCONF</code> environment variable, like this:</p>
+<p>If <code>configure</code> has problems locating your installation of
+autoconf, you can specify it using the <code>AUTOCONF</code> environment
+variable, like this:</p>
 <pre><code>AUTOCONF=&lt;path to autoconf&gt; configure ...</code></pre>
 <h3 id="gnu-make">GNU Make</h3>
-<p>The JDK requires <a href="http://www.gnu.org/software/make">GNU Make</a>. No other flavors of make are supported.</p>
-<p>At least version 3.81 of GNU Make must be used. For distributions supporting GNU Make 4.0 or above, we strongly recommend it. GNU Make 4.0 contains useful functionality to handle parallel building (supported by <code>--with-output-sync</code>) and speed and stability improvements.</p>
-<p>Note that <code>configure</code> locates and verifies a properly functioning version of <code>make</code> and stores the path to this <code>make</code> binary in the configuration. If you start a build using <code>make</code> on the command line, you will be using the version of make found first in your <code>PATH</code>, and not necessarily the one stored in the configuration. This initial make will be used as &quot;bootstrap make&quot;, and in a second stage, the make located by <code>configure</code> will be called. Normally, this will present no issues, but if you have a very old <code>make</code>, or a non-GNU Make <code>make</code> in your path, this might cause issues.</p>
-<p>If you want to override the default make found by <code>configure</code>, use the <code>MAKE</code> configure variable, e.g. <code>configure MAKE=/opt/gnu/make</code>.</p>
+<p>The JDK requires <a href="http://www.gnu.org/software/make">GNU
+Make</a>. No other flavors of make are supported.</p>
+<p>At least version 3.81 of GNU Make must be used. For distributions
+supporting GNU Make 4.0 or above, we strongly recommend it. GNU Make 4.0
+contains useful functionality to handle parallel building (supported by
+<code>--with-output-sync</code>) and speed and stability
+improvements.</p>
+<p>Note that <code>configure</code> locates and verifies a properly
+functioning version of <code>make</code> and stores the path to this
+<code>make</code> binary in the configuration. If you start a build
+using <code>make</code> on the command line, you will be using the
+version of make found first in your <code>PATH</code>, and not
+necessarily the one stored in the configuration. This initial make will
+be used as "bootstrap make", and in a second stage, the make located by
+<code>configure</code> will be called. Normally, this will present no
+issues, but if you have a very old <code>make</code>, or a non-GNU Make
+<code>make</code> in your path, this might cause issues.</p>
+<p>If you want to override the default make found by
+<code>configure</code>, use the <code>MAKE</code> configure variable,
+e.g. <code>configure MAKE=/opt/gnu/make</code>.</p>
 <h3 id="gnu-bash">GNU Bash</h3>
-<p>The JDK requires <a href="http://www.gnu.org/software/bash">GNU Bash</a>. No other shells are supported.</p>
+<p>The JDK requires <a href="http://www.gnu.org/software/bash">GNU
+Bash</a>. No other shells are supported.</p>
 <p>At least version 3.2 of GNU Bash must be used.</p>
 <h2 id="running-configure">Running Configure</h2>
-<p>To build the JDK, you need a &quot;configuration&quot;, which consists of a directory where to store the build output, coupled with information about the platform, the specific build machine, and choices that affect how the JDK is built.</p>
-<p>The configuration is created by the <code>configure</code> script. The basic invocation of the <code>configure</code> script looks like this:</p>
+<p>To build the JDK, you need a "configuration", which consists of a
+directory where to store the build output, coupled with information
+about the platform, the specific build machine, and choices that affect
+how the JDK is built.</p>
+<p>The configuration is created by the <code>configure</code> script.
+The basic invocation of the <code>configure</code> script looks like
+this:</p>
 <pre><code>bash configure [options]</code></pre>
-<p>This will create an output directory containing the configuration and setup an area for the build result. This directory typically looks like <code>build/linux-x64-server-release</code>, but the actual name depends on your specific configuration. (It can also be set directly, see <a href="#using-multiple-configurations">Using Multiple Configurations</a>). This directory is referred to as <code>$BUILD</code> in this documentation.</p>
-<p><code>configure</code> will try to figure out what system you are running on and where all necessary build components are. If you have all prerequisites for building installed, it should find everything. If it fails to detect any component automatically, it will exit and inform you about the problem.</p>
+<p>This will create an output directory containing the configuration and
+setup an area for the build result. This directory typically looks like
+<code>build/linux-x64-server-release</code>, but the actual name depends
+on your specific configuration. (It can also be set directly, see <a
+href="#using-multiple-configurations">Using Multiple
+Configurations</a>). This directory is referred to as
+<code>$BUILD</code> in this documentation.</p>
+<p><code>configure</code> will try to figure out what system you are
+running on and where all necessary build components are. If you have all
+prerequisites for building installed, it should find everything. If it
+fails to detect any component automatically, it will exit and inform you
+about the problem.</p>
 <p>Some command line examples:</p>
 <ul>
-<li><p>Create a 32-bit build for Windows with FreeType2 in <code>C:\freetype-i586</code>:</p>
-<pre><code>bash configure --with-freetype=/cygdrive/c/freetype-i586 --with-target-bits=32</code></pre></li>
-<li><p>Create a debug build with the <code>server</code> JVM and DTrace enabled:</p>
-<pre><code>bash configure --enable-debug --with-jvm-variants=server --enable-dtrace</code></pre></li>
+<li><p>Create a 32-bit build for Windows with FreeType2 in
+<code>C:\freetype-i586</code>:
+<code>bash configure --with-freetype=/cygdrive/c/freetype-i586 --with-target-bits=32</code></p></li>
+<li><p>Create a debug build with the <code>server</code> JVM and DTrace
+enabled:
+<code>bash configure --enable-debug --with-jvm-variants=server --enable-dtrace</code></p></li>
 </ul>
 <h3 id="common-configure-arguments">Common Configure Arguments</h3>
-<p>Here follows some of the most common and important <code>configure</code> argument.</p>
-<p>To get up-to-date information on <em>all</em> available <code>configure</code> argument, please run:</p>
+<p>Here follows some of the most common and important
+<code>configure</code> argument.</p>
+<p>To get up-to-date information on <em>all</em> available
+<code>configure</code> argument, please run:</p>
 <pre><code>bash configure --help</code></pre>
-<p>(Note that this help text also include general autoconf options, like <code>--dvidir</code>, that is not relevant to the JDK. To list only JDK-specific features, use <code>bash configure --help=short</code> instead.)</p>
-<h4 id="configure-arguments-for-tailoring-the-build">Configure Arguments for Tailoring the Build</h4>
+<p>(Note that this help text also include general autoconf options, like
+<code>--dvidir</code>, that is not relevant to the JDK. To list only
+JDK-specific features, use <code>bash configure --help=short</code>
+instead.)</p>
+<h4 id="configure-arguments-for-tailoring-the-build">Configure Arguments
+for Tailoring the Build</h4>
 <ul>
-<li><code>--enable-debug</code> - Set the debug level to <code>fastdebug</code> (this is a shorthand for <code>--with-debug-level=fastdebug</code>)</li>
-<li><code>--with-debug-level=&lt;level&gt;</code> - Set the debug level, which can be <code>release</code>, <code>fastdebug</code>, <code>slowdebug</code> or <code>optimized</code>. Default is <code>release</code>. <code>optimized</code> is variant of <code>release</code> with additional Hotspot debug code.</li>
-<li><code>--with-native-debug-symbols=&lt;method&gt;</code> - Specify if and how native debug symbols should be built. Available methods are <code>none</code>, <code>internal</code>, <code>external</code>, <code>zipped</code>. Default behavior depends on platform. See <a href="#native-debug-symbols">Native Debug Symbols</a> for more details.</li>
-<li><code>--with-version-string=&lt;string&gt;</code> - Specify the version string this build will be identified with.</li>
-<li><code>--with-version-&lt;part&gt;=&lt;value&gt;</code> - A group of options, where <code>&lt;part&gt;</code> can be any of <code>pre</code>, <code>opt</code>, <code>build</code>, <code>major</code>, <code>minor</code>, <code>security</code> or <code>patch</code>. Use these options to modify just the corresponding part of the version string from the default, or the value provided by <code>--with-version-string</code>.</li>
-<li><code>--with-jvm-variants=&lt;variant&gt;[,&lt;variant&gt;...]</code> - Build the specified variant (or variants) of Hotspot. Valid variants are: <code>server</code>, <code>client</code>, <code>minimal</code>, <code>core</code>, <code>zero</code>, <code>custom</code>. Note that not all variants are possible to combine in a single build.</li>
-<li><code>--enable-jvm-feature-&lt;feature&gt;</code> or <code>--disable-jvm-feature-&lt;feature&gt;</code> - Include (or exclude) <code>&lt;feature&gt;</code> as a JVM feature in Hotspot. You can also specify a list of features to be enabled, separated by space or comma, as <code>--with-jvm-features=&lt;feature&gt;[,&lt;feature&gt;...]</code>. If you prefix <code>&lt;feature&gt;</code> with a <code>-</code>, it will be disabled. These options will modify the default list of features for the JVM variant(s) you are building. For the <code>custom</code> JVM variant, the default list is empty. A complete list of valid JVM features can be found using <code>bash configure --help</code>.</li>
-<li><code>--with-target-bits=&lt;bits&gt;</code> - Create a target binary suitable for running on a <code>&lt;bits&gt;</code> platform. Use this to create 32-bit output on a 64-bit build platform, instead of doing a full cross-compile. (This is known as a <em>reduced</em> build.)</li>
+<li><code>--enable-debug</code> - Set the debug level to
+<code>fastdebug</code> (this is a shorthand for
+<code>--with-debug-level=fastdebug</code>)</li>
+<li><code>--with-debug-level=&lt;level&gt;</code> - Set the debug level,
+which can be <code>release</code>, <code>fastdebug</code>,
+<code>slowdebug</code> or <code>optimized</code>. Default is
+<code>release</code>. <code>optimized</code> is variant of
+<code>release</code> with additional Hotspot debug code.</li>
+<li><code>--with-native-debug-symbols=&lt;method&gt;</code> - Specify if
+and how native debug symbols should be built. Available methods are
+<code>none</code>, <code>internal</code>, <code>external</code>,
+<code>zipped</code>. Default behavior depends on platform. See <a
+href="#native-debug-symbols">Native Debug Symbols</a> for more
+details.</li>
+<li><code>--with-version-string=&lt;string&gt;</code> - Specify the
+version string this build will be identified with.</li>
+<li><code>--with-version-&lt;part&gt;=&lt;value&gt;</code> - A group of
+options, where <code>&lt;part&gt;</code> can be any of <code>pre</code>,
+<code>opt</code>, <code>build</code>, <code>major</code>,
+<code>minor</code>, <code>security</code> or <code>patch</code>. Use
+these options to modify just the corresponding part of the version
+string from the default, or the value provided by
+<code>--with-version-string</code>.</li>
+<li><code>--with-jvm-variants=&lt;variant&gt;[,&lt;variant&gt;...]</code>
+- Build the specified variant (or variants) of Hotspot. Valid variants
+are: <code>server</code>, <code>client</code>, <code>minimal</code>,
+<code>core</code>, <code>zero</code>, <code>custom</code>. Note that not
+all variants are possible to combine in a single build.</li>
+<li><code>--enable-jvm-feature-&lt;feature&gt;</code> or
+<code>--disable-jvm-feature-&lt;feature&gt;</code> - Include (or
+exclude) <code>&lt;feature&gt;</code> as a JVM feature in Hotspot. You
+can also specify a list of features to be enabled, separated by space or
+comma, as
+<code>--with-jvm-features=&lt;feature&gt;[,&lt;feature&gt;...]</code>.
+If you prefix <code>&lt;feature&gt;</code> with a <code>-</code>, it
+will be disabled. These options will modify the default list of features
+for the JVM variant(s) you are building. For the <code>custom</code> JVM
+variant, the default list is empty. A complete list of valid JVM
+features can be found using <code>bash configure --help</code>.</li>
+<li><code>--with-target-bits=&lt;bits&gt;</code> - Create a target
+binary suitable for running on a <code>&lt;bits&gt;</code> platform. Use
+this to create 32-bit output on a 64-bit build platform, instead of
+doing a full cross-compile. (This is known as a <em>reduced</em>
+build.)</li>
 </ul>
-<p>On Linux, BSD and AIX, it is possible to override where Java by default searches for runtime/JNI libraries. This can be useful in situations where there is a special shared directory for system JNI libraries. This setting can in turn be overridden at runtime by setting the <code>java.library.path</code> property.</p>
+<p>On Linux, BSD and AIX, it is possible to override where Java by
+default searches for runtime/JNI libraries. This can be useful in
+situations where there is a special shared directory for system JNI
+libraries. This setting can in turn be overridden at runtime by setting
+the <code>java.library.path</code> property.</p>
 <ul>
-<li><code>--with-jni-libpath=&lt;path&gt;</code> - Use the specified path as a default when searching for runtime libraries.</li>
+<li><code>--with-jni-libpath=&lt;path&gt;</code> - Use the specified
+path as a default when searching for runtime libraries.</li>
 </ul>
-<h4 id="configure-arguments-for-native-compilation">Configure Arguments for Native Compilation</h4>
+<h4 id="configure-arguments-for-native-compilation">Configure Arguments
+for Native Compilation</h4>
 <ul>
-<li><code>--with-devkit=&lt;path&gt;</code> - Use this devkit for compilers, tools and resources</li>
-<li><code>--with-sysroot=&lt;path&gt;</code> - Use this directory as sysroot</li>
-<li><code>--with-extra-path=&lt;path&gt;[;&lt;path&gt;]</code> - Prepend these directories to the default path when searching for all kinds of binaries</li>
-<li><code>--with-toolchain-path=&lt;path&gt;[;&lt;path&gt;]</code> - Prepend these directories when searching for toolchain binaries (compilers etc)</li>
-<li><code>--with-extra-cflags=&lt;flags&gt;</code> - Append these flags when compiling JDK C files</li>
-<li><code>--with-extra-cxxflags=&lt;flags&gt;</code> - Append these flags when compiling JDK C++ files</li>
-<li><code>--with-extra-ldflags=&lt;flags&gt;</code> - Append these flags when linking JDK libraries</li>
+<li><code>--with-devkit=&lt;path&gt;</code> - Use this devkit for
+compilers, tools and resources</li>
+<li><code>--with-sysroot=&lt;path&gt;</code> - Use this directory as
+sysroot</li>
+<li><code>--with-extra-path=&lt;path&gt;[;&lt;path&gt;]</code> - Prepend
+these directories to the default path when searching for all kinds of
+binaries</li>
+<li><code>--with-toolchain-path=&lt;path&gt;[;&lt;path&gt;]</code> -
+Prepend these directories when searching for toolchain binaries
+(compilers etc)</li>
+<li><code>--with-extra-cflags=&lt;flags&gt;</code> - Append these flags
+when compiling JDK C files</li>
+<li><code>--with-extra-cxxflags=&lt;flags&gt;</code> - Append these
+flags when compiling JDK C++ files</li>
+<li><code>--with-extra-ldflags=&lt;flags&gt;</code> - Append these flags
+when linking JDK libraries</li>
 </ul>
-<h4 id="configure-arguments-for-external-dependencies">Configure Arguments for External Dependencies</h4>
+<h4 id="configure-arguments-for-external-dependencies">Configure
+Arguments for External Dependencies</h4>
 <ul>
-<li><code>--with-boot-jdk=&lt;path&gt;</code> - Set the path to the <a href="#boot-jdk-requirements">Boot JDK</a></li>
-<li><code>--with-freetype=&lt;path&gt;</code> - Set the path to <a href="#freetype">FreeType</a></li>
-<li><code>--with-cups=&lt;path&gt;</code> - Set the path to <a href="#cups">CUPS</a></li>
-<li><code>--with-x=&lt;path&gt;</code> - Set the path to <a href="#x11">X11</a></li>
-<li><code>--with-alsa=&lt;path&gt;</code> - Set the path to <a href="#alsa">ALSA</a></li>
-<li><code>--with-libffi=&lt;path&gt;</code> - Set the path to <a href="#libffi">libffi</a></li>
-<li><code>--with-jtreg=&lt;path&gt;</code> - Set the path to JTReg. See <a href="#running-tests">Running Tests</a></li>
+<li><code>--with-boot-jdk=&lt;path&gt;</code> - Set the path to the <a
+href="#boot-jdk-requirements">Boot JDK</a></li>
+<li><code>--with-freetype=&lt;path&gt;</code> - Set the path to <a
+href="#freetype">FreeType</a></li>
+<li><code>--with-cups=&lt;path&gt;</code> - Set the path to <a
+href="#cups">CUPS</a></li>
+<li><code>--with-x=&lt;path&gt;</code> - Set the path to <a
+href="#x11">X11</a></li>
+<li><code>--with-alsa=&lt;path&gt;</code> - Set the path to <a
+href="#alsa">ALSA</a></li>
+<li><code>--with-libffi=&lt;path&gt;</code> - Set the path to <a
+href="#libffi">libffi</a></li>
+<li><code>--with-jtreg=&lt;path&gt;</code> - Set the path to JTReg. See
+<a href="#running-tests">Running Tests</a></li>
 </ul>
-<p>Certain third-party libraries used by the JDK (libjpeg, giflib, libpng, lcms and zlib) are included in the JDK repository. The default behavior of the JDK build is to use the included (&quot;bundled&quot;) versions of libjpeg, giflib, libpng and lcms. For zlib, the system lib (if present) is used except on Windows and AIX. However the bundled libraries may be replaced by an external version. To do so, specify <code>system</code> as the <code>&lt;source&gt;</code> option in these arguments. (The default is <code>bundled</code>).</p>
+<p>Certain third-party libraries used by the JDK (libjpeg, giflib,
+libpng, lcms and zlib) are included in the JDK repository. The default
+behavior of the JDK build is to use the included ("bundled") versions of
+libjpeg, giflib, libpng and lcms. For zlib, the system lib (if present)
+is used except on Windows and AIX. However the bundled libraries may be
+replaced by an external version. To do so, specify <code>system</code>
+as the <code>&lt;source&gt;</code> option in these arguments. (The
+default is <code>bundled</code>).</p>
 <ul>
-<li><code>--with-libjpeg=&lt;source&gt;</code> - Use the specified source for libjpeg</li>
-<li><code>--with-giflib=&lt;source&gt;</code> - Use the specified source for giflib</li>
-<li><code>--with-libpng=&lt;source&gt;</code> - Use the specified source for libpng</li>
-<li><code>--with-lcms=&lt;source&gt;</code> - Use the specified source for lcms</li>
-<li><code>--with-zlib=&lt;source&gt;</code> - Use the specified source for zlib</li>
+<li><code>--with-libjpeg=&lt;source&gt;</code> - Use the specified
+source for libjpeg</li>
+<li><code>--with-giflib=&lt;source&gt;</code> - Use the specified source
+for giflib</li>
+<li><code>--with-libpng=&lt;source&gt;</code> - Use the specified source
+for libpng</li>
+<li><code>--with-lcms=&lt;source&gt;</code> - Use the specified source
+for lcms</li>
+<li><code>--with-zlib=&lt;source&gt;</code> - Use the specified source
+for zlib</li>
 </ul>
-<p>On Linux, it is possible to select either static or dynamic linking of the C++ runtime. The default is static linking, with dynamic linking as fallback if the static library is not found.</p>
+<p>On Linux, it is possible to select either static or dynamic linking
+of the C++ runtime. The default is static linking, with dynamic linking
+as fallback if the static library is not found.</p>
 <ul>
-<li><code>--with-stdc++lib=&lt;method&gt;</code> - Use the specified method (<code>static</code>, <code>dynamic</code> or <code>default</code>) for linking the C++ runtime.</li>
+<li><code>--with-stdc++lib=&lt;method&gt;</code> - Use the specified
+method (<code>static</code>, <code>dynamic</code> or
+<code>default</code>) for linking the C++ runtime.</li>
 </ul>
 <h3 id="configure-control-variables">Configure Control Variables</h3>
-<p>It is possible to control certain aspects of <code>configure</code> by overriding the value of <code>configure</code> variables, either on the command line or in the environment.</p>
-<p>Normally, this is <strong>not recommended</strong>. If used improperly, it can lead to a broken configuration. Unless you're well versed in the build system, this is hard to use properly. Therefore, <code>configure</code> will print a warning if this is detected.</p>
-<p>However, there are a few <code>configure</code> variables, known as <em>control variables</em> that are supposed to be overridden on the command line. These are variables that describe the location of tools needed by the build, like <code>MAKE</code> or <code>GREP</code>. If any such variable is specified, <code>configure</code> will use that value instead of trying to autodetect the tool. For instance, <code>bash configure MAKE=/opt/gnumake4.0/bin/make</code>.</p>
-<p>If a configure argument exists, use that instead, e.g. use <code>--with-jtreg</code> instead of setting <code>JTREGEXE</code>.</p>
-<p>Also note that, despite what autoconf claims, setting <code>CFLAGS</code> will not accomplish anything. Instead use <code>--with-extra-cflags</code> (and similar for <code>cxxflags</code> and <code>ldflags</code>).</p>
+<p>It is possible to control certain aspects of <code>configure</code>
+by overriding the value of <code>configure</code> variables, either on
+the command line or in the environment.</p>
+<p>Normally, this is <strong>not recommended</strong>. If used
+improperly, it can lead to a broken configuration. Unless you're well
+versed in the build system, this is hard to use properly. Therefore,
+<code>configure</code> will print a warning if this is detected.</p>
+<p>However, there are a few <code>configure</code> variables, known as
+<em>control variables</em> that are supposed to be overridden on the
+command line. These are variables that describe the location of tools
+needed by the build, like <code>MAKE</code> or <code>GREP</code>. If any
+such variable is specified, <code>configure</code> will use that value
+instead of trying to autodetect the tool. For instance,
+<code>bash configure MAKE=/opt/gnumake4.0/bin/make</code>.</p>
+<p>If a configure argument exists, use that instead, e.g. use
+<code>--with-jtreg</code> instead of setting <code>JTREGEXE</code>.</p>
+<p>Also note that, despite what autoconf claims, setting
+<code>CFLAGS</code> will not accomplish anything. Instead use
+<code>--with-extra-cflags</code> (and similar for <code>cxxflags</code>
+and <code>ldflags</code>).</p>
 <h2 id="running-make">Running Make</h2>
-<p>When you have a proper configuration, all you need to do to build the JDK is to run <code>make</code>. (But see the warning at <a href="#gnu-make">GNU Make</a> about running the correct version of make.)</p>
-<p>When running <code>make</code> without any arguments, the default target is used, which is the same as running <code>make default</code> or <code>make jdk</code>. This will build a minimal (or roughly minimal) set of compiled output (known as an &quot;exploded image&quot;) needed for a developer to actually execute the newly built JDK. The idea is that in an incremental development fashion, when doing a normal make, you should only spend time recompiling what's changed (making it purely incremental) and only do the work that's needed to actually run and test your code.</p>
-<p>The output of the exploded image resides in <code>$BUILD/jdk</code>. You can test the newly built JDK like this: <code>$BUILD/jdk/bin/java -version</code>.</p>
+<p>When you have a proper configuration, all you need to do to build the
+JDK is to run <code>make</code>. (But see the warning at <a
+href="#gnu-make">GNU Make</a> about running the correct version of
+make.)</p>
+<p>When running <code>make</code> without any arguments, the default
+target is used, which is the same as running <code>make default</code>
+or <code>make jdk</code>. This will build a minimal (or roughly minimal)
+set of compiled output (known as an "exploded image") needed for a
+developer to actually execute the newly built JDK. The idea is that in
+an incremental development fashion, when doing a normal make, you should
+only spend time recompiling what's changed (making it purely
+incremental) and only do the work that's needed to actually run and test
+your code.</p>
+<p>The output of the exploded image resides in <code>$BUILD/jdk</code>.
+You can test the newly built JDK like this:
+<code>$BUILD/jdk/bin/java -version</code>.</p>
 <h3 id="common-make-targets">Common Make Targets</h3>
 <p>Apart from the default target, here are some common make targets:</p>
 <ul>
 <li><code>hotspot</code> - Build all of hotspot (but only hotspot)</li>
-<li><code>hotspot-&lt;variant&gt;</code> - Build just the specified jvm variant</li>
-<li><code>images</code> or <code>product-images</code> - Build the JDK image</li>
-<li><code>docs</code> or <code>docs-image</code> - Build the documentation image</li>
+<li><code>hotspot-&lt;variant&gt;</code> - Build just the specified jvm
+variant</li>
+<li><code>images</code> or <code>product-images</code> - Build the JDK
+image</li>
+<li><code>docs</code> or <code>docs-image</code> - Build the
+documentation image</li>
 <li><code>test-image</code> - Build the test image</li>
-<li><code>all</code> or <code>all-images</code> - Build all images (product, docs and test)</li>
-<li><code>bootcycle-images</code> - Build images twice, second time with newly built JDK (good for testing)</li>
-<li><code>clean</code> - Remove all files generated by make, but not those generated by configure</li>
-<li><code>dist-clean</code> - Remove all files, including configuration</li>
+<li><code>all</code> or <code>all-images</code> - Build all images
+(product, docs and test)</li>
+<li><code>bootcycle-images</code> - Build images twice, second time with
+newly built JDK (good for testing)</li>
+<li><code>clean</code> - Remove all files generated by make, but not
+those generated by configure</li>
+<li><code>dist-clean</code> - Remove all files, including
+configuration</li>
 </ul>
-<p>Run <code>make help</code> to get an up-to-date list of important make targets and make control variables.</p>
-<p>It is possible to build just a single module, a single phase, or a single phase of a single module, by creating make targets according to these followin patterns. A phase can be either of <code>gensrc</code>, <code>gendata</code>, <code>copy</code>, <code>java</code>, <code>launchers</code>, or <code>libs</code>. See <a href="#using-fine-grained-make-targets">Using Fine-Grained Make Targets</a> for more details about this functionality.</p>
+<p>Run <code>make help</code> to get an up-to-date list of important
+make targets and make control variables.</p>
+<p>It is possible to build just a single module, a single phase, or a
+single phase of a single module, by creating make targets according to
+these followin patterns. A phase can be either of <code>gensrc</code>,
+<code>gendata</code>, <code>copy</code>, <code>java</code>,
+<code>launchers</code>, or <code>libs</code>. See <a
+href="#using-fine-grained-make-targets">Using Fine-Grained Make
+Targets</a> for more details about this functionality.</p>
 <ul>
-<li><code>&lt;phase&gt;</code> - Build the specified phase and everything it depends on</li>
-<li><code>&lt;module&gt;</code> - Build the specified module and everything it depends on</li>
-<li><code>&lt;module&gt;-&lt;phase&gt;</code> - Compile the specified phase for the specified module and everything it depends on</li>
+<li><code>&lt;phase&gt;</code> - Build the specified phase and
+everything it depends on</li>
+<li><code>&lt;module&gt;</code> - Build the specified module and
+everything it depends on</li>
+<li><code>&lt;module&gt;-&lt;phase&gt;</code> - Compile the specified
+phase for the specified module and everything it depends on</li>
 </ul>
-<p>Similarly, it is possible to clean just a part of the build by creating make targets according to these patterns:</p>
+<p>Similarly, it is possible to clean just a part of the build by
+creating make targets according to these patterns:</p>
 <ul>
-<li><code>clean-&lt;outputdir&gt;</code> - Remove the subdir in the output dir with the name</li>
-<li><code>clean-&lt;phase&gt;</code> - Remove all build results related to a certain build phase</li>
-<li><code>clean-&lt;module&gt;</code> - Remove all build results related to a certain module</li>
-<li><code>clean-&lt;module&gt;-&lt;phase&gt;</code> - Remove all build results related to a certain module and phase</li>
+<li><code>clean-&lt;outputdir&gt;</code> - Remove the subdir in the
+output dir with the name</li>
+<li><code>clean-&lt;phase&gt;</code> - Remove all build results related
+to a certain build phase</li>
+<li><code>clean-&lt;module&gt;</code> - Remove all build results related
+to a certain module</li>
+<li><code>clean-&lt;module&gt;-&lt;phase&gt;</code> - Remove all build
+results related to a certain module and phase</li>
 </ul>
 <h3 id="make-control-variables">Make Control Variables</h3>
-<p>It is possible to control <code>make</code> behavior by overriding the value of <code>make</code> variables, either on the command line or in the environment.</p>
-<p>Normally, this is <strong>not recommended</strong>. If used improperly, it can lead to a broken build. Unless you're well versed in the build system, this is hard to use properly. Therefore, <code>make</code> will print a warning if this is detected.</p>
-<p>However, there are a few <code>make</code> variables, known as <em>control variables</em> that are supposed to be overridden on the command line. These make up the &quot;make time&quot; configuration, as opposed to the &quot;configure time&quot; configuration.</p>
-<h4 id="general-make-control-variables">General Make Control Variables</h4>
+<p>It is possible to control <code>make</code> behavior by overriding
+the value of <code>make</code> variables, either on the command line or
+in the environment.</p>
+<p>Normally, this is <strong>not recommended</strong>. If used
+improperly, it can lead to a broken build. Unless you're well versed in
+the build system, this is hard to use properly. Therefore,
+<code>make</code> will print a warning if this is detected.</p>
+<p>However, there are a few <code>make</code> variables, known as
+<em>control variables</em> that are supposed to be overridden on the
+command line. These make up the "make time" configuration, as opposed to
+the "configure time" configuration.</p>
+<h4 id="general-make-control-variables">General Make Control
+Variables</h4>
 <ul>
-<li><code>JOBS</code> - Specify the number of jobs to build with. See <a href="#build-performance">Build Performance</a>.</li>
-<li><code>LOG</code> - Specify the logging level and functionality. See <a href="#checking-the-build-log-file">Checking the Build Log File</a></li>
-<li><code>CONF</code> and <code>CONF_NAME</code> - Selecting the configuration(s) to use. See <a href="#using-multiple-configurations">Using Multiple Configurations</a></li>
+<li><code>JOBS</code> - Specify the number of jobs to build with. See <a
+href="#build-performance">Build Performance</a>.</li>
+<li><code>LOG</code> - Specify the logging level and functionality. See
+<a href="#checking-the-build-log-file">Checking the Build Log
+File</a></li>
+<li><code>CONF</code> and <code>CONF_NAME</code> - Selecting the
+configuration(s) to use. See <a
+href="#using-multiple-configurations">Using Multiple
+Configurations</a></li>
 </ul>
 <h4 id="test-make-control-variables">Test Make Control Variables</h4>
-<p>These make control variables only make sense when running tests. Please see <strong>Testing the JDK</strong> (<a href="testing.html">html</a>, <a href="testing.md">markdown</a>) for details.</p>
+<p>These make control variables only make sense when running tests.
+Please see <strong>Testing the JDK</strong> (<a
+href="testing.html">html</a>, <a href="testing.md">markdown</a>) for
+details.</p>
 <ul>
 <li><code>TEST</code></li>
 <li><code>TEST_JOBS</code></li>
 <li><code>JTREG</code></li>
 <li><code>GTEST</code></li>
 </ul>
-<h4 id="advanced-make-control-variables">Advanced Make Control Variables</h4>
-<p>These advanced make control variables can be potentially unsafe. See <a href="#hints-and-suggestions-for-advanced-users">Hints and Suggestions for Advanced Users</a> and <a href="#understanding-the-build-system">Understanding the Build System</a> for details.</p>
+<h4 id="advanced-make-control-variables">Advanced Make Control
+Variables</h4>
+<p>These advanced make control variables can be potentially unsafe. See
+<a href="#hints-and-suggestions-for-advanced-users">Hints and
+Suggestions for Advanced Users</a> and <a
+href="#understanding-the-build-system">Understanding the Build
+System</a> for details.</p>
 <ul>
 <li><code>SPEC</code></li>
 <li><code>CONF_CHECK</code></li>
@@ -512,35 +1072,119 @@
 <li><code>SPEC_FILTER</code></li>
 </ul>
 <h2 id="running-tests">Running Tests</h2>
-<p>Most of the JDK tests are using the <a href="http://openjdk.org/jtreg">JTReg</a> test framework. Make sure that your configuration knows where to find your installation of JTReg. If this is not picked up automatically, use the <code>--with-jtreg=&lt;path to jtreg home&gt;</code> option to point to the JTReg framework. Note that this option should point to the JTReg home, i.e. the top directory, containing <code>lib/jtreg.jar</code> etc.</p>
-<p>The <a href="https://wiki.openjdk.org/display/Adoption">Adoption Group</a> provides recent builds of jtreg <a href="https://ci.adoptopenjdk.net/view/Dependencies/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/">here</a>. Download the latest <code>.tar.gz</code> file, unpack it, and point <code>--with-jtreg</code> to the <code>jtreg</code> directory that you just unpacked.</p>
-<p>Building of Hotspot Gtest suite requires the source code of Google Test framework. The top directory, which contains both <code>googletest</code> and <code>googlemock</code> directories, should be specified via <code>--with-gtest</code>. The supported version of Google Test is 1.8.1, whose source code can be obtained:</p>
+<p>Most of the JDK tests are using the <a
+href="http://openjdk.org/jtreg">JTReg</a> test framework. Make sure that
+your configuration knows where to find your installation of JTReg. If
+this is not picked up automatically, use the
+<code>--with-jtreg=&lt;path to jtreg home&gt;</code> option to point to
+the JTReg framework. Note that this option should point to the JTReg
+home, i.e. the top directory, containing <code>lib/jtreg.jar</code>
+etc.</p>
+<p>The <a href="https://wiki.openjdk.org/display/Adoption">Adoption
+Group</a> provides recent builds of jtreg <a
+href="https://ci.adoptopenjdk.net/view/Dependencies/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/">here</a>.
+Download the latest <code>.tar.gz</code> file, unpack it, and point
+<code>--with-jtreg</code> to the <code>jtreg</code> directory that you
+just unpacked.</p>
+<p>Building of Hotspot Gtest suite requires the source code of Google
+Test framework. The top directory, which contains both
+<code>googletest</code> and <code>googlemock</code> directories, should
+be specified via <code>--with-gtest</code>. The supported version of
+Google Test is 1.8.1, whose source code can be obtained:</p>
 <ul>
-<li>by downloading and unpacking the source bundle from <a href="https://github.com/google/googletest/releases/tag/release-1.8.1">here</a></li>
-<li>or by checking out <code>release-1.8.1</code> tag of <code>googletest</code> project: <code>git clone -b release-1.8.1 https://github.com/google/googletest</code></li>
+<li>by downloading and unpacking the source bundle from <a
+href="https://github.com/google/googletest/releases/tag/release-1.8.1">here</a></li>
+<li>or by checking out <code>release-1.8.1</code> tag of
+<code>googletest</code> project:
+<code>git clone -b release-1.8.1 https://github.com/google/googletest</code></li>
 </ul>
 <p>To execute the most basic tests (tier 1), use:</p>
 <pre><code>make run-test-tier1</code></pre>
-<p>For more details on how to run tests, please see <strong>Testing the JDK</strong> (<a href="testing.html">html</a>, <a href="testing.md">markdown</a>).</p>
+<p>For more details on how to run tests, please see <strong>Testing the
+JDK</strong> (<a href="testing.html">html</a>, <a
+href="testing.md">markdown</a>).</p>
 <h2 id="signing">Signing</h2>
 <h3 id="macos-1">macOS</h3>
-<p>Modern versions of macOS require applications to be signed and notarizied before distribution. See Apple's documentation for more background on what this means and how it works. To help support this, the JDK build can be configured to automatically sign all native binaries, and the JDK bundle, with all the options needed for successful notarization, as well as all the entitlements required by the JDK. To enable <code>hardened</code> signing, use configure parameter <code>--with-macosx-codesign=hardened</code> and configure the signing identity you wish to use with <code>--with-macosx-codesign-identity=&lt;identity&gt;</code>. The identity refers to a signing identity from Apple that needs to be preinstalled on the build host.</p>
-<p>When not signing for distribution with the hardened option, the JDK build will still attempt to perform <code>adhoc</code> signing to add the special entitlement <code>com.apple.security.get-task-allow</code> to each binary. This entitlement is required to be able to dump core files from a process. Note that adding this entitlement makes the build invalid for notarization, so it is only added when signing in <code>debug</code> mode. To explicitly enable this kind of adhoc signing, use configure parameter <code>--with-macosx-codesign=debug</code>. It will be enabled by default in most cases.</p>
-<p>It's also possible to completely disable any explicit codesign operations done by the JDK build using the configure parameter <code>--without-macosx-codesign</code>. The exact behavior then depends on the architecture. For macOS on x64, it (at least at the time of this writing) results in completely unsigned binaries that should still work fine for development and debugging purposes. On aarch64, the Xcode linker will apply a default &quot;adhoc&quot; signing, without any entitlements. Such a build does not allow dumping core files.</p>
-<p>The default mode &quot;auto&quot; will try for <code>hardened</code> signing if the debug level is <code>release</code> and either the default identity or the specified identity is valid. If hardened isn't possible, then <code>debug</code> signing is chosen if it works. If nothing works, the codesign build step is disabled.</p>
+<p>Modern versions of macOS require applications to be signed and
+notarizied before distribution. See Apple's documentation for more
+background on what this means and how it works. To help support this,
+the JDK build can be configured to automatically sign all native
+binaries, and the JDK bundle, with all the options needed for successful
+notarization, as well as all the entitlements required by the JDK. To
+enable <code>hardened</code> signing, use configure parameter
+<code>--with-macosx-codesign=hardened</code> and configure the signing
+identity you wish to use with
+<code>--with-macosx-codesign-identity=&lt;identity&gt;</code>. The
+identity refers to a signing identity from Apple that needs to be
+preinstalled on the build host.</p>
+<p>When not signing for distribution with the hardened option, the JDK
+build will still attempt to perform <code>adhoc</code> signing to add
+the special entitlement <code>com.apple.security.get-task-allow</code>
+to each binary. This entitlement is required to be able to dump core
+files from a process. Note that adding this entitlement makes the build
+invalid for notarization, so it is only added when signing in
+<code>debug</code> mode. To explicitly enable this kind of adhoc
+signing, use configure parameter
+<code>--with-macosx-codesign=debug</code>. It will be enabled by default
+in most cases.</p>
+<p>It's also possible to completely disable any explicit codesign
+operations done by the JDK build using the configure parameter
+<code>--without-macosx-codesign</code>. The exact behavior then depends
+on the architecture. For macOS on x64, it (at least at the time of this
+writing) results in completely unsigned binaries that should still work
+fine for development and debugging purposes. On aarch64, the Xcode
+linker will apply a default "adhoc" signing, without any entitlements.
+Such a build does not allow dumping core files.</p>
+<p>The default mode "auto" will try for <code>hardened</code> signing if
+the debug level is <code>release</code> and either the default identity
+or the specified identity is valid. If hardened isn't possible, then
+<code>debug</code> signing is chosen if it works. If nothing works, the
+codesign build step is disabled.</p>
 <h2 id="cross-compiling">Cross-compiling</h2>
-<p>Cross-compiling means using one platform (the <em>build</em> platform) to generate output that can ran on another platform (the <em>target</em> platform).</p>
-<p>The typical reason for cross-compiling is that the build is performed on a more powerful desktop computer, but the resulting binaries will be able to run on a different, typically low-performing system. Most of the complications that arise when building for embedded is due to this separation of <em>build</em> and <em>target</em> systems.</p>
-<p>This requires a more complex setup and build procedure. This section assumes you are familiar with cross-compiling in general, and will only deal with the particularities of cross-compiling the JDK. If you are new to cross-compiling, please see the <a href="https://en.wikipedia.org/wiki/Cross_compiler#External_links">external links at Wikipedia</a> for a good start on reading materials.</p>
-<p>Cross-compiling the JDK requires you to be able to build both for the build platform and for the target platform. The reason for the former is that we need to build and execute tools during the build process, both native tools and Java tools.</p>
-<p>If all you want to do is to compile a 32-bit version, for the same OS, on a 64-bit machine, consider using <code>--with-target-bits=32</code> instead of doing a full-blown cross-compilation. (While this surely is possible, it's a lot more work and will take much longer to build.)</p>
-<h3 id="cross-compiling-the-easy-way-with-openjdk-devkits">Cross compiling the easy way with OpenJDK devkits</h3>
-<p>The OpenJDK build system provides out-of-the box support for creating and using so called devkits. A <code>devkit</code> is basically a collection of a cross-compiling toolchain and a sysroot environment which can easily be used together with the <code>--with-devkit</code> configure option to cross compile the OpenJDK. On Linux/x86_64, the following command:</p>
+<p>Cross-compiling means using one platform (the <em>build</em>
+platform) to generate output that can ran on another platform (the
+<em>target</em> platform).</p>
+<p>The typical reason for cross-compiling is that the build is performed
+on a more powerful desktop computer, but the resulting binaries will be
+able to run on a different, typically low-performing system. Most of the
+complications that arise when building for embedded is due to this
+separation of <em>build</em> and <em>target</em> systems.</p>
+<p>This requires a more complex setup and build procedure. This section
+assumes you are familiar with cross-compiling in general, and will only
+deal with the particularities of cross-compiling the JDK. If you are new
+to cross-compiling, please see the <a
+href="https://en.wikipedia.org/wiki/Cross_compiler#External_links">external
+links at Wikipedia</a> for a good start on reading materials.</p>
+<p>Cross-compiling the JDK requires you to be able to build both for the
+build platform and for the target platform. The reason for the former is
+that we need to build and execute tools during the build process, both
+native tools and Java tools.</p>
+<p>If all you want to do is to compile a 32-bit version, for the same
+OS, on a 64-bit machine, consider using
+<code>--with-target-bits=32</code> instead of doing a full-blown
+cross-compilation. (While this surely is possible, it's a lot more work
+and will take much longer to build.)</p>
+<h3 id="cross-compiling-the-easy-way-with-openjdk-devkits">Cross
+compiling the easy way with OpenJDK devkits</h3>
+<p>The OpenJDK build system provides out-of-the box support for creating
+and using so called devkits. A <code>devkit</code> is basically a
+collection of a cross-compiling toolchain and a sysroot environment
+which can easily be used together with the <code>--with-devkit</code>
+configure option to cross compile the OpenJDK. On Linux/x86_64, the
+following command:</p>
 <pre><code>bash configure --with-devkit=&lt;devkit-path&gt; --openjdk-target=ppc64-linux-gnu &amp;&amp; make</code></pre>
-<p>will configure and build OpenJDK for Linux/ppc64 assuming that <code>&lt;devkit-path&gt;</code> points to a Linux/x86_64 to Linux/ppc64 devkit.</p>
-<p>Devkits can be created from the <code>make/devkit</code> directory by executing:</p>
+<p>will configure and build OpenJDK for Linux/ppc64 assuming that
+<code>&lt;devkit-path&gt;</code> points to a Linux/x86_64 to Linux/ppc64
+devkit.</p>
+<p>Devkits can be created from the <code>make/devkit</code> directory by
+executing:</p>
 <pre><code>make [ TARGETS=&quot;&lt;TARGET_TRIPLET&gt;+&quot; ] [ BASE_OS=&lt;OS&gt; ] [ BASE_OS_VERSION=&lt;VER&gt; ]</code></pre>
-<p>where <code>TARGETS</code> contains one or more <code>TARGET_TRIPLET</code>s of the form described in <a href="https://sourceware.org/autobook/autobook/autobook_17.html">section 3.4 of the GNU Autobook</a>. If no targets are given, a native toolchain for the current platform will be created. Currently, at least the following targets are known to work:</p>
+<p>where <code>TARGETS</code> contains one or more
+<code>TARGET_TRIPLET</code>s of the form described in <a
+href="https://sourceware.org/autobook/autobook/autobook_17.html">section
+3.4 of the GNU Autobook</a>. If no targets are given, a native toolchain
+for the current platform will be created. Currently, at least the
+following targets are known to work:</p>
 <table>
 <thead>
 <tr class="header">
@@ -568,46 +1212,119 @@
 </tr>
 </tbody>
 </table>
-<p><code>BASE_OS</code> must be one of &quot;OEL6&quot; for Oracle Enterprise Linux 6 or &quot;Fedora&quot; (if not specified &quot;OEL6&quot; will be the default). If the base OS is &quot;Fedora&quot; the corresponding Fedora release can be specified with the help of the <code>BASE_OS_VERSION</code> option (with &quot;27&quot; as default version). If the build is successful, the new devkits can be found in the <code>build/devkit/result</code> subdirectory:</p>
+<p><code>BASE_OS</code> must be one of "OEL6" for Oracle Enterprise
+Linux 6 or "Fedora" (if not specified "OEL6" will be the default). If
+the base OS is "Fedora" the corresponding Fedora release can be
+specified with the help of the <code>BASE_OS_VERSION</code> option (with
+"27" as default version). If the build is successful, the new devkits
+can be found in the <code>build/devkit/result</code> subdirectory:</p>
 <pre><code>cd make/devkit
 make TARGETS=&quot;ppc64le-linux-gnu aarch64-linux-gnu&quot; BASE_OS=Fedora BASE_OS_VERSION=21
 ls -1 ../../build/devkit/result/
 x86_64-linux-gnu-to-aarch64-linux-gnu
 x86_64-linux-gnu-to-ppc64le-linux-gnu</code></pre>
-<p>Notice that devkits are not only useful for targeting different build platforms. Because they contain the full build dependencies for a system (i.e. compiler and root file system), they can easily be used to build well-known, reliable and reproducible build environments. You can for example create and use a devkit with GCC 7.3 and a Fedora 12 sysroot environment (with glibc 2.11) on Ubuntu 14.04 (which doesn't have GCC 7.3 by default) to produce OpenJDK binaries which will run on all Linux systems with runtime libraries newer than the ones from Fedora 12 (e.g. Ubuntu 16.04, SLES 11 or RHEL 6).</p>
+<p>Notice that devkits are not only useful for targeting different build
+platforms. Because they contain the full build dependencies for a system
+(i.e. compiler and root file system), they can easily be used to build
+well-known, reliable and reproducible build environments. You can for
+example create and use a devkit with GCC 7.3 and a Fedora 12 sysroot
+environment (with glibc 2.11) on Ubuntu 14.04 (which doesn't have GCC
+7.3 by default) to produce OpenJDK binaries which will run on all Linux
+systems with runtime libraries newer than the ones from Fedora 12 (e.g.
+Ubuntu 16.04, SLES 11 or RHEL 6).</p>
 <h3 id="boot-jdk-and-build-jdk">Boot JDK and Build JDK</h3>
-<p>When cross-compiling, make sure you use a boot JDK that runs on the <em>build</em> system, and not on the <em>target</em> system.</p>
-<p>To be able to build, we need a &quot;Build JDK&quot;, which is a JDK built from the current sources (that is, the same as the end result of the entire build process), but able to run on the <em>build</em> system, and not the <em>target</em> system. (In contrast, the Boot JDK should be from an older release, e.g. JDK 8 when building JDK 9.)</p>
-<p>The build process will create a minimal Build JDK for you, as part of building. To speed up the build, you can use <code>--with-build-jdk</code> to <code>configure</code> to point to a pre-built Build JDK. Please note that the build result is unpredictable, and can possibly break in subtle ways, if the Build JDK does not <strong>exactly</strong> match the current sources.</p>
-<h3 id="specifying-the-target-platform">Specifying the Target Platform</h3>
-<p>You <em>must</em> specify the target platform when cross-compiling. Doing so will also automatically turn the build into a cross-compiling mode. The simplest way to do this is to use the <code>--openjdk-target</code> argument, e.g. <code>--openjdk-target=arm-linux-gnueabihf</code>. or <code>--openjdk-target=aarch64-oe-linux</code>. This will automatically set the <code>--host</code> and <code>--target</code> options for autoconf, which can otherwise be confusing. (In autoconf terminology, the &quot;target&quot; is known as &quot;host&quot;, and &quot;target&quot; is used for building a Canadian cross-compiler.)</p>
-<p>If <code>--build</code> has not been explicitly passed to configure, <code>--openjdk-target</code> will autodetect the build platform and internally set the flag automatically, otherwise the platform that was explicitly passed to <code>--build</code> will be used instead.</p>
+<p>When cross-compiling, make sure you use a boot JDK that runs on the
+<em>build</em> system, and not on the <em>target</em> system.</p>
+<p>To be able to build, we need a "Build JDK", which is a JDK built from
+the current sources (that is, the same as the end result of the entire
+build process), but able to run on the <em>build</em> system, and not
+the <em>target</em> system. (In contrast, the Boot JDK should be from an
+older release, e.g. JDK 8 when building JDK 9.)</p>
+<p>The build process will create a minimal Build JDK for you, as part of
+building. To speed up the build, you can use
+<code>--with-build-jdk</code> to <code>configure</code> to point to a
+pre-built Build JDK. Please note that the build result is unpredictable,
+and can possibly break in subtle ways, if the Build JDK does not
+<strong>exactly</strong> match the current sources.</p>
+<h3 id="specifying-the-target-platform">Specifying the Target
+Platform</h3>
+<p>You <em>must</em> specify the target platform when cross-compiling.
+Doing so will also automatically turn the build into a cross-compiling
+mode. The simplest way to do this is to use the
+<code>--openjdk-target</code> argument, e.g.
+<code>--openjdk-target=arm-linux-gnueabihf</code>. or
+<code>--openjdk-target=aarch64-oe-linux</code>. This will automatically
+set the <code>--host</code> and <code>--target</code> options for
+autoconf, which can otherwise be confusing. (In autoconf terminology,
+the "target" is known as "host", and "target" is used for building a
+Canadian cross-compiler.)</p>
+<p>If <code>--build</code> has not been explicitly passed to configure,
+<code>--openjdk-target</code> will autodetect the build platform and
+internally set the flag automatically, otherwise the platform that was
+explicitly passed to <code>--build</code> will be used instead.</p>
 <h3 id="toolchain-considerations">Toolchain Considerations</h3>
-<p>You will need two copies of your toolchain, one which generates output that can run on the target system (the normal, or <em>target</em>, toolchain), and one that generates output that can run on the build system (the <em>build</em> toolchain). Note that cross-compiling is only supported for gcc at the time being. The gcc standard is to prefix cross-compiling toolchains with the target denominator. If you follow this standard, <code>configure</code> is likely to pick up the toolchain correctly.</p>
-<p>The <em>build</em> toolchain will be autodetected just the same way the normal <em>build</em>/<em>target</em> toolchain will be autodetected when not cross-compiling. If this is not what you want, or if the autodetection fails, you can specify a devkit containing the <em>build</em> toolchain using <code>--with-build-devkit</code> to <code>configure</code>, or by giving <code>BUILD_CC</code> and <code>BUILD_CXX</code> arguments.</p>
-<p>It is often helpful to locate the cross-compilation tools, headers and libraries in a separate directory, outside the normal path, and point out that directory to <code>configure</code>. Do this by setting the sysroot (<code>--with-sysroot</code>) and appending the directory when searching for cross-compilations tools (<code>--with-toolchain-path</code>). As a compact form, you can also use <code>--with-devkit</code> to point to a single directory, if it is correctly setup. (See <code>basics.m4</code> for details.)</p>
+<p>You will need two copies of your toolchain, one which generates
+output that can run on the target system (the normal, or
+<em>target</em>, toolchain), and one that generates output that can run
+on the build system (the <em>build</em> toolchain). Note that
+cross-compiling is only supported for gcc at the time being. The gcc
+standard is to prefix cross-compiling toolchains with the target
+denominator. If you follow this standard, <code>configure</code> is
+likely to pick up the toolchain correctly.</p>
+<p>The <em>build</em> toolchain will be autodetected just the same way
+the normal <em>build</em>/<em>target</em> toolchain will be autodetected
+when not cross-compiling. If this is not what you want, or if the
+autodetection fails, you can specify a devkit containing the
+<em>build</em> toolchain using <code>--with-build-devkit</code> to
+<code>configure</code>, or by giving <code>BUILD_CC</code> and
+<code>BUILD_CXX</code> arguments.</p>
+<p>It is often helpful to locate the cross-compilation tools, headers
+and libraries in a separate directory, outside the normal path, and
+point out that directory to <code>configure</code>. Do this by setting
+the sysroot (<code>--with-sysroot</code>) and appending the directory
+when searching for cross-compilations tools
+(<code>--with-toolchain-path</code>). As a compact form, you can also
+use <code>--with-devkit</code> to point to a single directory, if it is
+correctly setup. (See <code>basics.m4</code> for details.)</p>
 <h3 id="native-libraries">Native Libraries</h3>
-<p>You will need copies of external native libraries for the <em>target</em> system, present on the <em>build</em> machine while building.</p>
-<p>Take care not to replace the <em>build</em> system's version of these libraries by mistake, since that can render the <em>build</em> machine unusable.</p>
-<p>Make sure that the libraries you point to (ALSA, X11, etc) are for the <em>target</em>, not the <em>build</em>, platform.</p>
+<p>You will need copies of external native libraries for the
+<em>target</em> system, present on the <em>build</em> machine while
+building.</p>
+<p>Take care not to replace the <em>build</em> system's version of these
+libraries by mistake, since that can render the <em>build</em> machine
+unusable.</p>
+<p>Make sure that the libraries you point to (ALSA, X11, etc) are for
+the <em>target</em>, not the <em>build</em>, platform.</p>
 <h4 id="alsa-1">ALSA</h4>
-<p>You will need alsa libraries suitable for your <em>target</em> system. For most cases, using Debian's pre-built libraries work fine.</p>
-<p>Note that alsa is needed even if you only want to build a headless JDK.</p>
+<p>You will need alsa libraries suitable for your <em>target</em>
+system. For most cases, using Debian's pre-built libraries work
+fine.</p>
+<p>Note that alsa is needed even if you only want to build a headless
+JDK.</p>
 <ul>
-<li><p>Go to <a href="https://www.debian.org/distrib/packages">Debian Package Search</a> and search for the <code>libasound2</code> and <code>libasound2-dev</code> packages for your <em>target</em> system. Download them to /tmp.</p></li>
-<li>Install the libraries into the cross-compilation toolchain. For instance:</li>
+<li><p>Go to <a href="https://www.debian.org/distrib/packages">Debian
+Package Search</a> and search for the <code>libasound2</code> and
+<code>libasound2-dev</code> packages for your <em>target</em> system.
+Download them to /tmp.</p></li>
+<li><p>Install the libraries into the cross-compilation toolchain. For
+instance:</p></li>
 </ul>
 <pre><code>cd /tools/gcc-linaro-arm-linux-gnueabihf-raspbian-2012.09-20120921_linux/arm-linux-gnueabihf/libc
 dpkg-deb -x /tmp/libasound2_1.0.25-4_armhf.deb .
 dpkg-deb -x /tmp/libasound2-dev_1.0.25-4_armhf.deb .</code></pre>
 <ul>
-<li>If alsa is not properly detected by <code>configure</code>, you can point it out by <code>--with-alsa</code>.</li>
+<li>If alsa is not properly detected by <code>configure</code>, you can
+point it out by <code>--with-alsa</code>.</li>
 </ul>
 <h4 id="x11-1">X11</h4>
-<p>You will need X11 libraries suitable for your <em>target</em> system. For most cases, using Debian's pre-built libraries work fine.</p>
-<p>Note that X11 is needed even if you only want to build a headless JDK.</p>
+<p>You will need X11 libraries suitable for your <em>target</em> system.
+For most cases, using Debian's pre-built libraries work fine.</p>
+<p>Note that X11 is needed even if you only want to build a headless
+JDK.</p>
 <ul>
-<li>Go to <a href="https://www.debian.org/distrib/packages">Debian Package Search</a>, search for the following packages for your <em>target</em> system, and download them to /tmp/target-x11:
+<li><p>Go to <a href="https://www.debian.org/distrib/packages">Debian
+Package Search</a>, search for the following packages for your
+<em>target</em> system, and download them to /tmp/target-x11:</p>
 <ul>
 <li>libxi</li>
 <li>libxi-dev</li>
@@ -629,53 +1346,69 @@ dpkg-deb -x /tmp/libasound2-dev_1.0.25-4_armhf.deb .</code></pre>
 <li>libxext</li>
 <li>libxext-dev</li>
 </ul></li>
-<li><p>Install the libraries into the cross-compilation toolchain. For instance:</p>
-<pre><code>cd /tools/gcc-linaro-arm-linux-gnueabihf-raspbian-2012.09-20120921_linux/arm-linux-gnueabihf/libc/usr
-mkdir X11R6
-cd X11R6
-for deb in /tmp/target-x11/*.deb ; do dpkg-deb -x $deb . ; done
-mv usr/* .
-cd lib
-cp arm-linux-gnueabihf/* .</code></pre>
-<p>You can ignore the following messages. These libraries are not needed to successfully complete a full JDK build.</p>
-<pre><code>cp: cannot stat `arm-linux-gnueabihf/libICE.so&#39;: No such file or directory
-cp: cannot stat `arm-linux-gnueabihf/libSM.so&#39;: No such file or directory
-cp: cannot stat `arm-linux-gnueabihf/libXt.so&#39;: No such file or directory</code></pre></li>
-<li><p>If the X11 libraries are not properly detected by <code>configure</code>, you can point them out by <code>--with-x</code>.</p></li>
+<li><p>Install the libraries into the cross-compilation toolchain. For
+instance:</p>
+<pre><code>    cd /tools/gcc-linaro-arm-linux-gnueabihf-raspbian-2012.09-20120921_linux/arm-linux-gnueabihf/libc/usr
+    mkdir X11R6
+    cd X11R6
+    for deb in /tmp/target-x11/*.deb ; do dpkg-deb -x $deb . ; done
+    mv usr/* .
+    cd lib
+    cp arm-linux-gnueabihf/* .
+    ```
+
+You can ignore the following messages. These libraries are not needed to
+successfully complete a full JDK build.</code></pre>
+<p>cp: cannot stat
+<code>arm-linux-gnueabihf/libICE.so': No such file or directory cp: cannot stat</code>arm-linux-gnueabihf/libSM.so':
+No such file or directory cp: cannot stat
+`arm-linux-gnueabihf/libXt.so': No such file or directory ```</p></li>
+<li><p>If the X11 libraries are not properly detected by
+<code>configure</code>, you can point them out by
+<code>--with-x</code>.</p></li>
 </ul>
-<h3 id="cross-compiling-with-debian-sysroots">Cross compiling with Debian sysroots</h3>
-<p>Fortunately, you can create sysroots for foreign architectures with tools provided by your OS. On Debian/Ubuntu systems, one could use <code>qemu-deboostrap</code> to create the <em>target</em> system chroot, which would have the native libraries and headers specific to that <em>target</em> system. After that, we can use the cross-compiler on the <em>build</em> system, pointing into chroot to get the build dependencies right. This allows building for foreign architectures with native compilation speed.</p>
-<p>For example, cross-compiling to AArch64 from x86_64 could be done like this:</p>
+<h3 id="cross-compiling-with-debian-sysroots">Cross compiling with
+Debian sysroots</h3>
+<p>Fortunately, you can create sysroots for foreign architectures with
+tools provided by your OS. On Debian/Ubuntu systems, one could use
+<code>qemu-deboostrap</code> to create the <em>target</em> system
+chroot, which would have the native libraries and headers specific to
+that <em>target</em> system. After that, we can use the cross-compiler
+on the <em>build</em> system, pointing into chroot to get the build
+dependencies right. This allows building for foreign architectures with
+native compilation speed.</p>
+<p>For example, cross-compiling to AArch64 from x86_64 could be done
+like this:</p>
 <ul>
-<li><p>Install cross-compiler on the <em>build</em> system:</p>
-<pre><code>apt install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu</code></pre></li>
-<li><p>Create chroot on the <em>build</em> system, configuring it for <em>target</em> system:</p>
-<pre><code>sudo qemu-debootstrap \
-  --arch=arm64 \
-  --verbose \
-  --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev,libffi-dev \
-  --resolve-deps \
-  buster \
-  ~/sysroot-arm64 \
-  http://httpredir.debian.org/debian/</code></pre></li>
-<li><p>Make sure the symlinks inside the newly created chroot point to proper locations:</p>
-<pre><code>sudo chroot ~/sysroot-arm64 symlinks -cr .</code></pre></li>
-<li><p>Configure and build with newly created chroot as sysroot/toolchain-path:</p>
-<pre><code>sh ./configure \
-  --openjdk-target=aarch64-linux-gnu \
-  --with-sysroot=~/sysroot-arm64
-make images
-ls build/linux-aarch64-server-release/</code></pre></li>
+<li><p>Install cross-compiler on the <em>build</em> system:
+<code>apt install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu</code></p></li>
+<li><p>Create chroot on the <em>build</em> system, configuring it for
+<em>target</em> system:
+<code>sudo qemu-debootstrap \       --arch=arm64 \       --verbose \       --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev,libffi-dev \       --resolve-deps \       buster \       ~/sysroot-arm64 \       http://httpredir.debian.org/debian/</code></p></li>
+<li><p>Make sure the symlinks inside the newly created chroot point to
+proper locations:
+<code>sudo chroot ~/sysroot-arm64 symlinks -cr .</code></p></li>
+<li><p>Configure and build with newly created chroot as
+sysroot/toolchain-path:
+<code>sh ./configure \       --openjdk-target=aarch64-linux-gnu \       --with-sysroot=~/sysroot-arm64     make images     ls build/linux-aarch64-server-release/</code></p></li>
 </ul>
-<p>The build does not create new files in that chroot, so it can be reused for multiple builds without additional cleanup.</p>
-<p>The build system should automatically detect the toolchain paths and dependencies, but sometimes it might require a little nudge with:</p>
+<p>The build does not create new files in that chroot, so it can be
+reused for multiple builds without additional cleanup.</p>
+<p>The build system should automatically detect the toolchain paths and
+dependencies, but sometimes it might require a little nudge with:</p>
 <ul>
-<li><p>Native compilers: override <code>CC</code> or <code>CXX</code> for <code>./configure</code></p></li>
-<li><p>Freetype lib location: override <code>--with-freetype-lib</code>, for example <code>${sysroot}/usr/lib/${target}/</code></p></li>
-<li><p>Freetype includes location: override <code>--with-freetype-include</code> for example <code>${sysroot}/usr/include/freetype2/</code></p></li>
-<li><p>X11 libraries location: override <code>--x-libraries</code>, for example <code>${sysroot}/usr/lib/${target}/</code></p></li>
+<li><p>Native compilers: override <code>CC</code> or <code>CXX</code>
+for <code>./configure</code></p></li>
+<li><p>Freetype lib location: override <code>--with-freetype-lib</code>,
+for example <code>${sysroot}/usr/lib/${target}/</code></p></li>
+<li><p>Freetype includes location: override
+<code>--with-freetype-include</code> for example
+<code>${sysroot}/usr/include/freetype2/</code></p></li>
+<li><p>X11 libraries location: override <code>--x-libraries</code>, for
+example <code>${sysroot}/usr/lib/${target}/</code></p></li>
 </ul>
-<p>Architectures that are known to successfully cross-compile like this are:</p>
+<p>Architectures that are known to successfully cross-compile like this
+are:</p>
 <table>
 <thead>
 <tr class="header">
@@ -781,9 +1514,19 @@ ls build/linux-aarch64-server-release/</code></pre></li>
 </tbody>
 </table>
 <h3 id="building-for-armaarch64">Building for ARM/aarch64</h3>
-<p>A common cross-compilation target is the ARM CPU. When building for ARM, it is useful to set the ABI profile. A number of pre-defined ABI profiles are available using <code>--with-abi-profile</code>: arm-vfp-sflt, arm-vfp-hflt, arm-sflt, armv5-vfp-sflt, armv6-vfp-hflt. Note that soft-float ABIs are no longer properly supported by the JDK.</p>
+<p>A common cross-compilation target is the ARM CPU. When building for
+ARM, it is useful to set the ABI profile. A number of pre-defined ABI
+profiles are available using <code>--with-abi-profile</code>:
+arm-vfp-sflt, arm-vfp-hflt, arm-sflt, armv5-vfp-sflt, armv6-vfp-hflt.
+Note that soft-float ABIs are no longer properly supported by the
+JDK.</p>
 <h3 id="building-for-musl">Building for musl</h3>
-<p>Just like it's possible to cross-compile for a different CPU, it's possible to cross-compile for musl libc on a glibc-based <em>build</em> system. A devkit suitable for most target CPU architectures can be obtained from <a href="https://musl.cc">musl.cc</a>. After installing the required packages in the sysroot, configure the build with <code>--openjdk-target</code>:</p>
+<p>Just like it's possible to cross-compile for a different CPU, it's
+possible to cross-compile for musl libc on a glibc-based <em>build</em>
+system. A devkit suitable for most target CPU architectures can be
+obtained from <a href="https://musl.cc">musl.cc</a>. After installing
+the required packages in the sysroot, configure the build with
+<code>--openjdk-target</code>:</p>
 <pre><code>sh ./configure --with-jvm-variants=server \
 --with-boot-jdk=$BOOT_JDK \
 --with-build-jdk=$BUILD_JDK \
@@ -792,44 +1535,102 @@ ls build/linux-aarch64-server-release/</code></pre></li>
 --with-sysroot=$SYSROOT</code></pre>
 <p>and run <code>make</code> normally.</p>
 <h3 id="verifying-the-build">Verifying the Build</h3>
-<p>The build will end up in a directory named like <code>build/linux-arm-normal-server-release</code>.</p>
-<p>Inside this build output directory, the <code>images/jdk</code> will contain the newly built JDK, for your <em>target</em> system.</p>
-<p>Copy these folders to your <em>target</em> system. Then you can run e.g. <code>images/jdk/bin/java -version</code>.</p>
+<p>The build will end up in a directory named like
+<code>build/linux-arm-normal-server-release</code>.</p>
+<p>Inside this build output directory, the <code>images/jdk</code> will
+contain the newly built JDK, for your <em>target</em> system.</p>
+<p>Copy these folders to your <em>target</em> system. Then you can run
+e.g. <code>images/jdk/bin/java -version</code>.</p>
 <h2 id="build-performance">Build Performance</h2>
-<p>Building the JDK requires a lot of horsepower. Some of the build tools can be adjusted to utilize more or less of resources such as parallel threads and memory. The <code>configure</code> script analyzes your system and selects reasonable values for such options based on your hardware. If you encounter resource problems, such as out of memory conditions, you can modify the detected values with:</p>
+<p>Building the JDK requires a lot of horsepower. Some of the build
+tools can be adjusted to utilize more or less of resources such as
+parallel threads and memory. The <code>configure</code> script analyzes
+your system and selects reasonable values for such options based on your
+hardware. If you encounter resource problems, such as out of memory
+conditions, you can modify the detected values with:</p>
 <ul>
-<li><p><code>--with-num-cores</code> -- number of cores in the build system, e.g. <code>--with-num-cores=8</code>.</p></li>
-<li><p><code>--with-memory-size</code> -- memory (in MB) available in the build system, e.g. <code>--with-memory-size=1024</code></p></li>
+<li><p><code>--with-num-cores</code> -- number of cores in the build
+system, e.g. <code>--with-num-cores=8</code>.</p></li>
+<li><p><code>--with-memory-size</code> -- memory (in MB) available in
+the build system, e.g. <code>--with-memory-size=1024</code></p></li>
 </ul>
-<p>You can also specify directly the number of build jobs to use with <code>--with-jobs=N</code> to <code>configure</code>, or <code>JOBS=N</code> to <code>make</code>. Do not use the <code>-j</code> flag to <code>make</code>. In most cases it will be ignored by the makefiles, but it can cause problems for some make targets.</p>
-<p>It might also be necessary to specify the JVM arguments passed to the Boot JDK, using e.g. <code>--with-boot-jdk-jvmargs=&quot;-Xmx8G&quot;</code>. Doing so will override the default JVM arguments passed to the Boot JDK.</p>
-<p>At the end of a successful execution of <code>configure</code>, you will get a performance summary, indicating how well the build will perform. Here you will also get performance hints. If you want to build fast, pay attention to those!</p>
-<p>If you want to tweak build performance, run with <code>make LOG=info</code> to get a build time summary at the end of the build process.</p>
+<p>You can also specify directly the number of build jobs to use with
+<code>--with-jobs=N</code> to <code>configure</code>, or
+<code>JOBS=N</code> to <code>make</code>. Do not use the <code>-j</code>
+flag to <code>make</code>. In most cases it will be ignored by the
+makefiles, but it can cause problems for some make targets.</p>
+<p>It might also be necessary to specify the JVM arguments passed to the
+Boot JDK, using e.g. <code>--with-boot-jdk-jvmargs="-Xmx8G"</code>.
+Doing so will override the default JVM arguments passed to the Boot
+JDK.</p>
+<p>At the end of a successful execution of <code>configure</code>, you
+will get a performance summary, indicating how well the build will
+perform. Here you will also get performance hints. If you want to build
+fast, pay attention to those!</p>
+<p>If you want to tweak build performance, run with
+<code>make LOG=info</code> to get a build time summary at the end of the
+build process.</p>
 <h3 id="disk-speed">Disk Speed</h3>
-<p>If you are using network shares, e.g. via NFS, for your source code, make sure the build directory is situated on local disk (e.g. by <code>ln -s /localdisk/jdk-build $JDK-SHARE/build</code>). The performance penalty is extremely high for building on a network share; close to unusable.</p>
-<p>Also, make sure that your build tools (including Boot JDK and toolchain) is located on a local disk and not a network share.</p>
-<p>As has been stressed elsewhere, do use SSD for source code and build directory, as well as (if possible) the build tools.</p>
+<p>If you are using network shares, e.g. via NFS, for your source code,
+make sure the build directory is situated on local disk (e.g. by
+<code>ln -s /localdisk/jdk-build $JDK-SHARE/build</code>). The
+performance penalty is extremely high for building on a network share;
+close to unusable.</p>
+<p>Also, make sure that your build tools (including Boot JDK and
+toolchain) is located on a local disk and not a network share.</p>
+<p>As has been stressed elsewhere, do use SSD for source code and build
+directory, as well as (if possible) the build tools.</p>
 <h3 id="virus-checking">Virus Checking</h3>
-<p>The use of virus checking software, especially on Windows, can <em>significantly</em> slow down building of the JDK. If possible, turn off such software, or exclude the directory containing the JDK source code from on-the-fly checking.</p>
+<p>The use of virus checking software, especially on Windows, can
+<em>significantly</em> slow down building of the JDK. If possible, turn
+off such software, or exclude the directory containing the JDK source
+code from on-the-fly checking.</p>
 <h3 id="ccache">Ccache</h3>
-<p>The JDK build supports building with ccache when using gcc or clang. Using ccache can radically speed up compilation of native code if you often rebuild the same sources. Your milage may vary however, so we recommend evaluating it for yourself. To enable it, make sure it's on the path and configure with <code>--enable-ccache</code>.</p>
+<p>The JDK build supports building with ccache when using gcc or clang.
+Using ccache can radically speed up compilation of native code if you
+often rebuild the same sources. Your milage may vary however, so we
+recommend evaluating it for yourself. To enable it, make sure it's on
+the path and configure with <code>--enable-ccache</code>.</p>
 <h3 id="precompiled-headers">Precompiled Headers</h3>
-<p>By default, the Hotspot build uses preccompiled headers (PCH) on the toolchains were it is properly supported (clang, gcc, and Visual Studio). Normally, this speeds up the build process, but in some circumstances, it can actually slow things down.</p>
-<p>You can experiment by disabling precompiled headers using <code>--disable-precompiled-headers</code>.</p>
+<p>By default, the Hotspot build uses preccompiled headers (PCH) on the
+toolchains were it is properly supported (clang, gcc, and Visual
+Studio). Normally, this speeds up the build process, but in some
+circumstances, it can actually slow things down.</p>
+<p>You can experiment by disabling precompiled headers using
+<code>--disable-precompiled-headers</code>.</p>
 <h3 id="icecc-icecream">Icecc / icecream</h3>
-<p><a href="http://github.com/icecc/icecream">icecc/icecream</a> is a simple way to setup a distributed compiler network. If you have multiple machines available for building the JDK, you can drastically cut individual build times by utilizing it.</p>
-<p>To use, setup an icecc network, and install icecc on the build machine. Then run <code>configure</code> using <code>--enable-icecc</code>.</p>
+<p><a href="http://github.com/icecc/icecream">icecc/icecream</a> is a
+simple way to setup a distributed compiler network. If you have multiple
+machines available for building the JDK, you can drastically cut
+individual build times by utilizing it.</p>
+<p>To use, setup an icecc network, and install icecc on the build
+machine. Then run <code>configure</code> using
+<code>--enable-icecc</code>.</p>
 <h3 id="using-the-javac-server">Using the javac server</h3>
-<p>To speed up compilation of Java code, especially during incremental compilations, the javac server is automatically enabled in the configuration step by default. To explicitly enable or disable the javac server, use either <code>--enable-javac-server</code> or <code>--disable-javac-server</code>.</p>
+<p>To speed up compilation of Java code, especially during incremental
+compilations, the javac server is automatically enabled in the
+configuration step by default. To explicitly enable or disable the javac
+server, use either <code>--enable-javac-server</code> or
+<code>--disable-javac-server</code>.</p>
 <h3 id="building-the-right-target">Building the Right Target</h3>
-<p>Selecting the proper target to build can have dramatic impact on build time. For normal usage, <code>jdk</code> or the default target is just fine. You only need to build <code>images</code> for shipping, or if your tests require it.</p>
-<p>See also <a href="#using-fine-grained-make-targets">Using Fine-Grained Make Targets</a> on how to build an even smaller subset of the product.</p>
+<p>Selecting the proper target to build can have dramatic impact on
+build time. For normal usage, <code>jdk</code> or the default target is
+just fine. You only need to build <code>images</code> for shipping, or
+if your tests require it.</p>
+<p>See also <a href="#using-fine-grained-make-targets">Using
+Fine-Grained Make Targets</a> on how to build an even smaller subset of
+the product.</p>
 <h2 id="troubleshooting">Troubleshooting</h2>
-<p>If your build fails, it can sometimes be difficult to pinpoint the problem or find a proper solution.</p>
-<h3 id="locating-the-source-of-the-error">Locating the Source of the Error</h3>
-<p>When a build fails, it can be hard to pinpoint the actual cause of the error. In a typical build process, different parts of the product build in parallel, with the output interlaced.</p>
+<p>If your build fails, it can sometimes be difficult to pinpoint the
+problem or find a proper solution.</p>
+<h3 id="locating-the-source-of-the-error">Locating the Source of the
+Error</h3>
+<p>When a build fails, it can be hard to pinpoint the actual cause of
+the error. In a typical build process, different parts of the product
+build in parallel, with the output interlaced.</p>
 <h4 id="build-failure-summary">Build Failure Summary</h4>
-<p>To help you, the build system will print a failure summary at the end. It looks like this:</p>
+<p>To help you, the build system will print a failure summary at the
+end. It looks like this:</p>
 <pre><code>ERROR: Build failed for target &#39;hotspot&#39; in configuration &#39;linux-x64&#39; (exit code 2)
 
 === Output from failing command(s) repeated here ===
@@ -847,86 +1648,270 @@ make/Main.gmk:263: recipe for target &#39;hotspot-server-libs&#39; failed
 
 Hint: Try searching the build log for the name of the first failed target.
 Hint: If caused by a warning, try configure --disable-warnings-as-errors.</code></pre>
-<p>Let's break it down! First, the selected configuration, and the top-level target you entered on the command line that caused the failure is printed.</p>
-<p>Then, between the <code>Output from failing command(s) repeated here</code> and <code>End of repeated output</code> the first lines of output (stdout and stderr) from the actual failing command is repeated. In most cases, this is the error message that caused the build to fail. If multiple commands were failing (this can happen in a parallel build), output from all failed commands will be printed here.</p>
-<p>The path to the <code>failure-logs</code> directory is printed. In this file you will find a <code>&lt;target&gt;.log</code> file that contains the output from this command in its entirety, and also a <code>&lt;target&gt;.cmd</code>, which contain the complete command line used for running this command. You can re-run the failing command by executing <code>. &lt;path to failure-logs&gt;/&lt;target&gt;.cmd</code> in your shell.</p>
-<p>Another way to trace the failure is to follow the chain of make targets, from top-level targets to individual file targets. Between <code>Make failed targets repeated here</code> and <code>End of repeated output</code> the output from make showing this chain is repeated. The first failed recipe will typically contain the full path to the file in question that failed to compile. Following lines will show a trace of make targets why we ended up trying to compile that file.</p>
-<p>Finally, some hints are given on how to locate the error in the complete log. In this example, we would try searching the log file for &quot;<code>psMemoryPool.o</code>&quot;. Another way to quickly locate make errors in the log is to search for &quot;<code>] Error</code>&quot; or &quot;<code>***</code>&quot;.</p>
-<p>Note that the build failure summary will only help you if the issue was a compilation failure or similar. If the problem is more esoteric, or is due to errors in the build machinery, you will likely get empty output logs, and <code>No indication of failed target found</code> instead of the make target chain.</p>
+<p>Let's break it down! First, the selected configuration, and the
+top-level target you entered on the command line that caused the failure
+is printed.</p>
+<p>Then, between the
+<code>Output from failing command(s) repeated here</code> and
+<code>End of repeated output</code> the first lines of output (stdout
+and stderr) from the actual failing command is repeated. In most cases,
+this is the error message that caused the build to fail. If multiple
+commands were failing (this can happen in a parallel build), output from
+all failed commands will be printed here.</p>
+<p>The path to the <code>failure-logs</code> directory is printed. In
+this file you will find a <code>&lt;target&gt;.log</code> file that
+contains the output from this command in its entirety, and also a
+<code>&lt;target&gt;.cmd</code>, which contain the complete command line
+used for running this command. You can re-run the failing command by
+executing <code>. &lt;path to failure-logs&gt;/&lt;target&gt;.cmd</code>
+in your shell.</p>
+<p>Another way to trace the failure is to follow the chain of make
+targets, from top-level targets to individual file targets. Between
+<code>Make failed targets repeated here</code> and
+<code>End of repeated output</code> the output from make showing this
+chain is repeated. The first failed recipe will typically contain the
+full path to the file in question that failed to compile. Following
+lines will show a trace of make targets why we ended up trying to
+compile that file.</p>
+<p>Finally, some hints are given on how to locate the error in the
+complete log. In this example, we would try searching the log file for
+"<code>psMemoryPool.o</code>". Another way to quickly locate make errors
+in the log is to search for "<code>] Error</code>" or
+"<code>***</code>".</p>
+<p>Note that the build failure summary will only help you if the issue
+was a compilation failure or similar. If the problem is more esoteric,
+or is due to errors in the build machinery, you will likely get empty
+output logs, and <code>No indication of failed target found</code>
+instead of the make target chain.</p>
 <h4 id="checking-the-build-log-file">Checking the Build Log File</h4>
-<p>The output (stdout and stderr) from the latest build is always stored in <code>$BUILD/build.log</code>. The previous build log is stored as <code>build.log.old</code>. This means that it is not necessary to redirect the build output yourself if you want to process it.</p>
-<p>You can increase the verbosity of the log file, by the <code>LOG</code> control variable to <code>make</code>. If you want to see the command lines used in compilations, use <code>LOG=cmdlines</code>. To increase the general verbosity, use <code>LOG=info</code>, <code>LOG=debug</code> or <code>LOG=trace</code>. Both of these can be combined with <code>cmdlines</code>, e.g. <code>LOG=info,cmdlines</code>. The <code>debug</code> log level will show most shell commands executed by make, and <code>trace</code> will show all. Beware that both these log levels will produce a massive build log!</p>
-<h3 id="fixing-unexpected-build-failures">Fixing Unexpected Build Failures</h3>
-<p>Most of the time, the build will fail due to incorrect changes in the source code.</p>
-<p>Sometimes the build can fail with no apparent changes that have caused the failure. If this is the first time you are building the JDK on this particular computer, and the build fails, the problem is likely with your build environment. But even if you have previously built the JDK with success, and it now fails, your build environment might have changed (perhaps due to OS upgrades or similar). But most likely, such failures are due to problems with the incremental rebuild.</p>
-<h4 id="problems-with-the-build-environment">Problems with the Build Environment</h4>
-<p>Make sure your configuration is correct. Re-run <code>configure</code>, and look for any warnings. Warnings that appear in the middle of the <code>configure</code> output is also repeated at the end, after the summary. The entire log is stored in <code>$BUILD/configure.log</code>.</p>
-<p>Verify that the summary at the end looks correct. Are you indeed using the Boot JDK and native toolchain that you expect?</p>
-<p>By default, the JDK has a strict approach where warnings from the compiler is considered errors which fail the build. For very new or very old compiler versions, this can trigger new classes of warnings, which thus fails the build. Run <code>configure</code> with <code>--disable-warnings-as-errors</code> to turn of this behavior. (The warnings will still show, but not make the build fail.)</p>
-<h4 id="problems-with-incremental-rebuilds">Problems with Incremental Rebuilds</h4>
-<p>Incremental rebuilds mean that when you modify part of the product, only the affected parts get rebuilt. While this works great in most cases, and significantly speed up the development process, from time to time complex interdependencies will result in an incorrect build result. This is the most common cause for unexpected build problems.</p>
-<p>Here are a suggested list of things to try if you are having unexpected build problems. Each step requires more time than the one before, so try them in order. Most issues will be solved at step 1 or 2.</p>
+<p>The output (stdout and stderr) from the latest build is always stored
+in <code>$BUILD/build.log</code>. The previous build log is stored as
+<code>build.log.old</code>. This means that it is not necessary to
+redirect the build output yourself if you want to process it.</p>
+<p>You can increase the verbosity of the log file, by the
+<code>LOG</code> control variable to <code>make</code>. If you want to
+see the command lines used in compilations, use
+<code>LOG=cmdlines</code>. To increase the general verbosity, use
+<code>LOG=info</code>, <code>LOG=debug</code> or <code>LOG=trace</code>.
+Both of these can be combined with <code>cmdlines</code>, e.g.
+<code>LOG=info,cmdlines</code>. The <code>debug</code> log level will
+show most shell commands executed by make, and <code>trace</code> will
+show all. Beware that both these log levels will produce a massive build
+log!</p>
+<h3 id="fixing-unexpected-build-failures">Fixing Unexpected Build
+Failures</h3>
+<p>Most of the time, the build will fail due to incorrect changes in the
+source code.</p>
+<p>Sometimes the build can fail with no apparent changes that have
+caused the failure. If this is the first time you are building the JDK
+on this particular computer, and the build fails, the problem is likely
+with your build environment. But even if you have previously built the
+JDK with success, and it now fails, your build environment might have
+changed (perhaps due to OS upgrades or similar). But most likely, such
+failures are due to problems with the incremental rebuild.</p>
+<h4 id="problems-with-the-build-environment">Problems with the Build
+Environment</h4>
+<p>Make sure your configuration is correct. Re-run
+<code>configure</code>, and look for any warnings. Warnings that appear
+in the middle of the <code>configure</code> output is also repeated at
+the end, after the summary. The entire log is stored in
+<code>$BUILD/configure.log</code>.</p>
+<p>Verify that the summary at the end looks correct. Are you indeed
+using the Boot JDK and native toolchain that you expect?</p>
+<p>By default, the JDK has a strict approach where warnings from the
+compiler is considered errors which fail the build. For very new or very
+old compiler versions, this can trigger new classes of warnings, which
+thus fails the build. Run <code>configure</code> with
+<code>--disable-warnings-as-errors</code> to turn of this behavior. (The
+warnings will still show, but not make the build fail.)</p>
+<h4 id="problems-with-incremental-rebuilds">Problems with Incremental
+Rebuilds</h4>
+<p>Incremental rebuilds mean that when you modify part of the product,
+only the affected parts get rebuilt. While this works great in most
+cases, and significantly speed up the development process, from time to
+time complex interdependencies will result in an incorrect build result.
+This is the most common cause for unexpected build problems.</p>
+<p>Here are a suggested list of things to try if you are having
+unexpected build problems. Each step requires more time than the one
+before, so try them in order. Most issues will be solved at step 1 or
+2.</p>
 <ol type="1">
 <li><p>Make sure your repository is up-to-date</p>
-<p>Run <code>git pull origin master</code> to make sure you have the latest changes.</p></li>
+<p>Run <code>git pull origin master</code> to make sure you have the
+latest changes.</p></li>
 <li><p>Clean build results</p>
-<p>The simplest way to fix incremental rebuild issues is to run <code>make clean</code>. This will remove all build results, but not the configuration or any build system support artifacts. In most cases, this will solve build errors resulting from incremental build mismatches.</p></li>
+<p>The simplest way to fix incremental rebuild issues is to run
+<code>make clean</code>. This will remove all build results, but not the
+configuration or any build system support artifacts. In most cases, this
+will solve build errors resulting from incremental build
+mismatches.</p></li>
 <li><p>Completely clean the build directory.</p>
-<p>If this does not work, the next step is to run <code>make dist-clean</code>, or removing the build output directory (<code>$BUILD</code>). This will clean all generated output, including your configuration. You will need to re-run <code>configure</code> after this step. A good idea is to run <code>make print-configuration</code> before running <code>make dist-clean</code>, as this will print your current <code>configure</code> command line. Here's a way to do this:</p>
+<p>If this does not work, the next step is to run
+<code>make dist-clean</code>, or removing the build output directory
+(<code>$BUILD</code>). This will clean all generated output, including
+your configuration. You will need to re-run <code>configure</code> after
+this step. A good idea is to run <code>make print-configuration</code>
+before running <code>make dist-clean</code>, as this will print your
+current <code>configure</code> command line. Here's a way to do
+this:</p>
 <pre><code>make print-configuration &gt; current-configuration
 make dist-clean
 bash configure $(cat current-configuration)
 make</code></pre></li>
 <li><p>Re-clone the Git repository</p>
-<p>Sometimes the Git repository gets in a state that causes the product to be un-buildable. In such a case, the simplest solution is often the &quot;sledgehammer approach&quot;: delete the entire repository, and re-clone it. If you have local changes, save them first to a different location using <code>git format-patch</code>.</p></li>
+<p>Sometimes the Git repository gets in a state that causes the product
+to be un-buildable. In such a case, the simplest solution is often the
+"sledgehammer approach": delete the entire repository, and re-clone it.
+If you have local changes, save them first to a different location using
+<code>git format-patch</code>.</p></li>
 </ol>
 <h3 id="specific-build-issues">Specific Build Issues</h3>
 <h4 id="clock-skew">Clock Skew</h4>
 <p>If you get an error message like this:</p>
 <pre><code>File &#39;xxx&#39; has modification time in the future.
 Clock skew detected. Your build may be incomplete.</code></pre>
-<p>then the clock on your build machine is out of sync with the timestamps on the source files. Other errors, apparently unrelated but in fact caused by the clock skew, can occur along with the clock skew warnings. These secondary errors may tend to obscure the fact that the true root cause of the problem is an out-of-sync clock.</p>
-<p>If you see these warnings, reset the clock on the build machine, run <code>make clean</code> and restart the build.</p>
+<p>then the clock on your build machine is out of sync with the
+timestamps on the source files. Other errors, apparently unrelated but
+in fact caused by the clock skew, can occur along with the clock skew
+warnings. These secondary errors may tend to obscure the fact that the
+true root cause of the problem is an out-of-sync clock.</p>
+<p>If you see these warnings, reset the clock on the build machine, run
+<code>make clean</code> and restart the build.</p>
 <h4 id="out-of-memory-errors">Out of Memory Errors</h4>
 <p>On Windows, you might get error messages like this:</p>
 <pre><code>fatal error - couldn&#39;t allocate heap
 cannot create ... Permission denied
 spawn failed</code></pre>
-<p>This can be a sign of a Cygwin problem. See the information about solving problems in the <a href="#cygwin">Cygwin</a> section. Rebooting the computer might help temporarily.</p>
+<p>This can be a sign of a Cygwin problem. See the information about
+solving problems in the <a href="#cygwin">Cygwin</a> section. Rebooting
+the computer might help temporarily.</p>
 <h4 id="spaces-in-path">Spaces in Path</h4>
-<p>On Windows, when configuring, <code>fixpath.sh</code> may report that some directory names have spaces. Usually, it assumes those directories have <a href="https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/fsutil-8dot3name">short paths</a>. You can run <code>fsutil file setshortname</code> in <code>cmd</code> on certain directories, such as <code>Microsoft Visual Studio</code> or <code>Windows Kits</code>, to assign arbitrary short paths so <code>configure</code> can access them.</p>
+<p>On Windows, when configuring, <code>fixpath.sh</code> may report that
+some directory names have spaces. Usually, it assumes those directories
+have <a
+href="https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/fsutil-8dot3name">short
+paths</a>. You can run <code>fsutil file setshortname</code> in
+<code>cmd</code> on certain directories, such as
+<code>Microsoft Visual Studio</code> or <code>Windows Kits</code>, to
+assign arbitrary short paths so <code>configure</code> can access
+them.</p>
 <h3 id="getting-help">Getting Help</h3>
-<p>If none of the suggestions in this document helps you, or if you find what you believe is a bug in the build system, please contact the Build Group by sending a mail to <a href="mailto:build-dev@openjdk.org">build-dev@openjdk.org</a>. Please include the relevant parts of the configure and/or build log.</p>
-<p>If you need general help or advice about developing for the JDK, you can also contact the Adoption Group. See the section on <a href="#contributing-to-openjdk">Contributing to OpenJDK</a> for more information.</p>
+<p>If none of the suggestions in this document helps you, or if you find
+what you believe is a bug in the build system, please contact the Build
+Group by sending a mail to <a
+href="mailto:build-dev@openjdk.org">build-dev@openjdk.org</a>. Please
+include the relevant parts of the configure and/or build log.</p>
+<p>If you need general help or advice about developing for the JDK, you
+can also contact the Adoption Group. See the section on <a
+href="#contributing-to-openjdk">Contributing to OpenJDK</a> for more
+information.</p>
 <h2 id="reproducible-builds">Reproducible Builds</h2>
-<p>Build reproducibility is the property of getting exactly the same bits out when building, every time, independent on who builds the product, or where. This is for many reasons a harder goal than it initially appears, but it is an important goal, for security reasons and others. Please see <a href="https://reproducible-builds.org">Reproducible Builds</a> for more information about the background and reasons for reproducible builds.</p>
-<p>Currently, it is not possible to build OpenJDK fully reproducibly, but getting there is an ongoing effort.</p>
-<p>An absolute prerequisite for building reproducible is to speficy a fixed build time, since time stamps are embedded in many file formats. This is done by setting the <code>SOURCE_DATE_EPOCH</code> environment variable, which is an <a href="https://reproducible-builds.org/docs/source-date-epoch/">industry standard</a>, that many tools, such as gcc, recognize, and use in place of the current time when generating output.</p>
-<p>To generate reproducible builds, you must set <code>SOURCE_DATE_EPOCH</code> before running <code>configure</code>. The value in <code>SOURCE_DATE_EPOCH</code> will be stored in the configuration, and used by <code>make</code>. Setting <code>SOURCE_DATE_EPOCH</code> before running <code>make</code> will have no effect on the build.</p>
-<p>You must also make sure your build does not rely on <code>configure</code>'s default adhoc version strings. Default adhoc version strings <code>OPT</code> segment include user name and source directory. You can either override just the <code>OPT</code> segment using <code>--with-version-opt=&lt;any fixed string&gt;</code>, or you can specify the entire version string using <code>--with-version-string=&lt;your version&gt;</code>.</p>
-<p>This is a typical example of how to build the JDK in a reproducible way:</p>
+<p>Build reproducibility is the property of getting exactly the same
+bits out when building, every time, independent on who builds the
+product, or where. This is for many reasons a harder goal than it
+initially appears, but it is an important goal, for security reasons and
+others. Please see <a
+href="https://reproducible-builds.org">Reproducible Builds</a> for more
+information about the background and reasons for reproducible
+builds.</p>
+<p>Currently, it is not possible to build OpenJDK fully reproducibly,
+but getting there is an ongoing effort.</p>
+<p>An absolute prerequisite for building reproducible is to speficy a
+fixed build time, since time stamps are embedded in many file formats.
+This is done by setting the <code>SOURCE_DATE_EPOCH</code> environment
+variable, which is an <a
+href="https://reproducible-builds.org/docs/source-date-epoch/">industry
+standard</a>, that many tools, such as gcc, recognize, and use in place
+of the current time when generating output.</p>
+<p>To generate reproducible builds, you must set
+<code>SOURCE_DATE_EPOCH</code> before running <code>configure</code>.
+The value in <code>SOURCE_DATE_EPOCH</code> will be stored in the
+configuration, and used by <code>make</code>. Setting
+<code>SOURCE_DATE_EPOCH</code> before running <code>make</code> will
+have no effect on the build.</p>
+<p>You must also make sure your build does not rely on
+<code>configure</code>'s default adhoc version strings. Default adhoc
+version strings <code>OPT</code> segment include user name and source
+directory. You can either override just the <code>OPT</code> segment
+using <code>--with-version-opt=&lt;any fixed string&gt;</code>, or you
+can specify the entire version string using
+<code>--with-version-string=&lt;your version&gt;</code>.</p>
+<p>This is a typical example of how to build the JDK in a reproducible
+way:</p>
 <pre><code>export SOURCE_DATE_EPOCH=946684800
 bash configure --with-version-opt=adhoc
 make</code></pre>
-<p>Note that regardless if you specify a source date for <code>configure</code> or not, the JDK build system will set <code>SOURCE_DATE_EPOCH</code> for all build tools when building. If <code>--with-source-date</code> has the value <code>current</code> (which is the default unless <code>SOURCE_DATE_EPOCH</code> is found by in the environment by <code>configure</code>), the source date value will be determined at configure time.</p>
-<p>There are several aspects of reproducible builds that can be individually adjusted by <code>configure</code> arguments. If any of these are given, they will override the value derived from <code>SOURCE_DATE_EPOCH</code>. These arguments are:</p>
+<p>Note that regardless if you specify a source date for
+<code>configure</code> or not, the JDK build system will set
+<code>SOURCE_DATE_EPOCH</code> for all build tools when building. If
+<code>--with-source-date</code> has the value <code>current</code>
+(which is the default unless <code>SOURCE_DATE_EPOCH</code> is found by
+in the environment by <code>configure</code>), the source date value
+will be determined at configure time.</p>
+<p>There are several aspects of reproducible builds that can be
+individually adjusted by <code>configure</code> arguments. If any of
+these are given, they will override the value derived from
+<code>SOURCE_DATE_EPOCH</code>. These arguments are:</p>
 <ul>
 <li><p><code>--with-source-date</code></p>
-<p>This option controls how the JDK build sets <code>SOURCE_DATE_EPOCH</code> when building. It can be set to a value describing a date, either an epoch based timestamp as an integer, or a valid ISO-8601 date.</p>
-<p>It can also be set to one of the special values <code>current</code>, <code>updated</code> or <code>version</code>. <code>current</code> means that the time of running <code>configure</code> will be used. <code>version</code> will use the nominal release date for the current JDK version. <code>updated</code>, which means that <code>SOURCE_DATE_EPOCH</code> will be set to the current time each time you are running <code>make</code>. All choices, except for <code>updated</code>, will set a fixed value for the source date timestamp.</p>
-<p>When <code>SOURCE_DATE_EPOCH</code> is set, the default value for <code>--with-source-date</code> will be the value given by <code>SOURCE_DATE_EPOCH</code>. Otherwise, the default value is <code>current</code>.</p></li>
+<p>This option controls how the JDK build sets
+<code>SOURCE_DATE_EPOCH</code> when building. It can be set to a value
+describing a date, either an epoch based timestamp as an integer, or a
+valid ISO-8601 date.</p>
+<p>It can also be set to one of the special values <code>current</code>,
+<code>updated</code> or <code>version</code>. <code>current</code> means
+that the time of running <code>configure</code> will be used.
+<code>version</code> will use the nominal release date for the current
+JDK version. <code>updated</code>, which means that
+<code>SOURCE_DATE_EPOCH</code> will be set to the current time each time
+you are running <code>make</code>. All choices, except for
+<code>updated</code>, will set a fixed value for the source date
+timestamp.</p>
+<p>When <code>SOURCE_DATE_EPOCH</code> is set, the default value for
+<code>--with-source-date</code> will be the value given by
+<code>SOURCE_DATE_EPOCH</code>. Otherwise, the default value is
+<code>current</code>.</p></li>
 <li><p><code>--with-hotspot-build-time</code></p>
-<p>This option controls the build time string that will be included in the hotspot library (<code>libjvm.so</code> or <code>jvm.dll</code>). When the source date is fixed (e.g. by setting <code>SOURCE_DATE_EPOCH</code>), the default value for <code>--with-hotspot-build-time</code> will be an ISO 8601 representation of that time stamp. Otherwise the default value will be the current time when building hotspot.</p></li>
+<p>This option controls the build time string that will be included in
+the hotspot library (<code>libjvm.so</code> or <code>jvm.dll</code>).
+When the source date is fixed (e.g. by setting
+<code>SOURCE_DATE_EPOCH</code>), the default value for
+<code>--with-hotspot-build-time</code> will be an ISO 8601
+representation of that time stamp. Otherwise the default value will be
+the current time when building hotspot.</p></li>
 <li><p><code>--with-copyright-year</code></p>
-<p>This option controls the copyright year in some generated text files. When the source date is fixed (e.g. by setting <code>SOURCE_DATE_EPOCH</code>), the default value for <code>--with-copyright-year</code> will be the year of that time stamp. Otherwise the default is the current year at the time of running configure. This can be overridden by <code>--with-copyright-year=&lt;year&gt;</code>.</p></li>
+<p>This option controls the copyright year in some generated text files.
+When the source date is fixed (e.g. by setting
+<code>SOURCE_DATE_EPOCH</code>), the default value for
+<code>--with-copyright-year</code> will be the year of that time stamp.
+Otherwise the default is the current year at the time of running
+configure. This can be overridden by
+<code>--with-copyright-year=&lt;year&gt;</code>.</p></li>
 <li><p><code>--enable-reproducible-build</code></p>
-<p>This option controls some additional behavior needed to make the build reproducible. When the source date is fixed (e.g. by setting <code>SOURCE_DATE_EPOCH</code>), this flag will be turned on by default. Otherwise, the value is determined by heuristics. If it is explicitly turned off, the build might not be reproducible.</p></li>
+<p>This option controls some additional behavior needed to make the
+build reproducible. When the source date is fixed (e.g. by setting
+<code>SOURCE_DATE_EPOCH</code>), this flag will be turned on by default.
+Otherwise, the value is determined by heuristics. If it is explicitly
+turned off, the build might not be reproducible.</p></li>
 </ul>
-<h2 id="hints-and-suggestions-for-advanced-users">Hints and Suggestions for Advanced Users</h2>
+<h2 id="hints-and-suggestions-for-advanced-users">Hints and Suggestions
+for Advanced Users</h2>
 <h3 id="bash-completion">Bash Completion</h3>
-<p>The <code>configure</code> and <code>make</code> commands tries to play nice with bash command-line completion (using <code>&lt;tab&gt;</code> or <code>&lt;tab&gt;&lt;tab&gt;</code>). To use this functionality, make sure you enable completion in your <code>~/.bashrc</code> (see instructions for bash in your operating system).</p>
-<p>Make completion will work out of the box, and will complete valid make targets. For instance, typing <code>make jdk-i&lt;tab&gt;</code> will complete to <code>make jdk-image</code>.</p>
-<p>The <code>configure</code> script can get completion for options, but for this to work you need to help <code>bash</code> on the way. The standard way of running the script, <code>bash configure</code>, will not be understood by bash completion. You need <code>configure</code> to be the command to run. One way to achieve this is to add a simple helper script to your path:</p>
+<p>The <code>configure</code> and <code>make</code> commands tries to
+play nice with bash command-line completion (using
+<code>&lt;tab&gt;</code> or <code>&lt;tab&gt;&lt;tab&gt;</code>). To use
+this functionality, make sure you enable completion in your
+<code>~/.bashrc</code> (see instructions for bash in your operating
+system).</p>
+<p>Make completion will work out of the box, and will complete valid
+make targets. For instance, typing <code>make jdk-i&lt;tab&gt;</code>
+will complete to <code>make jdk-image</code>.</p>
+<p>The <code>configure</code> script can get completion for options, but
+for this to work you need to help <code>bash</code> on the way. The
+standard way of running the script, <code>bash configure</code>, will
+not be understood by bash completion. You need <code>configure</code> to
+be the command to run. One way to achieve this is to add a simple helper
+script to your path:</p>
 <pre><code>cat &lt;&lt; EOT &gt; /tmp/configure
 #!/bin/bash
 if [ \$(pwd) = \$(cd \$(dirname \$0); pwd) ] ; then
@@ -938,23 +1923,73 @@ bash \$PWD/configure &quot;\$@&quot;
 EOT
 chmod +x /tmp/configure
 sudo mv /tmp/configure /usr/local/bin</code></pre>
-<p>Now <code>configure --en&lt;tab&gt;-dt&lt;tab&gt;</code> will result in <code>configure --enable-dtrace</code>.</p>
-<h3 id="using-multiple-configurations">Using Multiple Configurations</h3>
-<p>You can have multiple configurations for a single source repository. When you create a new configuration, run <code>configure --with-conf-name=&lt;name&gt;</code> to create a configuration with the name <code>&lt;name&gt;</code>. Alternatively, you can create a directory under <code>build</code> and run <code>configure</code> from there, e.g. <code>mkdir build/&lt;name&gt; &amp;&amp; cd build/&lt;name&gt; &amp;&amp; bash ../../configure</code>.</p>
-<p>Then you can build that configuration using <code>make CONF_NAME=&lt;name&gt;</code> or <code>make CONF=&lt;pattern&gt;</code>, where <code>&lt;pattern&gt;</code> is a substring matching one or several configurations, e.g. <code>CONF=debug</code>. The special empty pattern (<code>CONF=</code>) will match <em>all</em> available configuration, so <code>make CONF= hotspot</code> will build the <code>hotspot</code> target for all configurations. Alternatively, you can execute <code>make</code> in the configuration directory, e.g. <code>cd build/&lt;name&gt; &amp;&amp; make</code>.</p>
+<p>Now <code>configure --en&lt;tab&gt;-dt&lt;tab&gt;</code> will result
+in <code>configure --enable-dtrace</code>.</p>
+<h3 id="using-multiple-configurations">Using Multiple
+Configurations</h3>
+<p>You can have multiple configurations for a single source repository.
+When you create a new configuration, run
+<code>configure --with-conf-name=&lt;name&gt;</code> to create a
+configuration with the name <code>&lt;name&gt;</code>. Alternatively,
+you can create a directory under <code>build</code> and run
+<code>configure</code> from there, e.g.
+<code>mkdir build/&lt;name&gt; &amp;&amp; cd build/&lt;name&gt; &amp;&amp; bash ../../configure</code>.</p>
+<p>Then you can build that configuration using
+<code>make CONF_NAME=&lt;name&gt;</code> or
+<code>make CONF=&lt;pattern&gt;</code>, where
+<code>&lt;pattern&gt;</code> is a substring matching one or several
+configurations, e.g. <code>CONF=debug</code>. The special empty pattern
+(<code>CONF=</code>) will match <em>all</em> available configuration, so
+<code>make CONF= hotspot</code> will build the <code>hotspot</code>
+target for all configurations. Alternatively, you can execute
+<code>make</code> in the configuration directory, e.g.
+<code>cd build/&lt;name&gt; &amp;&amp; make</code>.</p>
 <h3 id="handling-reconfigurations">Handling Reconfigurations</h3>
-<p>If you update the repository and part of the configure script has changed, the build system will force you to re-run <code>configure</code>.</p>
-<p>Most of the time, you will be fine by running <code>configure</code> again with the same arguments as the last time, which can easily be performed by <code>make reconfigure</code>. To simplify this, you can use the <code>CONF_CHECK</code> make control variable, either as <code>make CONF_CHECK=auto</code>, or by setting an environment variable. For instance, if you add <code>export CONF_CHECK=auto</code> to your <code>.bashrc</code> file, <code>make</code> will always run <code>reconfigure</code> automatically whenever the configure script has changed.</p>
-<p>You can also use <code>CONF_CHECK=ignore</code> to skip the check for a needed configure update. This might speed up the build, but comes at the risk of an incorrect build result. This is only recommended if you know what you're doing.</p>
-<p>From time to time, you will also need to modify the command line to <code>configure</code> due to changes. Use <code>make print-configuration</code> to show the command line used for your current configuration.</p>
-<h3 id="using-fine-grained-make-targets">Using Fine-Grained Make Targets</h3>
-<p>The default behavior for make is to create consistent and correct output, at the expense of build speed, if necessary.</p>
-<p>If you are prepared to take some risk of an incorrect build, and know enough of the system to understand how things build and interact, you can speed up the build process considerably by instructing make to only build a portion of the product.</p>
+<p>If you update the repository and part of the configure script has
+changed, the build system will force you to re-run
+<code>configure</code>.</p>
+<p>Most of the time, you will be fine by running <code>configure</code>
+again with the same arguments as the last time, which can easily be
+performed by <code>make reconfigure</code>. To simplify this, you can
+use the <code>CONF_CHECK</code> make control variable, either as
+<code>make CONF_CHECK=auto</code>, or by setting an environment
+variable. For instance, if you add <code>export CONF_CHECK=auto</code>
+to your <code>.bashrc</code> file, <code>make</code> will always run
+<code>reconfigure</code> automatically whenever the configure script has
+changed.</p>
+<p>You can also use <code>CONF_CHECK=ignore</code> to skip the check for
+a needed configure update. This might speed up the build, but comes at
+the risk of an incorrect build result. This is only recommended if you
+know what you're doing.</p>
+<p>From time to time, you will also need to modify the command line to
+<code>configure</code> due to changes. Use
+<code>make print-configuration</code> to show the command line used for
+your current configuration.</p>
+<h3 id="using-fine-grained-make-targets">Using Fine-Grained Make
+Targets</h3>
+<p>The default behavior for make is to create consistent and correct
+output, at the expense of build speed, if necessary.</p>
+<p>If you are prepared to take some risk of an incorrect build, and know
+enough of the system to understand how things build and interact, you
+can speed up the build process considerably by instructing make to only
+build a portion of the product.</p>
 <h4 id="building-individual-modules">Building Individual Modules</h4>
-<p>The safe way to use fine-grained make targets is to use the module specific make targets. All source code in the JDK is organized so it belongs to a module, e.g. <code>java.base</code> or <code>jdk.jdwp.agent</code>. You can build only a specific module, by giving it as make target: <code>make jdk.jdwp.agent</code>. If the specified module depends on other modules (e.g. <code>java.base</code>), those modules will be built first.</p>
-<p>You can also specify a set of modules, just as you can always specify a set of make targets: <code>make jdk.crypto.cryptoki jdk.crypto.ec jdk.crypto.mscapi</code></p>
-<h4 id="building-individual-module-phases">Building Individual Module Phases</h4>
-<p>The build process for each module is divided into separate phases. Not all modules need all phases. Which are needed depends on what kind of source code and other artifact the module consists of. The phases are:</p>
+<p>The safe way to use fine-grained make targets is to use the module
+specific make targets. All source code in the JDK is organized so it
+belongs to a module, e.g. <code>java.base</code> or
+<code>jdk.jdwp.agent</code>. You can build only a specific module, by
+giving it as make target: <code>make jdk.jdwp.agent</code>. If the
+specified module depends on other modules (e.g. <code>java.base</code>),
+those modules will be built first.</p>
+<p>You can also specify a set of modules, just as you can always specify
+a set of make targets:
+<code>make jdk.crypto.cryptoki jdk.crypto.ec jdk.crypto.mscapi</code></p>
+<h4 id="building-individual-module-phases">Building Individual Module
+Phases</h4>
+<p>The build process for each module is divided into separate phases.
+Not all modules need all phases. Which are needed depends on what kind
+of source code and other artifact the module consists of. The phases
+are:</p>
 <ul>
 <li><code>gensrc</code> (Generate source code to compile)</li>
 <li><code>gendata</code> (Generate non-source code artifacts)</li>
@@ -963,25 +1998,66 @@ sudo mv /tmp/configure /usr/local/bin</code></pre>
 <li><code>launchers</code> (Compile native executables)</li>
 <li><code>libs</code> (Compile native libraries)</li>
 </ul>
-<p>You can build only a single phase for a module by using the notation <code>$MODULE-$PHASE</code>. For instance, to build the <code>gensrc</code> phase for <code>java.base</code>, use <code>make java.base-gensrc</code>.</p>
-<p>Note that some phases may depend on others, e.g. <code>java</code> depends on <code>gensrc</code> (if present). Make will build all needed prerequisites before building the requested phase.</p>
-<h4 id="skipping-the-dependency-check">Skipping the Dependency Check</h4>
-<p>When using an iterative development style with frequent quick rebuilds, the dependency check made by make can take up a significant portion of the time spent on the rebuild. In such cases, it can be useful to bypass the dependency check in make.</p>
+<p>You can build only a single phase for a module by using the notation
+<code>$MODULE-$PHASE</code>. For instance, to build the
+<code>gensrc</code> phase for <code>java.base</code>, use
+<code>make java.base-gensrc</code>.</p>
+<p>Note that some phases may depend on others, e.g. <code>java</code>
+depends on <code>gensrc</code> (if present). Make will build all needed
+prerequisites before building the requested phase.</p>
+<h4 id="skipping-the-dependency-check">Skipping the Dependency
+Check</h4>
+<p>When using an iterative development style with frequent quick
+rebuilds, the dependency check made by make can take up a significant
+portion of the time spent on the rebuild. In such cases, it can be
+useful to bypass the dependency check in make.</p>
 <blockquote>
-<p><strong>Note that if used incorrectly, this can lead to a broken build!</strong></p>
+<p><strong>Note that if used incorrectly, this can lead to a broken
+build!</strong></p>
 </blockquote>
-<p>To achieve this, append <code>-only</code> to the build target. For instance, <code>make jdk.jdwp.agent-java-only</code> will <em>only</em> build the <code>java</code> phase of the <code>jdk.jdwp.agent</code> module. If the required dependencies are not present, the build can fail. On the other hand, the execution time measures in milliseconds.</p>
-<p>A useful pattern is to build the first time normally (e.g. <code>make jdk.jdwp.agent</code>) and then on subsequent builds, use the <code>-only</code> make target.</p>
-<h4 id="rebuilding-part-of-java.base-jdk_filter">Rebuilding Part of java.base (JDK_FILTER)</h4>
-<p>If you are modifying files in <code>java.base</code>, which is the by far largest module in the JDK, then you need to rebuild all those files whenever a single file has changed. (This inefficiency will hopefully be addressed in JDK 10.)</p>
-<p>As a hack, you can use the make control variable <code>JDK_FILTER</code> to specify a pattern that will be used to limit the set of files being recompiled. For instance, <code>make java.base JDK_FILTER=javax/crypto</code> (or, to combine methods, <code>make java.base-java-only JDK_FILTER=javax/crypto</code>) will limit the compilation to files in the <code>javax.crypto</code> package.</p>
-<h2 id="understanding-the-build-system">Understanding the Build System</h2>
-<p>This section will give you a more technical description on the details of the build system.</p>
+<p>To achieve this, append <code>-only</code> to the build target. For
+instance, <code>make jdk.jdwp.agent-java-only</code> will <em>only</em>
+build the <code>java</code> phase of the <code>jdk.jdwp.agent</code>
+module. If the required dependencies are not present, the build can
+fail. On the other hand, the execution time measures in
+milliseconds.</p>
+<p>A useful pattern is to build the first time normally (e.g.
+<code>make jdk.jdwp.agent</code>) and then on subsequent builds, use the
+<code>-only</code> make target.</p>
+<h4 id="rebuilding-part-of-java.base-jdk_filter">Rebuilding Part of
+java.base (JDK_FILTER)</h4>
+<p>If you are modifying files in <code>java.base</code>, which is the by
+far largest module in the JDK, then you need to rebuild all those files
+whenever a single file has changed. (This inefficiency will hopefully be
+addressed in JDK 10.)</p>
+<p>As a hack, you can use the make control variable
+<code>JDK_FILTER</code> to specify a pattern that will be used to limit
+the set of files being recompiled. For instance,
+<code>make java.base JDK_FILTER=javax/crypto</code> (or, to combine
+methods, <code>make java.base-java-only JDK_FILTER=javax/crypto</code>)
+will limit the compilation to files in the <code>javax.crypto</code>
+package.</p>
+<h2 id="understanding-the-build-system">Understanding the Build
+System</h2>
+<p>This section will give you a more technical description on the
+details of the build system.</p>
 <h3 id="configurations">Configurations</h3>
-<p>The build system expects to find one or more configuration. These are technically defined by the <code>spec.gmk</code> in a subdirectory to the <code>build</code> subdirectory. The <code>spec.gmk</code> file is generated by <code>configure</code>, and contains in principle the configuration (directly or by files included by <code>spec.gmk</code>).</p>
-<p>You can, in fact, select a configuration to build by pointing to the <code>spec.gmk</code> file with the <code>SPEC</code> make control variable, e.g. <code>make SPEC=$BUILD/spec.gmk</code>. While this is not the recommended way to call <code>make</code> as a user, it is what is used under the hood by the build system.</p>
+<p>The build system expects to find one or more configuration. These are
+technically defined by the <code>spec.gmk</code> in a subdirectory to
+the <code>build</code> subdirectory. The <code>spec.gmk</code> file is
+generated by <code>configure</code>, and contains in principle the
+configuration (directly or by files included by
+<code>spec.gmk</code>).</p>
+<p>You can, in fact, select a configuration to build by pointing to the
+<code>spec.gmk</code> file with the <code>SPEC</code> make control
+variable, e.g. <code>make SPEC=$BUILD/spec.gmk</code>. While this is not
+the recommended way to call <code>make</code> as a user, it is what is
+used under the hood by the build system.</p>
 <h3 id="build-output-structure">Build Output Structure</h3>
-<p>The build output for a configuration will end up in <code>build/&lt;configuration name&gt;</code>, which we refer to as <code>$BUILD</code> in this document. The <code>$BUILD</code> directory contains the following important directories:</p>
+<p>The build output for a configuration will end up in
+<code>build/&lt;configuration name&gt;</code>, which we refer to as
+<code>$BUILD</code> in this document. The <code>$BUILD</code> directory
+contains the following important directories:</p>
 <pre><code>buildtools/
 configure-support/
 hotspot/
@@ -993,57 +2069,156 @@ test-results/
 test-support/</code></pre>
 <p>This is what they are used for:</p>
 <ul>
-<li><p><code>images</code>: This is the directory were the output of the <code>*-image</code> make targets end up. For instance, <code>make jdk-image</code> ends up in <code>images/jdk</code>.</p></li>
-<li><p><code>jdk</code>: This is the &quot;exploded image&quot;. After <code>make jdk</code>, you will be able to launch the newly built JDK by running <code>$BUILD/jdk/bin/java</code>.</p></li>
-<li><p><code>test-results</code>: This directory contains the results from running tests.</p></li>
-<li><p><code>support</code>: This is an area for intermediate files needed during the build, e.g. generated source code, object files and class files. Some noteworthy directories in <code>support</code> is <code>gensrc</code>, which contains the generated source code, and the <code>modules_*</code> directories, which contains the files in a per-module hierarchy that will later be collapsed into the <code>jdk</code> directory of the exploded image.</p></li>
-<li><p><code>buildtools</code>: This is an area for tools compiled for the build platform that are used during the rest of the build.</p></li>
-<li><p><code>hotspot</code>: This is an area for intermediate files needed when building hotspot.</p></li>
-<li><p><code>configure-support</code>, <code>make-support</code> and <code>test-support</code>: These directories contain files that are needed by the build system for <code>configure</code>, <code>make</code> and for running tests.</p></li>
+<li><p><code>images</code>: This is the directory were the output of the
+<code>*-image</code> make targets end up. For instance,
+<code>make jdk-image</code> ends up in <code>images/jdk</code>.</p></li>
+<li><p><code>jdk</code>: This is the "exploded image". After
+<code>make jdk</code>, you will be able to launch the newly built JDK by
+running <code>$BUILD/jdk/bin/java</code>.</p></li>
+<li><p><code>test-results</code>: This directory contains the results
+from running tests.</p></li>
+<li><p><code>support</code>: This is an area for intermediate files
+needed during the build, e.g. generated source code, object files and
+class files. Some noteworthy directories in <code>support</code> is
+<code>gensrc</code>, which contains the generated source code, and the
+<code>modules_*</code> directories, which contains the files in a
+per-module hierarchy that will later be collapsed into the
+<code>jdk</code> directory of the exploded image.</p></li>
+<li><p><code>buildtools</code>: This is an area for tools compiled for
+the build platform that are used during the rest of the build.</p></li>
+<li><p><code>hotspot</code>: This is an area for intermediate files
+needed when building hotspot.</p></li>
+<li><p><code>configure-support</code>, <code>make-support</code> and
+<code>test-support</code>: These directories contain files that are
+needed by the build system for <code>configure</code>, <code>make</code>
+and for running tests.</p></li>
 </ul>
 <h3 id="fixpath">Fixpath</h3>
-<p>Windows path typically look like <code>C:\User\foo</code>, while Unix paths look like <code>/home/foo</code>. Tools with roots from Unix often experience issues related to this mismatch when running on Windows.</p>
-<p>In the JDK build, we always use Unix paths internally, and only just before calling a tool that does not understand Unix paths do we convert them to Windows paths.</p>
-<p>This conversion is done by the <code>fixpath</code> tool, which is a small wrapper that modifies unix-style paths to Windows-style paths in command lines. Fixpath is compiled automatically by <code>configure</code>.</p>
+<p>Windows path typically look like <code>C:\User\foo</code>, while Unix
+paths look like <code>/home/foo</code>. Tools with roots from Unix often
+experience issues related to this mismatch when running on Windows.</p>
+<p>In the JDK build, we always use Unix paths internally, and only just
+before calling a tool that does not understand Unix paths do we convert
+them to Windows paths.</p>
+<p>This conversion is done by the <code>fixpath</code> tool, which is a
+small wrapper that modifies unix-style paths to Windows-style paths in
+command lines. Fixpath is compiled automatically by
+<code>configure</code>.</p>
 <h3 id="native-debug-symbols">Native Debug Symbols</h3>
-<p>Native libraries and executables can have debug symbol (and other debug information) associated with them. How this works is very much platform dependent, but a common problem is that debug symbol information takes a lot of disk space, but is rarely needed by the end user.</p>
-<p>The JDK supports different methods on how to handle debug symbols. The method used is selected by <code>--with-native-debug-symbols</code>, and available methods are <code>none</code>, <code>internal</code>, <code>external</code>, <code>zipped</code>.</p>
+<p>Native libraries and executables can have debug symbol (and other
+debug information) associated with them. How this works is very much
+platform dependent, but a common problem is that debug symbol
+information takes a lot of disk space, but is rarely needed by the end
+user.</p>
+<p>The JDK supports different methods on how to handle debug symbols.
+The method used is selected by <code>--with-native-debug-symbols</code>,
+and available methods are <code>none</code>, <code>internal</code>,
+<code>external</code>, <code>zipped</code>.</p>
 <ul>
-<li><p><code>none</code> means that no debug symbols will be generated during the build.</p></li>
-<li><p><code>internal</code> means that debug symbols will be generated during the build, and they will be stored in the generated binary.</p></li>
-<li><p><code>external</code> means that debug symbols will be generated during the build, and after the compilation, they will be moved into a separate <code>.debuginfo</code> file. (This was previously known as FDS, Full Debug Symbols).</p></li>
-<li><p><code>zipped</code> is like <code>external</code>, but the .debuginfo file will also be zipped into a <code>.diz</code> file.</p></li>
+<li><p><code>none</code> means that no debug symbols will be generated
+during the build.</p></li>
+<li><p><code>internal</code> means that debug symbols will be generated
+during the build, and they will be stored in the generated
+binary.</p></li>
+<li><p><code>external</code> means that debug symbols will be generated
+during the build, and after the compilation, they will be moved into a
+separate <code>.debuginfo</code> file. (This was previously known as
+FDS, Full Debug Symbols).</p></li>
+<li><p><code>zipped</code> is like <code>external</code>, but the
+.debuginfo file will also be zipped into a <code>.diz</code>
+file.</p></li>
 </ul>
-<p>When building for distribution, <code>zipped</code> is a good solution. Binaries built with <code>internal</code> is suitable for use by developers, since they facilitate debugging, but should be stripped before distributed to end users.</p>
+<p>When building for distribution, <code>zipped</code> is a good
+solution. Binaries built with <code>internal</code> is suitable for use
+by developers, since they facilitate debugging, but should be stripped
+before distributed to end users.</p>
 <h3 id="autoconf-details">Autoconf Details</h3>
-<p>The <code>configure</code> script is based on the autoconf framework, but in some details deviate from a normal autoconf <code>configure</code> script.</p>
-<p>The <code>configure</code> script in the top level directory of the JDK is just a thin wrapper that calls <code>make/autoconf/configure</code>. This in turn will run <code>autoconf</code> to create the runnable (generated) configure script, as <code>.build/generated-configure.sh</code>. Apart from being responsible for the generation of the runnable script, the <code>configure</code> script also provides functionality that is not easily expressed in the normal Autoconf framework. As part of this functionality, the generated script is called.</p>
-<p>The build system will detect if the Autoconf source files have changed, and will trigger a regeneration of the generated script if needed. You can also manually request such an update by <code>bash configure autogen</code>.</p>
-<p>In previous versions of the JDK, the generated script was checked in at <code>make/autoconf/generated-configure.sh</code>. This is no longer the case.</p>
-<h3 id="developing-the-build-system-itself">Developing the Build System Itself</h3>
-<p>This section contains a few remarks about how to develop for the build system itself. It is not relevant if you are only making changes in the product source code.</p>
-<p>While technically using <code>make</code>, the make source files of the JDK does not resemble most other Makefiles. Instead of listing specific targets and actions (perhaps using patterns), the basic modus operandi is to call a high-level function (or properly, macro) from the API in <code>make/common</code>. For instance, to compile all classes in the <code>jdk.internal.foo</code> package in the <code>jdk.foo</code> module, a call like this would be made:</p>
+<p>The <code>configure</code> script is based on the autoconf framework,
+but in some details deviate from a normal autoconf
+<code>configure</code> script.</p>
+<p>The <code>configure</code> script in the top level directory of the
+JDK is just a thin wrapper that calls
+<code>make/autoconf/configure</code>. This in turn will run
+<code>autoconf</code> to create the runnable (generated) configure
+script, as <code>.build/generated-configure.sh</code>. Apart from being
+responsible for the generation of the runnable script, the
+<code>configure</code> script also provides functionality that is not
+easily expressed in the normal Autoconf framework. As part of this
+functionality, the generated script is called.</p>
+<p>The build system will detect if the Autoconf source files have
+changed, and will trigger a regeneration of the generated script if
+needed. You can also manually request such an update by
+<code>bash configure autogen</code>.</p>
+<p>In previous versions of the JDK, the generated script was checked in
+at <code>make/autoconf/generated-configure.sh</code>. This is no longer
+the case.</p>
+<h3 id="developing-the-build-system-itself">Developing the Build System
+Itself</h3>
+<p>This section contains a few remarks about how to develop for the
+build system itself. It is not relevant if you are only making changes
+in the product source code.</p>
+<p>While technically using <code>make</code>, the make source files of
+the JDK does not resemble most other Makefiles. Instead of listing
+specific targets and actions (perhaps using patterns), the basic modus
+operandi is to call a high-level function (or properly, macro) from the
+API in <code>make/common</code>. For instance, to compile all classes in
+the <code>jdk.internal.foo</code> package in the <code>jdk.foo</code>
+module, a call like this would be made:</p>
 <pre><code>$(eval $(call SetupJavaCompilation, BUILD_FOO_CLASSES, \
     SETUP := GENERATE_OLDBYTECODE, \
     SRC := $(TOPDIR)/src/jkd.foo/share/classes, \
     INCLUDES := jdk/internal/foo, \
     BIN := $(SUPPORT_OUTPUTDIR)/foo_classes, \
 ))</code></pre>
-<p>By encapsulating and expressing the high-level knowledge of <em>what</em> should be done, rather than <em>how</em> it should be done (as is normal in Makefiles), we can build a much more powerful and flexible build system.</p>
-<p>Correct dependency tracking is paramount. Sloppy dependency tracking will lead to improper parallelization, or worse, race conditions.</p>
-<p>To test for/debug race conditions, try running <code>make JOBS=1</code> and <code>make JOBS=100</code> and see if it makes any difference. (It shouldn't).</p>
-<p>To compare the output of two different builds and see if, and how, they differ, run <code>$BUILD1/compare.sh -o $BUILD2</code>, where <code>$BUILD1</code> and <code>$BUILD2</code> are the two builds you want to compare.</p>
-<p>To automatically build two consecutive versions and compare them, use <code>COMPARE_BUILD</code>. The value of <code>COMPARE_BUILD</code> is a set of variable=value assignments, like this:</p>
+<p>By encapsulating and expressing the high-level knowledge of
+<em>what</em> should be done, rather than <em>how</em> it should be done
+(as is normal in Makefiles), we can build a much more powerful and
+flexible build system.</p>
+<p>Correct dependency tracking is paramount. Sloppy dependency tracking
+will lead to improper parallelization, or worse, race conditions.</p>
+<p>To test for/debug race conditions, try running
+<code>make JOBS=1</code> and <code>make JOBS=100</code> and see if it
+makes any difference. (It shouldn't).</p>
+<p>To compare the output of two different builds and see if, and how,
+they differ, run <code>$BUILD1/compare.sh -o $BUILD2</code>, where
+<code>$BUILD1</code> and <code>$BUILD2</code> are the two builds you
+want to compare.</p>
+<p>To automatically build two consecutive versions and compare them, use
+<code>COMPARE_BUILD</code>. The value of <code>COMPARE_BUILD</code> is a
+set of variable=value assignments, like this:</p>
 <pre><code>make COMPARE_BUILD=CONF=--enable-new-hotspot-feature:MAKE=hotspot</code></pre>
-<p>See <code>make/InitSupport.gmk</code> for details on how to use <code>COMPARE_BUILD</code>.</p>
-<p>To analyze build performance, run with <code>LOG=trace</code> and check <code>$BUILD/build-trace-time.log</code>. Use <code>JOBS=1</code> to avoid parallelism.</p>
-<p>Please check that you adhere to the <a href="http://openjdk.org/groups/build/doc/code-conventions.html">Code Conventions for the Build System</a> before submitting patches.</p>
+<p>See <code>make/InitSupport.gmk</code> for details on how to use
+<code>COMPARE_BUILD</code>.</p>
+<p>To analyze build performance, run with <code>LOG=trace</code> and
+check <code>$BUILD/build-trace-time.log</code>. Use <code>JOBS=1</code>
+to avoid parallelism.</p>
+<p>Please check that you adhere to the <a
+href="http://openjdk.org/groups/build/doc/code-conventions.html">Code
+Conventions for the Build System</a> before submitting patches.</p>
 <h2 id="contributing-to-the-jdk">Contributing to the JDK</h2>
-<p>So, now you've built your JDK, and made your first patch, and want to contribute it back to the OpenJDK Community.</p>
-<p>First of all: Thank you! We gladly welcome your contribution. However, please bear in mind that the JDK is a massive project, and we must ask you to follow our rules and guidelines to be able to accept your contribution.</p>
-<p>The official place to start is the <a href="http://openjdk.org/contribute/">'How to contribute' page</a>. There is also an official (but somewhat outdated and skimpy on details) <a href="http://openjdk.org/guide/">Developer's Guide</a>.</p>
-<p>If this seems overwhelming to you, the Adoption Group is there to help you! A good place to start is their <a href="https://wiki.openjdk.org/display/Adoption/New+Contributor">'New Contributor' page</a>, or start reading the comprehensive <a href="https://adoptopenjdk.gitbooks.io/adoptopenjdk-getting-started-kit/en/">Getting Started Kit</a>. The Adoption Group will also happily answer any questions you have about contributing. Contact them by <a href="http://mail.openjdk.org/mailman/listinfo/adoption-discuss">mail</a> or <a href="http://openjdk.org/irc/">IRC</a>.</p>
+<p>So, now you've built your JDK, and made your first patch, and want to
+contribute it back to the OpenJDK Community.</p>
+<p>First of all: Thank you! We gladly welcome your contribution.
+However, please bear in mind that the JDK is a massive project, and we
+must ask you to follow our rules and guidelines to be able to accept
+your contribution.</p>
+<p>The official place to start is the <a
+href="http://openjdk.org/contribute/">'How to contribute' page</a>.
+There is also an official (but somewhat outdated and skimpy on details)
+<a href="http://openjdk.org/guide/">Developer's Guide</a>.</p>
+<p>If this seems overwhelming to you, the Adoption Group is there to
+help you! A good place to start is their <a
+href="https://wiki.openjdk.org/display/Adoption/New+Contributor">'New
+Contributor' page</a>, or start reading the comprehensive <a
+href="https://adoptopenjdk.gitbooks.io/adoptopenjdk-getting-started-kit/en/">Getting
+Started Kit</a>. The Adoption Group will also happily answer any
+questions you have about contributing. Contact them by <a
+href="http://mail.openjdk.org/mailman/listinfo/adoption-discuss">mail</a>
+or <a href="http://openjdk.org/irc/">IRC</a>.</p>
 <h2 id="editing-this-document">Editing this document</h2>
-<p>If you want to contribute changes to this document, edit <code>doc/building.md</code> and then run <code>make update-build-docs</code> to generate the same changes in <code>doc/building.html</code>.</p>
+<p>If you want to contribute changes to this document, edit
+<code>doc/building.md</code> and then run
+<code>make update-build-docs</code> to generate the same changes in
+<code>doc/building.html</code>.</p>
 </body>
 </html>

--- a/doc/hotspot-style.html
+++ b/doc/hotspot-style.html
@@ -5,11 +5,19 @@
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
   <title>HotSpot Coding Style</title>
-  <style type="text/css">
-      code{white-space: pre-wrap;}
-      span.smallcaps{font-variant: small-caps;}
-      span.underline{text-decoration: underline;}
-      div.column{display: inline-block; vertical-align: top; width: 50%;}
+  <style>
+    code{white-space: pre-wrap;}
+    span.smallcaps{font-variant: small-caps;}
+    div.columns{display: flex; gap: min(4vw, 1.5em);}
+    div.column{flex: auto; overflow-x: auto;}
+    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+    ul.task-list{list-style: none;}
+    ul.task-list li input[type="checkbox"] {
+      width: 0.8em;
+      margin: 0 0.8em 0.2em -1.6em;
+      vertical-align: middle;
+    }
+    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
   </style>
   <link rel="stylesheet" href="../make/data/docs-resources/resources/jdk-default.css" />
   <!--[if lt IE 9]>
@@ -20,294 +28,748 @@
 <header id="title-block-header">
 <h1 class="title">HotSpot Coding Style</h1>
 </header>
-<nav id="TOC">
+<nav id="TOC" role="doc-toc">
 <ul>
-<li><a href="#introduction">Introduction</a><ul>
-<li><a href="#why-care-about-style">Why Care About Style?</a></li>
-<li><a href="#counterexamples-and-updates">Counterexamples and Updates</a></li>
+<li><a href="#introduction" id="toc-introduction">Introduction</a>
+<ul>
+<li><a href="#why-care-about-style" id="toc-why-care-about-style">Why
+Care About Style?</a></li>
+<li><a href="#counterexamples-and-updates"
+id="toc-counterexamples-and-updates">Counterexamples and
+Updates</a></li>
 </ul></li>
-<li><a href="#structure-and-formatting">Structure and Formatting</a><ul>
-<li><a href="#factoring-and-class-design">Factoring and Class Design</a></li>
-<li><a href="#source-files">Source Files</a></li>
-<li><a href="#jtreg-tests">JTReg Tests</a></li>
-<li><a href="#naming">Naming</a></li>
-<li><a href="#commenting">Commenting</a></li>
-<li><a href="#macros">Macros</a></li>
-<li><a href="#whitespace">Whitespace</a></li>
-<li><a href="#miscellaneous">Miscellaneous</a></li>
+<li><a href="#structure-and-formatting"
+id="toc-structure-and-formatting">Structure and Formatting</a>
+<ul>
+<li><a href="#factoring-and-class-design"
+id="toc-factoring-and-class-design">Factoring and Class Design</a></li>
+<li><a href="#source-files" id="toc-source-files">Source Files</a></li>
+<li><a href="#jtreg-tests" id="toc-jtreg-tests">JTReg Tests</a></li>
+<li><a href="#naming" id="toc-naming">Naming</a></li>
+<li><a href="#commenting" id="toc-commenting">Commenting</a></li>
+<li><a href="#macros" id="toc-macros">Macros</a></li>
+<li><a href="#whitespace" id="toc-whitespace">Whitespace</a></li>
+<li><a href="#miscellaneous"
+id="toc-miscellaneous">Miscellaneous</a></li>
 </ul></li>
-<li><a href="#use-of-c-features">Use of C++ Features</a><ul>
-<li><a href="#error-handling">Error Handling</a></li>
-<li><a href="#rtti-runtime-type-information">RTTI (Runtime Type Information)</a></li>
-<li><a href="#memory-allocation">Memory Allocation</a></li>
-<li><a href="#class-inheritance">Class Inheritance</a></li>
-<li><a href="#namespaces">Namespaces</a></li>
-<li><a href="#c-standard-library">C++ Standard Library</a></li>
-<li><a href="#type-deduction">Type Deduction</a></li>
-<li><a href="#expression-sfinae">Expression SFINAE</a></li>
-<li><a href="#enum">enum</a></li>
-<li><a href="#thread_local">thread_local</a></li>
-<li><a href="#nullptr">nullptr</a></li>
-<li><a href="#atomic">&lt;atomic&gt;</a></li>
-<li><a href="#uniform-initialization">Uniform Initialization</a></li>
-<li><a href="#local-function-objects">Local Function Objects</a></li>
-<li><a href="#inheriting-constructors">Inheriting constructors</a></li>
-<li><a href="#additional-permitted-features">Additional Permitted Features</a></li>
-<li><a href="#excluded-features">Excluded Features</a></li>
-<li><a href="#undecided-features">Undecided Features</a></li>
+<li><a href="#use-of-c-features" id="toc-use-of-c-features">Use of C++
+Features</a>
+<ul>
+<li><a href="#error-handling" id="toc-error-handling">Error
+Handling</a></li>
+<li><a href="#rtti-runtime-type-information"
+id="toc-rtti-runtime-type-information">RTTI (Runtime Type
+Information)</a></li>
+<li><a href="#memory-allocation" id="toc-memory-allocation">Memory
+Allocation</a></li>
+<li><a href="#class-inheritance" id="toc-class-inheritance">Class
+Inheritance</a></li>
+<li><a href="#namespaces" id="toc-namespaces">Namespaces</a></li>
+<li><a href="#c-standard-library" id="toc-c-standard-library">C++
+Standard Library</a></li>
+<li><a href="#type-deduction" id="toc-type-deduction">Type
+Deduction</a></li>
+<li><a href="#expression-sfinae" id="toc-expression-sfinae">Expression
+SFINAE</a></li>
+<li><a href="#enum" id="toc-enum">enum</a></li>
+<li><a href="#thread_local" id="toc-thread_local">thread_local</a></li>
+<li><a href="#nullptr" id="toc-nullptr">nullptr</a></li>
+<li><a href="#atomic" id="toc-atomic">&lt;atomic&gt;</a></li>
+<li><a href="#uniform-initialization"
+id="toc-uniform-initialization">Uniform Initialization</a></li>
+<li><a href="#local-function-objects"
+id="toc-local-function-objects">Local Function Objects</a></li>
+<li><a href="#inheriting-constructors"
+id="toc-inheriting-constructors">Inheriting constructors</a></li>
+<li><a href="#additional-permitted-features"
+id="toc-additional-permitted-features">Additional Permitted
+Features</a></li>
+<li><a href="#excluded-features" id="toc-excluded-features">Excluded
+Features</a></li>
+<li><a href="#undecided-features" id="toc-undecided-features">Undecided
+Features</a></li>
 </ul></li>
 </ul>
 </nav>
 <h2 id="introduction">Introduction</h2>
-<p>This is a collection of rules, guidelines, and suggestions for writing HotSpot code. Following these will help new code fit in with existing HotSpot code, making it easier to read and maintain. Failure to follow these guidelines may lead to discussion during code reviews, if not outright rejection of a change.</p>
+<p>This is a collection of rules, guidelines, and suggestions for
+writing HotSpot code. Following these will help new code fit in with
+existing HotSpot code, making it easier to read and maintain. Failure to
+follow these guidelines may lead to discussion during code reviews, if
+not outright rejection of a change.</p>
 <h3 id="why-care-about-style">Why Care About Style?</h3>
-<p>Some programmers seem to have lexers and even C preprocessors installed directly behind their eyeballs. The rest of us require code that is not only functionally correct but also easy to read. More than that, since there is no one style for easy-to-read code, and since a mashup of many styles is just as confusing as no style at all, it is important for coders to be conscious of the many implicit stylistic choices that historically have gone into the HotSpot code base.</p>
-<p>Some of these guidelines are driven by the cross-platform requirements for HotSpot. Shared code must work on a variety of platforms, and may encounter deficiencies in some. Using platform conditionalization in shared code is usually avoided, while shared code is strongly preferred to multiple platform-dependent implementations, so some language features may be recommended against.</p>
-<p>Some of the guidelines here are relatively arbitrary choices among equally plausible alternatives. The purpose of stating and enforcing these rules is largely to provide a consistent look to the code. That consistency makes the code more readable by avoiding non-functional distractions from the interesting functionality.</p>
-<p>When changing pre-existing code, it is reasonable to adjust it to match these conventions. Exception: If the pre-existing code clearly conforms locally to its own peculiar conventions, it is not worth reformatting the whole thing. Also consider separating changes that make extensive stylistic updates from those which make functional changes.</p>
+<p>Some programmers seem to have lexers and even C preprocessors
+installed directly behind their eyeballs. The rest of us require code
+that is not only functionally correct but also easy to read. More than
+that, since there is no one style for easy-to-read code, and since a
+mashup of many styles is just as confusing as no style at all, it is
+important for coders to be conscious of the many implicit stylistic
+choices that historically have gone into the HotSpot code base.</p>
+<p>Some of these guidelines are driven by the cross-platform
+requirements for HotSpot. Shared code must work on a variety of
+platforms, and may encounter deficiencies in some. Using platform
+conditionalization in shared code is usually avoided, while shared code
+is strongly preferred to multiple platform-dependent implementations, so
+some language features may be recommended against.</p>
+<p>Some of the guidelines here are relatively arbitrary choices among
+equally plausible alternatives. The purpose of stating and enforcing
+these rules is largely to provide a consistent look to the code. That
+consistency makes the code more readable by avoiding non-functional
+distractions from the interesting functionality.</p>
+<p>When changing pre-existing code, it is reasonable to adjust it to
+match these conventions. Exception: If the pre-existing code clearly
+conforms locally to its own peculiar conventions, it is not worth
+reformatting the whole thing. Also consider separating changes that make
+extensive stylistic updates from those which make functional
+changes.</p>
 <h3 id="counterexamples-and-updates">Counterexamples and Updates</h3>
-<p>Many of the guidelines mentioned here have (sometimes widespread) counterexamples in the HotSpot code base. Finding a counterexample is not sufficient justification for new code to follow the counterexample as a precedent, since readers of your code will rightfully expect your code to follow the greater bulk of precedents documented here.</p>
-<p>Occasionally a guideline mentioned here may be just out of synch with the actual HotSpot code base. If you find that a guideline is consistently contradicted by a large number of counterexamples, please bring it up for discussion and possible change. The architectural rule, of course, is &quot;When in Rome do as the Romans&quot;. Sometimes in the suburbs of Rome the rules are a little different; these differences can be pointed out here.</p>
-<p>Proposed changes should be discussed on the <a href="mailto:hotspot-dev@openjdk.org">HotSpot Developers</a> mailing list. Changes are likely to be cautious and incremental, since HotSpot coders have been using these guidelines for years.</p>
-<p>Substantive changes are approved by <a href="https://www.rfc-editor.org/rfc/rfc7282.html">rough consensus</a> of the <a href="https://openjdk.org/census#hotspot">HotSpot Group</a> Members. The Group Lead determines whether consensus has been reached.</p>
-<p>Editorial changes (changes that only affect the description of HotSpot style, not its substance) do not require the full consensus gathering process. The normal HotSpot pull request process may be used for editorial changes, with the additional requirement that the requisite reviewers are also HotSpot Group Members.</p>
+<p>Many of the guidelines mentioned here have (sometimes widespread)
+counterexamples in the HotSpot code base. Finding a counterexample is
+not sufficient justification for new code to follow the counterexample
+as a precedent, since readers of your code will rightfully expect your
+code to follow the greater bulk of precedents documented here.</p>
+<p>Occasionally a guideline mentioned here may be just out of synch with
+the actual HotSpot code base. If you find that a guideline is
+consistently contradicted by a large number of counterexamples, please
+bring it up for discussion and possible change. The architectural rule,
+of course, is "When in Rome do as the Romans". Sometimes in the suburbs
+of Rome the rules are a little different; these differences can be
+pointed out here.</p>
+<p>Proposed changes should be discussed on the <a
+href="mailto:hotspot-dev@openjdk.org">HotSpot Developers</a> mailing
+list. Changes are likely to be cautious and incremental, since HotSpot
+coders have been using these guidelines for years.</p>
+<p>Substantive changes are approved by <a
+href="https://www.rfc-editor.org/rfc/rfc7282.html">rough consensus</a>
+of the <a href="https://openjdk.org/census#hotspot">HotSpot Group</a>
+Members. The Group Lead determines whether consensus has been
+reached.</p>
+<p>Editorial changes (changes that only affect the description of
+HotSpot style, not its substance) do not require the full consensus
+gathering process. The normal HotSpot pull request process may be used
+for editorial changes, with the additional requirement that the
+requisite reviewers are also HotSpot Group Members.</p>
 <h2 id="structure-and-formatting">Structure and Formatting</h2>
 <h3 id="factoring-and-class-design">Factoring and Class Design</h3>
 <ul>
-<li><p>Group related code together, so readers can concentrate on one section of one file.</p></li>
-<li><p>Classes are the primary code structuring mechanism. Place related functionality in a class, or a set of related classes. Use of either namespaces or public non-member functions is rare in HotSpot code. Static non-member functions are not uncommon.</p></li>
-<li><p>If a class <code>FooBar</code> is going to be used in more than one place, put it a file named fooBar.hpp and fooBar.cpp. If the class is a sidekick to a more important class <code>BazBat</code>, it can go in bazBat.hpp.</p></li>
-<li><p>Put a member function <code>FooBar::bang</code> into the same file that defined <code>FooBar</code>, or its associated <em>.inline.hpp or </em>.cpp file.</p></li>
-<li><p>Use public accessor functions for member variables accessed outside the class.</p></li>
-<li><p>Assign names to constant literals and use the names instead.</p></li>
-<li><p>Keep functions small, a screenful at most. Split out chunks of logic into file-local classes or static functions if needed.</p></li>
-<li><p>Factor away nonessential complexity into local inline helper functions and helper classes.</p></li>
-<li><p>Think clearly about internal invariants that apply to each class, and document them in the form of asserts within member functions.</p></li>
-<li><p>Make simple, self-evident contracts for member functions. If you cannot communicate a simple contract, redesign the class.</p></li>
-<li><p>Implement classes as if expecting rough usage by clients. Check for incorrect usage of a class using <code>assert(...)</code>, <code>guarantee(...)</code>, <code>ShouldNotReachHere()</code> and comments wherever needed. Performance is almost never a reason to omit asserts.</p></li>
-<li><p>When possible, design as if for reusability. This forces a clear design of the class's externals, and clean hiding of its internals.</p></li>
-<li><p>Initialize all variables and data structures to a known state. If a class has a constructor, initialize it there.</p></li>
-<li><p>Do no optimization before its time. Prove the need to optimize.</p></li>
-<li><p>When you must defactor to optimize, preserve as much structure as possible. If you must hand-inline some name, label the local copy with the original name.</p></li>
-<li><p>If you need to use a hidden detail (e.g., a structure offset), name it (as a constant or function) in the class that owns it.</p></li>
-<li><p>Don't use the Copy and Paste keys to replicate more than a couple lines of code. Name what you must repeat.</p></li>
-<li><p>If a class needs a member function to change a user-visible attribute, the change should be done with a &quot;setter&quot; accessor matched to the simple &quot;getter&quot;.</p></li>
+<li><p>Group related code together, so readers can concentrate on one
+section of one file.</p></li>
+<li><p>Classes are the primary code structuring mechanism. Place related
+functionality in a class, or a set of related classes. Use of either
+namespaces or public non-member functions is rare in HotSpot code.
+Static non-member functions are not uncommon.</p></li>
+<li><p>If a class <code>FooBar</code> is going to be used in more than
+one place, put it a file named fooBar.hpp and fooBar.cpp. If the class
+is a sidekick to a more important class <code>BazBat</code>, it can go
+in bazBat.hpp.</p></li>
+<li><p>Put a member function <code>FooBar::bang</code> into the same
+file that defined <code>FooBar</code>, or its associated <em>.inline.hpp
+or </em>.cpp file.</p></li>
+<li><p>Use public accessor functions for member variables accessed
+outside the class.</p></li>
+<li><p>Assign names to constant literals and use the names
+instead.</p></li>
+<li><p>Keep functions small, a screenful at most. Split out chunks of
+logic into file-local classes or static functions if needed.</p></li>
+<li><p>Factor away nonessential complexity into local inline helper
+functions and helper classes.</p></li>
+<li><p>Think clearly about internal invariants that apply to each class,
+and document them in the form of asserts within member
+functions.</p></li>
+<li><p>Make simple, self-evident contracts for member functions. If you
+cannot communicate a simple contract, redesign the class.</p></li>
+<li><p>Implement classes as if expecting rough usage by clients. Check
+for incorrect usage of a class using <code>assert(...)</code>,
+<code>guarantee(...)</code>, <code>ShouldNotReachHere()</code> and
+comments wherever needed. Performance is almost never a reason to omit
+asserts.</p></li>
+<li><p>When possible, design as if for reusability. This forces a clear
+design of the class's externals, and clean hiding of its
+internals.</p></li>
+<li><p>Initialize all variables and data structures to a known state. If
+a class has a constructor, initialize it there.</p></li>
+<li><p>Do no optimization before its time. Prove the need to
+optimize.</p></li>
+<li><p>When you must defactor to optimize, preserve as much structure as
+possible. If you must hand-inline some name, label the local copy with
+the original name.</p></li>
+<li><p>If you need to use a hidden detail (e.g., a structure offset),
+name it (as a constant or function) in the class that owns it.</p></li>
+<li><p>Don't use the Copy and Paste keys to replicate more than a couple
+lines of code. Name what you must repeat.</p></li>
+<li><p>If a class needs a member function to change a user-visible
+attribute, the change should be done with a "setter" accessor matched to
+the simple "getter".</p></li>
 </ul>
 <h3 id="source-files">Source Files</h3>
 <ul>
-<li><p>All source files must have a globally unique basename. The build system depends on this uniqueness.</p></li>
-<li><p>Do not put non-trivial function implementations in .hpp files. If the implementation depends on other .hpp files, put it in a .cpp or a .inline.hpp file.</p></li>
-<li><p>.inline.hpp files should only be included in .cpp or .inline.hpp files.</p></li>
-<li><p>All .inline.hpp files should include their corresponding .hpp file as the first include line. Declarations needed by other files should be put in the .hpp file, and not in the .inline.hpp file. This rule exists to resolve problems with circular dependencies between .inline.hpp files.</p></li>
-<li><p>All .cpp files include precompiled.hpp as the first include line.</p></li>
-<li><p>precompiled.hpp is just a build time optimization, so don't rely on it to resolve include problems.</p></li>
+<li><p>All source files must have a globally unique basename. The build
+system depends on this uniqueness.</p></li>
+<li><p>Do not put non-trivial function implementations in .hpp files. If
+the implementation depends on other .hpp files, put it in a .cpp or a
+.inline.hpp file.</p></li>
+<li><p>.inline.hpp files should only be included in .cpp or .inline.hpp
+files.</p></li>
+<li><p>All .inline.hpp files should include their corresponding .hpp
+file as the first include line. Declarations needed by other files
+should be put in the .hpp file, and not in the .inline.hpp file. This
+rule exists to resolve problems with circular dependencies between
+.inline.hpp files.</p></li>
+<li><p>All .cpp files include precompiled.hpp as the first include
+line.</p></li>
+<li><p>precompiled.hpp is just a build time optimization, so don't rely
+on it to resolve include problems.</p></li>
 <li><p>Keep the include lines alphabetically sorted.</p></li>
-<li><p>Put conditional inclusions (<code>#if ...</code>) at the end of the include list.</p></li>
+<li><p>Put conditional inclusions (<code>#if ...</code>) at the end of
+the include list.</p></li>
 </ul>
 <h3 id="jtreg-tests">JTReg Tests</h3>
 <ul>
 <li><p>JTReg tests should have meaningful names.</p></li>
-<li><p>JTReg tests associated with specific bugs should be tagged with the <code>@bug</code> keyword in the test description.</p></li>
-<li><p>JTReg tests should be organized by component or feature under <code>test/</code>, in a directory hierarchy that generally follows that of the <code>src/</code> directory. There may be additional subdirectories to further categorize tests by feature. This structure makes it easy to run a collection of tests associated with a specific feature by specifying the associated directory as the source of the tests to run.</p>
+<li><p>JTReg tests associated with specific bugs should be tagged with
+the <code>@bug</code> keyword in the test description.</p></li>
+<li><p>JTReg tests should be organized by component or feature under
+<code>test/</code>, in a directory hierarchy that generally follows that
+of the <code>src/</code> directory. There may be additional
+subdirectories to further categorize tests by feature. This structure
+makes it easy to run a collection of tests associated with a specific
+feature by specifying the associated directory as the source of the
+tests to run.</p>
 <ul>
-<li>Some (older) tests use the associated bug number in the directory name, the test name, or both. That naming style should no longer be used, with existing tests using that style being candidates for migration.</li>
+<li>Some (older) tests use the associated bug number in the directory
+name, the test name, or both. That naming style should no longer be
+used, with existing tests using that style being candidates for
+migration.</li>
 </ul></li>
 </ul>
 <h3 id="naming">Naming</h3>
 <ul>
-<li><p>The length of a name may be correlated to the size of its scope. In particular, short names (even single letter names) may be fine in a small scope, but are usually inappropriate for larger scopes.</p></li>
-<li><p>Prefer whole words rather than abbreviations, unless the abbreviation is more widely used than the long form in the code's domain.</p></li>
-<li><p>Choose names consistently. Do not introduce spurious variations. Abbreviate corresponding terms to a consistent length.</p></li>
-<li><p>Global names must be unique, to avoid <a href="https://en.cppreference.com/w/cpp/language/definition" title="One Definition Rule">One Definition Rule</a> (ODR) violations. A common prefixing scheme for related global names is often used. (This is instead of using namespaces, which are mostly avoided in HotSpot.)</p></li>
-<li><p>Don't give two names to the semantically same thing. But use different names for semantically different things, even if they are representationally the same. (So use meaningful <code>typedef</code> or template alias names where appropriate.)</p></li>
-<li><p>When choosing names, avoid categorical nouns like &quot;variable&quot;, &quot;field&quot;, &quot;parameter&quot;, &quot;value&quot;, and verbs like &quot;compute&quot;, &quot;get&quot;. (<code>storeValue(int param)</code> is bad.)</p></li>
-<li><p>Type names and global names should use mixed-case with the first letter of each word capitalized (<code>FooBar</code>).</p></li>
-<li><p>Embedded abbreviations in otherwise mixed-case names are usually capitalized entirely rather than being treated as a single word with only the initial letter capitalized, e.g. &quot;HTML&quot; rather than &quot;Html&quot;.</p></li>
-<li><p>Function and local variable names use lowercase with words separated by a single underscore (<code>foo_bar</code>).</p></li>
-<li><p>Class data member names have a leading underscore, and use lowercase with words separated by a single underscore (<code>_foo_bar</code>).</p></li>
-<li><p>Constant names may be upper-case or mixed-case, according to historical necessity. (Note: There are many examples of constants with lowercase names.)</p></li>
-<li><p>Constant names should follow an existing pattern, and must have a distinct appearance from other names in related APIs.</p></li>
-<li><p>Class and type names should be noun phrases. Consider an &quot;er&quot; suffix for a class that represents an action.</p></li>
-<li><p>Function names should be verb phrases that reflect changes of state known to a class's user, or else noun phrases if they cause no change of state visible to the class's user.</p></li>
-<li><p>Getter accessor names are noun phrases, with no &quot;<code>get_</code>&quot; noise word. Boolean getters can also begin with &quot;<code>is_</code>&quot; or &quot;<code>has_</code>&quot;. Member function for reading data members usually have the same name as the data member, exclusive of the leading underscore.</p></li>
-<li><p>Setter accessor names prepend &quot;<code>set_</code>&quot; to the getter name.</p></li>
-<li><p>Other member function names are verb phrases, as if commands to the receiver.</p></li>
-<li><p>Avoid leading underscores (as &quot;<code>_oop</code>&quot;) except in cases required above. (Names with leading underscores can cause portability problems.)</p></li>
+<li><p>The length of a name may be correlated to the size of its scope.
+In particular, short names (even single letter names) may be fine in a
+small scope, but are usually inappropriate for larger scopes.</p></li>
+<li><p>Prefer whole words rather than abbreviations, unless the
+abbreviation is more widely used than the long form in the code's
+domain.</p></li>
+<li><p>Choose names consistently. Do not introduce spurious variations.
+Abbreviate corresponding terms to a consistent length.</p></li>
+<li><p>Global names must be unique, to avoid <a
+href="https://en.cppreference.com/w/cpp/language/definition"
+title="One Definition Rule">One Definition Rule</a> (ODR) violations. A
+common prefixing scheme for related global names is often used. (This is
+instead of using namespaces, which are mostly avoided in
+HotSpot.)</p></li>
+<li><p>Don't give two names to the semantically same thing. But use
+different names for semantically different things, even if they are
+representationally the same. (So use meaningful <code>typedef</code> or
+template alias names where appropriate.)</p></li>
+<li><p>When choosing names, avoid categorical nouns like "variable",
+"field", "parameter", "value", and verbs like "compute", "get".
+(<code>storeValue(int param)</code> is bad.)</p></li>
+<li><p>Type names and global names should use mixed-case with the first
+letter of each word capitalized (<code>FooBar</code>).</p></li>
+<li><p>Embedded abbreviations in otherwise mixed-case names are usually
+capitalized entirely rather than being treated as a single word with
+only the initial letter capitalized, e.g. "HTML" rather than
+"Html".</p></li>
+<li><p>Function and local variable names use lowercase with words
+separated by a single underscore (<code>foo_bar</code>).</p></li>
+<li><p>Class data member names have a leading underscore, and use
+lowercase with words separated by a single underscore
+(<code>_foo_bar</code>).</p></li>
+<li><p>Constant names may be upper-case or mixed-case, according to
+historical necessity. (Note: There are many examples of constants with
+lowercase names.)</p></li>
+<li><p>Constant names should follow an existing pattern, and must have a
+distinct appearance from other names in related APIs.</p></li>
+<li><p>Class and type names should be noun phrases. Consider an "er"
+suffix for a class that represents an action.</p></li>
+<li><p>Function names should be verb phrases that reflect changes of
+state known to a class's user, or else noun phrases if they cause no
+change of state visible to the class's user.</p></li>
+<li><p>Getter accessor names are noun phrases, with no
+"<code>get_</code>" noise word. Boolean getters can also begin with
+"<code>is_</code>" or "<code>has_</code>". Member function for reading
+data members usually have the same name as the data member, exclusive of
+the leading underscore.</p></li>
+<li><p>Setter accessor names prepend "<code>set_</code>" to the getter
+name.</p></li>
+<li><p>Other member function names are verb phrases, as if commands to
+the receiver.</p></li>
+<li><p>Avoid leading underscores (as "<code>_oop</code>") except in
+cases required above. (Names with leading underscores can cause
+portability problems.)</p></li>
 </ul>
 <h3 id="commenting">Commenting</h3>
 <ul>
 <li><p>Clearly comment subtle fixes.</p></li>
 <li><p>Clearly comment tricky classes and functions.</p></li>
-<li><p>If you have to choose between commenting code and writing wiki content, comment the code. Link from the wiki to the source file if it makes sense.</p></li>
-<li><p>As a general rule don't add bug numbers to comments (they would soon overwhelm the code). But if the bug report contains significant information that can't reasonably be added as a comment, then refer to the bug report.</p></li>
-<li><p>Personal names are discouraged in the source code, which is a team product.</p></li>
+<li><p>If you have to choose between commenting code and writing wiki
+content, comment the code. Link from the wiki to the source file if it
+makes sense.</p></li>
+<li><p>As a general rule don't add bug numbers to comments (they would
+soon overwhelm the code). But if the bug report contains significant
+information that can't reasonably be added as a comment, then refer to
+the bug report.</p></li>
+<li><p>Personal names are discouraged in the source code, which is a
+team product.</p></li>
 </ul>
 <h3 id="macros">Macros</h3>
 <ul>
-<li><p>You can almost always use an inline function or class instead of a macro. Use a macro only when you really need it.</p></li>
-<li><p>Templates may be preferable to multi-line macros. (There may be subtle performance effects with templates on some platforms; revert to macros if absolutely necessary.)</p></li>
-<li><p><code>#ifdef</code>s should not be used to introduce platform-specific code into shared code (except for <code>_LP64</code>). They must be used to manage header files, in the pattern found at the top of every source file. They should be used mainly for major build features, including <code>PRODUCT</code>, <code>ASSERT</code>, <code>_LP64</code>, <code>INCLUDE_SERIALGC</code>, <code>COMPILER1</code>, etc.</p></li>
-<li><p>For build features such as <code>PRODUCT</code>, use <code>#ifdef PRODUCT</code> for multiple-line inclusions or exclusions.</p></li>
-<li><p>For short inclusions or exclusions based on build features, use macros like <code>PRODUCT_ONLY</code> and <code>NOT_PRODUCT</code>. But avoid using them with multiple-line arguments, since debuggers do not handle that well.</p></li>
-<li><p>Use <code>CATCH</code>, <code>THROW</code>, etc. for HotSpot-specific exception processing.</p></li>
+<li><p>You can almost always use an inline function or class instead of
+a macro. Use a macro only when you really need it.</p></li>
+<li><p>Templates may be preferable to multi-line macros. (There may be
+subtle performance effects with templates on some platforms; revert to
+macros if absolutely necessary.)</p></li>
+<li><p><code>#ifdef</code>s should not be used to introduce
+platform-specific code into shared code (except for <code>_LP64</code>).
+They must be used to manage header files, in the pattern found at the
+top of every source file. They should be used mainly for major build
+features, including <code>PRODUCT</code>, <code>ASSERT</code>,
+<code>_LP64</code>, <code>INCLUDE_SERIALGC</code>,
+<code>COMPILER1</code>, etc.</p></li>
+<li><p>For build features such as <code>PRODUCT</code>, use
+<code>#ifdef PRODUCT</code> for multiple-line inclusions or
+exclusions.</p></li>
+<li><p>For short inclusions or exclusions based on build features, use
+macros like <code>PRODUCT_ONLY</code> and <code>NOT_PRODUCT</code>. But
+avoid using them with multiple-line arguments, since debuggers do not
+handle that well.</p></li>
+<li><p>Use <code>CATCH</code>, <code>THROW</code>, etc. for
+HotSpot-specific exception processing.</p></li>
 </ul>
 <h3 id="whitespace">Whitespace</h3>
 <ul>
-<li><p>In general, don't change whitespace unless it improves readability or consistency. Gratuitous whitespace changes will make integrations and backports more difficult.</p></li>
-<li><p>Use <a href="https://en.wikipedia.org/wiki/Indentation_style#Variant:_1TBS_(OTBS)">One-True-Brace-Style</a>. The opening brace for a function or class is normally at the end of the line; it is sometimes moved to the beginning of the next line for emphasis. Substatements are enclosed in braces, even if there is only a single statement. Extremely simple one-line statements may drop braces around a substatement.</p></li>
+<li><p>In general, don't change whitespace unless it improves
+readability or consistency. Gratuitous whitespace changes will make
+integrations and backports more difficult.</p></li>
+<li><p>Use <a
+href="https://en.wikipedia.org/wiki/Indentation_style#Variant:_1TBS_(OTBS)">One-True-Brace-Style</a>.
+The opening brace for a function or class is normally at the end of the
+line; it is sometimes moved to the beginning of the next line for
+emphasis. Substatements are enclosed in braces, even if there is only a
+single statement. Extremely simple one-line statements may drop braces
+around a substatement.</p></li>
 <li><p>Indentation levels are two columns.</p></li>
-<li><p>There is no hard line length limit. That said, bear in mind that excessively long lines can cause difficulties. Some people like to have multiple side-by-side windows in their editors, and long lines may force them to choose among unpleasant options. They can use wide windows, reducing the number that can fit across the screen, and wasting a lot of screen real estate because most lines are not that long. Alternatively, they can have more windows across the screen, with long lines wrapping (or worse, requiring scrolling to see in their entirety), which is harder to read. Similar issues exist for side-by-side code reviews.</p></li>
-<li><p>Tabs are not allowed in code. Set your editor accordingly.<br> (Emacs: <code>(setq-default indent-tabs-mode nil)</code>.)</p></li>
-<li><p>Use good taste to break lines and align corresponding tokens on adjacent lines.</p></li>
-<li><p>Use spaces around operators, especially comparisons and assignments. (Relaxable for boolean expressions and high-precedence operators in classic math-style formulas.)</p></li>
-<li><p>Put spaces on both sides of control flow keywords <code>if</code>, <code>else</code>, <code>for</code>, <code>switch</code>, etc. Don't add spaces around the associated <em>control</em> expressions. Examples:</p>
+<li><p>There is no hard line length limit. That said, bear in mind that
+excessively long lines can cause difficulties. Some people like to have
+multiple side-by-side windows in their editors, and long lines may force
+them to choose among unpleasant options. They can use wide windows,
+reducing the number that can fit across the screen, and wasting a lot of
+screen real estate because most lines are not that long. Alternatively,
+they can have more windows across the screen, with long lines wrapping
+(or worse, requiring scrolling to see in their entirety), which is
+harder to read. Similar issues exist for side-by-side code
+reviews.</p></li>
+<li><p>Tabs are not allowed in code. Set your editor accordingly.<br>
+(Emacs: <code>(setq-default indent-tabs-mode nil)</code>.)</p></li>
+<li><p>Use good taste to break lines and align corresponding tokens on
+adjacent lines.</p></li>
+<li><p>Use spaces around operators, especially comparisons and
+assignments. (Relaxable for boolean expressions and high-precedence
+operators in classic math-style formulas.)</p></li>
+<li><p>Put spaces on both sides of control flow keywords
+<code>if</code>, <code>else</code>, <code>for</code>,
+<code>switch</code>, etc. Don't add spaces around the associated
+<em>control</em> expressions. Examples:</p>
 <pre><code>while (test_foo(args...)) {   // Yes
 while(test_foo(args...)) {    // No, missing space after while
 while ( test_foo(args...) ) { // No, excess spaces around control</code></pre></li>
-<li><p>Use extra parentheses in expressions whenever operator precedence seems doubtful. Always use parentheses in shift/mask expressions (<code>&lt;&lt;</code>, <code>&amp;</code>, <code>|</code>). Don't add whitespace immediately inside parentheses.</p></li>
-<li><p>Use more spaces and blank lines between larger constructs, such as classes or function definitions.</p></li>
-<li><p>If the surrounding code has any sort of vertical organization, adjust new lines horizontally to be consistent with that organization. (E.g., trailing backslashes on long macro definitions often align.)</p></li>
+<li><p>Use extra parentheses in expressions whenever operator precedence
+seems doubtful. Always use parentheses in shift/mask expressions
+(<code>&lt;&lt;</code>, <code>&amp;</code>, <code>|</code>). Don't add
+whitespace immediately inside parentheses.</p></li>
+<li><p>Use more spaces and blank lines between larger constructs, such
+as classes or function definitions.</p></li>
+<li><p>If the surrounding code has any sort of vertical organization,
+adjust new lines horizontally to be consistent with that organization.
+(E.g., trailing backslashes on long macro definitions often
+align.)</p></li>
 </ul>
 <h3 id="miscellaneous">Miscellaneous</h3>
 <ul>
-<li><p>Use the <a href="https://en.cppreference.com/w/cpp/language/raii" title="Resource Acquisition Is Initialization">Resource Acquisition Is Initialization</a> (RAII) design pattern to manage bracketed critical sections. See class <code>ResourceMark</code> for an example.</p></li>
-<li>Avoid implicit conversions to <code>bool</code>.
+<li><p>Use the <a href="https://en.cppreference.com/w/cpp/language/raii"
+title="Resource Acquisition Is Initialization">Resource Acquisition Is
+Initialization</a> (RAII) design pattern to manage bracketed critical
+sections. See class <code>ResourceMark</code> for an example.</p></li>
+<li><p>Avoid implicit conversions to <code>bool</code>.</p>
 <ul>
 <li>Use <code>bool</code> for boolean values.</li>
-<li>Do not use ints or pointers as (implicit) booleans with <code>&amp;&amp;</code>, <code>||</code>, <code>if</code>, <code>while</code>. Instead, compare explicitly, i.e. <code>if (x != 0)</code> or <code>if (ptr != nullptr)</code>, etc.</li>
-<li>Do not use declarations in <em>condition</em> forms, i.e. don't use <code>if (T v = value) { ... }</code>.</li>
+<li>Do not use ints or pointers as (implicit) booleans with
+<code>&amp;&amp;</code>, <code>||</code>, <code>if</code>,
+<code>while</code>. Instead, compare explicitly, i.e.
+<code>if (x != 0)</code> or <code>if (ptr != nullptr)</code>, etc.</li>
+<li>Do not use declarations in <em>condition</em> forms, i.e. don't use
+<code>if (T v = value) { ... }</code>.</li>
 </ul></li>
-<li><p>Use functions from globalDefinitions.hpp and related files when performing bitwise operations on integers. Do not code directly as C operators, unless they are extremely simple. (Examples: <code>align_up</code>, <code>is_power_of_2</code>, <code>exact_log2</code>.)</p></li>
+<li><p>Use functions from globalDefinitions.hpp and related files when
+performing bitwise operations on integers. Do not code directly as C
+operators, unless they are extremely simple. (Examples:
+<code>align_up</code>, <code>is_power_of_2</code>,
+<code>exact_log2</code>.)</p></li>
 <li><p>Use arrays with abstractions supporting range checks.</p></li>
-<li><p>Always enumerate all cases in a switch statement or provide a default case. It is ok to have an empty default with comment.</p></li>
+<li><p>Always enumerate all cases in a switch statement or provide a
+default case. It is ok to have an empty default with comment.</p></li>
 </ul>
 <h2 id="use-of-c-features">Use of C++ Features</h2>
-<p>HotSpot was originally written in a subset of the C++98/03 language. More recently, support for C++14 is provided, though again, HotSpot only uses a subset. (Backports to JDK versions lacking support for more recent Standards must of course stick with the original C++98/03 subset.)</p>
-<p>This section describes that subset. Features from the C++98/03 language may be used unless explicitly excluded here. Features from C++11 and C++14 may be explicitly permitted or explicitly excluded, and discussed accordingly here. There is a third category, undecided features, about which HotSpot developers have not yet reached a consensus, or perhaps have not discussed at all. Use of these features is also excluded.</p>
-<p>(The use of some features may not be immediately obvious and may slip in anyway, since the compiler will accept them. The code review process is the main defense against this.)</p>
-<p>Some features are discussed in their own subsection, typically to provide more extensive discussion or rationale for limitations. Features that don't have their own subsection are listed in omnibus feature sections for permitted, excluded, and undecided features.</p>
-<p>Lists of new features for C++11 and C++14, along with links to their descriptions, can be found in the online documentation for some of the compilers and libraries. The C++14 Standard is the definitive description.</p>
+<p>HotSpot was originally written in a subset of the C++98/03 language.
+More recently, support for C++14 is provided, though again, HotSpot only
+uses a subset. (Backports to JDK versions lacking support for more
+recent Standards must of course stick with the original C++98/03
+subset.)</p>
+<p>This section describes that subset. Features from the C++98/03
+language may be used unless explicitly excluded here. Features from
+C++11 and C++14 may be explicitly permitted or explicitly excluded, and
+discussed accordingly here. There is a third category, undecided
+features, about which HotSpot developers have not yet reached a
+consensus, or perhaps have not discussed at all. Use of these features
+is also excluded.</p>
+<p>(The use of some features may not be immediately obvious and may slip
+in anyway, since the compiler will accept them. The code review process
+is the main defense against this.)</p>
+<p>Some features are discussed in their own subsection, typically to
+provide more extensive discussion or rationale for limitations. Features
+that don't have their own subsection are listed in omnibus feature
+sections for permitted, excluded, and undecided features.</p>
+<p>Lists of new features for C++11 and C++14, along with links to their
+descriptions, can be found in the online documentation for some of the
+compilers and libraries. The C++14 Standard is the definitive
+description.</p>
 <ul>
-<li><a href="https://gcc.gnu.org/projects/cxx-status.html">C++ Standards Support in GCC</a></li>
-<li><a href="https://clang.llvm.org/cxx_status.html">C++ Support in Clang</a></li>
-<li><a href="https://docs.microsoft.com/en-us/cpp/visual-cpp-language-conformance">Visual C++ Language Conformance</a></li>
-<li><a href="https://gcc.gnu.org/onlinedocs/libstdc++/manual/status.html">libstdc++ Status</a></li>
-<li><a href="https://libcxx.llvm.org/cxx1y_status.html">libc++ Status</a></li>
+<li><a href="https://gcc.gnu.org/projects/cxx-status.html">C++ Standards
+Support in GCC</a></li>
+<li><a href="https://clang.llvm.org/cxx_status.html">C++ Support in
+Clang</a></li>
+<li><a
+href="https://docs.microsoft.com/en-us/cpp/visual-cpp-language-conformance">Visual
+C++ Language Conformance</a></li>
+<li><a
+href="https://gcc.gnu.org/onlinedocs/libstdc++/manual/status.html">libstdc++
+Status</a></li>
+<li><a href="https://libcxx.llvm.org/cxx1y_status.html">libc++
+Status</a></li>
 </ul>
-<p>As a rule of thumb, permitting features which simplify writing code and, especially, reading code, is encouraged.</p>
+<p>As a rule of thumb, permitting features which simplify writing code
+and, especially, reading code, is encouraged.</p>
 <p>Similar discussions for some other projects:</p>
 <ul>
-<li><p><a href="https://google.github.io/styleguide/cppguide.html">Google C++ Style Guide</a> — Currently (2020) targeting C++17.</p></li>
-<li><p><a href="https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++-features.md">C++11 and C++14 use in Chromium</a> — Categorizes features as allowed, banned, or to be discussed.</p></li>
-<li><p><a href="https://llvm.org/docs/CodingStandards.html">llvm Coding Standards</a> — Currently (2020) targeting C++14.</p></li>
-<li><p><a href="https://firefox-source-docs.mozilla.org/code-quality/coding-style/using_cxx_in_firefox_code.html">Using C++ in Mozilla code</a> — C++17 support is required for recent versions (2020).</p></li>
+<li><p><a
+href="https://google.github.io/styleguide/cppguide.html">Google C++
+Style Guide</a> — Currently (2020) targeting C++17.</p></li>
+<li><p><a
+href="https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++-features.md">C++11
+and C++14 use in Chromium</a> — Categorizes features as allowed, banned,
+or to be discussed.</p></li>
+<li><p><a href="https://llvm.org/docs/CodingStandards.html">llvm Coding
+Standards</a> — Currently (2020) targeting C++14.</p></li>
+<li><p><a
+href="https://firefox-source-docs.mozilla.org/code-quality/coding-style/using_cxx_in_firefox_code.html">Using
+C++ in Mozilla code</a> — C++17 support is required for recent versions
+(2020).</p></li>
 </ul>
 <h3 id="error-handling">Error Handling</h3>
-<p>Do not use exceptions. Exceptions are disabled by the build configuration for some platforms.</p>
-<p>Rationale: There is significant concern over the performance cost of exceptions and their usage model and implications for maintainable code. That's not just a matter of history that has been fixed; there remain questions and problems even today (2019). See, for example, <a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0709r0.pdf">Zero cost deterministic exceptions</a>. Because of this, HotSpot has always used a build configuration that disables exceptions where that is available. As a result, HotSpot code uses error handling mechanisms such as two-phase construction, factory functions, returning error codes, and immediate termination. Even if the cost of exceptions were not a concern, the existing body of code was not written with exception safety in mind. Making HotSpot exception safe would be a very large undertaking.</p>
-<p>In addition to the usual alternatives to exceptions, HotSpot provides its own exception mechanism. This is based on a set of macros defined in utilities/exceptions.hpp.</p>
-<h3 id="rtti-runtime-type-information">RTTI (Runtime Type Information)</h3>
-<p>Do not use <a href="https://en.wikipedia.org/wiki/Run-time_type_information" title="Runtime Type Information">Runtime Type Information</a> (RTTI). <a href="https://en.wikipedia.org/wiki/Run-time_type_information" title="Runtime Type Information">RTTI</a> is disabled by the build configuration for some platforms. Among other things, this means <code>dynamic_cast</code> cannot be used.</p>
-<p>Rationale: Other than to implement exceptions (which HotSpot doesn't use), most potential uses of <a href="https://en.wikipedia.org/wiki/Run-time_type_information" title="Runtime Type Information">RTTI</a> are better done via virtual functions. Some of the remainder can be replaced by bespoke mechanisms. The cost of the additional runtime data structures needed to support <a href="https://en.wikipedia.org/wiki/Run-time_type_information" title="Runtime Type Information">RTTI</a> are deemed not worthwhile, given the alternatives.</p>
+<p>Do not use exceptions. Exceptions are disabled by the build
+configuration for some platforms.</p>
+<p>Rationale: There is significant concern over the performance cost of
+exceptions and their usage model and implications for maintainable code.
+That's not just a matter of history that has been fixed; there remain
+questions and problems even today (2019). See, for example, <a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0709r0.pdf">Zero
+cost deterministic exceptions</a>. Because of this, HotSpot has always
+used a build configuration that disables exceptions where that is
+available. As a result, HotSpot code uses error handling mechanisms such
+as two-phase construction, factory functions, returning error codes, and
+immediate termination. Even if the cost of exceptions were not a
+concern, the existing body of code was not written with exception safety
+in mind. Making HotSpot exception safe would be a very large
+undertaking.</p>
+<p>In addition to the usual alternatives to exceptions, HotSpot provides
+its own exception mechanism. This is based on a set of macros defined in
+utilities/exceptions.hpp.</p>
+<h3 id="rtti-runtime-type-information">RTTI (Runtime Type
+Information)</h3>
+<p>Do not use <a
+href="https://en.wikipedia.org/wiki/Run-time_type_information"
+title="Runtime Type Information">Runtime Type Information</a> (RTTI). <a
+href="https://en.wikipedia.org/wiki/Run-time_type_information"
+title="Runtime Type Information">RTTI</a> is disabled by the build
+configuration for some platforms. Among other things, this means
+<code>dynamic_cast</code> cannot be used.</p>
+<p>Rationale: Other than to implement exceptions (which HotSpot doesn't
+use), most potential uses of <a
+href="https://en.wikipedia.org/wiki/Run-time_type_information"
+title="Runtime Type Information">RTTI</a> are better done via virtual
+functions. Some of the remainder can be replaced by bespoke mechanisms.
+The cost of the additional runtime data structures needed to support <a
+href="https://en.wikipedia.org/wiki/Run-time_type_information"
+title="Runtime Type Information">RTTI</a> are deemed not worthwhile,
+given the alternatives.</p>
 <h3 id="memory-allocation">Memory Allocation</h3>
-<p>Do not use the standard global allocation and deallocation functions (operator new and related functions). Use of these functions by HotSpot code is disabled for some platforms.</p>
-<p>Rationale: HotSpot often uses &quot;resource&quot; or &quot;arena&quot; allocation. Even where heap allocation is used, the standard global functions are avoided in favor of wrappers around malloc and free that support the VM's Native Memory Tracking (NMT) feature. Typically, uses of the global operator new are inadvertent and therefore often associated with memory leaks.</p>
-<p>Native memory allocation failures are often treated as non-recoverable. The place where &quot;out of memory&quot; is (first) detected may be an innocent bystander, unrelated to the actual culprit.</p>
+<p>Do not use the standard global allocation and deallocation functions
+(operator new and related functions). Use of these functions by HotSpot
+code is disabled for some platforms.</p>
+<p>Rationale: HotSpot often uses "resource" or "arena" allocation. Even
+where heap allocation is used, the standard global functions are avoided
+in favor of wrappers around malloc and free that support the VM's Native
+Memory Tracking (NMT) feature. Typically, uses of the global operator
+new are inadvertent and therefore often associated with memory
+leaks.</p>
+<p>Native memory allocation failures are often treated as
+non-recoverable. The place where "out of memory" is (first) detected may
+be an innocent bystander, unrelated to the actual culprit.</p>
 <h3 id="class-inheritance">Class Inheritance</h3>
 <p>Use public single inheritance.</p>
 <p>Prefer composition rather than non-public inheritance.</p>
-<p>Restrict inheritance to the &quot;is-a&quot; case; use composition rather than non-is-a related inheritance.</p>
+<p>Restrict inheritance to the "is-a" case; use composition rather than
+non-is-a related inheritance.</p>
 <p>Avoid multiple inheritance. Never use virtual inheritance.</p>
 <h3 id="namespaces">Namespaces</h3>
-<p>Avoid using namespaces. HotSpot code normally uses &quot;all static&quot; classes rather than namespaces for grouping. An &quot;all static&quot; class is not instantiable, has only static members, and is normally derived (possibly indirectly) from the helper class <code>AllStatic</code>.</p>
+<p>Avoid using namespaces. HotSpot code normally uses "all static"
+classes rather than namespaces for grouping. An "all static" class is
+not instantiable, has only static members, and is normally derived
+(possibly indirectly) from the helper class <code>AllStatic</code>.</p>
 <p>Benefits of using such classes include:</p>
 <ul>
-<li><p>Provides access control for members, which is unavailable with namespaces.</p></li>
-<li><p>Avoids <a href="https://en.cppreference.com/w/cpp/language/adl" title="Argument Dependent Lookup">Argument Dependent Lookup</a> (ADL).</p></li>
-<li><p>Closed for additional members. Namespaces allow names to be added in multiple contexts, making it harder to see the complete API.</p></li>
+<li><p>Provides access control for members, which is unavailable with
+namespaces.</p></li>
+<li><p>Avoids <a href="https://en.cppreference.com/w/cpp/language/adl"
+title="Argument Dependent Lookup">Argument Dependent Lookup</a>
+(ADL).</p></li>
+<li><p>Closed for additional members. Namespaces allow names to be added
+in multiple contexts, making it harder to see the complete API.</p></li>
 </ul>
-<p>Namespaces should be used only in cases where one of those &quot;benefits&quot; is actually a hindrance.</p>
-<p>In particular, don't use anonymous namespaces. They seem like they should be useful, and indeed have some real benefits for naming and generated code size on some platforms. Unfortunately, debuggers don't seem to like them at all.</p>
-<p><a href="https://groups.google.com/forum/#!topic/mozilla.dev.platform/KsaG3lEEaRM" class="uri">https://groups.google.com/forum/#!topic/mozilla.dev.platform/KsaG3lEEaRM</a><br> Suggests Visual Studio debugger might not be able to refer to anonymous namespace symbols, so can't set breakpoints in them. Though the discussion seems to go back and forth on that.</p>
-<p><a href="https://firefox-source-docs.mozilla.org/code-quality/coding-style/coding_style_cpp.html" class="uri">https://firefox-source-docs.mozilla.org/code-quality/coding-style/coding_style_cpp.html</a><br> Search for &quot;Anonymous namespaces&quot; Suggests preferring &quot;static&quot; to anonymous namespaces where applicable, because of poor debugger support for anonymous namespaces.</p>
-<p><a href="https://sourceware.org/bugzilla/show_bug.cgi?id=16874" class="uri">https://sourceware.org/bugzilla/show_bug.cgi?id=16874</a><br> Bug for similar gdb problems.</p>
+<p>Namespaces should be used only in cases where one of those "benefits"
+is actually a hindrance.</p>
+<p>In particular, don't use anonymous namespaces. They seem like they
+should be useful, and indeed have some real benefits for naming and
+generated code size on some platforms. Unfortunately, debuggers don't
+seem to like them at all.</p>
+<p><a
+href="https://groups.google.com/forum/#!topic/mozilla.dev.platform/KsaG3lEEaRM"
+class="uri">https://groups.google.com/forum/#!topic/mozilla.dev.platform/KsaG3lEEaRM</a><br>
+Suggests Visual Studio debugger might not be able to refer to anonymous
+namespace symbols, so can't set breakpoints in them. Though the
+discussion seems to go back and forth on that.</p>
+<p><a
+href="https://firefox-source-docs.mozilla.org/code-quality/coding-style/coding_style_cpp.html"
+class="uri">https://firefox-source-docs.mozilla.org/code-quality/coding-style/coding_style_cpp.html</a><br>
+Search for "Anonymous namespaces" Suggests preferring "static" to
+anonymous namespaces where applicable, because of poor debugger support
+for anonymous namespaces.</p>
+<p><a href="https://sourceware.org/bugzilla/show_bug.cgi?id=16874"
+class="uri">https://sourceware.org/bugzilla/show_bug.cgi?id=16874</a><br>
+Bug for similar gdb problems.</p>
 <h3 id="c-standard-library">C++ Standard Library</h3>
 <p>Avoid using the C++ Standard Library.</p>
-<p>Historically, HotSpot has mostly avoided use of the Standard Library.</p>
-<p>(It used to be impossible to use most of it in shared code, because the build configuration for Solaris with Solaris Studio made all but a couple of pieces inaccessible. Support for header-only parts was added in mid-2017. Support for Solaris was removed in 2020.)</p>
+<p>Historically, HotSpot has mostly avoided use of the Standard
+Library.</p>
+<p>(It used to be impossible to use most of it in shared code, because
+the build configuration for Solaris with Solaris Studio made all but a
+couple of pieces inaccessible. Support for header-only parts was added
+in mid-2017. Support for Solaris was removed in 2020.)</p>
 <p>Some reasons for this include</p>
 <ul>
-<li><p>Exceptions. Perhaps the largest core issue with adopting the use of Standard Library facilities is exceptions. HotSpot does not use exceptions and, for platforms which allow doing so, builds with them turned off. Many Standard Library facilities implicitly or explicitly use exceptions.</p></li>
-<li><p><code>assert</code>. An issue that is quickly encountered is the <code>assert</code> macro name collision (<a href="https://bugs.openjdk.org/browse/JDK-8007770">JDK-8007770</a>). Some mechanism for addressing this would be needed before much of the Standard Library could be used. (Not all Standard Library implementations use assert in header files, but some do.)</p></li>
-<li><p>Memory allocation. HotSpot requires explicit control over where allocations occur. The C++98/03 <code>std::allocator</code> class is too limited to support our usage. (Changes in more recent Standards may remove this limitation.)</p></li>
-<li><p>Implementation vagaries. Bugs, or simply different implementation choices, can lead to different behaviors among the various Standard Libraries we need to deal with.</p></li>
-<li><p>Inconsistent naming conventions. HotSpot and the C++ Standard use different naming conventions. The coexistence of those different conventions might appear jarring and reduce readability.</p></li>
+<li><p>Exceptions. Perhaps the largest core issue with adopting the use
+of Standard Library facilities is exceptions. HotSpot does not use
+exceptions and, for platforms which allow doing so, builds with them
+turned off. Many Standard Library facilities implicitly or explicitly
+use exceptions.</p></li>
+<li><p><code>assert</code>. An issue that is quickly encountered is the
+<code>assert</code> macro name collision (<a
+href="https://bugs.openjdk.org/browse/JDK-8007770">JDK-8007770</a>).
+Some mechanism for addressing this would be needed before much of the
+Standard Library could be used. (Not all Standard Library
+implementations use assert in header files, but some do.)</p></li>
+<li><p>Memory allocation. HotSpot requires explicit control over where
+allocations occur. The C++98/03 <code>std::allocator</code> class is too
+limited to support our usage. (Changes in more recent Standards may
+remove this limitation.)</p></li>
+<li><p>Implementation vagaries. Bugs, or simply different implementation
+choices, can lead to different behaviors among the various Standard
+Libraries we need to deal with.</p></li>
+<li><p>Inconsistent naming conventions. HotSpot and the C++ Standard use
+different naming conventions. The coexistence of those different
+conventions might appear jarring and reduce readability.</p></li>
 </ul>
 <p>There are a few exceptions to this rule.</p>
 <ul>
-<li><code>#include &lt;new&gt;</code> to use placement <code>new</code>, <code>std::nothrow</code>, and <code>std::nothrow_t</code>.</li>
-<li><code>#include &lt;limits&gt;</code> to use <code>std::numeric_limits</code>.</li>
+<li><code>#include &lt;new&gt;</code> to use placement <code>new</code>,
+<code>std::nothrow</code>, and <code>std::nothrow_t</code>.</li>
+<li><code>#include &lt;limits&gt;</code> to use
+<code>std::numeric_limits</code>.</li>
 <li><code>#include &lt;type_traits&gt;</code>.</li>
-<li><code>#include &lt;cstddef&gt;</code> to use <code>std::nullptr_t</code>.</li>
+<li><code>#include &lt;cstddef&gt;</code> to use
+<code>std::nullptr_t</code>.</li>
 </ul>
-<p>TODO: Rather than directly #including (permitted) Standard Library headers, use a convention of #including wrapper headers (in some location like hotspot/shared/stdcpp). This provides a single place for dealing with issues we might have for any given header, esp. platform-specific issues.</p>
+<p>TODO: Rather than directly #including (permitted) Standard Library
+headers, use a convention of #including wrapper headers (in some
+location like hotspot/shared/stdcpp). This provides a single place for
+dealing with issues we might have for any given header, esp.
+platform-specific issues.</p>
 <h3 id="type-deduction">Type Deduction</h3>
-<p>Use type deduction only if it makes the code clearer or safer. Do not use it merely to avoid the inconvenience of writing an explicit type, unless that type is itself difficult to write. An example of the latter is a function template return type that depends on template parameters in a non-trivial way.</p>
+<p>Use type deduction only if it makes the code clearer or safer. Do not
+use it merely to avoid the inconvenience of writing an explicit type,
+unless that type is itself difficult to write. An example of the latter
+is a function template return type that depends on template parameters
+in a non-trivial way.</p>
 <p>There are several contexts where types are deduced.</p>
 <ul>
-<li><p>Function argument deduction. This is always permitted, and indeed encouraged. It is nearly always better to allow the type of a function template argument to be deduced rather than explicitly specified.</p></li>
-<li><p><code>auto</code> variable declarations (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2006/n1984.pdf">n1984</a>)<br> For local variables, this can be used to make the code clearer by eliminating type information that is obvious or irrelevant. Excessive use can make code much harder to understand.</p></li>
-<li><p>Function return type deduction (<a href="https://isocpp.org/files/papers/N3638.html">n3638</a>)<br> Only use if the function body has a very small number of <code>return</code> statements, and generally relatively little other code.</p></li>
-<li><p>Also see <a href="#lambdaexpressions">lambda expressions</a>.</p></li>
+<li><p>Function argument deduction. This is always permitted, and indeed
+encouraged. It is nearly always better to allow the type of a function
+template argument to be deduced rather than explicitly
+specified.</p></li>
+<li><p><code>auto</code> variable declarations (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2006/n1984.pdf">n1984</a>)<br>
+For local variables, this can be used to make the code clearer by
+eliminating type information that is obvious or irrelevant. Excessive
+use can make code much harder to understand.</p></li>
+<li><p>Function return type deduction (<a
+href="https://isocpp.org/files/papers/N3638.html">n3638</a>)<br> Only
+use if the function body has a very small number of <code>return</code>
+statements, and generally relatively little other code.</p></li>
+<li><p>Also see <a href="#lambdaexpressions">lambda
+expressions</a>.</p></li>
 </ul>
 <h3 id="expression-sfinae">Expression SFINAE</h3>
-<p><a href="https://en.cppreference.com/w/cpp/language/sfinae" title="Substitution Failure Is Not An Error">Substitution Failure Is Not An Error</a> (SFINAE) is a template metaprogramming technique that makes use of template parameter substitution failures to make compile-time decisions.</p>
-<p>C++11 relaxed the rules for what constitutes a hard-error when attempting to substitute template parameters with template arguments, making most deduction errors be substitution errors; see (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2634.html">n2634</a>). This makes <a href="https://en.cppreference.com/w/cpp/language/sfinae" title="Substitution Failure Is Not An Error">SFINAE</a> more powerful and easier to use. However, the implementation complexity for this change is significant, and this seems to be a place where obscure corner-case bugs in various compilers can be found. So while this feature can (and indeed should) be used (and would be difficult to avoid), caution should be used when pushing to extremes.</p>
-<p>Here are a few closely related example bugs:<br> <a href="https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95468" class="uri">https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95468</a><br> <a href="https://developercommunity.visualstudio.com/content/problem/396562/sizeof-deduced-type-is-sometimes-not-a-constant-ex.html" class="uri">https://developercommunity.visualstudio.com/content/problem/396562/sizeof-deduced-type-is-sometimes-not-a-constant-ex.html</a></p>
+<p><a href="https://en.cppreference.com/w/cpp/language/sfinae"
+title="Substitution Failure Is Not An Error">Substitution Failure Is Not
+An Error</a> (SFINAE) is a template metaprogramming technique that makes
+use of template parameter substitution failures to make compile-time
+decisions.</p>
+<p>C++11 relaxed the rules for what constitutes a hard-error when
+attempting to substitute template parameters with template arguments,
+making most deduction errors be substitution errors; see (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2634.html">n2634</a>).
+This makes <a href="https://en.cppreference.com/w/cpp/language/sfinae"
+title="Substitution Failure Is Not An Error">SFINAE</a> more powerful
+and easier to use. However, the implementation complexity for this
+change is significant, and this seems to be a place where obscure
+corner-case bugs in various compilers can be found. So while this
+feature can (and indeed should) be used (and would be difficult to
+avoid), caution should be used when pushing to extremes.</p>
+<p>Here are a few closely related example bugs:<br> <a
+href="https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95468"
+class="uri">https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95468</a><br>
+<a
+href="https://developercommunity.visualstudio.com/content/problem/396562/sizeof-deduced-type-is-sometimes-not-a-constant-ex.html"
+class="uri">https://developercommunity.visualstudio.com/content/problem/396562/sizeof-deduced-type-is-sometimes-not-a-constant-ex.html</a></p>
 <h3 id="enum">enum</h3>
-<p>Where appropriate, <em>scoped-enums</em> should be used. (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2347.pdf">n2347</a>)</p>
-<p>Use of <em>unscoped-enums</em> is permitted, though ordinary constants may be preferable when the automatic initializer feature isn't used.</p>
-<p>The underlying type (the <em>enum-base</em>) of an unscoped enum type should always be specified explicitly. When unspecified, the underlying type is dependent on the range of the enumerator values and the platform.</p>
-<p>The underlying type of a <em>scoped-enum</em> should also be specified explicitly if conversions may be applied to values of that type.</p>
-<p>Due to bugs in certain (very old) compilers, there is widespread use of enums and avoidance of in-class initialization of static integral constant members. Compilers having such bugs are no longer supported. Except where an enum is semantically appropriate, new code should use integral constants.</p>
+<p>Where appropriate, <em>scoped-enums</em> should be used. (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2347.pdf">n2347</a>)</p>
+<p>Use of <em>unscoped-enums</em> is permitted, though ordinary
+constants may be preferable when the automatic initializer feature isn't
+used.</p>
+<p>The underlying type (the <em>enum-base</em>) of an unscoped enum type
+should always be specified explicitly. When unspecified, the underlying
+type is dependent on the range of the enumerator values and the
+platform.</p>
+<p>The underlying type of a <em>scoped-enum</em> should also be
+specified explicitly if conversions may be applied to values of that
+type.</p>
+<p>Due to bugs in certain (very old) compilers, there is widespread use
+of enums and avoidance of in-class initialization of static integral
+constant members. Compilers having such bugs are no longer supported.
+Except where an enum is semantically appropriate, new code should use
+integral constants.</p>
 <h3 id="thread_local">thread_local</h3>
-<p>Avoid use of <code>thread_local</code> (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2659.htm">n2659</a>); and instead, use the HotSpot macro <code>THREAD_LOCAL</code>, for which the initializer must be a constant expression. When <code>thread_local</code> must be used, use the Hotspot macro <code>APPROVED_CPP_THREAD_LOCAL</code> to indicate that the use has been given appropriate consideration.</p>
-<p>As was discussed in the review for <a href="https://mail.openjdk.org/pipermail/hotspot-dev/2019-September/039487.html">JDK-8230877</a>, <code>thread_local</code> allows dynamic initialization and destruction semantics. However, that support requires a run-time penalty for references to non-function-local <code>thread_local</code> variables defined in a different translation unit, even if they don't need dynamic initialization. Dynamic initialization and destruction of non-local <code>thread_local</code> variables also has the same ordering problems as for ordinary non-local variables. So we avoid use of <code>thread_local</code> in general, limiting its use to only those cases where dynamic initialization or destruction are essential. See <a href="https://bugs.openjdk.org/browse/JDK-8282469">JDK-8282469</a> for further discussion.</p>
+<p>Avoid use of <code>thread_local</code> (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2659.htm">n2659</a>);
+and instead, use the HotSpot macro <code>THREAD_LOCAL</code>, for which
+the initializer must be a constant expression. When
+<code>thread_local</code> must be used, use the Hotspot macro
+<code>APPROVED_CPP_THREAD_LOCAL</code> to indicate that the use has been
+given appropriate consideration.</p>
+<p>As was discussed in the review for <a
+href="https://mail.openjdk.org/pipermail/hotspot-dev/2019-September/039487.html">JDK-8230877</a>,
+<code>thread_local</code> allows dynamic initialization and destruction
+semantics. However, that support requires a run-time penalty for
+references to non-function-local <code>thread_local</code> variables
+defined in a different translation unit, even if they don't need dynamic
+initialization. Dynamic initialization and destruction of non-local
+<code>thread_local</code> variables also has the same ordering problems
+as for ordinary non-local variables. So we avoid use of
+<code>thread_local</code> in general, limiting its use to only those
+cases where dynamic initialization or destruction are essential. See <a
+href="https://bugs.openjdk.org/browse/JDK-8282469">JDK-8282469</a> for
+further discussion.</p>
 <h3 id="nullptr">nullptr</h3>
-<p>Prefer <code>nullptr</code> (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2431.pdf">n2431</a>) to <code>NULL</code>. Don't use (constexpr or literal) 0 for pointers.</p>
-<p>For historical reasons there are widespread uses of both <code>NULL</code> and of integer 0 as a pointer value.</p>
+<p>Prefer <code>nullptr</code> (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2431.pdf">n2431</a>)
+to <code>NULL</code>. Don't use (constexpr or literal) 0 for
+pointers.</p>
+<p>For historical reasons there are widespread uses of both
+<code>NULL</code> and of integer 0 as a pointer value.</p>
 <h3 id="atomic">&lt;atomic&gt;</h3>
-<p>Do not use facilities provided by the <code>&lt;atomic&gt;</code> header (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2427.html">n2427</a>), (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2752.htm">n2752</a>); instead, use the HotSpot <code>Atomic</code> class and related facilities.</p>
-<p>Atomic operations in HotSpot code must have semantics which are consistent with those provided by the JDK's compilers for Java. There are platform-specific implementation choices that a C++ compiler might make or change that are outside the scope of the C++ Standard, and might differ from what the Java compilers implement.</p>
-<p>In addition, HotSpot <code>Atomic</code> has a concept of &quot;conservative&quot; memory ordering, which may differ from (may be stronger than) sequentially consistent. There are algorithms in HotSpot that are believed to rely on that ordering.</p>
+<p>Do not use facilities provided by the <code>&lt;atomic&gt;</code>
+header (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2427.html">n2427</a>),
+(<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2752.htm">n2752</a>);
+instead, use the HotSpot <code>Atomic</code> class and related
+facilities.</p>
+<p>Atomic operations in HotSpot code must have semantics which are
+consistent with those provided by the JDK's compilers for Java. There
+are platform-specific implementation choices that a C++ compiler might
+make or change that are outside the scope of the C++ Standard, and might
+differ from what the Java compilers implement.</p>
+<p>In addition, HotSpot <code>Atomic</code> has a concept of
+"conservative" memory ordering, which may differ from (may be stronger
+than) sequentially consistent. There are algorithms in HotSpot that are
+believed to rely on that ordering.</p>
 <h3 id="uniform-initialization">Uniform Initialization</h3>
-<p>The use of <em>uniform initialization</em> (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2672.htm">n2672</a>), also known as <em>brace initialization</em>, is permitted.</p>
+<p>The use of <em>uniform initialization</em> (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2672.htm">n2672</a>),
+also known as <em>brace initialization</em>, is permitted.</p>
 <p>Some relevant sections from cppreference.com:</p>
 <ul>
-<li><a href="https://en.cppreference.com/w/cpp/language/initialization">initialization</a></li>
-<li><a href="https://en.cppreference.com/w/cpp/language/value_initialization">value initialization</a></li>
-<li><a href="https://en.cppreference.com/w/cpp/language/direct_initialization">direct initialization</a></li>
-<li><a href="https://en.cppreference.com/w/cpp/language/list_initialization">list initialization</a></li>
-<li><a href="https://en.cppreference.com/w/cpp/language/aggregate_initialization">aggregate initialization</a></li>
+<li><a
+href="https://en.cppreference.com/w/cpp/language/initialization">initialization</a></li>
+<li><a
+href="https://en.cppreference.com/w/cpp/language/value_initialization">value
+initialization</a></li>
+<li><a
+href="https://en.cppreference.com/w/cpp/language/direct_initialization">direct
+initialization</a></li>
+<li><a
+href="https://en.cppreference.com/w/cpp/language/list_initialization">list
+initialization</a></li>
+<li><a
+href="https://en.cppreference.com/w/cpp/language/aggregate_initialization">aggregate
+initialization</a></li>
 </ul>
-<p>Although related, the use of <code>std::initializer_list</code> remains forbidden, as part of the avoidance of the C++ Standard Library in HotSpot code.</p>
+<p>Although related, the use of <code>std::initializer_list</code>
+remains forbidden, as part of the avoidance of the C++ Standard Library
+in HotSpot code.</p>
 <h3 id="local-function-objects">Local Function Objects</h3>
 <ul>
-<li>Local function objects, including lambda expressions, may be used.</li>
+<li>Local function objects, including lambda expressions, may be
+used.</li>
 <li>Lambda expressions must only be used as a downward value.</li>
-<li>Prefer <code>[&amp;]</code> as the capture list of a lambda expression.</li>
-<li>Return type deduction for lambda expressions is permitted, and indeed encouraged.</li>
+<li>Prefer <code>[&amp;]</code> as the capture list of a lambda
+expression.</li>
+<li>Return type deduction for lambda expressions is permitted, and
+indeed encouraged.</li>
 <li>An empty parameter list for a lambda expression may be elided.</li>
 <li>A lambda expression must not be <code>mutable</code>.</li>
 <li>Generic lambda expressions are permitted.</li>
 <li>Lambda expressions should be relatively simple.</li>
-<li>Anonymous lambda expressions should not overly clutter the enclosing expression.</li>
+<li>Anonymous lambda expressions should not overly clutter the enclosing
+expression.</li>
 <li>An anonymous lambda expression must not be directly invoked.</li>
 <li>Bind expressions are forbidden.</li>
 </ul>
-<p>Single-use function objects can be defined locally within a function, directly at the point of use. This is an alternative to having a function or function object class defined at class or namespace scope.</p>
-<p>This usage was somewhat limited by C++03, which does not permit such a class to be used as a template parameter. That restriction was removed by C++11 (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2657.htm">n2657</a>). Use of this feature is permitted.</p>
-<p>Many HotSpot protocols involve &quot;function-like&quot; objects that involve some named member function rather than a call operator. For example, a function that performs some action on all threads might be written as</p>
+<p>Single-use function objects can be defined locally within a function,
+directly at the point of use. This is an alternative to having a
+function or function object class defined at class or namespace
+scope.</p>
+<p>This usage was somewhat limited by C++03, which does not permit such
+a class to be used as a template parameter. That restriction was removed
+by C++11 (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2657.htm">n2657</a>).
+Use of this feature is permitted.</p>
+<p>Many HotSpot protocols involve "function-like" objects that involve
+some named member function rather than a call operator. For example, a
+function that performs some action on all threads might be written
+as</p>
 <pre><code>void do_something() {
   struct DoSomething : public ThreadClosure {
     virtual void do_thread(Thread* t) {
@@ -316,44 +778,137 @@ while ( test_foo(args...) ) { // No, excess spaces around control</code></pre></
   } closure;
   Threads::threads_do(&amp;closure);
 }</code></pre>
-<p>HotSpot code has historically usually placed the DoSomething class at namespace (or sometimes class) scope. This separates the function's code from its use, often to the detriment of readability. It requires giving the class a globally unique name (if at namespace scope). It also loses the information that the class is intended for use in exactly one place, and does not have any subclasses. (However, the latter can now be indicated by declaring it <code>final</code>.) Often, for simplicity, a local class will skip things like access control and accessor functions, giving the enclosing function direct access to the implementation and eliminating some boilerplate that might be provided if the class is in some outer (more accessible) scope. On the other hand, if there is a lot of surrounding code in the function body or the local class is of significant size, defining it locally can increase clutter and reduce readability.</p>
-<p><a name="lambdaexpressions"></a> C++11 added <em>lambda expressions</em> as a new way to write a function object. Simple lambda expressions can be significantly more concise than a function object, eliminating a lot of boiler-plate. On the other hand, a complex lambda expression may not provide much, if any, readability benefit compared to an ordinary function object. Also, while a lambda can encapsulate a call to a &quot;function-like&quot; object, it cannot be used in place of such.</p>
-<p>A common use for local functions is as one-use <a href="https://en.cppreference.com/w/cpp/language/raii" title="Resource Acquisition Is Initialization">RAII</a> objects. The amount of boilerplate for a function object class (local or not) makes such usage somewhat clumsy and verbose. But with the help of a small amount of supporting utility code, lambdas work particularly well for this use case.</p>
-<p>Another use for local functions is <a href="https://en.wikipedia.org/wiki/Partial_application" title="Partial Application">partial application</a>. Again here, lambdas are typically much simpler and less verbose than function object classes.</p>
-<p>Because of these benefits, lambda expressions are permitted in HotSpot code, with some restrictions and usage guidance. An anonymous lambda is one which is passed directly as an argument. A named lambda is the value of a variable, which is its name.</p>
-<p>Lambda expressions should only be passed downward. In particular, a lambda should not be returned from a function or stored in a global variable, whether directly or as the value of a member of some other object. Lambda capture is syntactically subtle (by design), and propagating a lambda in such ways can easily pass references to captured values to places where they are no longer valid. In particular, members of the enclosing <code>this</code> object are effectively captured by reference, even if the default capture is by-value. For such uses-cases a function object class should be used to make the desired value capturing and propagation explicit.</p>
-<p>Limiting the capture list to <code>[&amp;]</code> (implicitly capture by reference) is a simplifying restriction that still provides good support for HotSpot usage, while reducing the cases a reader must recognize and understand.</p>
+<p>HotSpot code has historically usually placed the DoSomething class at
+namespace (or sometimes class) scope. This separates the function's code
+from its use, often to the detriment of readability. It requires giving
+the class a globally unique name (if at namespace scope). It also loses
+the information that the class is intended for use in exactly one place,
+and does not have any subclasses. (However, the latter can now be
+indicated by declaring it <code>final</code>.) Often, for simplicity, a
+local class will skip things like access control and accessor functions,
+giving the enclosing function direct access to the implementation and
+eliminating some boilerplate that might be provided if the class is in
+some outer (more accessible) scope. On the other hand, if there is a lot
+of surrounding code in the function body or the local class is of
+significant size, defining it locally can increase clutter and reduce
+readability.</p>
+<p><a name="lambdaexpressions"></a> C++11 added <em>lambda
+expressions</em> as a new way to write a function object. Simple lambda
+expressions can be significantly more concise than a function object,
+eliminating a lot of boiler-plate. On the other hand, a complex lambda
+expression may not provide much, if any, readability benefit compared to
+an ordinary function object. Also, while a lambda can encapsulate a call
+to a "function-like" object, it cannot be used in place of such.</p>
+<p>A common use for local functions is as one-use <a
+href="https://en.cppreference.com/w/cpp/language/raii"
+title="Resource Acquisition Is Initialization">RAII</a> objects. The
+amount of boilerplate for a function object class (local or not) makes
+such usage somewhat clumsy and verbose. But with the help of a small
+amount of supporting utility code, lambdas work particularly well for
+this use case.</p>
+<p>Another use for local functions is <a
+href="https://en.wikipedia.org/wiki/Partial_application"
+title="Partial Application">partial application</a>. Again here, lambdas
+are typically much simpler and less verbose than function object
+classes.</p>
+<p>Because of these benefits, lambda expressions are permitted in
+HotSpot code, with some restrictions and usage guidance. An anonymous
+lambda is one which is passed directly as an argument. A named lambda is
+the value of a variable, which is its name.</p>
+<p>Lambda expressions should only be passed downward. In particular, a
+lambda should not be returned from a function or stored in a global
+variable, whether directly or as the value of a member of some other
+object. Lambda capture is syntactically subtle (by design), and
+propagating a lambda in such ways can easily pass references to captured
+values to places where they are no longer valid. In particular, members
+of the enclosing <code>this</code> object are effectively captured by
+reference, even if the default capture is by-value. For such uses-cases
+a function object class should be used to make the desired value
+capturing and propagation explicit.</p>
+<p>Limiting the capture list to <code>[&amp;]</code> (implicitly capture
+by reference) is a simplifying restriction that still provides good
+support for HotSpot usage, while reducing the cases a reader must
+recognize and understand.</p>
 <ul>
-<li><p>Many common lambda uses require reference capture. Not permitting it would substantially reduce the utility of lambdas.</p></li>
-<li><p>Referential transparency. Implicit reference capture makes variable references in the lambda body have the same meaning they would have in the enclosing code. There isn't a semantic barrier across which the meaning of a variable changes.</p></li>
-<li><p>Explicit reference capture introduces significant clutter, especially when lambda expressions are relatively small and simple, as they should be in HotSpot code.</p></li>
-<li><p>There are a number of reasons why by-value capture might be used, but for the most part they don't apply to HotSpot code, given other usage restrictions.</p>
+<li><p>Many common lambda uses require reference capture. Not permitting
+it would substantially reduce the utility of lambdas.</p></li>
+<li><p>Referential transparency. Implicit reference capture makes
+variable references in the lambda body have the same meaning they would
+have in the enclosing code. There isn't a semantic barrier across which
+the meaning of a variable changes.</p></li>
+<li><p>Explicit reference capture introduces significant clutter,
+especially when lambda expressions are relatively small and simple, as
+they should be in HotSpot code.</p></li>
+<li><p>There are a number of reasons why by-value capture might be used,
+but for the most part they don't apply to HotSpot code, given other
+usage restrictions.</p>
 <ul>
-<li><p>A primary use-case for by-value capture is to support escaping uses, where values captured by-reference might become invalid. That use-case doesn't apply if only downward lambdas are used.</p></li>
-<li><p>By-value capture can also make a lambda-local copy for mutation, which requires making the lambda <code>mutable</code>; see below.</p></li>
-<li><p>By-value capture might be viewed as an optimization, avoiding any overhead for reference capture of cheap to copy values. But the compiler can often eliminate any such overhead.</p></li>
-<li><p>By-value capture by a non-<code>mutable</code> lambda makes the captured values const, preventing any modification by the lambda and making the captured value unaffected by modifications to the outer variable. But this only applies to captured auto variables, not member variables, and is inconsistent with referential transparency.</p></li>
+<li><p>A primary use-case for by-value capture is to support escaping
+uses, where values captured by-reference might become invalid. That
+use-case doesn't apply if only downward lambdas are used.</p></li>
+<li><p>By-value capture can also make a lambda-local copy for mutation,
+which requires making the lambda <code>mutable</code>; see
+below.</p></li>
+<li><p>By-value capture might be viewed as an optimization, avoiding any
+overhead for reference capture of cheap to copy values. But the compiler
+can often eliminate any such overhead.</p></li>
+<li><p>By-value capture by a non-<code>mutable</code> lambda makes the
+captured values const, preventing any modification by the lambda and
+making the captured value unaffected by modifications to the outer
+variable. But this only applies to captured auto variables, not member
+variables, and is inconsistent with referential transparency.</p></li>
 </ul></li>
-<li><p>Non-capturing lambdas (with an empty capture list - <code>[]</code>) have limited utility. There are cases where no captures are required (pure functions, for example), but if the function is small and simple then that's obvious anyway.</p></li>
-<li><p>Capture initializers (a C++14 feature - <a href="https://isocpp.org/files/papers/N3649.html">N3649</a>) are not permitted. Capture initializers inherently increase the complexity of the capture list, and provide little benefit over an additional in-scope local variable.</p></li>
+<li><p>Non-capturing lambdas (with an empty capture list -
+<code>[]</code>) have limited utility. There are cases where no captures
+are required (pure functions, for example), but if the function is small
+and simple then that's obvious anyway.</p></li>
+<li><p>Capture initializers (a C++14 feature - <a
+href="https://isocpp.org/files/papers/N3649.html">N3649</a>) are not
+permitted. Capture initializers inherently increase the complexity of
+the capture list, and provide little benefit over an additional in-scope
+local variable.</p></li>
 </ul>
-<p>The use of <code>mutable</code> lambda expressions is forbidden because there don't seem to be many, if any, good use-cases for them in HotSpot. A lambda expression needs to be mutable in order to modify a by-value captured value. But with only downward lambdas, such usage seems likely to be rare and complicated. It is better to use a function object class in any such cases that arise, rather than requiring all HotSpot developers to understand this relatively obscure feature.</p>
-<p>While it is possible to directly invoke an anonymous lambda expression, that feature should not be used, as such a form can be confusing to readers. Instead, name the lambda and call it by name.</p>
-<p>Some reasons to prefer a named lambda instead of an anonymous lambda are</p>
+<p>The use of <code>mutable</code> lambda expressions is forbidden
+because there don't seem to be many, if any, good use-cases for them in
+HotSpot. A lambda expression needs to be mutable in order to modify a
+by-value captured value. But with only downward lambdas, such usage
+seems likely to be rare and complicated. It is better to use a function
+object class in any such cases that arise, rather than requiring all
+HotSpot developers to understand this relatively obscure feature.</p>
+<p>While it is possible to directly invoke an anonymous lambda
+expression, that feature should not be used, as such a form can be
+confusing to readers. Instead, name the lambda and call it by name.</p>
+<p>Some reasons to prefer a named lambda instead of an anonymous lambda
+are</p>
 <ul>
-<li><p>The body contains non-trivial control flow or declarations or other nested constructs.</p></li>
-<li><p>Its role in an argument list is hard to guess without examining the function declaration. Give it a name that indicates its purpose.</p></li>
+<li><p>The body contains non-trivial control flow or declarations or
+other nested constructs.</p></li>
+<li><p>Its role in an argument list is hard to guess without examining
+the function declaration. Give it a name that indicates its
+purpose.</p></li>
 <li><p>It has an unusual capture list.</p></li>
-<li><p>It has a complex explicit return type or parameter types.</p></li>
+<li><p>It has a complex explicit return type or parameter
+types.</p></li>
 </ul>
-<p>Lambda expressions, and particularly anonymous lambda expressions, should be simple and compact. One-liners are good. Anonymous lambdas should usually be limited to a couple lines of body code. More complex lambdas should be named. A named lambda should not clutter the enclosing function and make it long and complex; do continue to break up large functions via the use of separate helper functions.</p>
-<p>An anonymous lambda expression should either be a one-liner in a one-line expression, or isolated in its own set of lines. Don't place part of a lambda expression on the same line as other arguments to a function. The body of a multi-line lambda argument should be indented from the start of the capture list, as if that were the start of an ordinary function definition. The body of a multi-line named lambda should be indented one step from the variable's indentation.</p>
+<p>Lambda expressions, and particularly anonymous lambda expressions,
+should be simple and compact. One-liners are good. Anonymous lambdas
+should usually be limited to a couple lines of body code. More complex
+lambdas should be named. A named lambda should not clutter the enclosing
+function and make it long and complex; do continue to break up large
+functions via the use of separate helper functions.</p>
+<p>An anonymous lambda expression should either be a one-liner in a
+one-line expression, or isolated in its own set of lines. Don't place
+part of a lambda expression on the same line as other arguments to a
+function. The body of a multi-line lambda argument should be indented
+from the start of the capture list, as if that were the start of an
+ordinary function definition. The body of a multi-line named lambda
+should be indented one step from the variable's indentation.</p>
 <p>Some examples:</p>
 <ol type="1">
-<li><code>foo([&amp;] { ++counter; });</code></li>
-<li><code>foo(x, [&amp;] { ++counter; });</code></li>
-<li><code>foo([&amp;] { if (predicate) ++counter; });</code></li>
-<li><code>foo([&amp;] { auto tmp = process(x); tmp.f(); return tmp.g(); })</code></li>
+<li><p><code>foo([&amp;] { ++counter; });</code></p></li>
+<li><p><code>foo(x, [&amp;] { ++counter; });</code></p></li>
+<li><p><code>foo([&amp;] { if (predicate) ++counter; });</code></p></li>
+<li><p><code>foo([&amp;] { auto tmp = process(x); tmp.f(); return tmp.g(); })</code></p></li>
 <li><p>Separate one-line lambda from other arguments:</p>
 <pre><code>foo(c.begin(), c.end(),
     [&amp;] (const X&amp; x) { do_something(x); return x.value(); });</code></pre></li>
@@ -377,86 +932,199 @@ while ( test_foo(args...) ) { // No, excess spaces around control</code></pre></
   do_something2(x, c);
 };</code></pre></li>
 </ol>
-<p>Item 4, and especially items 6 and 7, are pushing the simplicity limits for anonymous lambdas. Item 6 might be better written using a named lambda:</p>
+<p>Item 4, and especially items 6 and 7, are pushing the simplicity
+limits for anonymous lambdas. Item 6 might be better written using a
+named lambda:</p>
 <pre><code>c.do_entries(do_entry);</code></pre>
-<p>Note that C++11 also added <em>bind expressions</em> as a way to write a function object for partial application, using <code>std::bind</code> and related facilities from the Standard Library. <code>std::bind</code> generalizes and replaces some of the binders from C++03. Bind expressions are not permitted in HotSpot code. They don't provide enough benefit over lambdas or local function classes in the cases where bind expressions are applicable to warrant the introduction of yet another mechanism in this space into HotSpot code.</p>
+<p>Note that C++11 also added <em>bind expressions</em> as a way to
+write a function object for partial application, using
+<code>std::bind</code> and related facilities from the Standard Library.
+<code>std::bind</code> generalizes and replaces some of the binders from
+C++03. Bind expressions are not permitted in HotSpot code. They don't
+provide enough benefit over lambdas or local function classes in the
+cases where bind expressions are applicable to warrant the introduction
+of yet another mechanism in this space into HotSpot code.</p>
 <p>References:</p>
 <ul>
-<li>Local and unnamed types as template parameters (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2657.htm">n2657</a>)</li>
-<li>New wording for C++0x lambdas (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2009/n2927.pdf">n2927</a>)</li>
-<li>Generalized lambda capture (init-capture) (<a href="https://isocpp.org/files/papers/N3648.html">N3648</a>)</li>
-<li>Generic (polymorphic) lambda expressions (<a href="https://isocpp.org/files/papers/N3649.html">N3649</a>)</li>
+<li>Local and unnamed types as template parameters (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2657.htm">n2657</a>)</li>
+<li>New wording for C++0x lambdas (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2009/n2927.pdf">n2927</a>)</li>
+<li>Generalized lambda capture (init-capture) (<a
+href="https://isocpp.org/files/papers/N3648.html">N3648</a>)</li>
+<li>Generic (polymorphic) lambda expressions (<a
+href="https://isocpp.org/files/papers/N3649.html">N3649</a>)</li>
 </ul>
 <p>References from C++17</p>
 <ul>
-<li>Wording for constexpr lambda (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0170r1.pdf">p0170r1</a>)</li>
-<li>Lambda capture of *this by Value (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0018r3.html">p0018r3</a>)</li>
+<li>Wording for constexpr lambda (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0170r1.pdf">p0170r1</a>)</li>
+<li>Lambda capture of *this by Value (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0018r3.html">p0018r3</a>)</li>
 </ul>
 <p>References from C++20</p>
 <ul>
-<li>Allow lambda capture [=, this] (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0409r2.html">p0409r2</a>)</li>
-<li>Familiar template syntax for generic lambdas (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0428r2.pdf">p0428r2</a>)</li>
-<li>Simplifying implicit lambda capture (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0588r1.html">p0588r1</a>)</li>
-<li>Default constructible and assignable stateless lambdas (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0624r2.pdf">p0624r2</a>)</li>
-<li>Lambdas in unevaluated contexts (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0315r4.pdf">p0315r4</a>)</li>
-<li>Allow pack expansion in lambda init-capture (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0780r2.html">p0780r2</a>) (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2095r0.html">p2095r0</a>)</li>
-<li>Deprecate implicit capture of this via [=] (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0806r2.html">p0806r2</a>)</li>
+<li>Allow lambda capture [=, this] (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0409r2.html">p0409r2</a>)</li>
+<li>Familiar template syntax for generic lambdas (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0428r2.pdf">p0428r2</a>)</li>
+<li>Simplifying implicit lambda capture (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0588r1.html">p0588r1</a>)</li>
+<li>Default constructible and assignable stateless lambdas (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0624r2.pdf">p0624r2</a>)</li>
+<li>Lambdas in unevaluated contexts (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0315r4.pdf">p0315r4</a>)</li>
+<li>Allow pack expansion in lambda init-capture (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0780r2.html">p0780r2</a>)
+(<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2095r0.html">p2095r0</a>)</li>
+<li>Deprecate implicit capture of this via [=] (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0806r2.html">p0806r2</a>)</li>
 </ul>
 <p>References from C++23</p>
 <ul>
-<li>Make () more optional for lambdas (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1102r2.html">p1102r2</a>)</li>
+<li>Make () more optional for lambdas (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1102r2.html">p1102r2</a>)</li>
 </ul>
 <h3 id="inheriting-constructors">Inheriting constructors</h3>
-<p>Do not use <em>inheriting constructors</em> (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2540.htm">n2540</a>).</p>
-<p>C++11 provides simple syntax allowing a class to inherit the constructors of a base class. Unfortunately there are a number of problems with the original specification, and C++17 contains significant revisions (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0136r1.html" title="p0136r1">p0136r1</a> opens with a list of 8 Core Issues). Since HotSpot doesn't support use of C++17, use of inherited constructors could run into those problems. Such uses might also change behavior in a future HotSpot update to use C++17 or later, potentially in subtle ways that could lead to hard to diagnose problems. Because of this, HotSpot code must not use inherited constructors.</p>
-<p>Note that gcc7 provides the <code>-fnew-inheriting-ctors</code> option to use the <a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0136r1.html" title="p0136r1">p0136r1</a> semantics. This is enabled by default when using C++17 or later. It is also enabled by default for <code>fabi-version=11</code> (introduced by gcc7) or higher when using C++11/14, as the change is considered a Defect Report that applies to those versions. Earlier versions of gcc don't have that option, and other supported compilers may not have anything similar.</p>
-<h3 id="additional-permitted-features">Additional Permitted Features</h3>
+<p>Do not use <em>inheriting constructors</em> (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2540.htm">n2540</a>).</p>
+<p>C++11 provides simple syntax allowing a class to inherit the
+constructors of a base class. Unfortunately there are a number of
+problems with the original specification, and C++17 contains significant
+revisions (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0136r1.html"
+title="p0136r1">p0136r1</a> opens with a list of 8 Core Issues). Since
+HotSpot doesn't support use of C++17, use of inherited constructors
+could run into those problems. Such uses might also change behavior in a
+future HotSpot update to use C++17 or later, potentially in subtle ways
+that could lead to hard to diagnose problems. Because of this, HotSpot
+code must not use inherited constructors.</p>
+<p>Note that gcc7 provides the <code>-fnew-inheriting-ctors</code>
+option to use the <a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0136r1.html"
+title="p0136r1">p0136r1</a> semantics. This is enabled by default when
+using C++17 or later. It is also enabled by default for
+<code>fabi-version=11</code> (introduced by gcc7) or higher when using
+C++11/14, as the change is considered a Defect Report that applies to
+those versions. Earlier versions of gcc don't have that option, and
+other supported compilers may not have anything similar.</p>
+<h3 id="additional-permitted-features">Additional Permitted
+Features</h3>
 <ul>
-<li><p><code>constexpr</code> (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2235.pdf">n2235</a>) (<a href="https://isocpp.org/files/papers/N3652.html">n3652</a>)</p></li>
-<li><p>Sized deallocation (<a href="https://isocpp.org/files/papers/n3778.html">n3778</a>)</p></li>
-<li><p>Variadic templates (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2242.pdf">n2242</a>) (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2555.pdf">n2555</a>)</p></li>
-<li><p>Static assertions (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2004/n1720.html">n1720</a>)</p></li>
-<li><p><code>decltype</code> (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2343.pdf">n2343</a>) (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2011/n3276.pdf">n3276</a>)</p></li>
-<li><p>Right angle brackets (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2005/n1757.html">n1757</a>)</p></li>
-<li><p>Default template arguments for function templates (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#226">CWG D226</a>)</p></li>
-<li><p>Template aliases (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2258.pdf">n2258</a>)</p></li>
-<li><p>Delegating constructors (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2006/n1986.pdf">n1986</a>)</p></li>
-<li><p>Explicit conversion operators (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2437.pdf">n2437</a>)</p></li>
-<li><p>Standard Layout Types (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2342.htm">n2342</a>)</p></li>
-<li><p>Defaulted and deleted functions (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2346.htm">n2346</a>)</p></li>
-<li><p>Dynamic initialization and destruction with concurrency (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2660.htm">n2660</a>)</p></li>
-<li><p><code>final</code> virtual specifiers for classes and virtual functions (<a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2009/n2928.htm">n2928</a>), (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2010/n3206.htm">n3206</a>), (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2011/n3272.htm">n3272</a>)</p></li>
-<li><p><code>override</code> virtual specifiers for virtual functions (<a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2009/n2928.htm">n2928</a>), (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2010/n3206.htm">n3206</a>), (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2011/n3272.htm">n3272</a>)</p></li>
-<li><p>Range-based <code>for</code> loops (<a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2009/n2930.html">n2930</a>) (<a href="https://en.cppreference.com/w/cpp/language/range-for">range-for</a>)</p></li>
-<li><p>Unrestricted Unions (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2544.pdf">n2544</a>)</p></li>
+<li><p><code>constexpr</code> (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2235.pdf">n2235</a>)
+(<a
+href="https://isocpp.org/files/papers/N3652.html">n3652</a>)</p></li>
+<li><p>Sized deallocation (<a
+href="https://isocpp.org/files/papers/n3778.html">n3778</a>)</p></li>
+<li><p>Variadic templates (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2242.pdf">n2242</a>)
+(<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2555.pdf">n2555</a>)</p></li>
+<li><p>Static assertions (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2004/n1720.html">n1720</a>)</p></li>
+<li><p><code>decltype</code> (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2343.pdf">n2343</a>)
+(<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2011/n3276.pdf">n3276</a>)</p></li>
+<li><p>Right angle brackets (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2005/n1757.html">n1757</a>)</p></li>
+<li><p>Default template arguments for function templates (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#226">CWG
+D226</a>)</p></li>
+<li><p>Template aliases (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2258.pdf">n2258</a>)</p></li>
+<li><p>Delegating constructors (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2006/n1986.pdf">n1986</a>)</p></li>
+<li><p>Explicit conversion operators (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2437.pdf">n2437</a>)</p></li>
+<li><p>Standard Layout Types (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2342.htm">n2342</a>)</p></li>
+<li><p>Defaulted and deleted functions (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2346.htm">n2346</a>)</p></li>
+<li><p>Dynamic initialization and destruction with concurrency (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2660.htm">n2660</a>)</p></li>
+<li><p><code>final</code> virtual specifiers for classes and virtual
+functions (<a
+href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2009/n2928.htm">n2928</a>),
+(<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2010/n3206.htm">n3206</a>),
+(<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2011/n3272.htm">n3272</a>)</p></li>
+<li><p><code>override</code> virtual specifiers for virtual functions
+(<a
+href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2009/n2928.htm">n2928</a>),
+(<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2010/n3206.htm">n3206</a>),
+(<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2011/n3272.htm">n3272</a>)</p></li>
+<li><p>Range-based <code>for</code> loops (<a
+href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2009/n2930.html">n2930</a>)
+(<a
+href="https://en.cppreference.com/w/cpp/language/range-for">range-for</a>)</p></li>
+<li><p>Unrestricted Unions (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2544.pdf">n2544</a>)</p></li>
 </ul>
 <h3 id="excluded-features">Excluded Features</h3>
 <ul>
-<li>New string and character literals
+<li><p>New string and character literals</p>
 <ul>
-<li>New character types (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2249.html">n2249</a>)</li>
-<li>Unicode string literals (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2442.htm">n2442</a>)</li>
-<li>Raw string literals (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2442.htm">n2442</a>)</li>
-<li>Universal character name literals (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2170.html">n2170</a>)</li>
+<li>New character types (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2249.html">n2249</a>)</li>
+<li>Unicode string literals (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2442.htm">n2442</a>)</li>
+<li>Raw string literals (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2442.htm">n2442</a>)</li>
+<li>Universal character name literals (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2170.html">n2170</a>)</li>
 </ul>
-<p>HotSpot doesn't need any of the new character and string literal types.</p></li>
-<li><p>User-defined literals (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2765.pdf">n2765</a>) — User-defined literals should not be added casually, but only through a proposal to add a specific UDL.</p></li>
-<li><p>Inline namespaces (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2535.htm">n2535</a>) — HotSpot makes very limited use of namespaces.</p></li>
-<li><p><code>using namespace</code> directives. In particular, don't use <code>using namespace std;</code> to avoid needing to qualify Standard Library names.</p></li>
-<li><p>Propagating exceptions (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2179.html">n2179</a>) — HotSpot does not permit the use of exceptions, so this feature isn't useful.</p></li>
-<li><p>Avoid non-local variables with non-constexpr initialization. In particular, avoid variables with types requiring non-trivial initialization or destruction. Initialization order problems can be difficult to deal with and lead to surprises, as can destruction ordering. HotSpot doesn't generally try to cleanup on exit, and running destructors at exit can also lead to problems.</p></li>
-<li><p><code>[[deprecated]]</code> attribute (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3760.html">n3760</a>) — Not relevant in HotSpot code.</p></li>
-<li><p>Avoid most operator overloading, preferring named functions. When operator overloading is used, ensure the semantics conform to the normal expected behavior of the operation.</p></li>
-<li><p>Avoid most implicit conversion constructors and (implicit or explicit) conversion operators. (Note that conversion to <code>bool</code> isn't needed in HotSpot code because of the &quot;no implicit boolean&quot; guideline.)</p></li>
+<p>HotSpot doesn't need any of the new character and string literal
+types.</p></li>
+<li><p>User-defined literals (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2765.pdf">n2765</a>)
+— User-defined literals should not be added casually, but only through a
+proposal to add a specific UDL.</p></li>
+<li><p>Inline namespaces (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2535.htm">n2535</a>)
+— HotSpot makes very limited use of namespaces.</p></li>
+<li><p><code>using namespace</code> directives. In particular, don't use
+<code>using namespace std;</code> to avoid needing to qualify Standard
+Library names.</p></li>
+<li><p>Propagating exceptions (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2179.html">n2179</a>)
+— HotSpot does not permit the use of exceptions, so this feature isn't
+useful.</p></li>
+<li><p>Avoid non-local variables with non-constexpr initialization. In
+particular, avoid variables with types requiring non-trivial
+initialization or destruction. Initialization order problems can be
+difficult to deal with and lead to surprises, as can destruction
+ordering. HotSpot doesn't generally try to cleanup on exit, and running
+destructors at exit can also lead to problems.</p></li>
+<li><p><code>[[deprecated]]</code> attribute (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3760.html">n3760</a>)
+— Not relevant in HotSpot code.</p></li>
+<li><p>Avoid most operator overloading, preferring named functions. When
+operator overloading is used, ensure the semantics conform to the normal
+expected behavior of the operation.</p></li>
+<li><p>Avoid most implicit conversion constructors and (implicit or
+explicit) conversion operators. (Note that conversion to
+<code>bool</code> isn't needed in HotSpot code because of the "no
+implicit boolean" guideline.)</p></li>
 <li><p>Avoid <code>goto</code> statements.</p></li>
 </ul>
 <h3 id="undecided-features">Undecided Features</h3>
-<p>This list is incomplete; it serves to explicitly call out some features that have not yet been discussed.</p>
+<p>This list is incomplete; it serves to explicitly call out some
+features that have not yet been discussed.</p>
 <ul>
-<li><p>Trailing return type syntax for functions (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2541.htm">n2541</a>)</p></li>
-<li><p>Variable templates (<a href="https://isocpp.org/files/papers/N3651.pdf">n3651</a>)</p></li>
-<li><p>Member initializers and aggregates (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3653.html">n3653</a>)</p></li>
-<li><p><code>[[noreturn]]</code> attribute (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2761.pdf">n2761</a>)</p></li>
+<li><p>Trailing return type syntax for functions (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2541.htm">n2541</a>)</p></li>
+<li><p>Variable templates (<a
+href="https://isocpp.org/files/papers/N3651.pdf">n3651</a>)</p></li>
+<li><p>Member initializers and aggregates (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3653.html">n3653</a>)</p></li>
+<li><p><code>[[noreturn]]</code> attribute (<a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2761.pdf">n2761</a>)</p></li>
 <li><p>Rvalue references and move semantics</p></li>
 </ul>
 </body>

--- a/doc/hotspot-unit-tests.html
+++ b/doc/hotspot-unit-tests.html
@@ -5,11 +5,19 @@
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
   <title>Native/Unit Test Development Guidelines</title>
-  <style type="text/css">
-      code{white-space: pre-wrap;}
-      span.smallcaps{font-variant: small-caps;}
-      span.underline{text-decoration: underline;}
-      div.column{display: inline-block; vertical-align: top; width: 50%;}
+  <style>
+    code{white-space: pre-wrap;}
+    span.smallcaps{font-variant: small-caps;}
+    div.columns{display: flex; gap: min(4vw, 1.5em);}
+    div.column{flex: auto; overflow-x: auto;}
+    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+    ul.task-list{list-style: none;}
+    ul.task-list li input[type="checkbox"] {
+      width: 0.8em;
+      margin: 0 0.8em 0.2em -1.6em;
+      vertical-align: middle;
+    }
+    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
   </style>
   <link rel="stylesheet" href="../make/data/docs-resources/resources/jdk-default.css" />
   <!--[if lt IE 9]>
@@ -20,174 +28,442 @@
 <header id="title-block-header">
 <h1 class="title">Native/Unit Test Development Guidelines</h1>
 </header>
-<nav id="TOC">
+<nav id="TOC" role="doc-toc">
 <ul>
-<li><a href="#good-test-properties">Good test properties</a><ul>
-<li><a href="#lightness">Lightness</a></li>
-<li><a href="#isolation">Isolation</a></li>
-<li><a href="#atomicity-and-self-containment">Atomicity and self-containment</a></li>
-<li><a href="#repeatability">Repeatability</a></li>
-<li><a href="#informativeness">Informativeness</a></li>
-<li><a href="#testing-instead-of-visiting">Testing instead of visiting</a></li>
-<li><a href="#nearness">Nearness</a></li>
+<li><a href="#good-test-properties" id="toc-good-test-properties">Good
+test properties</a>
+<ul>
+<li><a href="#lightness" id="toc-lightness">Lightness</a></li>
+<li><a href="#isolation" id="toc-isolation">Isolation</a></li>
+<li><a href="#atomicity-and-self-containment"
+id="toc-atomicity-and-self-containment">Atomicity and
+self-containment</a></li>
+<li><a href="#repeatability"
+id="toc-repeatability">Repeatability</a></li>
+<li><a href="#informativeness"
+id="toc-informativeness">Informativeness</a></li>
+<li><a href="#testing-instead-of-visiting"
+id="toc-testing-instead-of-visiting">Testing instead of
+visiting</a></li>
+<li><a href="#nearness" id="toc-nearness">Nearness</a></li>
 </ul></li>
-<li><a href="#asserts">Asserts</a><ul>
-<li><a href="#several-checks">Several checks</a></li>
-<li><a href="#first-parameter-is-expected-value">First parameter is expected value</a></li>
-<li><a href="#floating-point-comparison">Floating-point comparison</a></li>
-<li><a href="#c-string-comparison">C string comparison</a></li>
-<li><a href="#error-messages">Error messages</a></li>
-<li><a href="#uncluttered-output">Uncluttered output</a></li>
-<li><a href="#failures-propagation">Failures propagation</a></li>
+<li><a href="#asserts" id="toc-asserts">Asserts</a>
+<ul>
+<li><a href="#several-checks" id="toc-several-checks">Several
+checks</a></li>
+<li><a href="#first-parameter-is-expected-value"
+id="toc-first-parameter-is-expected-value">First parameter is expected
+value</a></li>
+<li><a href="#floating-point-comparison"
+id="toc-floating-point-comparison">Floating-point comparison</a></li>
+<li><a href="#c-string-comparison" id="toc-c-string-comparison">C string
+comparison</a></li>
+<li><a href="#error-messages" id="toc-error-messages">Error
+messages</a></li>
+<li><a href="#uncluttered-output"
+id="toc-uncluttered-output">Uncluttered output</a></li>
+<li><a href="#failures-propagation"
+id="toc-failures-propagation">Failures propagation</a></li>
 </ul></li>
-<li><a href="#naming-and-grouping">Naming and Grouping</a><ul>
-<li><a href="#test-group-names">Test group names</a></li>
-<li><a href="#filename">Filename</a></li>
-<li><a href="#file-location">File location</a></li>
-<li><a href="#test-names">Test names</a></li>
-<li><a href="#fixture-classes">Fixture classes</a></li>
-<li><a href="#friend-classes">Friend classes</a></li>
-<li><a href="#oscpu-specific-tests">OS/CPU specific tests</a></li>
+<li><a href="#naming-and-grouping" id="toc-naming-and-grouping">Naming
+and Grouping</a>
+<ul>
+<li><a href="#test-group-names" id="toc-test-group-names">Test group
+names</a></li>
+<li><a href="#filename" id="toc-filename">Filename</a></li>
+<li><a href="#file-location" id="toc-file-location">File
+location</a></li>
+<li><a href="#test-names" id="toc-test-names">Test names</a></li>
+<li><a href="#fixture-classes" id="toc-fixture-classes">Fixture
+classes</a></li>
+<li><a href="#friend-classes" id="toc-friend-classes">Friend
+classes</a></li>
+<li><a href="#oscpu-specific-tests" id="toc-oscpu-specific-tests">OS/CPU
+specific tests</a></li>
 </ul></li>
-<li><a href="#miscellaneous">Miscellaneous</a><ul>
-<li><a href="#hotspot-style">Hotspot style</a></li>
-<li><a href="#codetest-metrics">Code/test metrics</a></li>
-<li><a href="#access-to-non-public-members">Access to non-public members</a></li>
-<li><a href="#death-tests">Death tests</a></li>
-<li><a href="#external-flags">External flags</a></li>
-<li><a href="#test-specific-flags">Test-specific flags</a></li>
-<li><a href="#flag-restoring">Flag restoring</a></li>
-<li><a href="#googletest-documentation">GoogleTest documentation</a></li>
+<li><a href="#miscellaneous" id="toc-miscellaneous">Miscellaneous</a>
+<ul>
+<li><a href="#hotspot-style" id="toc-hotspot-style">Hotspot
+style</a></li>
+<li><a href="#codetest-metrics" id="toc-codetest-metrics">Code/test
+metrics</a></li>
+<li><a href="#access-to-non-public-members"
+id="toc-access-to-non-public-members">Access to non-public
+members</a></li>
+<li><a href="#death-tests" id="toc-death-tests">Death tests</a></li>
+<li><a href="#external-flags" id="toc-external-flags">External
+flags</a></li>
+<li><a href="#test-specific-flags"
+id="toc-test-specific-flags">Test-specific flags</a></li>
+<li><a href="#flag-restoring" id="toc-flag-restoring">Flag
+restoring</a></li>
+<li><a href="#googletest-documentation"
+id="toc-googletest-documentation">GoogleTest documentation</a></li>
 </ul></li>
-<li><a href="#todo">TODO</a></li>
+<li><a href="#todo" id="toc-todo">TODO</a></li>
 </ul>
 </nav>
-<p>The purpose of these guidelines is to establish a shared vision on what kind of native tests and how we want to develop them for Hotspot using GoogleTest. Hence these guidelines include style items as well as test approach items.</p>
-<p>First section of this document describes properties of good tests which are common for almost all types of test regardless of language, framework, etc. Further sections provide recommendations to achieve those properties and other HotSpot and/or GoogleTest specific guidelines.</p>
+<p>The purpose of these guidelines is to establish a shared vision on
+what kind of native tests and how we want to develop them for Hotspot
+using GoogleTest. Hence these guidelines include style items as well as
+test approach items.</p>
+<p>First section of this document describes properties of good tests
+which are common for almost all types of test regardless of language,
+framework, etc. Further sections provide recommendations to achieve
+those properties and other HotSpot and/or GoogleTest specific
+guidelines.</p>
 <h2 id="good-test-properties">Good test properties</h2>
 <h3 id="lightness">Lightness</h3>
 <p>Use the most lightweight type of tests.</p>
-<p>In Hotspot, there are 3 different types of tests regarding their dependency on a JVM, each next level is slower than previous</p>
+<p>In Hotspot, there are 3 different types of tests regarding their
+dependency on a JVM, each next level is slower than previous</p>
 <ul>
 <li><p><code>TEST</code> : a test does not depend on a JVM</p></li>
-<li><p><code>TEST_VM</code> : a test does depend on an initialized JVM, but are supposed not to break a JVM, i.e. leave it in a workable state.</p></li>
-<li><p><code>TEST_OTHER_VM</code> : a test depends on a JVM and requires a freshly initialized JVM or leaves a JVM in non-workable state</p></li>
+<li><p><code>TEST_VM</code> : a test does depend on an initialized JVM,
+but are supposed not to break a JVM, i.e. leave it in a workable
+state.</p></li>
+<li><p><code>TEST_OTHER_VM</code> : a test depends on a JVM and requires
+a freshly initialized JVM or leaves a JVM in non-workable state</p></li>
 </ul>
 <h3 id="isolation">Isolation</h3>
-<p>Tests have to be isolated: not to have visible side-effects, influences on other tests results.</p>
-<p>Results of one test should not depend on test execution order, other tests, otherwise it is becoming almost impossible to find out why a test failed. Due to hotspot-specific, it is not so easy to get a full isolation, e.g. we share an initialized JVM between all <code>TEST_VM</code> tests, so if your test changes JVM's state too drastically and does not change it back, you had better consider <code>TEST_OTHER_VM</code>.</p>
-<h3 id="atomicity-and-self-containment">Atomicity and self-containment</h3>
-<p>Tests should be <em>atomic</em> and <em>self-contained</em> at the same time.</p>
-<p>One test should check a particular part of a class, subsystem, functionality, etc. Then it is quite easy to determine what parts of a product are broken basing on test failures. On the other hand, a test should test that part more-or-less entirely, because when one sees a test <code>FooTest::bar</code>, they assume all aspects of bar from <code>Foo</code> are tested.</p>
-<p>However, it is impossible to cover all aspects even of a method, not to mention a subsystem. In such cases, it is recommended to have several tests, one for each aspect of a thing under test. For example one test to tests how <code>Foo::bar</code> works if an argument is <code>null</code>, another test to test how it works if an argument is acceptable but <code>Foo</code> is not in the right state to accept it and so on. This helps not only to make tests atomic, self-contained but also makes test name self-descriptive (discussed in more details in <a href="#test-names">Test names</a>).</p>
+<p>Tests have to be isolated: not to have visible side-effects,
+influences on other tests results.</p>
+<p>Results of one test should not depend on test execution order, other
+tests, otherwise it is becoming almost impossible to find out why a test
+failed. Due to hotspot-specific, it is not so easy to get a full
+isolation, e.g. we share an initialized JVM between all
+<code>TEST_VM</code> tests, so if your test changes JVM's state too
+drastically and does not change it back, you had better consider
+<code>TEST_OTHER_VM</code>.</p>
+<h3 id="atomicity-and-self-containment">Atomicity and
+self-containment</h3>
+<p>Tests should be <em>atomic</em> and <em>self-contained</em> at the
+same time.</p>
+<p>One test should check a particular part of a class, subsystem,
+functionality, etc. Then it is quite easy to determine what parts of a
+product are broken basing on test failures. On the other hand, a test
+should test that part more-or-less entirely, because when one sees a
+test <code>FooTest::bar</code>, they assume all aspects of bar from
+<code>Foo</code> are tested.</p>
+<p>However, it is impossible to cover all aspects even of a method, not
+to mention a subsystem. In such cases, it is recommended to have several
+tests, one for each aspect of a thing under test. For example one test
+to tests how <code>Foo::bar</code> works if an argument is
+<code>null</code>, another test to test how it works if an argument is
+acceptable but <code>Foo</code> is not in the right state to accept it
+and so on. This helps not only to make tests atomic, self-contained but
+also makes test name self-descriptive (discussed in more details in <a
+href="#test-names">Test names</a>).</p>
 <h3 id="repeatability">Repeatability</h3>
 <p>Tests have to be repeatable.</p>
-<p>Reproducibility is very crucial for a test. No one likes sporadic test failures, they are hard to investigate, fix and verify a fix.</p>
-<p>In some cases, it is quite hard to write a 100% repeatable test, since besides a test there can be other moving parts, e.g. in case of <code>TEST_VM</code> there are several concurrently running threads. Despite this, we should try to make a test as reproducible as possible.</p>
+<p>Reproducibility is very crucial for a test. No one likes sporadic
+test failures, they are hard to investigate, fix and verify a fix.</p>
+<p>In some cases, it is quite hard to write a 100% repeatable test,
+since besides a test there can be other moving parts, e.g. in case of
+<code>TEST_VM</code> there are several concurrently running threads.
+Despite this, we should try to make a test as reproducible as
+possible.</p>
 <h3 id="informativeness">Informativeness</h3>
-<p>In case of a failure, a test should be as <em>informative</em> as possible.</p>
-<p>Having more information about a test failure than just compared values can be very useful for failure troubleshooting, it can reduce or even completely eliminate debugging hours. This is even more important in case of not 100% reproducible failures.</p>
-<p>Achieving this property, one can easily make a test too verbose, so it will be really hard to find useful information in the ocean of useless information. Hence they should not only think about how to provide <a href="#error-messages">good information</a>, but also <a href="#uncluttered-output">when to do it</a>.</p>
+<p>In case of a failure, a test should be as <em>informative</em> as
+possible.</p>
+<p>Having more information about a test failure than just compared
+values can be very useful for failure troubleshooting, it can reduce or
+even completely eliminate debugging hours. This is even more important
+in case of not 100% reproducible failures.</p>
+<p>Achieving this property, one can easily make a test too verbose, so
+it will be really hard to find useful information in the ocean of
+useless information. Hence they should not only think about how to
+provide <a href="#error-messages">good information</a>, but also <a
+href="#uncluttered-output">when to do it</a>.</p>
 <h3 id="testing-instead-of-visiting">Testing instead of visiting</h3>
 <p>Tests should <em>test</em>.</p>
-<p>It is not enough just to &quot;visit&quot; some code, a test should check that code does that it has to do, compare return values with expected values, check that desired side effects are done, and undesired are not, and so on. In other words, a test should contain at least one GoogleTest assertion and do not rely on JVM asserts.</p>
-<p>Generally speaking to write a good test, one should create a model of the system under tests, a model of possible bugs (or bugs which one wants to find) and design tests using those models.</p>
+<p>It is not enough just to "visit" some code, a test should check that
+code does that it has to do, compare return values with expected values,
+check that desired side effects are done, and undesired are not, and so
+on. In other words, a test should contain at least one GoogleTest
+assertion and do not rely on JVM asserts.</p>
+<p>Generally speaking to write a good test, one should create a model of
+the system under tests, a model of possible bugs (or bugs which one
+wants to find) and design tests using those models.</p>
 <h3 id="nearness">Nearness</h3>
 <p>Prefer having checks inside test code.</p>
-<p>Not only does having test logic outside, e.g. verification method, depending on asserts in product code contradict with several items above but also decreases test’s readability and stability. It is much easier to understand that a test is testing when all testing logic is located inside a test or nearby in shared test libraries. As a rule of thumb, the closer a check to a test, the better.</p>
+<p>Not only does having test logic outside, e.g. verification method,
+depending on asserts in product code contradict with several items above
+but also decreases test’s readability and stability. It is much easier
+to understand that a test is testing when all testing logic is located
+inside a test or nearby in shared test libraries. As a rule of thumb,
+the closer a check to a test, the better.</p>
 <h2 id="asserts">Asserts</h2>
 <h3 id="several-checks">Several checks</h3>
 <p>Prefer <code>EXPECT</code> over <code>ASSERT</code> if possible.</p>
-<p>This is related to the <a href="#informativeness">informativeness</a> property of tests, information for other checks can help to better localize a defect’s root-cause. One should use <code>ASSERT</code> if it is impossible to continue test execution or if it does not make much sense. Later in the text, <code>EXPECT</code> forms will be used to refer to both <code>ASSERT/EXPECT</code>.</p>
-<p>When it is possible to make several different checks, but impossible to continue test execution if at least one check fails, you can use <code>::testing::Test::HasNonfatalFailure()</code> function. The recommended way to express that is <code>ASSERT_FALSE(::testing::Test::HasNonfatalFailure())</code>. Besides making it clear why a test is aborted, it also allows you to provide more information about a failure.</p>
-<h3 id="first-parameter-is-expected-value">First parameter is expected value</h3>
-<p>In all equality assertions, expected values should be passed as the first parameter.</p>
-<p>This convention is adopted by GoogleTest, and there is a slight difference in how GoogleTest treats parameters, the most important one is <code>null</code> detection. Due to different reasons, <code>null</code> detection is enabled only for the first parameter, that is to said <code>EXPECT_EQ(NULL, object)</code> checks that object is <code>null</code>, while <code>EXPECT_EQ(object, NULL)</code> checks that object equals to <code>NULL</code>, GoogleTest is very strict regarding types of compared values so the latter will generates a compile-time error.</p>
+<p>This is related to the <a href="#informativeness">informativeness</a>
+property of tests, information for other checks can help to better
+localize a defect’s root-cause. One should use <code>ASSERT</code> if it
+is impossible to continue test execution or if it does not make much
+sense. Later in the text, <code>EXPECT</code> forms will be used to
+refer to both <code>ASSERT/EXPECT</code>.</p>
+<p>When it is possible to make several different checks, but impossible
+to continue test execution if at least one check fails, you can use
+<code>::testing::Test::HasNonfatalFailure()</code> function. The
+recommended way to express that is
+<code>ASSERT_FALSE(::testing::Test::HasNonfatalFailure())</code>.
+Besides making it clear why a test is aborted, it also allows you to
+provide more information about a failure.</p>
+<h3 id="first-parameter-is-expected-value">First parameter is expected
+value</h3>
+<p>In all equality assertions, expected values should be passed as the
+first parameter.</p>
+<p>This convention is adopted by GoogleTest, and there is a slight
+difference in how GoogleTest treats parameters, the most important one
+is <code>null</code> detection. Due to different reasons,
+<code>null</code> detection is enabled only for the first parameter,
+that is to said <code>EXPECT_EQ(NULL, object)</code> checks that object
+is <code>null</code>, while <code>EXPECT_EQ(object, NULL)</code> checks
+that object equals to <code>NULL</code>, GoogleTest is very strict
+regarding types of compared values so the latter will generates a
+compile-time error.</p>
 <h3 id="floating-point-comparison">Floating-point comparison</h3>
-<p>Use floating-point special macros to compare <code>float/double</code> values.</p>
-<p>Because of floating-point number representations and round-off errors, regular equality comparison will not return true in most cases. There are special <code>EXPECT_FLOAT_EQ/EXPECT_DOUBLE_EQ</code> assertions which check that the distance between compared values is not more than 4 ULPs, there is also <code>EXPECT_NEAR(v1, v2, eps)</code> which checks that the absolute value of the difference between <code>v1</code> and <code>v2</code> is not greater than <code>eps</code>.</p>
+<p>Use floating-point special macros to compare
+<code>float/double</code> values.</p>
+<p>Because of floating-point number representations and round-off
+errors, regular equality comparison will not return true in most cases.
+There are special <code>EXPECT_FLOAT_EQ/EXPECT_DOUBLE_EQ</code>
+assertions which check that the distance between compared values is not
+more than 4 ULPs, there is also <code>EXPECT_NEAR(v1, v2, eps)</code>
+which checks that the absolute value of the difference between
+<code>v1</code> and <code>v2</code> is not greater than
+<code>eps</code>.</p>
 <h3 id="c-string-comparison">C string comparison</h3>
 <p>Use string special macros for C strings comparisons.</p>
-<p><code>EXPECT_EQ</code> just compares pointers’ values, which is hardly what one wants comparing C strings. GoogleTest provides <code>EXPECT_STREQ</code> and <code>EXPECT_STRNE</code> macros to compare C string contents. There are also case-insensitive versions <code>EXPECT_STRCASEEQ</code>, <code>EXPECT_STRCASENE</code>.</p>
+<p><code>EXPECT_EQ</code> just compares pointers’ values, which is
+hardly what one wants comparing C strings. GoogleTest provides
+<code>EXPECT_STREQ</code> and <code>EXPECT_STRNE</code> macros to
+compare C string contents. There are also case-insensitive versions
+<code>EXPECT_STRCASEEQ</code>, <code>EXPECT_STRCASENE</code>.</p>
 <h3 id="error-messages">Error messages</h3>
 <p>Provide informative, but not too verbose error messages.</p>
-<p>All GoogleTest asserts print compared expressions and their values, so there is no need to have them in error messages. Asserts print only compared values, they do not print any of interim variables, e.g. <code>ASSERT_TRUE((val1 == val2 &amp;&amp; isFail(foo(8)) || i == 18)</code> prints only one value. If you use some complex predicates, please consider <code>EXPECT_PRED*</code> or <code>EXPECT_FORMAT_PRED</code> assertions family, they check that a predicate returns true/success and print out all parameters values.</p>
-<p>However in some cases, default information is not enough, a commonly used example is an assert inside a loop, GoogleTest will not print iteration values (unless it is an assert's parameter). Other demonstrative examples are printing error code and a corresponding error message; printing internal states which might have an impact on results. One should add this information to assert message using <code>&lt;&lt;</code> operator.</p>
+<p>All GoogleTest asserts print compared expressions and their values,
+so there is no need to have them in error messages. Asserts print only
+compared values, they do not print any of interim variables, e.g.
+<code>ASSERT_TRUE((val1 == val2 &amp;&amp; isFail(foo(8)) || i == 18)</code>
+prints only one value. If you use some complex predicates, please
+consider <code>EXPECT_PRED*</code> or <code>EXPECT_FORMAT_PRED</code>
+assertions family, they check that a predicate returns true/success and
+print out all parameters values.</p>
+<p>However in some cases, default information is not enough, a commonly
+used example is an assert inside a loop, GoogleTest will not print
+iteration values (unless it is an assert's parameter). Other
+demonstrative examples are printing error code and a corresponding error
+message; printing internal states which might have an impact on results.
+One should add this information to assert message using
+<code>&lt;&lt;</code> operator.</p>
 <h3 id="uncluttered-output">Uncluttered output</h3>
 <p>Print information only if it is needed.</p>
-<p>Too verbose tests which print all information even if they pass are very bad practice. They just pollute output, so it becomes harder to find useful information. In order not print information till it is really needed, one should consider saving it to a temporary buffer and pass to an assert. <a href="https://git.openjdk.org/jdk/blob/master/test/hotspot/gtest/gc/shared/test_memset_with_concurrent_readers.cpp" class="uri">https://git.openjdk.org/jdk/blob/master/test/hotspot/gtest/gc/shared/test_memset_with_concurrent_readers.cpp</a> has a good example how to do that.</p>
+<p>Too verbose tests which print all information even if they pass are
+very bad practice. They just pollute output, so it becomes harder to
+find useful information. In order not print information till it is
+really needed, one should consider saving it to a temporary buffer and
+pass to an assert. <a
+href="https://git.openjdk.org/jdk/blob/master/test/hotspot/gtest/gc/shared/test_memset_with_concurrent_readers.cpp"
+class="uri">https://git.openjdk.org/jdk/blob/master/test/hotspot/gtest/gc/shared/test_memset_with_concurrent_readers.cpp</a>
+has a good example how to do that.</p>
 <h3 id="failures-propagation">Failures propagation</h3>
-<p>Wrap a subroutine call into <code>EXPECT_NO_FATAL_FAILURE</code> macro to propagate failures.</p>
-<p><code>ASSERT</code> and <code>FAIL</code> abort only the current function, so if you have them in a subroutine, a test will not be aborted after the subroutine even if <code>ASSERT</code> or <code>FAIL</code> fails. You should call such subroutines in <code>ASSERT_NO_FATAL_FAILURE</code> macro to propagate fatal failures and abort a test. <code>(EXPECT|ASSERT)_NO_FATAL_FAILURE</code> can also be used to provide more information.</p>
-<p>Due to obvious reasons, there are no <code>(EXPECT|ASSERT)_NO_NONFATAL_FAILURE</code> macros. However, if you need to check if a subroutine generated a nonfatal failure (failed an <code>EXPECT</code>), you can use <code>::testing::Test::HasNonfatalFailure</code> function, or <code>::testing::Test::HasFailure</code> function to check if a subroutine generated any failures, see <a href="#several-checks">Several checks</a>.</p>
+<p>Wrap a subroutine call into <code>EXPECT_NO_FATAL_FAILURE</code>
+macro to propagate failures.</p>
+<p><code>ASSERT</code> and <code>FAIL</code> abort only the current
+function, so if you have them in a subroutine, a test will not be
+aborted after the subroutine even if <code>ASSERT</code> or
+<code>FAIL</code> fails. You should call such subroutines in
+<code>ASSERT_NO_FATAL_FAILURE</code> macro to propagate fatal failures
+and abort a test. <code>(EXPECT|ASSERT)_NO_FATAL_FAILURE</code> can also
+be used to provide more information.</p>
+<p>Due to obvious reasons, there are no
+<code>(EXPECT|ASSERT)_NO_NONFATAL_FAILURE</code> macros. However, if you
+need to check if a subroutine generated a nonfatal failure (failed an
+<code>EXPECT</code>), you can use
+<code>::testing::Test::HasNonfatalFailure</code> function, or
+<code>::testing::Test::HasFailure</code> function to check if a
+subroutine generated any failures, see <a href="#several-checks">Several
+checks</a>.</p>
 <h2 id="naming-and-grouping">Naming and Grouping</h2>
 <h3 id="test-group-names">Test group names</h3>
-<p>Test group names should be in CamelCase, start and end with a letter. A test group should be named after tested class, functionality, subsystem, etc.</p>
-<p>This naming scheme helps to find tests, filter them and simplifies test failure analysis. For example, class <code>Foo</code> - test group <code>Foo</code>, compiler logging subsystem - test group <code>CompilerLogging</code>, G1 GC — test group <code>G1GC</code>, and so forth.</p>
+<p>Test group names should be in CamelCase, start and end with a letter.
+A test group should be named after tested class, functionality,
+subsystem, etc.</p>
+<p>This naming scheme helps to find tests, filter them and simplifies
+test failure analysis. For example, class <code>Foo</code> - test group
+<code>Foo</code>, compiler logging subsystem - test group
+<code>CompilerLogging</code>, G1 GC — test group <code>G1GC</code>, and
+so forth.</p>
 <h3 id="filename">Filename</h3>
-<p>A test file must have <code>test_</code> prefix and <code>.cpp</code> suffix.</p>
-<p>Both are actually requirements from the current build system to recognize your tests.</p>
+<p>A test file must have <code>test_</code> prefix and <code>.cpp</code>
+suffix.</p>
+<p>Both are actually requirements from the current build system to
+recognize your tests.</p>
 <h3 id="file-location">File location</h3>
-<p>Test file location should reflect a location of the tested part of the product.</p>
+<p>Test file location should reflect a location of the tested part of
+the product.</p>
 <ul>
-<li><p>All unit tests for a class from <code>foo/bar/baz.cpp</code> should be placed <code>foo/bar/test_baz.cpp</code> in <code>hotspot/test/native/</code> directory. Having all tests for a class in one file is a common practice for unit tests, it helps to see all existing tests at once, share functions and/or resources without losing encapsulation.</p></li>
-<li><p>For tests which test more than one class, directory hierarchy should be the same as product hierarchy, and file name should reflect the name of the tested subsystem/functionality. For example, if a sub-system under tests belongs to <code>gc/g1</code>, tests should be placed in <code>gc/g1</code> directory.</p></li>
+<li><p>All unit tests for a class from <code>foo/bar/baz.cpp</code>
+should be placed <code>foo/bar/test_baz.cpp</code> in
+<code>hotspot/test/native/</code> directory. Having all tests for a
+class in one file is a common practice for unit tests, it helps to see
+all existing tests at once, share functions and/or resources without
+losing encapsulation.</p></li>
+<li><p>For tests which test more than one class, directory hierarchy
+should be the same as product hierarchy, and file name should reflect
+the name of the tested subsystem/functionality. For example, if a
+sub-system under tests belongs to <code>gc/g1</code>, tests should be
+placed in <code>gc/g1</code> directory.</p></li>
 </ul>
-<p>Please note that framework prepends directory name to a test group name. For example, if <code>TEST(foo, check_this)</code> and <code>TEST(bar, check_that)</code> are defined in <code>hotspot/test/native/gc/shared/test_foo.cpp</code> file, they will be reported as <code>gc/shared/foo::check_this</code> and <code>gc/shared/bar::check_that</code>.</p>
+<p>Please note that framework prepends directory name to a test group
+name. For example, if <code>TEST(foo, check_this)</code> and
+<code>TEST(bar, check_that)</code> are defined in
+<code>hotspot/test/native/gc/shared/test_foo.cpp</code> file, they will
+be reported as <code>gc/shared/foo::check_this</code> and
+<code>gc/shared/bar::check_that</code>.</p>
 <h3 id="test-names">Test names</h3>
-<p>Test names should be in small_snake_case, start and end with a letter. A test name should reflect that a test checks.</p>
-<p>Such naming makes tests self-descriptive and helps a lot during the whole test life cycle. It is easy to do test planning, test inventory, to see what things are not tested, to review tests, to analyze test failures, to evolve a test, etc. For example <code>foo_return_0_if_name_is_null</code> is better than <code>foo_sanity</code> or <code>foo_basic</code> or just <code>foo</code>, <code>humongous_objects_can_not_be_moved_by_young_gc</code> is better than <code>ho_young_gc</code>.</p>
-<p>Actually using underscore is against GoogleTest project convention, because it can lead to illegal identifiers, however, this is too strict. Restricting usage of underscore for test names only and prohibiting test name starts or ends with an underscore are enough to be safe.</p>
+<p>Test names should be in small_snake_case, start and end with a
+letter. A test name should reflect that a test checks.</p>
+<p>Such naming makes tests self-descriptive and helps a lot during the
+whole test life cycle. It is easy to do test planning, test inventory,
+to see what things are not tested, to review tests, to analyze test
+failures, to evolve a test, etc. For example
+<code>foo_return_0_if_name_is_null</code> is better than
+<code>foo_sanity</code> or <code>foo_basic</code> or just
+<code>foo</code>,
+<code>humongous_objects_can_not_be_moved_by_young_gc</code> is better
+than <code>ho_young_gc</code>.</p>
+<p>Actually using underscore is against GoogleTest project convention,
+because it can lead to illegal identifiers, however, this is too strict.
+Restricting usage of underscore for test names only and prohibiting test
+name starts or ends with an underscore are enough to be safe.</p>
 <h3 id="fixture-classes">Fixture classes</h3>
-<p>Fixture classes should be named after tested classes, subsystems, etc (follow <a href="#test-group-names">Test group names rule</a>) and have <code>Test</code> suffix to prevent class name conflicts.</p>
+<p>Fixture classes should be named after tested classes, subsystems, etc
+(follow <a href="#test-group-names">Test group names rule</a>) and have
+<code>Test</code> suffix to prevent class name conflicts.</p>
 <h3 id="friend-classes">Friend classes</h3>
-<p>All test purpose friends should have either <code>Test</code> or <code>Testable</code> suffix.</p>
-<p>It greatly simplifies understanding of friendship’s purpose and allows statically check that private members are not exposed unexpectedly. Having <code>FooTest</code> as a friend of <code>Foo</code> without any comments will be understood as a necessary evil to get testability.</p>
+<p>All test purpose friends should have either <code>Test</code> or
+<code>Testable</code> suffix.</p>
+<p>It greatly simplifies understanding of friendship’s purpose and
+allows statically check that private members are not exposed
+unexpectedly. Having <code>FooTest</code> as a friend of
+<code>Foo</code> without any comments will be understood as a necessary
+evil to get testability.</p>
 <h3 id="oscpu-specific-tests">OS/CPU specific tests</h3>
-<p>Guard OS/CPU specific tests by <code>#ifdef</code> and have OS/CPU name in filename.</p>
-<p>For the time being, we do not support separate directories for OS, CPU, OS-CPU specific tests, in case we will have lots of such tests, we will change directory layout and build system to support that in the same way it is done in hotspot.</p>
+<p>Guard OS/CPU specific tests by <code>#ifdef</code> and have OS/CPU
+name in filename.</p>
+<p>For the time being, we do not support separate directories for OS,
+CPU, OS-CPU specific tests, in case we will have lots of such tests, we
+will change directory layout and build system to support that in the
+same way it is done in hotspot.</p>
 <h2 id="miscellaneous">Miscellaneous</h2>
 <h3 id="hotspot-style">Hotspot style</h3>
 <p>Abide the norms and rules accepted in Hotspot style guide.</p>
-<p>Tests are a part of Hotspot, so everything (if applicable) we use for Hotspot, should be used for tests as well. Those guidelines cover test-specific things.</p>
+<p>Tests are a part of Hotspot, so everything (if applicable) we use for
+Hotspot, should be used for tests as well. Those guidelines cover
+test-specific things.</p>
 <h3 id="codetest-metrics">Code/test metrics</h3>
-<p>Coverage information and other code/test metrics are quite useful to decide what tests should be written, what tests should be improved and what can be removed.</p>
-<p>For unit tests, widely used and well-known coverage metric is branch coverage, which provides good quality of tests with relatively easy test development process. For other levels of testing, branch coverage is not as good, and one should consider others metrics, e.g. transaction flow coverage, data flow coverage.</p>
+<p>Coverage information and other code/test metrics are quite useful to
+decide what tests should be written, what tests should be improved and
+what can be removed.</p>
+<p>For unit tests, widely used and well-known coverage metric is branch
+coverage, which provides good quality of tests with relatively easy test
+development process. For other levels of testing, branch coverage is not
+as good, and one should consider others metrics, e.g. transaction flow
+coverage, data flow coverage.</p>
 <h3 id="access-to-non-public-members">Access to non-public members</h3>
 <p>Use explicit friend class to get access to non-public members.</p>
-<p>We do not use GoogleTest macro to declare friendship relation, because, from our point of view, it is less clear than an explicit declaration.</p>
-<p>Declaring a test fixture class as a friend class of a tested test is the easiest and the clearest way to get access. However, it has some disadvantages, here is some of them:</p>
+<p>We do not use GoogleTest macro to declare friendship relation,
+because, from our point of view, it is less clear than an explicit
+declaration.</p>
+<p>Declaring a test fixture class as a friend class of a tested test is
+the easiest and the clearest way to get access. However, it has some
+disadvantages, here is some of them:</p>
 <ul>
 <li>Each test has to be declared as a friend</li>
 <li>Subclasses do not inheritance friendship relation</li>
 </ul>
-<p>In other words, it is harder to share code between tests. Hence if you want to share code or expect it to be useful in other tests, you should consider making members in a tested class protected and introduce a shared test-only class which expose those members via public functions, or even making members publicly accessible right away in a product class. If it is not an option to change members visibility, one can create a friend class which exposes members.</p>
+<p>In other words, it is harder to share code between tests. Hence if
+you want to share code or expect it to be useful in other tests, you
+should consider making members in a tested class protected and introduce
+a shared test-only class which expose those members via public
+functions, or even making members publicly accessible right away in a
+product class. If it is not an option to change members visibility, one
+can create a friend class which exposes members.</p>
 <h3 id="death-tests">Death tests</h3>
-<p>You can not use death tests inside <code>TEST_OTHER_VM</code> and <code>TEST_VM_ASSERT*</code>.</p>
-<p>We tried to make Hotspot-GoogleTest integration as transparent as possible, however, due to the current implementation of <code>TEST_OTHER_VM</code> and <code>TEST_VM_ASSERT*</code> tests, you cannot use death test functionality in them. These tests are implemented as GoogleTest death tests, and GoogleTest does not allow to have a death test inside another death test.</p>
+<p>You can not use death tests inside <code>TEST_OTHER_VM</code> and
+<code>TEST_VM_ASSERT*</code>.</p>
+<p>We tried to make Hotspot-GoogleTest integration as transparent as
+possible, however, due to the current implementation of
+<code>TEST_OTHER_VM</code> and <code>TEST_VM_ASSERT*</code> tests, you
+cannot use death test functionality in them. These tests are implemented
+as GoogleTest death tests, and GoogleTest does not allow to have a death
+test inside another death test.</p>
 <h3 id="external-flags">External flags</h3>
 <p>Passing external flags to a tested JVM is not supported.</p>
-<p>The rationality of such design decision is to simplify both tests and a test framework and to avoid failures related to incompatible flags combination till there is a good solution for that. However there are cases when one wants to test a JVM with specific flags combination, <code>_JAVA_OPTIONS</code> environment variable can be used to do that. Flags from <code>_JAVA_OPTIONS</code> will be used in <code>TEST_VM</code>, <code>TEST_OTHER_VM</code> and <code>TEST_VM_ASSERT*</code> tests.</p>
+<p>The rationality of such design decision is to simplify both tests and
+a test framework and to avoid failures related to incompatible flags
+combination till there is a good solution for that. However there are
+cases when one wants to test a JVM with specific flags combination,
+<code>_JAVA_OPTIONS</code> environment variable can be used to do that.
+Flags from <code>_JAVA_OPTIONS</code> will be used in
+<code>TEST_VM</code>, <code>TEST_OTHER_VM</code> and
+<code>TEST_VM_ASSERT*</code> tests.</p>
 <h3 id="test-specific-flags">Test-specific flags</h3>
-<p>Passing flags to a tested JVM in <code>TEST_OTHER_VM</code> and <code>TEST_VM_ASSERT*</code> should be possible, but is not implemented yet.</p>
-<p>Facility to pass test-specific flags is needed for system, regression or other types of tests which require a fully initialized JVM in some particular configuration, e.g. with Serial GC selected. There is no support for such tests now, however, there is a plan to add that in upcoming releases.</p>
-<p>For now, if a test depends on flags values, it should have <code>if (!&lt;flag&gt;) { return }</code> guards in the very beginning and <code>@requires</code> comment similar to jtreg <code>@requires</code> directive right before test macros. <a href="https://git.openjdk.org/jdk/blob/master/test/hotspot/gtest/gc/g1/test_g1IHOPControl.cpp" class="uri">https://git.openjdk.org/jdk/blob/master/test/hotspot/gtest/gc/g1/test_g1IHOPControl.cpp</a> ha an example of this temporary workaround. It is important to follow that pattern as it allows us to easily find all such tests and update them as soon as there is an implementation of flag passing facility.</p>
-<p>In long-term, we expect jtreg to support GoogleTest tests as first class citizens, that is to say, jtreg will parse <span class="citation" data-cites="requires">@requires</span> comments and filter out inapplicable tests.</p>
+<p>Passing flags to a tested JVM in <code>TEST_OTHER_VM</code> and
+<code>TEST_VM_ASSERT*</code> should be possible, but is not implemented
+yet.</p>
+<p>Facility to pass test-specific flags is needed for system, regression
+or other types of tests which require a fully initialized JVM in some
+particular configuration, e.g. with Serial GC selected. There is no
+support for such tests now, however, there is a plan to add that in
+upcoming releases.</p>
+<p>For now, if a test depends on flags values, it should have
+<code>if (!&lt;flag&gt;) { return }</code> guards in the very beginning
+and <code>@requires</code> comment similar to jtreg
+<code>@requires</code> directive right before test macros. <a
+href="https://git.openjdk.org/jdk/blob/master/test/hotspot/gtest/gc/g1/test_g1IHOPControl.cpp"
+class="uri">https://git.openjdk.org/jdk/blob/master/test/hotspot/gtest/gc/g1/test_g1IHOPControl.cpp</a>
+ha an example of this temporary workaround. It is important to follow
+that pattern as it allows us to easily find all such tests and update
+them as soon as there is an implementation of flag passing facility.</p>
+<p>In long-term, we expect jtreg to support GoogleTest tests as first
+class citizens, that is to say, jtreg will parse <span class="citation"
+data-cites="requires">@requires</span> comments and filter out
+inapplicable tests.</p>
 <h3 id="flag-restoring">Flag restoring</h3>
 <p>Restore changed flags.</p>
-<p>It is quite common for tests to configure JVM in a certain way changing flags’ values. GoogleTest provides two ways to set up environment before a test and restore it afterward: using either constructor and destructor or <code>SetUp</code> and <code>TearDown</code> functions. Both ways require to use a test fixture class, which sometimes is too wordy. The simpler facilities like <code>FLAG_GUARD</code> macro or <code>*FlagSetting</code> classes could be used in such cases to restore/set values.</p>
+<p>It is quite common for tests to configure JVM in a certain way
+changing flags’ values. GoogleTest provides two ways to set up
+environment before a test and restore it afterward: using either
+constructor and destructor or <code>SetUp</code> and
+<code>TearDown</code> functions. Both ways require to use a test fixture
+class, which sometimes is too wordy. The simpler facilities like
+<code>FLAG_GUARD</code> macro or <code>*FlagSetting</code> classes could
+be used in such cases to restore/set values.</p>
 <p>Caveats:</p>
 <ul>
-<li><p>Changing a flag’s value could break the invariants between flags' values and hence could lead to unexpected/unsupported JVM state.</p></li>
-<li><p><code>FLAG_SET_*</code> macros can change more than one flag (in order to maintain invariants) so it is hard to predict what flags will be changed and it makes restoring all changed flags a nontrivial task. Thus in case one uses <code>FLAG_SET_*</code> macros, they should use <code>TEST_OTHER_VM</code> test type.</p></li>
+<li><p>Changing a flag’s value could break the invariants between flags'
+values and hence could lead to unexpected/unsupported JVM
+state.</p></li>
+<li><p><code>FLAG_SET_*</code> macros can change more than one flag (in
+order to maintain invariants) so it is hard to predict what flags will
+be changed and it makes restoring all changed flags a nontrivial task.
+Thus in case one uses <code>FLAG_SET_*</code> macros, they should use
+<code>TEST_OTHER_VM</code> test type.</p></li>
 </ul>
 <h3 id="googletest-documentation">GoogleTest documentation</h3>
-<p>In case you have any questions regarding GoogleTest itself, its asserts, test declaration macros, other macros, etc, please consult its documentation.</p>
+<p>In case you have any questions regarding GoogleTest itself, its
+asserts, test declaration macros, other macros, etc, please consult its
+documentation.</p>
 <h2 id="todo">TODO</h2>
-<p>Although this document provides guidelines on the most important parts of test development using GTest, it still misses a few items:</p>
+<p>Although this document provides guidelines on the most important
+parts of test development using GTest, it still misses a few items:</p>
 <ul>
-<li><p>Examples, esp for <a href="#access-to-non-public-members">access to non-public members</a></p></li>
-<li>test types: purpose, drawbacks, limitation
+<li><p>Examples, esp for <a href="#access-to-non-public-members">access
+to non-public members</a></p></li>
+<li><p>test types: purpose, drawbacks, limitation</p>
 <ul>
 <li><code>TEST_VM</code></li>
 <li><code>TEST_VM_F</code></li>
@@ -195,7 +471,7 @@
 <li><code>TEST_VM_ASSERT</code></li>
 <li><code>TEST_VM_ASSERT_MSG</code></li>
 </ul></li>
-<li>Miscellaneous
+<li><p>Miscellaneous</p>
 <ul>
 <li>Test libraries
 <ul>
@@ -208,7 +484,8 @@
 <li>how to run tests in random order</li>
 <li>how to run only specific tests</li>
 <li>how to run each test separately</li>
-<li>check that a test can find bugs it is supposed to by introducing them</li>
+<li>check that a test can find bugs it is supposed to by introducing
+them</li>
 </ul></li>
 <li>mocks/stubs/dependency injection</li>
 <li>setUp/tearDown

--- a/doc/ide.html
+++ b/doc/ide.html
@@ -5,11 +5,19 @@
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
   <title>IDE support in the JDK</title>
-  <style type="text/css">
-      code{white-space: pre-wrap;}
-      span.smallcaps{font-variant: small-caps;}
-      span.underline{text-decoration: underline;}
-      div.column{display: inline-block; vertical-align: top; width: 50%;}
+  <style>
+    code{white-space: pre-wrap;}
+    span.smallcaps{font-variant: small-caps;}
+    div.columns{display: flex; gap: min(4vw, 1.5em);}
+    div.column{flex: auto; overflow-x: auto;}
+    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+    ul.task-list{list-style: none;}
+    ul.task-list li input[type="checkbox"] {
+      width: 0.8em;
+      margin: 0 0.8em 0.2em -1.6em;
+      vertical-align: middle;
+    }
+    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
   </style>
   <link rel="stylesheet" href="../make/data/docs-resources/resources/jdk-default.css" />
   <!--[if lt IE 9]>
@@ -20,41 +28,82 @@
 <header id="title-block-header">
 <h1 class="title">IDE support in the JDK</h1>
 </header>
-<nav id="TOC">
+<nav id="TOC" role="doc-toc">
 <ul>
-<li><a href="#introduction">Introduction</a><ul>
-<li><a href="#ide-support-for-native-code">IDE support for native code</a></li>
-<li><a href="#ide-support-for-java-code">IDE support for Java code</a></li>
+<li><a href="#introduction" id="toc-introduction">Introduction</a>
+<ul>
+<li><a href="#ide-support-for-native-code"
+id="toc-ide-support-for-native-code">IDE support for native
+code</a></li>
+<li><a href="#ide-support-for-java-code"
+id="toc-ide-support-for-java-code">IDE support for Java code</a></li>
 </ul></li>
 </ul>
 </nav>
 <h2 id="introduction">Introduction</h2>
-<p>When you are familiar with building and testing the JDK, you may want to configure an IDE to work with the source code. The instructions differ a bit depending on whether you are interested in working with the native (C/C++) or the Java code.</p>
+<p>When you are familiar with building and testing the JDK, you may want
+to configure an IDE to work with the source code. The instructions
+differ a bit depending on whether you are interested in working with the
+native (C/C++) or the Java code.</p>
 <h3 id="ide-support-for-native-code">IDE support for native code</h3>
-<p>There are a few ways to generate IDE configuration for the native sources, depending on which IDE to use.</p>
+<p>There are a few ways to generate IDE configuration for the native
+sources, depending on which IDE to use.</p>
 <h4 id="visual-studio-code">Visual Studio Code</h4>
-<p>The make system can generate a <a href="https://code.visualstudio.com">Visual Studio Code</a> workspace that has C/C++ source indexing configured correctly, as well as launcher targets for tests and the Java launcher. After configuring, a workspace for the configuration can be generated using:</p>
+<p>The make system can generate a <a
+href="https://code.visualstudio.com">Visual Studio Code</a> workspace
+that has C/C++ source indexing configured correctly, as well as launcher
+targets for tests and the Java launcher. After configuring, a workspace
+for the configuration can be generated using:</p>
 <pre class="shell"><code>make vscode-project</code></pre>
-<p>This creates a file called <code>jdk.code-workspace</code> in the build output folder. The full location will be printed after the workspace has been generated. To use it, choose <code>File -&gt; Open Workspace...</code> in Visual Studio Code.</p>
+<p>This creates a file called <code>jdk.code-workspace</code> in the
+build output folder. The full location will be printed after the
+workspace has been generated. To use it, choose
+<code>File -&gt; Open Workspace...</code> in Visual Studio Code.</p>
 <h5 id="alternative-indexers">Alternative indexers</h5>
-<p>The main <code>vscode-project</code> target configures the default C++ support in Visual Studio Code. There are also other source indexers that can be installed, that may provide additional features. It's currently possible to generate configuration for two such indexers, <a href="https://clang.llvm.org/extra/clangd/">clangd</a> and <a href="https://github.com/Andersbakken/rtags">rtags</a>. These can be configured by appending the name of the indexer to the make target, such as:</p>
+<p>The main <code>vscode-project</code> target configures the default
+C++ support in Visual Studio Code. There are also other source indexers
+that can be installed, that may provide additional features. It's
+currently possible to generate configuration for two such indexers, <a
+href="https://clang.llvm.org/extra/clangd/">clangd</a> and <a
+href="https://github.com/Andersbakken/rtags">rtags</a>. These can be
+configured by appending the name of the indexer to the make target, such
+as:</p>
 <pre class="shell"><code>make vscode-project-clangd</code></pre>
-<p>Additional instructions for configuring the given indexer will be displayed after the workspace has been generated.</p>
+<p>Additional instructions for configuring the given indexer will be
+displayed after the workspace has been generated.</p>
 <h4 id="visual-studio">Visual Studio</h4>
-<p>The make system can generate a Visual Studio project for the Hotspot native source. After configuring, the project is generated using:</p>
+<p>The make system can generate a Visual Studio project for the Hotspot
+native source. After configuring, the project is generated using:</p>
 <pre class="shell"><code>make hotspot-ide-project</code></pre>
-<p>This creates a file named <code>jvm.vcxproj</code> in <code>ide\hotspot-visualstudio</code> subfolder of the build output folder. The file can be opened in Visual Studio via <code>File -&gt; Open -&gt; Project/Solution</code>.</p>
+<p>This creates a file named <code>jvm.vcxproj</code> in
+<code>ide\hotspot-visualstudio</code> subfolder of the build output
+folder. The file can be opened in Visual Studio via
+<code>File -&gt; Open -&gt; Project/Solution</code>.</p>
 <h4 id="compilation-database">Compilation Database</h4>
-<p>The make system can generate generic native code indexing support in the form of a <a href="https://clang.llvm.org/docs/JSONCompilationDatabase.html">Compilation Database</a> that can be used by many different IDEs and source code indexers.</p>
+<p>The make system can generate generic native code indexing support in
+the form of a <a
+href="https://clang.llvm.org/docs/JSONCompilationDatabase.html">Compilation
+Database</a> that can be used by many different IDEs and source code
+indexers.</p>
 <pre class="shell"><code>make compile-commands</code></pre>
-<p>It's also possible to generate the Compilation Database for the HotSpot source code only, which is a bit faster as it includes less information.</p>
+<p>It's also possible to generate the Compilation Database for the
+HotSpot source code only, which is a bit faster as it includes less
+information.</p>
 <pre class="shell"><code>make compile-commands-hotspot</code></pre>
 <h3 id="ide-support-for-java-code">IDE support for Java code</h3>
 <h4 id="intellij-idea">IntelliJ IDEA</h4>
-<p>The JDK project has a script that can be used for indexing the project with IntelliJ. After configuring and building the JDK, an IntelliJ workspace can be generated by running the following command in the top-level folder of the cloned repository:</p>
+<p>The JDK project has a script that can be used for indexing the
+project with IntelliJ. After configuring and building the JDK, an
+IntelliJ workspace can be generated by running the following command in
+the top-level folder of the cloned repository:</p>
 <pre class="shell"><code>bash bin/idea.sh</code></pre>
-<p>To use it, choose <code>File -&gt; Open...</code> in IntelliJ and select the folder where you ran the above script.</p>
-<p>Next, configure the project SDK in IntelliJ. Open <code>File -&gt; Project Structure -&gt; Project</code> and select <code>build/&lt;config&gt;/images/jdk</code> as the SDK to use.</p>
-<p>In order to run the tests from the IDE, you can use the JTReg plugin. Instructions for building and using the plugin can be found <a href="https://github.com/openjdk/jtreg/tree/master/plugins/idea">here</a>.</p>
+<p>To use it, choose <code>File -&gt; Open...</code> in IntelliJ and
+select the folder where you ran the above script.</p>
+<p>Next, configure the project SDK in IntelliJ. Open
+<code>File -&gt; Project Structure -&gt; Project</code> and select
+<code>build/&lt;config&gt;/images/jdk</code> as the SDK to use.</p>
+<p>In order to run the tests from the IDE, you can use the JTReg plugin.
+Instructions for building and using the plugin can be found <a
+href="https://github.com/openjdk/jtreg/tree/master/plugins/idea">here</a>.</p>
 </body>
 </html>

--- a/doc/testing.html
+++ b/doc/testing.html
@@ -5,57 +5,99 @@
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
   <title>Testing the JDK</title>
-  <style type="text/css">
-      code{white-space: pre-wrap;}
-      span.smallcaps{font-variant: small-caps;}
-      span.underline{text-decoration: underline;}
-      div.column{display: inline-block; vertical-align: top; width: 50%;}
+  <style>
+    code{white-space: pre-wrap;}
+    span.smallcaps{font-variant: small-caps;}
+    div.columns{display: flex; gap: min(4vw, 1.5em);}
+    div.column{flex: auto; overflow-x: auto;}
+    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+    ul.task-list{list-style: none;}
+    ul.task-list li input[type="checkbox"] {
+      width: 0.8em;
+      margin: 0 0.8em 0.2em -1.6em;
+      vertical-align: middle;
+    }
+    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
   </style>
   <link rel="stylesheet" href="../make/data/docs-resources/resources/jdk-default.css" />
+  <style type="text/css">pre, code, tt { color: #1d6ae5; }</style>
   <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
   <![endif]-->
-  <style type="text/css">pre, code, tt { color: #1d6ae5; }</style>
 </head>
 <body>
 <header id="title-block-header">
 <h1 class="title">Testing the JDK</h1>
 </header>
-<nav id="TOC">
+<nav id="TOC" role="doc-toc">
 <ul>
-<li><a href="#overview">Overview</a></li>
-<li><a href="#running-tests-locally-with-make-test">Running tests locally with <code>make test</code></a><ul>
-<li><a href="#configuration">Configuration</a></li>
+<li><a href="#overview" id="toc-overview">Overview</a></li>
+<li><a href="#running-tests-locally-with-make-test"
+id="toc-running-tests-locally-with-make-test">Running tests locally with
+<code>make test</code></a>
+<ul>
+<li><a href="#configuration"
+id="toc-configuration">Configuration</a></li>
 </ul></li>
-<li><a href="#test-selection">Test selection</a><ul>
-<li><a href="#common-test-groups">Common Test Groups</a></li>
-<li><a href="#jtreg">JTReg</a></li>
-<li><a href="#gtest">Gtest</a></li>
-<li><a href="#microbenchmarks">Microbenchmarks</a></li>
-<li><a href="#special-tests">Special tests</a></li>
+<li><a href="#test-selection" id="toc-test-selection">Test selection</a>
+<ul>
+<li><a href="#common-test-groups" id="toc-common-test-groups">Common
+Test Groups</a></li>
+<li><a href="#jtreg" id="toc-jtreg">JTReg</a></li>
+<li><a href="#gtest" id="toc-gtest">Gtest</a></li>
+<li><a href="#microbenchmarks"
+id="toc-microbenchmarks">Microbenchmarks</a></li>
+<li><a href="#special-tests" id="toc-special-tests">Special
+tests</a></li>
 </ul></li>
-<li><a href="#test-results-and-summary">Test results and summary</a></li>
-<li><a href="#test-suite-control">Test suite control</a><ul>
-<li><a href="#general-keywords-test_opts">General keywords (TEST_OPTS)</a></li>
-<li><a href="#jtreg-keywords">JTReg keywords</a></li>
-<li><a href="#gtest-keywords">Gtest keywords</a></li>
-<li><a href="#microbenchmark-keywords">Microbenchmark keywords</a></li>
+<li><a href="#test-results-and-summary"
+id="toc-test-results-and-summary">Test results and summary</a></li>
+<li><a href="#test-suite-control" id="toc-test-suite-control">Test suite
+control</a>
+<ul>
+<li><a href="#general-keywords-test_opts"
+id="toc-general-keywords-test_opts">General keywords
+(TEST_OPTS)</a></li>
+<li><a href="#jtreg-keywords" id="toc-jtreg-keywords">JTReg
+keywords</a></li>
+<li><a href="#gtest-keywords" id="toc-gtest-keywords">Gtest
+keywords</a></li>
+<li><a href="#microbenchmark-keywords"
+id="toc-microbenchmark-keywords">Microbenchmark keywords</a></li>
 </ul></li>
-<li><a href="#notes-for-specific-tests">Notes for Specific Tests</a><ul>
-<li><a href="#docker-tests">Docker Tests</a></li>
-<li><a href="#non-us-locale">Non-US locale</a></li>
-<li><a href="#pkcs11-tests">PKCS11 Tests</a></li>
-<li><a href="#client-ui-tests">Client UI Tests</a></li>
+<li><a href="#notes-for-specific-tests"
+id="toc-notes-for-specific-tests">Notes for Specific Tests</a>
+<ul>
+<li><a href="#docker-tests" id="toc-docker-tests">Docker Tests</a></li>
+<li><a href="#non-us-locale" id="toc-non-us-locale">Non-US
+locale</a></li>
+<li><a href="#pkcs11-tests" id="toc-pkcs11-tests">PKCS11 Tests</a></li>
+<li><a href="#client-ui-tests" id="toc-client-ui-tests">Client UI
+Tests</a></li>
 </ul></li>
-<li><a href="#editing-this-document">Editing this document</a></li>
+<li><a href="#editing-this-document"
+id="toc-editing-this-document">Editing this document</a></li>
 </ul>
 </nav>
 <h2 id="overview">Overview</h2>
-<p>The bulk of JDK tests use <a href="https://openjdk.org/jtreg/">jtreg</a>, a regression test framework and test runner built for the JDK's specific needs. Other test frameworks are also used. The different test frameworks can be executed directly, but there is also a set of make targets intended to simplify the interface, and figure out how to run your tests for you.</p>
-<h2 id="running-tests-locally-with-make-test">Running tests locally with <code>make test</code></h2>
-<p>This is the easiest way to get started. Assuming you've built the JDK locally, execute:</p>
+<p>The bulk of JDK tests use <a
+href="https://openjdk.org/jtreg/">jtreg</a>, a regression test framework
+and test runner built for the JDK's specific needs. Other test
+frameworks are also used. The different test frameworks can be executed
+directly, but there is also a set of make targets intended to simplify
+the interface, and figure out how to run your tests for you.</p>
+<h2 id="running-tests-locally-with-make-test">Running tests locally with
+<code>make test</code></h2>
+<p>This is the easiest way to get started. Assuming you've built the JDK
+locally, execute:</p>
 <pre><code>$ make test</code></pre>
-<p>This will run a default set of tests against the JDK, and present you with the results. <code>make test</code> is part of a family of test-related make targets which simplify running tests, because they invoke the various test frameworks for you. The &quot;make test framework&quot; is simple to start with, but more complex ad-hoc combination of tests is also possible. You can always invoke the test frameworks directly if you want even more control.</p>
+<p>This will run a default set of tests against the JDK, and present you
+with the results. <code>make test</code> is part of a family of
+test-related make targets which simplify running tests, because they
+invoke the various test frameworks for you. The "make test framework" is
+simple to start with, but more complex ad-hoc combination of tests is
+also possible. You can always invoke the test frameworks directly if you
+want even more control.</p>
 <p>Some example command-lines:</p>
 <pre><code>$ make test-tier1
 $ make test-jdk_lang JTREG=&quot;JOBS=8&quot;
@@ -65,54 +107,214 @@ $ make test TEST=&quot;hotspot:hotspot_gc&quot; JTREG=&quot;JOBS=1;TIMEOUT_FACTO
 $ make test TEST=&quot;jtreg:test/hotspot:hotspot_gc test/hotspot/jtreg/native_sanity/JniVersion.java&quot;
 $ make test TEST=&quot;micro:java.lang.reflect&quot; MICRO=&quot;FORK=1;WARMUP_ITER=2&quot;
 $ make exploded-test TEST=tier2</code></pre>
-<p>&quot;tier1&quot; and &quot;tier2&quot; refer to tiered testing, see further down. &quot;TEST&quot; is a test selection argument which the make test framework will use to try to find the tests you want. It iterates over the available test frameworks, and if the test isn't present in one, it tries the next one. The main target <code>test</code> uses the jdk-image as the tested product. There is also an alternate target <code>exploded-test</code> that uses the exploded image instead. Not all tests will run successfully on the exploded image, but using this target can greatly improve rebuild times for certain workflows.</p>
-<p>Previously, <code>make test</code> was used to invoke an old system for running tests, and <code>make run-test</code> was used for the new test framework. For backward compatibility with scripts and muscle memory, <code>run-test</code> and variants like <code>exploded-run-test</code> or <code>run-test-tier1</code> are kept as aliases.</p>
+<p>"tier1" and "tier2" refer to tiered testing, see further down. "TEST"
+is a test selection argument which the make test framework will use to
+try to find the tests you want. It iterates over the available test
+frameworks, and if the test isn't present in one, it tries the next one.
+The main target <code>test</code> uses the jdk-image as the tested
+product. There is also an alternate target <code>exploded-test</code>
+that uses the exploded image instead. Not all tests will run
+successfully on the exploded image, but using this target can greatly
+improve rebuild times for certain workflows.</p>
+<p>Previously, <code>make test</code> was used to invoke an old system
+for running tests, and <code>make run-test</code> was used for the new
+test framework. For backward compatibility with scripts and muscle
+memory, <code>run-test</code> and variants like
+<code>exploded-run-test</code> or <code>run-test-tier1</code> are kept
+as aliases.</p>
 <h3 id="configuration">Configuration</h3>
-<p>To be able to run JTReg tests, <code>configure</code> needs to know where to find the JTReg test framework. If it is not picked up automatically by configure, use the <code>--with-jtreg=&lt;path to jtreg home&gt;</code> option to point to the JTReg framework. Note that this option should point to the JTReg home, i.e. the top directory, containing <code>lib/jtreg.jar</code> etc. (An alternative is to set the <code>JT_HOME</code> environment variable to point to the JTReg home before running <code>configure</code>.)</p>
-<p>To be able to run microbenchmarks, <code>configure</code> needs to know where to find the JMH dependency. Use <code>--with-jmh=&lt;path to JMH jars&gt;</code> to point to a directory containing the core JMH and transitive dependencies. The recommended dependencies can be retrieved by running <code>sh make/devkit/createJMHBundle.sh</code>, after which <code>--with-jmh=build/jmh/jars</code> should work.</p>
-<p>When tests fail or timeout, jtreg runs its failure handler to capture necessary data from the system where the test was run. This data can then be used to analyze the test failures. Collecting this data involves running various commands (which are listed in files residing in <code>test/failure_handler/src/share/conf</code>) and some of these commands use <code>sudo</code>. If the system's <code>sudoers</code> file isn't configured to allow running these commands, then it can result in password being prompted during the failure handler execution. Typically, when running locally, collecting this additional data isn't always necessary. To disable running the failure handler, use <code>--enable-jtreg-failure-handler=no</code> when running <code>configure</code>. If, however, you want to let the failure handler to run and don't want to be prompted for sudo password, then you can configure your <code>sudoers</code> file appropriately. Please read the necessary documentation of your operating system to see how to do that; here we only show one possible way of doing that - edit the <code>/etc/sudoers.d/sudoers</code> file to include the following line:</p>
+<p>To be able to run JTReg tests, <code>configure</code> needs to know
+where to find the JTReg test framework. If it is not picked up
+automatically by configure, use the
+<code>--with-jtreg=&lt;path to jtreg home&gt;</code> option to point to
+the JTReg framework. Note that this option should point to the JTReg
+home, i.e. the top directory, containing <code>lib/jtreg.jar</code> etc.
+(An alternative is to set the <code>JT_HOME</code> environment variable
+to point to the JTReg home before running <code>configure</code>.)</p>
+<p>To be able to run microbenchmarks, <code>configure</code> needs to
+know where to find the JMH dependency. Use
+<code>--with-jmh=&lt;path to JMH jars&gt;</code> to point to a directory
+containing the core JMH and transitive dependencies. The recommended
+dependencies can be retrieved by running
+<code>sh make/devkit/createJMHBundle.sh</code>, after which
+<code>--with-jmh=build/jmh/jars</code> should work.</p>
+<p>When tests fail or timeout, jtreg runs its failure handler to capture
+necessary data from the system where the test was run. This data can
+then be used to analyze the test failures. Collecting this data involves
+running various commands (which are listed in files residing in
+<code>test/failure_handler/src/share/conf</code>) and some of these
+commands use <code>sudo</code>. If the system's <code>sudoers</code>
+file isn't configured to allow running these commands, then it can
+result in password being prompted during the failure handler execution.
+Typically, when running locally, collecting this additional data isn't
+always necessary. To disable running the failure handler, use
+<code>--enable-jtreg-failure-handler=no</code> when running
+<code>configure</code>. If, however, you want to let the failure handler
+to run and don't want to be prompted for sudo password, then you can
+configure your <code>sudoers</code> file appropriately. Please read the
+necessary documentation of your operating system to see how to do that;
+here we only show one possible way of doing that - edit the
+<code>/etc/sudoers.d/sudoers</code> file to include the following
+line:</p>
 <pre><code>johndoe ALL=(ALL) NOPASSWD: /sbin/dmesg</code></pre>
-<p>This line configures <code>sudo</code> to <em>not</em> prompt for password for the <code>/sbin/dmesg</code> command (this is one of the commands that is listed in the files at <code>test/failure_handler/src/share/conf</code>), for the user <code>johndoe</code>. Here <code>johndoe</code> is the user account under which the jtreg tests are run. Replace the username with a relevant user account of your system.</p>
+<p>This line configures <code>sudo</code> to <em>not</em> prompt for
+password for the <code>/sbin/dmesg</code> command (this is one of the
+commands that is listed in the files at
+<code>test/failure_handler/src/share/conf</code>), for the user
+<code>johndoe</code>. Here <code>johndoe</code> is the user account
+under which the jtreg tests are run. Replace the username with a
+relevant user account of your system.</p>
 <h2 id="test-selection">Test selection</h2>
-<p>All functionality is available using the <code>test</code> make target. In this use case, the test or tests to be executed is controlled using the <code>TEST</code> variable. To speed up subsequent test runs with no source code changes, <code>test-only</code> can be used instead, which do not depend on the source and test image build.</p>
-<p>For some common top-level tests, direct make targets have been generated. This includes all JTReg test groups, the hotspot gtest, and custom tests (if present). This means that <code>make test-tier1</code> is equivalent to <code>make test TEST=&quot;tier1&quot;</code>, but the latter is more tab-completion friendly. For more complex test runs, the <code>test TEST=&quot;x&quot;</code> solution needs to be used.</p>
-<p>The test specifications given in <code>TEST</code> is parsed into fully qualified test descriptors, which clearly and unambigously show which tests will be run. As an example, <code>:tier1</code> will expand to <code>jtreg:$(TOPDIR)/test/hotspot/jtreg:tier1 jtreg:$(TOPDIR)/test/jdk:tier1 jtreg:$(TOPDIR)/test/langtools:tier1 jtreg:$(TOPDIR)/test/nashorn:tier1 jtreg:$(TOPDIR)/test/jaxp:tier1</code>. You can always submit a list of fully qualified test descriptors in the <code>TEST</code> variable if you want to shortcut the parser.</p>
+<p>All functionality is available using the <code>test</code> make
+target. In this use case, the test or tests to be executed is controlled
+using the <code>TEST</code> variable. To speed up subsequent test runs
+with no source code changes, <code>test-only</code> can be used instead,
+which do not depend on the source and test image build.</p>
+<p>For some common top-level tests, direct make targets have been
+generated. This includes all JTReg test groups, the hotspot gtest, and
+custom tests (if present). This means that <code>make test-tier1</code>
+is equivalent to <code>make test TEST="tier1"</code>, but the latter is
+more tab-completion friendly. For more complex test runs, the
+<code>test TEST="x"</code> solution needs to be used.</p>
+<p>The test specifications given in <code>TEST</code> is parsed into
+fully qualified test descriptors, which clearly and unambigously show
+which tests will be run. As an example, <code>:tier1</code> will expand
+to
+<code>jtreg:$(TOPDIR)/test/hotspot/jtreg:tier1 jtreg:$(TOPDIR)/test/jdk:tier1 jtreg:$(TOPDIR)/test/langtools:tier1 jtreg:$(TOPDIR)/test/nashorn:tier1 jtreg:$(TOPDIR)/test/jaxp:tier1</code>.
+You can always submit a list of fully qualified test descriptors in the
+<code>TEST</code> variable if you want to shortcut the parser.</p>
 <h3 id="common-test-groups">Common Test Groups</h3>
-<p>Ideally, all tests are run for every change but this may not be practical due to the limited testing resources, the scope of the change, etc.</p>
-<p>The source tree currently defines a few common test groups in the relevant <code>TEST.groups</code> files. There are test groups that cover a specific component, for example <code>hotspot_gc</code>. It is a good idea to look into <code>TEST.groups</code> files to get a sense what tests are relevant to a particular JDK component.</p>
-<p>Component-specific tests may miss some unintended consequences of a change, so other tests should also be run. Again, it might be impractical to run all tests, and therefore <em>tiered</em> test groups exist. Tiered test groups are not component-specific, but rather cover the significant parts of the entire JDK.</p>
-<p>Multiple tiers allow balancing test coverage and testing costs. Lower test tiers are supposed to contain the simpler, quicker and more stable tests. Higher tiers are supposed to contain progressively more thorough, slower, and sometimes less stable tests, or the tests that require special configuration.</p>
-<p>Contributors are expected to run the tests for the areas that are changed, and the first N tiers they can afford to run, but at least tier1.</p>
+<p>Ideally, all tests are run for every change but this may not be
+practical due to the limited testing resources, the scope of the change,
+etc.</p>
+<p>The source tree currently defines a few common test groups in the
+relevant <code>TEST.groups</code> files. There are test groups that
+cover a specific component, for example <code>hotspot_gc</code>. It is a
+good idea to look into <code>TEST.groups</code> files to get a sense
+what tests are relevant to a particular JDK component.</p>
+<p>Component-specific tests may miss some unintended consequences of a
+change, so other tests should also be run. Again, it might be
+impractical to run all tests, and therefore <em>tiered</em> test groups
+exist. Tiered test groups are not component-specific, but rather cover
+the significant parts of the entire JDK.</p>
+<p>Multiple tiers allow balancing test coverage and testing costs. Lower
+test tiers are supposed to contain the simpler, quicker and more stable
+tests. Higher tiers are supposed to contain progressively more thorough,
+slower, and sometimes less stable tests, or the tests that require
+special configuration.</p>
+<p>Contributors are expected to run the tests for the areas that are
+changed, and the first N tiers they can afford to run, but at least
+tier1.</p>
 <p>A brief description of the tiered test groups:</p>
 <ul>
-<li><p><code>tier1</code>: This is the lowest test tier. Multiple developers run these tests every day. Because of the widespread use, the tests in <code>tier1</code> are carefully selected and optimized to run fast, and to run in the most stable manner. The test failures in <code>tier1</code> are usually followed up on quickly, either with fixes, or adding relevant tests to problem list. GitHub Actions workflows, if enabled, run <code>tier1</code> tests.</p></li>
-<li><p><code>tier2</code>: This test group covers even more ground. These contain, among other things, tests that either run for too long to be at <code>tier1</code>, or may require special configuration, or tests that are less stable, or cover the broader range of non-core JVM and JDK features/components(for example, XML).</p></li>
-<li><p><code>tier3</code>: This test group includes more stressful tests, the tests for corner cases not covered by previous tiers, plus the tests that require GUIs. As such, this suite should either be run with low concurrency (<code>TEST_JOBS=1</code>), or without headful tests(<code>JTREG_KEYWORDS=\!headful</code>), or both.</p></li>
-<li><p><code>tier4</code>: This test group includes every other test not covered by previous tiers. It includes, for example, <code>vmTestbase</code> suites for Hotspot, which run for many hours even on large machines. It also runs GUI tests, so the same <code>TEST_JOBS</code> and <code>JTREG_KEYWORDS</code> caveats apply.</p></li>
+<li><p><code>tier1</code>: This is the lowest test tier. Multiple
+developers run these tests every day. Because of the widespread use, the
+tests in <code>tier1</code> are carefully selected and optimized to run
+fast, and to run in the most stable manner. The test failures in
+<code>tier1</code> are usually followed up on quickly, either with
+fixes, or adding relevant tests to problem list. GitHub Actions
+workflows, if enabled, run <code>tier1</code> tests.</p></li>
+<li><p><code>tier2</code>: This test group covers even more ground.
+These contain, among other things, tests that either run for too long to
+be at <code>tier1</code>, or may require special configuration, or tests
+that are less stable, or cover the broader range of non-core JVM and JDK
+features/components(for example, XML).</p></li>
+<li><p><code>tier3</code>: This test group includes more stressful
+tests, the tests for corner cases not covered by previous tiers, plus
+the tests that require GUIs. As such, this suite should either be run
+with low concurrency (<code>TEST_JOBS=1</code>), or without headful
+tests(<code>JTREG_KEYWORDS=\!headful</code>), or both.</p></li>
+<li><p><code>tier4</code>: This test group includes every other test not
+covered by previous tiers. It includes, for example,
+<code>vmTestbase</code> suites for Hotspot, which run for many hours
+even on large machines. It also runs GUI tests, so the same
+<code>TEST_JOBS</code> and <code>JTREG_KEYWORDS</code> caveats
+apply.</p></li>
 </ul>
 <h3 id="jtreg">JTReg</h3>
-<p>JTReg tests can be selected either by picking a JTReg test group, or a selection of files or directories containing JTReg tests. Documentation can be found at <a href="https://openjdk.org/jtreg/">https://openjdk.org/jtreg/</a>, note especially the extensive <a href="https://openjdk.org/jtreg/faq.html">FAQ</a>.</p>
-<p>JTReg test groups can be specified either without a test root, e.g. <code>:tier1</code> (or <code>tier1</code>, the initial colon is optional), or with, e.g. <code>hotspot:tier1</code>, <code>test/jdk:jdk_util</code> or <code>$(TOPDIR)/test/hotspot/jtreg:hotspot_all</code>. The test root can be specified either as an absolute path, or a path relative to the JDK top directory, or the <code>test</code> directory. For simplicity, the hotspot JTReg test root, which really is <code>hotspot/jtreg</code> can be abbreviated as just <code>hotspot</code>.</p>
-<p>When specified without a test root, all matching groups from all test roots will be added. Otherwise, only the group from the specified test root will be added.</p>
-<p>Individual JTReg tests or directories containing JTReg tests can also be specified, like <code>test/hotspot/jtreg/native_sanity/JniVersion.java</code> or <code>hotspot/jtreg/native_sanity</code>. Just like for test root selection, you can either specify an absolute path (which can even point to JTReg tests outside the source tree), or a path relative to either the JDK top directory or the <code>test</code> directory. <code>hotspot</code> can be used as an alias for <code>hotspot/jtreg</code> here as well.</p>
-<p>As long as the test groups or test paths can be uniquely resolved, you do not need to enter the <code>jtreg:</code> prefix. If this is not possible, or if you want to use a fully qualified test descriptor, add <code>jtreg:</code>, e.g. <code>jtreg:test/hotspot/jtreg/native_sanity</code>.</p>
+<p>JTReg tests can be selected either by picking a JTReg test group, or
+a selection of files or directories containing JTReg tests.
+Documentation can be found at <a
+href="https://openjdk.org/jtreg/">https://openjdk.org/jtreg/</a>, note
+especially the extensive <a
+href="https://openjdk.org/jtreg/faq.html">FAQ</a>.</p>
+<p>JTReg test groups can be specified either without a test root, e.g.
+<code>:tier1</code> (or <code>tier1</code>, the initial colon is
+optional), or with, e.g. <code>hotspot:tier1</code>,
+<code>test/jdk:jdk_util</code> or
+<code>$(TOPDIR)/test/hotspot/jtreg:hotspot_all</code>. The test root can
+be specified either as an absolute path, or a path relative to the JDK
+top directory, or the <code>test</code> directory. For simplicity, the
+hotspot JTReg test root, which really is <code>hotspot/jtreg</code> can
+be abbreviated as just <code>hotspot</code>.</p>
+<p>When specified without a test root, all matching groups from all test
+roots will be added. Otherwise, only the group from the specified test
+root will be added.</p>
+<p>Individual JTReg tests or directories containing JTReg tests can also
+be specified, like
+<code>test/hotspot/jtreg/native_sanity/JniVersion.java</code> or
+<code>hotspot/jtreg/native_sanity</code>. Just like for test root
+selection, you can either specify an absolute path (which can even point
+to JTReg tests outside the source tree), or a path relative to either
+the JDK top directory or the <code>test</code> directory.
+<code>hotspot</code> can be used as an alias for
+<code>hotspot/jtreg</code> here as well.</p>
+<p>As long as the test groups or test paths can be uniquely resolved,
+you do not need to enter the <code>jtreg:</code> prefix. If this is not
+possible, or if you want to use a fully qualified test descriptor, add
+<code>jtreg:</code>, e.g.
+<code>jtreg:test/hotspot/jtreg/native_sanity</code>.</p>
 <h3 id="gtest">Gtest</h3>
-<p><strong>Note:</strong> To be able to run the Gtest suite, you need to configure your build to be able to find a proper version of the gtest source. For details, see the section <a href="building.html#running-tests">&quot;Running Tests&quot; in the build documentation</a>.</p>
-<p>Since the Hotspot Gtest suite is so quick, the default is to run all tests. This is specified by just <code>gtest</code>, or as a fully qualified test descriptor <code>gtest:all</code>.</p>
-<p>If you want, you can single out an individual test or a group of tests, for instance <code>gtest:LogDecorations</code> or <code>gtest:LogDecorations.level_test_vm</code>. This can be particularly useful if you want to run a shaky test repeatedly.</p>
-<p>For Gtest, there is a separate test suite for each JVM variant. The JVM variant is defined by adding <code>/&lt;variant&gt;</code> to the test descriptor, e.g. <code>gtest:Log/client</code>. If you specify no variant, gtest will run once for each JVM variant present (e.g. server, client). So if you only have the server JVM present, then <code>gtest:all</code> will be equivalent to <code>gtest:all/server</code>.</p>
+<p><strong>Note:</strong> To be able to run the Gtest suite, you need to
+configure your build to be able to find a proper version of the gtest
+source. For details, see the section <a
+href="building.html#running-tests">"Running Tests" in the build
+documentation</a>.</p>
+<p>Since the Hotspot Gtest suite is so quick, the default is to run all
+tests. This is specified by just <code>gtest</code>, or as a fully
+qualified test descriptor <code>gtest:all</code>.</p>
+<p>If you want, you can single out an individual test or a group of
+tests, for instance <code>gtest:LogDecorations</code> or
+<code>gtest:LogDecorations.level_test_vm</code>. This can be
+particularly useful if you want to run a shaky test repeatedly.</p>
+<p>For Gtest, there is a separate test suite for each JVM variant. The
+JVM variant is defined by adding <code>/&lt;variant&gt;</code> to the
+test descriptor, e.g. <code>gtest:Log/client</code>. If you specify no
+variant, gtest will run once for each JVM variant present (e.g. server,
+client). So if you only have the server JVM present, then
+<code>gtest:all</code> will be equivalent to
+<code>gtest:all/server</code>.</p>
 <h3 id="microbenchmarks">Microbenchmarks</h3>
-<p>Which microbenchmarks to run is selected using a regular expression following the <code>micro:</code> test descriptor, e.g., <code>micro:java.lang.reflect</code>. This delegates the test selection to JMH, meaning package name, class name and even benchmark method names can be used to select tests.</p>
-<p>Using special characters like <code>|</code> in the regular expression is possible, but needs to be escaped multiple times: <code>micro:ArrayCopy\\\\\|reflect</code>.</p>
+<p>Which microbenchmarks to run is selected using a regular expression
+following the <code>micro:</code> test descriptor, e.g.,
+<code>micro:java.lang.reflect</code>. This delegates the test selection
+to JMH, meaning package name, class name and even benchmark method names
+can be used to select tests.</p>
+<p>Using special characters like <code>|</code> in the regular
+expression is possible, but needs to be escaped multiple times:
+<code>micro:ArrayCopy\\\\\|reflect</code>.</p>
 <h3 id="special-tests">Special tests</h3>
-<p>A handful of odd tests that are not covered by any other testing framework are accessible using the <code>special:</code> test descriptor. Currently, this includes <code>failure-handler</code> and <code>make</code>.</p>
+<p>A handful of odd tests that are not covered by any other testing
+framework are accessible using the <code>special:</code> test
+descriptor. Currently, this includes <code>failure-handler</code> and
+<code>make</code>.</p>
 <ul>
-<li><p>Failure handler testing is run using <code>special:failure-handler</code> or just <code>failure-handler</code> as test descriptor.</p></li>
-<li><p>Tests for the build system, including both makefiles and related functionality, is run using <code>special:make</code> or just <code>make</code> as test descriptor. This is equivalent to <code>special:make:all</code>.</p>
-<p>A specific make test can be run by supplying it as argument, e.g. <code>special:make:idea</code>. As a special syntax, this can also be expressed as <code>make-idea</code>, which allows for command lines as <code>make test-make-idea</code>.</p></li>
+<li><p>Failure handler testing is run using
+<code>special:failure-handler</code> or just
+<code>failure-handler</code> as test descriptor.</p></li>
+<li><p>Tests for the build system, including both makefiles and related
+functionality, is run using <code>special:make</code> or just
+<code>make</code> as test descriptor. This is equivalent to
+<code>special:make:all</code>.</p>
+<p>A specific make test can be run by supplying it as argument, e.g.
+<code>special:make:idea</code>. As a special syntax, this can also be
+expressed as <code>make-idea</code>, which allows for command lines as
+<code>make test-make-idea</code>.</p></li>
 </ul>
 <h2 id="test-results-and-summary">Test results and summary</h2>
-<p>At the end of the test run, a summary of all tests run will be presented. This will have a consistent look, regardless of what test suites were used. This is a sample summary:</p>
+<p>At the end of the test run, a summary of all tests run will be
+presented. This will have a consistent look, regardless of what test
+suites were used. This is a sample summary:</p>
 <pre><code>==============================
 Test summary
 ==============================
@@ -122,20 +324,61 @@ Test summary
    jtreg:nashorn/test:tier1                        133   133     0     0
 ==============================
 TEST FAILURE</code></pre>
-<p>Tests where the number of TOTAL tests does not equal the number of PASSed tests will be considered a test failure. These are marked with the <code>&gt;&gt; ... &lt;&lt;</code> marker for easy identification.</p>
-<p>The classification of non-passed tests differs a bit between test suites. In the summary, ERROR is used as a catch-all for tests that neither passed nor are classified as failed by the framework. This might indicate test framework error, timeout or other problems.</p>
-<p>In case of test failures, <code>make test</code> will exit with a non-zero exit value.</p>
-<p>All tests have their result stored in <code>build/$BUILD/test-results/$TEST_ID</code>, where TEST_ID is a path-safe conversion from the fully qualified test descriptor, e.g. for <code>jtreg:jdk/test:tier1</code> the TEST_ID is <code>jtreg_jdk_test_tier1</code>. This path is also printed in the log at the end of the test run.</p>
-<p>Additional work data is stored in <code>build/$BUILD/test-support/$TEST_ID</code>. For some frameworks, this directory might contain information that is useful in determining the cause of a failed test.</p>
+<p>Tests where the number of TOTAL tests does not equal the number of
+PASSed tests will be considered a test failure. These are marked with
+the <code>&gt;&gt; ... &lt;&lt;</code> marker for easy
+identification.</p>
+<p>The classification of non-passed tests differs a bit between test
+suites. In the summary, ERROR is used as a catch-all for tests that
+neither passed nor are classified as failed by the framework. This might
+indicate test framework error, timeout or other problems.</p>
+<p>In case of test failures, <code>make test</code> will exit with a
+non-zero exit value.</p>
+<p>All tests have their result stored in
+<code>build/$BUILD/test-results/$TEST_ID</code>, where TEST_ID is a
+path-safe conversion from the fully qualified test descriptor, e.g. for
+<code>jtreg:jdk/test:tier1</code> the TEST_ID is
+<code>jtreg_jdk_test_tier1</code>. This path is also printed in the log
+at the end of the test run.</p>
+<p>Additional work data is stored in
+<code>build/$BUILD/test-support/$TEST_ID</code>. For some frameworks,
+this directory might contain information that is useful in determining
+the cause of a failed test.</p>
 <h2 id="test-suite-control">Test suite control</h2>
-<p>It is possible to control various aspects of the test suites using make control variables.</p>
-<p>These variables use a keyword=value approach to allow multiple values to be set. So, for instance, <code>JTREG=&quot;JOBS=1;TIMEOUT_FACTOR=8&quot;</code> will set the JTReg concurrency level to 1 and the timeout factor to 8. This is equivalent to setting <code>JTREG_JOBS=1 JTREG_TIMEOUT_FACTOR=8</code>, but using the keyword format means that the <code>JTREG</code> variable is parsed and verified for correctness, so <code>JTREG=&quot;TMIEOUT_FACTOR=8&quot;</code> would give an error, while <code>JTREG_TMIEOUT_FACTOR=8</code> would just pass unnoticed.</p>
-<p>To separate multiple keyword=value pairs, use <code>;</code> (semicolon). Since the shell normally eats <code>;</code>, the recommended usage is to write the assignment inside qoutes, e.g. <code>JTREG=&quot;...;...&quot;</code>. This will also make sure spaces are preserved, as in <code>JTREG=&quot;JAVA_OPTIONS=-XshowSettings -Xlog:gc+ref=debug&quot;</code>.</p>
-<p>(Other ways are possible, e.g. using backslash: <code>JTREG=JOBS=1\;TIMEOUT_FACTOR=8</code>. Also, as a special technique, the string <code>%20</code> will be replaced with space for certain options, e.g. <code>JTREG=JAVA_OPTIONS=-XshowSettings%20-Xlog:gc+ref=debug</code>. This can be useful if you have layers of scripts and have trouble getting proper quoting of command line arguments through.)</p>
-<p>As far as possible, the names of the keywords have been standardized between test suites.</p>
+<p>It is possible to control various aspects of the test suites using
+make control variables.</p>
+<p>These variables use a keyword=value approach to allow multiple values
+to be set. So, for instance,
+<code>JTREG="JOBS=1;TIMEOUT_FACTOR=8"</code> will set the JTReg
+concurrency level to 1 and the timeout factor to 8. This is equivalent
+to setting <code>JTREG_JOBS=1 JTREG_TIMEOUT_FACTOR=8</code>, but using
+the keyword format means that the <code>JTREG</code> variable is parsed
+and verified for correctness, so <code>JTREG="TMIEOUT_FACTOR=8"</code>
+would give an error, while <code>JTREG_TMIEOUT_FACTOR=8</code> would
+just pass unnoticed.</p>
+<p>To separate multiple keyword=value pairs, use <code>;</code>
+(semicolon). Since the shell normally eats <code>;</code>, the
+recommended usage is to write the assignment inside qoutes, e.g.
+<code>JTREG="...;..."</code>. This will also make sure spaces are
+preserved, as in
+<code>JTREG="JAVA_OPTIONS=-XshowSettings -Xlog:gc+ref=debug"</code>.</p>
+<p>(Other ways are possible, e.g. using backslash:
+<code>JTREG=JOBS=1\;TIMEOUT_FACTOR=8</code>. Also, as a special
+technique, the string <code>%20</code> will be replaced with space for
+certain options, e.g.
+<code>JTREG=JAVA_OPTIONS=-XshowSettings%20-Xlog:gc+ref=debug</code>.
+This can be useful if you have layers of scripts and have trouble
+getting proper quoting of command line arguments through.)</p>
+<p>As far as possible, the names of the keywords have been standardized
+between test suites.</p>
 <h3 id="general-keywords-test_opts">General keywords (TEST_OPTS)</h3>
-<p>Some keywords are valid across different test suites. If you want to run tests from multiple test suites, or just don't want to care which test suite specific control variable to use, then you can use the general TEST_OPTS control variable.</p>
-<p>There are also some keywords that applies globally to the test runner system, not to any specific test suites. These are also available as TEST_OPTS keywords.</p>
+<p>Some keywords are valid across different test suites. If you want to
+run tests from multiple test suites, or just don't want to care which
+test suite specific control variable to use, then you can use the
+general TEST_OPTS control variable.</p>
+<p>There are also some keywords that applies globally to the test runner
+system, not to any specific test suites. These are also available as
+TEST_OPTS keywords.</p>
 <h4 id="jobs">JOBS</h4>
 <p>Currently only applies to JTReg.</p>
 <h4 id="timeout_factor">TIMEOUT_FACTOR</h4>
@@ -147,28 +390,49 @@ TEST FAILURE</code></pre>
 <h4 id="aot_modules">AOT_MODULES</h4>
 <p>Applies to JTReg and GTest.</p>
 <h4 id="jcov">JCOV</h4>
-<p>This keywords applies globally to the test runner system. If set to <code>true</code>, it enables JCov coverage reporting for all tests run. To be useful, the JDK under test must be run with a JDK built with JCov instrumentation (<code>configure --with-jcov=&lt;path to directory containing lib/jcov.jar&gt;</code>, <code>make jcov-image</code>).</p>
-<p>The simplest way to run tests with JCov coverage report is to use the special target <code>jcov-test</code> instead of <code>test</code>, e.g. <code>make jcov-test TEST=jdk_lang</code>. This will make sure the JCov image is built, and that JCov reporting is enabled.</p>
-<p>The JCov report is stored in <code>build/$BUILD/test-results/jcov-output/report</code>.</p>
-<p>Please note that running with JCov reporting can be very memory intensive.</p>
+<p>This keywords applies globally to the test runner system. If set to
+<code>true</code>, it enables JCov coverage reporting for all tests run.
+To be useful, the JDK under test must be run with a JDK built with JCov
+instrumentation
+(<code>configure --with-jcov=&lt;path to directory containing lib/jcov.jar&gt;</code>,
+<code>make jcov-image</code>).</p>
+<p>The simplest way to run tests with JCov coverage report is to use the
+special target <code>jcov-test</code> instead of <code>test</code>, e.g.
+<code>make jcov-test TEST=jdk_lang</code>. This will make sure the JCov
+image is built, and that JCov reporting is enabled.</p>
+<p>The JCov report is stored in
+<code>build/$BUILD/test-results/jcov-output/report</code>.</p>
+<p>Please note that running with JCov reporting can be very memory
+intensive.</p>
 <h4 id="jcov_diff_changeset">JCOV_DIFF_CHANGESET</h4>
-<p>While collecting code coverage with JCov, it is also possible to find coverage for only recently changed code. JCOV_DIFF_CHANGESET specifies a source revision. A textual report will be generated showing coverage of the diff between the specified revision and the repository tip.</p>
-<p>The report is stored in <code>build/$BUILD/test-results/jcov-output/diff_coverage_report</code> file.</p>
+<p>While collecting code coverage with JCov, it is also possible to find
+coverage for only recently changed code. JCOV_DIFF_CHANGESET specifies a
+source revision. A textual report will be generated showing coverage of
+the diff between the specified revision and the repository tip.</p>
+<p>The report is stored in
+<code>build/$BUILD/test-results/jcov-output/diff_coverage_report</code>
+file.</p>
 <h3 id="jtreg-keywords">JTReg keywords</h3>
 <h4 id="jobs-1">JOBS</h4>
 <p>The test concurrency (<code>-concurrency</code>).</p>
-<p>Defaults to TEST_JOBS (if set by <code>--with-test-jobs=</code>), otherwise it defaults to JOBS, except for Hotspot, where the default is <em>number of CPU cores/2</em>, but never more than <em>memory size in GB/2</em>.</p>
+<p>Defaults to TEST_JOBS (if set by <code>--with-test-jobs=</code>),
+otherwise it defaults to JOBS, except for Hotspot, where the default is
+<em>number of CPU cores/2</em>, but never more than <em>memory size in
+GB/2</em>.</p>
 <h4 id="timeout_factor-1">TIMEOUT_FACTOR</h4>
 <p>The timeout factor (<code>-timeoutFactor</code>).</p>
 <p>Defaults to 4.</p>
 <h4 id="failure_handler_timeout">FAILURE_HANDLER_TIMEOUT</h4>
-<p>Sets the argument <code>-timeoutHandlerTimeout</code> for JTReg. The default value is 0. This is only valid if the failure handler is built.</p>
+<p>Sets the argument <code>-timeoutHandlerTimeout</code> for JTReg. The
+default value is 0. This is only valid if the failure handler is
+built.</p>
 <h4 id="test_mode">TEST_MODE</h4>
 <p>The test mode (<code>agentvm</code> or <code>othervm</code>).</p>
 <p>Defaults to <code>agentvm</code>.</p>
 <h4 id="assert">ASSERT</h4>
 <p>Enable asserts (<code>-ea -esa</code>, or none).</p>
-<p>Set to <code>true</code> or <code>false</code>. If true, adds <code>-ea -esa</code>. Defaults to true, except for hotspot.</p>
+<p>Set to <code>true</code> or <code>false</code>. If true, adds
+<code>-ea -esa</code>. Defaults to true, except for hotspot.</p>
 <h4 id="verbose">VERBOSE</h4>
 <p>The verbosity level (<code>-verbose</code>).</p>
 <p>Defaults to <code>fail,error,summary</code>.</p>
@@ -176,92 +440,172 @@ TEST FAILURE</code></pre>
 <p>What test data to retain (<code>-retain</code>).</p>
 <p>Defaults to <code>fail,error</code>.</p>
 <h4 id="max_mem">MAX_MEM</h4>
-<p>Limit memory consumption (<code>-Xmx</code> and <code>-vmoption:-Xmx</code>, or none).</p>
-<p>Limit memory consumption for JTReg test framework and VM under test. Set to 0 to disable the limits.</p>
-<p>Defaults to 512m, except for hotspot, where it defaults to 0 (no limit).</p>
+<p>Limit memory consumption (<code>-Xmx</code> and
+<code>-vmoption:-Xmx</code>, or none).</p>
+<p>Limit memory consumption for JTReg test framework and VM under test.
+Set to 0 to disable the limits.</p>
+<p>Defaults to 512m, except for hotspot, where it defaults to 0 (no
+limit).</p>
 <h4 id="max_output">MAX_OUTPUT</h4>
-<p>Set the property <code>javatest.maxOutputSize</code> for the launcher, to change the default JTReg log limit.</p>
+<p>Set the property <code>javatest.maxOutputSize</code> for the
+launcher, to change the default JTReg log limit.</p>
 <h4 id="keywords">KEYWORDS</h4>
-<p>JTReg keywords sent to JTReg using <code>-k</code>. Please be careful in making sure that spaces and special characters (like <code>!</code>) are properly quoted. To avoid some issues, the special value <code>%20</code> can be used instead of space.</p>
+<p>JTReg keywords sent to JTReg using <code>-k</code>. Please be careful
+in making sure that spaces and special characters (like <code>!</code>)
+are properly quoted. To avoid some issues, the special value
+<code>%20</code> can be used instead of space.</p>
 <h4 id="extra_problem_lists">EXTRA_PROBLEM_LISTS</h4>
-<p>Use additional problem lists file or files, in addition to the default ProblemList.txt located at the JTReg test roots.</p>
-<p>If multiple file names are specified, they should be separated by space (or, to help avoid quoting issues, the special value <code>%20</code>).</p>
-<p>The file names should be either absolute, or relative to the JTReg test root of the tests to be run.</p>
+<p>Use additional problem lists file or files, in addition to the
+default ProblemList.txt located at the JTReg test roots.</p>
+<p>If multiple file names are specified, they should be separated by
+space (or, to help avoid quoting issues, the special value
+<code>%20</code>).</p>
+<p>The file names should be either absolute, or relative to the JTReg
+test root of the tests to be run.</p>
 <h4 id="run_problem_lists">RUN_PROBLEM_LISTS</h4>
 <p>Use the problem lists to select tests instead of excluding them.</p>
-<p>Set to <code>true</code> or <code>false</code>. If <code>true</code>, JTReg will use <code>-match:</code> option, otherwise <code>-exclude:</code> will be used. Default is <code>false</code>.</p>
+<p>Set to <code>true</code> or <code>false</code>. If <code>true</code>,
+JTReg will use <code>-match:</code> option, otherwise
+<code>-exclude:</code> will be used. Default is <code>false</code>.</p>
 <h4 id="options">OPTIONS</h4>
 <p>Additional options to the JTReg test framework.</p>
-<p>Use <code>JTREG=&quot;OPTIONS=--help all&quot;</code> to see all available JTReg options.</p>
+<p>Use <code>JTREG="OPTIONS=--help all"</code> to see all available
+JTReg options.</p>
 <h4 id="java_options-1">JAVA_OPTIONS</h4>
-<p>Additional Java options for running test classes (sent to JTReg as <code>-javaoption</code>).</p>
+<p>Additional Java options for running test classes (sent to JTReg as
+<code>-javaoption</code>).</p>
 <h4 id="vm_options-1">VM_OPTIONS</h4>
-<p>Additional Java options to be used when compiling and running classes (sent to JTReg as <code>-vmoption</code>).</p>
-<p>This option is only needed in special circumstances. To pass Java options to your test classes, use <code>JAVA_OPTIONS</code>.</p>
+<p>Additional Java options to be used when compiling and running classes
+(sent to JTReg as <code>-vmoption</code>).</p>
+<p>This option is only needed in special circumstances. To pass Java
+options to your test classes, use <code>JAVA_OPTIONS</code>.</p>
 <h4 id="launcher_options">LAUNCHER_OPTIONS</h4>
-<p>Additional Java options that are sent to the java launcher that starts the JTReg harness.</p>
+<p>Additional Java options that are sent to the java launcher that
+starts the JTReg harness.</p>
 <h4 id="aot_modules-1">AOT_MODULES</h4>
-<p>Generate AOT modules before testing for the specified module, or set of modules. If multiple modules are specified, they should be separated by space (or, to help avoid quoting issues, the special value <code>%20</code>).</p>
+<p>Generate AOT modules before testing for the specified module, or set
+of modules. If multiple modules are specified, they should be separated
+by space (or, to help avoid quoting issues, the special value
+<code>%20</code>).</p>
 <h4 id="retry_count">RETRY_COUNT</h4>
-<p>Retry failed tests up to a set number of times, until they pass. This allows to pass the tests with intermittent failures. Defaults to 0.</p>
+<p>Retry failed tests up to a set number of times, until they pass. This
+allows to pass the tests with intermittent failures. Defaults to 0.</p>
 <h4 id="repeat_count">REPEAT_COUNT</h4>
-<p>Repeat the tests up to a set number of times, stopping at first failure. This helps to reproduce intermittent test failures. Defaults to 0.</p>
+<p>Repeat the tests up to a set number of times, stopping at first
+failure. This helps to reproduce intermittent test failures. Defaults to
+0.</p>
 <h3 id="gtest-keywords">Gtest keywords</h3>
 <h4 id="repeat">REPEAT</h4>
-<p>The number of times to repeat the tests (<code>--gtest_repeat</code>).</p>
-<p>Default is 1. Set to -1 to repeat indefinitely. This can be especially useful combined with <code>OPTIONS=--gtest_break_on_failure</code> to reproduce an intermittent problem.</p>
+<p>The number of times to repeat the tests
+(<code>--gtest_repeat</code>).</p>
+<p>Default is 1. Set to -1 to repeat indefinitely. This can be
+especially useful combined with
+<code>OPTIONS=--gtest_break_on_failure</code> to reproduce an
+intermittent problem.</p>
 <h4 id="options-1">OPTIONS</h4>
 <p>Additional options to the Gtest test framework.</p>
-<p>Use <code>GTEST=&quot;OPTIONS=--help&quot;</code> to see all available Gtest options.</p>
+<p>Use <code>GTEST="OPTIONS=--help"</code> to see all available Gtest
+options.</p>
 <h4 id="aot_modules-2">AOT_MODULES</h4>
-<p>Generate AOT modules before testing for the specified module, or set of modules. If multiple modules are specified, they should be separated by space (or, to help avoid quoting issues, the special value <code>%20</code>).</p>
+<p>Generate AOT modules before testing for the specified module, or set
+of modules. If multiple modules are specified, they should be separated
+by space (or, to help avoid quoting issues, the special value
+<code>%20</code>).</p>
 <h3 id="microbenchmark-keywords">Microbenchmark keywords</h3>
 <h4 id="fork">FORK</h4>
-<p>Override the number of benchmark forks to spawn. Same as specifying <code>-f &lt;num&gt;</code>.</p>
+<p>Override the number of benchmark forks to spawn. Same as specifying
+<code>-f &lt;num&gt;</code>.</p>
 <h4 id="iter">ITER</h4>
-<p>Number of measurement iterations per fork. Same as specifying <code>-i &lt;num&gt;</code>.</p>
+<p>Number of measurement iterations per fork. Same as specifying
+<code>-i &lt;num&gt;</code>.</p>
 <h4 id="time">TIME</h4>
-<p>Amount of time to spend in each measurement iteration, in seconds. Same as specifying <code>-r &lt;num&gt;</code></p>
+<p>Amount of time to spend in each measurement iteration, in seconds.
+Same as specifying <code>-r &lt;num&gt;</code></p>
 <h4 id="warmup_iter">WARMUP_ITER</h4>
-<p>Number of warmup iterations to run before the measurement phase in each fork. Same as specifying <code>-wi &lt;num&gt;</code>.</p>
+<p>Number of warmup iterations to run before the measurement phase in
+each fork. Same as specifying <code>-wi &lt;num&gt;</code>.</p>
 <h4 id="warmup_time">WARMUP_TIME</h4>
-<p>Amount of time to spend in each warmup iteration. Same as specifying <code>-w &lt;num&gt;</code>.</p>
+<p>Amount of time to spend in each warmup iteration. Same as specifying
+<code>-w &lt;num&gt;</code>.</p>
 <h4 id="results_format">RESULTS_FORMAT</h4>
-<p>Specify to have the test run save a log of the values. Accepts the same values as <code>-rff</code>, i.e., <code>text</code>, <code>csv</code>, <code>scsv</code>, <code>json</code>, or <code>latex</code>.</p>
+<p>Specify to have the test run save a log of the values. Accepts the
+same values as <code>-rff</code>, i.e., <code>text</code>,
+<code>csv</code>, <code>scsv</code>, <code>json</code>, or
+<code>latex</code>.</p>
 <h4 id="vm_options-2">VM_OPTIONS</h4>
-<p>Additional VM arguments to provide to forked off VMs. Same as <code>-jvmArgs &lt;args&gt;</code></p>
+<p>Additional VM arguments to provide to forked off VMs. Same as
+<code>-jvmArgs &lt;args&gt;</code></p>
 <h4 id="options-2">OPTIONS</h4>
 <p>Additional arguments to send to JMH.</p>
 <h2 id="notes-for-specific-tests">Notes for Specific Tests</h2>
 <h3 id="docker-tests">Docker Tests</h3>
-<p>Docker tests with default parameters may fail on systems with glibc versions not compatible with the one used in the default docker image (e.g., Oracle Linux 7.6 for x86). For example, they pass on Ubuntu 16.04 but fail on Ubuntu 18.04 if run like this on x86:</p>
+<p>Docker tests with default parameters may fail on systems with glibc
+versions not compatible with the one used in the default docker image
+(e.g., Oracle Linux 7.6 for x86). For example, they pass on Ubuntu 16.04
+but fail on Ubuntu 18.04 if run like this on x86:</p>
 <pre><code>$ make test TEST=&quot;jtreg:test/hotspot/jtreg/containers/docker&quot;</code></pre>
-<p>To run these tests correctly, additional parameters for the correct docker image are required on Ubuntu 18.04 by using <code>JAVA_OPTIONS</code>.</p>
+<p>To run these tests correctly, additional parameters for the correct
+docker image are required on Ubuntu 18.04 by using
+<code>JAVA_OPTIONS</code>.</p>
 <pre><code>$ make test TEST=&quot;jtreg:test/hotspot/jtreg/containers/docker&quot; \
     JTREG=&quot;JAVA_OPTIONS=-Djdk.test.docker.image.name=ubuntu
     -Djdk.test.docker.image.version=latest&quot;</code></pre>
 <h3 id="non-us-locale">Non-US locale</h3>
-<p>If your locale is non-US, some tests are likely to fail. To work around this you can set the locale to US. On Unix platforms simply setting <code>LANG=&quot;en_US&quot;</code> in the environment before running tests should work. On Windows or MacOS, setting <code>JTREG=&quot;VM_OPTIONS=-Duser.language=en -Duser.country=US&quot;</code> helps for most, but not all test cases.</p>
+<p>If your locale is non-US, some tests are likely to fail. To work
+around this you can set the locale to US. On Unix platforms simply
+setting <code>LANG="en_US"</code> in the environment before running
+tests should work. On Windows or MacOS, setting
+<code>JTREG="VM_OPTIONS=-Duser.language=en -Duser.country=US"</code>
+helps for most, but not all test cases.</p>
 <p>For example:</p>
 <pre><code>$ export LANG=&quot;en_US&quot; &amp;&amp; make test TEST=...
 $ make test JTREG=&quot;VM_OPTIONS=-Duser.language=en -Duser.country=US&quot; TEST=...</code></pre>
 <h3 id="pkcs11-tests">PKCS11 Tests</h3>
-<p>It is highly recommended to use the latest NSS version when running PKCS11 tests. Improper NSS version may lead to unexpected failures which are hard to diagnose. For example, sun/security/pkcs11/Secmod/AddTrustedCert.java may fail on Ubuntu 18.04 with the default NSS version in the system. To run these tests correctly, the system property <code>test.nss.lib.paths</code> is required on Ubuntu 18.04 to specify the alternative NSS lib directories.</p>
+<p>It is highly recommended to use the latest NSS version when running
+PKCS11 tests. Improper NSS version may lead to unexpected failures which
+are hard to diagnose. For example,
+sun/security/pkcs11/Secmod/AddTrustedCert.java may fail on Ubuntu 18.04
+with the default NSS version in the system. To run these tests
+correctly, the system property <code>test.nss.lib.paths</code> is
+required on Ubuntu 18.04 to specify the alternative NSS lib
+directories.</p>
 <p>For example:</p>
 <pre><code>$ make test TEST=&quot;jtreg:sun/security/pkcs11/Secmod/AddTrustedCert.java&quot; \
     JTREG=&quot;JAVA_OPTIONS=-Dtest.nss.lib.paths=/path/to/your/latest/NSS-libs&quot;</code></pre>
-<p>For more notes about the PKCS11 tests, please refer to test/jdk/sun/security/pkcs11/README.</p>
+<p>For more notes about the PKCS11 tests, please refer to
+test/jdk/sun/security/pkcs11/README.</p>
 <h3 id="client-ui-tests">Client UI Tests</h3>
-<p>Some Client UI tests use key sequences which may be reserved by the operating system. Usually that causes the test failure. So it is highly recommended to disable system key shortcuts prior testing. The steps to access and disable system key shortcuts for various platforms are provided below.</p>
+<p>Some Client UI tests use key sequences which may be reserved by the
+operating system. Usually that causes the test failure. So it is highly
+recommended to disable system key shortcuts prior testing. The steps to
+access and disable system key shortcuts for various platforms are
+provided below.</p>
 <h4 id="macos">MacOS</h4>
-<p>Choose Apple menu; System Preferences, click Keyboard, then click Shortcuts; select or deselect desired shortcut.</p>
-<p>For example, test/jdk/javax/swing/TooltipManager/JMenuItemToolTipKeyBindingsTest/JMenuItemToolTipKeyBindingsTest.java fails on MacOS because it uses <code>CTRL + F1</code> key sequence to show or hide tooltip message but the key combination is reserved by the operating system. To run the test correctly the default global key shortcut should be disabled using the steps described above, and then deselect &quot;Turn keyboard access on or off&quot; option which is responsible for <code>CTRL + F1</code> combination.</p>
+<p>Choose Apple menu; System Preferences, click Keyboard, then click
+Shortcuts; select or deselect desired shortcut.</p>
+<p>For example,
+test/jdk/javax/swing/TooltipManager/JMenuItemToolTipKeyBindingsTest/JMenuItemToolTipKeyBindingsTest.java
+fails on MacOS because it uses <code>CTRL + F1</code> key sequence to
+show or hide tooltip message but the key combination is reserved by the
+operating system. To run the test correctly the default global key
+shortcut should be disabled using the steps described above, and then
+deselect "Turn keyboard access on or off" option which is responsible
+for <code>CTRL + F1</code> combination.</p>
 <h4 id="linux">Linux</h4>
-<p>Open the Activities overview and start typing Settings; Choose Settings, click Devices, then click Keyboard; set or override desired shortcut.</p>
+<p>Open the Activities overview and start typing Settings; Choose
+Settings, click Devices, then click Keyboard; set or override desired
+shortcut.</p>
 <h4 id="windows">Windows</h4>
-<p>Type <code>gpedit</code> in the Search and then click Edit group policy; navigate to User Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; File Explorer; in the right-side pane look for &quot;Turn off Windows key hotkeys&quot; and double click on it; enable or disable hotkeys.</p>
+<p>Type <code>gpedit</code> in the Search and then click Edit group
+policy; navigate to User Configuration -&gt; Administrative Templates
+-&gt; Windows Components -&gt; File Explorer; in the right-side pane
+look for "Turn off Windows key hotkeys" and double click on it; enable
+or disable hotkeys.</p>
 <p>Note: restart is required to make the settings take effect.</p>
 <h2 id="editing-this-document">Editing this document</h2>
-<p>If you want to contribute changes to this document, edit <code>doc/testing.md</code> and then run <code>make update-build-docs</code> to generate the same changes in <code>doc/testing.html</code>.</p>
+<p>If you want to contribute changes to this document, edit
+<code>doc/testing.md</code> and then run
+<code>make update-build-docs</code> to generate the same changes in
+<code>doc/testing.html</code>.</p>
 </body>
 </html>


### PR DESCRIPTION
Following JDK-8297165, we should regenerate all checked in html files using pandoc 1.19.2, to avoid spurious changes to the files with future changes to the markdown source files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297353](https://bugs.openjdk.org/browse/JDK-8297353): Regenerated checked-in html files with new pandoc


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11274/head:pull/11274` \
`$ git checkout pull/11274`

Update a local copy of the PR: \
`$ git checkout pull/11274` \
`$ git pull https://git.openjdk.org/jdk pull/11274/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11274`

View PR using the GUI difftool: \
`$ git pr show -t 11274`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11274.diff">https://git.openjdk.org/jdk/pull/11274.diff</a>

</details>
