### PR TITLE
8297503: Merge FilteringDCTOC into ContiguousSpaceDCTOC

### DIFF
--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -189,9 +189,9 @@ HeapWord* ContiguousSpaceDCTOC::get_actual_top(HeapWord* top,
   return top;
 }
 
-void FilteringDCTOC::walk_mem_region(MemRegion mr,
-                                     HeapWord* bottom,
-                                     HeapWord* top) {
+void ContiguousSpaceDCTOC::walk_mem_region(MemRegion mr,
+                                           HeapWord* bottom,
+                                           HeapWord* top) {
   // Note that this assumption won't hold if we have a concurrent
   // collector in this space, which may have freed up objects after
   // they were dirtied and before the stop-the-world GC that is

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -545,13 +545,13 @@ class ContiguousSpace: public CompactibleSpace {
 // sub-classes). It knows how to filter out objects that are outside of the
 // _boundary.
 //
+// Assumptions:
 // 1. That the actual top of any area in a memory region
 //    contained by the space is bounded by the end of the contiguous
 //    region of the space.
 // 2. That the space is really made up of objects and not just
 //    blocks.
 class ContiguousSpaceDCTOC : public DirtyCardToOopClosure {
-protected:
   // Overrides.
   void walk_mem_region(MemRegion mr,
                        HeapWord* bottom, HeapWord* top);

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -541,14 +541,22 @@ class ContiguousSpace: public CompactibleSpace {
   virtual void verify() const;
 };
 
-
-// A dirty card to oop closure that does filtering.
-// It knows how to filter out objects that are outside of the _boundary.
-class FilteringDCTOC : public DirtyCardToOopClosure {
+// A dirty card to oop closure for contiguous spaces (ContiguousSpace and
+// sub-classes). It knows how to filter out objects that are outside of the
+// _boundary.
+//
+// 1. That the actual top of any area in a memory region
+//    contained by the space is bounded by the end of the contiguous
+//    region of the space.
+// 2. That the space is really made up of objects and not just
+//    blocks.
+class ContiguousSpaceDCTOC : public DirtyCardToOopClosure {
 protected:
-  // Override.
+  // Overrides.
   void walk_mem_region(MemRegion mr,
                        HeapWord* bottom, HeapWord* top);
+
+  HeapWord* get_actual_top(HeapWord* top, HeapWord* top_obj);
 
   // Walk the given memory region, from bottom to top, applying
   // the given oop closure to (possibly) all objects found. The
@@ -557,47 +565,18 @@ protected:
   // be a filtering closure which makes use of the _boundary.
   // We offer two signatures, so the FilteringClosure static type is
   // apparent.
-  virtual void walk_mem_region_with_cl(MemRegion mr,
-                                       HeapWord* bottom, HeapWord* top,
-                                       OopIterateClosure* cl) = 0;
-  virtual void walk_mem_region_with_cl(MemRegion mr,
-                                       HeapWord* bottom, HeapWord* top,
-                                       FilteringClosure* cl) = 0;
-
-public:
-  FilteringDCTOC(Space* sp, OopIterateClosure* cl,
-                  CardTable::PrecisionStyle precision,
-                  HeapWord* boundary) :
-    DirtyCardToOopClosure(sp, cl, precision, boundary) {}
-};
-
-// A dirty card to oop closure for contiguous spaces
-// (ContiguousSpace and sub-classes).
-// It is a FilteringClosure, as defined above, and it knows:
-//
-// 1. That the actual top of any area in a memory region
-//    contained by the space is bounded by the end of the contiguous
-//    region of the space.
-// 2. That the space is really made up of objects and not just
-//    blocks.
-
-class ContiguousSpaceDCTOC : public FilteringDCTOC {
-protected:
-  // Overrides.
-  HeapWord* get_actual_top(HeapWord* top, HeapWord* top_obj);
-
-  virtual void walk_mem_region_with_cl(MemRegion mr,
-                                       HeapWord* bottom, HeapWord* top,
-                                       OopIterateClosure* cl);
-  virtual void walk_mem_region_with_cl(MemRegion mr,
-                                       HeapWord* bottom, HeapWord* top,
-                                       FilteringClosure* cl);
+  void walk_mem_region_with_cl(MemRegion mr,
+                               HeapWord* bottom, HeapWord* top,
+                               OopIterateClosure* cl);
+  void walk_mem_region_with_cl(MemRegion mr,
+                               HeapWord* bottom, HeapWord* top,
+                               FilteringClosure* cl);
 
 public:
   ContiguousSpaceDCTOC(ContiguousSpace* sp, OopIterateClosure* cl,
                        CardTable::PrecisionStyle precision,
                        HeapWord* boundary) :
-    FilteringDCTOC(sp, cl, precision, boundary)
+    DirtyCardToOopClosure(sp, cl, precision, boundary)
   {}
 };
 


### PR DESCRIPTION
Simple cleanup of trimming unnecessary type hierarchy levels.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297503](https://bugs.openjdk.org/browse/JDK-8297503): Merge FilteringDCTOC into ContiguousSpaceDCTOC


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11322/head:pull/11322` \
`$ git checkout pull/11322`

Update a local copy of the PR: \
`$ git checkout pull/11322` \
`$ git pull https://git.openjdk.org/jdk pull/11322/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11322`

View PR using the GUI difftool: \
`$ git pr show -t 11322`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11322.diff">https://git.openjdk.org/jdk/pull/11322.diff</a>

</details>
