### PR TITLE
8297609: Add application/wasm MIME type for wasm file extension

### DIFF
--- a/src/java.base/unix/classes/sun/net/www/content-types.properties
+++ b/src/java.base/unix/classes/sun/net/www/content-types.properties
@@ -258,8 +258,8 @@ image/webp: \
 	file_extensions=.webp;
 
 text/css: \
-    description=CSS File;\
-    file_extensions=.css;
+	description=CSS File;\
+	file_extensions=.css;
 
 text/html: \
 	description=HTML Document;\
@@ -267,8 +267,8 @@ text/html: \
 	icon=html
 
 text/javascript: \
-    description=JavaScript File;\
-    file_extensions=.js;
+	description=JavaScript File;\
+	file_extensions=.js;
 
 text/plain: \
 	description=Plain Text;\
@@ -289,8 +289,8 @@ text/csv: \
 	file_extensions=.csv;
 
 text/markdown: \
-    description=Markdown File;\
-    file_extensions=.md,.markdown
+	description=Markdown File;\
+	file_extensions=.md,.markdown
 
 video/mp4: \
 	description=MPEG-4 Video;\
@@ -353,7 +353,7 @@ application/vnd.oasis.opendocument.text: \
 	file_extensions=.odt;
 
 application/vnd.ms-excel: \
-    description=Microsoft Excel File;\
+	description=Microsoft Excel File;\
 	file_extensions=.xls;
 
 application/vnd.openxmlformats-officedocument.spreadsheetml.sheet: \
@@ -395,3 +395,7 @@ application/bz2: \
 application/java-archive: \
 	description=JAR File;\
 	file_extensions=.jar;
+
+application/wasm: \
+	description=WASM File;\
+	file_extensions=.wasm;

--- a/src/java.base/unix/classes/sun/net/www/content-types.properties
+++ b/src/java.base/unix/classes/sun/net/www/content-types.properties
@@ -397,5 +397,5 @@ application/java-archive: \
 	file_extensions=.jar;
 
 application/wasm: \
-	description=WASM File;\
+	description=WebAssembly File;\
 	file_extensions=.wasm;

--- a/src/java.base/windows/classes/sun/net/www/content-types.properties
+++ b/src/java.base/windows/classes/sun/net/www/content-types.properties
@@ -259,8 +259,8 @@ image/webp: \
 	file_extensions=.webp;
 
 text/css: \
-    description=CSS File;\
-    file_extensions=.css;
+	description=CSS File;\
+	file_extensions=.css;
 
 text/html: \
 	description=HTML Document;\
@@ -290,8 +290,8 @@ text/csv: \
 	file_extensions=.csv;
 
 text/markdown: \
-    description=Markdown File;\
-    file_extensions=.md,.markdown
+	description=Markdown File;\
+	file_extensions=.md,.markdown
 
 video/mp4: \
 	description=MPEG-4 Video;\
@@ -387,4 +387,8 @@ application/bz2: \
 
 application/java-archive: \
 	description=JAR File;\
-    file_extensions=.jar;
+	file_extensions=.jar;
+
+application/wasm: \
+	description=WASM File;\
+	file_extensions=.wasm;

--- a/src/java.base/windows/classes/sun/net/www/content-types.properties
+++ b/src/java.base/windows/classes/sun/net/www/content-types.properties
@@ -390,5 +390,5 @@ application/java-archive: \
 	file_extensions=.jar;
 
 application/wasm: \
-	description=WASM File;\
+	description=WebAssembly File;\
 	file_extensions=.wasm;

--- a/test/jdk/java/nio/file/Files/probeContentType/Basic.java
+++ b/test/jdk/java/nio/file/Files/probeContentType/Basic.java
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4313887 8129632 8129633 8162624 8146215 8162745 8273655 8274171 8287237
+ * @bug 4313887 8129632 8129633 8162624 8146215 8162745 8273655 8274171 8287237 8297609
  * @summary Unit test for probeContentType method
  * @library ../..
  * @build Basic SimpleFileTypeDetector

