### PR TITLE
JDK-8297216: Search results omit some methods

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template
@@ -157,30 +157,21 @@ function createMatcher(term, camelCase) {
     re.upperCase = upperCase;
     return re;
 }
-function analyzeMatch(matcher, input, startOfName, category) {
+function findMatch(matcher, input, startOfName, endOfName) {
     var from = startOfName;
     matcher.lastIndex = from;
     var match = matcher.exec(input);
-    while (!match && from > 1) {
+    // Expand search area until we get a valid result or reach the beginning of the string
+    while (!match || match.index + match[0].length < startOfName || endOfName < match.index) {
+        if (from === 0) {
+            return NO_MATCH;
+        }
         from = input.lastIndexOf(".", from - 2) + 1;
         matcher.lastIndex = from;
         match = matcher.exec(input);
     }
-    if (!match) {
-        return NO_MATCH;
-    }
     var boundaries = [];
     var matchEnd = match.index + match[0].length;
-    var leftParen = input.indexOf("(");
-    // exclude peripheral matches
-    if (category !== "modules" && category !== "searchTags") {
-        if (leftParen > -1 && leftParen < match.index) {
-            return NO_MATCH;
-        } else if (startOfName - 1 >= matchEnd) {
-            return NO_MATCH;
-        }
-    }
-    var endOfName = leftParen > -1 ? leftParen : input.length;
     var score = 5;
     var start = match.index;
     var prevEnd = -1;
@@ -220,7 +211,6 @@ function analyzeMatch(matcher, input, startOfName, category) {
     return {
         input: input,
         score: score,
-        category: category,
         boundaries: boundaries
     };
 }
@@ -285,13 +275,16 @@ function doSearch(request, response) {
             var useQualified = useQualifiedName(category);
             var input = useQualified ? qualifiedName : simpleName;
             var startOfName = useQualified ? prefix.length : 0;
-            var m = analyzeMatch(matcher.plainMatcher, input, startOfName, category);
+            var endOfName = category === "members" && input.indexOf("(", startOfName) > -1
+                ? input.indexOf("(", startOfName) : input.length;
+            var m = findMatch(matcher.plainMatcher, input, startOfName, endOfName);
             if (m === NO_MATCH && matcher.camelCaseMatcher) {
-                m = analyzeMatch(matcher.camelCaseMatcher, input, startOfName, category);
+                m = findMatch(matcher.camelCaseMatcher, input, startOfName, endOfName);
             }
             if (m !== NO_MATCH) {
                 m.indexItem = item;
                 m.prefix = prefix;
+                m.category = category;
                 if (!useQualified) {
                     m.input = qualifiedName;
                     m.boundaries = m.boundaries.map(function(b) {

--- a/test/langtools/jdk/javadoc/doclet/testSearchScript/TestSearchScript.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearchScript/TestSearchScript.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8178982 8220497 8210683 8241982
+ * @bug 8178982 8220497 8210683 8241982 8297216
  * @summary Test the search feature of javadoc.
  * @library ../../lib
  * @library /test/lib
@@ -60,13 +60,16 @@ public class TestSearchScript extends JavadocTester {
     }
 
     private Invocable getEngine() throws ScriptException, IOException, NoSuchMethodException {
+        // For installing and using GraalVM JS on stock JDK see
+        // https://github.com/oracle/graaljs/blob/master/docs/user/RunOnJDK.md
+        // and https://github.com/graalvm/graal-js-jdk11-maven-demo
         ScriptEngineManager engineManager = new ScriptEngineManager();
         // Use "js" engine name to use any available JavaScript engine.
         ScriptEngine engine = engineManager.getEngineByName("js");
         if (engine == null) {
             throw new SkippedException("JavaScript engine is not available.");
         }
-        // For GraalJS set Nashorn compatibility mode via Bindings,
+        // Set Nashorn compatibility mode via Bindings for use with GraalVM JS,
         // see https://github.com/graalvm/graaljs/blob/master/docs/user/ScriptEngine.md
         Bindings bindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
         bindings.put("polyglot.js.nashorn-compat", true);
@@ -332,6 +335,29 @@ public class TestSearchScript extends JavadocTester {
         checkSearch(inv, "with map", List.of(
                 "listpkg.Nolist.withTypeParams(Map<String, ? extends Collection>)"));
 
+    }
+
+    @Test
+    public void testChannelSearch() throws ScriptException, IOException, NoSuchMethodException {
+        javadoc("-d", "out-channel",
+                "-Xdoclint:none",
+                "-use",
+                "-use",
+                "-sourcepath", testSrc,
+                "channels");
+        checkExit(Exit.OK);
+
+        Invocable inv = getEngine();
+
+        checkSearch(inv, "FileChannel", List.of("channels.FileChannel", "channels.FileChannel.Map",
+                "channels.FileChannel.FileChannel()"));
+        checkSearch(inv, "FileChannel.", List.of("channels.FileChannel.Map",
+                "channels.FileChannel.FileChannel()", "channels.FileChannel.map(FileChannel.Map, int)"));
+        checkSearch(inv, "filechannel.M", List.of("channels.FileChannel.Map",
+                "channels.FileChannel.map(FileChannel.Map, int)"));
+        checkSearch(inv, "FileChannel.map", List.of("channels.FileChannel.Map",
+                "channels.FileChannel.map(FileChannel.Map, int)"));
+        checkSearch(inv, "FileChannel.map(", List.of("channels.FileChannel.map(FileChannel.Map, int)"));
     }
 
     void checkSearch(Invocable inv, String query, List<String> results) throws ScriptException, NoSuchMethodException {

--- a/test/langtools/jdk/javadoc/doclet/testSearchScript/TestSearchScript.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearchScript/TestSearchScript.java
@@ -342,7 +342,6 @@ public class TestSearchScript extends JavadocTester {
         javadoc("-d", "out-channel",
                 "-Xdoclint:none",
                 "-use",
-                "-use",
                 "-sourcepath", testSrc,
                 "channels");
         checkExit(Exit.OK);


### PR DESCRIPTION
Please review a fix for a bug where a method's parameter type could "mask" a method and result in the method to not appear in the search results. The fix consists in checking whether a match covers an element's name in the match loop. 

Note that the added test must be run manually as it requires GraalVM JS (or some other JS engine) to be installed. In addition to running the test I did extensive A/B testing to make sure search results remain unchanged apart from the bug fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297216](https://bugs.openjdk.org/browse/JDK-8297216): Search results omit some methods


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to [524d1b5d](https://git.openjdk.org/jdk/pull/11287/files/524d1b5d0bf8b2748f88e40aaed64580d5715759)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11287/head:pull/11287` \
`$ git checkout pull/11287`

Update a local copy of the PR: \
`$ git checkout pull/11287` \
`$ git pull https://git.openjdk.org/jdk pull/11287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11287`

View PR using the GUI difftool: \
`$ git pr show -t 11287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11287.diff">https://git.openjdk.org/jdk/pull/11287.diff</a>

</details>
