### PR TITLE
8297499: Parallel: Missing iteration over klass when marking objArrays/objArrayOops during Full GC

### DIFF
--- a/src/hotspot/share/gc/parallel/psCompactionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.inline.hpp
@@ -162,10 +162,12 @@ inline void ParCompactionManager::update_contents(oop obj) {
 
 inline void ParCompactionManager::follow_contents(oop obj) {
   assert(PSParallelCompact::mark_bitmap()->is_marked(obj), "should be marked");
+  PCIterateMarkAndPushClosure cl(this, PSParallelCompact::ref_processor());
+
   if (obj->is_objArray()) {
+    cl.do_klass(obj->klass());
     follow_array(objArrayOop(obj), 0);
   } else {
-    PCIterateMarkAndPushClosure cl(this, PSParallelCompact::ref_processor());
     obj->oop_iterate(&cl);
   }
 }

--- a/test/hotspot/jtreg/runtime/ClassUnload/UnloadTest.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/UnloadTest.java
@@ -35,29 +35,33 @@
 import jdk.test.whitebox.WhiteBox;
 import jdk.test.lib.classloader.ClassUnloadCommon;
 
+import java.lang.reflect.Array;
+
 /**
- * Test that verifies that classes are unloaded when they are no longer reachable.
+ * Test that verifies that liveness of classes is correctly tracked.
  *
- * The test creates a class loader, uses the loader to load a class and creates an instance
- * of that class. The it nulls out all the references to the instance, class and class loader
- * and tries to trigger class unloading. Then it verifies that the class is no longer
- * loaded by the VM.
+ * The test creates a class loader, uses the loader to load a class and creates
+ * an instance related to that class.
+ * 1. Then, it nulls out references to the class loader, triggers class
+ *    unloading and verifies the class is *not* unloaded.
+ * 2. Next, it nulls out references to the instance, triggers class unloading
+ *    and verifies the class is unloaded.
  */
 public class UnloadTest {
-    private static String className = "test.Empty";
 
     public static void main(String... args) throws Exception {
-       run();
+       test_unload_instance_klass();
+       test_unload_obj_array_klass();
     }
 
-    private static void run() throws Exception {
+    private static void test_unload_instance_klass() throws Exception {
+        final String className = "test.Empty";
         final WhiteBox wb = WhiteBox.getWhiteBox();
 
         ClassUnloadCommon.failIf(wb.isClassAlive(className), "is not expected to be alive yet");
 
         ClassLoader cl = ClassUnloadCommon.newClassLoader();
-        Class<?> c = cl.loadClass(className);
-        Object o = c.newInstance();
+        Object o = cl.loadClass(className).newInstance();
 
         ClassUnloadCommon.failIf(!wb.isClassAlive(className), "should be live here");
 
@@ -65,8 +69,42 @@ public class UnloadTest {
         int loadedRefcount = wb.getSymbolRefcount(loaderName);
         System.out.println("Refcount of symbol " + loaderName + " is " + loadedRefcount);
 
-        cl = null; c = null; o = null;
+        cl = null;
         ClassUnloadCommon.triggerUnloading();
+
+        ClassUnloadCommon.failIf(!wb.isClassAlive(className), "should still be live");
+
+        o = null;
+        ClassUnloadCommon.triggerUnloading();
+
+
+        ClassUnloadCommon.failIf(wb.isClassAlive(className), "should have been unloaded");
+
+        int unloadedRefcount = wb.getSymbolRefcount(loaderName);
+        System.out.println("Refcount of symbol " + loaderName + " is " + unloadedRefcount);
+        ClassUnloadCommon.failIf(unloadedRefcount != (loadedRefcount - 1), "Refcount must be decremented");
+    }
+
+    private static void test_unload_obj_array_klass() throws Exception {
+        final WhiteBox wb = WhiteBox.getWhiteBox();
+
+        ClassLoader cl = ClassUnloadCommon.newClassLoader();
+        Object o = Array.newInstance(cl.loadClass("test.Empty"), 1);
+        final String className = o.getClass().getName();
+
+        ClassUnloadCommon.failIf(!wb.isClassAlive(className), "should be live here");
+
+        String loaderName = cl.getName();
+        int loadedRefcount = wb.getSymbolRefcount(loaderName);
+        System.out.println("Refcount of symbol " + loaderName + " is " + loadedRefcount);
+
+        cl = null;
+        ClassUnloadCommon.triggerUnloading();
+        ClassUnloadCommon.failIf(!wb.isClassAlive(className), "should still be live");
+
+        o = null;
+        ClassUnloadCommon.triggerUnloading();
+
         ClassUnloadCommon.failIf(wb.isClassAlive(className), "should have been unloaded");
 
         int unloadedRefcount = wb.getSymbolRefcount(loaderName);


### PR DESCRIPTION
Extending the current class-unloading test to expose a pre-existing issue in Parallel and the fix.

Test: the revised test fails for Parallel without the fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297499](https://bugs.openjdk.org/browse/JDK-8297499): Parallel: Missing iteration over klass when marking objArrays/objArrayOops during Full GC


### Reviewers
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Contributors
 * Stefan Johansson `<sjohanss@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11321/head:pull/11321` \
`$ git checkout pull/11321`

Update a local copy of the PR: \
`$ git checkout pull/11321` \
`$ git pull https://git.openjdk.org/jdk pull/11321/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11321`

View PR using the GUI difftool: \
`$ git pr show -t 11321`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11321.diff">https://git.openjdk.org/jdk/pull/11321.diff</a>

</details>
