### PR TITLE
8297445: PPC64: Represent Registers as values

### DIFF
--- a/src/hotspot/cpu/ppc/assembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.hpp
@@ -1932,7 +1932,7 @@ class Assembler : public AbstractAssembler {
 
   // More convenient version.
   int condition_register_bit(ConditionRegister cr, Condition c) {
-    return 4 * (int)(intptr_t)cr + c;
+    return 4 * cr.encoding() + c;
   }
   void crand( ConditionRegister crdst, Condition cdst, ConditionRegister crsrc, Condition csrc);
   void crnand(ConditionRegister crdst, Condition cdst, ConditionRegister crsrc, Condition csrc);

--- a/src/hotspot/cpu/ppc/assembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -577,7 +577,7 @@ void LIR_Assembler::emit_opConvert(LIR_OpConvert* op) {
     case Bytecodes::_f2i: {
       bool dst_in_memory = !VM_Version::has_mtfprd();
       FloatRegister rsrc = (code == Bytecodes::_d2i) ? src->as_double_reg() : src->as_float_reg();
-      Address       addr = dst_in_memory ? frame_map()->address_for_slot(dst->double_stack_ix()) : NULL;
+      Address       addr = dst_in_memory ? frame_map()->address_for_slot(dst->double_stack_ix()) : Address();
       Label L;
       // Result must be 0 if value is NaN; test by comparing value to itself.
       __ fcmpu(CCR0, rsrc, rsrc);
@@ -601,7 +601,7 @@ void LIR_Assembler::emit_opConvert(LIR_OpConvert* op) {
     case Bytecodes::_f2l: {
       bool dst_in_memory = !VM_Version::has_mtfprd();
       FloatRegister rsrc = (code == Bytecodes::_d2l) ? src->as_double_reg() : src->as_float_reg();
-      Address       addr = dst_in_memory ? frame_map()->address_for_slot(dst->double_stack_ix()) : NULL;
+      Address       addr = dst_in_memory ? frame_map()->address_for_slot(dst->double_stack_ix()) : Address();
       Label L;
       // Result must be 0 if value is NaN; test by comparing value to itself.
       __ fcmpu(CCR0, rsrc, rsrc);

--- a/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.cpp
@@ -540,15 +540,15 @@ class ZSetupArguments {
 
       if (_ref != R4_ARG2) {
         // Calculate address first as the address' base register might clash with R4_ARG2
-        __ add(R4_ARG2, (intptr_t) _ref_addr.disp(), _ref_addr.base());
+        __ addi(R4_ARG2, _ref_addr.base(), _ref_addr.disp());
         __ mr_if_needed(R3_ARG1, _ref);
       } else if (_ref_addr.base() != R3_ARG1) {
         __ mr(R3_ARG1, _ref);
-        __ add(R4_ARG2, (intptr_t) _ref_addr.disp(), _ref_addr.base()); // Clobbering _ref
+        __ addi(R4_ARG2, _ref_addr.base(), _ref_addr.disp()); // Clobbering _ref
       } else {
         // Arguments are provided in inverse order (i.e. _ref == R4_ARG2, _ref_addr == R3_ARG1)
         __ mr(R0, _ref);
-        __ add(R4_ARG2, (intptr_t) _ref_addr.disp(), _ref_addr.base());
+        __ addi(R4_ARG2, _ref_addr.base(), _ref_addr.disp());
         __ mr(R3_ARG1, R0);
       }
     }

--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -1769,7 +1769,7 @@ void InterpreterMacroAssembler::profile_arguments_type(Register callee,
     if (MethodData::profile_arguments()) {
       Label done;
       int off_to_args = in_bytes(TypeEntriesAtCall::args_data_offset());
-      add(R28_mdx, off_to_args, R28_mdx);
+      addi(R28_mdx, R28_mdx, off_to_args);
 
       for (int i = 0; i < TypeProfileArgsLimit; i++) {
         if (i > 0 || MethodData::profile_return()) {

--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/ppc/methodHandles_ppc.cpp
+++ b/src/hotspot/cpu/ppc/methodHandles_ppc.cpp
@@ -301,7 +301,7 @@ address MethodHandles::generate_method_handle_interpreter_entry(MacroAssembler* 
     }
     Register R19_member = R19_method;  // MemberName ptr; incoming method ptr is dead now
     __ ld(R19_member, RegisterOrConstant((intptr_t)8), R15_argbase);
-    __ add(R15_argbase, Interpreter::stackElementSize, R15_argbase);
+    __ addi(R15_argbase, R15_argbase, Interpreter::stackElementSize);
     generate_method_handle_dispatch(_masm, iid, tmp_recv, R19_member, not_for_compiler_entry);
   }
 

--- a/src/hotspot/cpu/ppc/methodHandles_ppc.cpp
+++ b/src/hotspot/cpu/ppc/methodHandles_ppc.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/ppc/register_ppc.cpp
+++ b/src/hotspot/cpu/ppc/register_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2018 SAP SE. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/ppc/register_ppc.cpp
+++ b/src/hotspot/cpu/ppc/register_ppc.cpp
@@ -26,8 +26,7 @@
 #include "precompiled.hpp"
 #include "register_ppc.hpp"
 
-
-const char* RegisterImpl::name() const {
+const char* Register::name() const {
   const char* names[number_of_registers] = {
     "R0",  "R1",  "R2",  "R3",  "R4",  "R5",  "R6",  "R7",
     "R8",  "R9",  "R10", "R11", "R12", "R13", "R14", "R15",
@@ -37,14 +36,14 @@ const char* RegisterImpl::name() const {
   return is_valid() ? names[encoding()] : "noreg";
 }
 
-const char* ConditionRegisterImpl::name() const {
+const char* ConditionRegister::name() const {
   const char* names[number_of_registers] = {
     "CR0",  "CR1",  "CR2",  "CR3",  "CR4",  "CR5",  "CR6",  "CR7"
   };
   return is_valid() ? names[encoding()] : "cnoreg";
 }
 
-const char* FloatRegisterImpl::name() const {
+const char* FloatRegister::name() const {
   const char* names[number_of_registers] = {
     "F0",  "F1",  "F2",  "F3",  "F4",  "F5",  "F6",  "F7",
     "F8",  "F9",  "F10", "F11", "F12", "F13", "F14", "F15",
@@ -54,14 +53,14 @@ const char* FloatRegisterImpl::name() const {
   return is_valid() ? names[encoding()] : "fnoreg";
 }
 
-const char* SpecialRegisterImpl::name() const {
+const char* SpecialRegister::name() const {
   const char* names[number_of_registers] = {
     "SR_XER", "SR_LR", "SR_CTR", "SR_VRSAVE", "SR_SPEFSCR", "SR_PPR"
   };
   return is_valid() ? names[encoding()] : "snoreg";
 }
 
-const char* VectorRegisterImpl::name() const {
+const char* VectorRegister::name() const {
   const char* names[number_of_registers] = {
     "VR0",  "VR1",  "VR2",  "VR3",  "VR4",  "VR5",  "VR6",  "VR7",
     "VR8",  "VR9",  "VR10", "VR11", "VR12", "VR13", "VR14", "VR15",
@@ -71,7 +70,7 @@ const char* VectorRegisterImpl::name() const {
   return is_valid() ? names[encoding()] : "vnoreg";
 }
 
-const char* VectorSRegisterImpl::name() const {
+const char* VectorSRegister::name() const {
   const char* names[number_of_registers] = {
     "VSR0",  "VSR1",  "VSR2",  "VSR3",  "VSR4",  "VSR5",  "VSR6",  "VSR7",
     "VSR8",  "VSR9",  "VSR10", "VSR11", "VSR12", "VSR13", "VSR14", "VSR15",
@@ -86,19 +85,19 @@ const char* VectorSRegisterImpl::name() const {
 }
 
 // Method to convert a FloatRegister to a Vector-Scalar Register (VectorSRegister)
-VectorSRegister FloatRegisterImpl::to_vsr() const {
-  if (this == fnoreg) { return vsnoreg; }
+VectorSRegister FloatRegister::to_vsr() const {
+  if (*this == fnoreg) { return vsnoreg; }
   return as_VectorSRegister(encoding());
 }
 
 // Method to convert a VectorRegister to a Vector-Scalar Register (VectorSRegister)
-VectorSRegister VectorRegisterImpl::to_vsr() const {
-  if (this == vnoreg) { return vsnoreg; }
+VectorSRegister VectorRegister::to_vsr() const {
+  if (*this == vnoreg) { return vsnoreg; }
   return as_VectorSRegister(encoding() + 32);
 }
 
 // Method to convert a VectorSRegister to a Vector Register (VectorRegister)
-VectorRegister VectorSRegisterImpl::to_vr() const {
-  if (this == vsnoreg) { return vnoreg; }
+VectorRegister VectorSRegister::to_vr() const {
+  if (*this == vsnoreg) { return vnoreg; }
   return as_VectorRegister(encoding() - 32);
 }

--- a/src/hotspot/cpu/ppc/register_ppc.hpp
+++ b/src/hotspot/cpu/ppc/register_ppc.hpp
@@ -29,7 +29,6 @@
 #include "asm/register.hpp"
 
 // forward declaration
-class Address;
 class VMRegImpl;
 typedef VMRegImpl* VMReg;
 
@@ -75,207 +74,145 @@ typedef VMRegImpl* VMReg;
 //  vs0-31    Alias for f0-f31 (64 bit, see above)
 //  vs32-63   Alias for v0-31 (128 bit, see above)
 
-// Use Register as shortcut
-class RegisterImpl;
-typedef RegisterImpl* Register;
-
-inline Register as_Register(int encoding) {
-  assert(encoding >= -1 && encoding < 32, "bad register encoding");
-  return (Register)(intptr_t)encoding;
-}
 
 // The implementation of integer registers for the Power architecture
-class RegisterImpl: public AbstractRegisterImpl {
+class Register {
+  int _encoding;
  public:
   enum {
     number_of_registers = 32
   };
 
+  constexpr Register(int encoding = -1) : _encoding(encoding) {}
+  bool operator==(const Register rhs) const { return _encoding == rhs._encoding; }
+  bool operator!=(const Register rhs) const { return _encoding != rhs._encoding; }
+  const Register* operator->() const { return this; }
+
   // general construction
-  inline friend Register as_Register(int encoding);
+  inline constexpr friend Register as_Register(int encoding);
 
   // accessors
-  int encoding() const { assert(is_valid(), "invalid register"); return value(); }
-  inline VMReg as_VMReg();
-  Register successor() const { return as_Register(encoding() + 1); }
+  int encoding() const { assert(is_valid(), "invalid register"); return _encoding; }
+  inline VMReg as_VMReg() const;
+  Register successor() const { return Register(encoding() + 1); }
 
   // testers
-  bool is_valid()       const { return ( 0 <= (value()&0x7F) && (value()&0x7F) <  number_of_registers); }
-  bool is_volatile()    const { return ( 0 <= (value()&0x7F) && (value()&0x7F) <= 13 ); }
-  bool is_nonvolatile() const { return (14 <= (value()&0x7F) && (value()&0x7F) <= 31 ); }
+  bool is_valid()       const { return ( 0 <= _encoding && _encoding <  number_of_registers); }
+  bool is_volatile()    const { return ( 0 <= _encoding && _encoding <= 13 ); }
+  bool is_nonvolatile() const { return (14 <= _encoding && _encoding <= 31 ); }
 
   const char* name() const;
 };
 
-// The integer registers of the PPC architecture
-CONSTANT_REGISTER_DECLARATION(Register, noreg, (-1));
-
-CONSTANT_REGISTER_DECLARATION(Register, R0,   (0));
-CONSTANT_REGISTER_DECLARATION(Register, R1,   (1));
-CONSTANT_REGISTER_DECLARATION(Register, R2,   (2));
-CONSTANT_REGISTER_DECLARATION(Register, R3,   (3));
-CONSTANT_REGISTER_DECLARATION(Register, R4,   (4));
-CONSTANT_REGISTER_DECLARATION(Register, R5,   (5));
-CONSTANT_REGISTER_DECLARATION(Register, R6,   (6));
-CONSTANT_REGISTER_DECLARATION(Register, R7,   (7));
-CONSTANT_REGISTER_DECLARATION(Register, R8,   (8));
-CONSTANT_REGISTER_DECLARATION(Register, R9,   (9));
-CONSTANT_REGISTER_DECLARATION(Register, R10, (10));
-CONSTANT_REGISTER_DECLARATION(Register, R11, (11));
-CONSTANT_REGISTER_DECLARATION(Register, R12, (12));
-CONSTANT_REGISTER_DECLARATION(Register, R13, (13));
-CONSTANT_REGISTER_DECLARATION(Register, R14, (14));
-CONSTANT_REGISTER_DECLARATION(Register, R15, (15));
-CONSTANT_REGISTER_DECLARATION(Register, R16, (16));
-CONSTANT_REGISTER_DECLARATION(Register, R17, (17));
-CONSTANT_REGISTER_DECLARATION(Register, R18, (18));
-CONSTANT_REGISTER_DECLARATION(Register, R19, (19));
-CONSTANT_REGISTER_DECLARATION(Register, R20, (20));
-CONSTANT_REGISTER_DECLARATION(Register, R21, (21));
-CONSTANT_REGISTER_DECLARATION(Register, R22, (22));
-CONSTANT_REGISTER_DECLARATION(Register, R23, (23));
-CONSTANT_REGISTER_DECLARATION(Register, R24, (24));
-CONSTANT_REGISTER_DECLARATION(Register, R25, (25));
-CONSTANT_REGISTER_DECLARATION(Register, R26, (26));
-CONSTANT_REGISTER_DECLARATION(Register, R27, (27));
-CONSTANT_REGISTER_DECLARATION(Register, R28, (28));
-CONSTANT_REGISTER_DECLARATION(Register, R29, (29));
-CONSTANT_REGISTER_DECLARATION(Register, R30, (30));
-CONSTANT_REGISTER_DECLARATION(Register, R31, (31));
-
-
-//
-// Because Power has many registers, #define'ing values for them is
-// beneficial in code size and is worth the cost of some of the
-// dangers of defines. If a particular file has a problem with these
-// defines then it's possible to turn them off in that file by
-// defining DONT_USE_REGISTER_DEFINES. Register_definition_ppc.cpp
-// does that so that it's able to provide real definitions of these
-// registers for use in debuggers and such.
-//
-
-#ifndef DONT_USE_REGISTER_DEFINES
-#define noreg ((Register)(noreg_RegisterEnumValue))
-
-#define R0 ((Register)(R0_RegisterEnumValue))
-#define R1 ((Register)(R1_RegisterEnumValue))
-#define R2 ((Register)(R2_RegisterEnumValue))
-#define R3 ((Register)(R3_RegisterEnumValue))
-#define R4 ((Register)(R4_RegisterEnumValue))
-#define R5 ((Register)(R5_RegisterEnumValue))
-#define R6 ((Register)(R6_RegisterEnumValue))
-#define R7 ((Register)(R7_RegisterEnumValue))
-#define R8 ((Register)(R8_RegisterEnumValue))
-#define R9 ((Register)(R9_RegisterEnumValue))
-#define R10 ((Register)(R10_RegisterEnumValue))
-#define R11 ((Register)(R11_RegisterEnumValue))
-#define R12 ((Register)(R12_RegisterEnumValue))
-#define R13 ((Register)(R13_RegisterEnumValue))
-#define R14 ((Register)(R14_RegisterEnumValue))
-#define R15 ((Register)(R15_RegisterEnumValue))
-#define R16 ((Register)(R16_RegisterEnumValue))
-#define R17 ((Register)(R17_RegisterEnumValue))
-#define R18 ((Register)(R18_RegisterEnumValue))
-#define R19 ((Register)(R19_RegisterEnumValue))
-#define R20 ((Register)(R20_RegisterEnumValue))
-#define R21 ((Register)(R21_RegisterEnumValue))
-#define R22 ((Register)(R22_RegisterEnumValue))
-#define R23 ((Register)(R23_RegisterEnumValue))
-#define R24 ((Register)(R24_RegisterEnumValue))
-#define R25 ((Register)(R25_RegisterEnumValue))
-#define R26 ((Register)(R26_RegisterEnumValue))
-#define R27 ((Register)(R27_RegisterEnumValue))
-#define R28 ((Register)(R28_RegisterEnumValue))
-#define R29 ((Register)(R29_RegisterEnumValue))
-#define R30 ((Register)(R30_RegisterEnumValue))
-#define R31 ((Register)(R31_RegisterEnumValue))
-#endif
-
-// Use ConditionRegister as shortcut
-class ConditionRegisterImpl;
-typedef ConditionRegisterImpl* ConditionRegister;
-
-inline ConditionRegister as_ConditionRegister(int encoding) {
-  assert(encoding >= 0 && encoding < 8, "bad condition register encoding");
-  return (ConditionRegister)(intptr_t)encoding;
+inline constexpr Register as_Register(int encoding) {
+  assert(encoding >= -1 && encoding < 32, "bad register encoding");
+  return Register(encoding);
 }
 
+// The integer registers of the PPC architecture
+constexpr Register noreg = as_Register(-1);
+
+constexpr Register  R0 = as_Register( 0);
+constexpr Register  R1 = as_Register( 1);
+constexpr Register  R2 = as_Register( 2);
+constexpr Register  R3 = as_Register( 3);
+constexpr Register  R4 = as_Register( 4);
+constexpr Register  R5 = as_Register( 5);
+constexpr Register  R6 = as_Register( 6);
+constexpr Register  R7 = as_Register( 7);
+constexpr Register  R8 = as_Register( 8);
+constexpr Register  R9 = as_Register( 9);
+constexpr Register R10 = as_Register(10);
+constexpr Register R11 = as_Register(11);
+constexpr Register R12 = as_Register(12);
+constexpr Register R13 = as_Register(13);
+constexpr Register R14 = as_Register(14);
+constexpr Register R15 = as_Register(15);
+constexpr Register R16 = as_Register(16);
+constexpr Register R17 = as_Register(17);
+constexpr Register R18 = as_Register(18);
+constexpr Register R19 = as_Register(19);
+constexpr Register R20 = as_Register(20);
+constexpr Register R21 = as_Register(21);
+constexpr Register R22 = as_Register(22);
+constexpr Register R23 = as_Register(23);
+constexpr Register R24 = as_Register(24);
+constexpr Register R25 = as_Register(25);
+constexpr Register R26 = as_Register(26);
+constexpr Register R27 = as_Register(27);
+constexpr Register R28 = as_Register(28);
+constexpr Register R29 = as_Register(29);
+constexpr Register R30 = as_Register(30);
+constexpr Register R31 = as_Register(31);
+
+
 // The implementation of condition register(s) for the PPC architecture
-class ConditionRegisterImpl: public AbstractRegisterImpl {
+class ConditionRegister {
+  int _encoding;
  public:
   enum {
     number_of_registers = 8
   };
 
+  constexpr ConditionRegister(int encoding = -1) : _encoding(encoding) {}
+  bool operator==(const ConditionRegister rhs) const { return _encoding == rhs._encoding; }
+  bool operator!=(const ConditionRegister rhs) const { return _encoding != rhs._encoding; }
+  const ConditionRegister* operator->() const { return this; }
+
   // construction.
-  inline friend ConditionRegister as_ConditionRegister(int encoding);
+  inline constexpr friend ConditionRegister as_ConditionRegister(int encoding);
 
   // accessors
-  int encoding() const { assert(is_valid(), "invalid register"); return value(); }
-  inline VMReg as_VMReg();
+  int encoding() const { assert(is_valid(), "invalid register"); return _encoding; }
+  inline VMReg as_VMReg() const;
 
   // testers
-  bool is_valid()       const { return  (0 <= value()        &&  value() < number_of_registers); }
-  bool is_nonvolatile() const { return  (2 <= (value()&0x7F) && (value()&0x7F) <= 4 );  }
+  bool is_valid()       const { return (0 <= _encoding && _encoding <  number_of_registers); }
+  bool is_nonvolatile() const { return (2 <= _encoding && _encoding <= 4 );  }
 
   const char* name() const;
 };
 
-// The (parts of the) condition register(s) of the PPC architecture
-// sys/ioctl.h on AIX defines CR0-CR3, so I name these CCR.
-CONSTANT_REGISTER_DECLARATION(ConditionRegister, CCR0,   (0));
-CONSTANT_REGISTER_DECLARATION(ConditionRegister, CCR1,   (1));
-CONSTANT_REGISTER_DECLARATION(ConditionRegister, CCR2,   (2));
-CONSTANT_REGISTER_DECLARATION(ConditionRegister, CCR3,   (3));
-CONSTANT_REGISTER_DECLARATION(ConditionRegister, CCR4,   (4));
-CONSTANT_REGISTER_DECLARATION(ConditionRegister, CCR5,   (5));
-CONSTANT_REGISTER_DECLARATION(ConditionRegister, CCR6,   (6));
-CONSTANT_REGISTER_DECLARATION(ConditionRegister, CCR7,   (7));
-
-#ifndef DONT_USE_REGISTER_DEFINES
-
-#define CCR0 ((ConditionRegister)(CCR0_ConditionRegisterEnumValue))
-#define CCR1 ((ConditionRegister)(CCR1_ConditionRegisterEnumValue))
-#define CCR2 ((ConditionRegister)(CCR2_ConditionRegisterEnumValue))
-#define CCR3 ((ConditionRegister)(CCR3_ConditionRegisterEnumValue))
-#define CCR4 ((ConditionRegister)(CCR4_ConditionRegisterEnumValue))
-#define CCR5 ((ConditionRegister)(CCR5_ConditionRegisterEnumValue))
-#define CCR6 ((ConditionRegister)(CCR6_ConditionRegisterEnumValue))
-#define CCR7 ((ConditionRegister)(CCR7_ConditionRegisterEnumValue))
-
-#endif // DONT_USE_REGISTER_DEFINES
-
-// Forward declaration
-// Use VectorSRegister as a shortcut.
-class VectorSRegisterImpl;
-typedef VectorSRegisterImpl* VectorSRegister;
-
-// Use FloatRegister as shortcut
-class FloatRegisterImpl;
-typedef FloatRegisterImpl* FloatRegister;
-
-inline FloatRegister as_FloatRegister(int encoding) {
-  assert(encoding >= -1 && encoding < 32, "bad float register encoding");
-  return (FloatRegister)(intptr_t)encoding;
+inline constexpr ConditionRegister as_ConditionRegister(int encoding) {
+  assert(encoding >= 0 && encoding < 8, "bad condition register encoding");
+  return ConditionRegister(encoding);
 }
 
+constexpr ConditionRegister CCR0 = as_ConditionRegister(0);
+constexpr ConditionRegister CCR1 = as_ConditionRegister(1);
+constexpr ConditionRegister CCR2 = as_ConditionRegister(2);
+constexpr ConditionRegister CCR3 = as_ConditionRegister(3);
+constexpr ConditionRegister CCR4 = as_ConditionRegister(4);
+constexpr ConditionRegister CCR5 = as_ConditionRegister(5);
+constexpr ConditionRegister CCR6 = as_ConditionRegister(6);
+constexpr ConditionRegister CCR7 = as_ConditionRegister(7);
+
+
+class VectorSRegister;
+
 // The implementation of float registers for the PPC architecture
-class FloatRegisterImpl: public AbstractRegisterImpl {
+class FloatRegister {
+  int _encoding;
  public:
   enum {
     number_of_registers = 32
   };
 
+  constexpr FloatRegister(int encoding = -1) : _encoding(encoding) {}
+  bool operator==(const FloatRegister rhs) const { return _encoding == rhs._encoding; }
+  bool operator!=(const FloatRegister rhs) const { return _encoding != rhs._encoding; }
+  const FloatRegister* operator->() const { return this; }
+
   // construction
-  inline friend FloatRegister as_FloatRegister(int encoding);
+  inline constexpr friend FloatRegister as_FloatRegister(int encoding);
 
   // accessors
-  int           encoding() const { assert(is_valid(), "invalid register"); return value(); }
-  inline VMReg  as_VMReg();
-  FloatRegister successor() const { return as_FloatRegister(encoding() + 1); }
+  int encoding() const { assert(is_valid(), "invalid register"); return _encoding; }
+  inline VMReg as_VMReg() const;
+  FloatRegister successor() const { return FloatRegister(encoding() + 1); }
 
   // testers
-  bool is_valid() const { return (0 <= value() && value() < number_of_registers); }
+  bool is_valid() const { return (0 <= _encoding && _encoding < number_of_registers); }
 
   const char* name() const;
 
@@ -283,147 +220,108 @@ class FloatRegisterImpl: public AbstractRegisterImpl {
   VectorSRegister to_vsr() const;
 };
 
-// The float registers of the PPC architecture
-CONSTANT_REGISTER_DECLARATION(FloatRegister, fnoreg, (-1));
-
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F0,  ( 0));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F1,  ( 1));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F2,  ( 2));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F3,  ( 3));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F4,  ( 4));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F5,  ( 5));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F6,  ( 6));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F7,  ( 7));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F8,  ( 8));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F9,  ( 9));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F10, (10));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F11, (11));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F12, (12));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F13, (13));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F14, (14));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F15, (15));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F16, (16));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F17, (17));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F18, (18));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F19, (19));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F20, (20));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F21, (21));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F22, (22));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F23, (23));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F24, (24));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F25, (25));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F26, (26));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F27, (27));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F28, (28));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F29, (29));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F30, (30));
-CONSTANT_REGISTER_DECLARATION(FloatRegister, F31, (31));
-
-#ifndef DONT_USE_REGISTER_DEFINES
-#define fnoreg ((FloatRegister)(fnoreg_FloatRegisterEnumValue))
-#define F0     ((FloatRegister)(    F0_FloatRegisterEnumValue))
-#define F1     ((FloatRegister)(    F1_FloatRegisterEnumValue))
-#define F2     ((FloatRegister)(    F2_FloatRegisterEnumValue))
-#define F3     ((FloatRegister)(    F3_FloatRegisterEnumValue))
-#define F4     ((FloatRegister)(    F4_FloatRegisterEnumValue))
-#define F5     ((FloatRegister)(    F5_FloatRegisterEnumValue))
-#define F6     ((FloatRegister)(    F6_FloatRegisterEnumValue))
-#define F7     ((FloatRegister)(    F7_FloatRegisterEnumValue))
-#define F8     ((FloatRegister)(    F8_FloatRegisterEnumValue))
-#define F9     ((FloatRegister)(    F9_FloatRegisterEnumValue))
-#define F10    ((FloatRegister)(   F10_FloatRegisterEnumValue))
-#define F11    ((FloatRegister)(   F11_FloatRegisterEnumValue))
-#define F12    ((FloatRegister)(   F12_FloatRegisterEnumValue))
-#define F13    ((FloatRegister)(   F13_FloatRegisterEnumValue))
-#define F14    ((FloatRegister)(   F14_FloatRegisterEnumValue))
-#define F15    ((FloatRegister)(   F15_FloatRegisterEnumValue))
-#define F16    ((FloatRegister)(   F16_FloatRegisterEnumValue))
-#define F17    ((FloatRegister)(   F17_FloatRegisterEnumValue))
-#define F18    ((FloatRegister)(   F18_FloatRegisterEnumValue))
-#define F19    ((FloatRegister)(   F19_FloatRegisterEnumValue))
-#define F20    ((FloatRegister)(   F20_FloatRegisterEnumValue))
-#define F21    ((FloatRegister)(   F21_FloatRegisterEnumValue))
-#define F22    ((FloatRegister)(   F22_FloatRegisterEnumValue))
-#define F23    ((FloatRegister)(   F23_FloatRegisterEnumValue))
-#define F24    ((FloatRegister)(   F24_FloatRegisterEnumValue))
-#define F25    ((FloatRegister)(   F25_FloatRegisterEnumValue))
-#define F26    ((FloatRegister)(   F26_FloatRegisterEnumValue))
-#define F27    ((FloatRegister)(   F27_FloatRegisterEnumValue))
-#define F28    ((FloatRegister)(   F28_FloatRegisterEnumValue))
-#define F29    ((FloatRegister)(   F29_FloatRegisterEnumValue))
-#define F30    ((FloatRegister)(   F30_FloatRegisterEnumValue))
-#define F31    ((FloatRegister)(   F31_FloatRegisterEnumValue))
-#endif // DONT_USE_REGISTER_DEFINES
-
-// Use SpecialRegister as shortcut
-class SpecialRegisterImpl;
-typedef SpecialRegisterImpl* SpecialRegister;
-
-inline SpecialRegister as_SpecialRegister(int encoding) {
-  return (SpecialRegister)(intptr_t)encoding;
+inline constexpr FloatRegister as_FloatRegister(int encoding) {
+  assert(encoding >= -1 && encoding < 32, "bad float register encoding");
+  return FloatRegister(encoding);
 }
 
+// The float registers of the PPC architecture
+constexpr FloatRegister fnoreg = as_FloatRegister(-1);
+
+constexpr FloatRegister  F0 = as_FloatRegister( 0);
+constexpr FloatRegister  F1 = as_FloatRegister( 1);
+constexpr FloatRegister  F2 = as_FloatRegister( 2);
+constexpr FloatRegister  F3 = as_FloatRegister( 3);
+constexpr FloatRegister  F4 = as_FloatRegister( 4);
+constexpr FloatRegister  F5 = as_FloatRegister( 5);
+constexpr FloatRegister  F6 = as_FloatRegister( 6);
+constexpr FloatRegister  F7 = as_FloatRegister( 7);
+constexpr FloatRegister  F8 = as_FloatRegister( 8);
+constexpr FloatRegister  F9 = as_FloatRegister( 9);
+constexpr FloatRegister F10 = as_FloatRegister(10);
+constexpr FloatRegister F11 = as_FloatRegister(11);
+constexpr FloatRegister F12 = as_FloatRegister(12);
+constexpr FloatRegister F13 = as_FloatRegister(13);
+constexpr FloatRegister F14 = as_FloatRegister(14);
+constexpr FloatRegister F15 = as_FloatRegister(15);
+constexpr FloatRegister F16 = as_FloatRegister(16);
+constexpr FloatRegister F17 = as_FloatRegister(17);
+constexpr FloatRegister F18 = as_FloatRegister(18);
+constexpr FloatRegister F19 = as_FloatRegister(19);
+constexpr FloatRegister F20 = as_FloatRegister(20);
+constexpr FloatRegister F21 = as_FloatRegister(21);
+constexpr FloatRegister F22 = as_FloatRegister(22);
+constexpr FloatRegister F23 = as_FloatRegister(23);
+constexpr FloatRegister F24 = as_FloatRegister(24);
+constexpr FloatRegister F25 = as_FloatRegister(25);
+constexpr FloatRegister F26 = as_FloatRegister(26);
+constexpr FloatRegister F27 = as_FloatRegister(27);
+constexpr FloatRegister F28 = as_FloatRegister(28);
+constexpr FloatRegister F29 = as_FloatRegister(29);
+constexpr FloatRegister F30 = as_FloatRegister(30);
+constexpr FloatRegister F31 = as_FloatRegister(31);
+
+
 // The implementation of special registers for the Power architecture (LR, CTR and friends)
-class SpecialRegisterImpl: public AbstractRegisterImpl {
+class SpecialRegister {
+  int _encoding;
  public:
   enum {
     number_of_registers = 6
   };
 
+  constexpr SpecialRegister(int encoding = -1) : _encoding(encoding) {}
+  bool operator==(const SpecialRegister rhs) const { return _encoding == rhs._encoding; }
+  bool operator!=(const SpecialRegister rhs) const { return _encoding != rhs._encoding; }
+  const SpecialRegister* operator->() const { return this; }
+
   // construction
-  inline friend SpecialRegister as_SpecialRegister(int encoding);
+  inline constexpr friend SpecialRegister as_SpecialRegister(int encoding);
 
   // accessors
-  int             encoding()  const { assert(is_valid(), "invalid register"); return value(); }
-  inline VMReg    as_VMReg();
+  int encoding() const { assert(is_valid(), "invalid register"); return _encoding; }
+  inline VMReg as_VMReg() const;
 
   // testers
-  bool is_valid()       const { return 0 <= value() && value() < number_of_registers; }
+  bool is_valid() const { return (0 <= _encoding && _encoding < number_of_registers); }
 
   const char* name() const;
 };
 
-// The special registers of the PPC architecture
-CONSTANT_REGISTER_DECLARATION(SpecialRegister, SR_XER,     (0));
-CONSTANT_REGISTER_DECLARATION(SpecialRegister, SR_LR,      (1));
-CONSTANT_REGISTER_DECLARATION(SpecialRegister, SR_CTR,     (2));
-CONSTANT_REGISTER_DECLARATION(SpecialRegister, SR_VRSAVE,  (3));
-CONSTANT_REGISTER_DECLARATION(SpecialRegister, SR_SPEFSCR, (4));
-CONSTANT_REGISTER_DECLARATION(SpecialRegister, SR_PPR,     (5));
-
-#ifndef DONT_USE_REGISTER_DEFINES
-#define SR_XER     ((SpecialRegister)(SR_XER_SpecialRegisterEnumValue))
-#define SR_LR      ((SpecialRegister)(SR_LR_SpecialRegisterEnumValue))
-#define SR_CTR     ((SpecialRegister)(SR_CTR_SpecialRegisterEnumValue))
-#define SR_VRSAVE  ((SpecialRegister)(SR_VRSAVE_SpecialRegisterEnumValue))
-#define SR_SPEFSCR ((SpecialRegister)(SR_SPEFSCR_SpecialRegisterEnumValue))
-#define SR_PPR     ((SpecialRegister)(SR_PPR_SpecialRegisterEnumValue))
-#endif // DONT_USE_REGISTER_DEFINES
-
-
-// Use VectorRegister as shortcut
-class VectorRegisterImpl;
-typedef VectorRegisterImpl* VectorRegister;
-
-inline VectorRegister as_VectorRegister(int encoding) {
-  return (VectorRegister)(intptr_t)encoding;
+inline constexpr SpecialRegister as_SpecialRegister(int encoding) {
+  return SpecialRegister(encoding);
 }
 
+// The special registers of the PPC architecture
+constexpr SpecialRegister SR_XER     = as_SpecialRegister(0);
+constexpr SpecialRegister SR_LR      = as_SpecialRegister(1);
+constexpr SpecialRegister SR_CTR     = as_SpecialRegister(2);
+constexpr SpecialRegister SR_VRSAVE  = as_SpecialRegister(3);
+constexpr SpecialRegister SR_SPEFSCR = as_SpecialRegister(4);
+constexpr SpecialRegister SR_PPR     = as_SpecialRegister(5);
+
+
 // The implementation of vector registers for the Power architecture
-class VectorRegisterImpl: public AbstractRegisterImpl {
+class VectorRegister {
+  int _encoding;
  public:
   enum {
     number_of_registers = 32
   };
 
+  constexpr VectorRegister(int encoding = -1) : _encoding(encoding) {}
+  bool operator==(const VectorRegister rhs) const { return _encoding == rhs._encoding; }
+  bool operator!=(const VectorRegister rhs) const { return _encoding != rhs._encoding; }
+  const VectorRegister* operator->() const { return this; }
+
   // construction
-  inline friend VectorRegister as_VectorRegister(int encoding);
+  inline constexpr friend VectorRegister as_VectorRegister(int encoding);
 
   // accessors
-  int            encoding()  const { assert(is_valid(), "invalid register"); return value(); }
+  int encoding()  const { assert(is_valid(), "invalid register"); return _encoding; }
 
   // testers
-  bool is_valid()       const { return   0 <=  value()       &&  value() < number_of_registers; }
+  bool is_valid() const { return (0 <= _encoding && _encoding < number_of_registers); }
 
   const char* name() const;
 
@@ -431,100 +329,69 @@ class VectorRegisterImpl: public AbstractRegisterImpl {
   VectorSRegister to_vsr() const;
 };
 
-// The Vector registers of the Power architecture
-
-CONSTANT_REGISTER_DECLARATION(VectorRegister, vnoreg, (-1));
-
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR0,  ( 0));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR1,  ( 1));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR2,  ( 2));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR3,  ( 3));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR4,  ( 4));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR5,  ( 5));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR6,  ( 6));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR7,  ( 7));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR8,  ( 8));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR9,  ( 9));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR10, (10));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR11, (11));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR12, (12));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR13, (13));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR14, (14));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR15, (15));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR16, (16));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR17, (17));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR18, (18));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR19, (19));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR20, (20));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR21, (21));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR22, (22));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR23, (23));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR24, (24));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR25, (25));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR26, (26));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR27, (27));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR28, (28));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR29, (29));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR30, (30));
-CONSTANT_REGISTER_DECLARATION(VectorRegister, VR31, (31));
-
-#ifndef DONT_USE_REGISTER_DEFINES
-#define vnoreg ((VectorRegister)(vnoreg_VectorRegisterEnumValue))
-#define VR0    ((VectorRegister)(   VR0_VectorRegisterEnumValue))
-#define VR1    ((VectorRegister)(   VR1_VectorRegisterEnumValue))
-#define VR2    ((VectorRegister)(   VR2_VectorRegisterEnumValue))
-#define VR3    ((VectorRegister)(   VR3_VectorRegisterEnumValue))
-#define VR4    ((VectorRegister)(   VR4_VectorRegisterEnumValue))
-#define VR5    ((VectorRegister)(   VR5_VectorRegisterEnumValue))
-#define VR6    ((VectorRegister)(   VR6_VectorRegisterEnumValue))
-#define VR7    ((VectorRegister)(   VR7_VectorRegisterEnumValue))
-#define VR8    ((VectorRegister)(   VR8_VectorRegisterEnumValue))
-#define VR9    ((VectorRegister)(   VR9_VectorRegisterEnumValue))
-#define VR10   ((VectorRegister)(  VR10_VectorRegisterEnumValue))
-#define VR11   ((VectorRegister)(  VR11_VectorRegisterEnumValue))
-#define VR12   ((VectorRegister)(  VR12_VectorRegisterEnumValue))
-#define VR13   ((VectorRegister)(  VR13_VectorRegisterEnumValue))
-#define VR14   ((VectorRegister)(  VR14_VectorRegisterEnumValue))
-#define VR15   ((VectorRegister)(  VR15_VectorRegisterEnumValue))
-#define VR16   ((VectorRegister)(  VR16_VectorRegisterEnumValue))
-#define VR17   ((VectorRegister)(  VR17_VectorRegisterEnumValue))
-#define VR18   ((VectorRegister)(  VR18_VectorRegisterEnumValue))
-#define VR19   ((VectorRegister)(  VR19_VectorRegisterEnumValue))
-#define VR20   ((VectorRegister)(  VR20_VectorRegisterEnumValue))
-#define VR21   ((VectorRegister)(  VR21_VectorRegisterEnumValue))
-#define VR22   ((VectorRegister)(  VR22_VectorRegisterEnumValue))
-#define VR23   ((VectorRegister)(  VR23_VectorRegisterEnumValue))
-#define VR24   ((VectorRegister)(  VR24_VectorRegisterEnumValue))
-#define VR25   ((VectorRegister)(  VR25_VectorRegisterEnumValue))
-#define VR26   ((VectorRegister)(  VR26_VectorRegisterEnumValue))
-#define VR27   ((VectorRegister)(  VR27_VectorRegisterEnumValue))
-#define VR28   ((VectorRegister)(  VR28_VectorRegisterEnumValue))
-#define VR29   ((VectorRegister)(  VR29_VectorRegisterEnumValue))
-#define VR30   ((VectorRegister)(  VR30_VectorRegisterEnumValue))
-#define VR31   ((VectorRegister)(  VR31_VectorRegisterEnumValue))
-#endif // DONT_USE_REGISTER_DEFINES
-
-
-inline VectorSRegister as_VectorSRegister(int encoding) {
-  return (VectorSRegister)(intptr_t)encoding;
+inline constexpr VectorRegister as_VectorRegister(int encoding) {
+  return VectorRegister(encoding);
 }
 
+// The Vector registers of the Power architecture
+constexpr VectorRegister vnoreg = as_VectorRegister(-1);
+
+constexpr VectorRegister  VR0 = as_VectorRegister( 0);
+constexpr VectorRegister  VR1 = as_VectorRegister( 1);
+constexpr VectorRegister  VR2 = as_VectorRegister( 2);
+constexpr VectorRegister  VR3 = as_VectorRegister( 3);
+constexpr VectorRegister  VR4 = as_VectorRegister( 4);
+constexpr VectorRegister  VR5 = as_VectorRegister( 5);
+constexpr VectorRegister  VR6 = as_VectorRegister( 6);
+constexpr VectorRegister  VR7 = as_VectorRegister( 7);
+constexpr VectorRegister  VR8 = as_VectorRegister( 8);
+constexpr VectorRegister  VR9 = as_VectorRegister( 9);
+constexpr VectorRegister VR10 = as_VectorRegister(10);
+constexpr VectorRegister VR11 = as_VectorRegister(11);
+constexpr VectorRegister VR12 = as_VectorRegister(12);
+constexpr VectorRegister VR13 = as_VectorRegister(13);
+constexpr VectorRegister VR14 = as_VectorRegister(14);
+constexpr VectorRegister VR15 = as_VectorRegister(15);
+constexpr VectorRegister VR16 = as_VectorRegister(16);
+constexpr VectorRegister VR17 = as_VectorRegister(17);
+constexpr VectorRegister VR18 = as_VectorRegister(18);
+constexpr VectorRegister VR19 = as_VectorRegister(19);
+constexpr VectorRegister VR20 = as_VectorRegister(20);
+constexpr VectorRegister VR21 = as_VectorRegister(21);
+constexpr VectorRegister VR22 = as_VectorRegister(22);
+constexpr VectorRegister VR23 = as_VectorRegister(23);
+constexpr VectorRegister VR24 = as_VectorRegister(24);
+constexpr VectorRegister VR25 = as_VectorRegister(25);
+constexpr VectorRegister VR26 = as_VectorRegister(26);
+constexpr VectorRegister VR27 = as_VectorRegister(27);
+constexpr VectorRegister VR28 = as_VectorRegister(28);
+constexpr VectorRegister VR29 = as_VectorRegister(29);
+constexpr VectorRegister VR30 = as_VectorRegister(30);
+constexpr VectorRegister VR31 = as_VectorRegister(31);
+
+
 // The implementation of Vector-Scalar (VSX) registers on POWER architecture.
-class VectorSRegisterImpl: public AbstractRegisterImpl {
+class VectorSRegister {
+  int _encoding;
  public:
   enum {
     number_of_registers = 64
   };
 
+  constexpr VectorSRegister(int encoding = -1) : _encoding(encoding) {}
+  bool operator==(const VectorSRegister rhs) const { return _encoding == rhs._encoding; }
+  bool operator!=(const VectorSRegister rhs) const { return _encoding != rhs._encoding; }
+  const VectorSRegister* operator->() const { return this; }
+
   // construction
-  inline friend VectorSRegister as_VectorSRegister(int encoding);
+  inline constexpr friend VectorSRegister as_VectorSRegister(int encoding);
 
   // accessors
-  int encoding() const { assert(is_valid(), "invalid register"); return value(); }
-  inline VMReg as_VMReg();
+  int encoding() const { assert(is_valid(), "invalid register"); return _encoding; }
+  inline VMReg as_VMReg() const;
 
   // testers
-  bool is_valid() const { return 0 <=  value() &&  value() < number_of_registers; }
+  bool is_valid() const { return (0 <= _encoding && _encoding < number_of_registers); }
 
   const char* name() const;
 
@@ -532,145 +399,77 @@ class VectorSRegisterImpl: public AbstractRegisterImpl {
   VectorRegister to_vr() const;
 };
 
+inline constexpr VectorSRegister as_VectorSRegister(int encoding) {
+  return VectorSRegister(encoding);
+}
+
 // The Vector-Scalar (VSX) registers of the POWER architecture.
+constexpr VectorSRegister vsnoreg = as_VectorSRegister(-1);
 
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, vsnoreg, (-1));
-
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR0,  ( 0));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR1,  ( 1));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR2,  ( 2));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR3,  ( 3));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR4,  ( 4));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR5,  ( 5));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR6,  ( 6));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR7,  ( 7));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR8,  ( 8));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR9,  ( 9));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR10, (10));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR11, (11));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR12, (12));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR13, (13));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR14, (14));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR15, (15));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR16, (16));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR17, (17));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR18, (18));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR19, (19));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR20, (20));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR21, (21));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR22, (22));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR23, (23));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR24, (24));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR25, (25));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR26, (26));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR27, (27));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR28, (28));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR29, (29));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR30, (30));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR31, (31));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR32, (32));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR33, (33));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR34, (34));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR35, (35));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR36, (36));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR37, (37));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR38, (38));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR39, (39));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR40, (40));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR41, (41));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR42, (42));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR43, (43));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR44, (44));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR45, (45));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR46, (46));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR47, (47));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR48, (48));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR49, (49));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR50, (50));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR51, (51));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR52, (52));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR53, (53));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR54, (54));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR55, (55));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR56, (56));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR57, (57));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR58, (58));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR59, (59));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR60, (60));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR61, (61));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR62, (62));
-CONSTANT_REGISTER_DECLARATION(VectorSRegister, VSR63, (63));
-
-#ifndef DONT_USE_REGISTER_DEFINES
-#define vsnoreg ((VectorSRegister)(vsnoreg_VectorSRegisterEnumValue))
-#define VSR0    ((VectorSRegister)(   VSR0_VectorSRegisterEnumValue))
-#define VSR1    ((VectorSRegister)(   VSR1_VectorSRegisterEnumValue))
-#define VSR2    ((VectorSRegister)(   VSR2_VectorSRegisterEnumValue))
-#define VSR3    ((VectorSRegister)(   VSR3_VectorSRegisterEnumValue))
-#define VSR4    ((VectorSRegister)(   VSR4_VectorSRegisterEnumValue))
-#define VSR5    ((VectorSRegister)(   VSR5_VectorSRegisterEnumValue))
-#define VSR6    ((VectorSRegister)(   VSR6_VectorSRegisterEnumValue))
-#define VSR7    ((VectorSRegister)(   VSR7_VectorSRegisterEnumValue))
-#define VSR8    ((VectorSRegister)(   VSR8_VectorSRegisterEnumValue))
-#define VSR9    ((VectorSRegister)(   VSR9_VectorSRegisterEnumValue))
-#define VSR10   ((VectorSRegister)(  VSR10_VectorSRegisterEnumValue))
-#define VSR11   ((VectorSRegister)(  VSR11_VectorSRegisterEnumValue))
-#define VSR12   ((VectorSRegister)(  VSR12_VectorSRegisterEnumValue))
-#define VSR13   ((VectorSRegister)(  VSR13_VectorSRegisterEnumValue))
-#define VSR14   ((VectorSRegister)(  VSR14_VectorSRegisterEnumValue))
-#define VSR15   ((VectorSRegister)(  VSR15_VectorSRegisterEnumValue))
-#define VSR16   ((VectorSRegister)(  VSR16_VectorSRegisterEnumValue))
-#define VSR17   ((VectorSRegister)(  VSR17_VectorSRegisterEnumValue))
-#define VSR18   ((VectorSRegister)(  VSR18_VectorSRegisterEnumValue))
-#define VSR19   ((VectorSRegister)(  VSR19_VectorSRegisterEnumValue))
-#define VSR20   ((VectorSRegister)(  VSR20_VectorSRegisterEnumValue))
-#define VSR21   ((VectorSRegister)(  VSR21_VectorSRegisterEnumValue))
-#define VSR22   ((VectorSRegister)(  VSR22_VectorSRegisterEnumValue))
-#define VSR23   ((VectorSRegister)(  VSR23_VectorSRegisterEnumValue))
-#define VSR24   ((VectorSRegister)(  VSR24_VectorSRegisterEnumValue))
-#define VSR25   ((VectorSRegister)(  VSR25_VectorSRegisterEnumValue))
-#define VSR26   ((VectorSRegister)(  VSR26_VectorSRegisterEnumValue))
-#define VSR27   ((VectorSRegister)(  VSR27_VectorSRegisterEnumValue))
-#define VSR28   ((VectorSRegister)(  VSR28_VectorSRegisterEnumValue))
-#define VSR29   ((VectorSRegister)(  VSR29_VectorSRegisterEnumValue))
-#define VSR30   ((VectorSRegister)(  VSR30_VectorSRegisterEnumValue))
-#define VSR31   ((VectorSRegister)(  VSR31_VectorSRegisterEnumValue))
-#define VSR32   ((VectorSRegister)(  VSR32_VectorSRegisterEnumValue))
-#define VSR33   ((VectorSRegister)(  VSR33_VectorSRegisterEnumValue))
-#define VSR34   ((VectorSRegister)(  VSR34_VectorSRegisterEnumValue))
-#define VSR35   ((VectorSRegister)(  VSR35_VectorSRegisterEnumValue))
-#define VSR36   ((VectorSRegister)(  VSR36_VectorSRegisterEnumValue))
-#define VSR37   ((VectorSRegister)(  VSR37_VectorSRegisterEnumValue))
-#define VSR38   ((VectorSRegister)(  VSR38_VectorSRegisterEnumValue))
-#define VSR39   ((VectorSRegister)(  VSR39_VectorSRegisterEnumValue))
-#define VSR40   ((VectorSRegister)(  VSR40_VectorSRegisterEnumValue))
-#define VSR41   ((VectorSRegister)(  VSR41_VectorSRegisterEnumValue))
-#define VSR42   ((VectorSRegister)(  VSR42_VectorSRegisterEnumValue))
-#define VSR43   ((VectorSRegister)(  VSR43_VectorSRegisterEnumValue))
-#define VSR44   ((VectorSRegister)(  VSR44_VectorSRegisterEnumValue))
-#define VSR45   ((VectorSRegister)(  VSR45_VectorSRegisterEnumValue))
-#define VSR46   ((VectorSRegister)(  VSR46_VectorSRegisterEnumValue))
-#define VSR47   ((VectorSRegister)(  VSR47_VectorSRegisterEnumValue))
-#define VSR48   ((VectorSRegister)(  VSR48_VectorSRegisterEnumValue))
-#define VSR49   ((VectorSRegister)(  VSR49_VectorSRegisterEnumValue))
-#define VSR50   ((VectorSRegister)(  VSR50_VectorSRegisterEnumValue))
-#define VSR51   ((VectorSRegister)(  VSR51_VectorSRegisterEnumValue))
-#define VSR52   ((VectorSRegister)(  VSR52_VectorSRegisterEnumValue))
-#define VSR53   ((VectorSRegister)(  VSR53_VectorSRegisterEnumValue))
-#define VSR54   ((VectorSRegister)(  VSR54_VectorSRegisterEnumValue))
-#define VSR55   ((VectorSRegister)(  VSR55_VectorSRegisterEnumValue))
-#define VSR56   ((VectorSRegister)(  VSR56_VectorSRegisterEnumValue))
-#define VSR57   ((VectorSRegister)(  VSR57_VectorSRegisterEnumValue))
-#define VSR58   ((VectorSRegister)(  VSR58_VectorSRegisterEnumValue))
-#define VSR59   ((VectorSRegister)(  VSR59_VectorSRegisterEnumValue))
-#define VSR60   ((VectorSRegister)(  VSR60_VectorSRegisterEnumValue))
-#define VSR61   ((VectorSRegister)(  VSR61_VectorSRegisterEnumValue))
-#define VSR62   ((VectorSRegister)(  VSR62_VectorSRegisterEnumValue))
-#define VSR63   ((VectorSRegister)(  VSR63_VectorSRegisterEnumValue))
-#endif // DONT_USE_REGISTER_DEFINES
-
-// Maximum number of incoming arguments that can be passed in i registers.
-const int PPC_ARGS_IN_REGS_NUM = 8;
+constexpr VectorSRegister  VSR0 = as_VectorSRegister( 0);
+constexpr VectorSRegister  VSR1 = as_VectorSRegister( 1);
+constexpr VectorSRegister  VSR2 = as_VectorSRegister( 2);
+constexpr VectorSRegister  VSR3 = as_VectorSRegister( 3);
+constexpr VectorSRegister  VSR4 = as_VectorSRegister( 4);
+constexpr VectorSRegister  VSR5 = as_VectorSRegister( 5);
+constexpr VectorSRegister  VSR6 = as_VectorSRegister( 6);
+constexpr VectorSRegister  VSR7 = as_VectorSRegister( 7);
+constexpr VectorSRegister  VSR8 = as_VectorSRegister( 8);
+constexpr VectorSRegister  VSR9 = as_VectorSRegister( 9);
+constexpr VectorSRegister VSR10 = as_VectorSRegister(10);
+constexpr VectorSRegister VSR11 = as_VectorSRegister(11);
+constexpr VectorSRegister VSR12 = as_VectorSRegister(12);
+constexpr VectorSRegister VSR13 = as_VectorSRegister(13);
+constexpr VectorSRegister VSR14 = as_VectorSRegister(14);
+constexpr VectorSRegister VSR15 = as_VectorSRegister(15);
+constexpr VectorSRegister VSR16 = as_VectorSRegister(16);
+constexpr VectorSRegister VSR17 = as_VectorSRegister(17);
+constexpr VectorSRegister VSR18 = as_VectorSRegister(18);
+constexpr VectorSRegister VSR19 = as_VectorSRegister(19);
+constexpr VectorSRegister VSR20 = as_VectorSRegister(20);
+constexpr VectorSRegister VSR21 = as_VectorSRegister(21);
+constexpr VectorSRegister VSR22 = as_VectorSRegister(22);
+constexpr VectorSRegister VSR23 = as_VectorSRegister(23);
+constexpr VectorSRegister VSR24 = as_VectorSRegister(24);
+constexpr VectorSRegister VSR25 = as_VectorSRegister(25);
+constexpr VectorSRegister VSR26 = as_VectorSRegister(26);
+constexpr VectorSRegister VSR27 = as_VectorSRegister(27);
+constexpr VectorSRegister VSR28 = as_VectorSRegister(28);
+constexpr VectorSRegister VSR29 = as_VectorSRegister(29);
+constexpr VectorSRegister VSR30 = as_VectorSRegister(30);
+constexpr VectorSRegister VSR31 = as_VectorSRegister(31);
+constexpr VectorSRegister VSR32 = as_VectorSRegister(32);
+constexpr VectorSRegister VSR33 = as_VectorSRegister(33);
+constexpr VectorSRegister VSR34 = as_VectorSRegister(34);
+constexpr VectorSRegister VSR35 = as_VectorSRegister(35);
+constexpr VectorSRegister VSR36 = as_VectorSRegister(36);
+constexpr VectorSRegister VSR37 = as_VectorSRegister(37);
+constexpr VectorSRegister VSR38 = as_VectorSRegister(38);
+constexpr VectorSRegister VSR39 = as_VectorSRegister(39);
+constexpr VectorSRegister VSR40 = as_VectorSRegister(40);
+constexpr VectorSRegister VSR41 = as_VectorSRegister(41);
+constexpr VectorSRegister VSR42 = as_VectorSRegister(42);
+constexpr VectorSRegister VSR43 = as_VectorSRegister(43);
+constexpr VectorSRegister VSR44 = as_VectorSRegister(44);
+constexpr VectorSRegister VSR45 = as_VectorSRegister(45);
+constexpr VectorSRegister VSR46 = as_VectorSRegister(46);
+constexpr VectorSRegister VSR47 = as_VectorSRegister(47);
+constexpr VectorSRegister VSR48 = as_VectorSRegister(48);
+constexpr VectorSRegister VSR49 = as_VectorSRegister(49);
+constexpr VectorSRegister VSR50 = as_VectorSRegister(50);
+constexpr VectorSRegister VSR51 = as_VectorSRegister(51);
+constexpr VectorSRegister VSR52 = as_VectorSRegister(52);
+constexpr VectorSRegister VSR53 = as_VectorSRegister(53);
+constexpr VectorSRegister VSR54 = as_VectorSRegister(54);
+constexpr VectorSRegister VSR55 = as_VectorSRegister(55);
+constexpr VectorSRegister VSR56 = as_VectorSRegister(56);
+constexpr VectorSRegister VSR57 = as_VectorSRegister(57);
+constexpr VectorSRegister VSR58 = as_VectorSRegister(58);
+constexpr VectorSRegister VSR59 = as_VectorSRegister(59);
+constexpr VectorSRegister VSR60 = as_VectorSRegister(60);
+constexpr VectorSRegister VSR61 = as_VectorSRegister(61);
+constexpr VectorSRegister VSR62 = as_VectorSRegister(62);
+constexpr VectorSRegister VSR63 = as_VectorSRegister(63);
 
 
 // Need to know the total number of registers of all sorts for SharedInfo.
