### PR TITLE
8297338: JFR: RemoteRecordingStream doesn't respect setMaxAge and setMaxSize

### DIFF
--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
@@ -156,7 +156,10 @@ public final class RemoteRecordingStream implements EventStream {
     volatile Instant startTime;
     volatile Instant endTime;
     volatile boolean closed;
-    private boolean started; // always guarded by lock
+    // always guarded by lock
+    private boolean started;
+    private Duration maxAge;
+    private long maxSize;
 
     /**
      * Creates an event stream that operates against a {@link MBeanServerConnection}
@@ -415,7 +418,11 @@ public final class RemoteRecordingStream implements EventStream {
      */
     public void setMaxAge(Duration maxAge) {
         Objects.requireNonNull(maxAge);
-        repository.setMaxAge(maxAge);
+        synchronized (lock) {
+            repository.setMaxAge(maxAge);
+            this.maxAge = maxAge;
+            updateOnCompleteHandler();
+        }
     }
 
     /**
@@ -441,7 +448,11 @@ public final class RemoteRecordingStream implements EventStream {
         if (maxSize < 0) {
             throw new IllegalArgumentException("Max size of recording can't be negative");
         }
-        repository.setMaxSize(maxSize);
+        synchronized (lock) {
+            repository.setMaxSize(maxSize);
+            this.maxSize = maxSize;
+            updateOnCompleteHandler();
+        }
     }
 
     @Override
@@ -643,6 +654,15 @@ public final class RemoteRecordingStream implements EventStream {
 
     private static Path makeTempDirectory() throws IOException {
         return Files.createTempDirectory("jfr-streaming");
+    }
+
+    private void updateOnCompleteHandler() {
+        if (maxAge != null || maxSize != 0) {
+            // User has set a chunk removal policy
+            ManagementSupport.setOnChunkCompleteHandler(stream, null);
+        } else {
+            ManagementSupport.setOnChunkCompleteHandler(stream, new ChunkConsumer(repository));
+        }
     }
 
     private void startDownload() {

--- a/test/jdk/jdk/jfr/jmx/streaming/TestDumpOrder.java
+++ b/test/jdk/jdk/jfr/jmx/streaming/TestDumpOrder.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.jmx.streaming;
+
+import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.management.MBeanServerConnection;
+
+import jdk.jfr.Event;
+import jdk.jfr.StackTrace;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+import jdk.management.jfr.RemoteRecordingStream;
+
+/**
+ * @test
+ * @key jfr
+ * @summary Tests that evenst arrive in the same order they were comitted
+ * @requires vm.hasJFR
+ * @library /test/lib /test/jdk
+ * @run main/othervm jdk.jfr.jmx.streaming.TestDumpOrder
+ */
+public class TestDumpOrder {
+
+    private static final MBeanServerConnection CONNECTION = ManagementFactory.getPlatformMBeanServer();
+
+    @StackTrace(false)
+    static class Ant extends Event {
+        long id;
+    }
+
+    public static void main(String... args) throws Exception {
+        // Set up the test so half of the events have been consumed
+        // when the dump occurs.
+        AtomicLong eventCount = new AtomicLong();
+        CountDownLatch halfLatch = new CountDownLatch(1);
+        CountDownLatch dumpLatch = new CountDownLatch(1);
+        Path directory = Path.of("chunks");
+        Files.createDirectory(directory);
+        try (var rs = new RemoteRecordingStream(CONNECTION, directory)) {
+            rs.setMaxSize(100_000_000); // keep all data
+            rs.onEvent(event -> {
+                try {
+                    eventCount.incrementAndGet();
+                    if (eventCount.get() == 10) {
+                        halfLatch.countDown();
+                        dumpLatch.await();
+                    }
+                } catch (InterruptedException ie) {
+                    ie.printStackTrace();
+                }
+            });
+            rs.setOrdered(true);
+            rs.startAsync();
+            long counter = 0;
+            for (int i = 0; i < 10; i++) {
+                try (Recording r = new Recording()) {
+                    r.start();
+                    Ant a = new Ant();
+                    a.id = counter++;
+                    a.commit();
+                    Ant b = new Ant();
+                    b.id = counter++;
+                    b.commit();
+                }
+                if (counter == 10) {
+                    halfLatch.await();
+                }
+            }
+            Path file = Path.of("events.jfr");
+            // Wait for most (but not all) chunk files to be downloaded
+            // before dumping
+            awaitChunkFiles(directory);
+            rs.dump(file);
+            // release consumer thread
+            dumpLatch.countDown();
+            // Print event order for debugging purposes
+            List<RecordedEvent> events = RecordingFile.readAllEvents(file);
+            for (var event : events) {
+                System.out.println(event);
+            }
+            long expected = 0;
+            for (var event : RecordingFile.readAllEvents(file)) {
+                long value = event.getLong("id");
+                if (value != expected) {
+                    throw new Exception("Expected " + expected + ", got " + value);
+                }
+                expected = value + 1;
+            }
+        }
+    }
+
+    private static void awaitChunkFiles(Path directory) throws Exception {
+        while (true) {
+            if (Files.list(directory).count() > 6) {
+                return;
+            }
+            Thread.sleep(10);
+        }
+    }
+}

--- a/test/jdk/jdk/jfr/jmx/streaming/TestDumpOrder.java
+++ b/test/jdk/jdk/jfr/jmx/streaming/TestDumpOrder.java
@@ -116,6 +116,9 @@ public class TestDumpOrder {
                 }
                 expected++;
             }
