### PR TITLE
8295424: adjust timeout for another JLI GetObjectSizeIntrinsicsTest.java subtest

### DIFF
--- a/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
+++ b/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
@@ -288,7 +288,7 @@
  *                   -Xbatch -XX:TieredStopAtLevel=1
  *                   -javaagent:basicAgent.jar GetObjectSizeIntrinsicsTest GetObjectSizeIntrinsicsTest large
  *
- * @run main/othervm -Xmx8g
+ * @run main/othervm/timeout=180 -Xmx8g
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  *                   -Xbatch -XX:-TieredCompilation
  *                   -javaagent:basicAgent.jar GetObjectSizeIntrinsicsTest GetObjectSizeIntrinsicsTest large

--- a/test/jdk/jdk/internal/vm/Continuation/Fuzz.java
+++ b/test/jdk/jdk/internal/vm/Continuation/Fuzz.java
@@ -72,6 +72,9 @@ import jdk.internal.vm.annotation.DontInline;
 import jdk.test.lib.Utils;
 import jdk.test.whitebox.WhiteBox;
 
+import jdk.test.lib.Platform;
+import jtreg.SkippedException;
+
 public class Fuzz implements Runnable {
     static final boolean VERIFY_STACK = true; // could add significant time
     static final boolean FILE    = true;
@@ -84,6 +87,10 @@ public class Fuzz implements Runnable {
     static final Path TEST_DIR = Path.of(System.getProperty("test.src", "."));
 
     public static void main(String[] args) {
+        if (Platform.isSlowDebugBuild() && Platform.isOSX() && Platform.isAArch64()) {
+            throw new SkippedException("Test is unstable with slowdebug bits "
+                                       + "on macosx-aarch64");
+        }
         warmup();
         for (int compileLevel : new int[]{4}) {
             for (boolean compileRun : new boolean[]{true}) {

--- a/test/langtools/jdk/javadoc/doclet/testLinkOption/TestRedirectLinks.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkOption/TestRedirectLinks.java
@@ -26,11 +26,14 @@
  * @bug 8190312
  * @summary test redirected URLs for -link
  * @library /tools/lib ../../lib
+ * @library /test/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  *          jdk.javadoc/jdk.javadoc.internal.api
  *          jdk.javadoc/jdk.javadoc.internal.tool
  * @build toolbox.ToolBox toolbox.JavacTask javadoc.tester.*
+ * @build jtreg.SkippedException
+ * @build jdk.test.lib.Platform
  * @run main TestRedirectLinks
  */
 
@@ -66,12 +69,18 @@ import javadoc.tester.JavadocTester;
 import toolbox.JavacTask;
 import toolbox.ToolBox;
 
+import jdk.test.lib.Platform;
+import jtreg.SkippedException;
+
 public class TestRedirectLinks extends JavadocTester {
     /**
      * The entry point of the test.
      * @param args the array of command line arguments.
      */
     public static void main(String... args) throws Exception {
+        if (Platform.isSlowDebugBuild()) {
+            throw new SkippedException("Test is unstable with slowdebug bits");
+        }
         TestRedirectLinks tester = new TestRedirectLinks();
         tester.runTests();
     }


### PR DESCRIPTION
Misc stress testing related fixes:

[JDK-8295424](https://bugs.openjdk.org/browse/JDK-8295424) adjust timeout for another JLI GetObjectSizeIntrinsicsTest.java subtest
[JDK-8297367](https://bugs.openjdk.org/browse/JDK-8297367) disable TestRedirectLinks.java in slowdebug mode
[JDK-8297369](https://bugs.openjdk.org/browse/JDK-8297369) disable Fuzz.java in slowdebug mode

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8295424](https://bugs.openjdk.org/browse/JDK-8295424): adjust timeout for another JLI GetObjectSizeIntrinsicsTest.java subtest
 * [JDK-8297367](https://bugs.openjdk.org/browse/JDK-8297367): disable TestRedirectLinks.java in slowdebug mode
 * [JDK-8297369](https://bugs.openjdk.org/browse/JDK-8297369): disable Fuzz.java in slowdebug mode


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11278/head:pull/11278` \
`$ git checkout pull/11278`

Update a local copy of the PR: \
`$ git checkout pull/11278` \
`$ git pull https://git.openjdk.org/jdk pull/11278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11278`

View PR using the GUI difftool: \
`$ git pr show -t 11278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11278.diff">https://git.openjdk.org/jdk/pull/11278.diff</a>

</details>
