### PR TITLE
Fix a problem in parseInt(String s, int radix)

### DIFF
--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -640,7 +640,10 @@ public final class Integer extends Number
         boolean negative = false;
         int i = 0, len = s.length();
         int limit = -Integer.MAX_VALUE;
-
+        
+        // SilenceZheng66 ADDED!
+        if(len==32&&radix==2&&(s.charAt(0)=='0'||s.charAt(0)=='1')) return parseUnsignedInt(s, radix);
+        
         if (len > 0) {
             char firstChar = s.charAt(0);
             if (firstChar < '0') { // Possible leading "+" or "-"
@@ -720,7 +723,7 @@ public final class Integer extends Number
         boolean negative = false;
         int i = beginIndex;
         int limit = -Integer.MAX_VALUE;
-
+        
         if (i < endIndex) {
             char firstChar = s.charAt(i);
             if (firstChar < '0') { // Possible leading "+" or "-"


### PR DESCRIPTION
When I wanted to parse "11111111111111111111111111111101" to Integer, there will be an Exception, but the input is legal 32bits binary number.

So I read the code and find the problem: when the length of s is 32 and radix is 2, the  function can't realize that the negative should be judged by first '0' or '1', rather than '-' and '+',  for binary number only。But the parseUnsignedInt() works well. So I add a condition judger to fix this problem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11342/head:pull/11342` \
`$ git checkout pull/11342`

Update a local copy of the PR: \
`$ git checkout pull/11342` \
`$ git pull https://git.openjdk.org/jdk pull/11342/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11342`

View PR using the GUI difftool: \
`$ git pr show -t 11342`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11342.diff">https://git.openjdk.org/jdk/pull/11342.diff</a>

</details>