+            if (expected != counter) {
+                throw new Exception("Not all events found");
+            }
         }
     }
 

--- a/test/jdk/jdk/jfr/jmx/streaming/TestRemoteDump.java
+++ b/test/jdk/jdk/jfr/jmx/streaming/TestRemoteDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/jfr/jmx/streaming/TestRemoteDump.java
+++ b/test/jdk/jdk/jfr/jmx/streaming/TestRemoteDump.java
@@ -26,16 +26,19 @@ import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import javax.management.MBeanServerConnection;
 
 import jdk.jfr.Event;
 import jdk.jfr.Name;
+import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordingFile;
 import jdk.jfr.consumer.RecordingStream;
@@ -63,6 +66,9 @@ public class TestRemoteDump {
         testOneDump();
         testMultipleDumps();
         testEventAfterDump();
+        testSetNoPolicy();
+        testSetMaxAge();
+        testSetMaxSize();
     }
 
     private static void testUnstarted() throws Exception {
@@ -88,6 +94,70 @@ public class TestRemoteDump {
             throw new Exception("Should not be able to dump closed recording");
         } catch (IOException ise) {
             // OK, expected
+        }
+    }
+
+    private static List<RecordedEvent> recordWithPolicy(String filename, Consumer<RemoteRecordingStream> policy) throws Exception {
+        CountDownLatch latch1 = new CountDownLatch(1);
+        CountDownLatch latch2 = new CountDownLatch(2);
+        CountDownLatch latch3 = new CountDownLatch(3);
+        try (var rs = new RemoteRecordingStream(CONNECTION)) {
+            policy.accept(rs);
+            rs.onEvent(e -> {
+                latch1.countDown();
+                latch2.countDown();
+                latch3.countDown();
+            });
+            rs.startAsync();
+            DumpEvent e1 = new DumpEvent();
+            e1.commit();
+            latch1.await();
+            // Force chunk rotation
+            try (Recording r = new Recording()) {
+                r.start();
+                DumpEvent e2 = new DumpEvent();
+                e2.commit();
+            }
+            latch2.await();
+            DumpEvent e3 = new DumpEvent();
+            e3.commit();
+            latch3.await();
+            Path p = Path.of(filename);
+            rs.dump(p);
+            return RecordingFile.readAllEvents(p);
+        }
+    }
+
+    private static void testSetMaxSize() throws Exception {
+        var events = recordWithPolicy("max-size.jfr", rs -> {
+            // keeps all events for the dump
+            rs.setMaxSize(100_000_000);
+        });
+        if (events.size() != 3) {
+            throw new Exception("Expected all 3 events to be in dump after setMaxSize");
+        }
+
+    }
+
+    private static void testSetMaxAge() throws Exception {
+        var events = recordWithPolicy("max-age.jfr", rs -> {
+            // keeps all events for the dump
+            rs.setMaxAge(Duration.ofDays(1));
+        });
+        if (events.size() != 3) {
+            throw new Exception("Expected all 3 events to be in dump after setMaxAge");
+        }
+
+    }
+
+    private static void testSetNoPolicy() throws Exception {
+        var events = recordWithPolicy("no-policy.jfr", rs -> {
+            // use default policy, remove after consumption
+        });
+        // Since latch3 have been triggered at least two events/chunks
+        // before must have been consumed, possibly 3, but it's a race.
+        if (events.size() > 1) {
+            throw new Exception("Expected at most one event to not be consumed");
         }
     }
 


### PR DESCRIPTION
Could I have a review of a PR  that fixes so event data is kept in the disk repository if max age or max size have been set. This is similar implementation as RecordingStream:
https://github.com/openjdk/jdk/blob/b366d17a94e5b16710fd915ef4cf04aaf911b455/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java#L287

I also fixed a problem where chunks may we written out of order in the dump file and disk chunks not being released properly in case of an IOException. To make the code easier to understand, the code uses more logical methods when interacting with the Deque , such as peekLast(), pollLast() and addFirst().

Testing: 100 * test/jdk/jdk/jfr/jmx/stream/TestRemoteDump.java + 1 * test/jdk/jdk/jfr/

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297338](https://bugs.openjdk.org/browse/JDK-8297338): JFR: RemoteRecordingStream doesn't respect setMaxAge and setMaxSize


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11275/head:pull/11275` \
`$ git checkout pull/11275`

Update a local copy of the PR: \
`$ git checkout pull/11275` \
`$ git pull https://git.openjdk.org/jdk pull/11275/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11275`

View PR using the GUI difftool: \
`$ git pr show -t 11275`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11275.diff">https://git.openjdk.org/jdk/pull/11275.diff</a>

</details>
