### PR TITLE
8297082: Remove sun/tools/jhsdb/BasicLauncherTest.java from problem list

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -723,8 +723,6 @@ sun/util/locale/provider/CalendarDataRegression.java            8268379 macosx-x
 
 # svc_tools
 
-sun/tools/jhsdb/BasicLauncherTest.java                          8228649 linux-ppc64,linux-ppc64le
-
 sun/tools/jstatd/TestJstatdDefaults.java                        8081569,8226420 windows-all
 sun/tools/jstatd/TestJstatdRmiPort.java                         8226420,8251259,8293577 generic-all
 sun/tools/jstatd/TestJstatdServer.java                          8081569,8226420 windows-all


### PR DESCRIPTION
Related issue is fixed with [JDK-8228649](https://bugs.openjdk.org/browse/JDK-8228649)
Test has passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297082](https://bugs.openjdk.org/browse/JDK-8297082): Remove sun/tools/jhsdb/BasicLauncherTest.java from problem list


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11351/head:pull/11351` \
`$ git checkout pull/11351`

Update a local copy of the PR: \
`$ git checkout pull/11351` \
`$ git pull https://git.openjdk.org/jdk pull/11351/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11351`

View PR using the GUI difftool: \
`$ git pr show -t 11351`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11351.diff">https://git.openjdk.org/jdk/pull/11351.diff</a>

</details>
