### PR TITLE
8297525: jdk/jshell/ToolBasicTest.java fails after JDK-8295984

### DIFF
--- a/test/langtools/jdk/jshell/ToolBasicTest.java
+++ b/test/langtools/jdk/jshell/ToolBasicTest.java
@@ -67,8 +67,6 @@ import static org.testng.Assert.fail;
 @Test
 public class ToolBasicTest extends ReplToolTesting {
 
-    private static final String NL = System.getProperty("line.separator");
-
     public void elideStartUpFromList() {
         test(
                 (a) -> assertCommandOutputContains(a, "123", "==> 123"),
@@ -545,7 +543,7 @@ public class ToolBasicTest extends ReplToolTesting {
                 );
             }
             test(new String[] {urlAddress},
-                 "File '" + urlAddress + "' for 'jshell' is not found." + NL);
+                 "File '" + urlAddress + "' for 'jshell' is not found.\n");
         } finally {
             httpServer.stop(0);
         }


### PR DESCRIPTION
The expected text uses a platform newline, but the actual text seems to always use `'\n'`. Sorry for that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297525](https://bugs.openjdk.org/browse/JDK-8297525): jdk/jshell/ToolBasicTest.java fails after JDK-8295984


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11330/head:pull/11330` \
`$ git checkout pull/11330`

Update a local copy of the PR: \
`$ git checkout pull/11330` \
`$ git pull https://git.openjdk.org/jdk pull/11330/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11330`

View PR using the GUI difftool: \
`$ git pr show -t 11330`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11330.diff">https://git.openjdk.org/jdk/pull/11330.diff</a>

</details>
