### PR TITLE
8297138: UB leading to crash in Amalloc with optimized builds

### DIFF
--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -416,14 +416,14 @@ bool Arena::contains( const void *ptr ) const {
 }
 
 
-#ifdef ASSERT
+
 void* Arena::malloc(size_t size) {
   assert(UseMallocOnly, "shouldn't call");
   // use malloc, but save pointer in res. area for later freeing
   char** save = (char**)internal_amalloc(sizeof(char*));
   return (*save = (char*)os::malloc(size, mtChunk));
 }
-#endif
+
 
 
 //--------------------------------------------------------------------------------------

--- a/src/hotspot/share/memory/arena.hpp
+++ b/src/hotspot/share/memory/arena.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,7 +101,7 @@ protected:
   void* grow(size_t x, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
   size_t _size_in_bytes;        // Size of arena (used for native memory tracking)
 
-  debug_only(void* malloc(size_t size);)
+  void* malloc(size_t size);
 
   void* internal_amalloc(size_t x, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM)  {
     assert(is_aligned(x, BytesPerWord), "misaligned size");
@@ -121,11 +121,15 @@ protected:
   void  destruct_contents();
   char* hwm() const             { return _hwm; }
 
+
   // Fast allocate in the arena.  Common case aligns to the size of jlong which is 64 bits
   // on both 32 and 64 bit platforms. Required for atomic jlong operations on 32 bits.
   void* Amalloc(size_t x, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM) {
     x = ARENA_ALIGN(x);  // note for 32 bits this should align _hwm as well.
-    debug_only(if (UseMallocOnly) return malloc(x);)
+
+    if (UseMallocOnly) {
+      return malloc(x);
+    }
     // Amalloc guarantees 64-bit alignment and we need to ensure that in case the preceding
     // allocation was AmallocWords. Only needed on 32-bit - on 64-bit Amalloc and AmallocWords are
     // identical.
@@ -138,7 +142,9 @@ protected:
   // is 4 bytes on 32 bits, hence the name.
   void* AmallocWords(size_t x, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM) {
     assert(is_aligned(x, BytesPerWord), "misaligned size");
-    debug_only(if (UseMallocOnly) return malloc(x);)
+    if (UseMallocOnly) {
+      return malloc(x);
+    }
     return internal_amalloc(x, alloc_failmode);
   }
 


### PR DESCRIPTION
### Problem Description , from JBS:
In Amalloc() we do this:

debug_only(if (UseMallocOnly) return malloc(x);) 
so, if and only if DEBUG is on do we use malloc().

However, the matching free() in ResourceArea::rollback_to() does not have a matching debug_only guard:

if (UseMallocOnly) { 
    free_malloced_objects ... 
UseMallocOnly is a product flag. So, if PRODUCT is true, and DEBUG is true, we have a mismatched malloc() and free(). This is undefined behaviour.

I suggest we should remove the debug_only guard.

### Patch:
removed debug_only instances and #if ASSERT around Arena::malloc().

### Test
**Configure**: --with-debug-level=optimized
**Test**: make test TEST=runtime/8007475
**Mach5**: tier1 to tier5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297138](https://bugs.openjdk.org/browse/JDK-8297138): UB leading to crash in Amalloc with optimized builds


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11320/head:pull/11320` \
`$ git checkout pull/11320`

Update a local copy of the PR: \
`$ git checkout pull/11320` \
`$ git pull https://git.openjdk.org/jdk pull/11320/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11320`

View PR using the GUI difftool: \
`$ git pr show -t 11320`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11320.diff">https://git.openjdk.org/jdk/pull/11320.diff</a>

</details>
