### PR TITLE
8297569: URLPermission constructor throws IllegalArgumentException: Invalid characters in hostname after JDK-8294378

### DIFF
--- a/src/java.base/share/classes/java/net/HostPortrange.java
+++ b/src/java.base/share/classes/java/net/HostPortrange.java
@@ -149,9 +149,6 @@ class HostPortrange {
                         // regular domain name
                         hoststr = toLowerCase(hoststr);
                     }
-                } else {
-                    // regular domain name
-                    hoststr = toLowerCase(hoststr);
                 }
             }
             hostname = hoststr;

--- a/src/java.base/share/classes/java/net/URLPermission.java
+++ b/src/java.base/share/classes/java/net/URLPermission.java
@@ -494,7 +494,7 @@ public final class URLPermission extends Permission {
             auth = authpath.substring(0, delim);
             this.path = authpath.substring(delim);
         }
-        this.authority = new Authority(scheme, auth);
+        this.authority = new Authority(scheme, auth.toLowerCase(Locale.ROOT));
     }
 
     private String actions() {

--- a/test/jdk/java/net/URLPermission/URLPermissionTest.java
+++ b/test/jdk/java/net/URLPermission/URLPermissionTest.java
@@ -402,7 +402,9 @@ public class URLPermissionTest {
     static Test[] createTests = {
         createtest("http://user@foo.com/a/b/c"),
         createtest("http://user:pass@foo.com/a/b/c"),
-        createtest("http://user:@foo.com/a/b/c")
+        createtest("http://user:@foo.com/a/b/c"),
+        createtest("http://foo_bar"),
+        createtest("http://foo_bar:12345")
     };
 
     static boolean failed = false;


### PR DESCRIPTION
Can I please get a review of this change which proposes to fix https://bugs.openjdk.org/browse/JDK-8297569?

Recently we fixed a bug in `java.net.URLPermission` where that class used to run into an exception while trying to convert a hostname into lowercase, when run in Turkish locale https://bugs.openjdk.org/browse/JDK-8294378. The approach we decided to take in that fix  was to use an internal `HostPortRange.toLowerCase` method which was unaffected by `Locale`s. The other alternative was to use `String.toLowerCase(Locale.ROOT)`, but we decided to use the former since it was already being used in other parts of the code in that area.

The implementation of `HostPortRange.toLowerCase` is very strict and it allows only a specific set of characters. The `_` (underscore character) isn't one of them. Before the change we did there, a `URLPermission` constructor could be passed a string `http://foo_bar` and it used to construct the instance successfully. However, after that change, it now fails with the exception noted in the issue.

The commit here reverts the previous fix and instead now uses `String.toLowerCase(Locale.ROOT)` to lowercase the authority. Additionally, an `else` block that we had introduced in the previous fix has been removed to bring us back to the old behaviour.

The test has been updated to include `http://foo_bar` (and its one more variant) string to construct the `URLPermission` instance.

JCK testing with the changes in this PR passed and other `tier` testing is currently in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297569](https://bugs.openjdk.org/browse/JDK-8297569): URLPermission constructor throws IllegalArgumentException: Invalid characters in hostname after JDK-8294378


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11353/head:pull/11353` \
`$ git checkout pull/11353`

Update a local copy of the PR: \
`$ git checkout pull/11353` \
`$ git pull https://git.openjdk.org/jdk pull/11353/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11353`

View PR using the GUI difftool: \
`$ git pr show -t 11353`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11353.diff">https://git.openjdk.org/jdk/pull/11353.diff</a>

</details>
