### PR TITLE
8297192: Warning generating API docs for javax.management.MBeanServer: overridden methods do not document exception type

### DIFF
--- a/src/java.management/share/classes/javax/management/MBeanServer.java
+++ b/src/java.management/share/classes/javax/management/MBeanServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.management/share/classes/javax/management/MBeanServer.java
+++ b/src/java.management/share/classes/javax/management/MBeanServer.java
@@ -393,14 +393,12 @@ public interface MBeanServer extends MBeanServerConnection {
 
     /**
      * {@inheritDoc}
-      * @throws RuntimeOperationsException {@inheritDoc}
      */
     public Set<ObjectInstance> queryMBeans(ObjectName name, QueryExp query);
 
     /**
      * {@inheritDoc}
-      * @throws RuntimeOperationsException {@inheritDoc}
-    */
+     */
     public Set<ObjectName> queryNames(ObjectName name, QueryExp query);
 
     // doc comment inherited from MBeanServerConnection


### PR DESCRIPTION
Simple change to remove these mentions of RuntimeOperationsException.

More notes in the bug, but this seems like a long-standing oversight that has become the only warning in "make docs".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297192](https://bugs.openjdk.org/browse/JDK-8297192): Warning generating API docs for javax.management.MBeanServer: overridden methods do not document exception type


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11318/head:pull/11318` \
`$ git checkout pull/11318`

Update a local copy of the PR: \
`$ git checkout pull/11318` \
`$ git pull https://git.openjdk.org/jdk pull/11318/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11318`

View PR using the GUI difftool: \
`$ git pr show -t 11318`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11318.diff">https://git.openjdk.org/jdk/pull/11318.diff</a>

</details>
