### PR TITLE
8295351: java/lang/Float/Binary16Conversion.java fails with "Unexpected result of converting"

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -450,7 +450,7 @@ JRT_END
 
 // Reference implementation at src/java.base/share/classes/java/lang/Float.java:floatToFloat16
 JRT_LEAF(jshort, SharedRuntime::f2hf(jfloat  x))
-  union {jfloat f; juint i;} bits;
+  union {jfloat f; jint i;} bits;
   bits.f = x;
   jint doppel = bits.i;
   jshort sign_bit = (jshort) ((doppel & 0x80000000) >> 16);
@@ -503,7 +503,7 @@ JRT_END
 JRT_LEAF(jfloat, SharedRuntime::hf2f(jshort x))
   // Halffloat format has 1 signbit, 5 exponent bits and
   // 10 significand bits
-  union {jfloat f; juint i;} bits;
+  union {jfloat f; jint i;} bits;
   jint hf_arg = (jint)x;
   jint hf_sign_bit = 0x8000 & hf_arg;
   jint hf_exp_bits = 0x7c00 & hf_arg;
@@ -519,15 +519,15 @@ JRT_LEAF(jfloat, SharedRuntime::hf2f(jshort x))
   if (hf_exp == -15) {
     // For subnormal values, return 2^-24 * significand bits
     return (sign * (pow(2,-24)) * hf_significand_bits);
-  }else if (hf_exp == 16) {
-   if (hf_significand_bits == 0) {
-     bits.i = 0x7f800000;
-     return sign * bits.f;
-   } else {
-     bits.i = (hf_sign_bit << 16) | 0x7f800000 |
-              (hf_significand_bits << significand_shift);
-     return bits.f;
-   }
+  } else if (hf_exp == 16) {
+    if (hf_significand_bits == 0) {
+      bits.i = 0x7f800000;
+      return sign * bits.f;
+    } else {
+      bits.i = (hf_sign_bit << 16) | 0x7f800000 |
+               (hf_significand_bits << significand_shift);
+      return bits.f;
+    }
   }
 
   // Add the bias of float exponent and shift

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -521,7 +521,8 @@ JRT_LEAF(jfloat, SharedRuntime::hf2f(jshort x))
     return (sign * (pow(2,-24)) * hf_significand_bits);
   }else if (hf_exp == 16) {
    if (hf_significand_bits == 0) {
-     return sign * (1.0f/0.0f);
+     bits.i = 0x7f800000;
+     return sign * bits.f;
    } else {
      bits.i = (hf_sign_bit << 16) | 0x7f800000 |
               (hf_significand_bits << significand_shift);

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -450,7 +450,9 @@ JRT_END
 
 // Reference implementation at src/java.base/share/classes/java/lang/Float.java:floatToFloat16
 JRT_LEAF(jshort, SharedRuntime::f2hf(jfloat  x))
-  jint doppel = SharedRuntime::f2i(x);
+  union {jfloat f; juint i;} bits;
+  bits.f = x;
+  jint doppel = bits.i;
   jshort sign_bit = (jshort) ((doppel & 0x80000000) >> 16);
   if (g_isnan(x))
     return (jshort)(sign_bit | 0x7c00 | (doppel & 0x007fe000) >> 13 | (doppel & 0x00001ff0) >> 4 | (doppel & 0x0000000f));
@@ -467,7 +469,7 @@ JRT_LEAF(jshort, SharedRuntime::f2hf(jfloat  x))
     return sign_bit; // Positive or negative zero
   }
 
-  jint exp = 0x7f800000 & doppel;
+  jint exp = ((0x7f800000 & doppel) >> (24 -1)) - 127;
 
   // For binary16 subnormals, beside forcing exp to -15, retain
   // the difference exp_delta = E_min - exp.  This is the excess
@@ -501,6 +503,7 @@ JRT_END
 JRT_LEAF(jfloat, SharedRuntime::hf2f(jshort x))
   // Halffloat format has 1 signbit, 5 exponent bits and
   // 10 significand bits
+  union {jfloat f; juint i;} bits;
   jint hf_arg = (jint)x;
   jint hf_sign_bit = 0x8000 & hf_arg;
   jint hf_exp_bits = 0x7c00 & hf_arg;
@@ -517,15 +520,23 @@ JRT_LEAF(jfloat, SharedRuntime::hf2f(jshort x))
     // For subnormal values, return 2^-24 * significand bits
     return (sign * (pow(2,-24)) * hf_significand_bits);
   }else if (hf_exp == 16) {
-    return (hf_significand_bits == 0) ? sign * float_infinity : (SharedRuntime::i2f((hf_sign_bit << 16) | 0x7f800000 |
-           (hf_significand_bits << significand_shift)));
+   if (hf_significand_bits == 0) {
+     return sign * (1.0f/0.0f);
+   } else {
+     bits.i = (hf_sign_bit << 16) | 0x7f800000 |
+              (hf_significand_bits << significand_shift);
+     return bits.f;
+   }
   }
 
   // Add the bias of float exponent and shift
-  int float_exp_bits = (hf_exp + 127) << (24 - 1);
+  jint float_exp_bits = (hf_exp + 127) << (24 - 1);
 
   // Combine sign, exponent and significand bits
-  return SharedRuntime::i2f((hf_sign_bit << 16) | float_exp_bits | (hf_significand_bits << significand_shift));
+  bits.i = (hf_sign_bit << 16) | float_exp_bits |
+           (hf_significand_bits << significand_shift);
+
+  return bits.f;
 JRT_END
 
 // Exception handling across interpreter/compiler boundaries

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -469,7 +469,7 @@ JRT_LEAF(jshort, SharedRuntime::f2hf(jfloat  x))
     return sign_bit; // Positive or negative zero
   }
 
-  jint exp = ((0x7f800000 & doppel) >> (24 -1)) - 127;
+  jint exp = ((0x7f800000 & doppel) >> (24 - 1)) - 127;
 
   // For binary16 subnormals, beside forcing exp to -15, retain
   // the difference exp_delta = E_min - exp.  This is the excess

--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -30,4 +30,3 @@
 java/lang/invoke/MethodHandles/CatchExceptionTest.java 8146623 generic-all
 java/lang/ref/ReferenceEnqueue.java 8284236 generic-all
 
-java/lang/Float/Binary16Conversion.java 8295351 generic-x64


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295351](https://bugs.openjdk.org/browse/JDK-8295351): java/lang/Float/Binary16Conversion.java fails with "Unexpected result of converting"


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**) ⚠️ Review applies to [5af25e9b](https://git.openjdk.org/jdk/pull/11301/files/5af25e9b52b3b331163ae65b44aa0bf55367fffc)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [5af25e9b](https://git.openjdk.org/jdk/pull/11301/files/5af25e9b52b3b331163ae65b44aa0bf55367fffc)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11301/head:pull/11301` \
`$ git checkout pull/11301`

Update a local copy of the PR: \
`$ git checkout pull/11301` \
`$ git pull https://git.openjdk.org/jdk pull/11301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11301`

View PR using the GUI difftool: \
`$ git pr show -t 11301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11301.diff">https://git.openjdk.org/jdk/pull/11301.diff</a>

</details>
