### PR TITLE
8297276: Remove thread text from Subject.current

### DIFF
--- a/src/java.base/share/classes/javax/security/auth/Subject.java
+++ b/src/java.base/share/classes/javax/security/auth/Subject.java
@@ -325,10 +325,6 @@ public final class Subject implements java.io.Serializable {
      * retrieved by this method. After {@code action} is finished, the current
      * subject is reset to its previous value. The current
      * subject is {@code null} before the first call of {@code callAs()}.
-     * <p>
-     * When a new thread is created, its current subject is the same as
-     * the one of its parent thread, and will not change even if
-     * its parent thread's current subject is changed to another value.
      *
      * @implNote
      * This method returns the same value as


### PR DESCRIPTION
With the introduction of Virtual Threads, the current subject is no longer guaranteed to be inherited in a new thread. Remove this requirement until we find another way to implement `Subject::current`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8297276](https://bugs.openjdk.org/browse/JDK-8297276): Remove thread text from Subject.current
 * [JDK-8297351](https://bugs.openjdk.org/browse/JDK-8297351): Remove thread text from Subject.current (**CSR**)


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11292/head:pull/11292` \
`$ git checkout pull/11292`

Update a local copy of the PR: \
`$ git checkout pull/11292` \
`$ git pull https://git.openjdk.org/jdk pull/11292/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11292`

View PR using the GUI difftool: \
`$ git pr show -t 11292`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11292.diff">https://git.openjdk.org/jdk/pull/11292.diff</a>

</details>
