### PR TITLE
8297505: Declare fields in some sun.security.pkcs11 classes as final

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
@@ -88,7 +88,7 @@ final class Config {
     private static final boolean DEBUG = false;
 
     // file name containing this configuration
-    private String filename;
+    private final String filename;
 
     // Reader and StringTokenizer used during parsing
     private Reader reader;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
@@ -106,9 +106,9 @@ final class P11AEADCipher extends CipherSpi {
     private SecureRandom random = JCAUtil.getSecureRandom();
 
     // dataBuffer is cleared upon doFinal calls
-    private ByteArrayOutputStream dataBuffer = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream dataBuffer = new ByteArrayOutputStream();
     // aadBuffer is cleared upon successful init calls
-    private ByteArrayOutputStream aadBuffer = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream aadBuffer = new ByteArrayOutputStream();
     private boolean updateCalled = false;
 
     private boolean requireReinit = false;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -1320,7 +1320,7 @@ final class NativeKeyHolder {
     private long keyID;
 
     // phantom reference notification clean up for session keys
-    private SessionKeyRef ref;
+    private final SessionKeyRef ref;
 
     private int refCount;
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyWrapCipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyWrapCipher.java
@@ -114,7 +114,7 @@ final class P11KeyWrapCipher extends CipherSpi {
     private SecureRandom random = JCAUtil.getSecureRandom();
 
     // dataBuffer for storing enc/dec data; cleared upon doFinal calls
-    private ByteArrayOutputStream dataBuffer = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream dataBuffer = new ByteArrayOutputStream();
 
     P11KeyWrapCipher(Token token, String algorithm, long mechanism)
             throws PKCS11Exception, NoSuchAlgorithmException {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11RSACipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11RSACipher.java
@@ -650,7 +650,7 @@ final class ConstructKeys {
      *
      * @return a public key constructed from the encodedKey.
      */
-    private static final PublicKey constructPublicKey(byte[] encodedKey,
+    private static PublicKey constructPublicKey(byte[] encodedKey,
             String encodedKeyAlgorithm)
             throws InvalidKeyException, NoSuchAlgorithmException {
         try {
@@ -677,7 +677,7 @@ final class ConstructKeys {
      *
      * @return a private key constructed from the encodedKey.
      */
-    private static final PrivateKey constructPrivateKey(byte[] encodedKey,
+    private static PrivateKey constructPrivateKey(byte[] encodedKey,
             String encodedKeyAlgorithm) throws InvalidKeyException,
             NoSuchAlgorithmException {
         try {
@@ -704,12 +704,12 @@ final class ConstructKeys {
      *
      * @return a secret key constructed from the encodedKey.
      */
-    private static final SecretKey constructSecretKey(byte[] encodedKey,
+    private static SecretKey constructSecretKey(byte[] encodedKey,
             String encodedKeyAlgorithm) {
         return new SecretKeySpec(encodedKey, encodedKeyAlgorithm);
     }
 
-    static final Key constructKey(byte[] encoding, String keyAlgorithm,
+    static Key constructKey(byte[] encoding, String keyAlgorithm,
             int keyType) throws InvalidKeyException, NoSuchAlgorithmException {
         switch (keyType) {
         case Cipher.SECRET_KEY:

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11TlsRsaPremasterSecretGenerator.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11TlsRsaPremasterSecretGenerator.java
@@ -55,7 +55,7 @@ final class P11TlsRsaPremasterSecretGenerator extends KeyGeneratorSpi {
     private final String algorithm;
 
     // mechanism id
-    private long mechanism;
+    private final long mechanism;
 
     @SuppressWarnings("deprecation")
     private TlsRsaPremasterSecretParameterSpec spec;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java
@@ -43,7 +43,7 @@ public final class P11Util {
     // A cleaner, shared within this module.
     public static final Cleaner cleaner = Cleaner.create();
 
-    private static Object LOCK = new Object();
+    private static final Object LOCK = new Object();
 
     private static volatile Provider sun, sunRsaSign, sunJce;
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Session.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Session.java
@@ -135,7 +135,7 @@ final class Session implements Comparable<Session> {
     static boolean drainRefQueue() {
         boolean found = false;
         SessionRef next;
-        while ((next = (SessionRef) SessionRef.refQueue.poll())!= null) {
+        while ((next = (SessionRef) SessionRef.REF_QUEUE.poll())!= null) {
             found = true;
             next.dispose();
         }
@@ -150,24 +150,24 @@ final class Session implements Comparable<Session> {
 final class SessionRef extends PhantomReference<Session>
         implements Comparable<SessionRef> {
 
-    static ReferenceQueue<Session> refQueue = new ReferenceQueue<>();
+    static final ReferenceQueue<Session> REF_QUEUE = new ReferenceQueue<>();
 
-    private static Set<SessionRef> refList =
+    private static final Set<SessionRef> REF_LIST =
         Collections.synchronizedSortedSet(new TreeSet<>());
 
     // handle to the native session
-    private long id;
-    private Token token;
+    private final long id;
+    private final Token token;
 
     SessionRef(Session session, long id, Token token) {
-        super(session, refQueue);
+        super(session, REF_QUEUE);
         this.id = id;
         this.token = token;
-        refList.add(this);
+        REF_LIST.add(this);
     }
 
     void dispose() {
-        refList.remove(this);
+        REF_LIST.remove(this);
         try {
             if (token.isPresent(id)) {
                 token.p11.C_CloseSession(id);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SessionManager.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SessionManager.java
@@ -78,7 +78,7 @@ final class SessionManager {
     private final int maxSessions;
 
     // total number of active sessions
-    private AtomicInteger activeSessions = new AtomicInteger();
+    private final AtomicInteger activeSessions = new AtomicInteger();
 
     // pool of available object sessions
     private final Pool objSessions;
@@ -88,7 +88,7 @@ final class SessionManager {
 
     // maximum number of active sessions during this invocation, for debugging
     private int maxActiveSessions;
-    private Object maxActiveSessionsLock;
+    private final Object maxActiveSessionsLock;
 
     // flags to use in the C_OpenSession() call
     private final long openSessionFlags;
@@ -112,9 +112,9 @@ final class SessionManager {
         this.token = token;
         this.objSessions = new Pool(this, true);
         this.opSessions = new Pool(this, false);
-        if (debug != null) {
-            maxActiveSessionsLock = new Object();
-        }
+        this.maxActiveSessionsLock = (debug != null)
+                ? new Object()
+                : null;
     }
 
     // returns whether only a fairly low number of sessions are

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Token.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Token.java
@@ -46,7 +46,7 @@ import static sun.security.pkcs11.wrapper.PKCS11Exception.RV.*;
  * @author  Andreas Sterbenz
  * @since   1.5
  */
-class Token implements Serializable {
+final class Token implements Serializable {
 
     // need to be serializable to allow SecureRandom to be serialized
     private static final long serialVersionUID = 2541527649100571747L;


### PR DESCRIPTION
This PR proposes declaring some fields as `final` to potentially unlock performance optimisations and improve thread visibility (e.g. for GC threads). The PR also fixes a "synchronising on a non-final field" anti-pattern.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297505](https://bugs.openjdk.org/browse/JDK-8297505): Declare fields in some sun.security.pkcs11 classes as final


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11346/head:pull/11346` \
`$ git checkout pull/11346`

Update a local copy of the PR: \
`$ git checkout pull/11346` \
`$ git pull https://git.openjdk.org/jdk pull/11346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11346`

View PR using the GUI difftool: \
`$ git pr show -t 11346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11346.diff">https://git.openjdk.org/jdk/pull/11346.diff</a>

</details>
