### PR TITLE
8297570: jdk/jfr/threading/TestDeepVirtualStackTrace.java fails with -XX:-UseTLAB

### DIFF
--- a/test/jdk/jdk/jfr/threading/TestDeepVirtualStackTrace.java
+++ b/test/jdk/jdk/jfr/threading/TestDeepVirtualStackTrace.java
@@ -92,6 +92,9 @@ public class TestDeepVirtualStackTrace {
         System.out.println();
         System.out.println("Testing event: " + eventName);
         System.out.println("=============================");
+
+        boolean isTargetEventFound = false;
+
         try (Recording r = new Recording()) {
             r.enable(eventName).withoutThreshold();
             r.start();
@@ -99,25 +102,40 @@ public class TestDeepVirtualStackTrace {
             vt.join();
             r.stop();
             List<RecordedEvent> events = Events.fromRecording(r);
-            Asserts.assertEquals(events.size(), 1, "No event found in virtual thread");
-            RecordedEvent event = events.get(0);
-            System.out.println(event);
-            RecordedStackTrace stackTrace = event.getStackTrace();
-            List<RecordedFrame> frames = stackTrace.getFrames();
-            Asserts.assertTrue(stackTrace.isTruncated());
-            int count = 0;
-            for (RecordedFrame frame : frames) {
-                Asserts.assertTrue(frame.isJavaFrame());
-                Asserts.assertNotNull(frame.getMethod());
-                RecordedMethod m = frame.getMethod();
-                Asserts.assertNotNull(m.getType());
-                if (m.getName().contains(stackMethod)) {
-                    count++;
+            Asserts.assertFalse(events.isEmpty(), "No event found in virtual thread");
+            for (RecordedEvent event : events) {
+                System.out.println(event);
+                RecordedStackTrace stackTrace = event.getStackTrace();
+                if (stackTrace == null) {
+                    continue;
+                }
+                List<RecordedFrame> frames = stackTrace.getFrames();
+                int count = 0;
+                boolean isTargetEvent = false;
+                boolean isFirstFrame = true;
+                for (int c = 0; c < frames.size(); c++) {
+                    RecordedFrame frame = frames.get(c);
+                    Asserts.assertTrue(frame.isJavaFrame());
+                    Asserts.assertNotNull(frame.getMethod());
+                    RecordedMethod m = frame.getMethod();
+                    Asserts.assertNotNull(m.getType());
+                    if (m.getName().contains(stackMethod)) {
+                        if (c == 0) {
+                            isTargetEvent = true;
+                        }
+                        count++;
+                    }
+                }
+                if (isTargetEvent) {
+                    isTargetEventFound = true;
+                    Asserts.assertTrue(stackTrace.isTruncated());
+                    Asserts.assertEquals(count, FRAME_COUNT);
+                    Asserts.assertEquals(frames.size(), FRAME_COUNT);
                 }
             }
-            Asserts.assertEquals(count, FRAME_COUNT);
-            Asserts.assertEquals(frames.size(), FRAME_COUNT);
         }
+
+        Asserts.assertTrue(isTargetEventFound, "At least one target event found");
     }
 
 }


### PR DESCRIPTION
This is the only test in `jdk_loom` that fails without `-XX:-UseTLAB`. The test specifically looks for `ObjectAllocationOutsideTLAB` event, and there are lots of those events with `-XX:-UseTLAB`. We can fix the test to look for the event we actually want.

This depends on [JDK-8297491](https://bugs.openjdk.org/browse/JDK-8297491) that fixed Loom code to actually disable TLABs.

Additional testing:
 - [x] Linux x86_64 fastdebug, affected test with `-XX:+UseTLAB` and `-XX:-UseTLAB`
 - [x] Linux x86_64 fastdebug, `jdk_loom` with `{Serial, Parallel, G1, Shenandoah, Z} x {+UseTLAB, -UseTLAB}`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297570](https://bugs.openjdk.org/browse/JDK-8297570): jdk/jfr/threading/TestDeepVirtualStackTrace.java fails with -XX:-UseTLAB


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11352/head:pull/11352` \
`$ git checkout pull/11352`

Update a local copy of the PR: \
`$ git checkout pull/11352` \
`$ git pull https://git.openjdk.org/jdk pull/11352/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11352`

View PR using the GUI difftool: \
`$ git pr show -t 11352`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11352.diff">https://git.openjdk.org/jdk/pull/11352.diff</a>

</details>
