### PR TITLE
8297435: Remove unused CompactibleSpaceClosure

### DIFF
--- a/src/hotspot/share/memory/iterator.hpp
+++ b/src/hotspot/share/memory/iterator.hpp
@@ -233,13 +233,6 @@ class SpaceClosure : public StackObj {
   virtual void do_space(Space* s) = 0;
 };
 
-class CompactibleSpaceClosure : public StackObj {
- public:
-  // Called for each compactible space
-  virtual void do_space(CompactibleSpace* s) = 0;
-};
-
-
 // CodeBlobClosure is used for iterating through code blobs
 // in the code cache or on thread stacks
 


### PR DESCRIPTION
Trivial removing of dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297435](https://bugs.openjdk.org/browse/JDK-8297435): Remove unused CompactibleSpaceClosure


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11290/head:pull/11290` \
`$ git checkout pull/11290`

Update a local copy of the PR: \
`$ git checkout pull/11290` \
`$ git pull https://git.openjdk.org/jdk pull/11290/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11290`

View PR using the GUI difftool: \
`$ git pr show -t 11290`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11290.diff">https://git.openjdk.org/jdk/pull/11290.diff</a>

</details>
