### PR TITLE
8292265: Add old gen used field at G1HeapSummary JFR event

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2564,9 +2564,11 @@ G1HeapSummary G1CollectedHeap::create_g1_heap_summary() {
   size_t eden_capacity_bytes =
     (policy()->young_list_target_length() * HeapRegion::GrainBytes) - survivor_used_bytes;
 
+  size_t old_used_bytes = _monitoring_support->old_gen_used();
+
   VirtualSpaceSummary heap_summary = create_heap_space_summary();
   return G1HeapSummary(heap_summary, heap_used, eden_used_bytes,
-                       eden_capacity_bytes, survivor_used_bytes, num_regions());
+                       eden_capacity_bytes, survivor_used_bytes, old_used_bytes, num_regions());
 }
 
 G1EvacSummary G1CollectedHeap::create_g1_evac_summary(G1EvacStats* stats) {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2559,7 +2559,7 @@ G1HeapSummary G1CollectedHeap::create_g1_heap_summary() {
 
   size_t eden_used_bytes = _monitoring_support->eden_space_used();
   size_t survivor_used_bytes = _monitoring_support->survivor_space_used();
-  size_t old_used_bytes = _monitoring_support->old_gen_used();
+  size_t old_gen_used_bytes = _monitoring_support->old_gen_used();
   size_t heap_used = Heap_lock->owned_by_self() ? used() : used_unlocked();
 
   size_t eden_capacity_bytes =
@@ -2567,7 +2567,7 @@ G1HeapSummary G1CollectedHeap::create_g1_heap_summary() {
 
   VirtualSpaceSummary heap_summary = create_heap_space_summary();
   return G1HeapSummary(heap_summary, heap_used, eden_used_bytes, eden_capacity_bytes,
-                       survivor_used_bytes, old_used_bytes, num_regions());
+                       survivor_used_bytes, old_gen_used_bytes, num_regions());
 }
 
 G1EvacSummary G1CollectedHeap::create_g1_evac_summary(G1EvacStats* stats) {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2557,18 +2557,17 @@ bool G1CollectedHeap::print_location(outputStream* st, void* addr) const {
 
 G1HeapSummary G1CollectedHeap::create_g1_heap_summary() {
 
-  size_t eden_used_bytes = _eden.used_bytes();
-  size_t survivor_used_bytes = _survivor.used_bytes();
+  size_t eden_used_bytes = _monitoring_support->eden_space_used();
+  size_t survivor_used_bytes = _monitoring_support->survivor_space_used();
+  size_t old_used_bytes = _monitoring_support->old_gen_used();
   size_t heap_used = Heap_lock->owned_by_self() ? used() : used_unlocked();
 
   size_t eden_capacity_bytes =
     (policy()->young_list_target_length() * HeapRegion::GrainBytes) - survivor_used_bytes;
 
-  size_t old_used_bytes = _monitoring_support->old_gen_used();
-
   VirtualSpaceSummary heap_summary = create_heap_space_summary();
-  return G1HeapSummary(heap_summary, heap_used, eden_used_bytes,
-                       eden_capacity_bytes, survivor_used_bytes, old_used_bytes, num_regions());
+  return G1HeapSummary(heap_summary, heap_used, eden_used_bytes, eden_capacity_bytes,
+                       survivor_used_bytes, old_used_bytes, num_regions());
 }
 
 G1EvacSummary G1CollectedHeap::create_g1_evac_summary(G1EvacStats* stats) {

--- a/src/hotspot/share/gc/shared/gcHeapSummary.hpp
+++ b/src/hotspot/share/gc/shared/gcHeapSummary.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -117,13 +117,15 @@ class G1HeapSummary : public GCHeapSummary {
   size_t  _edenUsed;
   size_t  _edenCapacity;
   size_t  _survivorUsed;
+  size_t  _oldUsed;
   uint    _numberOfRegions;
  public:
-   G1HeapSummary(VirtualSpaceSummary& heap_space, size_t heap_used, size_t edenUsed, size_t edenCapacity, size_t survivorUsed, uint numberOfRegions) :
-      GCHeapSummary(heap_space, heap_used), _edenUsed(edenUsed), _edenCapacity(edenCapacity), _survivorUsed(survivorUsed), _numberOfRegions(numberOfRegions) { }
+   G1HeapSummary(VirtualSpaceSummary& heap_space, size_t heap_used, size_t edenUsed, size_t edenCapacity, size_t survivorUsed, size_t oldUsed, uint numberOfRegions) :
+      GCHeapSummary(heap_space, heap_used), _edenUsed(edenUsed), _edenCapacity(edenCapacity), _survivorUsed(survivorUsed), _oldUsed(oldUsed), _numberOfRegions(numberOfRegions) { }
    const size_t edenUsed() const { return _edenUsed; }
    const size_t edenCapacity() const { return _edenCapacity; }
    const size_t survivorUsed() const { return _survivorUsed; }
+   const size_t oldUsed() const { return _oldUsed; }
    const uint   numberOfRegions() const { return _numberOfRegions; }
 
    virtual void accept(GCHeapSummaryVisitor* visitor) const {

--- a/src/hotspot/share/gc/shared/gcHeapSummary.hpp
+++ b/src/hotspot/share/gc/shared/gcHeapSummary.hpp
@@ -117,15 +117,15 @@ class G1HeapSummary : public GCHeapSummary {
   size_t  _edenUsed;
   size_t  _edenCapacity;
   size_t  _survivorUsed;
-  size_t  _oldUsed;
+  size_t  _oldGenUsed;
   uint    _numberOfRegions;
  public:
-   G1HeapSummary(VirtualSpaceSummary& heap_space, size_t heap_used, size_t edenUsed, size_t edenCapacity, size_t survivorUsed, size_t oldUsed, uint numberOfRegions) :
-      GCHeapSummary(heap_space, heap_used), _edenUsed(edenUsed), _edenCapacity(edenCapacity), _survivorUsed(survivorUsed), _oldUsed(oldUsed), _numberOfRegions(numberOfRegions) { }
+   G1HeapSummary(VirtualSpaceSummary& heap_space, size_t heap_used, size_t edenUsed, size_t edenCapacity, size_t survivorUsed, size_t oldGenUsed, uint numberOfRegions) :
+      GCHeapSummary(heap_space, heap_used), _edenUsed(edenUsed), _edenCapacity(edenCapacity), _survivorUsed(survivorUsed), _oldGenUsed(oldGenUsed), _numberOfRegions(numberOfRegions) { }
    const size_t edenUsed() const { return _edenUsed; }
    const size_t edenCapacity() const { return _edenCapacity; }
    const size_t survivorUsed() const { return _survivorUsed; }
-   const size_t oldUsed() const { return _oldUsed; }
+   const size_t oldGenUsed() const { return _oldGenUsed; }
    const uint   numberOfRegions() const { return _numberOfRegions; }
 
    virtual void accept(GCHeapSummaryVisitor* visitor) const {

--- a/src/hotspot/share/gc/shared/gcTraceSend.cpp
+++ b/src/hotspot/share/gc/shared/gcTraceSend.cpp
@@ -244,6 +244,7 @@ class GCHeapSummaryEventSender : public GCHeapSummaryVisitor {
       e.set_edenUsedSize(g1_heap_summary->edenUsed());
       e.set_edenTotalSize(g1_heap_summary->edenCapacity());
       e.set_survivorUsedSize(g1_heap_summary->survivorUsed());
+      e.set_oldUsedSize(g1_heap_summary->oldUsed());
       e.set_numberOfRegions(g1_heap_summary->numberOfRegions());
       e.commit();
     }

--- a/src/hotspot/share/gc/shared/gcTraceSend.cpp
+++ b/src/hotspot/share/gc/shared/gcTraceSend.cpp
@@ -244,7 +244,7 @@ class GCHeapSummaryEventSender : public GCHeapSummaryVisitor {
       e.set_edenUsedSize(g1_heap_summary->edenUsed());
       e.set_edenTotalSize(g1_heap_summary->edenCapacity());
       e.set_survivorUsedSize(g1_heap_summary->survivorUsed());
-      e.set_oldUsedSize(g1_heap_summary->oldUsed());
+      e.set_oldGenUsedSize(g1_heap_summary->oldGenUsed());
       e.set_numberOfRegions(g1_heap_summary->numberOfRegions());
       e.commit();
     }

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -329,6 +329,7 @@
     <Field type="ulong" contentType="bytes" name="edenUsedSize" label="Eden Used Size" />
     <Field type="ulong" contentType="bytes" name="edenTotalSize" label="Eden Total Size" />
     <Field type="ulong" contentType="bytes" name="survivorUsedSize" label="Survivor Used Size" />
+    <Field type="ulong" contentType="bytes" name="oldUsedSize" label="Old Used Size" />
     <Field type="uint" name="numberOfRegions" label="Number of Regions" />
   </Event>
 

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -329,7 +329,7 @@
     <Field type="ulong" contentType="bytes" name="edenUsedSize" label="Eden Used Size" />
     <Field type="ulong" contentType="bytes" name="edenTotalSize" label="Eden Total Size" />
     <Field type="ulong" contentType="bytes" name="survivorUsedSize" label="Survivor Used Size" />
-    <Field type="ulong" contentType="bytes" name="oldUsedSize" label="Old Used Size" />
+    <Field type="ulong" contentType="bytes" name="oldGenUsedSize" label="Old Generation Used Size" />
     <Field type="uint" name="numberOfRegions" label="Number of Regions" />
   </Event>
 


### PR DESCRIPTION
Hi all,

Can I have reviews for this change which adds 'old gen used' field at existing G1HeapSummary event?

Testing: tier1 ~ tier3

Thanks,
Sangheon

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292265](https://bugs.openjdk.org/browse/JDK-8292265): Add old gen used field at G1HeapSummary JFR event


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [85a4ac3a](https://git.openjdk.org/jdk/pull/11303/files/85a4ac3ad1eabe82c760bf45115b5d7f59c853d3)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11303/head:pull/11303` \
`$ git checkout pull/11303`

Update a local copy of the PR: \
`$ git checkout pull/11303` \
`$ git pull https://git.openjdk.org/jdk pull/11303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11303`

View PR using the GUI difftool: \
`$ git pr show -t 11303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11303.diff">https://git.openjdk.org/jdk/pull/11303.diff</a>

</details>
