### PR TITLE
8202931: [macos] java/awt/Choice/ChoicePopupLocation/ChoicePopupLocation.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -421,7 +421,6 @@ java/awt/image/VolatileImage/GradientPaints.java 8199003 linux-all
 java/awt/JAWT/JAWT.sh 8197798 windows-all,linux-all
 java/awt/datatransfer/ConstructFlavoredObjectTest/ConstructFlavoredObjectTest.java 8202860 linux-all
 java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java 8202882 linux-all
-java/awt/Choice/ChoicePopupLocation/ChoicePopupLocation.java 8202931 macosx-all,linux-all
 java/awt/Focus/NonFocusableBlockedOwnerTest/NonFocusableBlockedOwnerTest.java 7124275 macosx-all
 java/awt/Focus/TranserFocusToWindow/TranserFocusToWindow.java 6848810 macosx-all,linux-all
 java/awt/FileDialog/ModalFocus/FileDialogModalFocusTest.java 8194751 linux-all

--- a/test/jdk/java/awt/Choice/ChoicePopupLocation/ChoicePopupLocation.java
+++ b/test/jdk/java/awt/Choice/ChoicePopupLocation/ChoicePopupLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,10 @@ import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.Toolkit;
 import java.awt.event.InputEvent;
+import java.awt.image.BufferedImage;
+import java.io.File;
+
+import javax.imageio.ImageIO;
 
 /**
  * @test
@@ -120,6 +124,11 @@ public final class ChoicePopupLocation {
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.waitForIdle();
         if (choice.getSelectedIndex() == 0) {
+            GraphicsConfiguration ge = GraphicsEnvironment
+                    .getLocalGraphicsEnvironment().getDefaultScreenDevice()
+                    .getDefaultConfiguration();
+            BufferedImage failImage = robot.createScreenCapture(ge.getBounds());
+            ImageIO.write(failImage, "png", new File("failImage.png"));
             throw new RuntimeException();
         }
     }

--- a/test/jdk/java/awt/Choice/ChoicePopupLocation/ChoicePopupLocation.java
+++ b/test/jdk/java/awt/Choice/ChoicePopupLocation/ChoicePopupLocation.java
@@ -48,6 +48,7 @@ public final class ChoicePopupLocation {
 
     private static final int SIZE = 350;
     private static int frameWidth;
+    private static Rectangle bounds;
 
     public static void main(final String[] args) throws Exception {
         GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
@@ -56,7 +57,7 @@ public final class ChoicePopupLocation {
         Point right = null;
         for (GraphicsDevice sd : sds) {
             GraphicsConfiguration gc = sd.getDefaultConfiguration();
-            Rectangle bounds = gc.getBounds();
+            bounds = gc.getBounds();
             if (left == null || left.x > bounds.x) {
                 left = new Point(bounds.x, bounds.y + bounds.height / 2);
             }
@@ -127,7 +128,7 @@ public final class ChoicePopupLocation {
             GraphicsConfiguration ge = GraphicsEnvironment
                     .getLocalGraphicsEnvironment().getDefaultScreenDevice()
                     .getDefaultConfiguration();
-            BufferedImage failImage = robot.createScreenCapture(ge.getBounds());
+            BufferedImage failImage = robot.createScreenCapture(bounds);
             ImageIO.write(failImage, "png", new File("failImage.png"));
             throw new RuntimeException();
         }

--- a/test/jdk/java/awt/Choice/ChoicePopupLocation/ChoicePopupLocation.java
+++ b/test/jdk/java/awt/Choice/ChoicePopupLocation/ChoicePopupLocation.java
@@ -125,9 +125,6 @@ public final class ChoicePopupLocation {
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.waitForIdle();
         if (choice.getSelectedIndex() == 0) {
-            GraphicsConfiguration ge = GraphicsEnvironment
-                    .getLocalGraphicsEnvironment().getDefaultScreenDevice()
-                    .getDefaultConfiguration();
             BufferedImage failImage = robot.createScreenCapture(bounds);
             ImageIO.write(failImage, "png", new File("failImage.png"));
             throw new RuntimeException();


### PR DESCRIPTION
Test ran on all OS 100 times and passed. Test previously failed on macOS but no longer reproducible. Added screen capture on moment of failure to have more evidence of failures in the future (previously a runtime exception was thrown only).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8202931](https://bugs.openjdk.org/browse/JDK-8202931): [macos] java/awt/Choice/ChoicePopupLocation/ChoicePopupLocation.java fails


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11277/head:pull/11277` \
`$ git checkout pull/11277`

Update a local copy of the PR: \
`$ git checkout pull/11277` \
`$ git pull https://git.openjdk.org/jdk pull/11277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11277`

View PR using the GUI difftool: \
`$ git pr show -t 11277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11277.diff">https://git.openjdk.org/jdk/pull/11277.diff</a>

</details>