--- a/test/jdk/java/nio/file/Files/probeContentType/Basic.java
+++ b/test/jdk/java/nio/file/Files/probeContentType/Basic.java
@@ -187,6 +187,7 @@ public class Basic {
                 new ExType("xls", List.of("application/vnd.ms-excel")),
                 new ExType("xlsx", List.of("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")),
                 new ExType("7z", List.of("application/x-7z-compressed")),
+                new ExType("wasm", List.of("application/wasm")),
         };
         failures += checkContentTypes(exTypes);
 


### PR DESCRIPTION
This PR adds a missing MIME: application/wasm and unifies the file format on tabs, as that seemed to be the winning side of the tabs/spaces war in this file.

# How to reproduce

You will need to compile a `.c` file to a `.wasm` binary. Use [Emscripten SDK](https://emscripten.org/docs/getting_started/downloads.html) for that or download the prebuilt files from this post, [out.zip](https://github.com/openjdk/jdk/files/10066496/out.zip),  if you choose to trust me with your browser...

## Sources

`main.c`:
```c
#include <stdio.h>

int main() {
  printf("Hello browser debug console...\n");
}
```

`Server.java`:
```java
import com.sun.net.httpserver.HttpServer;
import com.sun.net.httpserver.SimpleFileServer;

import java.net.InetAddress;
import java.net.InetSocketAddress;
import java.nio.file.Path;

import static java.lang.System.exit;
import static java.lang.System.out;

public class Server {
    public static void main(String... args) {
        if (args.length != 2) {
            out.println("Usage: java Server <port> <web dir path>");
            exit(1);
        }
        final int port = Integer.parseInt(args[0]);
        final InetSocketAddress ADDR = new InetSocketAddress(InetAddress.getLoopbackAddress(), port);
        final Path root = Path.of(args[1]).toAbsolutePath();
        final HttpServer server = SimpleFileServer.createFileServer(ADDR, root, SimpleFileServer.OutputLevel.VERBOSE);
        out.printf("Starting serving files from %s dir: http://%s:%d\n", root, ADDR.getAddress().getHostAddress(), port);
        server.start();
    }
}
```
## Build
```
$ mkdir out
$ emcc main.c -s WASM=1 -o out/main.html
$ ls out/
main.html  main.js  main.wasm
```
You can have these files here, built by me:  [out.zip](https://github.com/openjdk/jdk/files/10066496/out.zip)

## Execution
```
$ java --version
openjdk 19.0.1 2022-10-18
$ javac Server.java
$ java Server 8888 ./out/
Starting serving files from /tmp/hello_wasm/./out dir: http://127.0.0.1:8888
```

When I open my Firefox 106.0.5 (64-bit), I can see that the Java server offers the `.wasm` file with a suboptimal `application/octet-stream` MIME:

![bad](https://user-images.githubusercontent.com/691097/203292673-dff79256-7286-42b1-9b72-60ff6e9aadd3.png)

When I switch to the JDK patched with this patch and run the server again:
```
$ java Server 8888 ./out/
Starting serving files from /tmp/hello_wasm/./out dir: http://127.0.0.1:8888
```
I can see that the `.wasm` file is properly served to Firefox as `application/wasm`:

![good](https://user-images.githubusercontent.com/691097/203293296-77ff4913-b86d-45fe-976e-8cbcde79da36.png)

Thank you for your time.

Cheers
K.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297609](https://bugs.openjdk.org/browse/JDK-8297609): Add application/wasm MIME type for wasm file extension


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [77a4e79b](https://git.openjdk.org/jdk/pull/11284/files/77a4e79b60a4421694756bc8cff00bb8da1b9e12)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**) ⚠️ Review applies to [77a4e79b](https://git.openjdk.org/jdk/pull/11284/files/77a4e79b60a4421694756bc8cff00bb8da1b9e12)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11284/head:pull/11284` \
`$ git checkout pull/11284`

Update a local copy of the PR: \
`$ git checkout pull/11284` \
`$ git pull https://git.openjdk.org/jdk pull/11284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11284`

View PR using the GUI difftool: \
`$ git pr show -t 11284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11284.diff">https://git.openjdk.org/jdk/pull/11284.diff</a>

</details>
