### PR TITLE
8297491: Loom: Stack chunks allocation code uses TLABs even when TLABs are disabled

### DIFF
--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -380,7 +380,7 @@ oop MemAllocator::allocate() const {
 
 oop MemAllocator::try_allocate_in_existing_tlab() {
   oop obj = NULL;
-  {
+  if (UseTLAB) {
     HeapWord* mem = allocate_inside_tlab_fast();
     if (mem != NULL) {
       obj = initialize(mem);


### PR DESCRIPTION
See the bug for more details. The apparent fix it to just test for `UseTLAB` before reaching for TLAB-specific code.

Additional testing:
 - [x] Linux x86_64 fastdebug, `jdk_loom hotspot_loom`
 - [x] Linux x86_64 fastdebug, `jdk_loom hotspot_loom` with `-XX:-UseTLAB` (a single JFR test failure that does not expect a log of out-of-TLAB-alloc events, to be fixed separately)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297491](https://bugs.openjdk.org/browse/JDK-8297491): Loom: Stack chunks allocation code uses TLABs even when TLABs are disabled


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11317/head:pull/11317` \
`$ git checkout pull/11317`

Update a local copy of the PR: \
`$ git checkout pull/11317` \
`$ git pull https://git.openjdk.org/jdk pull/11317/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11317`

View PR using the GUI difftool: \
`$ git pr show -t 11317`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11317.diff">https://git.openjdk.org/jdk/pull/11317.diff</a>

</details>