@@ -678,11 +477,11 @@ const int PPC_ARGS_IN_REGS_NUM = 8;
 class ConcreteRegisterImpl : public AbstractRegisterImpl {
  public:
   enum {
-    max_gpr = RegisterImpl::number_of_registers * 2,
-    max_fpr = max_gpr + FloatRegisterImpl::number_of_registers * 2,
-    max_vsr = max_fpr + VectorSRegisterImpl::number_of_registers,
-    max_cnd = max_vsr + ConditionRegisterImpl::number_of_registers,
-    max_spr = max_cnd + SpecialRegisterImpl::number_of_registers,
+    max_gpr = Register::number_of_registers * 2,
+    max_fpr = max_gpr + FloatRegister::number_of_registers * 2,
+    max_vsr = max_fpr + VectorSRegister::number_of_registers,
+    max_cnd = max_vsr + ConditionRegister::number_of_registers,
+    max_spr = max_cnd + SpecialRegister::number_of_registers,
     // This number must be large enough to cover REG_COUNT (defined by c2) registers.
     // There is no requirement that any ordering here matches any ordering c2 gives
     // it's optoregs.
@@ -691,135 +490,69 @@ class ConcreteRegisterImpl : public AbstractRegisterImpl {
 };
 
 // Common register declarations used in assembler code.
-REGISTER_DECLARATION(Register,      R0_SCRATCH, R0);  // volatile
-REGISTER_DECLARATION(Register,      R1_SP,      R1);  // non-volatile
-REGISTER_DECLARATION(Register,      R2_TOC,     R2);  // volatile
-REGISTER_DECLARATION(Register,      R3_RET,     R3);  // volatile
-REGISTER_DECLARATION(Register,      R3_ARG1,    R3);  // volatile
-REGISTER_DECLARATION(Register,      R4_ARG2,    R4);  // volatile
-REGISTER_DECLARATION(Register,      R5_ARG3,    R5);  // volatile
-REGISTER_DECLARATION(Register,      R6_ARG4,    R6);  // volatile
-REGISTER_DECLARATION(Register,      R7_ARG5,    R7);  // volatile
-REGISTER_DECLARATION(Register,      R8_ARG6,    R8);  // volatile
-REGISTER_DECLARATION(Register,      R9_ARG7,    R9);  // volatile
-REGISTER_DECLARATION(Register,      R10_ARG8,   R10); // volatile
-REGISTER_DECLARATION(FloatRegister, F0_SCRATCH, F0);  // volatile
-REGISTER_DECLARATION(FloatRegister, F1_RET,     F1);  // volatile
-REGISTER_DECLARATION(FloatRegister, F1_ARG1,    F1);  // volatile
-REGISTER_DECLARATION(FloatRegister, F2_ARG2,    F2);  // volatile
-REGISTER_DECLARATION(FloatRegister, F3_ARG3,    F3);  // volatile
-REGISTER_DECLARATION(FloatRegister, F4_ARG4,    F4);  // volatile
-REGISTER_DECLARATION(FloatRegister, F5_ARG5,    F5);  // volatile
-REGISTER_DECLARATION(FloatRegister, F6_ARG6,    F6);  // volatile
-REGISTER_DECLARATION(FloatRegister, F7_ARG7,    F7);  // volatile
-REGISTER_DECLARATION(FloatRegister, F8_ARG8,    F8);  // volatile
-REGISTER_DECLARATION(FloatRegister, F9_ARG9,    F9);  // volatile
-REGISTER_DECLARATION(FloatRegister, F10_ARG10,  F10); // volatile
-REGISTER_DECLARATION(FloatRegister, F11_ARG11,  F11); // volatile
-REGISTER_DECLARATION(FloatRegister, F12_ARG12,  F12); // volatile
-REGISTER_DECLARATION(FloatRegister, F13_ARG13,  F13); // volatile
-
-#ifndef DONT_USE_REGISTER_DEFINES
-#define R0_SCRATCH         AS_REGISTER(Register, R0)
-#define R1_SP              AS_REGISTER(Register, R1)
-#define R2_TOC             AS_REGISTER(Register, R2)
-#define R3_RET             AS_REGISTER(Register, R3)
-#define R3_ARG1            AS_REGISTER(Register, R3)
-#define R4_ARG2            AS_REGISTER(Register, R4)
-#define R5_ARG3            AS_REGISTER(Register, R5)
-#define R6_ARG4            AS_REGISTER(Register, R6)
-#define R7_ARG5            AS_REGISTER(Register, R7)
-#define R8_ARG6            AS_REGISTER(Register, R8)
-#define R9_ARG7            AS_REGISTER(Register, R9)
-#define R10_ARG8           AS_REGISTER(Register, R10)
-#define F0_SCRATCH         AS_REGISTER(FloatRegister, F0)
-#define F1_RET             AS_REGISTER(FloatRegister, F1)
-#define F1_ARG1            AS_REGISTER(FloatRegister, F1)
-#define F2_ARG2            AS_REGISTER(FloatRegister, F2)
-#define F3_ARG3            AS_REGISTER(FloatRegister, F3)
-#define F4_ARG4            AS_REGISTER(FloatRegister, F4)
-#define F5_ARG5            AS_REGISTER(FloatRegister, F5)
-#define F6_ARG6            AS_REGISTER(FloatRegister, F6)
-#define F7_ARG7            AS_REGISTER(FloatRegister, F7)
-#define F8_ARG8            AS_REGISTER(FloatRegister, F8)
-#define F9_ARG9            AS_REGISTER(FloatRegister, F9)
-#define F10_ARG10          AS_REGISTER(FloatRegister, F10)
-#define F11_ARG11          AS_REGISTER(FloatRegister, F11)
-#define F12_ARG12          AS_REGISTER(FloatRegister, F12)
-#define F13_ARG13          AS_REGISTER(FloatRegister, F13)
-#endif
+constexpr Register R0_SCRATCH = R0;  // volatile
+constexpr Register R1_SP      = R1;  // non-volatile
+constexpr Register R2_TOC     = R2;  // volatile
+constexpr Register R3_RET     = R3;  // volatile
+constexpr Register R3_ARG1    = R3;  // volatile
+constexpr Register R4_ARG2    = R4;  // volatile
+constexpr Register R5_ARG3    = R5;  // volatile
+constexpr Register R6_ARG4    = R6;  // volatile
+constexpr Register R7_ARG5    = R7;  // volatile
+constexpr Register R8_ARG6    = R8;  // volatile
+constexpr Register R9_ARG7    = R9;  // volatile
+constexpr Register R10_ARG8   = R10; // volatile
+constexpr FloatRegister F0_SCRATCH = F0;  // volatile
+constexpr FloatRegister F1_RET     = F1;  // volatile
+constexpr FloatRegister F1_ARG1    = F1;  // volatile
+constexpr FloatRegister F2_ARG2    = F2;  // volatile
+constexpr FloatRegister F3_ARG3    = F3;  // volatile
+constexpr FloatRegister F4_ARG4    = F4;  // volatile
+constexpr FloatRegister F5_ARG5    = F5;  // volatile
+constexpr FloatRegister F6_ARG6    = F6;  // volatile
+constexpr FloatRegister F7_ARG7    = F7;  // volatile
+constexpr FloatRegister F8_ARG8    = F8;  // volatile
+constexpr FloatRegister F9_ARG9    = F9;  // volatile
+constexpr FloatRegister F10_ARG10  = F10; // volatile
+constexpr FloatRegister F11_ARG11  = F11; // volatile
+constexpr FloatRegister F12_ARG12  = F12; // volatile
+constexpr FloatRegister F13_ARG13  = F13; // volatile
 
 // Register declarations to be used in frame manager assembly code.
 // Use only non-volatile registers in order to keep values across C-calls.
-REGISTER_DECLARATION(Register, R14_bcp,        R14);
-REGISTER_DECLARATION(Register, R15_esp,        R15);
-REGISTER_DECLARATION(FloatRegister, F15_ftos,  F15);
-REGISTER_DECLARATION(Register, R16_thread,     R16);      // address of current thread
-REGISTER_DECLARATION(Register, R17_tos,        R17);      // address of Java tos (prepushed).
-REGISTER_DECLARATION(Register, R18_locals,     R18);      // address of first param slot (receiver).
-REGISTER_DECLARATION(Register, R19_method,     R19);      // address of current method
-#ifndef DONT_USE_REGISTER_DEFINES
-#define R14_bcp           AS_REGISTER(Register, R14)
-#define R15_esp           AS_REGISTER(Register, R15)
-#define F15_ftos          AS_REGISTER(FloatRegister, F15)
-#define R16_thread        AS_REGISTER(Register, R16)
-#define R17_tos           AS_REGISTER(Register, R17)
-#define R18_locals        AS_REGISTER(Register, R18)
-#define R19_method        AS_REGISTER(Register, R19)
-#define R21_sender_SP     AS_REGISTER(Register, R21)
-#define R23_method_handle AS_REGISTER(Register, R23)
-#endif
+constexpr Register R14_bcp       = R14;
+constexpr Register R15_esp       = R15;
+constexpr FloatRegister F15_ftos = F15;
+constexpr Register R16_thread    = R16;      // address of current thread
+constexpr Register R17_tos       = R17;      // address of Java tos (prepushed).
+constexpr Register R18_locals    = R18;      // address of first param slot (receiver).
+constexpr Register R19_method    = R19;      // address of current method
 
 // Temporary registers to be used within frame manager. We can use
 // the non-volatiles because the call stub has saved them.
 // Use only non-volatile registers in order to keep values across C-calls.
-REGISTER_DECLARATION(Register, R21_tmp1, R21);
-REGISTER_DECLARATION(Register, R22_tmp2, R22);
-REGISTER_DECLARATION(Register, R23_tmp3, R23);
-REGISTER_DECLARATION(Register, R24_tmp4, R24);
-REGISTER_DECLARATION(Register, R25_tmp5, R25);
-REGISTER_DECLARATION(Register, R26_tmp6, R26);
-REGISTER_DECLARATION(Register, R27_tmp7, R27);
-REGISTER_DECLARATION(Register, R28_tmp8, R28);
-REGISTER_DECLARATION(Register, R29_tmp9, R29);
-REGISTER_DECLARATION(Register, R24_dispatch_addr,     R24);
-REGISTER_DECLARATION(Register, R25_templateTableBase, R25);
-REGISTER_DECLARATION(Register, R26_monitor,           R26);
-REGISTER_DECLARATION(Register, R27_constPoolCache,    R27);
-REGISTER_DECLARATION(Register, R28_mdx,               R28);
+constexpr Register R21_tmp1 = R21;
+constexpr Register R22_tmp2 = R22;
+constexpr Register R23_tmp3 = R23;
+constexpr Register R24_tmp4 = R24;
+constexpr Register R25_tmp5 = R25;
+constexpr Register R26_tmp6 = R26;
+constexpr Register R27_tmp7 = R27;
+constexpr Register R28_tmp8 = R28;
+constexpr Register R29_tmp9 = R29;
+constexpr Register R24_dispatch_addr     = R24;
+constexpr Register R25_templateTableBase = R25;
+constexpr Register R26_monitor           = R26;
+constexpr Register R27_constPoolCache    = R27;
+constexpr Register R28_mdx               = R28;
 
-REGISTER_DECLARATION(Register, R19_inline_cache_reg, R19);
-REGISTER_DECLARATION(Register, R29_TOC, R29);
-
-#ifndef DONT_USE_REGISTER_DEFINES
-#define R21_tmp1         AS_REGISTER(Register, R21)
-#define R22_tmp2         AS_REGISTER(Register, R22)
-#define R23_tmp3         AS_REGISTER(Register, R23)
-#define R24_tmp4         AS_REGISTER(Register, R24)
-#define R25_tmp5         AS_REGISTER(Register, R25)
-#define R26_tmp6         AS_REGISTER(Register, R26)
-#define R27_tmp7         AS_REGISTER(Register, R27)
-#define R28_tmp8         AS_REGISTER(Register, R28)
-#define R29_tmp9         AS_REGISTER(Register, R29)
-//    Lmonitors  : monitor pointer
-//    LcpoolCache: constant pool cache
-//    mdx: method data index
-#define R24_dispatch_addr     AS_REGISTER(Register, R24)
-#define R25_templateTableBase AS_REGISTER(Register, R25)
-#define R26_monitor           AS_REGISTER(Register, R26)
-#define R27_constPoolCache    AS_REGISTER(Register, R27)
-#define R28_mdx               AS_REGISTER(Register, R28)
-
-#define R19_inline_cache_reg AS_REGISTER(Register, R19)
-#define R29_TOC AS_REGISTER(Register, R29)
-#endif
+constexpr Register R19_inline_cache_reg = R19;
+constexpr Register R21_sender_SP = R21;
+constexpr Register R23_method_handle = R23;
+constexpr Register R29_TOC = R29;
 
 // Scratch registers are volatile.
-REGISTER_DECLARATION(Register, R11_scratch1, R11);
-REGISTER_DECLARATION(Register, R12_scratch2, R12);
-#ifndef DONT_USE_REGISTER_DEFINES
-#define R11_scratch1   AS_REGISTER(Register, R11)
-#define R12_scratch2   AS_REGISTER(Register, R12)
-#endif
+constexpr Register R11_scratch1 = R11;
+constexpr Register R12_scratch2 = R12;
 
 #endif // CPU_PPC_REGISTER_PPC_HPP

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -324,7 +324,7 @@ OopMap* RegisterSaver::push_frame_reg_args_and_save_live_registers(MacroAssemble
         break;
       }
       case RegisterSaver::special_reg: {
-        if (reg_num == SR_CTR_SpecialRegisterEnumValue) {
+        if (reg_num == SR_CTR.encoding()) {
           __ mfctr(R30);
           __ std(R30, offset, R1_SP);
         } else {
@@ -403,7 +403,7 @@ void RegisterSaver::restore_live_registers_and_pop_frame(MacroAssembler* masm,
         break;
       }
       case RegisterSaver::special_reg: {
-        if (reg_num == SR_CTR_SpecialRegisterEnumValue) {
+        if (reg_num == SR_CTR.encoding()) {
           if (restore_ctr) { // Nothing to do here if ctr already contains the next address.
             __ ld(R31, offset, R1_SP);
             __ mtctr(R31);
@@ -583,7 +583,7 @@ static int reg2offset(VMReg r) {
 // as framesizes are fixed.
 // VMRegImpl::stack0 refers to the first slot 0(sp).
 // and VMRegImpl::stack0+1 refers to the memory word 4-bytes higher. Register
-// up to RegisterImpl::number_of_registers) are the 64-bit
+// up to Register::number_of_registers) are the 64-bit
 // integer registers.
 
 // Note: the INPUTS in sig_bt are in units of Java argument words, which are
@@ -1889,12 +1889,12 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
   //   out is the index of the outgoing C arguments
 
 #ifdef ASSERT
-  bool reg_destroyed[RegisterImpl::number_of_registers];
-  bool freg_destroyed[FloatRegisterImpl::number_of_registers];
-  for (int r = 0 ; r < RegisterImpl::number_of_registers ; r++) {
+  bool reg_destroyed[Register::number_of_registers];
+  bool freg_destroyed[FloatRegister::number_of_registers];
+  for (int r = 0 ; r < Register::number_of_registers ; r++) {
     reg_destroyed[r] = false;
   }
-  for (int f = 0 ; f < FloatRegisterImpl::number_of_registers ; f++) {
+  for (int f = 0 ; f < FloatRegister::number_of_registers ; f++) {
     freg_destroyed[f] = false;
   }
 #endif // ASSERT

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -2133,7 +2133,7 @@ class StubGenerator: public StubCodeGenerator {
 
     __ check_klass_subtype_fast_path(sub_klass, super_klass, temp, R0, &L_success, &L_miss, NULL,
                                      super_check_offset);
-    __ check_klass_subtype_slow_path(sub_klass, super_klass, temp, R0, &L_success, NULL);
+    __ check_klass_subtype_slow_path(sub_klass, super_klass, temp, R0, &L_success);
 
     // Fall through on failure!
     __ bind(L_miss);
@@ -3537,7 +3537,7 @@ class StubGenerator: public StubCodeGenerator {
     // passing the link register's value directly doesn't work.
     // Since we have to save the link register on the stack anyway, we calculate the corresponding stack address
     // and pass that one instead.
-    __ add(R3_ARG1, _abi0(lr), R1_SP);
+    __ addi(R3_ARG1, R1_SP, _abi0(lr));
 
     __ save_LR_CR(R0);
     __ push_frame_reg_args(nbytes_save, R0);

--- a/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2015, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
@@ -1010,7 +1010,7 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call, Regist
   if (native_call) {
     __ li(R14_bcp, 0); // Must initialize.
   } else {
-    __ add(R14_bcp, in_bytes(ConstMethod::codes_offset()), Rconst_method);
+    __ addi(R14_bcp, Rconst_method, in_bytes(ConstMethod::codes_offset()));
   }
 
   // Resize parent frame.

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2013, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2013, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -4070,7 +4070,7 @@ void TemplateTable::monitorenter() {
     Register Rlimit = Rcurrent_monitor;
 
     // Set up search loop - start with topmost monitor.
-    __ add(Rcurrent_obj_addr, BasicObjectLock::obj_offset_in_bytes(), R26_monitor);
+    __ addi(Rcurrent_obj_addr, R26_monitor, BasicObjectLock::obj_offset_in_bytes());
 
     __ ld(Rlimit, 0, R1_SP);
     __ addi(Rlimit, Rlimit, - (frame::ijava_state_size + frame::interpreter_frame_monitor_size_in_bytes() - BasicObjectLock::obj_offset_in_bytes())); // Monitor base

--- a/src/hotspot/cpu/ppc/vmreg_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vmreg_ppc.cpp
@@ -33,7 +33,7 @@ void VMRegImpl::set_regName() {
   for (i = 0; i < ConcreteRegisterImpl::max_gpr; ) {
     regName[i++] = reg->name();
     regName[i++] = reg->name();
-    if (reg->encoding() < RegisterImpl::number_of_registers-1)
+    if (reg->encoding() < Register::number_of_registers-1)
       reg = reg->successor();
   }
 
@@ -41,7 +41,7 @@ void VMRegImpl::set_regName() {
   for ( ; i < ConcreteRegisterImpl::max_fpr; ) {
     regName[i++] = freg->name();
     regName[i++] = freg->name();
-    if (reg->encoding() < FloatRegisterImpl::number_of_registers-1)
+    if (reg->encoding() < FloatRegister::number_of_registers-1)
       freg = freg->successor();
   }
 

--- a/src/hotspot/cpu/ppc/vmreg_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/vmreg_ppc.inline.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2018 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/ppc/vmreg_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/vmreg_ppc.inline.hpp
@@ -26,28 +26,30 @@
 #ifndef CPU_PPC_VMREG_PPC_INLINE_HPP
 #define CPU_PPC_VMREG_PPC_INLINE_HPP
 
-inline VMReg RegisterImpl::as_VMReg() {
-  if (this == noreg) return VMRegImpl::Bad();
+#include "code/vmreg.hpp"
+#include "register_ppc.hpp"
+
+inline VMReg Register::as_VMReg() const {
+  if (*this == noreg) return VMRegImpl::Bad();
   // Two halves, multiply by 2.
   return VMRegImpl::as_VMReg(encoding() << 1);
 }
 
-inline VMReg FloatRegisterImpl::as_VMReg() {
+inline VMReg FloatRegister::as_VMReg() const {
   // Two halves, multiply by 2.
   return VMRegImpl::as_VMReg((encoding() << 1) + ConcreteRegisterImpl::max_gpr);
 }
 
-inline VMReg VectorSRegisterImpl::as_VMReg() {
+inline VMReg VectorSRegister::as_VMReg() const {
   return VMRegImpl::as_VMReg((encoding()) + ConcreteRegisterImpl::max_fpr);
 }
 
-inline VMReg ConditionRegisterImpl::as_VMReg() {
+inline VMReg ConditionRegister::as_VMReg() const {
   return VMRegImpl::as_VMReg((encoding()) + ConcreteRegisterImpl::max_vsr);
 }
 
-inline VMReg SpecialRegisterImpl::as_VMReg() {
+inline VMReg SpecialRegister::as_VMReg() const {
   return VMRegImpl::as_VMReg((encoding()) + ConcreteRegisterImpl::max_cnd);
 }
-
 
 #endif // CPU_PPC_VMREG_PPC_INLINE_HPP


### PR DESCRIPTION
The recent Register implementation uses wild pointer (including null pointer) dereferences which exhibit undefined behavior. We should migrate away from pointer-based representation of Register values as it was done for x86 ([JDK-8292153](https://bugs.openjdk.org/browse/JDK-8292153)). Problems exist when trying to build with GCC 11 ([JDK-8297426](https://bugs.openjdk.org/browse/JDK-8297426)).
Note: Implicit conversion from `intptr_t` to `RegisterOrConstant` is no longer supported. That's why I had to replace some `add` instructions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297445](https://bugs.openjdk.org/browse/JDK-8297445): PPC64: Represent Registers as values


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**) ⚠️ Review applies to [5af4a37b](https://git.openjdk.org/jdk/pull/11297/files/5af4a37b0b2812a7fe904ea49153b41c3de921b2)
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11297/head:pull/11297` \
`$ git checkout pull/11297`

Update a local copy of the PR: \
`$ git checkout pull/11297` \
`$ git pull https://git.openjdk.org/jdk pull/11297/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11297`

View PR using the GUI difftool: \
`$ git pr show -t 11297`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11297.diff">https://git.openjdk.org/jdk/pull/11297.diff</a>

</details>
