### PR TITLE
8297030: Reduce Default Keep-Alive Timeout Value for httpclient

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -112,7 +112,7 @@ final class HttpClientImpl extends HttpClient implements Trackable {
     final Logger debugtimeout = Utils.getDebugLogger(this::dbgString, DEBUGTIMEOUT);
     static final AtomicLong CLIENT_IDS = new AtomicLong();
     private final AtomicLong CONNECTION_IDS = new AtomicLong();
-    static final int DEFAULT_KEEP_ALIVE_TIMEOUT = 1200;
+    static final int DEFAULT_KEEP_ALIVE_TIMEOUT = 30;
     static final long KEEP_ALIVE_TIMEOUT = getTimeoutProp("jdk.httpclient.keepalive.timeout", DEFAULT_KEEP_ALIVE_TIMEOUT);
     // Defaults to value used for HTTP/1 Keep-Alive Timeout. Can be overridden by jdk.httpclient.keepalive.timeout.h2 property.
     static final long IDLE_CONNECTION_TIMEOUT = getTimeoutProp("jdk.httpclient.keepalive.timeout.h2", KEEP_ALIVE_TIMEOUT);


### PR DESCRIPTION
Proposed changes to reduce the default Keep Alive Timeout value in `jdk/internal/net/http/HttpClientImpl.java` from 1200 seconds to 30 seconds. The current default value of 1200s is needlessly high and in remote connections that allow a client to suggest a value, this will mean that idle connections will wait very long before being dropped.

This value of 30 seconds was chosen by reviewing the current default values for Keep-Alive timeouts in common server implementations and choosing a value that would have the client's default value be lower whenever the value can be set.

Further discussion on this change can be seen the pull request [8288717: Add a means to close idle connections in HTTP/2 connection pool #10183](https://github.com/openjdk/jdk/pull/10183).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8297030](https://bugs.openjdk.org/browse/JDK-8297030): Reduce Default Keep-Alive Timeout Value for httpclient
 * [JDK-8297558](https://bugs.openjdk.org/browse/JDK-8297558): Reduce Default Keep-Alive Timeout Value for httpclient (**CSR**)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11285/head:pull/11285` \
`$ git checkout pull/11285`

Update a local copy of the PR: \
`$ git checkout pull/11285` \
`$ git pull https://git.openjdk.org/jdk pull/11285/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11285`

View PR using the GUI difftool: \
`$ git pr show -t 11285`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11285.diff">https://git.openjdk.org/jdk/pull/11285.diff</a>

</details>
