### PR TITLE
8297529: ProblemList javax/swing/JFileChooser/8046391/bug8046391.java on windows-x64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -670,6 +670,7 @@ java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 m
 javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8274106 macosx-aarch64
 
 java/awt/Mouse/EnterExitEvents/DragWindowTest.java 8297296 macosx-all
+javax/swing/JFileChooser/8046391/bug8046391.java 8293862 windowx-x64
 
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8293001 linux-all
 sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java 8265770 macosx-all

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -670,7 +670,7 @@ java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 m
 javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8274106 macosx-aarch64
 
 java/awt/Mouse/EnterExitEvents/DragWindowTest.java 8297296 macosx-all
-javax/swing/JFileChooser/8046391/bug8046391.java 8293862 windowx-x64
+javax/swing/JFileChooser/8046391/bug8046391.java 8293862 windows-x64
 
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8293001 linux-all
 sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java 8265770 macosx-all


### PR DESCRIPTION
A trivial fix to ProblemList javax/swing/JFileChooser/8046391/bug8046391.java on windows-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297529](https://bugs.openjdk.org/browse/JDK-8297529): ProblemList javax/swing/JFileChooser/8046391/bug8046391.java on windows-x64


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11333/head:pull/11333` \
`$ git checkout pull/11333`

Update a local copy of the PR: \
`$ git checkout pull/11333` \
`$ git pull https://git.openjdk.org/jdk pull/11333/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11333`

View PR using the GUI difftool: \
`$ git pr show -t 11333`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11333.diff">https://git.openjdk.org/jdk/pull/11333.diff</a>

</details>
