### PR TITLE
Comment fix: remove "Socialist Republic of" Romania

### DIFF
--- a/src/java.base/share/classes/java/util/LocaleISOData.java
+++ b/src/java.base/share/classes/java/util/LocaleISOData.java
@@ -414,7 +414,7 @@ class LocaleISOData {
         + "PY" + "PRY"  // Paraguay, Republic of
         + "QA" + "QAT"  // Qatar, State of
         + "RE" + "REU"  // Reunion
-        + "RO" + "ROU"  // Romania, Socialist Republic of
+        + "RO" + "ROU"  // Romania
         + "RS" + "SRB"  // Serbia, Republic of
         + "RU" + "RUS"  // Russian Federation
         + "RW" + "RWA"  // Rwanda, Rwandese Republic


### PR DESCRIPTION
Just a small comment correction: Romania hasn't had that name since 1989. It's just Romania.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11345/head:pull/11345` \
`$ git checkout pull/11345`

Update a local copy of the PR: \
`$ git checkout pull/11345` \
`$ git pull https://git.openjdk.org/jdk pull/11345/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11345`

View PR using the GUI difftool: \
`$ git pr show -t 11345`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11345.diff">https://git.openjdk.org/jdk/pull/11345.diff</a>

</details>
