### PR TITLE
8297507: Update header after JDK-8297230

### DIFF
--- a/src/java.desktop/share/classes/sun/java2d/marlin/DPQSSorterContext.java
+++ b/src/java.desktop/share/classes/sun/java2d/marlin/DPQSSorterContext.java
@@ -4,7 +4,9 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/java.desktop/share/classes/sun/java2d/marlin/DPQSSorterContext.java
+++ b/src/java.desktop/share/classes/sun/java2d/marlin/DPQSSorterContext.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation. Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/java.desktop/share/classes/sun/java2d/marlin/DPQSSorterContext.java
+++ b/src/java.desktop/share/classes/sun/java2d/marlin/DPQSSorterContext.java
@@ -10,7 +10,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *


### PR DESCRIPTION
Update header to add extra space

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297507](https://bugs.openjdk.org/browse/JDK-8297507): Update header after JDK-8297230


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**) ⚠️ Review applies to [21a54040](https://git.openjdk.org/jdk/pull/11324/files/21a54040f282bdd5158263b526d0c44774916eb0)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [21a54040](https://git.openjdk.org/jdk/pull/11324/files/21a54040f282bdd5158263b526d0c44774916eb0)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - Author)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to [21a54040](https://git.openjdk.org/jdk/pull/11324/files/21a54040f282bdd5158263b526d0c44774916eb0)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11324/head:pull/11324` \
`$ git checkout pull/11324`

Update a local copy of the PR: \
`$ git checkout pull/11324` \
`$ git pull https://git.openjdk.org/jdk pull/11324/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11324`

View PR using the GUI difftool: \
`$ git pr show -t 11324`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11324.diff">https://git.openjdk.org/jdk/pull/11324.diff</a>

</details>
