### PR TITLE
JDK-8297408: Consolidate code in runtime/ErrorHandling

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/BadNativeStackInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/BadNativeStackInErrorHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/ErrorHandling/BadNativeStackInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/BadNativeStackInErrorHandlingTest.java
@@ -58,44 +58,15 @@ public class BadNativeStackInErrorHandlingTest {
     output_detail.shouldMatch("# +(?:SIGSEGV|SIGBUS|EXCEPTION_ACCESS_VIOLATION).*");
 
     // extract hs-err file
-    String hs_err_file = output_detail.firstMatch("# *(\\S*hs_err_pid\\d+\\.log)", 1);
-    if (hs_err_file == null) {
-        throw new RuntimeException("Did not find hs-err file in output.\n");
-    }
-
-    File f = new File(hs_err_file);
-    if (!f.exists()) {
-        throw new RuntimeException("hs-err file missing at " +
-                                   f.getAbsolutePath() + ".\n");
-    }
-
-    System.out.println("Found hs_err file. Scanning...");
-
-    FileInputStream fis = new FileInputStream(f);
-    BufferedReader br = new BufferedReader(new InputStreamReader(fis));
-    String line = null;
+    File hs_err_file = HsErrFileUtils.openHsErrFileFromOutput(output_detail);
 
     // The failing line looks like this:
     // [error occurred during error reporting (printing native stack), id 0xb]
-    Pattern pattern =
-        Pattern.compile("\\[error occurred during error reporting \\(printing native stack\\), id .*\\]");
+    Pattern negativePatterns[] = {
+        Pattern.compile("\\[error occurred during error reporting \\(printing native stack\\), id .*\\]")
+    };
 
-    String lastLine = null;
-    while ((line = br.readLine()) != null) {
-        if (pattern.matcher(line).matches()) {
-            System.out.println("Found: " + line + ".");
-            throw new RuntimeException("hs-err file should not contain: '" +
-                                       pattern + "'");
-        }
-        lastLine = line;
-    }
-    br.close();
-
-    if (!lastLine.equals("END.")) {
-        throw new RuntimeException("hs-err file incomplete (missing END marker.)");
-    } else {
-        System.out.println("End marker found.");
-    }
+    HsErrFileUtils.checkHsErrFileContent(hs_err_file, null, negativePatterns, true, false);
 
     System.out.println("OK.");
   }

--- a/test/hotspot/jtreg/runtime/ErrorHandling/BadNativeStackInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/BadNativeStackInErrorHandlingTest.java
@@ -66,7 +66,7 @@ public class BadNativeStackInErrorHandlingTest {
         Pattern.compile("\\[error occurred during error reporting \\(printing native stack\\), id .*\\]")
     };
 
-    HsErrFileUtils.checkHsErrFileContent(hs_err_file, null, negativePatterns, true, false);
+    HsErrFileUtils.checkHsErrFileContent(hs_err_file, null, negativePatterns, true /* check end marker */, false /* verbose */);
 
     System.out.println("OK.");
   }

