### PR TITLE
8297402: jfr tool processes large padded integers incorrectly

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkHeader.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkHeader.java
@@ -223,7 +223,7 @@ public final class ChunkHeader {
 
     public MetadataDescriptor readMetadata(MetadataDescriptor previous) throws IOException {
         input.position(absoluteChunkStart + metadataPosition);
-        input.readInt(); // size
+        input.readPaddedInt(); // size
         long id = input.readLong(); // event type id
         if (id != METADATA_TYPE_ID) {
             throw new IOException("Expected metadata event. Type id=" + id + ", should have been " + METADATA_TYPE_ID);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
@@ -228,7 +228,7 @@ public final class ChunkParser {
         long absoluteChunkEnd = chunkHeader.getEnd();
         while (input.position() < absoluteChunkEnd) {
             long pos = input.position();
-            int size = input.readInt();
+            int size = input.readPaddedInt();
             if (size == 0) {
                 throw new IOException("Event can't have zero size");
             }
@@ -243,7 +243,7 @@ public final class ChunkParser {
                         if (chunkWriter.accept(event)) {
                             chunkWriter.writeEvent(pos, input.position());
                             input.position(pos);
-                            input.readInt(); // size
+                            input.readPaddedInt(); // size
                             input.readLong(); // type
                             chunkWriter.touch(ep.parseReferences(input));
                         }
@@ -310,7 +310,7 @@ public final class ChunkParser {
             }
             input.position(thisCP);
             lastCP = thisCP;
-            int size = input.readInt(); // size
+            int size = input.readPaddedInt(); // size
             long typeId = input.readLong();
             if (typeId != CONSTANT_POOL_TYPE_ID) {
                 throw new IOException("Expected check point event (id = 1) at position " + lastCP + ", but found type id = " + typeId);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/RecordingInput.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/RecordingInput.java
@@ -406,6 +406,26 @@ public final class RecordingInput implements DataInput, AutoCloseable {
         return ret + (((long) (b8 & 0XFF)) << 56);
     }
 
+    public int readPaddedInt() throws IOException {
+        return (int) readPadded(4);
+    }
+
+    private long readPadded(int size) throws IOException {
+        long ret = 0L;
+        int shift = 0;
+        for (int i = 0; i < size; i++) {
+            long b = readByte();
+            boolean isLastByte = (i == size - 1);
+            long mask = isLastByte ? 0XFFL : 0x7FL;
+            ret += ((b & mask) << shift);
+            if (b >= 0) {
+                return ret;
+            }
+            shift += 7;
+        }
+        return ret;
+    }
+
     public void setValidSize(long size) {
         if (size > this.size) {
             this.size = size;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/filter/ChunkWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/filter/ChunkWriter.java
@@ -183,7 +183,7 @@ public final class ChunkWriter implements Closeable {
     private void writeMetadataEvent(ChunkHeader header) throws IOException {
         long metadataposition = header.getMetadataPosition() + header.getAbsoluteChunkStart();
         input.position(metadataposition);
-        long size = input.readLong();
+        long size = input.readPaddedInt();
         input.position(metadataposition);
         for (int i = 0; i < size; i++) {
             output.writeByte(input.readByte());
@@ -194,7 +194,7 @@ public final class ChunkWriter implements Closeable {
         input.position(event.getStartPosition());
         long startPosition = output.position();
 
-        input.readLong(); // Read size
+        input.readPaddedInt(); // Read size
         output.writePaddedUnsignedInt(0); // Size, 4 bytes reserved
         output.writeLong(input.readLong()); // Constant pool id
         output.writeLong(input.readLong()); // Start time

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Summary.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Summary.java
@@ -116,7 +116,7 @@ final class Summary extends Command {
                 input.position(ch.getEventStart());
                 while (input.position() < chunkEnd) {
                     long pos = input.position();
-                    int size = input.readInt();
+                    int size = input.readPaddedInt();
                     long eventTypeId = input.readLong();
                     Statistics s = stats.get(eventTypeId);
                     if (s == null) {


### PR DESCRIPTION
Could I have a review of a PR that fixes jfr tool reading of large padded integers.

Some integer values are written to jfr recordings using write_padded_at_offset<u4>() method. Their size in recording is always 4 bytes.
jfr tool reads all integer values by readInt() method, which doesn't take size into account.
For padded values greater than (1 << 28), jfr tool tries to read 5 bytes from recording and fails.

I suggest to fix reading of padded integers in jfr tool.
If a value is written by write_padded_at_offset<u4>() then it should be read by readPaddedInt() method which doesn't read more than 4 bytes.
(It can be less then 4 bytes due to JDK-8246260)

Tested with jdk/jfr and tier1.
jfr recording generated by TestHugeStackTracePool.java with jdk11 (attached to JDK-8297402) is successfully processed by jfr tool after the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297402](https://bugs.openjdk.org/browse/JDK-8297402): jfr tool processes large padded integers incorrectly


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11289/head:pull/11289` \
`$ git checkout pull/11289`

Update a local copy of the PR: \
`$ git checkout pull/11289` \
`$ git pull https://git.openjdk.org/jdk pull/11289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11289`

View PR using the GUI difftool: \
`$ git pr show -t 11289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11289.diff">https://git.openjdk.org/jdk/pull/11289.diff</a>

</details>
