### PR TITLE
8297286: runtime/vthread tests crashing after JDK-8296324

### DIFF
--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -381,6 +381,7 @@ JvmtiExport::get_jvmti_interface(JavaVM *jvm, void **penv, jint version) {
     java_lang_VirtualThread::set_notify_jvmti_events(true);
     if (JvmtiEnv::get_phase() == JVMTI_PHASE_LIVE) {
       ThreadInVMfromNative __tiv(JavaThread::current());
+      JvmtiVTMSTransitionDisabler disabler;
       java_lang_VirtualThread::init_static_notify_jvmti_events();
     }
   }

--- a/src/java.base/share/classes/java/lang/VirtualThread.java
+++ b/src/java.base/share/classes/java/lang/VirtualThread.java
@@ -270,11 +270,10 @@ final class VirtualThread extends BaseVirtualThread {
     @ChangesCurrentThread
     private void run(Runnable task) {
         assert state == RUNNING;
-        boolean notifyJvmti = notifyJvmtiEvents;
 
         // first mount
         mount();
-        if (notifyJvmti) notifyJvmtiMountEnd(true);
+        if (notifyJvmtiEvents) notifyJvmtiMountEnd(true);
 
         // emit JFR event if enabled
         if (VirtualThreadStartEvent.isTurnedOn()) {
@@ -302,7 +301,7 @@ final class VirtualThread extends BaseVirtualThread {
 
             } finally {
                 // last unmount
-                if (notifyJvmti) notifyJvmtiUnmountBegin(true);
+                if (notifyJvmtiEvents) notifyJvmtiUnmountBegin(true);
                 unmount();
 
                 // final state

--- a/src/java.base/share/classes/java/lang/VirtualThread.java
+++ b/src/java.base/share/classes/java/lang/VirtualThread.java
@@ -393,17 +393,15 @@ final class VirtualThread extends BaseVirtualThread {
      */
     @ChangesCurrentThread
     private boolean yieldContinuation() {
-        boolean notifyJvmti = notifyJvmtiEvents;
-
         // unmount
-        if (notifyJvmti) notifyJvmtiUnmountBegin(false);
+        if (notifyJvmtiEvents) notifyJvmtiUnmountBegin(false);
         unmount();
         try {
             return Continuation.yield(VTHREAD_SCOPE);
         } finally {
             // re-mount
             mount();
-            if (notifyJvmti) notifyJvmtiMountEnd(false);
+            if (notifyJvmtiEvents) notifyJvmtiMountEnd(false);
         }
     }
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -100,8 +100,6 @@ runtime/os/TestTracePageSizes.java#G1 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
-runtime/vthread/RedefineClass.java 8297286 generic-all
-runtime/vthread/TestObjectAllocationSampleEvent.java 8297286 generic-all
 
 applications/jcstress/copy.java 8229852 linux-all
 


### PR DESCRIPTION
This problem has two sides.
One is that the `VirtualThread::run() `cashes the field `notifyJvmtiEvents` value.
It caused the native method `notifyJvmtiUnmountBegin()` not called after the field `notifyJvmtiEvents`
value has been set to `true` when an agent library is loaded into running VM.
The fix is to get rid of this cashing.
Another is that enabling `notifyJvmtiEvents` notifications needs a synchronization.
Otherwise, a VTMS transition start can be missed which will cause some asserts to fire.
The fix is to use a JvmtiVTMSTransitionDisabler helper for sync.

Testing:
The originally failed tests are passed now:
```
runtime/vthread/RedefineClass.java
runtime/vthread/TestObjectAllocationSampleEvent.java 
```
In progress:
Run the tiers 1-6 to make sure there are no regression.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Whitespace errors (failed with the updated jcheck configuration)

### Issue
 * [JDK-8297286](https://bugs.openjdk.org/browse/JDK-8297286): runtime/vthread tests crashing after JDK-8296324


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/11304/head:pull/11304` \
`$ git checkout pull/11304`

Update a local copy of the PR: \
`$ git checkout pull/11304` \
`$ git pull https://git.openjdk.org/jdk.git pull/11304/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11304`

View PR using the GUI difftool: \
`$ git pr show -t 11304`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11304.diff">https://git.openjdk.org/jdk/pull/11304.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/11304#issuecomment-1324402739)