### PR TITLE
8297561: Redundant index check in String.offsetByCodePoints()

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -1641,7 +1641,7 @@ public final class String
      * @param codePointOffset the offset in code points
      * @return the index within this {@code String}
      * @throws    IndexOutOfBoundsException if {@code index}
-     *   is negative or larger then the length of this
+     *   is negative or larger than the length of this
      *   {@code String}, or if {@code codePointOffset} is positive
      *   and the substring starting with {@code index} has fewer
      *   than {@code codePointOffset} code points,
@@ -1651,9 +1651,6 @@ public final class String
      * @since 1.5
      */
     public int offsetByCodePoints(int index, int codePointOffset) {
-        if (index < 0 || index > length()) {
-            throw new IndexOutOfBoundsException();
-        }
         return Character.offsetByCodePoints(this, index, codePointOffset);
     }
 


### PR DESCRIPTION
`String.offsetByCodePoints()` delegates to `Character.offsetByCodePoints()` which in turn specifies the same exception thrown under the same conditions and the implementation does exactly the same checks. This means we can remove the check from `String.offsetByCodePoints()` and rely on the one of `Character.offsetByCodePoints()`.