### PR TITLE
8297382: Test fails to compile after JDK-8288047

### DIFF
--- a/test/jdk/sun/security/util/math/BigIntegerModuloP.java
+++ b/test/jdk/sun/security/util/math/BigIntegerModuloP.java
@@ -155,6 +155,11 @@ public class BigIntegerModuloP implements IntegerFieldModuloP {
         public void asByteArray(byte[] result) {
             bigIntAsByteArray(v, result);
         }
+
+        @Override
+        public long[] getLimbs() {
+            return null;
+        }
     }
 
     private class ImmutableElement extends Element


### PR DESCRIPTION
[JDK-8288047](https://bugs.openjdk.org/browse/JDK-8288047) added `long[] getLimbs()` to `src/java.base/share/classes/sun/security/util/math/IntegerModuloP.java` but forgot to override that method in test implementation `test/jdk/sun/security/util/math/BigIntegerModuloP.java`.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297382](https://bugs.openjdk.org/browse/JDK-8297382): Test fails to compile after JDK-8288047


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11282/head:pull/11282` \
`$ git checkout pull/11282`

Update a local copy of the PR: \
`$ git checkout pull/11282` \
`$ git pull https://git.openjdk.org/jdk pull/11282/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11282`

View PR using the GUI difftool: \
`$ git pr show -t 11282`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11282.diff">https://git.openjdk.org/jdk/pull/11282.diff</a>

</details>
