### PR TITLE
JDK-8297480: GetPrimitiveArrayCritical in imageioJPEG misses result - NULL check

### DIFF
--- a/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
+++ b/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
@@ -713,6 +713,7 @@ static int setQTables(JNIEnv *env,
         CHECK_NULL_RETURN(table, 0);
         qdata = (*env)->GetObjectField(env, table, JPEGQTable_tableID);
         qdataBody = (*env)->GetPrimitiveArrayCritical(env, qdata, NULL);
+        CHECK_NULL_RETURN(qdataBody, 0);
 
         if (cinfo->is_decompressor) {
             decomp = (j_decompress_ptr) cinfo;


### PR DESCRIPTION
Seems there is a remaining GetPrimitiveArrayCritical in imageioJPEG that misses a result - NULL check, this should be added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297480](https://bugs.openjdk.org/browse/JDK-8297480): GetPrimitiveArrayCritical in imageioJPEG misses result - NULL check


### Reviewers
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11312/head:pull/11312` \
`$ git checkout pull/11312`

Update a local copy of the PR: \
`$ git checkout pull/11312` \
`$ git pull https://git.openjdk.org/jdk pull/11312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11312`

View PR using the GUI difftool: \
`$ git pr show -t 11312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11312.diff">https://git.openjdk.org/jdk/pull/11312.diff</a>

</details>
