### PR TITLE
8295253: Remove kludge from v1_0/PerfDataBuffer.java

### DIFF
--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/v1_0/PerfDataBuffer.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/v1_0/PerfDataBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,9 +135,6 @@ public class PerfDataBuffer extends PerfDataBufferImpl {
 
         // synchronize with the target jvm
         synchWithTarget(map);
-
-        // work around 1.4.2 counter inititization bugs
-        kludge(map);
 
         insertedMonitors = new ArrayList<Monitor>(map.values());
     }
@@ -299,151 +296,6 @@ public class PerfDataBuffer extends PerfDataBufferImpl {
             getNewMonitors(map);
         }
         return monitor;
-    }
-
-    /**
-     * method to make adjustments for known counter problems. This
-     * method depends on the availability of certain counters, which
-     * is generally guaranteed by the synchWithTarget() method.
-     */
-    protected void kludge(Map<String, Monitor> map) {
-        if (Boolean.getBoolean("sun.jvmstat.perfdata.disableKludge")) {
-            // bypass all kludges
-            return;
-        }
-
-        String name = "java.vm.version";
-        StringMonitor jvm_version = (StringMonitor)map.get(name);
-        if (jvm_version == null) {
-            jvm_version = (StringMonitor)findByAlias(name);
-        }
-
-        name = "java.vm.name";
-        StringMonitor jvm_name = (StringMonitor)map.get(name);
-        if (jvm_name == null) {
-            jvm_name = (StringMonitor)findByAlias(name);
-        }
-
-        name = "hotspot.vm.args";
-        StringMonitor args = (StringMonitor)map.get(name);
-        if (args == null) {
-            args = (StringMonitor)findByAlias(name);
-        }
-
-        assert ((jvm_name != null) && (jvm_version != null) && (args != null));
-
-        if (jvm_name.stringValue().indexOf("HotSpot") >= 0) {
-            if (jvm_version.stringValue().startsWith("1.4.2")) {
-                kludgeMantis(map, args);
-            }
-        }
-    }
-
-    /**
-     * method to repair the 1.4.2 parallel scavenge counters that are
-     * incorrectly initialized by the JVM when UseAdaptiveSizePolicy
-     * is set. This bug couldn't be fixed for 1.4.2 FCS due to putback
-     * restrictions.
-     */
-    private void kludgeMantis(Map<String, Monitor> map, StringMonitor args) {
-        /*
-         * the HotSpot 1.4.2 JVM with the +UseParallelGC option along
-         * with its default +UseAdaptiveSizePolicy option has a bug with
-         * the initialization of the sizes of the eden and survivor spaces.
-         * See bugid 4890736.
-         *
-         * note - use explicit 1.4.2 counter names here - don't update
-         * to latest counter names or attempt to find aliases.
-         */
-
-        String cname = "hotspot.gc.collector.0.name";
-        StringMonitor collector = (StringMonitor)map.get(cname);
-
-        if (collector.stringValue().equals("PSScavenge")) {
-            boolean adaptiveSizePolicy = true;
-
-            /*
-             * HotSpot processes the -XX:Flags/.hotspotrc arguments prior to
-             * processing the command line arguments. This allows the command
-             * line arguments to override any defaults set in .hotspotrc
-             */
-            cname = "hotspot.vm.flags";
-            StringMonitor flags = (StringMonitor)map.get(cname);
-            String allArgs = flags.stringValue() + " " + args.stringValue();
-
-            /*
-             * ignore the -XX: prefix as it only applies to the arguments
-             * passed from the command line (i.e. the invocation api).
-             * arguments passed through .hotspotrc omit the -XX: prefix.
-             */
-            int ahi = allArgs.lastIndexOf("+AggressiveHeap");
-            int aspi = allArgs.lastIndexOf("-UseAdaptiveSizePolicy");
-
-            if (ahi != -1) {
-                /*
-                 * +AggressiveHeap was set, check if -UseAdaptiveSizePolicy
-                 * is set after +AggressiveHeap.
-                 */
-                //
-                if ((aspi != -1) && (aspi > ahi)) {
-                    adaptiveSizePolicy = false;
-                }
-            } else {
-                /*
-                 * +AggressiveHeap not set, must be +UseParallelGC. The
-                 * relative position of -UseAdaptiveSizePolicy is not
-                 * important in this case, as it will override the
-                 * UseParallelGC default (+UseAdaptiveSizePolicy) if it
-                 * appears anywhere in the JVM arguments.
-                 */
-                if (aspi != -1) {
-                    adaptiveSizePolicy = false;
-                }
-            }
-
-            if (adaptiveSizePolicy) {
-                // adjust the buggy AdaptiveSizePolicy size counters.
-
-                // first remove the real counters.
-                String eden_size = "hotspot.gc.generation.0.space.0.size";
-                String s0_size = "hotspot.gc.generation.0.space.1.size";
-                String s1_size = "hotspot.gc.generation.0.space.2.size";
-                map.remove(eden_size);
-                map.remove(s0_size);
-                map.remove(s1_size);
-
-                // get the maximum new generation size
-                String new_max_name = "hotspot.gc.generation.0.capacity.max";
-                LongMonitor new_max = (LongMonitor)map.get(new_max_name);
-
-                /*
-                 * replace the real counters with pseudo counters that are
-                 * initialized to the correct values. The maximum size of
-                 * the eden and survivor spaces are supposed to be:
-                 *    max_eden_size = new_size - (2*alignment).
-                 *    max_survivor_size = new_size - (2*alignment).
-                 * since we don't know the alignment value used, and because
-                 * of other parallel scavenge bugs that result in oversized
-                 * spaces, we just set the maximum size of each space to the
-                 * full new gen size.
-                 */
-                Monitor monitor = null;
-
-                LongBuffer lb = LongBuffer.allocate(1);
-                lb.put(new_max.longValue());
-                monitor = new PerfLongMonitor(eden_size, Units.BYTES,
-                                              Variability.CONSTANT, false, lb);
-                map.put(eden_size, monitor);
-
-                monitor = new PerfLongMonitor(s0_size, Units.BYTES,
-                                              Variability.CONSTANT, false, lb);
-                map.put(s0_size, monitor);
-
-                monitor = new PerfLongMonitor(s1_size, Units.BYTES,
-                                              Variability.CONSTANT, false, lb);
-                map.put(s1_size, monitor);
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
Remove code for supporting an ancient JDK version (1.4.2). We don't have any test cases for this code so it's unclear whether it still works or not.

Testing: tiers 1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295253](https://bugs.openjdk.org/browse/JDK-8295253): Remove kludge from v1_0/PerfDataBuffer.java


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11329/head:pull/11329` \
`$ git checkout pull/11329`

Update a local copy of the PR: \
`$ git checkout pull/11329` \
`$ git pull https://git.openjdk.org/jdk pull/11329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11329`

View PR using the GUI difftool: \
`$ git pr show -t 11329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11329.diff">https://git.openjdk.org/jdk/pull/11329.diff</a>

</details>
