### PR TITLE
8297515: serialVersionUID fields are not annotated with @Serial

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
@@ -1061,6 +1061,7 @@ final class Config {
 }
 
 class ConfigurationException extends IOException {
+    @Serial
     private static final long serialVersionUID = 254492758807673194L;
     ConfigurationException(String msg) {
         super(msg);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -69,6 +69,7 @@ import sun.security.jca.JCAUtil;
  */
 abstract class P11Key implements Key, Length {
 
+    @Serial
     private static final long serialVersionUID = -2575874101938349339L;
 
     private static final String PUBLIC = "public";
@@ -421,6 +422,7 @@ abstract class P11Key implements Key, Length {
     // base class for all PKCS11 private keys
     private static abstract class P11PrivateKey extends P11Key implements
             PrivateKey {
+        @Serial
         private static final long serialVersionUID = -2138581185214187615L;
 
         protected byte[] encoded; // guard by synchronized
@@ -441,6 +443,7 @@ abstract class P11Key implements Key, Length {
     }
 
     private static class P11SecretKey extends P11Key implements SecretKey {
+        @Serial
         private static final long serialVersionUID = -7828241727014329084L;
 
         private volatile byte[] encoded; // guard by double-checked locking
@@ -484,6 +487,7 @@ abstract class P11Key implements Key, Length {
     // base class for all PKCS11 public keys
     private static abstract class P11PublicKey extends P11Key implements
             PublicKey {
+        @Serial
         private static final long serialVersionUID = 1L;
 
         protected byte[] encoded; // guard by synchronized
@@ -497,6 +501,7 @@ abstract class P11Key implements Key, Length {
     @SuppressWarnings("deprecation")
     private static class P11TlsMasterSecretKey extends P11SecretKey
             implements TlsMasterSecret {
+        @Serial
         private static final long serialVersionUID = -1318560923770573441L;
 
         private final int majorVersion, minorVersion;
@@ -517,6 +522,7 @@ abstract class P11Key implements Key, Length {
 
     // impl class for sensitive/unextractable RSA private keys
     static class P11RSAPrivateKeyInternal extends P11PrivateKey {
+        @Serial
         private static final long serialVersionUID = -2138581185214187615L;
 
         static P11RSAPrivateKeyInternal of(Session session, long keyID,
@@ -590,6 +596,7 @@ abstract class P11Key implements Key, Length {
     // RSA CRT private key
     private static final class P11RSAPrivateKey extends P11RSAPrivateKeyInternal
             implements RSAPrivateCrtKey {
+        @Serial
         private static final long serialVersionUID = 9215872438913515220L;
 
         private transient BigInteger e, d, p, q, pe, qe, coeff;
@@ -667,6 +674,7 @@ abstract class P11Key implements Key, Length {
     // RSA non-CRT private key
     private static final class P11RSAPrivateNonCRTKey extends
             P11RSAPrivateKeyInternal implements RSAPrivateKey {
+        @Serial
         private static final long serialVersionUID = 1137764983777411481L;
 
         private transient BigInteger d;
@@ -712,6 +720,7 @@ abstract class P11Key implements Key, Length {
 
     private static final class P11RSAPublicKey extends P11PublicKey
                                                 implements RSAPublicKey {
+        @Serial
         private static final long serialVersionUID = -826726289023854455L;
         private transient BigInteger n, e;
 
@@ -768,6 +777,7 @@ abstract class P11Key implements Key, Length {
 
     private static final class P11DSAPublicKey extends P11PublicKey
                                                 implements DSAPublicKey {
+        @Serial
         private static final long serialVersionUID = 5989753793316396637L;
 
         private transient BigInteger y;
@@ -827,6 +837,7 @@ abstract class P11Key implements Key, Length {
     }
 
     static class P11DSAPrivateKeyInternal extends P11PrivateKey {
+        @Serial
         private static final long serialVersionUID = 3119629997181999389L;
 
         protected transient DSAParams params;
@@ -868,6 +879,7 @@ abstract class P11Key implements Key, Length {
 
     private static final class P11DSAPrivateKey extends P11DSAPrivateKeyInternal
                                         implements DSAPrivateKey {
+        @Serial
         private static final long serialVersionUID = 3119629997181999389L;
 
         private transient BigInteger x; // params inside P11DSAPrivateKeyInternal
@@ -920,6 +932,7 @@ abstract class P11Key implements Key, Length {
     }
 
     static class P11DHPrivateKeyInternal extends P11PrivateKey {
+        @Serial
         private static final long serialVersionUID = 1L;
 
         protected transient DHParameterSpec params;
@@ -960,6 +973,7 @@ abstract class P11Key implements Key, Length {
 
     private static final class P11DHPrivateKey extends P11DHPrivateKeyInternal
                                                 implements DHPrivateKey {
+        @Serial
         private static final long serialVersionUID = -1698576167364928838L;
 
         private transient BigInteger x; // params in P11DHPrivateKeyInternal
@@ -1124,6 +1138,7 @@ abstract class P11Key implements Key, Length {
 
     static class P11ECPrivateKeyInternal extends P11PrivateKey {
 
+        @Serial
         private static final long serialVersionUID = 1L;
 
         protected transient ECParameterSpec params;
@@ -1168,6 +1183,7 @@ abstract class P11Key implements Key, Length {
 
     private static final class P11ECPrivateKey extends P11ECPrivateKeyInternal
                                                 implements ECPrivateKey {
+        @Serial
         private static final long serialVersionUID = -7786054399510515515L;
 
         private transient BigInteger s; // params in P11ECPrivateKeyInternal
@@ -1226,6 +1242,7 @@ abstract class P11Key implements Key, Length {
 
     private static final class P11ECPublicKey extends P11PublicKey
                                                 implements ECPublicKey {
+        @Serial
         private static final long serialVersionUID = -6371481375154806089L;
 
         private transient ECPoint w;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecureRandom.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecureRandom.java
@@ -47,6 +47,7 @@ import sun.security.pkcs11.wrapper.*;
  */
 final class P11SecureRandom extends SecureRandomSpi {
 
+    @Serial
     private static final long serialVersionUID = -8939510236124553291L;
 
     // token instance

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -62,6 +62,7 @@ import static sun.security.pkcs11.wrapper.PKCS11Exception.RV.*;
  */
 public final class SunPKCS11 extends AuthProvider {
 
+    @Serial
     private static final long serialVersionUID = -1354835039035306505L;
 
     static final Debug debug = Debug.getInstance("sunpkcs11");

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Token.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Token.java
@@ -49,6 +49,7 @@ import static sun.security.pkcs11.wrapper.PKCS11Exception.RV.*;
 class Token implements Serializable {
 
     // need to be serializable to allow SecureRandom to be serialized
+    @Serial
     private static final long serialVersionUID = 2541527649100571747L;
 
     // how often to check if the token is still present (in ms)
@@ -441,6 +442,7 @@ class Token implements Serializable {
     // and if the token has not been removed in the meantime
     private static class TokenRep implements Serializable {
 
+        @Serial
         private static final long serialVersionUID = 3503721168218219807L;
 
         private final byte[] tokenId;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
@@ -47,6 +47,7 @@
 
 package sun.security.pkcs11.wrapper;
 
+import java.io.Serial;
 import java.util.*;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
 
@@ -63,6 +64,7 @@ import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
  * @invariants
  */
 public class PKCS11Exception extends Exception {
+    @Serial
     private static final long serialVersionUID = 4077027363729192L;
 
     /**

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11RuntimeException.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11RuntimeException.java
@@ -48,6 +48,8 @@
 package sun.security.pkcs11.wrapper;
 
 
+import java.io.Serial;
+
 /**
  * This is the superclass of all runtime exception used by this library.
  * For instance, Runtime exceptions occur, if an internal error in the native
@@ -57,6 +59,7 @@ package sun.security.pkcs11.wrapper;
  * @invariants
  */
 public class PKCS11RuntimeException extends RuntimeException {
+    @Serial
     private static final long serialVersionUID = 7889842162743590564L;
 
     /**


### PR DESCRIPTION
This PR proposes adding `@Serial` annotations to certain fields participating in serialisation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297515](https://bugs.openjdk.org/browse/JDK-8297515): serialVersionUID fields are not annotated with @Serial


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11347/head:pull/11347` \
`$ git checkout pull/11347`

Update a local copy of the PR: \
`$ git checkout pull/11347` \
`$ git pull https://git.openjdk.org/jdk pull/11347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11347`

View PR using the GUI difftool: \
`$ git pr show -t 11347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11347.diff">https://git.openjdk.org/jdk/pull/11347.diff</a>

</details>
