### PR TITLE
8297534: Specify the size of MEMFLAGS

### DIFF
--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -26,6 +26,7 @@
 #define SHARE_MEMORY_ALLOCATION_HPP
 
 #include "memory/allStatic.hpp"
+#include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 
@@ -143,6 +144,8 @@ enum class MEMFLAGS : uint8_t  {
   mt_number_of_types   // number of memory types (mtDontTrack
                        // is not included as validate type)
 };
+// Extra insurance that MEMFLAGS truly has the same size as uint8_t.
+STATIC_ASSERT(sizeof(MEMFLAGS) == sizeof(uint8_t));
 
 #define MEMORY_TYPE_SHORTNAME(type, human_readable) \
   constexpr MEMFLAGS type = MEMFLAGS::type;

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -138,7 +138,7 @@ typedef AllocFailStrategy::AllocFailEnum AllocFailType;
 /*
  * Memory types
  */
-enum class MEMFLAGS {
+enum class MEMFLAGS : uint8_t  {
   MEMORY_TYPES_DO(MEMORY_TYPE_DECLARE_ENUM)
   mt_number_of_types   // number of memory types (mtDontTrack
                        // is not included as validate type)

--- a/src/hotspot/share/services/mallocHeader.hpp
+++ b/src/hotspot/share/services/mallocHeader.hpp
@@ -92,7 +92,7 @@ class MallocHeader {
   NOT_LP64(uint32_t _alt_canary);
   const size_t _size;
   const uint32_t _mst_marker;
-  const uint8_t _flags;
+  const MEMFLAGS _flags;
   const uint8_t _unused;
   uint16_t _canary;
 
@@ -119,7 +119,7 @@ class MallocHeader {
   inline MallocHeader(size_t size, MEMFLAGS flags, uint32_t mst_marker);
 
   inline size_t   size()  const { return _size; }
-  inline MEMFLAGS flags() const { return (MEMFLAGS)_flags; }
+  inline MEMFLAGS flags() const { return _flags; }
   inline uint32_t mst_marker() const { return _mst_marker; }
   bool get_stack(NativeCallStack& stack) const;
 

--- a/src/hotspot/share/services/mallocHeader.inline.hpp
+++ b/src/hotspot/share/services/mallocHeader.inline.hpp
@@ -35,7 +35,7 @@
 #include "utilities/nativeCallStack.hpp"
 
 inline MallocHeader::MallocHeader(size_t size, MEMFLAGS flags, uint32_t mst_marker)
-  : _size(size), _mst_marker(mst_marker), _flags(NMTUtil::flag_to_index(flags)),
+  : _size(size), _mst_marker(mst_marker), _flags(flags),
     _unused(0), _canary(_header_canary_life_mark)
 {
   assert(size < max_reasonable_malloc_size, "Too large allocation size?");


### PR DESCRIPTION
Hi!

In MallocHeader we assume that MEMFLAGS can be stored in a uint8_t, see:

```c++
class MallocHeader {

  NOT_LP64(uint32_t _alt_canary);
  const size_t _size;
  const uint32_t _mst_marker;
  const uint8_t _flags;
  const uint8_t _unused;
  uint16_t _canary;
// SNIP!
  inline MEMFLAGS flags() const { return (MEMFLAGS)_flags; }
```

With C++11 we can specify the underlying type of an `enum class`, so let's just do that. If we generate 257 memflags we'll get a compile error. I don't believe that this would lead to any change in the behavior of the code.

Testing: Compiled the code. Running tier1 testing right now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297534](https://bugs.openjdk.org/browse/JDK-8297534): Specify the size of MEMFLAGS


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [046f6abc](https://git.openjdk.org/jdk/pull/11336/files/046f6abc2c85bb58f5b06a9553b2571e1ab51ed3)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [ce9a1d24](https://git.openjdk.org/jdk/pull/11336/files/ce9a1d243af1abb482b21eba5f3460d8992b8df1)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11336/head:pull/11336` \
`$ git checkout pull/11336`

Update a local copy of the PR: \
`$ git checkout pull/11336` \
`$ git pull https://git.openjdk.org/jdk pull/11336/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11336`

View PR using the GUI difftool: \
`$ git pr show -t 11336`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11336.diff">https://git.openjdk.org/jdk/pull/11336.diff</a>

</details>
