### PR TITLE
8297519: Improve expressions and modernise code in PKCS

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
@@ -479,14 +479,11 @@ final class Config {
             }
             case "nssDbMode"-> {
                 String mode = parseStringEntry(st.sval);
-                if (mode.equals("readWrite")) {
-                    nssDbMode = Secmod.DbMode.READ_WRITE;
-                } else if (mode.equals("readOnly")) {
-                    nssDbMode = Secmod.DbMode.READ_ONLY;
-                } else if (mode.equals("noDb")) {
-                    nssDbMode = Secmod.DbMode.NO_DB;
-                } else {
-                    throw excToken("nssDbMode must be one of readWrite, readOnly, and noDb:");
+                switch (mode) {
+                    case "readWrite" -> nssDbMode = Secmod.DbMode.READ_WRITE;
+                    case "readOnly" -> nssDbMode = Secmod.DbMode.READ_ONLY;
+                    case "noDb" -> nssDbMode = Secmod.DbMode.NO_DB;
+                    default -> throw excToken("nssDbMode must be one of readWrite, readOnly, and noDb:");
                 }
                 nssUseSecmod = true;
             }
@@ -516,7 +513,7 @@ final class Config {
         if (name == null) {
             throw new ConfigurationException("name must be specified");
         }
-        if (nssUseSecmod == false) {
+        if (!nssUseSecmod) {
             if (library == null) {
                 throw new ConfigurationException("library must be specified");
             }
@@ -533,7 +530,7 @@ final class Config {
                 throw new ConfigurationException
                     ("nssArgs must not be specified in NSS mode");
             }
-            if (nssUseSecmodTrust != false) {
+            if (nssUseSecmodTrust) {
                 throw new ConfigurationException("nssUseSecmodTrust is an "
                     + "internal option and must not be specified in NSS mode");
             }
@@ -623,14 +620,11 @@ final class Config {
 
     private boolean parseBoolean() throws IOException {
         String val = parseWord();
-        switch (val) {
-            case "true":
-                return true;
-            case "false":
-                return false;
-            default:
-                throw excToken("Expected boolean value, read:");
-        }
+        return switch (val) {
+            case "true" -> true;
+            case "false" -> false;
+            default -> throw excToken("Expected boolean value, read:");
+        };
     }
 
     private String parseLine() throws IOException {
@@ -688,7 +682,7 @@ final class Config {
     }
 
     private byte[] decodeByteArray(String str) throws IOException {
-        if (str.startsWith("0h") == false) {
+        if (!str.startsWith("0h")) {
             throw excToken("Expected byte array value, read");
         }
         str = str.substring(2);
@@ -833,7 +827,7 @@ final class Config {
         int token = nextToken();
         if (token == '=') {
             String s = parseWord();
-            if (s.equals("compatibility") == false) {
+            if (!s.equals("compatibility")) {
                 throw excLine("Expected 'compatibility', read " + s);
             }
             setCompatibilityAttributes();
@@ -964,16 +958,12 @@ final class Config {
 
     private String parseOperation() throws IOException {
         String op = parseWord();
-        switch (op) {
-            case "*":
-                return TemplateManager.O_ANY;
-            case "generate":
-                return TemplateManager.O_GENERATE;
-            case "import":
-                return TemplateManager.O_IMPORT;
-            default:
-                throw excLine("Unknown operation " + op);
-        }
+        return switch (op) {
+            case "*" -> TemplateManager.O_ANY;
+            case "generate" -> TemplateManager.O_GENERATE;
+            case "import" -> TemplateManager.O_IMPORT;
+            default -> throw excLine("Unknown operation " + op);
+        };
     }
 
     private long parseObjectClass() throws IOException {
@@ -1044,14 +1034,11 @@ final class Config {
         checkDup(keyword);
         parseEquals();
         String val = parseWord();
-        if (val.equals("ignoreAll")) {
-            handleStartupErrors = ERR_IGNORE_ALL;
-        } else if (val.equals("ignoreMissingLibrary")) {
-            handleStartupErrors = ERR_IGNORE_LIB;
-        } else if (val.equals("halt")) {
-            handleStartupErrors = ERR_HALT;
-        } else {
-            throw excToken("Invalid value for handleStartupErrors:");
+        switch (val) {
+            case "ignoreAll" -> handleStartupErrors = ERR_IGNORE_ALL;
+            case "ignoreMissingLibrary" -> handleStartupErrors = ERR_IGNORE_LIB;
+            case "halt" -> handleStartupErrors = ERR_HALT;
+            default -> throw excToken("Invalid value for handleStartupErrors:");
         }
         if (DEBUG) {
             System.out.println("handleStartupErrors: " + handleStartupErrors);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
@@ -479,12 +479,12 @@ final class Config {
             }
             case "nssDbMode"-> {
                 String mode = parseStringEntry(st.sval);
-                switch (mode) {
-                    case "readWrite" -> nssDbMode = Secmod.DbMode.READ_WRITE;
-                    case "readOnly" -> nssDbMode = Secmod.DbMode.READ_ONLY;
-                    case "noDb" -> nssDbMode = Secmod.DbMode.NO_DB;
+                nssDbMode = switch (mode) {
+                    case "readWrite" -> Secmod.DbMode.READ_WRITE;
+                    case "readOnly" -> Secmod.DbMode.READ_ONLY;
+                    case "noDb" -> Secmod.DbMode.NO_DB;
                     default -> throw excToken("nssDbMode must be one of readWrite, readOnly, and noDb:");
-                }
+                };
                 nssUseSecmod = true;
             }
             case "nssNetscapeDbWorkaround"-> {
@@ -1034,12 +1034,12 @@ final class Config {
         checkDup(keyword);
         parseEquals();
         String val = parseWord();
-        switch (val) {
-            case "ignoreAll" -> handleStartupErrors = ERR_IGNORE_ALL;
-            case "ignoreMissingLibrary" -> handleStartupErrors = ERR_IGNORE_LIB;
-            case "halt" -> handleStartupErrors = ERR_HALT;
+        handleStartupErrors = switch (val) {
+            case "ignoreAll" -> ERR_IGNORE_ALL;
+            case "ignoreMissingLibrary" -> ERR_IGNORE_LIB;
+            case "halt" -> ERR_HALT;
             default -> throw excToken("Invalid value for handleStartupErrors:");
-        }
+        };
         if (DEBUG) {
             System.out.println("handleStartupErrors: " + handleStartupErrors);
         }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/KeyCache.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/KeyCache.java
@@ -65,7 +65,7 @@ final class KeyCache {
             if (this == o) {
                 return true;
             }
-            if (o instanceof IdentityWrapper == false) {
+            if (!(o instanceof IdentityWrapper)) {
                 return false;
             }
             IdentityWrapper other = (IdentityWrapper)o;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
@@ -208,7 +208,7 @@ final class P11AEADCipher extends CipherSpi {
         String apAlgo;
         AlgorithmParameterSpec spec = null;
         switch (type) {
-            case AES_GCM:
+            case AES_GCM -> {
                 apAlgo = "GCM";
                 if (encrypt && iv == null && tagLen == -1) {
                     iv = new byte[type.defIvLen];
@@ -218,8 +218,8 @@ final class P11AEADCipher extends CipherSpi {
                 if (iv != null) {
                     spec = new GCMParameterSpec(tagLen << 3, iv);
                 }
-            break;
-            case CHACHA20_POLY1305:
+            }
+            case CHACHA20_POLY1305 -> {
                 if (encrypt && iv == null) {
                     iv = new byte[type.defIvLen];
                     random.nextBytes(iv);
@@ -228,9 +228,8 @@ final class P11AEADCipher extends CipherSpi {
                 if (iv != null) {
                     spec = new IvParameterSpec(iv);
                 }
-            break;
-            default:
-                throw new AssertionError("Unsupported type " + type);
+            }
+            default -> throw new AssertionError("Unsupported type " + type);
         }
         if (spec != null) {
             try {
@@ -311,18 +310,10 @@ final class P11AEADCipher extends CipherSpi {
         try {
             AlgorithmParameterSpec paramSpec = null;
             if (params != null) {
-                switch (type) {
-                    case AES_GCM:
-                        paramSpec =
-                            params.getParameterSpec(GCMParameterSpec.class);
-                        break;
-                    case CHACHA20_POLY1305:
-                        paramSpec =
-                            params.getParameterSpec(IvParameterSpec.class);
-                        break;
-                    default:
-                        throw new AssertionError("Unsupported type " + type);
-                }
+                paramSpec = switch (type) {
+                    case AES_GCM -> params.getParameterSpec(GCMParameterSpec.class);
+                    case CHACHA20_POLY1305 -> params.getParameterSpec(IvParameterSpec.class);
+                };
             }
             engineInit(opmode, key, paramSpec, sr);
         } catch (InvalidParameterSpecException ex) {
@@ -343,7 +334,7 @@ final class P11AEADCipher extends CipherSpi {
         P11Key newKey = P11SecretKeyFactory.convertKey(token, key,
                 type.keyAlgo);
         switch (opmode) {
-            case Cipher.ENCRYPT_MODE:
+            case Cipher.ENCRYPT_MODE -> {
                 encrypt = true;
                 requireReinit = Arrays.equals(iv, lastEncIv) &&
                         (newKey == lastEncKey);
@@ -351,18 +342,16 @@ final class P11AEADCipher extends CipherSpi {
                     throw new InvalidAlgorithmParameterException(
                             "Cannot reuse the same key and iv pair");
                 }
-                break;
-            case Cipher.DECRYPT_MODE:
+            }
+            case Cipher.DECRYPT_MODE -> {
                 encrypt = false;
                 requireReinit = false;
-                break;
-            case Cipher.WRAP_MODE:
-            case Cipher.UNWRAP_MODE:
-                throw new UnsupportedOperationException
-                        ("Unsupported mode: " + opmode);
-            default:
+            }
+            case Cipher.WRAP_MODE, Cipher.UNWRAP_MODE -> throw new UnsupportedOperationException
+                    ("Unsupported mode: " + opmode);
+            default ->
                 // should never happen; checked by Cipher.init()
-                throw new AssertionError("Unknown mode: " + opmode);
+                    throw new AssertionError("Unknown mode: " + opmode);
         }
 
         // decryption without parameters is checked in all engineInit() calls
@@ -373,18 +362,17 @@ final class P11AEADCipher extends CipherSpi {
         if (iv == null && tagLen == -1) {
             // generate default values
             switch (type) {
-                case AES_GCM:
+                case AES_GCM -> {
                     iv = new byte[type.defIvLen];
                     this.random.nextBytes(iv);
                     tagLen = type.defTagLen;
-                    break;
-                case CHACHA20_POLY1305:
+                }
+                case CHACHA20_POLY1305 -> {
                     iv = new byte[type.defIvLen];
                     this.random.nextBytes(iv);
                     tagLen = type.defTagLen;
-                    break;
-                default:
-                    throw new AssertionError("Unsupported type " + type);
+                }
+                default -> throw new AssertionError("Unsupported type " + type);
             }
         }
         this.iv = iv;
@@ -463,19 +451,12 @@ final class P11AEADCipher extends CipherSpi {
 
         long p11KeyID = p11Key.getKeyID();
         try {
-            CK_MECHANISM mechWithParams;
-            switch (type) {
-                case AES_GCM:
-                    mechWithParams = new CK_MECHANISM(mechanism,
+            CK_MECHANISM mechWithParams = switch (type) {
+                case AES_GCM -> new CK_MECHANISM(mechanism,
                         new CK_GCM_PARAMS(tagLen << 3, iv, aad));
-                    break;
-                case CHACHA20_POLY1305:
-                    mechWithParams = new CK_MECHANISM(mechanism,
+                case CHACHA20_POLY1305 -> new CK_MECHANISM(mechanism,
                         new CK_SALSA20_CHACHA20_POLY1305_PARAMS(iv, aad));
-                    break;
-                default:
-                    throw new AssertionError("Unsupported type: " + type);
-            }
+            };
             if (session == null) {
                 session = token.getOpSession();
             }
@@ -513,7 +494,7 @@ final class P11AEADCipher extends CipherSpi {
                 result -= tagLen;
             }
         }
-        return (result > 0 ? result : 0);
+        return (Math.max(result, 0));
     }
 
     // reset the states to the pre-initialized values

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
@@ -361,19 +361,9 @@ final class P11AEADCipher extends CipherSpi {
 
         if (iv == null && tagLen == -1) {
             // generate default values
-            switch (type) {
-                case AES_GCM -> {
-                    iv = new byte[type.defIvLen];
-                    this.random.nextBytes(iv);
-                    tagLen = type.defTagLen;
-                }
-                case CHACHA20_POLY1305 -> {
-                    iv = new byte[type.defIvLen];
-                    this.random.nextBytes(iv);
-                    tagLen = type.defTagLen;
-                }
-                default -> throw new AssertionError("Unsupported type " + type);
-            }
+            iv = new byte[type.defIvLen];
+            this.random.nextBytes(iv);
+            tagLen = type.defTagLen;
         }
         this.iv = iv;
         this.tagLen = tagLen;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
@@ -226,18 +226,17 @@ final class P11Cipher extends CipherSpi {
     private int parseMode(String mode) throws NoSuchAlgorithmException {
         mode = mode.toUpperCase(Locale.ENGLISH);
         int result;
-        if (mode.equals("ECB")) {
-            result = MODE_ECB;
-        } else if (mode.equals("CBC")) {
-            if (blockSize == 0) {
-                throw new NoSuchAlgorithmException
-                        ("CBC mode not supported with stream ciphers");
+        switch (mode) {
+            case "ECB" -> result = MODE_ECB;
+            case "CBC" -> {
+                if (blockSize == 0) {
+                    throw new NoSuchAlgorithmException
+                            ("CBC mode not supported with stream ciphers");
+                }
+                result = MODE_CBC;
             }
-            result = MODE_CBC;
-        } else if (mode.equals("CTR")) {
-            result = MODE_CTR;
-        } else {
-            throw new NoSuchAlgorithmException("Unsupported mode " + mode);
+            case "CTR" -> result = MODE_CTR;
+            default -> throw new NoSuchAlgorithmException("Unsupported mode " + mode);
         }
         return result;
     }
@@ -321,7 +320,7 @@ final class P11Cipher extends CipherSpi {
             throws InvalidKeyException, InvalidAlgorithmParameterException {
         byte[] ivValue;
         if (params != null) {
-            if (params instanceof IvParameterSpec == false) {
+            if (!(params instanceof IvParameterSpec)) {
                 throw new InvalidAlgorithmParameterException
                         ("Only IvParameterSpec supported");
             }
@@ -364,19 +363,13 @@ final class P11Cipher extends CipherSpi {
             throw new InvalidKeyException("Key size is invalid");
         }
         switch (opmode) {
-            case Cipher.ENCRYPT_MODE:
-                encrypt = true;
-                break;
-            case Cipher.DECRYPT_MODE:
-                encrypt = false;
-                break;
-            case Cipher.WRAP_MODE:
-            case Cipher.UNWRAP_MODE:
-                throw new UnsupportedOperationException
-                        ("Unsupported mode: " + opmode);
-            default:
+            case Cipher.ENCRYPT_MODE -> encrypt = true;
+            case Cipher.DECRYPT_MODE -> encrypt = false;
+            case Cipher.WRAP_MODE, Cipher.UNWRAP_MODE -> throw new UnsupportedOperationException
+                    ("Unsupported mode: " + opmode);
+            default ->
                 // should never happen; checked by Cipher.init()
-                throw new AssertionError("Unknown mode: " + opmode);
+                    throw new AssertionError("Unknown mode: " + opmode);
         }
         if (blockMode == MODE_ECB) { // ECB or stream cipher
             if (iv != null) {
@@ -390,7 +383,7 @@ final class P11Cipher extends CipherSpi {
             }
         } else { // MODE_CBC or MODE_CTR
             if (iv == null) {
-                if (encrypt == false) {
+                if (!encrypt) {
                     String exMsg =
                         (blockMode == MODE_CBC ?
                          "IV must be specified for decryption in CBC mode" :

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
@@ -225,20 +225,18 @@ final class P11Cipher extends CipherSpi {
 
     private int parseMode(String mode) throws NoSuchAlgorithmException {
         mode = mode.toUpperCase(Locale.ENGLISH);
-        int result;
-        switch (mode) {
-            case "ECB" -> result = MODE_ECB;
+        return switch (mode) {
+            case "ECB" -> MODE_ECB;
             case "CBC" -> {
                 if (blockSize == 0) {
                     throw new NoSuchAlgorithmException
                             ("CBC mode not supported with stream ciphers");
                 }
-                result = MODE_CBC;
+                yield MODE_CBC;
             }
-            case "CTR" -> result = MODE_CTR;
+            case "CTR" -> MODE_CTR;
             default -> throw new NoSuchAlgorithmException("Unsupported mode " + mode);
-        }
-        return result;
+        };
     }
 
     // see JCE spec
@@ -362,15 +360,15 @@ final class P11Cipher extends CipherSpi {
                             key.getEncoded().length) != fixedKeySize) {
             throw new InvalidKeyException("Key size is invalid");
         }
-        switch (opmode) {
-            case Cipher.ENCRYPT_MODE -> encrypt = true;
-            case Cipher.DECRYPT_MODE -> encrypt = false;
+        encrypt = switch (opmode) {
+            case Cipher.ENCRYPT_MODE -> true;
+            case Cipher.DECRYPT_MODE -> false;
             case Cipher.WRAP_MODE, Cipher.UNWRAP_MODE -> throw new UnsupportedOperationException
                     ("Unsupported mode: " + opmode);
             default ->
                 // should never happen; checked by Cipher.init()
                     throw new AssertionError("Unknown mode: " + opmode);
-        }
+        };
         if (blockMode == MODE_ECB) { // ECB or stream cipher
             if (iv != null) {
                 if (blockSize == 0) {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11DHKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11DHKeyFactory.java
@@ -51,8 +51,7 @@ final class P11DHKeyFactory extends P11KeyFactory {
 
     PublicKey implTranslatePublicKey(PublicKey key) throws InvalidKeyException {
         try {
-            if (key instanceof DHPublicKey) {
-                DHPublicKey dhKey = (DHPublicKey)key;
+            if (key instanceof DHPublicKey dhKey) {
                 DHParameterSpec params = dhKey.getParams();
                 return generatePublic(
                     dhKey.getY(),
@@ -80,8 +79,7 @@ final class P11DHKeyFactory extends P11KeyFactory {
     PrivateKey implTranslatePrivateKey(PrivateKey key)
             throws InvalidKeyException {
         try {
-            if (key instanceof DHPrivateKey) {
-                DHPrivateKey dhKey = (DHPrivateKey)key;
+            if (key instanceof DHPrivateKey dhKey) {
                 DHParameterSpec params = dhKey.getParams();
                 return generatePrivate(
                     dhKey.getX(),
@@ -120,7 +118,7 @@ final class P11DHKeyFactory extends P11KeyFactory {
                         ("Could not create DH public key", e);
             }
         }
-        if (keySpec instanceof DHPublicKeySpec == false) {
+        if (!(keySpec instanceof DHPublicKeySpec)) {
             throw new InvalidKeySpecException("Only DHPublicKeySpec and "
                 + "X509EncodedKeySpec supported for DH public keys");
         }
@@ -151,7 +149,7 @@ final class P11DHKeyFactory extends P11KeyFactory {
                         ("Could not create DH private key", e);
             }
         }
-        if (keySpec instanceof DHPrivateKeySpec == false) {
+        if (!(keySpec instanceof DHPrivateKeySpec)) {
             throw new InvalidKeySpecException("Only DHPrivateKeySpec and "
                 + "PKCS8EncodedKeySpec supported for DH private keys");
         }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11DSAKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11DSAKeyFactory.java
@@ -49,8 +49,7 @@ final class P11DSAKeyFactory extends P11KeyFactory {
 
     PublicKey implTranslatePublicKey(PublicKey key) throws InvalidKeyException {
         try {
-            if (key instanceof DSAPublicKey) {
-                DSAPublicKey dsaKey = (DSAPublicKey)key;
+            if (key instanceof DSAPublicKey dsaKey) {
                 DSAParams params = dsaKey.getParams();
                 return generatePublic(
                     dsaKey.getY(),
@@ -75,8 +74,7 @@ final class P11DSAKeyFactory extends P11KeyFactory {
     PrivateKey implTranslatePrivateKey(PrivateKey key)
             throws InvalidKeyException {
         try {
-            if (key instanceof DSAPrivateKey) {
-                DSAPrivateKey dsaKey = (DSAPrivateKey)key;
+            if (key instanceof DSAPrivateKey dsaKey) {
                 DSAParams params = dsaKey.getParams();
                 return generatePrivate(
                     dsaKey.getX(),
@@ -112,7 +110,7 @@ final class P11DSAKeyFactory extends P11KeyFactory {
                         ("Could not create DSA public key", e);
             }
         }
-        if (keySpec instanceof DSAPublicKeySpec == false) {
+        if (!(keySpec instanceof DSAPublicKeySpec)) {
             throw new InvalidKeySpecException("Only DSAPublicKeySpec and "
                 + "X509EncodedKeySpec supported for DSA public keys");
         }
@@ -144,7 +142,7 @@ final class P11DSAKeyFactory extends P11KeyFactory {
                         ("Could not create DSA private key", e);
             }
         }
-        if (keySpec instanceof DSAPrivateKeySpec == false) {
+        if (!(keySpec instanceof DSAPrivateKeySpec)) {
             throw new InvalidKeySpecException("Only DSAPrivateKeySpec and "
                 + "PKCS8EncodedKeySpec supported for DSA private keys");
         }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11ECDHKeyAgreement.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11ECDHKeyAgreement.java
@@ -71,7 +71,7 @@ final class P11ECDHKeyAgreement extends KeyAgreementSpi {
     // see JCE spec
     protected void engineInit(Key key, SecureRandom random)
             throws InvalidKeyException {
-        if (key instanceof PrivateKey == false) {
+        if (!(key instanceof PrivateKey)) {
             throw new InvalidKeyException
                         ("Key must be instance of PrivateKey");
         }
@@ -99,15 +99,14 @@ final class P11ECDHKeyAgreement extends KeyAgreementSpi {
         if (publicValue != null) {
             throw new IllegalStateException("Phase already executed");
         }
-        if (lastPhase == false) {
+        if (!lastPhase) {
             throw new IllegalStateException
                 ("Only two party agreement supported, lastPhase must be true");
         }
-        if (key instanceof ECPublicKey == false) {
+        if (!(key instanceof ECPublicKey ecKey)) {
             throw new InvalidKeyException
                 ("Key must be a PublicKey with algorithm EC");
         }
-        ECPublicKey ecKey = (ECPublicKey)key;
         int keyLenBits = ecKey.getParams().getCurve().getField().getFieldSize();
         secretLen = (keyLenBits + 7) >> 3;
         publicValue = P11ECKeyFactory.getEncodedPublicValue(ecKey);
@@ -169,7 +168,7 @@ final class P11ECDHKeyAgreement extends KeyAgreementSpi {
         if (algorithm == null) {
             throw new NoSuchAlgorithmException("Algorithm must not be null");
         }
-        if (algorithm.equals("TlsPremasterSecret") == false) {
+        if (!algorithm.equals("TlsPremasterSecret")) {
             throw new NoSuchAlgorithmException
                 ("Only supported for algorithm TlsPremasterSecret");
         }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11ECKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11ECKeyFactory.java
@@ -91,8 +91,7 @@ final class P11ECKeyFactory extends P11KeyFactory {
 
     // Used by ECDH KeyAgreement
     static byte[] getEncodedPublicValue(PublicKey key) throws InvalidKeyException {
-        if (key instanceof ECPublicKey) {
-            ECPublicKey ecKey = (ECPublicKey)key;
+        if (key instanceof ECPublicKey ecKey) {
             ECPoint w = ecKey.getW();
             ECParameterSpec params = ecKey.getParams();
             return ECUtil.encodePoint(w, params.getCurve());
@@ -105,8 +104,7 @@ final class P11ECKeyFactory extends P11KeyFactory {
 
     PublicKey implTranslatePublicKey(PublicKey key) throws InvalidKeyException {
         try {
-            if (key instanceof ECPublicKey) {
-                ECPublicKey ecKey = (ECPublicKey)key;
+            if (key instanceof ECPublicKey ecKey) {
                 return generatePublic(
                     ecKey.getW(),
                     ecKey.getParams()
@@ -134,8 +132,7 @@ final class P11ECKeyFactory extends P11KeyFactory {
     PrivateKey implTranslatePrivateKey(PrivateKey key)
             throws InvalidKeyException {
         try {
-            if (key instanceof ECPrivateKey) {
-                ECPrivateKey ecKey = (ECPrivateKey)key;
+            if (key instanceof ECPrivateKey ecKey) {
                 return generatePrivate(
                     ecKey.getS(),
                     ecKey.getParams()
@@ -174,7 +171,7 @@ final class P11ECKeyFactory extends P11KeyFactory {
                         ("Could not create EC public key", e);
             }
         }
-        if (keySpec instanceof ECPublicKeySpec == false) {
+        if (!(keySpec instanceof ECPublicKeySpec)) {
             throw new InvalidKeySpecException("Only ECPublicKeySpec and "
                 + "X509EncodedKeySpec supported for EC public keys");
         }
@@ -204,7 +201,7 @@ final class P11ECKeyFactory extends P11KeyFactory {
                         ("Could not create EC private key", e);
             }
         }
-        if (keySpec instanceof ECPrivateKeySpec == false) {
+        if (!(keySpec instanceof ECPrivateKeySpec)) {
             throw new InvalidKeySpecException("Only ECPrivateKeySpec and "
                 + "PKCS8EncodedKeySpec supported for EC private keys");
         }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -188,10 +188,10 @@ abstract class P11Key implements Key, Length {
             return true;
         }
         // equals() should never throw exceptions
-        if (token.isValid() == false) {
+        if (!token.isValid()) {
             return false;
         }
-        if (obj instanceof Key == false) {
+        if (!(obj instanceof Key other)) {
             return false;
         }
         String thisFormat = getFormat();
@@ -200,8 +200,7 @@ abstract class P11Key implements Key, Length {
             // XXX getEncoded() for unextractable keys will change that
             return false;
         }
-        Key other = (Key)obj;
-        if (thisFormat.equals(other.getFormat()) == false) {
+        if (!thisFormat.equals(other.getFormat())) {
             return false;
         }
         byte[] thisEnc = this.getEncodedInternal();
@@ -216,7 +215,7 @@ abstract class P11Key implements Key, Length {
 
     public int hashCode() {
         // hashCode() should never throw exceptions
-        if (token.isValid() == false) {
+        if (!token.isValid()) {
             return 0;
         }
         byte[] b1 = getEncodedInternal();
@@ -369,23 +368,18 @@ abstract class P11Key implements Key, Length {
     // we assume that all components of public keys are always accessible
     static PublicKey publicKey(Session session, long keyID, String algorithm,
             int keyLength, CK_ATTRIBUTE[] attrs) {
-        switch (algorithm) {
-            case "RSA":
-                return new P11RSAPublicKey(session, keyID, algorithm,
-                        keyLength, attrs);
-            case "DSA":
-                return new P11DSAPublicKey(session, keyID, algorithm,
-                        keyLength, attrs);
-            case "DH":
-                return new P11DHPublicKey(session, keyID, algorithm,
-                        keyLength, attrs);
-            case "EC":
-                return new P11ECPublicKey(session, keyID, algorithm,
-                        keyLength, attrs);
-            default:
-                throw new ProviderException
+        return switch (algorithm) {
+            case "RSA" -> new P11RSAPublicKey(session, keyID, algorithm,
+                    keyLength, attrs);
+            case "DSA" -> new P11DSAPublicKey(session, keyID, algorithm,
+                    keyLength, attrs);
+            case "DH" -> new P11DHPublicKey(session, keyID, algorithm,
+                    keyLength, attrs);
+            case "EC" -> new P11ECPublicKey(session, keyID, algorithm,
+                    keyLength, attrs);
+            default -> throw new ProviderException
                     ("Unknown public key algorithm " + algorithm);
-        }
+        };
     }
 
     static PrivateKey privateKey(Session session, long keyID, String algorithm,
@@ -399,23 +393,18 @@ abstract class P11Key implements Key, Length {
         boolean keySensitive = (attrs[0].getBoolean() ||
                 attrs[1].getBoolean() || !attrs[2].getBoolean());
 
-        switch (algorithm) {
-        case "RSA":
-            return P11RSAPrivateKeyInternal.of(session, keyID, algorithm,
+        return switch (algorithm) {
+            case "RSA" -> P11RSAPrivateKeyInternal.of(session, keyID, algorithm,
                     keyLength, attrs, keySensitive);
-        case "DSA":
-            return P11DSAPrivateKeyInternal.of(session, keyID, algorithm,
+            case "DSA" -> P11DSAPrivateKeyInternal.of(session, keyID, algorithm,
                     keyLength, attrs, keySensitive);
-        case "DH":
-            return P11DHPrivateKeyInternal.of(session, keyID, algorithm,
+            case "DH" -> P11DHPrivateKeyInternal.of(session, keyID, algorithm,
                     keyLength, attrs, keySensitive);
-        case "EC":
-            return P11ECPrivateKeyInternal.of(session, keyID, algorithm,
+            case "EC" -> P11ECPrivateKeyInternal.of(session, keyID, algorithm,
                     keyLength, attrs, keySensitive);
-        default:
-            throw new ProviderException
+            default -> throw new ProviderException
                     ("Unknown private key algorithm " + algorithm);
-        }
+        };
     }
 
     // base class for all PKCS11 private keys
@@ -1098,7 +1087,7 @@ abstract class P11Key implements Key, Length {
                 + "\n  g: " + params.getG();
         }
         public int hashCode() {
-            if (token.isValid() == false) {
+            if (!token.isValid()) {
                 return 0;
             }
             fetchValues();
@@ -1107,14 +1096,13 @@ abstract class P11Key implements Key, Length {
         public boolean equals(Object obj) {
             if (this == obj) return true;
             // equals() should never throw exceptions
-            if (token.isValid() == false) {
+            if (!token.isValid()) {
                 return false;
             }
-            if (!(obj instanceof DHPublicKey)) {
+            if (!(obj instanceof DHPublicKey other)) {
                 return false;
             }
             fetchValues();
-            DHPublicKey other = (DHPublicKey) obj;
             DHParameterSpec otherParams = other.getParams();
             return ((this.y.compareTo(other.getY()) == 0) &&
                     (this.params.getP().compareTo(otherParams.getP()) == 0) &&

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyAgreement.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyAgreement.java
@@ -91,7 +91,7 @@ final class P11KeyAgreement extends KeyAgreementSpi {
     // see JCE spec
     protected void engineInit(Key key, SecureRandom random)
             throws InvalidKeyException {
-        if (key instanceof PrivateKey == false) {
+        if (!(key instanceof PrivateKey)) {
             throw new InvalidKeyException
                         ("Key must be instance of PrivateKey");
         }
@@ -126,7 +126,7 @@ final class P11KeyAgreement extends KeyAgreementSpi {
         // NOTE that we initialize using the P11Key, which will fail if it
         // is sensitive/unextractable. However, this is not an issue in the
         // compatibility configuration, which is all we are targeting here.
-        if ((multiPartyAgreement != null) || (lastPhase == false)) {
+        if ((multiPartyAgreement != null) || (!lastPhase)) {
             if (multiPartyAgreement == null) {
                 try {
                     multiPartyAgreement = KeyAgreement.getInstance
@@ -139,14 +139,13 @@ final class P11KeyAgreement extends KeyAgreementSpi {
             }
             return multiPartyAgreement.doPhase(key, lastPhase);
         }
-        if ((key instanceof PublicKey == false)
-                || (key.getAlgorithm().equals(algorithm) == false)) {
+        if ((!(key instanceof PublicKey))
+                || (!key.getAlgorithm().equals(algorithm))) {
             throw new InvalidKeyException
                 ("Key must be a PublicKey with algorithm DH");
         }
         BigInteger p, g, y;
-        if (key instanceof DHPublicKey) {
-            DHPublicKey dhKey = (DHPublicKey)key;
+        if (key instanceof DHPublicKey dhKey) {
 
             // validate the Diffie-Hellman public key
             KeyUtil.validate(dhKey);
@@ -176,11 +175,10 @@ final class P11KeyAgreement extends KeyAgreementSpi {
         // if parameters of private key are accessible, verify that
         // they match parameters of public key
         // XXX p and g should always be readable, even if the key is sensitive
-        if (privateKey instanceof DHPrivateKey) {
-            DHPrivateKey dhKey = (DHPrivateKey)privateKey;
+        if (privateKey instanceof DHPrivateKey dhKey) {
             DHParameterSpec params = dhKey.getParams();
-            if ((p.equals(params.getP()) == false)
-                                || (g.equals(params.getG()) == false)) {
+            if ((!p.equals(params.getP()))
+                                || (!g.equals(params.getG()))) {
                 throw new InvalidKeyException
                 ("PublicKey DH parameters must match PrivateKey DH parameters");
             }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyFactory.java
@@ -134,12 +134,11 @@ abstract class P11KeyFactory extends KeyFactorySpi {
         if (key == null) {
             throw new InvalidKeyException("Key must not be null");
         }
-        if (key.getAlgorithm().equals(this.algorithm) == false) {
+        if (!key.getAlgorithm().equals(this.algorithm)) {
             throw new InvalidKeyException
                 ("Key algorithm must be " + algorithm);
         }
-        if (key instanceof P11Key) {
-            P11Key p11Key = (P11Key)key;
+        if (key instanceof P11Key p11Key) {
             if (p11Key.token == token) {
                 // already a key of this token, no need to translate
                 return key;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyGenerator.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyGenerator.java
@@ -209,106 +209,105 @@ final class P11KeyGenerator extends KeyGeneratorSpi {
     // set default keysize and keyType
     private void setDefault() {
         significantKeySize = -1;
-        switch ((int)mechanism) {
-        case (int)CKM_DES_KEY_GEN:
-            keySize = 64;
-            keyType = CKK_DES;
-            significantKeySize = 56;
-            break;
-        case (int)CKM_DES2_KEY_GEN:
-            keySize = 128;
-            keyType = CKK_DES2;
-            significantKeySize = 112;
-            break;
-        case (int)CKM_DES3_KEY_GEN:
-            keySize = 192;
-            keyType = CKK_DES3;
-            significantKeySize = 168;
-            break;
-        case (int)CKM_AES_KEY_GEN:
-            keySize = adjustKeySize
-                    (SecurityProviderConstants.getDefAESKeySize(), range);
-            keyType = CKK_AES;
-            break;
-        case (int)CKM_RC4_KEY_GEN:
-            keySize = adjustKeySize(128, range);
-            keyType = CKK_RC4;
-            break;
-        case (int)CKM_BLOWFISH_KEY_GEN:
-            keySize = adjustKeySize(128, range);
-            keyType = CKK_BLOWFISH;
-            break;
-        case (int)CKM_CHACHA20_KEY_GEN:
-            keySize = 256;
-            keyType = CKK_CHACHA20;
-            break;
-        case (int)CKM_SHA_1_KEY_GEN:
-            keySize = adjustKeySize(160, range);
-            keyType = CKK_SHA_1_HMAC;
-            break;
-        case (int)CKM_SHA224_KEY_GEN:
-            keySize = adjustKeySize(224, range);
-            keyType = CKK_SHA224_HMAC;
-            break;
-        case (int)CKM_SHA256_KEY_GEN:
-            keySize = adjustKeySize(256, range);
-            keyType = CKK_SHA256_HMAC;
-            break;
-        case (int)CKM_SHA384_KEY_GEN:
-            keySize = adjustKeySize(384, range);
-            keyType = CKK_SHA384_HMAC;
-            break;
-        case (int)CKM_SHA512_KEY_GEN:
-            keySize = adjustKeySize(512, range);
-            keyType = CKK_SHA512_HMAC;
-            break;
-        case (int)CKM_SHA512_224_KEY_GEN:
-            keySize = adjustKeySize(224, range);
-            keyType = CKK_SHA512_224_HMAC;
-            break;
-        case (int)CKM_SHA512_256_KEY_GEN:
-            keySize = adjustKeySize(256, range);
-            keyType = CKK_SHA512_256_HMAC;
-            break;
-        case (int)CKM_SHA3_224_KEY_GEN:
-            keySize = adjustKeySize(224, range);
-            keyType = CKK_SHA3_224_HMAC;
-            break;
-        case (int)CKM_SHA3_256_KEY_GEN:
-            keySize = adjustKeySize(256, range);
-            keyType = CKK_SHA3_256_HMAC;
-            break;
-        case (int)CKM_SHA3_384_KEY_GEN:
-            keySize = adjustKeySize(384, range);
-            keyType = CKK_SHA3_384_HMAC;
-            break;
-        case (int)CKM_SHA3_512_KEY_GEN:
-            keySize = adjustKeySize(512, range);
-            keyType = CKK_SHA3_512_HMAC;
-            break;
-        case (int)CKM_GENERIC_SECRET_KEY_GEN:
-            if (algorithm.startsWith("Hmac")) {
-                String digest = algorithm.substring(4);
-                keySize = adjustKeySize(switch (digest) {
-                    case "MD5" -> 512;
-                    case "SHA1" -> 160;
-                    case "SHA224", "SHA512/224", "SHA3-224" -> 224;
-                    case "SHA256", "SHA512/256", "SHA3-256" -> 256;
-                    case "SHA384", "SHA3-384" -> 384;
-                    case "SHA512", "SHA3-512" -> 512;
-                    default -> {
-                        throw new ProviderException("Unsupported algorithm " +
-                            algorithm);
-                    }
-                }, range);
-            } else {
-                throw new ProviderException("Unsupported algorithm " +
-                        algorithm);
+        switch ((int) mechanism) {
+            case (int) CKM_DES_KEY_GEN -> {
+                keySize = 64;
+                keyType = CKK_DES;
+                significantKeySize = 56;
             }
-            keyType = CKK_GENERIC_SECRET;
-            break;
-        default:
-            throw new ProviderException("Unknown mechanism " + mechanism);
+            case (int) CKM_DES2_KEY_GEN -> {
+                keySize = 128;
+                keyType = CKK_DES2;
+                significantKeySize = 112;
+            }
+            case (int) CKM_DES3_KEY_GEN -> {
+                keySize = 192;
+                keyType = CKK_DES3;
+                significantKeySize = 168;
+            }
+            case (int) CKM_AES_KEY_GEN -> {
+                keySize = adjustKeySize
+                        (SecurityProviderConstants.getDefAESKeySize(), range);
+                keyType = CKK_AES;
+            }
+            case (int) CKM_RC4_KEY_GEN -> {
+                keySize = adjustKeySize(128, range);
+                keyType = CKK_RC4;
+            }
+            case (int) CKM_BLOWFISH_KEY_GEN -> {
+                keySize = adjustKeySize(128, range);
+                keyType = CKK_BLOWFISH;
+            }
+            case (int) CKM_CHACHA20_KEY_GEN -> {
+                keySize = 256;
+                keyType = CKK_CHACHA20;
+            }
+            case (int) CKM_SHA_1_KEY_GEN -> {
+                keySize = adjustKeySize(160, range);
+                keyType = CKK_SHA_1_HMAC;
+            }
+            case (int) CKM_SHA224_KEY_GEN -> {
+                keySize = adjustKeySize(224, range);
+                keyType = CKK_SHA224_HMAC;
+            }
+            case (int) CKM_SHA256_KEY_GEN -> {
+                keySize = adjustKeySize(256, range);
+                keyType = CKK_SHA256_HMAC;
+            }
+            case (int) CKM_SHA384_KEY_GEN -> {
+                keySize = adjustKeySize(384, range);
+                keyType = CKK_SHA384_HMAC;
+            }
+            case (int) CKM_SHA512_KEY_GEN -> {
+                keySize = adjustKeySize(512, range);
+                keyType = CKK_SHA512_HMAC;
+            }
+            case (int) CKM_SHA512_224_KEY_GEN -> {
+                keySize = adjustKeySize(224, range);
+                keyType = CKK_SHA512_224_HMAC;
+            }
+            case (int) CKM_SHA512_256_KEY_GEN -> {
+                keySize = adjustKeySize(256, range);
+                keyType = CKK_SHA512_256_HMAC;
+            }
+            case (int) CKM_SHA3_224_KEY_GEN -> {
+                keySize = adjustKeySize(224, range);
+                keyType = CKK_SHA3_224_HMAC;
+            }
+            case (int) CKM_SHA3_256_KEY_GEN -> {
+                keySize = adjustKeySize(256, range);
+                keyType = CKK_SHA3_256_HMAC;
+            }
+            case (int) CKM_SHA3_384_KEY_GEN -> {
+                keySize = adjustKeySize(384, range);
+                keyType = CKK_SHA3_384_HMAC;
+            }
+            case (int) CKM_SHA3_512_KEY_GEN -> {
+                keySize = adjustKeySize(512, range);
+                keyType = CKK_SHA3_512_HMAC;
+            }
+            case (int) CKM_GENERIC_SECRET_KEY_GEN -> {
+                if (algorithm.startsWith("Hmac")) {
+                    String digest = algorithm.substring(4);
+                    keySize = adjustKeySize(switch (digest) {
+                        case "MD5" -> 512;
+                        case "SHA1" -> 160;
+                        case "SHA224", "SHA512/224", "SHA3-224" -> 224;
+                        case "SHA256", "SHA512/256", "SHA3-256" -> 256;
+                        case "SHA384", "SHA3-384" -> 384;
+                        case "SHA512", "SHA3-512" -> 512;
+                        default -> {
+                            throw new ProviderException("Unsupported algorithm " +
+                                    algorithm);
+                        }
+                    }, range);
+                } else {
+                    throw new ProviderException("Unsupported algorithm " +
+                            algorithm);
+                }
+                keyType = CKK_GENERIC_SECRET;
+            }
+            default -> throw new ProviderException("Unknown mechanism " + mechanism);
         }
         if (significantKeySize == -1) {
             significantKeySize = keySize;
@@ -363,24 +362,18 @@ final class P11KeyGenerator extends KeyGeneratorSpi {
         Session session = null;
         try {
             session = token.getObjSession();
-            CK_ATTRIBUTE[] attributes;
+            CK_ATTRIBUTE[] attributes = switch ((int) mechanism) {
+                case (int) CKM_DES_KEY_GEN, (int) CKM_DES2_KEY_GEN, (int) CKM_DES3_KEY_GEN ->
+                    // fixed length, do not specify CKA_VALUE_LEN
+                        new CK_ATTRIBUTE[]{
+                                new CK_ATTRIBUTE(CKA_CLASS, CKO_SECRET_KEY),
+                        };
+                default -> new CK_ATTRIBUTE[]{
+                        new CK_ATTRIBUTE(CKA_CLASS, CKO_SECRET_KEY),
+                        new CK_ATTRIBUTE(CKA_VALUE_LEN, keySize >> 3),
+                };
+            };
 
-            switch ((int)mechanism) {
-            case (int)CKM_DES_KEY_GEN:
-            case (int)CKM_DES2_KEY_GEN:
-            case (int)CKM_DES3_KEY_GEN:
-                // fixed length, do not specify CKA_VALUE_LEN
-                attributes = new CK_ATTRIBUTE[] {
-                    new CK_ATTRIBUTE(CKA_CLASS, CKO_SECRET_KEY),
-                };
-                break;
-            default:
-                attributes = new CK_ATTRIBUTE[] {
-                    new CK_ATTRIBUTE(CKA_CLASS, CKO_SECRET_KEY),
-                    new CK_ATTRIBUTE(CKA_VALUE_LEN, keySize >> 3),
-                };
-                break;
-            }
             attributes = token.getAttributes
                 (O_GENERATE, CKO_SECRET_KEY, keyType, attributes);
             long keyID = token.p11.C_GenerateKey

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyPairGenerator.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyPairGenerator.java
@@ -172,63 +172,63 @@ final class P11KeyPairGenerator extends KeyPairGeneratorSpi {
             throws InvalidAlgorithmParameterException {
         token.ensureValid();
         int tmpKeySize;
-        if (algorithm.equals("DH")) {
-            if (params instanceof DHParameterSpec == false) {
-                throw new InvalidAlgorithmParameterException
-                        ("DHParameterSpec required for Diffie-Hellman");
-            }
-            DHParameterSpec dhParams = (DHParameterSpec) params;
-            tmpKeySize = dhParams.getP().bitLength();
-            checkKeySize(tmpKeySize, dhParams);
-            // XXX sanity check params
-        } else if (algorithm.equals("RSA")) {
-            if (params instanceof RSAKeyGenParameterSpec == false) {
-                throw new InvalidAlgorithmParameterException
-                        ("RSAKeyGenParameterSpec required for RSA");
-            }
-            RSAKeyGenParameterSpec rsaParams =
-                (RSAKeyGenParameterSpec) params;
-            tmpKeySize = rsaParams.getKeysize();
-            checkKeySize(tmpKeySize, rsaParams);
-            // override the supplied params to null
-            params = null;
-            this.rsaPublicExponent = rsaParams.getPublicExponent();
-            // XXX sanity check params
-        } else if (algorithm.equals("DSA")) {
-            if (params instanceof DSAParameterSpec == false) {
-                throw new InvalidAlgorithmParameterException
-                        ("DSAParameterSpec required for DSA");
-            }
-            DSAParameterSpec dsaParams = (DSAParameterSpec) params;
-            tmpKeySize = dsaParams.getP().bitLength();
-            checkKeySize(tmpKeySize, dsaParams);
-            // XXX sanity check params
-        } else if (algorithm.equals("EC")) {
-            ECParameterSpec ecParams;
-            if (params instanceof ECParameterSpec) {
-                ecParams = P11ECKeyFactory.getECParameterSpec(
-                    (ECParameterSpec)params);
-                if (ecParams == null) {
+        switch (algorithm) {
+            case "DH" -> {
+                if (!(params instanceof DHParameterSpec dhParams)) {
                     throw new InvalidAlgorithmParameterException
-                        ("Unsupported curve: " + params);
+                            ("DHParameterSpec required for Diffie-Hellman");
                 }
-            } else if (params instanceof ECGenParameterSpec) {
-                String name = ((ECGenParameterSpec) params).getName();
-                ecParams = P11ECKeyFactory.getECParameterSpec(name);
-                if (ecParams == null) {
-                    throw new InvalidAlgorithmParameterException
-                        ("Unknown curve name: " + name);
-                }
-                // override the supplied params with the derived one
-                params = ecParams;
-            } else {
-                throw new InvalidAlgorithmParameterException
-                    ("ECParameterSpec or ECGenParameterSpec required for EC");
+                tmpKeySize = dhParams.getP().bitLength();
+                checkKeySize(tmpKeySize, dhParams);
             }
-            tmpKeySize = ecParams.getCurve().getField().getFieldSize();
-            checkKeySize(tmpKeySize, ecParams);
-        } else {
-            throw new ProviderException("Unknown algorithm: " + algorithm);
+            // XXX sanity check params
+            case "RSA" -> {
+                if (!(params instanceof RSAKeyGenParameterSpec rsaParams)) {
+                    throw new InvalidAlgorithmParameterException
+                            ("RSAKeyGenParameterSpec required for RSA");
+                }
+                tmpKeySize = rsaParams.getKeysize();
+                checkKeySize(tmpKeySize, rsaParams);
+                // override the supplied params to null
+                params = null;
+                this.rsaPublicExponent = rsaParams.getPublicExponent();
+            }
+            // XXX sanity check params
+            case "DSA" -> {
+                if (!(params instanceof DSAParameterSpec dsaParams)) {
+                    throw new InvalidAlgorithmParameterException
+                            ("DSAParameterSpec required for DSA");
+                }
+                tmpKeySize = dsaParams.getP().bitLength();
+                checkKeySize(tmpKeySize, dsaParams);
+            }
+            // XXX sanity check params
+            case "EC" -> {
+                ECParameterSpec ecParams;
+                if (params instanceof ECParameterSpec) {
+                    ecParams = P11ECKeyFactory.getECParameterSpec(
+                            (ECParameterSpec) params);
+                    if (ecParams == null) {
+                        throw new InvalidAlgorithmParameterException
+                                ("Unsupported curve: " + params);
+                    }
+                } else if (params instanceof ECGenParameterSpec) {
+                    String name = ((ECGenParameterSpec) params).getName();
+                    ecParams = P11ECKeyFactory.getECParameterSpec(name);
+                    if (ecParams == null) {
+                        throw new InvalidAlgorithmParameterException
+                                ("Unknown curve name: " + name);
+                    }
+                    // override the supplied params with the derived one
+                    params = ecParams;
+                } else {
+                    throw new InvalidAlgorithmParameterException
+                            ("ECParameterSpec or ECGenParameterSpec required for EC");
+                }
+                tmpKeySize = ecParams.getCurve().getField().getFieldSize();
+                checkKeySize(tmpKeySize, ecParams);
+            }
+            default -> throw new ProviderException("Unknown algorithm: " + algorithm);
         }
         this.keySize = tmpKeySize;
         this.params = params;
@@ -337,77 +337,81 @@ final class P11KeyPairGenerator extends KeyPairGeneratorSpi {
         CK_ATTRIBUTE[] publicKeyTemplate;
         CK_ATTRIBUTE[] privateKeyTemplate;
         long keyType;
-        if (algorithm.equals("RSA")) {
-            keyType = CKK_RSA;
-            publicKeyTemplate = new CK_ATTRIBUTE[] {
-                new CK_ATTRIBUTE(CKA_MODULUS_BITS, keySize),
-                new CK_ATTRIBUTE(CKA_PUBLIC_EXPONENT, rsaPublicExponent),
-            };
-            privateKeyTemplate = new CK_ATTRIBUTE[] {
-                // empty
-            };
-        } else if (algorithm.equals("DSA")) {
-            keyType = CKK_DSA;
-            DSAParameterSpec dsaParams;
-            if (params == null) {
-                try {
-                    dsaParams = ParameterCache.getDSAParameterSpec
-                                                    (keySize, random);
-                } catch (GeneralSecurityException e) {
-                    throw new ProviderException
-                            ("Could not generate DSA parameters", e);
+        switch (algorithm) {
+            case "RSA" -> {
+                keyType = CKK_RSA;
+                publicKeyTemplate = new CK_ATTRIBUTE[]{
+                        new CK_ATTRIBUTE(CKA_MODULUS_BITS, keySize),
+                        new CK_ATTRIBUTE(CKA_PUBLIC_EXPONENT, rsaPublicExponent),
+                };
+                privateKeyTemplate = new CK_ATTRIBUTE[]{
+                        // empty
+                };
+            }
+            case "DSA" -> {
+                keyType = CKK_DSA;
+                DSAParameterSpec dsaParams;
+                if (params == null) {
+                    try {
+                        dsaParams = ParameterCache.getDSAParameterSpec
+                                (keySize, random);
+                    } catch (GeneralSecurityException e) {
+                        throw new ProviderException
+                                ("Could not generate DSA parameters", e);
+                    }
+                } else {
+                    dsaParams = (DSAParameterSpec) params;
                 }
-            } else {
-                dsaParams = (DSAParameterSpec)params;
+                publicKeyTemplate = new CK_ATTRIBUTE[]{
+                        new CK_ATTRIBUTE(CKA_PRIME, dsaParams.getP()),
+                        new CK_ATTRIBUTE(CKA_SUBPRIME, dsaParams.getQ()),
+                        new CK_ATTRIBUTE(CKA_BASE, dsaParams.getG()),
+                };
+                privateKeyTemplate = new CK_ATTRIBUTE[]{
+                        // empty
+                };
             }
-            publicKeyTemplate = new CK_ATTRIBUTE[] {
-                new CK_ATTRIBUTE(CKA_PRIME, dsaParams.getP()),
-                new CK_ATTRIBUTE(CKA_SUBPRIME, dsaParams.getQ()),
-                new CK_ATTRIBUTE(CKA_BASE, dsaParams.getG()),
-            };
-            privateKeyTemplate = new CK_ATTRIBUTE[] {
-                // empty
-            };
-        } else if (algorithm.equals("DH")) {
-            keyType = CKK_DH;
-            DHParameterSpec dhParams;
-            int privateBits;
-            if (params == null) {
-                try {
-                    dhParams = ParameterCache.getDHParameterSpec
-                                                    (keySize, random);
-                } catch (GeneralSecurityException e) {
-                    throw new ProviderException
-                            ("Could not generate DH parameters", e);
+            case "DH" -> {
+                keyType = CKK_DH;
+                DHParameterSpec dhParams;
+                int privateBits;
+                if (params == null) {
+                    try {
+                        dhParams = ParameterCache.getDHParameterSpec
+                                (keySize, random);
+                    } catch (GeneralSecurityException e) {
+                        throw new ProviderException
+                                ("Could not generate DH parameters", e);
+                    }
+                    privateBits = 0;
+                } else {
+                    dhParams = (DHParameterSpec) params;
+                    privateBits = dhParams.getL();
                 }
-                privateBits = 0;
-            } else {
-                dhParams = (DHParameterSpec)params;
-                privateBits = dhParams.getL();
+                if (privateBits <= 0) {
+                    // XXX find better defaults
+                    privateBits = (keySize >= 1024) ? 768 : 512;
+                }
+                publicKeyTemplate = new CK_ATTRIBUTE[]{
+                        new CK_ATTRIBUTE(CKA_PRIME, dhParams.getP()),
+                        new CK_ATTRIBUTE(CKA_BASE, dhParams.getG())
+                };
+                privateKeyTemplate = new CK_ATTRIBUTE[]{
+                        new CK_ATTRIBUTE(CKA_VALUE_BITS, privateBits),
+                };
             }
-            if (privateBits <= 0) {
-                // XXX find better defaults
-                privateBits = (keySize >= 1024) ? 768 : 512;
+            case "EC" -> {
+                keyType = CKK_EC;
+                byte[] encodedParams =
+                        P11ECKeyFactory.encodeParameters((ECParameterSpec) params);
+                publicKeyTemplate = new CK_ATTRIBUTE[]{
+                        new CK_ATTRIBUTE(CKA_EC_PARAMS, encodedParams),
+                };
+                privateKeyTemplate = new CK_ATTRIBUTE[]{
+                        // empty
+                };
             }
-            publicKeyTemplate = new CK_ATTRIBUTE[] {
-                new CK_ATTRIBUTE(CKA_PRIME, dhParams.getP()),
-                new CK_ATTRIBUTE(CKA_BASE, dhParams.getG())
-            };
-            privateKeyTemplate = new CK_ATTRIBUTE[] {
-                new CK_ATTRIBUTE(CKA_VALUE_BITS, privateBits),
-            };
-        } else if (algorithm.equals("EC")) {
-            keyType = CKK_EC;
-            byte[] encodedParams =
-                    P11ECKeyFactory.encodeParameters((ECParameterSpec)params);
-            publicKeyTemplate = new CK_ATTRIBUTE[] {
-                new CK_ATTRIBUTE(CKA_EC_PARAMS, encodedParams),
-            };
-            privateKeyTemplate = new CK_ATTRIBUTE[] {
-                // empty
-            };
-        } else {
-            throw new ProviderException("Unknown algorithm: " + algorithm);
+            default -> throw new ProviderException("Unknown algorithm: " + algorithm);
         }
         Session session = null;
         try {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyPairGenerator.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyPairGenerator.java
@@ -205,15 +205,14 @@ final class P11KeyPairGenerator extends KeyPairGeneratorSpi {
             // XXX sanity check params
             case "EC" -> {
                 ECParameterSpec ecParams;
-                if (params instanceof ECParameterSpec) {
-                    ecParams = P11ECKeyFactory.getECParameterSpec(
-                            (ECParameterSpec) params);
+                if (params instanceof ECParameterSpec ecParameterSpec) {
+                    ecParams = P11ECKeyFactory.getECParameterSpec(ecParameterSpec);
                     if (ecParams == null) {
                         throw new InvalidAlgorithmParameterException
                                 ("Unsupported curve: " + params);
                     }
-                } else if (params instanceof ECGenParameterSpec) {
-                    String name = ((ECGenParameterSpec) params).getName();
+                } else if (params instanceof ECGenParameterSpec ecGenParameterSpec) {
+                    String name = ecGenParameterSpec.getName();
                     ecParams = P11ECKeyFactory.getECParameterSpec(name);
                     if (ecParams == null) {
                         throw new InvalidAlgorithmParameterException

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java
@@ -779,7 +779,7 @@ final class P11KeyStore extends KeyStoreSpi {
         }
 
         try {
-            if (mapLabels() == true) {
+            if (mapLabels()) {
                 // CKA_LABELs are shared by multiple certs
                 writeDisabled = true;
             }
@@ -861,7 +861,7 @@ final class P11KeyStore extends KeyStoreSpi {
 
         try {
             login(handler);
-            if (mapLabels() == true) {
+            if (mapLabels()) {
                 // CKA_LABELs are shared by multiple certs
                 writeDisabled = true;
             }
@@ -1030,7 +1030,7 @@ final class P11KeyStore extends KeyStoreSpi {
 
         if (entry instanceof KeyStore.TrustedCertificateEntry) {
 
-            if (useSecmodTrust == false) {
+            if (!useSecmodTrust) {
                 // PKCS #11 does not allow app to modify trusted certs -
                 throw new KeyStoreException(new UnsupportedOperationException
                                     ("trusted certificates may only be set by " +
@@ -1043,10 +1043,9 @@ final class P11KeyStore extends KeyStoreSpi {
                     + "added to the NSS KeyStore module");
             }
             Certificate cert = ((TrustedCertificateEntry)entry).getTrustedCertificate();
-            if (cert instanceof X509Certificate == false) {
+            if (!(cert instanceof X509Certificate xcert)) {
                 throw new KeyStoreException("Certificate must be an X509Certificate");
             }
-            X509Certificate xcert = (X509Certificate)cert;
             AliasInfo info = aliasMap.get(alias);
             if (info != null) {
                 // XXX try to update
@@ -1122,9 +1121,8 @@ final class P11KeyStore extends KeyStoreSpi {
                     throw new KeyStoreException(pe);
                 }
 
-            } else if (entry instanceof KeyStore.SecretKeyEntry) {
+            } else if (entry instanceof SecretKeyEntry ske) {
 
-                KeyStore.SecretKeyEntry ske = (KeyStore.SecretKeyEntry)entry;
                 SecretKey skey = ske.getSecretKey();
 
                 try {
@@ -1215,7 +1213,7 @@ final class P11KeyStore extends KeyStoreSpi {
             // self signed
             return new X509Certificate[] { endCert };
         } else {
-            lChain = new ArrayList<X509Certificate>();
+            lChain = new ArrayList<>();
             lChain.add(endCert);
         }
 
@@ -1509,7 +1507,7 @@ final class P11KeyStore extends KeyStoreSpi {
         long keyID = key.getKeyID();
         try {
             session = token.getOpSession();
-            if (key.tokenObject == true) {
+            if (key.tokenObject) {
                 // token key - set new CKA_ID
 
                 CK_ATTRIBUTE[] attrs = new CK_ATTRIBUTE[] {
@@ -1549,7 +1547,7 @@ final class P11KeyStore extends KeyStoreSpi {
     private void storeCert(String alias, X509Certificate cert)
                 throws PKCS11Exception, CertificateException {
 
-        ArrayList<CK_ATTRIBUTE> attrList = new ArrayList<CK_ATTRIBUTE>();
+        ArrayList<CK_ATTRIBUTE> attrList = new ArrayList<>();
         attrList.add(ATTR_TOKEN_TRUE);
         attrList.add(ATTR_CLASS_CERT);
         attrList.add(ATTR_X509_CERT_TYPE);
@@ -1673,8 +1671,7 @@ final class P11KeyStore extends KeyStoreSpi {
         // If the key is a token object on this token, update it instead
         // of creating a duplicate key object.
         // Otherwise, treat a P11Key like any other key, if it is extractable.
-        if (key instanceof P11Key) {
-            P11Key p11Key = (P11Key)key;
+        if (key instanceof P11Key p11Key) {
             if (p11Key.tokenObject && (p11Key.token == this.token)) {
                 updateP11Pkey(alias, null, p11Key);
                 storeChain(alias, (X509Certificate[])pke.getCertificateChain());
@@ -1691,9 +1688,7 @@ final class P11KeyStore extends KeyStoreSpi {
             attrs = getRsaPrivKeyAttrs
                 (alias, (RSAPrivateKey)key, cert.getSubjectX500Principal());
 
-        } else if (key instanceof DSAPrivateKey) {
-
-            DSAPrivateKey dsaKey = (DSAPrivateKey)key;
+        } else if (key instanceof DSAPrivateKey dsaKey) {
 
             CK_ATTRIBUTE[] idAttrs = getIdAttributes(key, publicKey, false, useNDB);
             if (idAttrs[0] == null) {
@@ -1722,9 +1717,7 @@ final class P11KeyStore extends KeyStoreSpi {
                 debug.println("storePkey created DSA template");
             }
 
-        } else if (key instanceof DHPrivateKey) {
-
-            DHPrivateKey dhKey = (DHPrivateKey)key;
+        } else if (key instanceof DHPrivateKey dhKey) {
 
             CK_ATTRIBUTE[] idAttrs = getIdAttributes(key, publicKey, false, useNDB);
             if (idAttrs[0] == null) {
@@ -1748,9 +1741,7 @@ final class P11KeyStore extends KeyStoreSpi {
             attrs = token.getAttributes
                 (TemplateManager.O_IMPORT, CKO_PRIVATE_KEY, CKK_DH, attrs);
 
-        } else if (key instanceof ECPrivateKey) {
-
-            ECPrivateKey ecKey = (ECPrivateKey)key;
+        } else if (key instanceof ECPrivateKey ecKey) {
 
             CK_ATTRIBUTE[] idAttrs = getIdAttributes(key, publicKey, false, useNDB);
             if (idAttrs[0] == null) {
@@ -1779,9 +1770,8 @@ final class P11KeyStore extends KeyStoreSpi {
                 debug.println("storePkey created EC template");
             }
 
-        } else if (key instanceof P11Key) {
+        } else if (key instanceof P11Key p11Key) {
             // sensitive/non-extractable P11Key
-            P11Key p11Key = (P11Key)key;
             if (p11Key.token != this.token) {
                 throw new KeyStoreException
                     ("Cannot move sensitive keys across tokens");
@@ -1831,13 +1821,11 @@ final class P11KeyStore extends KeyStoreSpi {
         // subject is currently ignored - could be used to set CKA_SUBJECT
 
         CK_ATTRIBUTE[] attrs = null;
-        if (key instanceof RSAPrivateCrtKey) {
+        if (key instanceof RSAPrivateCrtKey rsaKey) {
 
             if (debug != null) {
                 debug.println("creating RSAPrivateCrtKey attrs");
             }
-
-            RSAPrivateCrtKey rsaKey = (RSAPrivateCrtKey)key;
 
             attrs = new CK_ATTRIBUTE[] {
                 ATTR_TOKEN_TRUE,
@@ -1870,8 +1858,6 @@ final class P11KeyStore extends KeyStoreSpi {
                 debug.println("creating RSAPrivateKey attrs");
             }
 
-            RSAPrivateKey rsaKey = key;
-
             attrs = new CK_ATTRIBUTE[] {
                 ATTR_TOKEN_TRUE,
                 ATTR_CLASS_PKEY,
@@ -1879,9 +1865,9 @@ final class P11KeyStore extends KeyStoreSpi {
                 new CK_ATTRIBUTE(CKA_KEY_TYPE, CKK_RSA),
                 new CK_ATTRIBUTE(CKA_ID, alias),
                 new CK_ATTRIBUTE(CKA_MODULUS,
-                                rsaKey.getModulus()),
+                                key.getModulus()),
                 new CK_ATTRIBUTE(CKA_PRIVATE_EXPONENT,
-                                rsaKey.getPrivateExponent()) };
+                                key.getPrivateExponent()) };
             attrs = token.getAttributes
                 (TemplateManager.O_IMPORT, CKO_PRIVATE_KEY, CKK_RSA, attrs);
         }
@@ -1905,7 +1891,7 @@ final class P11KeyStore extends KeyStoreSpi {
     private CK_ATTRIBUTE[] getIdAttributes(PrivateKey privateKey,
             PublicKey publicKey, boolean id, boolean netscapeDb) {
         CK_ATTRIBUTE[] attrs = new CK_ATTRIBUTE[2];
-        if ((id || netscapeDb) == false) {
+        if (!(id || netscapeDb)) {
             return attrs;
         }
         String alg = privateKey.getAlgorithm();
@@ -2010,7 +1996,7 @@ final class P11KeyStore extends KeyStoreSpi {
 
                 if (next.getSubjectX500Principal().equals
                     (next.getIssuerX500Principal())) {
-                    // self signed - done
+                    // self-signed - done
                     break;
                 }
 
@@ -2233,7 +2219,7 @@ final class P11KeyStore extends KeyStoreSpi {
 
             if (type == ATTR_CLASS_SKEY) {
 
-                ArrayList<THandle> list = new ArrayList<THandle>(h.length);
+                ArrayList<THandle> list = new ArrayList<>(h.length);
                 for (int i = 0; i < h.length; i++) {
 
                     CK_ATTRIBUTE[] label = new CK_ATTRIBUTE[]
@@ -2299,7 +2285,7 @@ final class P11KeyStore extends KeyStoreSpi {
 
             // get all private key CKA_IDs
 
-            ArrayList<byte[]> pkeyIDs = new ArrayList<byte[]>();
+            ArrayList<byte[]> pkeyIDs = new ArrayList<>();
             CK_ATTRIBUTE[] attrs = new CK_ATTRIBUTE[] {
                 ATTR_TOKEN_TRUE,
                 ATTR_CLASS_PKEY,
@@ -2326,7 +2312,7 @@ final class P11KeyStore extends KeyStoreSpi {
             // (multiple certs may be mapped to a single CKA_LABEL)
 
             HashMap<String, HashSet<AliasInfo>> certMap =
-                                new HashMap<String, HashSet<AliasInfo>>();
+                                new HashMap<>();
 
             attrs = new CK_ATTRIBUTE[] {
                 ATTR_TOKEN_TRUE,
@@ -2399,11 +2385,7 @@ final class P11KeyStore extends KeyStoreSpi {
                     }
                 }
 
-                HashSet<AliasInfo> infoSet = certMap.get(cka_label);
-                if (infoSet == null) {
-                    infoSet = new HashSet<AliasInfo>(2);
-                    certMap.put(cka_label, infoSet);
-                }
+                HashSet<AliasInfo> infoSet = certMap.computeIfAbsent(cka_label, k -> new HashSet<>(2));
 
                 // initially create private key entry AliasInfo entries -
                 // these entries will get resolved into their true
@@ -2421,7 +2403,7 @@ final class P11KeyStore extends KeyStoreSpi {
             // or between a secret key and another object),
             // throw an exception
             HashMap<String, AliasInfo> sKeyMap =
-                    new HashMap<String, AliasInfo>();
+                    new HashMap<>();
 
             attrs = new CK_ATTRIBUTE[] {
                 ATTR_SKEY_TOKEN_TRUE,
@@ -2477,10 +2459,10 @@ final class P11KeyStore extends KeyStoreSpi {
                 throws PKCS11Exception, CertificateException {
 
         // reset global alias map
-        aliasMap = new HashMap<String, AliasInfo>();
+        aliasMap = new HashMap<>();
 
         // list of matched certs that we will return
-        ArrayList<AliasInfo> matchedCerts = new ArrayList<AliasInfo>();
+        ArrayList<AliasInfo> matchedCerts = new ArrayList<>();
 
         for (byte[] pkeyID : pkeyIDs) {
 
@@ -2566,7 +2548,7 @@ final class P11KeyStore extends KeyStoreSpi {
             HashSet<AliasInfo> infoSet = certMap.get(certLabel);
             for (AliasInfo aliasInfo : infoSet) {
 
-                if (aliasInfo.matched == true) {
+                if (aliasInfo.matched) {
                     // already found a private key match for this cert -
                     // just continue
                     aliasInfo.trusted = false;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyWrapCipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyWrapCipher.java
@@ -345,14 +345,10 @@ final class P11KeyWrapCipher extends CipherSpi {
                     session = token.getOpSession();
                 }
                 switch (opmode) {
-                case Cipher.ENCRYPT_MODE:
-                    token.p11.C_EncryptInit(session.id(), mechWithParams,
+                    case Cipher.ENCRYPT_MODE -> token.p11.C_EncryptInit(session.id(), mechWithParams,
                             p11KeyID);
-                break;
-                case Cipher.DECRYPT_MODE:
-                    token.p11.C_DecryptInit(session.id(), mechWithParams,
+                    case Cipher.DECRYPT_MODE -> token.p11.C_DecryptInit(session.id(), mechWithParams,
                             p11KeyID);
-                break;
                 }
             } catch (PKCS11Exception e) {
                 session = token.releaseSession(session);
@@ -386,7 +382,7 @@ final class P11KeyWrapCipher extends CipherSpi {
         } else {
             result -= BLK_SIZE; // minus the leading block including the ICV
         }
-        return (result > 0 ? result : 0);
+        return (Math.max(result, 0));
     }
 
     // reset the states to the pre-initialized values
@@ -744,20 +740,20 @@ final class P11KeyWrapCipher extends CipherSpi {
         long keyClass;
         long keyType;
         switch (wrappedKeyType) {
-            case Cipher.PRIVATE_KEY:
+            case Cipher.PRIVATE_KEY -> {
                 keyClass = CKO_PRIVATE_KEY;
                 keyType = P11KeyFactory.getPKCS11KeyType(wrappedKeyAlgo);
-                break;
-            case Cipher.SECRET_KEY:
+            }
+            case Cipher.SECRET_KEY -> {
                 keyClass = CKO_SECRET_KEY;
                 keyType = P11SecretKeyFactory.getPKCS11KeyType(wrappedKeyAlgo);
-                break;
-            case Cipher.PUBLIC_KEY:
-                throw new UnsupportedOperationException
-                        ("cannot unwrap public keys");
-            default: // should never happen
-                throw new AssertionError();
-        };
+            }
+            case Cipher.PUBLIC_KEY -> throw new UnsupportedOperationException
+                    ("cannot unwrap public keys");
+            default -> // should never happen
+                    throw new AssertionError();
+        }
+        ;
 
         CK_ATTRIBUTE[] attributes;
         try {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyWrapCipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyWrapCipher.java
@@ -753,7 +753,6 @@ final class P11KeyWrapCipher extends CipherSpi {
             default -> // should never happen
                     throw new AssertionError();
         }
-        ;
 
         CK_ATTRIBUTE[] attributes;
         try {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
@@ -85,42 +85,23 @@ final class P11Mac extends MacSpi {
         this.token = token;
         this.algorithm = algorithm;
         Long params = null;
-        switch ((int)mechanism) {
-        case (int)CKM_MD5_HMAC:
-            macLength = 16;
-            break;
-        case (int)CKM_SHA_1_HMAC:
-            macLength = 20;
-            break;
-        case (int)CKM_SHA224_HMAC:
-        case (int)CKM_SHA512_224_HMAC:
-        case (int)CKM_SHA3_224_HMAC:
-            macLength = 28;
-            break;
-        case (int)CKM_SHA256_HMAC:
-        case (int)CKM_SHA512_256_HMAC:
-        case (int)CKM_SHA3_256_HMAC:
-            macLength = 32;
-            break;
-        case (int)CKM_SHA384_HMAC:
-        case (int)CKM_SHA3_384_HMAC:
-            macLength = 48;
-            break;
-        case (int)CKM_SHA512_HMAC:
-        case (int)CKM_SHA3_512_HMAC:
-            macLength = 64;
-            break;
-        case (int)CKM_SSL3_MD5_MAC:
-            macLength = 16;
-            params = Long.valueOf(16);
-            break;
-        case (int)CKM_SSL3_SHA1_MAC:
-            macLength = 20;
-            params = Long.valueOf(20);
-            break;
-        default:
-            throw new ProviderException("Unknown mechanism: " + mechanism);
-        }
+        macLength = switch ((int) mechanism) {
+            case (int) CKM_MD5_HMAC -> 16;
+            case (int) CKM_SHA_1_HMAC -> 20;
+            case (int) CKM_SHA224_HMAC, (int) CKM_SHA512_224_HMAC, (int) CKM_SHA3_224_HMAC -> 28;
+            case (int) CKM_SHA256_HMAC, (int) CKM_SHA512_256_HMAC, (int) CKM_SHA3_256_HMAC -> 32;
+            case (int) CKM_SHA384_HMAC, (int) CKM_SHA3_384_HMAC -> 48;
+            case (int) CKM_SHA512_HMAC, (int) CKM_SHA3_512_HMAC -> 64;
+            case (int) CKM_SSL3_MD5_MAC -> {
+                params = Long.valueOf(16);
+                yield 16;
+            }
+            case (int) CKM_SSL3_SHA1_MAC -> {
+                params = Long.valueOf(20);
+                yield 20;
+            }
+            default -> throw new ProviderException("Unknown mechanism: " + mechanism);
+        };
         ckMechanism = new CK_MECHANISM(mechanism, params);
     }
 
@@ -265,11 +246,11 @@ final class P11Mac extends MacSpi {
             if (len <= 0) {
                 return;
             }
-            if (byteBuffer instanceof DirectBuffer == false) {
+            if (!(byteBuffer instanceof DirectBuffer directBuffer)) {
                 super.engineUpdate(byteBuffer);
                 return;
             }
-            long addr = ((DirectBuffer)byteBuffer).address();
+            long addr = directBuffer.address();
             int ofs = byteBuffer.position();
             token.p11.C_SignUpdate(session.id(), addr + ofs, null, 0, len);
             byteBuffer.position(ofs + len);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PSSSignature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PSSSignature.java
@@ -71,8 +71,7 @@ final class P11PSSSignature extends SignatureSpi {
     private static final boolean DEBUG = false;
 
     // mappings of digest algorithms and their output length in bytes
-    private static final Hashtable<String, Integer> DIGEST_LENGTHS =
-        new Hashtable<String, Integer>();
+    private static final Hashtable<String, Integer> DIGEST_LENGTHS = new Hashtable<>();
 
     static {
         DIGEST_LENGTHS.put("SHA-1", 20);
@@ -173,32 +172,31 @@ final class P11PSSSignature extends SignatureSpi {
         this.mdAlg = (idx == -1 ?
                 null : toStdName(algorithm.substring(0, idx)));
 
-        switch ((int)mechId) {
-        case (int)CKM_SHA1_RSA_PKCS_PSS:
-        case (int)CKM_SHA224_RSA_PKCS_PSS:
-        case (int)CKM_SHA256_RSA_PKCS_PSS:
-        case (int)CKM_SHA384_RSA_PKCS_PSS:
-        case (int)CKM_SHA512_RSA_PKCS_PSS:
-        case (int)CKM_SHA3_224_RSA_PKCS_PSS:
-        case (int)CKM_SHA3_256_RSA_PKCS_PSS:
-        case (int)CKM_SHA3_384_RSA_PKCS_PSS:
-        case (int)CKM_SHA3_512_RSA_PKCS_PSS:
-            type = T_UPDATE;
-            this.md = null;
-            break;
-        case (int)CKM_RSA_PKCS_PSS:
-            // check if the digest algo is supported by underlying PKCS11 lib
-            if (this.mdAlg != null && token.getMechanismInfo
-                    (Functions.getHashMechId(this.mdAlg)) == null) {
-                throw new NoSuchAlgorithmException("Unsupported algorithm: " +
-                        algorithm);
+        switch ((int) mechId) {
+            case (int) CKM_SHA1_RSA_PKCS_PSS,
+                 (int) CKM_SHA224_RSA_PKCS_PSS,
+                 (int) CKM_SHA256_RSA_PKCS_PSS,
+                 (int) CKM_SHA384_RSA_PKCS_PSS,
+                 (int) CKM_SHA512_RSA_PKCS_PSS,
+                 (int) CKM_SHA3_224_RSA_PKCS_PSS,
+                 (int) CKM_SHA3_256_RSA_PKCS_PSS,
+                 (int) CKM_SHA3_384_RSA_PKCS_PSS,
+                 (int) CKM_SHA3_512_RSA_PKCS_PSS -> {
+                type = T_UPDATE;
+                this.md = null;
             }
-            this.md = (this.mdAlg == null ? null :
-                    MessageDigest.getInstance(this.mdAlg));
-            type = T_DIGEST;
-            break;
-        default:
-            throw new ProviderException("Unsupported mechanism: " + mechId);
+            case (int) CKM_RSA_PKCS_PSS -> {
+                // check if the digest algo is supported by underlying PKCS11 lib
+                if (this.mdAlg != null && token.getMechanismInfo
+                        (Functions.getHashMechId(this.mdAlg)) == null) {
+                    throw new NoSuchAlgorithmException("Unsupported algorithm: " +
+                            algorithm);
+                }
+                this.md = (this.mdAlg == null ? null :
+                        MessageDigest.getInstance(this.mdAlg));
+                type = T_DIGEST;
+            }
+            default -> throw new ProviderException("Unsupported mechanism: " + mechId);
         }
     }
 
@@ -235,7 +233,7 @@ final class P11PSSSignature extends SignatureSpi {
                     this.mdAlg, "MGF1", this.mdAlg, sigParams.getSaltLength()));
         }
 
-        if (initialized == false) {
+        if (!initialized) {
             try {
                 initialize();
             } catch (ProviderException pe) {
@@ -413,12 +411,11 @@ final class P11PSSSignature extends SignatureSpi {
         if (p == null) {
             throw new InvalidAlgorithmParameterException("PSS Parameter required");
         }
-        if (!(p instanceof PSSParameterSpec)) {
+        if (!(p instanceof PSSParameterSpec params)) {
             throw new InvalidAlgorithmParameterException
                 ("Only PSSParameterSpec is supported");
         }
         // no need to validate again if same as current signature parameters
-        PSSParameterSpec params = (PSSParameterSpec) p;
         if (params == this.sigParams) return;
 
         String digestAlgorithm = params.getDigestAlgorithm();
@@ -615,42 +612,43 @@ final class P11PSSSignature extends SignatureSpi {
         }
         isActive = true;
         switch (type) {
-        case T_UPDATE:
-            if (byteBuffer instanceof DirectBuffer == false) {
-                // cannot do better than default impl
-                super.engineUpdate(byteBuffer);
-                return;
-            }
-            long addr = ((DirectBuffer)byteBuffer).address();
-            int ofs = byteBuffer.position();
-            try {
-                if (mode == M_SIGN) {
-                    if (DEBUG) System.out.println(this + ": Calling C_SignUpdate");
-                    token.p11.C_SignUpdate
-                        (session.id(), addr + ofs, null, 0, len);
-                } else {
-                    if (DEBUG) System.out.println(this + ": Calling C_VerifyUpdate");
-                    token.p11.C_VerifyUpdate
-                        (session.id(), addr + ofs, null, 0, len);
+            case T_UPDATE -> {
+                if (byteBuffer instanceof DirectBuffer == false) {
+                    // cannot do better than default impl
+                    super.engineUpdate(byteBuffer);
+                    return;
                 }
+                long addr = ((DirectBuffer) byteBuffer).address();
+                int ofs = byteBuffer.position();
+                try {
+                    if (mode == M_SIGN) {
+                        if (DEBUG) System.out.println(this + ": Calling C_SignUpdate");
+                        token.p11.C_SignUpdate
+                                (session.id(), addr + ofs, null, 0, len);
+                    } else {
+                        if (DEBUG) System.out.println(this + ": Calling C_VerifyUpdate");
+                        token.p11.C_VerifyUpdate
+                                (session.id(), addr + ofs, null, 0, len);
+                    }
+                    bytesProcessed += len;
+                    byteBuffer.position(ofs + len);
+                } catch (PKCS11Exception e) {
+                    reset(false);
+                    throw new ProviderException("Update failed", e);
+                }
+            }
+            case T_DIGEST -> {
+                // should not happen as this should be covered by earlier checks
+                if (md == null) {
+                    throw new ProviderException("PSS Parameters required");
+                }
+                md.update(byteBuffer);
                 bytesProcessed += len;
-                byteBuffer.position(ofs + len);
-            } catch (PKCS11Exception e) {
+            }
+            default -> {
                 reset(false);
-                throw new ProviderException("Update failed", e);
+                throw new ProviderException("Internal error");
             }
-            break;
-        case T_DIGEST:
-            // should not happen as this should be covered by earlier checks
-            if (md == null) {
-                throw new ProviderException("PSS Parameters required");
-            }
-            md.update(byteBuffer);
-            bytesProcessed += len;
-            break;
-        default:
-            reset(false);
-            throw new ProviderException("Internal error");
         }
     }
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11RSACipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11RSACipher.java
@@ -122,7 +122,7 @@ final class P11RSACipher extends CipherSpi {
     // modes do not make sense for RSA, but allow ECB
     // see JCE spec
     protected void engineSetMode(String mode) throws NoSuchAlgorithmException {
-        if (mode.equalsIgnoreCase("ECB") == false) {
+        if (!mode.equalsIgnoreCase("ECB")) {
             throw new NoSuchAlgorithmException("Unsupported mode " + mode);
         }
     }
@@ -205,7 +205,7 @@ final class P11RSACipher extends CipherSpi {
         } else if (opmode == Cipher.DECRYPT_MODE) {
             encrypt = false;
         } else if (opmode == Cipher.WRAP_MODE) {
-            if (p11Key.isPublic() == false) {
+            if (!p11Key.isPublic()) {
                 throw new InvalidKeyException
                                 ("Wrap has to be used with public keys");
             }
@@ -213,7 +213,7 @@ final class P11RSACipher extends CipherSpi {
             // we can't use C_Wrap().
             return;
         } else if (opmode == Cipher.UNWRAP_MODE) {
-            if (p11Key.isPrivate() == false) {
+            if (!p11Key.isPrivate()) {
                 throw new InvalidKeyException
                                 ("Unwrap has to be used with private keys");
             }
@@ -289,22 +289,15 @@ final class P11RSACipher extends CipherSpi {
             int outLen = buffer.length;
             long sessId = session.id();
             switch (mode) {
-            case MODE_ENCRYPT:
-                p11.C_Encrypt(sessId, 0, buffer, 0, inLen, 0, buffer, 0, outLen);
-                break;
-            case MODE_DECRYPT:
-                p11.C_Decrypt(sessId, 0, buffer, 0, inLen, 0, buffer, 0, outLen);
-                break;
-            case MODE_SIGN:
-                byte[] tmpBuffer = new byte[maxInputSize];
-                p11.C_Sign(sessId, tmpBuffer);
-                break;
-            case MODE_VERIFY:
-                p11.C_VerifyRecover(sessId, buffer, 0, inLen, buffer,
+                case MODE_ENCRYPT -> p11.C_Encrypt(sessId, 0, buffer, 0, inLen, 0, buffer, 0, outLen);
+                case MODE_DECRYPT -> p11.C_Decrypt(sessId, 0, buffer, 0, inLen, 0, buffer, 0, outLen);
+                case MODE_SIGN -> {
+                    byte[] tmpBuffer = new byte[maxInputSize];
+                    p11.C_Sign(sessId, tmpBuffer);
+                }
+                case MODE_VERIFY -> p11.C_VerifyRecover(sessId, buffer, 0, inLen, buffer,
                         0, outLen);
-                break;
-            default:
-                throw new ProviderException("internal error");
+                default -> throw new ProviderException("internal error");
             }
         } catch (PKCS11Exception e) {
             // XXX ensure this always works, ignore error
@@ -332,20 +325,11 @@ final class P11RSACipher extends CipherSpi {
             PKCS11 p11 = token.p11;
             CK_MECHANISM ckMechanism = new CK_MECHANISM(mechanism);
             switch (mode) {
-            case MODE_ENCRYPT:
-                p11.C_EncryptInit(session.id(), ckMechanism, keyID);
-                break;
-            case MODE_DECRYPT:
-                p11.C_DecryptInit(session.id(), ckMechanism, keyID);
-                break;
-            case MODE_SIGN:
-                p11.C_SignInit(session.id(), ckMechanism, keyID);
-                break;
-            case MODE_VERIFY:
-                p11.C_VerifyRecoverInit(session.id(), ckMechanism, keyID);
-                break;
-            default:
-                throw new AssertionError("internal error");
+                case MODE_ENCRYPT -> p11.C_EncryptInit(session.id(), ckMechanism, keyID);
+                case MODE_DECRYPT -> p11.C_DecryptInit(session.id(), ckMechanism, keyID);
+                case MODE_SIGN -> p11.C_SignInit(session.id(), ckMechanism, keyID);
+                case MODE_VERIFY -> p11.C_VerifyRecoverInit(session.id(), ckMechanism, keyID);
+                default -> throw new AssertionError("internal error");
             }
             bufOfs = 0;
             initialized = true;
@@ -385,32 +369,25 @@ final class P11RSACipher extends CipherSpi {
             PKCS11 p11 = token.p11;
             int n;
             switch (mode) {
-            case MODE_ENCRYPT:
-                n = p11.C_Encrypt
+                case MODE_ENCRYPT -> n = p11.C_Encrypt
                         (session.id(), 0, buffer, 0, bufOfs, 0, out, outOfs, outLen);
-                break;
-            case MODE_DECRYPT:
-                n = p11.C_Decrypt
+                case MODE_DECRYPT -> n = p11.C_Decrypt
                         (session.id(), 0, buffer, 0, bufOfs, 0, out, outOfs, outLen);
-                break;
-            case MODE_SIGN:
-                byte[] tmpBuffer = new byte[bufOfs];
-                System.arraycopy(buffer, 0, tmpBuffer, 0, bufOfs);
-                tmpBuffer = p11.C_Sign(session.id(), tmpBuffer);
-                if (tmpBuffer.length > outLen) {
-                    throw new BadPaddingException(
-                        "Output buffer (" + outLen + ") is too small to " +
-                        "hold the produced data (" + tmpBuffer.length + ")");
+                case MODE_SIGN -> {
+                    byte[] tmpBuffer = new byte[bufOfs];
+                    System.arraycopy(buffer, 0, tmpBuffer, 0, bufOfs);
+                    tmpBuffer = p11.C_Sign(session.id(), tmpBuffer);
+                    if (tmpBuffer.length > outLen) {
+                        throw new BadPaddingException(
+                                "Output buffer (" + outLen + ") is too small to " +
+                                        "hold the produced data (" + tmpBuffer.length + ")");
+                    }
+                    System.arraycopy(tmpBuffer, 0, out, outOfs, tmpBuffer.length);
+                    n = tmpBuffer.length;
                 }
-                System.arraycopy(tmpBuffer, 0, out, outOfs, tmpBuffer.length);
-                n = tmpBuffer.length;
-                break;
-            case MODE_VERIFY:
-                n = p11.C_VerifyRecover
+                case MODE_VERIFY -> n = p11.C_VerifyRecover
                         (session.id(), buffer, 0, bufOfs, out, outOfs, outLen);
-                break;
-            default:
-                throw new ProviderException("internal error");
+                default -> throw new ProviderException("internal error");
             }
             return n;
         } catch (PKCS11Exception e) {
@@ -711,15 +688,11 @@ final class ConstructKeys {
 
     static final Key constructKey(byte[] encoding, String keyAlgorithm,
             int keyType) throws InvalidKeyException, NoSuchAlgorithmException {
-        switch (keyType) {
-        case Cipher.SECRET_KEY:
-            return constructSecretKey(encoding, keyAlgorithm);
-        case Cipher.PRIVATE_KEY:
-            return constructPrivateKey(encoding, keyAlgorithm);
-        case Cipher.PUBLIC_KEY:
-            return constructPublicKey(encoding, keyAlgorithm);
-        default:
-            throw new InvalidKeyException("Unknown keytype " + keyType);
-        }
+        return switch (keyType) {
+            case Cipher.SECRET_KEY -> constructSecretKey(encoding, keyAlgorithm);
+            case Cipher.PRIVATE_KEY -> constructPrivateKey(encoding, keyAlgorithm);
+            case Cipher.PUBLIC_KEY -> constructPublicKey(encoding, keyAlgorithm);
+            default -> throw new InvalidKeyException("Unknown keytype " + keyType);
+        };
     }
 }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11RSACipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11RSACipher.java
@@ -367,11 +367,10 @@ final class P11RSACipher extends CipherSpi {
         try {
             ensureInitialized();
             PKCS11 p11 = token.p11;
-            int n;
-            switch (mode) {
-                case MODE_ENCRYPT -> n = p11.C_Encrypt
+            return switch (mode) {
+                case MODE_ENCRYPT -> p11.C_Encrypt
                         (session.id(), 0, buffer, 0, bufOfs, 0, out, outOfs, outLen);
-                case MODE_DECRYPT -> n = p11.C_Decrypt
+                case MODE_DECRYPT ->  p11.C_Decrypt
                         (session.id(), 0, buffer, 0, bufOfs, 0, out, outOfs, outLen);
                 case MODE_SIGN -> {
                     byte[] tmpBuffer = new byte[bufOfs];
@@ -383,13 +382,12 @@ final class P11RSACipher extends CipherSpi {
                                         "hold the produced data (" + tmpBuffer.length + ")");
                     }
                     System.arraycopy(tmpBuffer, 0, out, outOfs, tmpBuffer.length);
-                    n = tmpBuffer.length;
+                    yield tmpBuffer.length;
                 }
-                case MODE_VERIFY -> n = p11.C_VerifyRecover
+                case MODE_VERIFY -> p11.C_VerifyRecover
                         (session.id(), buffer, 0, bufOfs, out, outOfs, outLen);
                 default -> throw new ProviderException("internal error");
-            }
-            return n;
+            };
         } catch (PKCS11Exception e) {
             throw (BadPaddingException)new BadPaddingException
                 ("doFinal() failed").initCause(e);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11RSAKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11RSAKeyFactory.java
@@ -54,8 +54,7 @@ final class P11RSAKeyFactory extends P11KeyFactory {
 
     PublicKey implTranslatePublicKey(PublicKey key) throws InvalidKeyException {
         try {
-            if (key instanceof RSAPublicKey) {
-                RSAPublicKey rsaKey = (RSAPublicKey)key;
+            if (key instanceof RSAPublicKey rsaKey) {
                 return generatePublic(
                     rsaKey.getModulus(),
                     rsaKey.getPublicExponent()
@@ -74,8 +73,7 @@ final class P11RSAKeyFactory extends P11KeyFactory {
     PrivateKey implTranslatePrivateKey(PrivateKey key)
             throws InvalidKeyException {
         try {
-            if (key instanceof RSAPrivateCrtKey) {
-                RSAPrivateCrtKey rsaKey = (RSAPrivateCrtKey)key;
+            if (key instanceof RSAPrivateCrtKey rsaKey) {
                 return generatePrivate(
                     rsaKey.getModulus(),
                     rsaKey.getPublicExponent(),
@@ -86,8 +84,7 @@ final class P11RSAKeyFactory extends P11KeyFactory {
                     rsaKey.getPrimeExponentQ(),
                     rsaKey.getCrtCoefficient()
                 );
-            } else if (key instanceof RSAPrivateKey) {
-                RSAPrivateKey rsaKey = (RSAPrivateKey)key;
+            } else if (key instanceof RSAPrivateKey rsaKey) {
                 return generatePrivate(
                     rsaKey.getModulus(),
                     rsaKey.getPrivateExponent()
@@ -117,7 +114,7 @@ final class P11RSAKeyFactory extends P11KeyFactory {
                         ("Could not create RSA public key", e);
             }
         }
-        if (keySpec instanceof RSAPublicKeySpec == false) {
+        if (!(keySpec instanceof RSAPublicKeySpec)) {
             throw new InvalidKeySpecException("Only RSAPublicKeySpec and "
                 + "X509EncodedKeySpec supported for RSA public keys");
         }
@@ -288,8 +285,7 @@ final class P11RSAKeyFactory extends P11KeyFactory {
         // that existing logic.
         if (keySpec.isAssignableFrom(RSAPrivateCrtKeySpec.class)) {
             // All supported keyspecs (other than PKCS8EncodedKeySpec) descend from RSAPrivateCrtKeySpec
-            if (key instanceof RSAPrivateCrtKey) {
-                RSAPrivateCrtKey crtKey = (RSAPrivateCrtKey)key;
+            if (key instanceof RSAPrivateCrtKey crtKey) {
                 return keySpec.cast(new RSAPrivateCrtKeySpec(
                     crtKey.getModulus(),
                     crtKey.getPublicExponent(),
@@ -307,7 +303,7 @@ final class P11RSAKeyFactory extends P11KeyFactory {
                         ("RSAPrivateCrtKeySpec can only be used with CRT keys");
                 }
 
-                if (!(key instanceof RSAPrivateKey)) {
+                if (!(key instanceof RSAPrivateKey rsaKey)) {
                     // We should never reach here as P11Key.privateKey() should always produce an instance
                     // of RSAPrivateKey when the RSA key is both extractable and non-sensitive.
                     throw new InvalidKeySpecException
@@ -315,7 +311,6 @@ final class P11RSAKeyFactory extends P11KeyFactory {
                 }
 
                 // fall through to RSAPrivateKey (non-CRT)
-                RSAPrivateKey rsaKey = (RSAPrivateKey) key;
                 return keySpec.cast(new RSAPrivateKeySpec(
                     rsaKey.getModulus(),
                     rsaKey.getPrivateExponent(),

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
@@ -136,7 +136,7 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
         if (key == null) {
             throw new InvalidKeyException("Key must not be null");
         }
-        if (key instanceof SecretKey == false) {
+        if (!(key instanceof SecretKey)) {
             throw new InvalidKeyException("Key must be a SecretKey");
         }
         long algoType;
@@ -155,8 +155,7 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
                 }
             }
         }
-        if (key instanceof P11Key) {
-            P11Key p11Key = (P11Key)key;
+        if (key instanceof P11Key p11Key) {
             if (p11Key.token == token) {
                 if (extraAttrs != null) {
                     P11Key newP11Key = null;
@@ -185,7 +184,7 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
         if (p11Key != null) {
             return p11Key;
         }
-        if ("RAW".equalsIgnoreCase(key.getFormat()) == false) {
+        if (!"RAW".equalsIgnoreCase(key.getFormat())) {
             throw new InvalidKeyException("Encoded format must be RAW");
         }
         byte[] encoded = key.getEncoded();
@@ -208,15 +207,15 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
         int n = encoded.length << 3;
         int keyLength = n;
         try {
-            switch ((int)keyType) {
-                case (int)CKK_DES:
+            switch ((int) keyType) {
+                case (int) CKK_DES -> {
                     keyLength =
-                        P11KeyGenerator.checkKeySize(CKM_DES_KEY_GEN, n, token);
+                            P11KeyGenerator.checkKeySize(CKM_DES_KEY_GEN, n, token);
                     fixDESParity(encoded, 0);
-                    break;
-                case (int)CKK_DES3:
+                }
+                case (int) CKK_DES3 -> {
                     keyLength =
-                        P11KeyGenerator.checkKeySize(CKM_DES3_KEY_GEN, n, token);
+                            P11KeyGenerator.checkKeySize(CKM_DES3_KEY_GEN, n, token);
                     fixDESParity(encoded, 0);
                     fixDESParity(encoded, 8);
                     if (keyLength == 112) {
@@ -225,41 +224,27 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
                         keyType = CKK_DES3;
                         fixDESParity(encoded, 16);
                     }
-                    break;
-                case (int)CKK_AES:
-                    keyLength =
+                }
+                case (int) CKK_AES -> keyLength =
                         P11KeyGenerator.checkKeySize(CKM_AES_KEY_GEN, n, token);
-                    break;
-                case (int)CKK_RC4:
-                    keyLength =
+                case (int) CKK_RC4 -> keyLength =
                         P11KeyGenerator.checkKeySize(CKM_RC4_KEY_GEN, n, token);
-                    break;
-                case (int)CKK_BLOWFISH:
-                    keyLength =
+                case (int) CKK_BLOWFISH -> keyLength =
                         P11KeyGenerator.checkKeySize(CKM_BLOWFISH_KEY_GEN, n,
-                        token);
-                    break;
-                case (int)CKK_CHACHA20:
-                    keyLength = P11KeyGenerator.checkKeySize(
+                                token);
+                case (int) CKK_CHACHA20 -> keyLength = P11KeyGenerator.checkKeySize(
                         CKM_CHACHA20_KEY_GEN, n, token);
-                    break;
-                case (int)CKK_GENERIC_SECRET:
-                case (int)PCKK_TLSPREMASTER:
-                case (int)PCKK_TLSRSAPREMASTER:
-                case (int)PCKK_TLSMASTER:
-                    keyType = CKK_GENERIC_SECRET;
-                    break;
-                case (int)PCKK_SSLMAC:
-                case (int)PCKK_HMAC:
+                case (int) CKK_GENERIC_SECRET, (int) PCKK_TLSPREMASTER, (int) PCKK_TLSRSAPREMASTER, (int) PCKK_TLSMASTER ->
+                        keyType = CKK_GENERIC_SECRET;
+                case (int) PCKK_SSLMAC, (int) PCKK_HMAC -> {
                     if (n == 0) {
                         throw new InvalidKeyException
                                 ("MAC keys must not be empty");
                     }
                     keyType = CKK_GENERIC_SECRET;
-                    break;
-                default:
-                    throw new InvalidKeyException("Unknown algorithm " +
-                            algorithm);
+                }
+                default -> throw new InvalidKeyException("Unknown algorithm " +
+                        algorithm);
             }
         } catch (InvalidAlgorithmParameterException iape) {
             throw new InvalidKeyException("Invalid key for " + algorithm,
@@ -328,7 +313,7 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
     private byte[] getKeyBytes(SecretKey key) throws InvalidKeySpecException {
         try {
             key = engineTranslateKey(key);
-            if ("RAW".equalsIgnoreCase(key.getFormat()) == false) {
+            if (!"RAW".equalsIgnoreCase(key.getFormat())) {
                 throw new InvalidKeySpecException
                     ("Could not obtain key bytes");
             }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
@@ -172,84 +172,82 @@ final class P11Signature extends SignatureSpi {
         byte[] buffer = null;
         ObjectIdentifier digestOID = null;
         MessageDigest md = null;
-        switch ((int)mechanism) {
-        case (int)CKM_MD2_RSA_PKCS:
-        case (int)CKM_MD5_RSA_PKCS:
-        case (int)CKM_SHA1_RSA_PKCS:
-        case (int)CKM_SHA224_RSA_PKCS:
-        case (int)CKM_SHA256_RSA_PKCS:
-        case (int)CKM_SHA384_RSA_PKCS:
-        case (int)CKM_SHA512_RSA_PKCS:
-        case (int)CKM_SHA3_224_RSA_PKCS:
-        case (int)CKM_SHA3_256_RSA_PKCS:
-        case (int)CKM_SHA3_384_RSA_PKCS:
-        case (int)CKM_SHA3_512_RSA_PKCS:
-            keyAlgorithm = "RSA";
-            type = T_UPDATE;
-            buffer = new byte[1];
-            break;
-        case (int)CKM_DSA_SHA1:
-        case (int)CKM_DSA_SHA224:
-        case (int)CKM_DSA_SHA256:
-        case (int)CKM_DSA_SHA384:
-        case (int)CKM_DSA_SHA512:
-        case (int)CKM_DSA_SHA3_224:
-        case (int)CKM_DSA_SHA3_256:
-        case (int)CKM_DSA_SHA3_384:
-        case (int)CKM_DSA_SHA3_512:
-            keyAlgorithm = "DSA";
-            type = T_UPDATE;
-            buffer = new byte[1];
-            break;
-        case (int)CKM_ECDSA_SHA1:
-        case (int)CKM_ECDSA_SHA224:
-        case (int)CKM_ECDSA_SHA256:
-        case (int)CKM_ECDSA_SHA384:
-        case (int)CKM_ECDSA_SHA512:
-        case (int)CKM_ECDSA_SHA3_224:
-        case (int)CKM_ECDSA_SHA3_256:
-        case (int)CKM_ECDSA_SHA3_384:
-        case (int)CKM_ECDSA_SHA3_512:
-            keyAlgorithm = "EC";
-            type = T_UPDATE;
-            buffer = new byte[1];
-            break;
-        case (int)CKM_DSA:
-            keyAlgorithm = "DSA";
-            if (algorithm.equals("DSA") ||
-                algorithm.equals("DSAinP1363Format")) {
-                type = T_DIGEST;
-                md = MessageDigest.getInstance("SHA-1");
-            } else if (algorithm.equals("RawDSA") ||
-                       algorithm.equals("RawDSAinP1363Format")) {
-                type = T_RAW;
-                buffer = new byte[20];
-            } else {
-                throw new ProviderException(algorithm);
+        switch ((int) mechanism) {
+            case (int) CKM_MD2_RSA_PKCS,
+                    (int) CKM_MD5_RSA_PKCS,
+                    (int) CKM_SHA1_RSA_PKCS,
+                    (int) CKM_SHA224_RSA_PKCS,
+                    (int) CKM_SHA256_RSA_PKCS,
+                    (int) CKM_SHA384_RSA_PKCS,
+                    (int) CKM_SHA512_RSA_PKCS,
+                    (int) CKM_SHA3_224_RSA_PKCS,
+                    (int) CKM_SHA3_256_RSA_PKCS,
+                    (int) CKM_SHA3_384_RSA_PKCS,
+                    (int) CKM_SHA3_512_RSA_PKCS -> {
+                keyAlgorithm = "RSA";
+                type = T_UPDATE;
+                buffer = new byte[1];
             }
-            break;
-        case (int)CKM_ECDSA:
-            keyAlgorithm = "EC";
-            if (algorithm.equals("NONEwithECDSA") ||
-                algorithm.equals("NONEwithECDSAinP1363Format")) {
-                type = T_RAW;
-                buffer = new byte[RAW_ECDSA_MAX];
-            } else {
-                type = T_DIGEST;
-                md = MessageDigest.getInstance
-                        (getDigestEnum(algorithm).stdName());
+            case (int) CKM_DSA_SHA1,
+                    (int) CKM_DSA_SHA224,
+                    (int) CKM_DSA_SHA256,
+                    (int) CKM_DSA_SHA384,
+                    (int) CKM_DSA_SHA512,
+                    (int) CKM_DSA_SHA3_224,
+                    (int) CKM_DSA_SHA3_256,
+                    (int) CKM_DSA_SHA3_384,
+                    (int) CKM_DSA_SHA3_512 -> {
+                keyAlgorithm = "DSA";
+                type = T_UPDATE;
+                buffer = new byte[1];
             }
-            break;
-        case (int)CKM_RSA_PKCS:
-        case (int)CKM_RSA_X_509:
-            keyAlgorithm = "RSA";
-            type = T_DIGEST;
-            KnownOIDs digestAlg = getDigestEnum(algorithm);
-            md = MessageDigest.getInstance(digestAlg.stdName());
-            digestOID = ObjectIdentifier.of(digestAlg);
-            break;
-        default:
-            throw new ProviderException("Unknown mechanism: " + mechanism);
+            case (int) CKM_ECDSA_SHA1,
+                    (int) CKM_ECDSA_SHA224,
+                    (int) CKM_ECDSA_SHA256,
+                    (int) CKM_ECDSA_SHA384,
+                    (int) CKM_ECDSA_SHA512,
+                    (int) CKM_ECDSA_SHA3_224,
+                    (int) CKM_ECDSA_SHA3_256,
+                    (int) CKM_ECDSA_SHA3_384,
+                    (int) CKM_ECDSA_SHA3_512 -> {
+                keyAlgorithm = "EC";
+                type = T_UPDATE;
+                buffer = new byte[1];
+            }
+            case (int) CKM_DSA -> {
+                keyAlgorithm = "DSA";
+                if (algorithm.equals("DSA") ||
+                        algorithm.equals("DSAinP1363Format")) {
+                    type = T_DIGEST;
+                    md = MessageDigest.getInstance("SHA-1");
+                } else if (algorithm.equals("RawDSA") ||
+                        algorithm.equals("RawDSAinP1363Format")) {
+                    type = T_RAW;
+                    buffer = new byte[20];
+                } else {
+                    throw new ProviderException(algorithm);
+                }
+            }
+            case (int) CKM_ECDSA -> {
+                keyAlgorithm = "EC";
+                if (algorithm.equals("NONEwithECDSA") ||
+                        algorithm.equals("NONEwithECDSAinP1363Format")) {
+                    type = T_RAW;
+                    buffer = new byte[RAW_ECDSA_MAX];
+                } else {
+                    type = T_DIGEST;
+                    md = MessageDigest.getInstance
+                            (getDigestEnum(algorithm).stdName());
+                }
+            }
+            case (int) CKM_RSA_PKCS, (int) CKM_RSA_X_509 -> {
+                keyAlgorithm = "RSA";
+                type = T_DIGEST;
+                KnownOIDs digestAlg = getDigestEnum(algorithm);
+                md = MessageDigest.getInstance(digestAlg.stdName());
+                digestOID = ObjectIdentifier.of(digestAlg);
+            }
+            default -> throw new ProviderException("Unknown mechanism: " + mechanism);
         }
         this.buffer = buffer;
         this.digestOID = digestOID;
@@ -408,19 +406,16 @@ final class P11Signature extends SignatureSpi {
                maxKeySize = 1024;
         }
         int keySize = 0;
-        if (key instanceof P11Key) {
-            keySize = ((P11Key) key).length();
+        if (key instanceof P11Key keyP11) {
+            keySize = keyP11.length();
         } else {
             try {
-                if (keyAlgo.equals("RSA")) {
-                    keySize = ((RSAKey) key).getModulus().bitLength();
-                } else if (keyAlgo.equals("DSA")) {
-                    keySize = ((DSAKey) key).getParams().getP().bitLength();
-                } else if (keyAlgo.equals("EC")) {
-                    keySize = ((ECKey) key).getParams().getCurve().getField().getFieldSize();
-                } else {
-                    throw new ProviderException("Error: unsupported algo " + keyAlgo);
-                }
+                keySize = switch (keyAlgo) {
+                    case "RSA" -> ((RSAKey) key).getModulus().bitLength();
+                    case "DSA" -> ((DSAKey) key).getParams().getP().bitLength();
+                    case "EC" -> ((ECKey) key).getParams().getCurve().getField().getFieldSize();
+                    default -> throw new ProviderException("Error: unsupported algo " + keyAlgo);
+                };
             } catch (ClassCastException cce) {
                 throw new InvalidKeyException(keyAlgo +
                     " key must be the right type", cce);
@@ -506,23 +501,22 @@ final class P11Signature extends SignatureSpi {
     protected void engineUpdate(byte b) throws SignatureException {
         ensureInitialized();
         switch (type) {
-        case T_UPDATE:
-            buffer[0] = b;
-            engineUpdate(buffer, 0, 1);
-            break;
-        case T_DIGEST:
-            md.update(b);
-            bytesProcessed++;
-            break;
-        case T_RAW:
-            if (bytesProcessed >= buffer.length) {
-                bytesProcessed = buffer.length + 1;
-                return;
+            case T_UPDATE -> {
+                buffer[0] = b;
+                engineUpdate(buffer, 0, 1);
             }
-            buffer[bytesProcessed++] = b;
-            break;
-        default:
-            throw new ProviderException("Internal error");
+            case T_DIGEST -> {
+                md.update(b);
+                bytesProcessed++;
+            }
+            case T_RAW -> {
+                if (bytesProcessed >= buffer.length) {
+                    bytesProcessed = buffer.length + 1;
+                    return;
+                }
+                buffer[bytesProcessed++] = b;
+            }
+            default -> throw new ProviderException("Internal error");
         }
     }
 
@@ -580,44 +574,45 @@ final class P11Signature extends SignatureSpi {
             return;
         }
         switch (type) {
-        case T_UPDATE:
-            if (byteBuffer instanceof DirectBuffer == false) {
-                // cannot do better than default impl
-                super.engineUpdate(byteBuffer);
-                return;
-            }
-            long addr = ((DirectBuffer)byteBuffer).address();
-            int ofs = byteBuffer.position();
-            try {
-                if (mode == M_SIGN) {
-                    token.p11.C_SignUpdate
-                        (session.id(), addr + ofs, null, 0, len);
-                } else {
-                    token.p11.C_VerifyUpdate
-                        (session.id(), addr + ofs, null, 0, len);
+            case T_UPDATE -> {
+                if (!(byteBuffer instanceof DirectBuffer)) {
+                    // cannot do better than default impl
+                    super.engineUpdate(byteBuffer);
+                    return;
                 }
+                long addr = ((DirectBuffer) byteBuffer).address();
+                int ofs = byteBuffer.position();
+                try {
+                    if (mode == M_SIGN) {
+                        token.p11.C_SignUpdate
+                                (session.id(), addr + ofs, null, 0, len);
+                    } else {
+                        token.p11.C_VerifyUpdate
+                                (session.id(), addr + ofs, null, 0, len);
+                    }
+                    bytesProcessed += len;
+                    byteBuffer.position(ofs + len);
+                } catch (PKCS11Exception e) {
+                    reset(false);
+                    throw new ProviderException("Update failed", e);
+                }
+            }
+            case T_DIGEST -> {
+                md.update(byteBuffer);
                 bytesProcessed += len;
-                byteBuffer.position(ofs + len);
-            } catch (PKCS11Exception e) {
+            }
+            case T_RAW -> {
+                if (bytesProcessed + len > buffer.length) {
+                    bytesProcessed = buffer.length + 1;
+                    return;
+                }
+                byteBuffer.get(buffer, bytesProcessed, len);
+                bytesProcessed += len;
+            }
+            default -> {
                 reset(false);
-                throw new ProviderException("Update failed", e);
+                throw new ProviderException("Internal error");
             }
-            break;
-        case T_DIGEST:
-            md.update(byteBuffer);
-            bytesProcessed += len;
-            break;
-        case T_RAW:
-            if (bytesProcessed + len > buffer.length) {
-                bytesProcessed = buffer.length + 1;
-                return;
-            }
-            byteBuffer.get(buffer, bytesProcessed, len);
-            bytesProcessed += len;
-            break;
-        default:
-            reset(false);
-            throw new ProviderException("Internal error");
         }
     }
 
@@ -651,7 +646,7 @@ final class P11Signature extends SignatureSpi {
                         System.arraycopy(buffer, 0, digest, 0, bytesProcessed);
                     }
                 }
-                if (keyAlgorithm.equals("RSA") == false) {
+                if (!keyAlgorithm.equals("RSA")) {
                     // DSA and ECDSA
                     signature = token.p11.C_Sign(session.id(), digest);
                 } else { // RSA
@@ -724,7 +719,7 @@ final class P11Signature extends SignatureSpi {
                         System.arraycopy(buffer, 0, digest, 0, bytesProcessed);
                     }
                 }
-                if (keyAlgorithm.equals("RSA") == false) {
+                if (!keyAlgorithm.equals("RSA")) {
                     // DSA and ECDSA
                     token.p11.C_Verify(session.id(), digest, signature);
                 } else { // RSA

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11TlsMasterSecretGenerator.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11TlsMasterSecretGenerator.java
@@ -87,7 +87,7 @@ public final class P11TlsMasterSecretGenerator extends KeyGeneratorSpi {
     @SuppressWarnings("deprecation")
     protected void engineInit(AlgorithmParameterSpec params,
             SecureRandom random) throws InvalidAlgorithmParameterException {
-        if (params instanceof TlsMasterSecretParameterSpec == false) {
+        if (!(params instanceof TlsMasterSecretParameterSpec)) {
             throw new InvalidAlgorithmParameterException(MSG);
         }
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11TlsPrfGenerator.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11TlsPrfGenerator.java
@@ -85,7 +85,7 @@ final class P11TlsPrfGenerator extends KeyGeneratorSpi {
     @SuppressWarnings("deprecation")
     protected void engineInit(AlgorithmParameterSpec params,
             SecureRandom random) throws InvalidAlgorithmParameterException {
-        if (params instanceof TlsPrfParameterSpec == false) {
+        if (!(params instanceof TlsPrfParameterSpec)) {
             throw new InvalidAlgorithmParameterException(MSG);
         }
         this.spec = (TlsPrfParameterSpec)params;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11TlsRsaPremasterSecretGenerator.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11TlsRsaPremasterSecretGenerator.java
@@ -83,12 +83,10 @@ final class P11TlsRsaPremasterSecretGenerator extends KeyGeneratorSpi {
     @SuppressWarnings("deprecation")
     protected void engineInit(AlgorithmParameterSpec params,
             SecureRandom random) throws InvalidAlgorithmParameterException {
-        if (!(params instanceof TlsRsaPremasterSecretParameterSpec)) {
+        if (!(params instanceof TlsRsaPremasterSecretParameterSpec spec)) {
             throw new InvalidAlgorithmParameterException(MSG);
         }
 
-        TlsRsaPremasterSecretParameterSpec spec =
-            (TlsRsaPremasterSecretParameterSpec) params;
         int tlsVersion = (spec.getMajorVersion() << 8) | spec.getMinorVersion();
 
         if ((tlsVersion == 0x0300 && !supportSSLv3) ||

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Secmod.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Secmod.java
@@ -133,10 +133,10 @@ public final class Secmod {
     public synchronized boolean isInitialized() throws IOException {
         // NSS does not allow us to check if it is initialized already
         // assume that if it is loaded it is also initialized
-        if (isLoaded() == false) {
+        if (!isLoaded()) {
             return false;
         }
-        if (supported == false) {
+        if (!supported) {
             throw new IOException
                 ("An incompatible version of NSS is already loaded, "
                 + "3.7 or later required");
@@ -194,11 +194,11 @@ public final class Secmod {
             platformPath = platformLibName;
         } else {
             File base = new File(nssLibDir);
-            if (base.isDirectory() == false) {
+            if (!base.isDirectory()) {
                 throw new IOException("nssLibDir must be a directory:" + nssLibDir);
             }
             File platformFile = new File(base, platformLibName);
-            if (platformFile.isFile() == false) {
+            if (!platformFile.isFile()) {
                 throw new FileNotFoundException(platformFile.getPath());
             }
             platformPath = platformFile.getPath();
@@ -214,12 +214,12 @@ public final class Secmod {
                 configDirPath = configDirPathSB.substring(sqlPrefix.length());
             }
             File configBase = new File(configDirPath);
-            if (configBase.isDirectory() == false ) {
+            if (!configBase.isDirectory()) {
                 throw new IOException("configDir must be a directory: " + configDirPath);
             }
             if (!configDir.startsWith(sqlPrefix)) {
                 File secmodFile = new File(configBase, "secmod.db");
-                if (secmodFile.isFile() == false) {
+                if (!secmodFile.isFile()) {
                     throw new FileNotFoundException(secmodFile.getPath());
                 }
             }
@@ -229,7 +229,7 @@ public final class Secmod {
         nssHandle = nssLoadLibrary(platformPath);
         if (DEBUG) System.out.println("handle: " + nssHandle);
         fetchVersions();
-        if (supported == false) {
+        if (!supported) {
             throw new IOException
                 ("The specified version of NSS is incompatible, "
                 + "3.7 or later required");
@@ -239,7 +239,7 @@ public final class Secmod {
         boolean initok = nssInitialize(dbMode.functionName, nssHandle,
             configDir, nssOptimizeSpace);
         if (DEBUG) System.out.println("init: " + initok);
-        if (initok == false) {
+        if (!initok) {
             throw new IOException("NSS initialization failed");
         }
 
@@ -255,7 +255,7 @@ public final class Secmod {
      */
     public synchronized List<Module> getModules() {
         try {
-            if (isInitialized() == false) {
+            if (!isInitialized()) {
                 throw new IllegalStateException("NSS not initialized");
             }
         } catch (IOException e) {
@@ -353,35 +353,40 @@ public final class Secmod {
         return null;
     }
 
-    static final String TEMPLATE_EXTERNAL =
-        "library = %s\n"
-        + "name = \"%s\"\n"
-        + "slotListIndex = %d\n";
+    static final String TEMPLATE_EXTERNAL =  """
+                    library = %s
+                    name = "%s"
+                    slotListIndex = %d
+                    """;
 
-    static final String TEMPLATE_TRUSTANCHOR =
-        "library = %s\n"
-        + "name = \"NSS Trust Anchors\"\n"
-        + "slotListIndex = 0\n"
-        + "enabledMechanisms = { KeyStore }\n"
-        + "nssUseSecmodTrust = true\n";
+    static final String TEMPLATE_TRUSTANCHOR = """
+                    library = %s
+                    name = "NSS Trust Anchors"
+                    slotListIndex = 0
+                    enabledMechanisms = { KeyStore }
+                    nssUseSecmodTrust = true
+                    """;
 
-    static final String TEMPLATE_CRYPTO =
-        "library = %s\n"
-        + "name = \"NSS SoftToken Crypto\"\n"
-        + "slotListIndex = 0\n"
-        + "disabledMechanisms = { KeyStore }\n";
+    static final String TEMPLATE_CRYPTO = """
+                    library = %s
+                    name = "NSS SoftToken Crypto"
+                    slotListIndex = 0
+                    disabledMechanisms = { KeyStore }
+                    """;
 
-    static final String TEMPLATE_KEYSTORE =
-        "library = %s\n"
-        + "name = \"NSS SoftToken KeyStore\"\n"
-        + "slotListIndex = 1\n"
-        + "nssUseSecmodTrust = true\n";
+    static final String TEMPLATE_KEYSTORE = """
+                    library = %s
+                    name = "NSS SoftToken KeyStore"
+                    slotListIndex = 1
+                    nssUseSecmodTrust = true
+                    """;
 
-    static final String TEMPLATE_FIPS =
-        "library = %s\n"
-        + "name = \"NSS FIPS SoftToken\"\n"
-        + "slotListIndex = 0\n"
-        + "nssUseSecmodTrust = true\n";
+    static final String TEMPLATE_FIPS = """
+                    library = %s
+                    name = "NSS FIPS SoftToken"
+                    slotListIndex = 0
+                    nssUseSecmodTrust = true
+                    """;
 
     /**
      * A representation of one PKCS#11 slot in a PKCS#11 module.
@@ -442,26 +447,13 @@ public final class Secmod {
         }
 
         private void initConfiguration() {
-            switch (type) {
-            case EXTERNAL:
-                config = String.format(TEMPLATE_EXTERNAL, libraryName,
-                                            commonName + " " + slot, slot);
-                break;
-            case CRYPTO:
-                config = String.format(TEMPLATE_CRYPTO, libraryName);
-                break;
-            case KEYSTORE:
-                config = String.format(TEMPLATE_KEYSTORE, libraryName);
-                break;
-            case FIPS:
-                config = String.format(TEMPLATE_FIPS, libraryName);
-                break;
-            case TRUSTANCHOR:
-                config = String.format(TEMPLATE_TRUSTANCHOR, libraryName);
-                break;
-            default:
-                throw new RuntimeException("Unknown module type: " + type);
-            }
+            config = switch (type) {
+                case EXTERNAL -> String.format(TEMPLATE_EXTERNAL, libraryName, commonName + " " + slot, slot);
+                case CRYPTO -> String.format(TEMPLATE_CRYPTO, libraryName);
+                case KEYSTORE -> String.format(TEMPLATE_KEYSTORE, libraryName);
+                case FIPS -> String.format(TEMPLATE_FIPS, libraryName);
+                case TRUSTANCHOR -> String.format(TEMPLATE_TRUSTANCHOR, libraryName);
+            };
         }
 
         /**
@@ -545,7 +537,7 @@ public final class Secmod {
                 trust.put(bytes, attr);
             } else {
                 // does it already have the correct trust settings?
-                if (attr.isTrusted(TrustType.ALL) == false) {
+                if (!attr.isTrusted(TrustType.ALL)) {
                     // XXX not yet implemented
                     throw new ProviderException("Cannot change existing trust attributes");
                 }
@@ -746,17 +738,16 @@ public final class Secmod {
             if (this == o) {
                 return true;
             }
-            if (o instanceof Bytes == false) {
+            if (!(o instanceof Bytes other)) {
                 return false;
             }
-            Bytes other = (Bytes)o;
             return Arrays.equals(this.b, other.b);
         }
     }
 
     private static Map<Bytes,TrustAttributes> getTrust(SunPKCS11 provider)
             throws PKCS11Exception {
-        Map<Bytes,TrustAttributes> trustMap = new HashMap<Bytes,TrustAttributes>();
+        Map<Bytes,TrustAttributes> trustMap = new HashMap<>();
         Token token = provider.getToken();
         Session session = null;
         boolean exceptionOccurred = true;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Secmod.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Secmod.java
@@ -353,7 +353,7 @@ public final class Secmod {
         return null;
     }
 
-    static final String TEMPLATE_EXTERNAL =  """
+    static final String TEMPLATE_EXTERNAL = """
                     library = %s
                     name = "%s"
                     slotListIndex = %d

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Session.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Session.java
@@ -83,7 +83,7 @@ final class Session implements Comparable<Session> {
     }
 
     long id() {
-        if (token.isPresent(this.id) == false) {
+        if (!token.isPresent(this.id)) {
             throw new ProviderException("Token has been removed");
         }
         lastAccess = System.currentTimeMillis();

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SessionManager.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SessionManager.java
@@ -161,7 +161,7 @@ final class SessionManager {
     }
 
     Session killSession(Session session) {
-        if ((session == null) || (token.isValid() == false)) {
+        if ((session == null) || (!token.isValid())) {
             return null;
         }
         if (debug != null) {
@@ -176,7 +176,7 @@ final class SessionManager {
     }
 
     Session releaseSession(Session session) {
-        if ((session == null) || (token.isValid() == false)) {
+        if ((session == null) || (!token.isValid())) {
             return null;
         }
         if (session.hasObjects()) {
@@ -193,7 +193,7 @@ final class SessionManager {
     }
 
     void demoteObjSession(Session session) {
-        if (token.isValid() == false) {
+        if (!token.isValid()) {
             return;
         }
         if (debug != null) {
@@ -202,14 +202,14 @@ final class SessionManager {
         }
 
         boolean present = objSessions.remove(session);
-        if (present == false) {
+        if (!present) {
             // session is currently in use
             // will be added to correct pool on release, nothing to do now
             return;
         }
         // Objects could have been added to this session by other thread between
         // check in Session.removeObject method and objSessions.remove call
-        // higher. Therefore releaseSession method, which performs additional
+        // higher. Therefore, releaseSession method, which performs additional
         // check for objects, is used here to avoid placing this session
         // in wrong pool due to race condition.
         releaseSession(session);
@@ -255,9 +255,9 @@ final class SessionManager {
         Pool(SessionManager mgr, boolean obj) {
             this.mgr = mgr;
             if (obj) {
-                pool = new LinkedBlockingQueue<Session>();
+                pool = new LinkedBlockingQueue<>();
             } else {
-                pool = new LinkedBlockingQueue<Session>(SESSION_MAX);
+                pool = new LinkedBlockingQueue<>(SESSION_MAX);
             }
         }
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -188,7 +188,7 @@ public final class SunPKCS11 extends AuthProvider {
                     if (nssSecmodDirectory != null) {
                         String s = secmod.getConfigDir();
                         if ((s != null) &&
-                                (s.equals(nssSecmodDirectory) == false)) {
+                                (!s.equals(nssSecmodDirectory))) {
                             throw new ProviderException("Secmod directory "
                                 + nssSecmodDirectory
                                 + " invalid, NSS already initialized with "
@@ -198,7 +198,7 @@ public final class SunPKCS11 extends AuthProvider {
                     if (nssLibraryDirectory != null) {
                         String s = secmod.getLibDir();
                         if ((s != null) &&
-                                (s.equals(nssLibraryDirectory) == false)) {
+                                (!s.equals(nssLibraryDirectory))) {
                             throw new ProviderException("NSS library directory "
                                 + nssLibraryDirectory
                                 + " invalid, NSS already initialized with "
@@ -301,8 +301,8 @@ public final class SunPKCS11 extends AuthProvider {
         // (e.g. "libpkcs11.so"), it may refer to a library somewhere on the
         // OS library search path. Omit the test for file existence as that
         // only looks in the current directory.
-        if (libraryFile.getName().equals(library) == false) {
-            if (new File(library).isFile() == false) {
+        if (!libraryFile.getName().equals(library)) {
+            if (!new File(library).isFile()) {
                 String msg = "Library " + library + " does not exist";
                 if (config.getHandleStartupErrors() == Config.ERR_HALT) {
                     throw new ProviderException(msg);
@@ -331,7 +331,7 @@ public final class SunPKCS11 extends AuthProvider {
                 if (debug != null) {
                     debug.println("Multi-threaded initialization failed: " + e);
                 }
-                if (config.getAllowSingleThreadedModules() == false) {
+                if (!config.getAllowSingleThreadedModules()) {
                     throw e;
                 }
                 // fall back to single threaded access
@@ -479,11 +479,7 @@ public final class SunPKCS11 extends AuthProvider {
         for (int i = 0; i < d.mechanisms.length; i++) {
             int m = d.mechanisms[i];
             Integer key = Integer.valueOf(m);
-            List<Descriptor> list = descriptors.get(key);
-            if (list == null) {
-                list = new ArrayList<Descriptor>();
-                descriptors.put(key, list);
-            }
+            List<Descriptor> list = descriptors.computeIfAbsent(key, k -> new ArrayList<>());
             list.add(d);
         }
     }
@@ -953,7 +949,7 @@ public final class SunPKCS11 extends AuthProvider {
                 } catch (InterruptedException e) {
                     break;
                 }
-                if (enabled == false) {
+                if (!enabled) {
                     break;
                 }
                 try {
@@ -1250,7 +1246,7 @@ public final class SunPKCS11 extends AuthProvider {
         @Override
         public Object newInstance(Object param)
                 throws NoSuchAlgorithmException {
-            if (token.isValid() == false) {
+            if (!token.isValid()) {
                 throw new NoSuchAlgorithmException("Token has been removed");
             }
             try {
@@ -1272,14 +1268,14 @@ public final class SunPKCS11 extends AuthProvider {
                 } else if (algorithm.endsWith("GCM/NoPadding") ||
                            algorithm.startsWith("ChaCha20-Poly1305")) {
                     return new P11AEADCipher(token, algorithm, mechanism);
-                } else if (algorithm.indexOf("/KW/") != -1 ||
-                        algorithm.indexOf("/KWP/") != -1) {
+                } else if (algorithm.contains("/KW/") ||
+                        algorithm.contains("/KWP/")) {
                     return new P11KeyWrapCipher(token, algorithm, mechanism);
                 } else {
                     return new P11Cipher(token, algorithm, mechanism);
                 }
             } else if (type == SIG) {
-                if (algorithm.indexOf("RSASSA-PSS") != -1) {
+                if (algorithm.contains("RSASSA-PSS")) {
                     return new P11PSSSignature(token, algorithm, mechanism);
                 } else {
                     return new P11Signature(token, algorithm, mechanism);
@@ -1338,20 +1334,19 @@ public final class SunPKCS11 extends AuthProvider {
         }
 
         public boolean supportsParameter(Object param) {
-            if ((param == null) || (token.isValid() == false)) {
+            if ((param == null) || (!token.isValid())) {
                 return false;
             }
-            if (param instanceof Key == false) {
+            if (!(param instanceof Key key)) {
                 throw new InvalidParameterException("Parameter must be a Key");
             }
             String algorithm = getAlgorithm();
             String type = getType();
-            Key key = (Key)param;
             String keyAlgorithm = key.getAlgorithm();
             // RSA signatures and cipher
             if (((type == CIP) && algorithm.startsWith("RSA"))
-                    || (type == SIG) && (algorithm.indexOf("RSA") != -1)) {
-                if (keyAlgorithm.equals("RSA") == false) {
+                    || (type == SIG) && (algorithm.contains("RSA"))) {
+                if (!keyAlgorithm.equals("RSA")) {
                     return false;
                 }
                 return isLocalKey(key)
@@ -1361,7 +1356,7 @@ public final class SunPKCS11 extends AuthProvider {
             // EC
             if (((type == KA) && algorithm.equals("ECDH"))
                     || ((type == SIG) && algorithm.contains("ECDSA"))) {
-                if (keyAlgorithm.equals("EC") == false) {
+                if (!keyAlgorithm.equals("EC")) {
                     return false;
                 }
                 return isLocalKey(key)
@@ -1371,7 +1366,7 @@ public final class SunPKCS11 extends AuthProvider {
             // DSA signatures
             if ((type == SIG) && algorithm.contains("DSA") &&
                     !algorithm.contains("ECDSA")) {
-                if (keyAlgorithm.equals("DSA") == false) {
+                if (!keyAlgorithm.equals("DSA")) {
                     return false;
                 }
                 return isLocalKey(key)
@@ -1385,7 +1380,7 @@ public final class SunPKCS11 extends AuthProvider {
             }
             // DH key agreement
             if (type == KA) {
-                if (keyAlgorithm.equals("DH") == false) {
+                if (!keyAlgorithm.equals("DH")) {
                     return false;
                 }
                 return isLocalKey(key)
@@ -1576,7 +1571,7 @@ public final class SunPKCS11 extends AuthProvider {
                 (new SecurityPermission("authProvider." + this.getName()));
         }
 
-        if (hasValidToken() == false) {
+        if (!hasValidToken()) {
             // app may call logout for cleanup, allow
             return;
         }
@@ -1774,7 +1769,7 @@ public final class SunPKCS11 extends AuthProvider {
 
         private Object readResolve() throws ObjectStreamException {
             SunPKCS11 p = (SunPKCS11)Security.getProvider(providerName);
-            if ((p == null) || (p.config.getFileName().equals(configName) == false)) {
+            if ((p == null) || (!p.config.getFileName().equals(configName))) {
                 throw new NotSerializableException("Could not find "
                         + providerName + " in installed providers");
             }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/TemplateManager.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/TemplateManager.java
@@ -85,8 +85,8 @@ final class TemplateManager {
     private final Map<TemplateKey,Template> compositeTemplates;
 
     TemplateManager() {
-        primitiveTemplates = new ArrayList<KeyAndTemplate>();
-        compositeTemplates = new ConcurrentHashMap<TemplateKey,Template>();
+        primitiveTemplates = new ArrayList<>();
+        compositeTemplates = new ConcurrentHashMap<>();
     }
 
     // add a template. Called by Config.
@@ -151,10 +151,9 @@ final class TemplateManager {
             if (this == obj) {
                 return true;
             }
-            if (obj instanceof TemplateKey == false) {
+            if (!(obj instanceof TemplateKey other)) {
                 return false;
             }
-            TemplateKey other = (TemplateKey)obj;
             boolean match = this.operation.equals(other.operation)
                         && (this.keyType == other.keyType)
                         && (this.keyAlgorithm == other.keyAlgorithm);
@@ -212,7 +211,7 @@ final class TemplateManager {
          */
         private static CK_ATTRIBUTE[] combine(CK_ATTRIBUTE[] attrs1,
                 CK_ATTRIBUTE[] attrs2) {
-            List<CK_ATTRIBUTE> attrs = new ArrayList<CK_ATTRIBUTE>();
+            List<CK_ATTRIBUTE> attrs = new ArrayList<>();
             for (CK_ATTRIBUTE attr : attrs1) {
                 if (attr.pValue != null) {
                     attrs.add(attr);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Token.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Token.java
@@ -53,7 +53,7 @@ class Token implements Serializable {
 
     // how often to check if the token is still present (in ms)
     // this is different from checking if a token has been inserted,
-    // that is done in SunPKCS11. Currently 50 ms.
+    // that is done in SunPKCS11. Currently, 50 ms.
     private static final long CHECK_INTERVAL = 50;
 
     final SunPKCS11 provider;
@@ -167,8 +167,7 @@ class Token implements Serializable {
         privateCache = new KeyCache();
         templateManager = config.getTemplateManager();
         explicitCancel = config.getExplicitCancel();
-        mechInfoMap =
-            new ConcurrentHashMap<Long, CK_MECHANISM_INFO>(10);
+        mechInfoMap = new ConcurrentHashMap<>(10);
     }
 
     boolean isWriteProtected() {
@@ -241,7 +240,7 @@ class Token implements Serializable {
     // ensure that we are logged in
     // call provider.login() if not
     void ensureLoggedIn(Session session) throws PKCS11Exception, LoginException {
-        if (isLoggedIn(session) == false) {
+        if (!isLoggedIn(session)) {
             provider.login(null, null);
         }
     }
@@ -249,14 +248,14 @@ class Token implements Serializable {
     // return whether this token object is valid (i.e. token not removed)
     // returns value from last check, does not perform new check
     boolean isValid() {
-        if (removable == false) {
+        if (!removable) {
             return true;
         }
         return valid;
     }
 
     void ensureValid() {
-        if (isValid() == false) {
+        if (!isValid()) {
             throw new ProviderException("Token has been removed");
         }
     }
@@ -264,10 +263,10 @@ class Token implements Serializable {
     // return whether a token is present (i.e. token not removed)
     // returns cached value if current, otherwise performs new check
     boolean isPresent(long sessionID) {
-        if (removable == false) {
+        if (!removable) {
             return true;
         }
-        if (valid == false) {
+        if (!valid) {
             return false;
         }
         long time = System.currentTimeMillis();
@@ -292,7 +291,7 @@ class Token implements Serializable {
                     }
                     valid = ok;
                     lastPresentCheck = System.currentTimeMillis();
-                    if (ok == false) {
+                    if (!ok) {
                         destroy();
                     }
                 }
@@ -417,7 +416,7 @@ class Token implements Serializable {
             SecureRandom random = JCAUtil.getSecureRandom();
             tokenId = new byte[20];
             random.nextBytes(tokenId);
-            serializedTokens.add(new WeakReference<Token>(this));
+            serializedTokens.add(new WeakReference<>(this));
         }
         return tokenId;
     }
@@ -426,11 +425,10 @@ class Token implements Serializable {
     // NOTE that elements are never removed from this list
     // the assumption is that the number of tokens that are serialized
     // is relatively small
-    private static final List<Reference<Token>> serializedTokens =
-        new ArrayList<Reference<Token>>();
+    private static final List<Reference<Token>> serializedTokens = new ArrayList<>();
 
     private Object writeReplace() throws ObjectStreamException {
-        if (isValid() == false) {
+        if (!isValid()) {
             throw new NotSerializableException("Token has been removed");
         }
         return new TokenRep(this);


### PR DESCRIPTION
During the work of another PR (https://github.com/openjdk/jdk/pull/11260), several improvement areas were identified. These are now adressed in this separate PR proposing the use of more modern Java constructs as well as simplifying a large number of logical expressions that were previously non-normative. 


This branch has been tested and passed tier1-4 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297519](https://bugs.openjdk.org/browse/JDK-8297519): Improve expressions and modernise code in PKCS


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11348/head:pull/11348` \
`$ git checkout pull/11348`

Update a local copy of the PR: \
`$ git checkout pull/11348` \
`$ git pull https://git.openjdk.org/jdk pull/11348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11348`

View PR using the GUI difftool: \
`$ git pr show -t 11348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11348.diff">https://git.openjdk.org/jdk/pull/11348.diff</a>

</details>
