### PR TITLE
8280798: com.sun.jdi.ObjectReference::setValue spec should prohibit any final field modification

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/jdi/ObjectReference.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/ObjectReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,7 +114,7 @@ public interface ObjectReference extends Value {
      * Sets the value of a given instance or static field in this object.
      * The {@link Field} must be valid for this ObjectReference; that is,
      * it must be from the mirrored object's class or a superclass of that class.
-     * If static, the field must not be final.
+     * The field must not be final.
      * <p>
      * Object values must be assignment compatible with the field type
      * (This implies that the field type must be loaded through the

--- a/src/jdk.jdi/share/classes/com/sun/jdi/ObjectReference.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/ObjectReference.java
@@ -129,7 +129,7 @@ public interface ObjectReference extends Value {
      * @param field the field containing the requested value
      * @param value the new value to assign
      * @throws java.lang.IllegalArgumentException if the field is not valid for
-     * this object's class.
+     * this object's class or the field is final.
      * @throws InvalidTypeException if the value's type does not match
      * the field's type.
      * @throws ClassNotLoadedException if 'value' is not null, and the field

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ import nsk.share.jdi.*;
  * <code>com.sun.jdi.ObjectReference.setValue()</code>
  * properly throws <i>IllegalArgumentException</i> when a
  * debugger part of the test attempts to set value of
- * debuggee's static field which is declared as final.<br>
+ * debuggee's final field.
  */
 public class setvalue004 {
     static final String DEBUGGEE_CLASS =
@@ -62,8 +62,8 @@ public class setvalue004 {
     static final String COMMAND_READY = "ready";
     static final String COMMAND_QUIT = "quit";
 
-    static final int FLDS_NUM = 9;
     static final String DEBUGGEE_FLDS[] = {
+        // static final fields
         "sByteFld",
         "sShortFld",
         "sIntFld",
@@ -72,7 +72,17 @@ public class setvalue004 {
         "sDoubleFld",
         "sCharFld",
         "sBooleanFld",
-        "sStrFld"
+        "sStrFld",
+        // instance final fields
+        "iByteFld",
+        "iShortFld",
+        "iIntFld",
+        "iLongFld",
+        "iFloatFld",
+        "iDoubleFld",
+        "iCharFld",
+        "iBooleanFld",
+        "iStrFld"
     };
 
     private Log log;
@@ -141,16 +151,16 @@ public class setvalue004 {
             rType = objRef.referenceType();
 
             // provoke the IllegalArgumentException
-            for (int i=0; i<FLDS_NUM; i++) {
+            for (int i = 0; i < DEBUGGEE_FLDS.length; i++) {
                 Field fld = rType.fieldByName(DEBUGGEE_FLDS[i]);
                 try {
-                    log.display("\nTrying to set value for the static final field \""
+                    log.display("\nTrying to set value for the final field \""
                         + fld.name() + "\"\n\tfrom the object reference \""
                         + objRef + "\" ...");
                     objRef.setValue(fld,
                         objRef.getValue(rType.fieldByName(fld.name())));
                     log.complain("TEST FAILED: expected IllegalArgumentException was not thrown"
-                        + "\n\twhen attempted to set value for the static final field \""
+                        + "\n\twhen attempted to set value for the final field \""
                         + fld.name() + "\" of " + fld.type() + " type \""
                         + "\"\n\tgotten from the debuggee's object reference \""
                         + objRef + "\"");
@@ -161,7 +171,7 @@ public class setvalue004 {
                     e.printStackTrace();
                     log.complain("TEST FAILED: ObjectReference.setValue(): caught unexpected "
                         + e + "\n\tinstead of expected IllegalArgumentException"
-                        + "\n\twhen attempted to set value for the static final field \""
+                        + "\n\twhen attempted to set value for the final field \""
                         + fld.name() + "\" of " + fld.type() + " type \""
                         + "\"\n\tgotten from the debuggee's object reference \""
                         + objRef + "\"");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue004/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,8 +32,7 @@
  *     This test checks that the JDI method
  *     com.sun.jdi.ObjectReference.setValue() properly throws
  *     IllegalArgumentException when a debugger part of the test
- *     attempts to set value of debuggee's static field which
- *     is declared as final.
+ *     attempts to set value of debuggee's final field.
  * COMMENTS
  *
  * @library /vmTestbase

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue004t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue004t.java
@@ -42,16 +42,16 @@ public class setvalue004t {
     static final boolean sBooleanFld = false;
     static final String  sStrFld = "instance field";
 
-    // tested static final fields
-    static final byte    iByteFld = 127;
-    static final short   iShortFld = -32768;
-    static final int     iIntFld = 2147483647;
-    static final long    iLongFld = 9223372036854775807L;
-    static final float   iFloatFld = 5.1F;
-    static final double  iDoubleFld = 6.2D;
-    static final char    iCharFld = 'a';
-    static final boolean iBooleanFld = false;
-    static final String  iStrFld = "instance field";
+    // tested instance final fields
+    final byte    iByteFld = 127;
+    final short   iShortFld = -32768;
+    final int     iIntFld = 2147483647;
+    final long    iLongFld = 9223372036854775807L;
+    final float   iFloatFld = 5.1F;
+    final double  iDoubleFld = 6.2D;
+    final char    iCharFld = 'a';
+    final boolean iBooleanFld = false;
+    final String  iStrFld = "instance field";
 
     public static void main(String args[]) {
         System.exit(run(args) + Consts.JCK_STATUS_BASE);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue004t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/setValue/setvalue004t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,17 @@ public class setvalue004t {
     static final char    sCharFld = 'a';
     static final boolean sBooleanFld = false;
     static final String  sStrFld = "instance field";
+
+    // tested static final fields
+    static final byte    iByteFld = 127;
+    static final short   iShortFld = -32768;
+    static final int     iIntFld = 2147483647;
+    static final long    iLongFld = 9223372036854775807L;
+    static final float   iFloatFld = 5.1F;
+    static final double  iDoubleFld = 6.2D;
+    static final char    iCharFld = 'a';
+    static final boolean iBooleanFld = false;
+    static final String  iStrFld = "instance field";
 
     public static void main(String args[]) {
         System.exit(run(args) + Consts.JCK_STATUS_BASE);


### PR DESCRIPTION
com.sun.jdi.ObjectReference::setValue spec says that final static fields cannot be modified, but openjdk implementation throws IllegalArgumentException for any final fields (static or instance).

The fix updates the spec to prohibit any final field modification
CSR: JDK-8281652

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8280798](https://bugs.openjdk.org/browse/JDK-8280798): com.sun.jdi.ObjectReference::setValue spec should prohibit any final field modification
 * [JDK-8281652](https://bugs.openjdk.org/browse/JDK-8281652): com.sun.jdi.ObjectReference::setValue spec should prohibit any final field modification (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [5d98874c](https://git.openjdk.org/jdk/pull/11279/files/5d98874cbea6675fa352a6d271ce953150f54f06)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11279/head:pull/11279` \
`$ git checkout pull/11279`

Update a local copy of the PR: \
`$ git checkout pull/11279` \
`$ git pull https://git.openjdk.org/jdk pull/11279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11279`

View PR using the GUI difftool: \
`$ git pr show -t 11279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11279.diff">https://git.openjdk.org/jdk/pull/11279.diff</a>

</details>
