### PR TITLE
8297247: Add GarbageCollectorMXBean for Remark and Cleanup pause time in G1

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullGCScope.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.cpp
@@ -50,7 +50,7 @@ G1FullGCScope::G1FullGCScope(G1MonitoringSupport* monitoring_support,
     _active(),
     _tracer_mark(&_timer, _tracer),
     _soft_refs(clear_soft, _g1h->soft_ref_policy()),
-    _monitoring_scope(monitoring_support, true /* full_gc */, true /* all_memory_pools_affected */),
+    _monitoring_scope(monitoring_support),
     _heap_printer(_g1h),
     _region_compaction_threshold(do_maximal_compaction ?
                                  HeapRegion::GrainWords :

--- a/src/hotspot/share/gc/g1/g1FullGCScope.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.hpp
@@ -55,7 +55,7 @@ class G1FullGCScope : public StackObj {
   IsGCActiveMark          _active;
   G1FullGCJFRTracerMark   _tracer_mark;
   ClearedAllSoftRefs      _soft_refs;
-  G1FullMonitoringScope   _monitoring_scope;
+  G1FullGCMonitoringScope _monitoring_scope;
   G1HeapPrinterMark       _heap_printer;
   size_t                  _region_compaction_threshold;
 

--- a/src/hotspot/share/gc/g1/g1FullGCScope.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.hpp
@@ -55,7 +55,7 @@ class G1FullGCScope : public StackObj {
   IsGCActiveMark          _active;
   G1FullGCJFRTracerMark   _tracer_mark;
   ClearedAllSoftRefs      _soft_refs;
-  G1MonitoringScope       _monitoring_scope;
+  G1FullMonitoringScope   _monitoring_scope;
   G1HeapPrinterMark       _heap_printer;
   size_t                  _region_compaction_threshold;
 

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
@@ -348,8 +348,8 @@ MemoryUsage G1MonitoringSupport::old_gen_memory_usage(size_t initial_size, size_
                      max_size);
 }
 
-G1MonitoringScope::G1MonitoringScope(G1MonitoringSupport* monitoring_support)
-: _monitoring_support(monitoring_support) { }
+G1MonitoringScope::G1MonitoringScope(G1MonitoringSupport* monitoring_support) :
+  _monitoring_support(monitoring_support) { }
 
 G1MonitoringScope::~G1MonitoringScope() {
   _monitoring_support->update_sizes();
@@ -357,21 +357,22 @@ G1MonitoringScope::~G1MonitoringScope() {
   MemoryService::track_memory_usage();
 }
 
-G1IncMonitoringScope::G1IncMonitoringScope(G1MonitoringSupport* monitoring_support, bool all_memory_pools_affected) :
+G1YoungGCMonitoringScope::G1YoungGCMonitoringScope(G1MonitoringSupport* monitoring_support,
+                                                   bool all_memory_pools_affected) :
   G1MonitoringScope(monitoring_support),
   _tcs(monitoring_support->_incremental_collection_counters),
   _tms(&monitoring_support->_incremental_memory_manager,
        G1CollectedHeap::heap()->gc_cause(), all_memory_pools_affected) {
 }
 
-G1FullMonitoringScope::G1FullMonitoringScope(G1MonitoringSupport* monitoring_support) :
+G1FullGCMonitoringScope::G1FullGCMonitoringScope(G1MonitoringSupport* monitoring_support) :
   G1MonitoringScope(monitoring_support),
   _tcs(monitoring_support->_full_collection_counters),
   _tms(&monitoring_support->_full_gc_memory_manager,
        G1CollectedHeap::heap()->gc_cause()) {
 }
 
-G1ConcMonitoringScope::G1ConcMonitoringScope(G1MonitoringSupport* monitoring_support) :
+G1ConcGCMonitoringScope::G1ConcGCMonitoringScope(G1MonitoringSupport* monitoring_support) :
   G1MonitoringScope(monitoring_support),
   _tcs(monitoring_support->_conc_collection_counters),
   _tms(&monitoring_support->_conc_gc_memory_manager,

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
@@ -90,6 +90,7 @@ G1MonitoringSupport::G1MonitoringSupport(G1CollectedHeap* g1h) :
   _g1h(g1h),
   _incremental_memory_manager("G1 Young Generation", "end of minor GC"),
   _full_gc_memory_manager("G1 Old Generation", "end of major GC"),
+  _conc_gc_memory_manager("G1 Concurrent GC", "end of concurrent GC pause"),
   _eden_space_pool(NULL),
   _survivor_space_pool(NULL),
   _old_gen_pool(NULL),
@@ -199,6 +200,8 @@ void G1MonitoringSupport::initialize_serviceability() {
   _full_gc_memory_manager.add_pool(_survivor_space_pool);
   _full_gc_memory_manager.add_pool(_old_gen_pool);
 
+  _conc_gc_memory_manager.add_pool(_old_gen_pool);
+
   _incremental_memory_manager.add_pool(_eden_space_pool);
   _incremental_memory_manager.add_pool(_survivor_space_pool);
   _incremental_memory_manager.add_pool(_old_gen_pool, false /* always_affected_by_gc */);
@@ -210,9 +213,10 @@ MemoryUsage G1MonitoringSupport::memory_usage() {
 }
 
 GrowableArray<GCMemoryManager*> G1MonitoringSupport::memory_managers() {
-  GrowableArray<GCMemoryManager*> memory_managers(2);
+  GrowableArray<GCMemoryManager*> memory_managers(3);
   memory_managers.append(&_incremental_memory_manager);
   memory_managers.append(&_full_gc_memory_manager);
+  memory_managers.append(&_conc_gc_memory_manager);
   return memory_managers;
 }
 
@@ -344,15 +348,32 @@ MemoryUsage G1MonitoringSupport::old_gen_memory_usage(size_t initial_size, size_
                      max_size);
 }
 
-G1MonitoringScope::G1MonitoringScope(G1MonitoringSupport* monitoring_support, bool full_gc, bool all_memory_pools_affected) :
-  _monitoring_support(monitoring_support),
-  _tcs(full_gc ? monitoring_support->_full_collection_counters : monitoring_support->_incremental_collection_counters),
-  _tms(full_gc ? &monitoring_support->_full_gc_memory_manager : &monitoring_support->_incremental_memory_manager,
-       G1CollectedHeap::heap()->gc_cause(), all_memory_pools_affected) {
-}
+G1MonitoringScope::G1MonitoringScope(G1MonitoringSupport* monitoring_support)
+: _monitoring_support(monitoring_support) { }
 
 G1MonitoringScope::~G1MonitoringScope() {
   _monitoring_support->update_sizes();
   // Needs to be called after updating pool sizes.
   MemoryService::track_memory_usage();
+}
+
+G1IncMonitoringScope::G1IncMonitoringScope(G1MonitoringSupport* monitoring_support, bool all_memory_pools_affected) :
+  G1MonitoringScope(monitoring_support),
+  _tcs(monitoring_support->_incremental_collection_counters),
+  _tms(&monitoring_support->_incremental_memory_manager,
+       G1CollectedHeap::heap()->gc_cause(), all_memory_pools_affected) {
+}
+
+G1FullMonitoringScope::G1FullMonitoringScope(G1MonitoringSupport* monitoring_support) :
+  G1MonitoringScope(monitoring_support),
+  _tcs(monitoring_support->_full_collection_counters),
+  _tms(&monitoring_support->_full_gc_memory_manager,
+       G1CollectedHeap::heap()->gc_cause()) {
+}
+
+G1ConcMonitoringScope::G1ConcMonitoringScope(G1MonitoringSupport* monitoring_support) :
+  G1MonitoringScope(monitoring_support),
+  _tcs(monitoring_support->_conc_collection_counters),
+  _tms(&monitoring_support->_conc_gc_memory_manager,
+       G1CollectedHeap::heap()->gc_cause()) {
 }

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
@@ -348,8 +348,15 @@ MemoryUsage G1MonitoringSupport::old_gen_memory_usage(size_t initial_size, size_
                      max_size);
 }
 
-G1MonitoringScope::G1MonitoringScope(G1MonitoringSupport* monitoring_support) :
-  _monitoring_support(monitoring_support) { }
+G1MonitoringScope::G1MonitoringScope(G1MonitoringSupport* monitoring_support,
+                                     CollectorCounters* collection_counters,
+                                     GCMemoryManager* gc_memory_manager,
+                                     bool all_memory_pools_affected) :
+  _monitoring_support(monitoring_support),
+  _tcs(collection_counters),
+  _tms(gc_memory_manager,
+       G1CollectedHeap::heap()->gc_cause(), all_memory_pools_affected) {
+}
 
 G1MonitoringScope::~G1MonitoringScope() {
   _monitoring_support->update_sizes();
@@ -359,22 +366,20 @@ G1MonitoringScope::~G1MonitoringScope() {
 
 G1YoungGCMonitoringScope::G1YoungGCMonitoringScope(G1MonitoringSupport* monitoring_support,
                                                    bool all_memory_pools_affected) :
-  G1MonitoringScope(monitoring_support),
-  _tcs(monitoring_support->_incremental_collection_counters),
-  _tms(&monitoring_support->_incremental_memory_manager,
-       G1CollectedHeap::heap()->gc_cause(), all_memory_pools_affected) {
+  G1MonitoringScope(monitoring_support,
+                    monitoring_support->_incremental_collection_counters,
+                    &monitoring_support->_incremental_memory_manager,
+                    all_memory_pools_affected) {
 }
 
 G1FullGCMonitoringScope::G1FullGCMonitoringScope(G1MonitoringSupport* monitoring_support) :
-  G1MonitoringScope(monitoring_support),
-  _tcs(monitoring_support->_full_collection_counters),
-  _tms(&monitoring_support->_full_gc_memory_manager,
-       G1CollectedHeap::heap()->gc_cause()) {
+  G1MonitoringScope(monitoring_support,
+                    monitoring_support->_full_collection_counters,
+                    &monitoring_support->_full_gc_memory_manager) {
 }
 
 G1ConcGCMonitoringScope::G1ConcGCMonitoringScope(G1MonitoringSupport* monitoring_support) :
-  G1MonitoringScope(monitoring_support),
-  _tcs(monitoring_support->_conc_collection_counters),
-  _tms(&monitoring_support->_conc_gc_memory_manager,
-       G1CollectedHeap::heap()->gc_cause()) {
+  G1MonitoringScope(monitoring_support,
+                    monitoring_support->_conc_collection_counters,
+                    &monitoring_support->_conc_gc_memory_manager) {
 }

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
@@ -122,12 +122,16 @@ class MemoryPool;
 class G1MonitoringSupport : public CHeapObj<mtGC> {
   friend class VMStructs;
   friend class G1MonitoringScope;
+  friend class G1IncMonitoringScope;
+  friend class G1FullMonitoringScope;
+  friend class G1ConcMonitoringScope;
 
   G1CollectedHeap* _g1h;
 
   // java.lang.management MemoryManager and MemoryPool support
   GCMemoryManager _incremental_memory_manager;
   GCMemoryManager _full_gc_memory_manager;
+  GCMemoryManager _conc_gc_memory_manager;
 
   MemoryPool* _eden_space_pool;
   MemoryPool* _survivor_space_pool;
@@ -210,10 +214,6 @@ public:
 
   void update_eden_size();
 
-  CollectorCounters* conc_collection_counters() {
-    return _conc_collection_counters;
-  }
-
   // Monitoring support used by
   //   MemoryService
   //   jstat counters
@@ -239,11 +239,32 @@ public:
 // Scope object for java.lang.management support.
 class G1MonitoringScope : public StackObj {
   G1MonitoringSupport* _monitoring_support;
-  TraceCollectorStats _tcs;
-  TraceMemoryManagerStats _tms;
 public:
-  G1MonitoringScope(G1MonitoringSupport* monitoring_support, bool full_gc, bool all_memory_pools_affected);
+  G1MonitoringScope(G1MonitoringSupport* monitoring_support);
   ~G1MonitoringScope();
 };
 
+class G1IncMonitoringScope : public G1MonitoringScope {
+  TraceCollectorStats _tcs;
+  TraceMemoryManagerStats _tms;
+public:
+  G1IncMonitoringScope(G1MonitoringSupport* monitoring_support, bool all_memory_pools_affected);
+  ~G1IncMonitoringScope() { }
+};
+
+class G1FullMonitoringScope : public G1MonitoringScope {
+  TraceCollectorStats _tcs;
+  TraceMemoryManagerStats _tms;
+public:
+  G1FullMonitoringScope(G1MonitoringSupport* monitoring_support);
+  ~G1FullMonitoringScope() { }
+};
+
+class G1ConcMonitoringScope : public G1MonitoringScope {
+  TraceCollectorStats _tcs;
+  TraceMemoryManagerStats _tms;
+public:
+  G1ConcMonitoringScope(G1MonitoringSupport* monitoring_support);
+  ~G1ConcMonitoringScope() { }
+};
 #endif // SHARE_GC_G1_G1MONITORINGSUPPORT_HPP

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
@@ -122,9 +122,9 @@ class MemoryPool;
 class G1MonitoringSupport : public CHeapObj<mtGC> {
   friend class VMStructs;
   friend class G1MonitoringScope;
-  friend class G1IncMonitoringScope;
-  friend class G1FullMonitoringScope;
-  friend class G1ConcMonitoringScope;
+  friend class G1YoungGCMonitoringScope;
+  friend class G1FullGCMonitoringScope;
+  friend class G1ConcGCMonitoringScope;
 
   G1CollectedHeap* _g1h;
 
@@ -244,27 +244,27 @@ public:
   ~G1MonitoringScope();
 };
 
-class G1IncMonitoringScope : public G1MonitoringScope {
+class G1YoungGCMonitoringScope : public G1MonitoringScope {
   TraceCollectorStats _tcs;
   TraceMemoryManagerStats _tms;
 public:
-  G1IncMonitoringScope(G1MonitoringSupport* monitoring_support, bool all_memory_pools_affected);
-  ~G1IncMonitoringScope() { }
+  G1YoungGCMonitoringScope(G1MonitoringSupport* monitoring_support, bool all_memory_pools_affected);
+  ~G1YoungGCMonitoringScope() { }
 };
 
-class G1FullMonitoringScope : public G1MonitoringScope {
+class G1FullGCMonitoringScope : public G1MonitoringScope {
   TraceCollectorStats _tcs;
   TraceMemoryManagerStats _tms;
 public:
-  G1FullMonitoringScope(G1MonitoringSupport* monitoring_support);
-  ~G1FullMonitoringScope() { }
+  G1FullGCMonitoringScope(G1MonitoringSupport* monitoring_support);
+  ~G1FullGCMonitoringScope() { }
 };
 
-class G1ConcMonitoringScope : public G1MonitoringScope {
+class G1ConcGCMonitoringScope : public G1MonitoringScope {
   TraceCollectorStats _tcs;
   TraceMemoryManagerStats _tms;
 public:
-  G1ConcMonitoringScope(G1MonitoringSupport* monitoring_support);
-  ~G1ConcMonitoringScope() { }
+  G1ConcGCMonitoringScope(G1MonitoringSupport* monitoring_support);
+  ~G1ConcGCMonitoringScope() { }
 };
 #endif // SHARE_GC_G1_G1MONITORINGSUPPORT_HPP

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
@@ -239,30 +239,29 @@ public:
 // Scope object for java.lang.management support.
 class G1MonitoringScope : public StackObj {
   G1MonitoringSupport* _monitoring_support;
+  TraceCollectorStats _tcs;
+  TraceMemoryManagerStats _tms;
 public:
-  G1MonitoringScope(G1MonitoringSupport* monitoring_support);
+  G1MonitoringScope(G1MonitoringSupport* monitoring_support,
+                    CollectorCounters* collection_counters,
+                    GCMemoryManager* gc_memory_manager,
+                    bool all_memory_pools_affected = true);
   ~G1MonitoringScope();
 };
 
 class G1YoungGCMonitoringScope : public G1MonitoringScope {
-  TraceCollectorStats _tcs;
-  TraceMemoryManagerStats _tms;
 public:
   G1YoungGCMonitoringScope(G1MonitoringSupport* monitoring_support, bool all_memory_pools_affected);
   ~G1YoungGCMonitoringScope() { }
 };
 
 class G1FullGCMonitoringScope : public G1MonitoringScope {
-  TraceCollectorStats _tcs;
-  TraceMemoryManagerStats _tms;
 public:
   G1FullGCMonitoringScope(G1MonitoringSupport* monitoring_support);
   ~G1FullGCMonitoringScope() { }
 };
 
 class G1ConcGCMonitoringScope : public G1MonitoringScope {
-  TraceCollectorStats _tcs;
-  TraceMemoryManagerStats _tms;
 public:
   G1ConcGCMonitoringScope(G1MonitoringSupport* monitoring_support);
   ~G1ConcGCMonitoringScope() { }

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
@@ -240,7 +240,7 @@ class G1MonitoringScope : public StackObj {
   G1MonitoringSupport* _monitoring_support;
   TraceCollectorStats _tcs;
   TraceMemoryManagerStats _tms;
-public:
+protected:
   G1MonitoringScope(G1MonitoringSupport* monitoring_support,
                     CollectorCounters* collection_counters,
                     GCMemoryManager* gc_memory_manager,
@@ -251,18 +251,15 @@ public:
 class G1YoungGCMonitoringScope : public G1MonitoringScope {
 public:
   G1YoungGCMonitoringScope(G1MonitoringSupport* monitoring_support, bool all_memory_pools_affected);
-  ~G1YoungGCMonitoringScope() { }
 };
 
 class G1FullGCMonitoringScope : public G1MonitoringScope {
 public:
   G1FullGCMonitoringScope(G1MonitoringSupport* monitoring_support);
-  ~G1FullGCMonitoringScope() { }
 };
 
 class G1ConcGCMonitoringScope : public G1MonitoringScope {
 public:
   G1ConcGCMonitoringScope(G1MonitoringSupport* monitoring_support);
-  ~G1ConcGCMonitoringScope() { }
 };
 #endif // SHARE_GC_G1_G1MONITORINGSUPPORT_HPP

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
@@ -121,7 +121,6 @@ class MemoryPool;
 
 class G1MonitoringSupport : public CHeapObj<mtGC> {
   friend class VMStructs;
-  friend class G1MonitoringScope;
   friend class G1YoungGCMonitoringScope;
   friend class G1FullGCMonitoringScope;
   friend class G1ConcGCMonitoringScope;

--- a/src/hotspot/share/gc/g1/g1VMOperations.cpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.cpp
@@ -172,7 +172,7 @@ void VM_G1PauseConcurrent::doit() {
   GCTraceTimePauseTimer       timer(_message, g1h->concurrent_mark()->gc_timer_cm());
   GCTraceTimeDriver           t(&logger, &timer);
 
-  TraceCollectorStats tcs(g1h->monitoring_support()->conc_collection_counters());
+  G1ConcMonitoringScope monitoring_scope(g1h->monitoring_support());
   SvcGCMarker sgcm(SvcGCMarker::CONCURRENT);
   IsGCActiveMark x;
 

--- a/src/hotspot/share/gc/g1/g1VMOperations.cpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.cpp
@@ -172,7 +172,7 @@ void VM_G1PauseConcurrent::doit() {
   GCTraceTimePauseTimer       timer(_message, g1h->concurrent_mark()->gc_timer_cm());
   GCTraceTimeDriver           t(&logger, &timer);
 
-  G1ConcMonitoringScope monitoring_scope(g1h->monitoring_support());
+  G1ConcGCMonitoringScope monitoring_scope(g1h->monitoring_support());
   SvcGCMarker sgcm(SvcGCMarker::CONCURRENT);
   IsGCActiveMark x;
 

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -1046,9 +1046,8 @@ void G1YoungCollector::collect() {
   // JFR
   G1YoungGCJFRTracerMark jtm(gc_timer_stw(), gc_tracer_stw(), _gc_cause);
   // JStat/MXBeans
-  G1MonitoringScope ms(monitoring_support(),
-                       false /* full_gc */,
-                       collector_state()->in_mixed_phase() /* all_memory_pools_affected */);
+  G1IncMonitoringScope ms(monitoring_support(),
+                          collector_state()->in_mixed_phase() /* all_memory_pools_affected */);
   // Create the heap printer before internal pause timing to have
   // heap information printed as last part of detailed GC log.
   G1HeapPrinterMark hpm(_g1h);

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -1046,8 +1046,8 @@ void G1YoungCollector::collect() {
   // JFR
   G1YoungGCJFRTracerMark jtm(gc_timer_stw(), gc_tracer_stw(), _gc_cause);
   // JStat/MXBeans
-  G1IncMonitoringScope ms(monitoring_support(),
-                          collector_state()->in_mixed_phase() /* all_memory_pools_affected */);
+  G1YoungGCMonitoringScope ms(monitoring_support(),
+                              collector_state()->in_mixed_phase() /* all_memory_pools_affected */);
   // Create the heap printer before internal pause timing to have
   // heap information printed as last part of detailed GC log.
   G1HeapPrinterMark hpm(_g1h);

--- a/test/hotspot/jtreg/gc/TestMemoryMXBeansAndPoolsPresence.java
+++ b/test/hotspot/jtreg/gc/TestMemoryMXBeansAndPoolsPresence.java
@@ -96,7 +96,8 @@ public class TestMemoryMXBeansAndPoolsPresence {
         switch (args[0]) {
             case "G1":
                 test(new GCBeanDescription("G1 Young Generation", new String[] {"G1 Eden Space", "G1 Survivor Space", "G1 Old Gen"}),
-                     new GCBeanDescription("G1 Old Generation",   new String[] {"G1 Eden Space", "G1 Survivor Space", "G1 Old Gen"}));
+                     new GCBeanDescription("G1 Old Generation",   new String[] {"G1 Eden Space", "G1 Survivor Space", "G1 Old Gen"}),
+                     new GCBeanDescription("G1 Concurrent GC",    new String[] {"G1 Old Gen"}));
                 break;
             case "Parallel":
                 test(new GCBeanDescription("PS Scavenge",         new String[] {"PS Eden Space", "PS Survivor Space"}),

--- a/test/hotspot/jtreg/gc/g1/TestRemarkCleanupMXBean.java
+++ b/test/hotspot/jtreg/gc/g1/TestRemarkCleanupMXBean.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2022, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package gc.g1;
+
+/*
+ * @test TestRemarkCleanupMXBean
+ * @bug 8297247
+ * @summary Test that Remark and Cleanup are correctly reported by
+ *          a GarbageCollectorMXBean
+ * @requires vm.gc.G1
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run main/othervm -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -Xlog:gc
+ *                   -Xmx16m -Xms16m -XX:G1HeapRegionSize=1m gc.g1.TestRemarkCleanupMXBean
+ */
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class TestRemarkCleanupMXBean {
+    public static List<byte[]> memory = new ArrayList<>();
+    static List<GarbageCollectorMXBean> beans = ManagementFactory.getGarbageCollectorMXBeans();
+
+    public static void main(String[] args) throws Exception {
+        HashMap<String, Long> counts = new HashMap<>();
+        int num = 16;
+        for (int i = 0; i < num; i++) {
+            memory.add(new byte[1024 * 128]);
+        }
+        System.gc();
+
+        for (int i = 0; i < beans.size(); i++) {
+            GarbageCollectorMXBean bean = beans.get(i);
+            counts.put(bean.getName(), bean.getCollectionCount());
+        }
+        memory = null;
+        System.gc();
+        boolean found = false;
+        for (int i = 0; i < beans.size(); i++) {
+            GarbageCollectorMXBean bean = beans.get(i);
+            long before = counts.get(bean.getName());
+            long after = bean.getCollectionCount();
+            if (after >= before + 2) { // Must report a Remark and a Cleanup
+                found = true;
+                System.out.println(bean.getName() + " reports a difference " +
+                                   after + " - " + before + " = " + (after - before));
+            }
+        }
+
+        if (found == false) {
+            throw new RuntimeException("Remark or Cleanup not reported by GarbageCollectorMXBean");
+        }
+    }
+}

--- a/test/hotspot/jtreg/gc/g1/TestRemarkCleanupMXBean.java
+++ b/test/hotspot/jtreg/gc/g1/TestRemarkCleanupMXBean.java
@@ -28,7 +28,7 @@ package gc.g1;
  * @bug 8297247
  * @summary Test that Remark and Cleanup are correctly reported by
  *          a GarbageCollectorMXBean
- * @requires vm.gc.G1 & vm.compMode != "Xcomp"
+ * @requires vm.gc.G1
  * @library /test/lib /
  * @build   jdk.test.whitebox.WhiteBox
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
@@ -104,6 +104,10 @@ class TestStringDeduplicationTools {
                     if ("end of GC cycle".equals(info.getGcAction())) {
                         gcCount++;
                     }
+                } else if (info.getGcName().startsWith("G1")) {
+                    if ("end of minor GC".equals(info.getGcAction())) {
+                        gcCount++;
+                    }
                 } else {
                     gcCount++;
                 }

--- a/test/hotspot/jtreg/gc/testlibrary/g1/MixedGCProvoker.java
+++ b/test/hotspot/jtreg/gc/testlibrary/g1/MixedGCProvoker.java
@@ -73,13 +73,20 @@ public class MixedGCProvoker {
     }
 
     /**
+     * Provoke a concurrent mark cycle, and wait for it to end.
+     */
+    public static void provokeConcMarkCycle() {
+        Helpers.waitTillCMCFinished(getWhiteBox(), 10);
+        getWhiteBox().g1StartConcMarkCycle();
+        Helpers.waitTillCMCFinished(getWhiteBox(), 10);
+    }
+
+    /**
      * Provoke at least one mixed gc by starting a marking cycle, waiting for its end and triggering two GCs.
      * @param liveOldObjects The objects supposed to survive this marking cycle.
      */
     public static void provokeMixedGC(List<byte[]> liveOldObjects) {
-        Helpers.waitTillCMCFinished(getWhiteBox(), 10);
-        getWhiteBox().g1StartConcMarkCycle();
-        Helpers.waitTillCMCFinished(getWhiteBox(), 10);
+        provokeConcMarkCycle();
         getWhiteBox().youngGC(); // the "Prepare Mixed" gc
         getWhiteBox().youngGC(); // the "Mixed" gc
 

--- a/test/jdk/com/sun/management/GarbageCollectorMXBean/GarbageCollectionNotificationContentTest.java
+++ b/test/jdk/com/sun/management/GarbageCollectorMXBean/GarbageCollectionNotificationContentTest.java
@@ -29,7 +29,11 @@
  * @requires vm.opt.ExplicitGCInvokesConcurrent == null | vm.opt.ExplicitGCInvokesConcurrent == false
  * @modules java.management/sun.management
  *          jdk.management
- * @run     main/othervm -Xms64m -Xmx64m GarbageCollectionNotificationContentTest
+ * @library /test/lib
+ * @build   jdk.test.whitebox.WhiteBox
+ * @run     driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run     main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                       -Xms64m -Xmx64m GarbageCollectionNotificationContentTest
   */
 
 import java.util.*;
@@ -42,6 +46,8 @@ import com.sun.management.GcInfo;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.lang.reflect.Field;
+import jdk.test.whitebox.WhiteBox;
+import jdk.test.whitebox.gc.GC;
 
 public class GarbageCollectionNotificationContentTest {
     private static HashMap<String,GarbageCollectionNotificationInfo> listenerInvoked
@@ -99,6 +105,14 @@ public class GarbageCollectionNotificationContentTest {
         Object data[] = new Object[32];
         for(int i = 0; i<10000000; i++) {
             data[i%32] = new int[8];
+        }
+        // Trigger G1's concrurent mark
+        WhiteBox wb = WhiteBox.getWhiteBox();
+        if (GC.G1.isSelected()) {
+            wb.g1StartConcMarkCycle();
+            while (wb.g1InConcurrentMark()) {
+                Thread.sleep(5);
+            }
         }
         int wakeup = 0;
         synchronized(synchronizer) {

--- a/test/jdk/com/sun/management/GarbageCollectorMXBean/GarbageCollectionNotificationContentTest.java
+++ b/test/jdk/com/sun/management/GarbageCollectorMXBean/GarbageCollectionNotificationContentTest.java
@@ -29,7 +29,7 @@
  * @requires vm.opt.ExplicitGCInvokesConcurrent == null | vm.opt.ExplicitGCInvokesConcurrent == false
  * @modules java.management/sun.management
  *          jdk.management
- * @library /test/lib
+ * @library /test/lib /test/hotspot/jtreg
  * @build   jdk.test.whitebox.WhiteBox
  * @run     driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run     main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
@@ -46,8 +46,8 @@ import com.sun.management.GcInfo;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.lang.reflect.Field;
-import jdk.test.whitebox.WhiteBox;
 import jdk.test.whitebox.gc.GC;
+import gc.testlibrary.g1.MixedGCProvoker;
 
 public class GarbageCollectionNotificationContentTest {
     private static HashMap<String,GarbageCollectionNotificationInfo> listenerInvoked
@@ -106,13 +106,9 @@ public class GarbageCollectionNotificationContentTest {
         for(int i = 0; i<10000000; i++) {
             data[i%32] = new int[8];
         }
-        // Trigger G1's concrurent mark
-        WhiteBox wb = WhiteBox.getWhiteBox();
+        // Trigger G1's concurrent mark
         if (GC.G1.isSelected()) {
-            wb.g1StartConcMarkCycle();
-            while (wb.g1InConcurrentMark()) {
-                Thread.sleep(5);
-            }
+            MixedGCProvoker.provokeConcMarkCycle();
         }
         int wakeup = 0;
         synchronized(synchronizer) {

--- a/test/jdk/com/sun/management/GarbageCollectorMXBean/GarbageCollectionNotificationTest.java
+++ b/test/jdk/com/sun/management/GarbageCollectorMXBean/GarbageCollectionNotificationTest.java
@@ -29,7 +29,11 @@
  * @requires vm.opt.ExplicitGCInvokesConcurrent == null | vm.opt.ExplicitGCInvokesConcurrent == false
  * @modules java.management/sun.management
  *          jdk.management
- * @run     main/othervm GarbageCollectionNotificationTest
+ * @library /test/lib
+ * @build   jdk.test.whitebox.WhiteBox
+ * @run     driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run     main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                       GarbageCollectionNotificationTest
  */
 
 import java.util.*;
@@ -42,6 +46,8 @@ import com.sun.management.GcInfo;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.lang.reflect.Field;
+import jdk.test.whitebox.WhiteBox;
+import jdk.test.whitebox.gc.GC;
 
 public class GarbageCollectionNotificationTest {
     private static HashMap<String,Boolean> listenerInvoked = new HashMap<String,Boolean>();
@@ -98,6 +104,14 @@ public class GarbageCollectionNotificationTest {
         Object data[] = new Object[32];
         for(int i = 0; i<100000000; i++) {
             data[i%32] = new int[8];
+        }
+        // Trigger G1's concrurent mark
+        WhiteBox wb = WhiteBox.getWhiteBox();
+        if (GC.G1.isSelected()) {
+            wb.g1StartConcMarkCycle();
+            while (wb.g1InConcurrentMark()) {
+                Thread.sleep(5);
+            }
         }
         int wakeup = 0;
         synchronized(synchronizer) {

--- a/test/jdk/com/sun/management/GarbageCollectorMXBean/GarbageCollectionNotificationTest.java
+++ b/test/jdk/com/sun/management/GarbageCollectorMXBean/GarbageCollectionNotificationTest.java
@@ -29,7 +29,7 @@
  * @requires vm.opt.ExplicitGCInvokesConcurrent == null | vm.opt.ExplicitGCInvokesConcurrent == false
  * @modules java.management/sun.management
  *          jdk.management
- * @library /test/lib
+ * @library /test/lib /test/hotspot/jtreg
  * @build   jdk.test.whitebox.WhiteBox
  * @run     driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run     main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
@@ -46,8 +46,8 @@ import com.sun.management.GcInfo;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.lang.reflect.Field;
-import jdk.test.whitebox.WhiteBox;
 import jdk.test.whitebox.gc.GC;
+import gc.testlibrary.g1.MixedGCProvoker;
 
 public class GarbageCollectionNotificationTest {
     private static HashMap<String,Boolean> listenerInvoked = new HashMap<String,Boolean>();
@@ -105,13 +105,9 @@ public class GarbageCollectionNotificationTest {
         for(int i = 0; i<100000000; i++) {
             data[i%32] = new int[8];
         }
-        // Trigger G1's concrurent mark
-        WhiteBox wb = WhiteBox.getWhiteBox();
+        // Trigger G1's concurrent mark
         if (GC.G1.isSelected()) {
-            wb.g1StartConcMarkCycle();
-            while (wb.g1InConcurrentMark()) {
-                Thread.sleep(5);
-            }
+            MixedGCProvoker.provokeConcMarkCycle();
         }
         int wakeup = 0;
         synchronized(synchronizer) {

--- a/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
@@ -26,7 +26,7 @@
  * @bug     4530538
  * @summary Basic unit test of MemoryMXBean.getMemoryPools() and
  *          MemoryMXBean.getMemoryManager().
- * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
+ * @requires vm.gc != "Z" & vm.gc != "Shenandoah" & !vm.gc.G1
  * @author  Mandy Chung
  *
  * @modules jdk.management
@@ -43,6 +43,18 @@
  *
  * @modules jdk.management
  * @run main MemoryTest 2 1
+ */
+
+/*
+ * @test
+ * @bug     4530538
+ * @summary Basic unit test of MemoryMXBean.getMemoryPools() and
+ *          MemoryMXBean.getMemoryManager().
+ * @requires vm.gc.G1
+ * @author  Mandy Chung
+ *
+ * @modules jdk.management
+ * @run main MemoryTest 3 3
  */
 
 /*

--- a/test/lib/jdk/test/lib/jfr/GCHelper.java
+++ b/test/lib/jdk/test/lib/jfr/GCHelper.java
@@ -175,6 +175,7 @@ public class GCHelper {
 
         // old GarbageCollectionMXBeans.
         beanCollectorTypes.put("G1 Old Generation", false);
+        beanCollectorTypes.put("G1 Concurrent GC", false);
         beanCollectorTypes.put("PS MarkSweep", false);
         beanCollectorTypes.put("MarkSweepCompact", false);
 


### PR DESCRIPTION
Hi,

This change uses a G1MonitorScope (covers jstat and GC beans) to replace TraceCollectorStats (only covers jstat) in VM_G1PauseConcurrent::doit(), so that now Remark and Cleanup phase time are both collected by a GC bean.
This change adds a third bean "G1 Concurrent GC", after "G1 Young Generation" and "G1 Old generation". This has good continuity, meaning that any current application code who uses "G1 Young Generation" and "G1 Old generation" will see nothing changed, but it will now observe a third bean and can decide what to do with it, e.g., summing all of them up.
Also now the gc beans and jstat fields have 1-to-1 correspondance:
"G1 Young Generation" -- YGC/YGCT
"G1 Old generation" -- FGC/FGCT
"G1 Concurrent GC" -- CGC/CGCT

Alternative:
I've considered using the existing bean "G1 Old generation", but it's currently used for Full GCs, and I find unifying Full GCs with Remark and Cleanup under the same bean is a little awkward. For example, I couldn't find a proper name for the G1MemoryManager, or a proper "gc end message" for the post-gc notification. Also, in this way, if users have previously hooked "G1 Old generation" to some kind of Full GC alarm, then they might suddenly find a lot of false-positives (caused by Remark and Cleanup). So this is undesirable.

Ran tests:
test/hotspot/jtreg:tier1-4
test/jdk:tier1
test/jdk:jdk_jfr_sanity
test/jdk:needs_g1gc
-Failure found and fixed: jdk/jfr/event/gc/collection/TestGCEventMixedWithG1ConcurrentMark.java
-Failure found and fixed: jdk/jfr/event/gc/collection/TestGCEventMixedWithG1FullCollection.java
test/jdk:jdk_management
-Failure found and fixed: com/sun/management/GarbageCollectorMXBean/GarbageCollectionNotificationContentTest.java
-Failure found and fixed: com/sun/management/GarbageCollectorMXBean/GarbageCollectionNotificationTest.java
-Failure found and fixed: java/lang/management/MemoryMXBean/MemoryTest.java#id0
test/hotspot/jtreg:vmTestbase_vm_gc
test/hotspot/jtreg:vmTestbase_nsk_monitoring
test/hotspot/jtreg:vmTestbase_vm_gc_misc
test/jdk:jdk_jmx
test/hotspot/jtreg:hotspot_containers_extended

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297247](https://bugs.openjdk.org/browse/JDK-8297247): Add GarbageCollectorMXBean for Remark and Cleanup pause time in G1


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11341/head:pull/11341` \
`$ git checkout pull/11341`

Update a local copy of the PR: \
`$ git checkout pull/11341` \
`$ git pull https://git.openjdk.org/jdk pull/11341/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11341`

View PR using the GUI difftool: \
`$ git pr show -t 11341`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11341.diff">https://git.openjdk.org/jdk/pull/11341.diff</a>

</details>