--- a/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
@@ -59,7 +59,7 @@ public class HsErrFileUtils {
     }
 
     /**
-     * Given an open hs-err file, read it line by line and check for existence of a set of pattern. Will fail
+     * Given an open hs-err file, read it line by line and check for existence of a set of patterns. Will fail
      * if patterns are missing, or if the END marker is missing.
      * @param f Input file
      * @param patterns An array of patterns that need to match, in that order

--- a/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
@@ -60,18 +60,6 @@ public class HsErrFileUtils {
         return f;
     }
 
-    public static void printHsErrFileContent(File f)  throws IOException {
-        try (
-            FileInputStream fis = new FileInputStream(f);
-            BufferedReader br = new BufferedReader(new InputStreamReader(fis));
-        ) {
-            String line = null;
-            while ((line = br.readLine()) != null) {
-                System.out.println(line);
-            }
-        }
-    }
-
     /**
      * Given an open hs-err file, read it line by line and check for existence of a pattern. Will fail
      * if pattern are missing, or if the END marker is missing.

--- a/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
@@ -48,8 +48,6 @@ public class HsErrFileUtils {
     /**
      * Given the output of a java VM that crashed, extract the name of the hs-err file from the output,
      * open that file and return its File.
-     * @param output
-     * @return
      */
     public static File openHsErrFileFromOutput(OutputAnalyzer output) {
         String name = extractHsErrFileNameFromOutput(output);
@@ -61,11 +59,11 @@ public class HsErrFileUtils {
     }
 
     /**
-     * Given an open hs-err file, read it line by line and check for existence of a pattern. Will fail
-     * if pattern are missing, or if the END marker is missing.
-     * @param f input file
-     * @param patterns an array of patterns that need to match, in that order
-     * @param verbose if true, the content of the hs-err file is printed while matching. If false, only the matched patterns
+     * Given an open hs-err file, read it line by line and check for existence of a set of pattern. Will fail
+     * if patterns are missing, or if the END marker is missing.
+     * @param f Input file
+     * @param patterns An array of patterns that need to match, in that order
+     * @param verbose If true, the content of the hs-err file is printed while matching. If false, only the matched patterns
      *                are printed.
      * @throws RuntimeException, {@link IOException}
      */
@@ -77,11 +75,11 @@ public class HsErrFileUtils {
      * Given an open hs-err file, read it line by line and check for various conditions.
      * @param f input file
      * @param positivePatterns Optional array of patterns that need to appear, in given order, in the file. Missing
-     *                        pattern cause the test to fail.
+     *                        patterns cause the test to fail.
      * @param negativePatterns Optional array of patterns that must not appear in the file; test fails if they do.
      *                        Order is irrelevant.
-     * @param checkEndMarker If true, we check for the final "END" in an hs-err file; it missing indicates hs-err file
-     *                       printing did not complete successfully.
+     * @param checkEndMarker If true, we check for the final "END" in an hs-err file; if it is missing it indicates
+     *                        that hs-err file printing did not complete successfully.
      * @param verbose If true, the content of the hs-err file is printed while matching. If false, only important
      *               information are printed.
      * @throws RuntimeException, {@link IOException}
@@ -130,7 +128,7 @@ public class HsErrFileUtils {
                     }
                 }
                 lastLine = line;
-                lineNo ++;
+                lineNo++;
             }
             // Found all positive pattern?
             if (!positivePatternStack.isEmpty()) {

--- a/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
@@ -34,6 +34,7 @@
  * @run driver MachCodeFramesInErrorFile
  */
 
+import java.io.File;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
@@ -126,12 +127,8 @@ public class MachCodeFramesInErrorFile {
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
         // Extract hs_err_pid file.
-        String hs_err_file = output.firstMatch("# *(\\S*hs_err_pid\\d+\\.log)", 1);
-        if (hs_err_file == null) {
-            output.reportDiagnosticSummary();
-            throw new RuntimeException("Did not find hs_err_pid file in output");
-        }
-        Path hsErrPath = Paths.get(hs_err_file);
+        File hs_err_file = HsErrFileUtils.openHsErrFileFromOutput(output);
+        Path hsErrPath = hs_err_file.toPath();
         if (!Files.exists(hsErrPath)) {
             throw new RuntimeException("hs_err_pid file missing at " + hsErrPath + ".\n");
         }

--- a/test/hotspot/jtreg/runtime/ErrorHandling/NestedThreadsListHandleInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/NestedThreadsListHandleInErrorHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/ErrorHandling/NestedThreadsListHandleInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/NestedThreadsListHandleInErrorHandlingTest.java
@@ -70,22 +70,7 @@ public class NestedThreadsListHandleInErrorHandlingTest {
     System.out.println("Found specific fatal error.");
 
     // Extract hs_err_pid file.
-    String hs_err_file = output_detail.firstMatch("# *(\\S*hs_err_pid\\d+\\.log)", 1);
-    if (hs_err_file == null) {
-        throw new RuntimeException("Did not find hs_err_pid file in output.\n");
-    }
-
-    File f = new File(hs_err_file);
-    if (!f.exists()) {
-        throw new RuntimeException("hs_err_pid file missing at "
-                                   + f.getAbsolutePath() + ".\n");
-    }
-
-    System.out.println("Found hs_err_pid file. Scanning...");
-
-    FileInputStream fis = new FileInputStream(f);
-    BufferedReader br = new BufferedReader(new InputStreamReader(fis));
-    String line = null;
+    File hs_err_file = HsErrFileUtils.openHsErrFileFromOutput(output_detail);
 
     Pattern [] pattern = new Pattern[] {
         // The "Current thread" line should show a hazard ptr and
@@ -101,31 +86,9 @@ public class NestedThreadsListHandleInErrorHandlingTest {
         // should show a nested hazard ptr:
         Pattern.compile("=>.* JavaThread \"main\" .*, _nested_threads_hazard_ptr_cnt=1, _nested_threads_hazard_ptr=0x[0-9A-Fa-f][0-9A-Fa-f]*.*"),
     };
-    int currentPattern = 0;
 
-    String lastLine = null;
-    while ((line = br.readLine()) != null) {
-        if (currentPattern < pattern.length) {
-            if (pattern[currentPattern].matcher(line).matches()) {
-                System.out.println("Found: " + line + ".");
-                currentPattern++;
-            }
-        }
-        lastLine = line;
-    }
-    br.close();
+    HsErrFileUtils.checkHsErrFileContent(hs_err_file, pattern, false);
 
-    if (currentPattern < pattern.length) {
-        throw new RuntimeException("hs_err_pid file incomplete (first missing pattern: " +  currentPattern + ")");
-    }
-
-    if (!lastLine.equals("END.")) {
-        throw new RuntimeException("hs-err file incomplete (missing END marker.)");
-    } else {
-        System.out.println("End marker found.");
-    }
-
-    System.out.println("Done scanning hs_err_pid_file.");
     System.out.println("PASSED.");
   }
 }

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ResourceMarkTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ResourceMarkTest.java
@@ -74,7 +74,7 @@ public class ResourceMarkTest {
         Pattern.compile("\\[error occurred during error reporting \\(test missing ResourceMark does not crash\\), id 0xe0000000, Internal Error \\(.*resourceArea.cpp:.*\\)\\]"),
     };
 
-    HsErrFileUtils.checkHsErrFileContent(hs_err_file, null, negativePattern, true, false);
+    HsErrFileUtils.checkHsErrFileContent(hs_err_file, null, negativePattern, true /* check end marker */, false /* verbose */);
 
     System.out.println("OK.");
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ResourceMarkTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ResourceMarkTest.java
@@ -63,54 +63,18 @@ public class ResourceMarkTest {
     output_detail.shouldMatch("This is a message with no ResourceMark");
 
     // extract hs-err file
-    String hs_err_file = output_detail.firstMatch("# *(\\S*hs_err_pid\\d+\\.log)", 1);
-    if (hs_err_file == null) {
-      throw new RuntimeException("Did not find hs-err file in output.\n");
-    }
+    File hs_err_file = HsErrFileUtils.openHsErrFileFromOutput(output_detail);
 
     // scan hs-err file: File should NOT contain the "[error occurred during error reporting..]"
     // markers which show that the secondary error handling kicked in and handled the
     // error successfully. As an added test, we check that the last line contains "END.",
     // which is an end marker written in the last step and proves that hs-err file was
     // completely written.
-    File f = new File(hs_err_file);
-    if (!f.exists()) {
-      throw new RuntimeException("hs-err file missing at "
-          + f.getAbsolutePath() + ".\n");
-    }
-
-    System.out.println("Found hs_err file. Scanning...");
-
-    FileInputStream fis = new FileInputStream(f);
-    BufferedReader br = new BufferedReader(new InputStreamReader(fis));
-    String line = null;
-
-    Pattern [] pattern = new Pattern[] {
+    Pattern [] negativePattern = new Pattern[] {
         Pattern.compile("\\[error occurred during error reporting \\(test missing ResourceMark does not crash\\), id 0xe0000000, Internal Error \\(.*resourceArea.cpp:.*\\)\\]"),
     };
-    int currentPattern = 0;
 
-    String lastLine = null;
-    while ((line = br.readLine()) != null) {
-      if (currentPattern < pattern.length) {
-        if (pattern[currentPattern].matcher(line).matches()) {
-          System.out.println("Found: " + line + ".");
-          currentPattern ++;
-        }
-      }
-      lastLine = line;
-    }
-    br.close();
-
-    if (currentPattern == pattern.length) {
-      throw new RuntimeException("hs-err file found secondary crash for ResourceMark");
-    }
-
-    if (!lastLine.equals("END.")) {
-      throw new RuntimeException("hs-err file incomplete (missing END marker.)");
-    } else {
-      System.out.println("End marker found.");
-    }
+    HsErrFileUtils.checkHsErrFileContent(hs_err_file, null, negativePattern, true, false);
 
     System.out.println("OK.");
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/SafeFetchInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/SafeFetchInErrorHandlingTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/ErrorHandling/SafeFetchInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/SafeFetchInErrorHandlingTest.java
@@ -60,50 +60,16 @@ public class SafeFetchInErrorHandlingTest {
     output_detail.shouldMatch("# +(?:SIGSEGV|SIGBUS|EXCEPTION_ACCESS_VIOLATION).*");
 
     // extract hs-err file
-    String hs_err_file = output_detail.firstMatch("# *(\\S*hs_err_pid\\d+\\.log)", 1);
-    if (hs_err_file == null) {
-      throw new RuntimeException("Did not find hs-err file in output.\n");
-    }
+    File hs_err_file = HsErrFileUtils.openHsErrFileFromOutput(output_detail);
 
-    File f = new File(hs_err_file);
-    if (!f.exists()) {
-      throw new RuntimeException("hs-err file missing at "
-          + f.getAbsolutePath() + ".\n");
-    }
-
-    System.out.println("Found hs_err file. Scanning...");
-
-    FileInputStream fis = new FileInputStream(f);
-    BufferedReader br = new BufferedReader(new InputStreamReader(fis));
-    String line = null;
-
+    // File should contain "Will test SafeFetch, SafeFetch OK". The latter indicates we survived the SafeFetch without
+    // a secondary crash.
     Pattern [] pattern = new Pattern[] {
         Pattern.compile("Will test SafeFetch..."),
         Pattern.compile("SafeFetch OK."),
     };
-    int currentPattern = 0;
 
-    String lastLine = null;
-    while ((line = br.readLine()) != null) {
-      if (currentPattern < pattern.length) {
-        if (pattern[currentPattern].matcher(line).matches()) {
-          System.out.println("Found: " + line + ".");
-          currentPattern ++;
-        }
-      }
-      lastLine = line;
-    }
-    br.close();
-
-    if (currentPattern < pattern.length) {
-      throw new RuntimeException("hs-err file incomplete (first missing pattern: " +  currentPattern + ")");
-    }
-
-    if (!lastLine.equals("END.")) {
-      throw new RuntimeException("hs-err file incomplete (missing END marker.)");
-    } else {
-      System.out.println("End marker found.");
-    }
+    HsErrFileUtils.checkHsErrFileContent(hs_err_file, pattern, true);
 
     System.out.println("OK.");
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/SecondaryErrorTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/SecondaryErrorTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +25,7 @@
 
 /*
  * @test
- * @bug 8065896
+ * @bug 8065895
  * @summary Synchronous signals during error reporting may terminate or hang VM process
  * @library /test/lib
  * @requires vm.debug

--- a/test/hotspot/jtreg/runtime/ErrorHandling/SecondaryErrorTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/SecondaryErrorTest.java
@@ -63,27 +63,13 @@ public class SecondaryErrorTest {
     output_detail.shouldMatch("#.+SIGFPE.*");
 
     // extract hs-err file
-    String hs_err_file = output_detail.firstMatch("# *(\\S*hs_err_pid\\d+\\.log)", 1);
-    if (hs_err_file == null) {
-      throw new RuntimeException("Did not find hs-err file in output.\n");
-    }
+    File hs_err_file = HsErrFileUtils.openHsErrFileFromOutput(output_detail);
 
     // scan hs-err file: File should contain the "[error occurred during error reporting..]"
     // markers which show that the secondary error handling kicked in and handled the
     // error successfully. As an added test, we check that the last line contains "END.",
     // which is an end marker written in the last step and proves that hs-err file was
     // completely written.
-    File f = new File(hs_err_file);
-    if (!f.exists()) {
-      throw new RuntimeException("hs-err file missing at "
-          + f.getAbsolutePath() + ".\n");
-    }
-
-    System.out.println("Found hs_err file. Scanning...");
-
-    FileInputStream fis = new FileInputStream(f);
-    BufferedReader br = new BufferedReader(new InputStreamReader(fis));
-    String line = null;
 
     Pattern [] pattern = new Pattern[] {
         Pattern.compile("Will crash now \\(TestCrashInErrorHandler=14\\)..."),
@@ -91,29 +77,8 @@ public class SecondaryErrorTest {
         Pattern.compile("Will crash now \\(TestCrashInErrorHandler=14\\)..."),
         Pattern.compile("\\[error occurred during error reporting \\(test secondary crash 2\\).*\\]"),
     };
-    int currentPattern = 0;
 
-    String lastLine = null;
-    while ((line = br.readLine()) != null) {
-      if (currentPattern < pattern.length) {
-        if (pattern[currentPattern].matcher(line).matches()) {
-          System.out.println("Found: " + line + ".");
-          currentPattern ++;
-        }
-      }
-      lastLine = line;
-    }
-    br.close();
-
-    if (currentPattern < pattern.length) {
-      throw new RuntimeException("hs-err file incomplete (first missing pattern: " +  currentPattern + ")");
-    }
-
-    if (!lastLine.equals("END.")) {
-      throw new RuntimeException("hs-err file incomplete (missing END marker.)");
-    } else {
-      System.out.println("End marker found.");
-    }
+    HsErrFileUtils.checkHsErrFileContent(hs_err_file, pattern, false);
 
     System.out.println("OK.");
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ShowRegistersOnAssertTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ShowRegistersOnAssertTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ShowRegistersOnAssertTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ShowRegistersOnAssertTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, 2022 SAP SE. All rights reserved.
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestCrashOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestCrashOnOutOfMemoryError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestCrashOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestCrashOnOutOfMemoryError.java
@@ -37,6 +37,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
+import java.util.regex.Pattern;
 
 public class TestCrashOnOutOfMemoryError {
 
@@ -88,36 +89,15 @@ public class TestCrashOnOutOfMemoryError {
         */
         output.shouldContain("Aborting due to java.lang.OutOfMemoryError: Requested array size exceeds VM limit");
         // extract hs-err file
-        String hs_err_file = output.firstMatch("# *(\\S*hs_err_pid\\d+\\.log)", 1);
-        if (hs_err_file == null) {
-            throw new Error("Did not find hs-err file in output.\n");
-        }
+        File hs_err_file = HsErrFileUtils.openHsErrFileFromOutput(output);
 
-        /*
-         * Check if hs_err files exist or not
-         */
-        File f = new File(hs_err_file);
-        if (!f.exists()) {
-            throw new Error("hs-err file missing at "+ f.getAbsolutePath() + ".\n");
-        }
+        // Do a perfunctory check of the hs-err file produced by the crash.
+        Pattern[] pattern = new Pattern[] {
+            Pattern.compile(".*fatal error: OutOfMemory encountered: Requested array size exceeds VM limit.*")
+        };
 
-        /*
-         * Checking the completness of hs_err file. If last line of hs_err file is "END"
-         * then it proves that file is complete.
-         */
-        try (FileInputStream fis = new FileInputStream(f);
-            BufferedReader br = new BufferedReader(new InputStreamReader(fis))) {
-            String line = null;
-            String lastLine = null;
-            while ((line = br.readLine()) != null) {
-                lastLine = line;
-            }
-            if (!lastLine.equals("END.")) {
-                throw new Error("hs-err file incomplete (missing END marker.)");
-            } else {
-                System.out.println("End marker found.");
-            }
-        }
+        HsErrFileUtils.checkHsErrFileContent(hs_err_file, pattern, false);
+
         System.out.println("PASSED");
     }
 }

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java
@@ -126,7 +126,8 @@ public class TestDwarf {
         System.out.println(crashOutputString);
 
         File hs_err_file = HsErrFileUtils.openHsErrFileFromOutput(crashOut);
-        try (BufferedReader reader = new BufferedReader(new FileReader(hs_err_file))) {
+        try (FileReader fr = new FileReader(hs_err_file);
+             BufferedReader reader = new BufferedReader(fr)) {
             String line;
             boolean foundNativeFrames = false;
             int matches = 0;

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java
@@ -123,18 +123,15 @@ public class TestDwarf {
         crashOut = ProcessTools.executeProcess(ProcessTools.createTestJvm(flags.getFlags()));
         String crashOutputString = crashOut.getOutput();
         Asserts.assertNotEquals(crashOut.getExitValue(), 0, "Crash JVM should not exit gracefully");
-        Pattern pattern = Pattern.compile("hs_err_pid[0-9]*.log");
-        Matcher matcher = pattern.matcher(crashOutputString);
         System.out.println(crashOutputString);
-        if (matcher.find()) {
-            String hsErrFileName = matcher.group();
-            System.out.println("hs_err_file: " + hsErrFileName);
-            File hs_err_file = new File(hsErrFileName);
-            BufferedReader reader = new BufferedReader(new FileReader(hs_err_file));
+
+        File hs_err_file = HsErrFileUtils.openHsErrFileFromOutput(crashOut);
+        try (BufferedReader reader = new BufferedReader(new FileReader(hs_err_file))) {
             String line;
             boolean foundNativeFrames = false;
             int matches = 0;
             int frameIdx = 0;
+            Pattern pattern = Pattern.compile("[CV][\\s\\t]+\\[([a-zA-Z0-9_.]+)\\+0x.+][\\s\\t]+.*\\+0x.+[\\s\\t]+\\([a-zA-Z0-9_.]+\\.[a-z]+:[1-9][0-9]*\\)");
             // Check all stack entries after the line starting with "Native frames" in the hs_err_file until an empty line
             // is found which denotes the end of the stack frames.
             while ((line = reader.readLine()) != null) {
@@ -147,8 +144,7 @@ public class TestDwarf {
                         matches++;
                         // File and library names are non-empty and may contain English letters, underscores, dots or numbers ([a-zA-Z0-9_.]+).
                         // Line numbers have at least one digit and start with non-zero ([1-9][0-9]*).
-                        pattern = Pattern.compile("[CV][\\s\\t]+\\[([a-zA-Z0-9_.]+)\\+0x.+][\\s\\t]+.*\\+0x.+[\\s\\t]+\\([a-zA-Z0-9_.]+\\.[a-z]+:[1-9][0-9]*\\)");
-                        matcher = pattern.matcher(line);
+                        Matcher matcher = pattern.matcher(line);
                         if (!matcher.find()) {
                             checkNoSourceLine(crashOutputString, line);
                         }
@@ -167,8 +163,6 @@ public class TestDwarf {
                 }
             }
             Asserts.assertGreaterThan(matches, 0, "Could not find any stack frames");
-        } else {
-            throw new RuntimeException("Could not find an hs_err_file");
         }
     }
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ThreadsListHandleInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ThreadsListHandleInErrorHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ThreadsListHandleInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ThreadsListHandleInErrorHandlingTest.java
@@ -70,22 +70,7 @@ public class ThreadsListHandleInErrorHandlingTest {
     System.out.println("Found specific fatal error.");
 
     // Extract hs_err_pid file.
-    String hs_err_file = output_detail.firstMatch("# *(\\S*hs_err_pid\\d+\\.log)", 1);
-    if (hs_err_file == null) {
-        throw new RuntimeException("Did not find hs_err_pid file in output.\n");
-    }
-
-    File f = new File(hs_err_file);
-    if (!f.exists()) {
-        throw new RuntimeException("hs_err_pid file missing at "
-                                   + f.getAbsolutePath() + ".\n");
-    }
-
-    System.out.println("Found hs_err_pid file. Scanning...");
-
-    FileInputStream fis = new FileInputStream(f);
-    BufferedReader br = new BufferedReader(new InputStreamReader(fis));
-    String line = null;
+    File hs_err_file = HsErrFileUtils.openHsErrFileFromOutput(output_detail);
 
     Pattern [] pattern = new Pattern[] {
         // The "Current thread" line should show a hazard ptr
@@ -101,31 +86,9 @@ public class ThreadsListHandleInErrorHandlingTest {
         // should show no nested hazard ptrs:
         Pattern.compile("=>.* JavaThread \"main\" .*, _nested_threads_hazard_ptr_cnt=0.*"),
     };
-    int currentPattern = 0;
 
-    String lastLine = null;
-    while ((line = br.readLine()) != null) {
-        if (currentPattern < pattern.length) {
-            if (pattern[currentPattern].matcher(line).matches()) {
-                System.out.println("Found: " + line + ".");
-                currentPattern++;
-            }
-        }
-        lastLine = line;
-    }
-    br.close();
+    HsErrFileUtils.checkHsErrFileContent(hs_err_file, pattern, false);
 
-    if (currentPattern < pattern.length) {
-        throw new RuntimeException("hs_err_pid file incomplete (first missing pattern: " +  currentPattern + ")");
-    }
-
-    if (!lastLine.equals("END.")) {
-        throw new RuntimeException("hs-err file incomplete (missing END marker.)");
-    } else {
-        System.out.println("End marker found.");
-    }
-
-    System.out.println("Done scanning hs_err_pid_file.");
     System.out.println("PASSED.");
   }
 }

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TimeoutInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TimeoutInErrorHandlingTest.java
@@ -117,7 +117,7 @@ public class TimeoutInErrorHandlingTest {
         // Note: we *dont* check for the end marker, since the hs-err file will likely not have
         // one but a global timeout marker. As explained above, we don't check for that one either
         // since it is too instable.
-        HsErrFileUtils.checkHsErrFileContent(hs_err_file, pattern, null, false,true);
+        HsErrFileUtils.checkHsErrFileContent(hs_err_file, pattern, null, false /* check end marker */,true /* verbose */);
 
         System.out.println("OK.");
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TimeoutInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TimeoutInErrorHandlingTest.java
@@ -95,68 +95,29 @@ public class TimeoutInErrorHandlingTest {
         output_detail.shouldMatch(".*timer expired, abort.*");
 
         // extract hs-err file
-        String hs_err_file = output_detail.firstMatch("# *(\\S*hs_err_pid\\d+\\.log)", 1);
-        if (hs_err_file == null) {
+        File hs_err_file;
+        try {
+            hs_err_file = HsErrFileUtils.openHsErrFileFromOutput(output_detail);
+        } catch (Exception e) {
             if (!verbose) {
                 System.err.println("<begin cmd output>");
                 System.err.println(output_detail.getOutput());
                 System.err.println("<end cmd output>");
             }
-            throw new RuntimeException("Did not find hs-err file in output.\n");
-        }
-
-        File f = new File(hs_err_file);
-        if (!f.exists()) {
-            if (!verbose) {
-                System.err.println("<begin cmd output>");
-                System.err.println(output_detail.getOutput());
-                System.err.println("<end cmd output>");
-            }
-            throw new RuntimeException("hs-err file missing at "
-                + f.getAbsolutePath() + ".\n");
+            throw e;
         }
 
         System.out.println("Found hs_err file. Scanning...");
-
-        FileInputStream fis = new FileInputStream(f);
-        BufferedReader br = new BufferedReader(new InputStreamReader(fis));
-        String line = null;
-
 
         Pattern [] pattern = new Pattern[] {
             Pattern.compile(".*timeout occurred during error reporting in step.*"),
             Pattern.compile(".*timeout occurred during error reporting in step.*")
         };
-        int currentPattern = 0;
 
-        String lastLine = null;
-        StringBuilder saved_hs_err = new StringBuilder();
-        while ((line = br.readLine()) != null) {
-            saved_hs_err.append(line + System.lineSeparator());
-            if (currentPattern < pattern.length) {
-                if (pattern[currentPattern].matcher(line).matches()) {
-                    System.out.println("Found: " + line + ".");
-                    currentPattern ++;
-                }
-            }
-            lastLine = line;
-        }
-        br.close();
-
-        if (verbose) {
-            System.err.println("<begin hs_err contents>");
-            System.err.print(saved_hs_err);
-            System.err.println("<end hs_err contents>");
-        }
-
-        if (currentPattern < pattern.length) {
-            if (!verbose) {
-                System.err.println("<begin hs_err contents>");
-                System.err.print(saved_hs_err);
-                System.err.println("<end hs_err contents>");
-            }
-            throw new RuntimeException("hs-err file incomplete (first missing pattern: " +  currentPattern + ")");
-        }
+        // Note: we *dont* check for the end marker, since the hs-err file will likely not have
+        // one but a global timeout marker. As explained above, we don't check for that one either
+        // since it is too instable.
+        HsErrFileUtils.checkHsErrFileContent(hs_err_file, pattern, null, false,true);
 
         System.out.println("OK.");
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TimeoutInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TimeoutInErrorHandlingTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/ErrorHandling/VeryEarlyAssertTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/VeryEarlyAssertTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, SAP. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022 SAP. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/ErrorHandling/VeryEarlyAssertTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/VeryEarlyAssertTest.java
@@ -72,7 +72,7 @@ public class VeryEarlyAssertTest {
     Pattern[] pattern = new Pattern[] {
             Pattern.compile(".*HOTSPOT_FATAL_ERROR_DURING_DYNAMIC_INITIALIZATION.*")
     };
-    HsErrFileUtils.checkHsErrFileContent(hs_err_file, pattern, null, false, true);
+    HsErrFileUtils.checkHsErrFileContent(hs_err_file, pattern, null, false /* check end marker */, true /* verbose */);
 
     System.out.println("OK.");
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/VeryEarlyAssertTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/VeryEarlyAssertTest.java
@@ -61,55 +61,18 @@ public class VeryEarlyAssertTest {
     output_detail.shouldMatch("#.*HOTSPOT_FATAL_ERROR_DURING_DYNAMIC_INITIALIZATION.*");
 
     // extract hs-err file
-    String hs_err_file = output_detail.firstMatch("# *(\\S*hs_err_pid\\d+\\.log)", 1);
-    if (hs_err_file == null) {
-      throw new RuntimeException("Did not find hs-err file in output.\n");
-    }
+    File hs_err_file = HsErrFileUtils.openHsErrFileFromOutput(output_detail);
 
     // scan hs-err file: File should contain the same assertion message. Other than that,
     // do not expect too much: file will be littered with secondary errors. The test
     // should test that we get a hs-err file at all.
-    File f = new File(hs_err_file);
-    if (!f.exists()) {
-      throw new RuntimeException("hs-err file missing at "
-              + f.getAbsolutePath() + ".\n");
-    }
+    // It is highly likely that we miss the END marker, too, since its likely we hit the
+    // secondary error recursion limit.
 
-    System.out.println("Found hs_err file. Scanning...");
-
-    FileInputStream fis = new FileInputStream(f);
-    BufferedReader br = new BufferedReader(new InputStreamReader(fis));
-    String line = null;
-
-    Pattern[] pattern = new Pattern[]{
+    Pattern[] pattern = new Pattern[] {
             Pattern.compile(".*HOTSPOT_FATAL_ERROR_DURING_DYNAMIC_INITIALIZATION.*")
     };
-    int currentPattern = 0;
-
-    boolean endMarkerFound = false;
-    while ((line = br.readLine()) != null) {
-      if (currentPattern < pattern.length) {
-        if (pattern[currentPattern].matcher(line).matches()) {
-          System.out.println("Found: " + line + ".");
-          currentPattern++;
-        }
-      }
-      if (line.equals("END.")) {
-        endMarkerFound = true;
-        break;
-      }
-    }
-    br.close();
-
-    if (currentPattern < pattern.length) {
-      throw new RuntimeException("hs-err file incomplete (first missing pattern: " + currentPattern + ")");
-    }
-
-    if (!endMarkerFound) {
-      throw new RuntimeException("hs-err file incomplete (missing END marker.)");
-    } else {
-      System.out.println("End marker found.");
-    }
+    HsErrFileUtils.checkHsErrFileContent(hs_err_file, pattern, null, false, true);
 
     System.out.println("OK.");
 


### PR DESCRIPTION
There is a lot of duplicate coding in runtime/ErrorHandling that could be cut down using the new HsErrFileUtils utilities added with [JDK-8296906](https://bugs.openjdk.org/browse/JDK-8296906).

This patch mainly cuts away duplicate coding. Very minor functional changes:
- All tests will now use try-with-resources when opening hs-err files
- [TestCrashOnOutOfMemoryError.java](https://github.com/openjdk/jdk/pull/11283/files#diff-7560f2e2700932e015563716b3b0880495922c4c5731ddadba3b33bd937358bd) now checks for at least one matching line in the hs-err file - before, it basically just scanned for the END marker, which seemed pointless
- [test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java](https://github.com/openjdk/jdk/pull/11283/files#diff-c04dd18d5a29a42e3a9a008c0b917663a7617c8c9a0d6e9efe8755773260ea95) : heaved Pattern construction out of loop
- [test/hotspot/jtreg/runtime/ErrorHandling/TimeoutInErrorHandlingTest.java](https://github.com/openjdk/jdk/pull/11283/files#diff-086956c42403a16043a111b0582736ac21ce0522dba866f5f9bc3fdb16037a0c) : I tried to preserve the debug output that was painstakingly added by @dcubed-ojdk apart from one change: I now printe the hs-err file as part of the scanning process. This works fine since in case of success, it will only be parsed as far as all patterns are matched, which happens after five-ish lines. Only if none are found, we scan and therefore print the whole hs-err file. So the old behavior is preserved in spirit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297408](https://bugs.openjdk.org/browse/JDK-8297408): Consolidate code in runtime/ErrorHandling


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [b9be700a](https://git.openjdk.org/jdk/pull/11283/files/b9be700a3f4c00feada2f5c0418cd1f7ca1f7dd5)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**) ⚠️ Review applies to [85996592](https://git.openjdk.org/jdk/pull/11283/files/85996592af82e035d29cfc71c29237caee5cdeac)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11283/head:pull/11283` \
`$ git checkout pull/11283`

Update a local copy of the PR: \
`$ git checkout pull/11283` \
`$ git pull https://git.openjdk.org/jdk pull/11283/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11283`

View PR using the GUI difftool: \
`$ git pr show -t 11283`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11283.diff">https://git.openjdk.org/jdk/pull/11283.diff</a>

</details>
