### PR TITLE
JDK-8297449: Update JInternalFrame Metal Border code

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalBorders.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalBorders.java
@@ -62,7 +62,6 @@ import javax.swing.plaf.UIResource;
 import javax.swing.plaf.basic.BasicBorders;
 import javax.swing.text.JTextComponent;
 
-import sun.java2d.pipe.Region;
 import sun.swing.StringUIClientPropertyKey;
 import sun.swing.SwingUtilities2;
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalBorders.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalBorders.java
@@ -269,10 +269,11 @@ public class MetalBorders {
             Color oldColor = null;
             boolean resetTransform = false;
             int stkWidth = 1;
+            double scaleFactor = 1;
 
-            if (g instanceof Graphics2D) {
-                Graphics2D g2d = (Graphics2D) g;
+            if (g instanceof Graphics2D g2d) {
                 at = g2d.getTransform();
+                scaleFactor = at.getScaleX();
                 oldColor = g2d.getColor();
                 oldStk = g2d.getStroke();
 
@@ -308,7 +309,8 @@ public class MetalBorders {
             g.translate(xtranslation, ytranslation);
 
             // scaled border
-            int thickness = (int) Math.ceil(4 * at.getScaleX());
+            int thickness = (scaleFactor == 1) ? 4 :
+                    (int) Math.ceil(4 * scaleFactor);
 
             g.setColor(background);
             // Draw the bulk of the border
@@ -320,11 +322,12 @@ public class MetalBorders {
                 // midpoint at which highlight & shadow lines
                 // are positioned on the border
                 int midPoint = thickness / 2;
-                int offset = ((at.getScaleX() - stkWidth) >= 0 && stkWidth % 2 != 0) ? 1 : 0;
+                int offset = (((scaleFactor - stkWidth) >= 0) && ((stkWidth % 2) != 0)) ? 1 : 0;
                 int loc1 = thickness % 2 == 0 ? midPoint + stkWidth / 2 - stkWidth : midPoint;
                 int loc2 = thickness % 2 == 0 ? midPoint + stkWidth / 2 : midPoint + stkWidth;
                 // scaled corner
-                int corner = (int) Math.round(CORNER * at.getScaleX());
+                int corner = (scaleFactor == 1) ? CORNER :
+                        (int) Math.round(CORNER * scaleFactor);
 
                 // Draw the Long highlight lines
                 g.setColor(highlight);

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalBorders.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalBorders.java
@@ -286,10 +286,10 @@ public class MetalBorders {
                 }
             }
 
-            int width;
-            int height;
             int xtranslation;
             int ytranslation;
+            int width;
+            int height;
 
             if (resetTransform) {
                 double xx = at.getScaleX() * x + at.getTranslateX();
@@ -299,10 +299,10 @@ public class MetalBorders {
                 width = clipRound(at.getScaleX() * w + xx) - xtranslation;
                 height = clipRound(at.getScaleY() * h + yy) - ytranslation;
             } else {
-                width = w;
-                height = h;
                 xtranslation = x;
                 ytranslation = y;
+                width = w;
+                height = h;
             }
             g.translate(xtranslation, ytranslation);
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalBorders.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalBorders.java
@@ -250,102 +250,108 @@ public class MetalBorders {
 
         public void paintBorder(Component c, Graphics g, int x, int y,
                                 int w, int h) {
+            Color background;
+            Color highlight;
+            Color shadow;
+
+            if (c instanceof JInternalFrame && ((JInternalFrame)c).isSelected()) {
+                background = MetalLookAndFeel.getPrimaryControlDarkShadow();
+                highlight = MetalLookAndFeel.getPrimaryControlShadow();
+                shadow = MetalLookAndFeel.getPrimaryControlInfo();
+            } else {
+                background = MetalLookAndFeel.getControlDarkShadow();
+                highlight = MetalLookAndFeel.getControlShadow();
+                shadow = MetalLookAndFeel.getControlInfo();
+            }
+
+            AffineTransform at = null;
+            Stroke oldStk = null;
+            Color oldColor = null;
+            boolean resetTransform = false;
+            int stkWidth = 1;
+
             if (g instanceof Graphics2D) {
                 Graphics2D g2d = (Graphics2D) g;
-                AffineTransform at = g2d.getTransform();
-                Stroke oldStk = g2d.getStroke();
-                Color oldColor = g2d.getColor();
-                int stkWidth = 1;
-
-                Color background;
-                Color highlight;
-                Color shadow;
-
-                if (c instanceof JInternalFrame && ((JInternalFrame)c).isSelected()) {
-                    background = MetalLookAndFeel.getPrimaryControlDarkShadow();
-                    highlight = MetalLookAndFeel.getPrimaryControlShadow();
-                    shadow = MetalLookAndFeel.getPrimaryControlInfo();
-                } else {
-                    background = MetalLookAndFeel.getControlDarkShadow();
-                    highlight = MetalLookAndFeel.getControlShadow();
-                    shadow = MetalLookAndFeel.getControlInfo();
-                }
+                at = g2d.getTransform();
+                oldColor = g2d.getColor();
+                oldStk = g2d.getStroke();
 
                 // if m01 or m10 is non-zero, then there is a rotation or shear
                 // skip resetting the transform
-                boolean resetTransform = ((at.getShearX() == 0) && (at.getShearY() == 0));
-
-                int xtranslation;
-                int ytranslation;
-                int width;
-                int height;
+                resetTransform = ((at.getShearX() == 0) && (at.getShearY() == 0));
 
                 if (resetTransform) {
                     g2d.setTransform(new AffineTransform());
                     stkWidth = clipRound(Math.min(at.getScaleX(), at.getScaleY()));
-
-                    double xx = at.getScaleX() * x + at.getTranslateX();
-                    double yy = at.getScaleY() * y + at.getTranslateY();
-                    xtranslation = clipRound(xx);
-                    ytranslation = clipRound(yy);
-                    width = clipRound(at.getScaleX() * w + xx) - xtranslation;
-                    height = clipRound(at.getScaleY() * h + yy) - ytranslation;
-                } else {
-                    width = w;
-                    height = h;
-                    xtranslation = x;
-                    ytranslation = y;
-                }
-                g2d.translate(xtranslation, ytranslation);
-
-                // scaled border
-                int thickness = (int) Math.ceil(4 * at.getScaleX());
-
-                g2d.setColor(background);
-                // Draw the bulk of the border
-                for (int i = 0; i <= thickness; i++) {
-                    g2d.drawRect(i, i, width - (i * 2), height - (i * 2));
-                }
-
-                if (c instanceof JInternalFrame && ((JInternalFrame)c).isResizable()) {
-                    // set new stroke to draw shadow and highlight lines
                     g2d.setStroke(new BasicStroke((float) stkWidth));
-
-                    // midpoint at which highlight & shadow lines
-                    // are positioned on the border
-                    int midPoint = thickness / 2;
-                    int offset = ((at.getScaleX() - stkWidth) >= 0 && stkWidth % 2 != 0) ? 1 : 0;
-                    int loc1 = thickness % 2 == 0 ? midPoint + stkWidth / 2 - stkWidth : midPoint;
-                    int loc2 = thickness % 2 == 0 ? midPoint + stkWidth / 2 : midPoint + stkWidth;
-                    // scaled corner
-                    int corner = (int) Math.round(CORNER * at.getScaleX());
-
-                    // Draw the Long highlight lines
-                    g2d.setColor(highlight);
-                    g2d.drawLine(corner + 1, loc2, width - corner, loc2); //top
-                    g2d.drawLine(loc2, corner + 1, loc2, height - corner); //left
-                    g2d.drawLine((width - offset) - loc1, corner + 1,
-                            (width - offset) - loc1, height - corner); //right
-                    g2d.drawLine(corner + 1, (height - offset) - loc1,
-                            width - corner, (height - offset) - loc1); //bottom
-
-                    // Draw the Long shadow lines
-                    g2d.setColor(shadow);
-                    g2d.drawLine(corner, loc1, width - corner - 1, loc1);
-                    g2d.drawLine(loc1, corner, loc1, height - corner - 1);
-                    g2d.drawLine((width - offset) - loc2, corner,
-                            (width - offset) - loc2, height - corner - 1);
-                    g2d.drawLine(corner, (height - offset) - loc2,
-                            width - corner - 1, (height - offset) - loc2);
                 }
+            }
 
-                // restore previous transform
-                g2d.translate(-xtranslation, -ytranslation);
-                if (resetTransform) {
-                    g2d.setColor(oldColor);
-                    g2d.setTransform(at);
-                    g2d.setStroke(oldStk);
-                }
+            int width;
+            int height;
+            int xtranslation;
+            int ytranslation;
+
+            if (resetTransform) {
+                double xx = at.getScaleX() * x + at.getTranslateX();
+                double yy = at.getScaleY() * y + at.getTranslateY();
+                xtranslation = clipRound(xx);
+                ytranslation = clipRound(yy);
+                width = clipRound(at.getScaleX() * w + xx) - xtranslation;
+                height = clipRound(at.getScaleY() * h + yy) - ytranslation;
+            } else {
+                width = w;
+                height = h;
+                xtranslation = x;
+                ytranslation = y;
+            }
+            g.translate(xtranslation, ytranslation);
+
+            // scaled border
+            int thickness = (int) Math.ceil(4 * at.getScaleX());
+
+            g.setColor(background);
+            // Draw the bulk of the border
+            for (int i = 0; i <= thickness; i++) {
+                g.drawRect(i, i, width - (i * 2), height - (i * 2));
+            }
+
+            if (c instanceof JInternalFrame && ((JInternalFrame)c).isResizable()) {
+                // midpoint at which highlight & shadow lines
+                // are positioned on the border
+                int midPoint = thickness / 2;
+                int offset = ((at.getScaleX() - stkWidth) >= 0 && stkWidth % 2 != 0) ? 1 : 0;
+                int loc1 = thickness % 2 == 0 ? midPoint + stkWidth / 2 - stkWidth : midPoint;
+                int loc2 = thickness % 2 == 0 ? midPoint + stkWidth / 2 : midPoint + stkWidth;
+                // scaled corner
+                int corner = (int) Math.round(CORNER * at.getScaleX());
+
+                // Draw the Long highlight lines
+                g.setColor(highlight);
+                g.drawLine(corner + 1, loc2, width - corner, loc2); //top
+                g.drawLine(loc2, corner + 1, loc2, height - corner); //left
+                g.drawLine((width - offset) - loc1, corner + 1,
+                        (width - offset) - loc1, height - corner); //right
+                g.drawLine(corner + 1, (height - offset) - loc1,
+                        width - corner, (height - offset) - loc1); //bottom
+
+                // Draw the Long shadow lines
+                g.setColor(shadow);
+                g.drawLine(corner, loc1, width - corner - 1, loc1);
+                g.drawLine(loc1, corner, loc1, height - corner - 1);
+                g.drawLine((width - offset) - loc2, corner,
+                        (width - offset) - loc2, height - corner - 1);
+                g.drawLine(corner, (height - offset) - loc2,
+                        width - corner - 1, (height - offset) - loc2);
+            }
+
+            // restore previous transform
+            g.translate(-xtranslation, -ytranslation);
+            if (resetTransform) {
+                Graphics2D g2d = (Graphics2D) g;
+                g2d.setColor(oldColor);
+                g2d.setTransform(at);
+                g2d.setStroke(oldStk);
             }
         }
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalBorders.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalBorders.java
@@ -266,7 +266,6 @@ public class MetalBorders {
 
             AffineTransform at = null;
             Stroke oldStk = null;
-            Color oldColor = null;
             boolean resetTransform = false;
             int stkWidth = 1;
             double scaleFactor = 1;
@@ -274,7 +273,6 @@ public class MetalBorders {
             if (g instanceof Graphics2D g2d) {
                 at = g2d.getTransform();
                 scaleFactor = at.getScaleX();
-                oldColor = g2d.getColor();
                 oldStk = g2d.getStroke();
 
                 // if m01 or m10 is non-zero, then there is a rotation or shear
@@ -309,8 +307,7 @@ public class MetalBorders {
             g.translate(xtranslation, ytranslation);
 
             // scaled border
-            int thickness = (scaleFactor == 1) ? 4 :
-                    (int) Math.ceil(4 * scaleFactor);
+            int thickness = (int) Math.ceil(4 * scaleFactor);
 
             g.setColor(background);
             // Draw the bulk of the border
@@ -326,8 +323,7 @@ public class MetalBorders {
                 int loc1 = thickness % 2 == 0 ? midPoint + stkWidth / 2 - stkWidth : midPoint;
                 int loc2 = thickness % 2 == 0 ? midPoint + stkWidth / 2 : midPoint + stkWidth;
                 // scaled corner
-                int corner = (scaleFactor == 1) ? CORNER :
-                        (int) Math.round(CORNER * scaleFactor);
+                int corner = (int) Math.round(CORNER * scaleFactor);
 
                 // Draw the Long highlight lines
                 g.setColor(highlight);
@@ -352,7 +348,6 @@ public class MetalBorders {
             g.translate(-xtranslation, -ytranslation);
             if (resetTransform) {
                 Graphics2D g2d = (Graphics2D) g;
-                g2d.setColor(oldColor);
                 g2d.setTransform(at);
                 g2d.setStroke(oldStk);
             }


### PR DESCRIPTION
Updated Metal Border code for JInternalFrame. 

- Added instanceof check before casting Graphics to G2D.
- Replaced roundHalfDown with Region.clipRound()

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297449](https://bugs.openjdk.org/browse/JDK-8297449): Update JInternalFrame Metal Border code


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**) ⚠️ Review applies to [b1e3557a](https://git.openjdk.org/jdk/pull/11305/files/b1e3557a88308297abcb9a1d7d341859d2c8c9c7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11305/head:pull/11305` \
`$ git checkout pull/11305`

Update a local copy of the PR: \
`$ git checkout pull/11305` \
`$ git pull https://git.openjdk.org/jdk pull/11305/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11305`

View PR using the GUI difftool: \
`$ git pr show -t 11305`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11305.diff">https://git.openjdk.org/jdk/pull/11305.diff</a>

</details>
