### PR TITLE
8297543: runtime/cds/appcds/cacheObject/ArchivedModuleCompareTest.java fail with jfx

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
@@ -665,11 +665,17 @@ public class TestCommon extends CDSTestUtils {
         Arrays.sort(sa2);
 
         int i = 0;
+        boolean found = false;
         for (String s : sa1) {
-            if (!s.equals(sa2[i])) {
-                throw new RuntimeException(s + " is different from " + sa2[i]);
+            found = false;
+            for (String s2 : sa2) {
+                if (s.equals(s2)) {
+                    found = true;
+                }
             }
-            i ++;
+            if (!found) {
+                throw new RuntimeException(s + " is not found");
+            }
         }
         return true;
     }


### PR DESCRIPTION
Hi,

configure --with-import-modules=modular-sdk

make run-test CONF=fastdebug TEST="runtime/cds/appcds/cacheObject/ArchivedModuleCompareTest.java" failed:

```
STDERR:
java.lang.RuntimeException: javafx.controls requires javafx.base jrt:/javafx.base is different from javafx.base requires jdk.jfr jrt:/jdk.jfr
        at TestCommon.checkOutputStrings(TestCommon.java:657)
        at ArchivedModuleCompareTest.main(ArchivedModuleCompareTest.java:82)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:312)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

debug patch:

```
diff --git a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleCompareTest.java b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleCompareTest.java
index 00ef746123f..5501e8264e0 100644
--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleCompareTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleCompareTest.java
@@ -75,6 +75,10 @@ public class ArchivedModuleCompareTest {
         TestCommon.checkExec(output);
         if (output.getStderr().contains("sharing")) {
             String moduleResolutionOut2 = TestCommon.filterOutLogs(output.getStdout());
+ System.out.println("************************* moduleResolutionOut1 ***************************");
+ System.out.println(moduleResolutionOut1);
+ System.out.println("************************* moduleResolutionOut2 ***************************");
+ System.out.println(moduleResolutionOut2);
             TestCommon.checkOutputStrings(
                 moduleResolutionOut1, moduleResolutionOut2, "\n");
         }
```

There are 2 javafx.base in the moduleResolutionOut2:

```
javafx.base requires jdk.jfr jrt:/jdk.jfr
javafx.base requires java.desktop jrt:/java.desktop
```

So it needs to find sa1's elements in the sa2.

Please review the patch.

Thanks,
Leslie Zhai

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297543](https://bugs.openjdk.org/browse/JDK-8297543): runtime/cds/appcds/cacheObject/ArchivedModuleCompareTest.java fail with jfx


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11343/head:pull/11343` \
`$ git checkout pull/11343`

Update a local copy of the PR: \
`$ git checkout pull/11343` \
`$ git pull https://git.openjdk.org/jdk pull/11343/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11343`

View PR using the GUI difftool: \
`$ git pr show -t 11343`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11343.diff">https://git.openjdk.org/jdk/pull/11343.diff</a>

</details>
