### PR TITLE
8078471: Backspace does not work in JFileChooser with GTK L&F

### DIFF
--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKFileChooserUI.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKFileChooserUI.java
@@ -351,6 +351,8 @@ class GTKFileChooserUI extends SynthFileChooserUI {
             }
             directoryComboBoxModel.addItem(currentDirectory);
             directoryListModel.directoryChanged();
+            FileSystemView fsv = getFileChooser().getFileSystemView();
+            getChangeToParentDirectoryAction().setEnabled(!fsv.isFileSystemRoot(currentDirectory));
         }
         super.doDirectoryChanged(e);
     }

--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKLookAndFeel.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKLookAndFeel.java
@@ -590,6 +590,7 @@ public class GTKLookAndFeel extends SynthLookAndFeel {
             "FileChooser.ancestorInputMap",
                new UIDefaults.LazyInputMap(new Object[] {
                      "ESCAPE", "cancelSelection",
+                 "BACK_SPACE", "Go Up",
                  "ctrl ENTER", "approveSelection"
                  }),
             "FileChooserUI", "com.sun.java.swing.plaf.gtk.GTKLookAndFeel",

--- a/test/jdk/com/sun/java/swing/plaf/gtk/TestBackSpaceAction.java
+++ b/test/jdk/com/sun/java/swing/plaf/gtk/TestBackSpaceAction.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.File;
+import java.awt.BorderLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+/* @test
+ * @bug 8078471
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @requires (os.family == "linux")
+ * @summary Verifies if filechooser current directory changed to parent directory on
+ * BACKSPACE key press from keyboard.
+ * @run main/manual TestBackSpaceAction
+ */
+
+public class TestBackSpaceAction {
+    static TestFrame testObj;
+    static final String instructions
+            = """
+            Default look and feel set to Metal.
+            
+            
+            INSTRUCTIONS:
+               1. Double click on 'subDir' to move into 'subDir' folder.
+               2. Press BACKSPACE key.
+               3. Verify the file chooser directory changed to 'testDir'.
+               4. Press Nimbus button to change look and feel to nimbus.
+               5. Repeat Steps 1 to 3.
+               6. Press GTK+ button to change look and feel to GTK.
+               7. Repeat Steps 1 to 3.
+               8. Press Pass if execution is as per instructions else Press Fail.
+            """;
+    static PassFailJFrame passFailJFrame;
+
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            try {
+                passFailJFrame = new PassFailJFrame("JFileChooser Test Instructions",
+                        instructions, 5, 15, 50);
+                testObj = new TestFrame();
+                PassFailJFrame.addTestWindow(testObj);
+                PassFailJFrame.positionTestWindow(testObj,
+                        PassFailJFrame.Position.HORIZONTAL);
+                testObj.setVisible(true);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        passFailJFrame.awaitAndCheck();
+    }
+}
+
+class TestFrame extends JFrame implements ActionListener {
+    static File testDir;
+    static File subDir;
+
+    public TestFrame() {
+        try {
+            // create test directory
+            String tmpDir = System.getProperty("java.io.tmpdir");
+            if (tmpDir.length() == 0) { //'java.io.tmpdir' isn't guaranteed to be defined
+                tmpDir = System.getProperty("user.home");
+            }
+            testDir = new File(tmpDir, "testDir");
+            testDir.mkdir();
+            testDir.deleteOnExit();
+
+            // create sub directory inside test directory
+            subDir = new File(testDir, "subDir");
+            subDir.mkdir();
+            subDir.deleteOnExit();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        initComponents();
+    }
+
+    public void initComponents() {
+        JPanel p = new JPanel();
+        JFileChooser fileChooser = new JFileChooser(testDir);
+        fileChooser.setControlButtonsAreShown(false);
+        getContentPane().add(fileChooser);
+
+        UIManager.LookAndFeelInfo[] lookAndFeel = UIManager.getInstalledLookAndFeels();
+        for (UIManager.LookAndFeelInfo laf : lookAndFeel) {
+            if(!laf.getClassName().contains("MotifLookAndFeel")) {
+                JButton btn = new JButton(laf.getName());
+                btn.setActionCommand(laf.getClassName());
+                btn.addActionListener(this);
+                p.add(btn);
+            }
+        }
+
+        getContentPane().add(p,BorderLayout.SOUTH);
+        setSize(500, 500);
+    }
+
+    private static void setLookAndFeel(String laf) {
+        try {
+            UIManager.setLookAndFeel(laf);
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.out.println("Unsupported L&F: " + laf);
+        } catch (ClassNotFoundException | InstantiationException
+                 | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    //Change the Look and Feel on user selection
+    public void actionPerformed(ActionEvent e) {
+        setLookAndFeel(e.getActionCommand());
+        SwingUtilities.updateComponentTreeUI(this);
+    }
+}

--- a/test/jdk/com/sun/java/swing/plaf/gtk/TestBackSpaceAction.java
+++ b/test/jdk/com/sun/java/swing/plaf/gtk/TestBackSpaceAction.java
@@ -49,8 +49,8 @@ public class TestBackSpaceAction {
     static final String instructions
             = """
             Default look and feel set to Metal.
-            
-            
+
+
             INSTRUCTIONS:
                1. Double click on 'subDir' to move into 'subDir' folder.
                2. Press BACKSPACE key.

--- a/test/jdk/com/sun/java/swing/plaf/gtk/TestBackSpaceAction.java
+++ b/test/jdk/com/sun/java/swing/plaf/gtk/TestBackSpaceAction.java
@@ -40,7 +40,7 @@ import javax.swing.UnsupportedLookAndFeelException;
  * @build PassFailJFrame
  * @requires (os.family == "linux")
  * @summary Verifies if filechooser current directory changed to parent directory on
- * BACKSPACE key press from keyboard.
+ * BACKSPACE key press from keyboard if not at root directory.
  * @run main/manual TestBackSpaceAction
  */
 
@@ -53,9 +53,10 @@ public class TestBackSpaceAction {
 
             INSTRUCTIONS:
                1. Double click on 'subDir' to move into 'subDir' folder.
-               2. Press BACKSPACE key.
-               3. Verify the file chooser directory changed to 'testDir'.
-               4. Press Nimbus button to change look and feel to nimbus.
+               2. Press BACKSPACE key multiple times.
+               3. Verify the file chooser directory changed to parent directory
+                  except root level.
+               4. Press Nimbus button to change look and feel to Nimbus.
                5. Repeat Steps 1 to 3.
                6. Press GTK+ button to change look and feel to GTK.
                7. Repeat Steps 1 to 3.
@@ -84,6 +85,7 @@ public class TestBackSpaceAction {
 class TestFrame extends JFrame implements ActionListener {
     static File testDir;
     static File subDir;
+    static JFileChooser fileChooser;
 
     public TestFrame() {
         try {
@@ -108,7 +110,7 @@ class TestFrame extends JFrame implements ActionListener {
 
     public void initComponents() {
         JPanel p = new JPanel();
-        JFileChooser fileChooser = new JFileChooser(testDir);
+        fileChooser = new JFileChooser(testDir);
         fileChooser.setControlButtonsAreShown(false);
         getContentPane().add(fileChooser);
 
@@ -141,5 +143,6 @@ class TestFrame extends JFrame implements ActionListener {
     public void actionPerformed(ActionEvent e) {
         setLookAndFeel(e.getActionCommand());
         SwingUtilities.updateComponentTreeUI(this);
+        fileChooser.setCurrentDirectory(testDir);
     }
 }

--- a/test/jdk/com/sun/java/swing/plaf/gtk/TestBackSpaceAction.java
+++ b/test/jdk/com/sun/java/swing/plaf/gtk/TestBackSpaceAction.java
@@ -81,8 +81,8 @@ public class TestBackSpaceAction {
                         UIManager.getInstalledLookAndFeels()) {
             if (!laf.getClassName().contains("MotifLookAndFeel")) {
                 System.out.println("Testing LAF: " + laf.getClassName());
-            	SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
-            	doTesting(laf);
+                SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
+                doTesting(laf);
             }
         }
     }

--- a/test/jdk/com/sun/java/swing/plaf/gtk/TestBackSpaceAction.java
+++ b/test/jdk/com/sun/java/swing/plaf/gtk/TestBackSpaceAction.java
@@ -26,8 +26,8 @@
  * @bug 8078471
  * @key headful
  * @requires (os.family == "linux")
- * @summary Verifies if filechooser current directory changed to parent directory on
- * BACKSPACE key press from keyboard except root directory.
+ * @summary Verifies if filechooser current directory changed to parent
+ * directory on BACKSPACE key press except root directory.
  * @run main TestBackSpaceAction
  */
 
@@ -62,7 +62,8 @@ public class TestBackSpaceAction {
         try {
             // create test directory
             String tmpDir = System.getProperty("java.io.tmpdir");
-            if (tmpDir.length() == 0) { //'java.io.tmpdir' isn't guaranteed to be defined
+            //'java.io.tmpdir' isn't guaranteed to be defined
+            if (tmpDir.length() == 0) {
                 tmpDir = System.getProperty("user.home");
             }
             testDir = new File(tmpDir, "testDir");
@@ -98,7 +99,8 @@ public class TestBackSpaceAction {
         }
     }
 
-    private static void doTesting(UIManager.LookAndFeelInfo laf) throws Exception{
+    private static void doTesting(UIManager.LookAndFeelInfo laf)
+            throws Exception {
         try {
             SwingUtilities.invokeAndWait(() -> {
                 createAndShowUI();
@@ -115,7 +117,7 @@ public class TestBackSpaceAction {
             }
 
             // check if backspace key changes directory at root level
-            while(!fileChooser.getFileSystemView().isFileSystemRoot(prevDir)) {
+            while (!fileChooser.getFileSystemView().isFileSystemRoot(prevDir)) {
                 clickBackSpace();
                 if (prevDir == crntDir) {
                     passed_2 = true;
@@ -126,8 +128,8 @@ public class TestBackSpaceAction {
             if (passed_1 && passed_2) {
                 System.out.println("Passed");
             } else {
-                throw new RuntimeException("BackSpace keyboard button does not" +
-                        "lead to parent directory for LAF: " + laf.getClassName());
+                throw new RuntimeException("BackSpace does not lead to " +
+                        "parent directory for LAF: " + laf.getClassName());
             }
         } finally {
             SwingUtilities.invokeAndWait(() -> {
@@ -144,8 +146,7 @@ public class TestBackSpaceAction {
         fileChooser = new JFileChooser(subDir);
         fileChooser.setControlButtonsAreShown(false);
         fileChooser.addHierarchyListener(new HierarchyListener(){
-            public void hierarchyChanged(HierarchyEvent he)
-            {
+            public void hierarchyChanged(HierarchyEvent he) {
                 grabFocusForComboBox(fileChooser.getComponents());
             }
         });


### PR DESCRIPTION
The Backspace key doesn't lead to parent directory of current directory for JFileChooser in GTK LAF. 
Added the lazy input value in `GTKLookandFeel` and fix is working fine.

Implemented a manual test to check BackSpace behavior for all installed LAF in Linux platform.
The test mentioned in [JDK-8078471](https://bugs.openjdk.org/browse/JDK-8078471) `javax/swing/JFileChooser/4150029/bug4150029.html` also working fine with GTK option (-client -Dswing.defaultlaf=com.sun.java.swing.plaf.gtk.GTKLookAndFeel).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8078471](https://bugs.openjdk.org/browse/JDK-8078471): Backspace does not work in JFileChooser with GTK L&F


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**) ⚠️ Review applies to [3b19e5cd](https://git.openjdk.org/jdk/pull/11291/files/3b19e5cd58e2d3fa619e01b90bf3c18ee8293f5a)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [3b19e5cd](https://git.openjdk.org/jdk/pull/11291/files/3b19e5cd58e2d3fa619e01b90bf3c18ee8293f5a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11291/head:pull/11291` \
`$ git checkout pull/11291`

Update a local copy of the PR: \
`$ git checkout pull/11291` \
`$ git pull https://git.openjdk.org/jdk pull/11291/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11291`

View PR using the GUI difftool: \
`$ git pr show -t 11291`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11291.diff">https://git.openjdk.org/jdk/pull/11291.diff</a>

</details>
