### PR TITLE
8297476: Increase InlineSmallCode default from 1000 to 2500 for RISC-V

### DIFF
--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -412,6 +412,12 @@ void CompilerConfig::set_compilation_policy_flags() {
       FLAG_SET_DEFAULT(InlineSmallCode, 2500);
     }
 #endif
+
+#if defined RISCV64
+    if (FLAG_IS_DEFAULT(InlineSmallCode)) {
+      FLAG_SET_DEFAULT(InlineSmallCode, 2000);
+    }
+#endif
 #endif // COMPILER2
   }
 

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -401,21 +401,9 @@ void CompilerConfig::set_compilation_policy_flags() {
   if (CompilerConfig::is_tiered() && CompilerConfig::is_c2_enabled()) {
 #ifdef COMPILER2
     // Some inlining tuning
-#ifdef X86
+#if defined(X86) || defined(AARCH64) || defined(RISCV64)
     if (FLAG_IS_DEFAULT(InlineSmallCode)) {
       FLAG_SET_DEFAULT(InlineSmallCode, 2500);
-    }
-#endif
-
-#if defined AARCH64
-    if (FLAG_IS_DEFAULT(InlineSmallCode)) {
-      FLAG_SET_DEFAULT(InlineSmallCode, 2500);
-    }
-#endif
-
-#if defined RISCV64
-    if (FLAG_IS_DEFAULT(InlineSmallCode)) {
-      FLAG_SET_DEFAULT(InlineSmallCode, 2000);
     }
 #endif
 #endif // COMPILER2


### PR DESCRIPTION
The current default value of InlineSmallCode on RISC-V is 1000. I witnessed notable performance improvement by increasing this value to 2000 when running the Renaissance benchmark. Here are the exact commands used for each of the benchmarks:

Before:
$ java -XX:InlineSmallCode=1000 -XX:+UseParallelGC -Xms12g -Xmx12g -jar renaissance-gpl-0.14.1.jar -r 40 all

After:
$ java -XX:InlineSmallCode=2000 -XX:+UseParallelGC -Xms12g -Xmx12g -jar renaissance-gpl-0.14.1.jar -r 40 all

Best run time for one repetition (ms – lower is better) on Unmatched board:

Benchmark | Before | After | Ratio
-- | -- | -- | --
AkkaUct | 75629.766 | 71839.905 | 5.01%
Reactors | 98120.668 | 91597.120 | 6.65%
DecTree | 12144.666 | 11801.740 | 2.82%
Als | 57719.166 | 53307.041 | 7.64%
ChiSquare | 21704.666 | 16301.189 | 24.89%
GaussMix | 17494.891 | 17497.291 | -0.02%
LogRegression | 11881.352 | 11382.722 | 4.20%
MovieLens | 100944.374 | 96510.793 | 4.39%
NaiveBayes | 81946.569 | 68566.763 | 16.32%
PageRank | 43689.497 | 43204.553 | 1.11%
FjKmeans | 68398.667 | 67261.674 | 1.66%
FutureGenetic | 31752.695 | 31524.457 | 0.72%
Mnemonics | 126312.832 | 115335.512 | 8.69%
ParMnemonics | 93406.666 | 88320.443 | 5.45%
Scrabble | 6894.853 | 6888.426 | 0.09%
RxScrabble | 5163.473 | 4875.730 | 5.08%
Dotty | 14852.405 | 14667.255 | 1.25%
ScalaDoku | 95770.117 | 39728.637 | 58.52%
Philosophers | 13974.965 | 11579.551 | 17.14%
ScalaStmBench7 | 12185.093 | 12243.016 | -0.47%
FinagleChirper | 32676.065 | 30900.282 | 5.44%
FinagleHttp | 30633.640 | 30191.792 | 1.44%

Other testing: tier1-tier3 tested on Unmatched board.

I have also tested other possible values for InlineSmallCode like 1500 and 2500, but the numbers say show 2000 would outperform those values in most of the cases. And I can verify no regressions across at least following benchmarks:

- Dacapo
- SPECjvm2008
- SPECjbb2005
- SPECjbb2015

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297476](https://bugs.openjdk.org/browse/JDK-8297476): Increase InlineSmallCode default from 1000 to 2500 for RISC-V


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Yanhong Zhu](https://openjdk.org/census#yzhu) (@yhzhu20 - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11310/head:pull/11310` \
`$ git checkout pull/11310`

Update a local copy of the PR: \
`$ git checkout pull/11310` \
`$ git pull https://git.openjdk.org/jdk pull/11310/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11310`

View PR using the GUI difftool: \
`$ git pr show -t 11310`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11310.diff">https://git.openjdk.org/jdk/pull/11310.diff</a>

</details>
