### PR TITLE
8293294: Remove dead code in Parse::check_interpreter_type

### DIFF
--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -175,8 +175,6 @@ Node* Parse::check_interpreter_type(Node* l, const Type* type,
     bad_type_exit->control()->add_req(bad_type_ctrl);
   }
 
-  BasicType bt_l = _gvn.type(l)->basic_type();
-  BasicType bt_t = type->basic_type();
   assert(_gvn.type(l)->higher_equal(type), "must constrain OSR typestate");
   return l;
 }


### PR DESCRIPTION
A small cleanup in Parse::check_interpreter_type to remove two dead declarations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293294](https://bugs.openjdk.org/browse/JDK-8293294): Remove dead code in Parse::check_interpreter_type


### Reviewers
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11325/head:pull/11325` \
`$ git checkout pull/11325`

Update a local copy of the PR: \
`$ git checkout pull/11325` \
`$ git pull https://git.openjdk.org/jdk pull/11325/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11325`

View PR using the GUI difftool: \
`$ git pr show -t 11325`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11325.diff">https://git.openjdk.org/jdk/pull/11325.diff</a>

</details>
