### PR TITLE
8297431: [JVMCI] HotSpotJVMCIRuntime.encodeThrowable should not throw an exception

### DIFF
--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -316,12 +316,21 @@ class ExceptionTranslation: public StackObj {
     int buffer_size = 2048;
     while (true) {
       ResourceMark rm;
-      jlong buffer = (jlong) NEW_RESOURCE_ARRAY_IN_THREAD(THREAD, jbyte, buffer_size);
-      int res = encode(THREAD, runtimeKlass, buffer, buffer_size);
-      if ((_from_env != nullptr && _from_env->has_pending_exception()) || HAS_PENDING_EXCEPTION) {
-        JVMCIRuntime::fatal_exception(_from_env, "HotSpotJVMCIRuntime.encodeThrowable should not throw an exception");
+      jlong buffer = (jlong) NEW_RESOURCE_ARRAY_IN_THREAD_RETURN_NULL(THREAD, jbyte, buffer_size);
+      if (buffer == 0L) {
+        decode(THREAD, runtimeKlass, 0L);
+        return;
       }
-      if (res < 0) {
+      int res = encode(THREAD, runtimeKlass, buffer, buffer_size);
+      if (_from_env != nullptr && _from_env->has_pending_exception()) {
+        _from_env->clear_pending_exception();
+        decode(THREAD, runtimeKlass, 0L);
+        return;
+      } else if (HAS_PENDING_EXCEPTION) {
+        CLEAR_PENDING_EXCEPTION;
+        decode(THREAD, runtimeKlass, 0L);
+        return;
+      } else if (res < 0) {
         int required_buffer_size = -res;
         if (required_buffer_size > buffer_size) {
           buffer_size = required_buffer_size;
@@ -329,7 +338,7 @@ class ExceptionTranslation: public StackObj {
       } else {
         decode(THREAD, runtimeKlass, buffer);
         if (!_to_env->has_pending_exception()) {
-          JVMCIRuntime::fatal_exception(_to_env, "HotSpotJVMCIRuntime.decodeAndThrowThrowable should throw an exception");
+          _to_env->throw_InternalError("HotSpotJVMCIRuntime.decodeAndThrowThrowable should have thrown an exception");
         }
         return;
       }

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
@@ -207,24 +207,35 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
     }
 
     /**
-     * Decodes the exception encoded in {@code buffer} and throws it. If {@code buffer == 0} then
-     * something went wrong (e.g. OutOfMemoryError) while encoding the exception. In this case, an
-     * {@link InternalError} is thrown.
+     * Decodes the exception encoded in {@code buffer} and throws it.
      *
-     * @param buffer a native byte buffer containing an exception encoded by
-     *            {@link #encodeThrowable}
+     * @param errorOrBuffer an error code or a native byte buffer containing an exception encoded by
+     *            {@link #encodeThrowable}. Error code values and their meanings are:
+     *
+     *            <pre>
+     *             0: native memory for the buffer could not be allocated
+     *            -1: an OutOfMemoryError was thrown while encoding the exception
+     *            -2: some other throwable was thrown while encoding the exception
+     *            </pre>
      */
     @VMEntryPoint
-    static void decodeAndThrowThrowable(long buffer) throws Throwable {
-        if (buffer == 0L) {
-            throw new InternalError(String.format("unexpected problem occurred while encoding an exception to translate it from %s to %s",
+    static void decodeAndThrowThrowable(long errorOrBuffer) throws Throwable {
+        if (errorOrBuffer >= -2L && errorOrBuffer <= 0) {
+            String context = String.format("while encoding an exception to translate it from %s to %s",
                             IS_IN_NATIVE_IMAGE ? "HotSpot" : "libjvmci",
-                            IS_IN_NATIVE_IMAGE ? "libjvmci" : "HotSpot"));
+                            IS_IN_NATIVE_IMAGE ? "libjvmci" : "HotSpot");
+            if (errorOrBuffer == 0) {
+                throw new InternalError("native buffer could not be allocated " + context);
+            }
+            if (errorOrBuffer == -1L) {
+                throw new OutOfMemoryError("OutOfMemoryError occurred " + context);
+            }
+            throw new InternalError("unexpected problem occurred " + context);
         }
         Unsafe unsafe = UnsafeAccess.UNSAFE;
-        int encodingLength = unsafe.getInt(buffer);
+        int encodingLength = unsafe.getInt(errorOrBuffer);
         byte[] encoding = new byte[encodingLength];
-        unsafe.copyMemory(null, buffer + 4, encoding, Unsafe.ARRAY_BYTE_BASE_OFFSET, encodingLength);
+        unsafe.copyMemory(null, errorOrBuffer + 4, encoding, Unsafe.ARRAY_BYTE_BASE_OFFSET, encodingLength);
         throw TranslatedException.decodeThrowable(encoding);
     }
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/TranslatedException.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/TranslatedException.java
@@ -149,7 +149,6 @@ final class TranslatedException extends Exception {
      * Encodes {@code throwable} including its stack and causes as a {@linkplain GZIPOutputStream
      * compressed} byte array that can be decoded by {@link #decodeThrowable}.
      */
-    @VMEntryPoint
     static byte[] encodeThrowable(Throwable throwable) throws Throwable {
         try {
             return encodeThrowable(throwable, true);
@@ -223,7 +222,6 @@ final class TranslatedException extends Exception {
      * @param encodedThrowable an encoded exception in the format specified by
      *            {@link #encodeThrowable}
      */
-    @VMEntryPoint
     static Throwable decodeThrowable(byte[] encodedThrowable) {
         try (DataInputStream dis = new DataInputStream(new GZIPInputStream(new ByteArrayInputStream(encodedThrowable)))) {
             Throwable cause = null;


### PR DESCRIPTION
JVMCI has a mechanism for translating exceptions from libjvmci to HotSpot and vice versa. This is important for proper error handling when a thread calls between these 2 runtime heaps.

This translation mechanism itself needs to be robust in the context of resource limits, especially heap limits, as it may be translating an OutOfMemoryError from HotSpot back into libjvmci. The existing code in [`HotSpotJVMCIRuntime.encodeThrowable`](https://github.com/graalvm/labs-openjdk-17/blob/f6b18b596fa5acb1ab7efa10e284d106669040a6/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java#L237) and [`TranslatedException.encodeThrowable`](https://github.com/graalvm/labs-openjdk-17/blob/f6b18b596fa5acb1ab7efa10e284d106669040a6/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/TranslatedException.java#L153) is designed to handle translation failures by falling back to non-allocating code. However, we still occasionally see [an OOME that breaks the translation mechanism](https://github.com/oracle/graal/issues/5470#issuecomment-1321749688). One speculated possibility for this is an OOME re-materializing oops during a deoptimization causing an unexpected execution path. This PR increases the robustness of the exception translation code in light of such issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297431](https://bugs.openjdk.org/browse/JDK-8297431): [JVMCI] HotSpotJVMCIRuntime.encodeThrowable should not throw an exception


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11286/head:pull/11286` \
`$ git checkout pull/11286`

Update a local copy of the PR: \
`$ git checkout pull/11286` \
`$ git pull https://git.openjdk.org/jdk pull/11286/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11286`

View PR using the GUI difftool: \
`$ git pr show -t 11286`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11286.diff">https://git.openjdk.org/jdk/pull/11286.diff</a>

</details>
