### PR TITLE
8297385: Remove duplicated null typos in javadoc

### DIFF
--- a/src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java
+++ b/src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java
@@ -155,7 +155,7 @@ public abstract class DocumentBuilder {
      * Parse the content of the given URI as an XML document
      * and return a new DOM {@link Document} object.
      * An <code>IllegalArgumentException</code> is thrown if the
-     * URI is <code>null</code> null.
+     * URI is <code>null</code>.
      *
      * @param uri The location of the content to be parsed.
      *
@@ -182,7 +182,7 @@ public abstract class DocumentBuilder {
      * Parse the content of the given file as an XML document
      * and return a new DOM {@link Document} object.
      * An <code>IllegalArgumentException</code> is thrown if the
-     * <code>File</code> is <code>null</code> null.
+     * <code>File</code> is <code>null</code>.
      *
      * @param f The file containing the XML to parse.
      *
@@ -210,7 +210,7 @@ public abstract class DocumentBuilder {
      * Parse the content of the given input source as an XML document
      * and return a new DOM {@link Document} object.
      * An <code>IllegalArgumentException</code> is thrown if the
-     * <code>InputSource</code> is <code>null</code> null.
+     * <code>InputSource</code> is <code>null</code>.
      *
      * @param is InputSource containing the content to be parsed.
      *


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297385](https://bugs.openjdk.org/browse/JDK-8297385): Remove duplicated null typos in javadoc


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11311/head:pull/11311` \
`$ git checkout pull/11311`

Update a local copy of the PR: \
`$ git checkout pull/11311` \
`$ git pull https://git.openjdk.org/jdk pull/11311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11311`

View PR using the GUI difftool: \
`$ git pr show -t 11311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11311.diff">https://git.openjdk.org/jdk/pull/11311.diff</a>

</details>
