### PR TITLE
8297549: RISC-V: Add support for Vector API vector load const operation

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -74,7 +74,6 @@ source %{
       case Op_VectorCastL2X:
       case Op_VectorCastS2X:
       case Op_VectorInsert:
-      case Op_VectorLoadConst:
       case Op_VectorLoadMask:
       case Op_VectorLoadShuffle:
       case Op_VectorMaskCmp:
@@ -2076,4 +2075,21 @@ instruct vclearArray_reg_reg(iRegL_R29 cnt, iRegP_R28 base, Universe dummy,
   %}
 
   ins_pipe(pipe_class_memory);
+%}
+
+// Vector Load Const
+instruct vloadcon(vReg dst, immI0 src) %{
+  match(Set dst (VectorLoadConst src));
+  ins_cost(VEC_COST);
+  format %{ "vloadcon $dst\t# generate iota indices" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
+    __ vsetvli(t0, x0, sew);
+    __ vid_v(as_VectorRegister($dst$$reg));
+    if (is_floating_point_type(bt)) {
+      __ vfcvt_f_x_v(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg));
+    }
+  %}
+  ins_pipe(pipe_slow);
 %}


### PR DESCRIPTION
The instruction which is matched `VectorLoadConst`  will create index starting from 0 and incremented by 1. In detail, the instruction populates the destination vector by setting the first element to 0 and monotonically incrementing the value by 1 for each subsequent element. 

We can add support of `VectorLoadConst` for RISC-V by `vid.v` . It was implemented by referring to RVV v1.0 [1].

We can use the JMH test from https://github.com/openjdk/jdk/pull/10332. Tests are performed on qemu with parameter `-cpu rv64,v=true,vlen=256,vext_spec=v1.0`. By adding the `-XX:+PrintAssembly`, the compilation log of `floatIndexVector` is as follows:

```
120     vloadcon V2	# generate iota indices
12c     vfmul.vv V1, V2, V1	#@vmulF
134     vfmv.v.f  V2, F8	#@replicateF
13c     vfadd.vv V1, V2, V1	#@vaddF
```
The above nodes match the logic of `Compute indexes with "vec + iota * scale"` in https://github.com/openjdk/jdk/pull/10332, which is the operation corresponding to `addIndex` in benchmark:
https://github.com/openjdk/jdk/blob/d6102110e1b48c065292db83744245a33e269cc2/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexVectorBenchmark.java#L92-L97

At the same time, the following assembly code will be generated when running the `floatIndexVector` case, there will be one more instruction than `intIndexVector`:
```
 0x000000401443cc9c:   .4byte	0x10072d7
 0x000000401443cca0:   .4byte	0x5208a157
 0x000000401443cca4:   .4byte	0x4a219157
```
`0x10072d7/0x5208a1d7` is the machine code for `vsetvli/vid.v` and `0x4a219157` is the additional machine code for `vfcvt.f.x.v`, which are the opcodes generated by `is_floating_point_type(bt)`:
```
    if (is_floating_point_type(bt)) {
      __ vfcvt_f_x_v(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg));
    }
```

After we implement these nodes, by using `-XX:+UseRVV`, the number of assembly instructions is reduced by about ~50% because of the different execution paths with the number of loops, similar to `AddTest` [3].

[1] https://github.com/riscv/riscv-v-spec/blob/v1.0/v-spec.adoc
[2] https://github.com/openjdk/jdk/blob/857b0f9b05bc711f3282a0da85fcff131fffab91/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexVectorBenchmark.java
[3] https://github.com/zifeihan/vector-api-test-rvv/blob/master/vector-api-rvv-performance.md

Please take a look and have some reviews. Thanks a lot.

## Testing:

- hotspot and jdk tier1 without new failures (release with UseRVV on QEMU)
- hotspot, jdk and langtools tier2 without new failures (release with UseRVV on QEMU)
- test/jdk/jdk/incubator/vector/* (fastdebug/release with UseRVV on QEMU)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297549](https://bugs.openjdk.org/browse/JDK-8297549): RISC-V: Add support for Vector API vector load const operation


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Gui Cao](https://openjdk.org/census#gcao) (@zifeihan - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11344/head:pull/11344` \
`$ git checkout pull/11344`

Update a local copy of the PR: \
`$ git checkout pull/11344` \
`$ git pull https://git.openjdk.org/jdk pull/11344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11344`

View PR using the GUI difftool: \
`$ git pr show -t 11344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11344.diff">https://git.openjdk.org/jdk/pull/11344.diff</a>

</details>
