### PR TITLE
8296660: Swing HTML table with omitted closing tags misparsed

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/parser/Parser.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/parser/Parser.java
@@ -703,7 +703,7 @@ class Parser implements DTDConstants {
                 }
                 if (!s.terminate() || (strict && !s.elem.omitEnd())) {
                     break;
-                } else if (s.terminate()) {
+                } else if (s.terminate() && !s.elem.omitEnd()) {
                     // Since the current tag is not valid in current context
                     // as otherwise s.advance(elem) would have returned true
                     // so check if the stack is to be terminated

--- a/src/java.desktop/share/classes/javax/swing/text/html/parser/Parser.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/parser/Parser.java
@@ -708,6 +708,7 @@ class Parser implements DTDConstants {
                     // as otherwise s.advance(elem) would have returned true
                     // so check if the stack is to be terminated
                     // in which case return false
+                    // but not if the closing tag is optional like tr,th,td
                     return false;
                 }
             }

--- a/test/jdk/javax/swing/text/html/parser/TestHtmlOptionalClosingTag.java
+++ b/test/jdk/javax/swing/text/html/parser/TestHtmlOptionalClosingTag.java
@@ -33,7 +33,6 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.SwingUtilities;
 
-
 public class TestHtmlOptionalClosingTag {
 
     private static JFrame frame;
@@ -54,9 +53,7 @@ public class TestHtmlOptionalClosingTag {
             "<tr><th align=right>Audio:<td>Stereo - 44100 Hz - 123 kbps - AAC";
 
         JLabel label = new JLabel(html);
-
         frame.add(label);
-
         frame.pack();
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);	    

--- a/test/jdk/javax/swing/text/html/parser/TestHtmlOptionalClosingTag.java
+++ b/test/jdk/javax/swing/text/html/parser/TestHtmlOptionalClosingTag.java
@@ -38,9 +38,9 @@ public class TestHtmlOptionalClosingTag {
     private static JFrame frame;
 
     private static final String INSTRUCTIONS =
-        " A Swing JLabel with a two-column HTML table is shown\n " + 
-	" If the table is shown without any alignment issue\n " +
-	" then press Pass, otherwise test fails";
+        " A Swing JLabel with a two-column HTML table is shown\n " +
+        " If the table is shown without any alignment issue\n " +
+        " then press Pass, otherwise test fails";
 
     public static void createAndShowGUI() {
         frame = new JFrame();
@@ -56,17 +56,17 @@ public class TestHtmlOptionalClosingTag {
         frame.add(label);
         frame.pack();
         frame.setLocationRelativeTo(null);
-        frame.setVisible(true);	    
+        frame.setVisible(true);
     }
 
 
     public static void main(String[] argv) throws Exception {
         PassFailJFrame passFailJFrame = new PassFailJFrame(
-                "SwingHtmlTable Test", INSTRUCTIONS, 5);	    
+                "SwingHtmlTable Test", INSTRUCTIONS, 5);
         SwingUtilities.invokeAndWait(() -> createAndShowGUI());
-	PassFailJFrame.addTestWindow(frame);
-	PassFailJFrame.positionTestWindow(
+        PassFailJFrame.addTestWindow(frame);
+        PassFailJFrame.positionTestWindow(
                 frame, PassFailJFrame.Position.HORIZONTAL);
-	passFailJFrame.awaitAndCheck();
+        passFailJFrame.awaitAndCheck();
     }
 }

--- a/test/jdk/javax/swing/text/html/parser/TestHtmlOptionalClosingTag.java
+++ b/test/jdk/javax/swing/text/html/parser/TestHtmlOptionalClosingTag.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8296660
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Verifies Swing HTML table with omitted closing tags parsed correctly
+ * @run main/manual TestHtmlOptionalClosingTag
+ */
+
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
+
+
+public class TestHtmlOptionalClosingTag {
+
+    private static JFrame frame;
+
+    private static final String INSTRUCTIONS =
+        " A Swing JLabel with a two-column HTML table is shown\n " + 
+	" If the table is shown without any alignment issue\n " +
+	" then press Pass, otherwise test fails";
+
+    public static void createAndShowGUI() {
+        frame = new JFrame();
+        String html = "<html><table>" +
+            "<tr><th align=right>Name:<td>sync-001.mp4" +
+            "<tr><th align=right>Modified:<td>2017-Jul-31, 00:14:55" +
+            "<tr><th align=right>File size:<td>3.1 MB" +
+            "<tr><th align=right>Duration:<td>1m03s" +
+            "<tr><th align=right>Video:<td>854 x 480 - 16:9 - 30.0 fps - 271 kbps - H.264 / AVC" +
+            "<tr><th align=right>Audio:<td>Stereo - 44100 Hz - 123 kbps - AAC";
+
+        JLabel label = new JLabel(html);
+
+        frame.add(label);
+
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);	    
+    }
+
+
+    public static void main(String[] argv) throws Exception {
+        PassFailJFrame passFailJFrame = new PassFailJFrame(
+                "SwingHtmlTable Test", INSTRUCTIONS, 5);	    
+        SwingUtilities.invokeAndWait(() -> createAndShowGUI());
+	PassFailJFrame.addTestWindow(frame);
+	PassFailJFrame.positionTestWindow(
+                frame, PassFailJFrame.Position.HORIZONTAL);
+	passFailJFrame.awaitAndCheck();
+    }
+}

--- a/test/jdk/javax/swing/text/html/parser/TestHtmlOptionalClosingTag.java
+++ b/test/jdk/javax/swing/text/html/parser/TestHtmlOptionalClosingTag.java
@@ -54,7 +54,7 @@ public class TestHtmlOptionalClosingTag {
 
         JLabel label = new JLabel(html);
         frame.add(label);
-        frame.pack();
+        frame.setSize(400, 400);
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
@@ -70,3 +70,4 @@ public class TestHtmlOptionalClosingTag {
         passFailJFrame.awaitAndCheck();
     }
 }
+


### PR DESCRIPTION
This is in continuation with https://github.com/openjdk/jdk/commit/7133fc93e168f3671d048b2ae654f84ec289b98d fix done for [JDK-7172359](https://bugs.openjdk.org/browse/JDK-7172359) issue where fix was done to rectify invalid tag causing StackOverflowError but it caused alignment issue if the closing tags are optional, so the fix is modified to check for optional closing tag in which case dont return false for legalElementContext()

JDK-7172359 fix and other CI regression tests are fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296660](https://bugs.openjdk.org/browse/JDK-8296660): Swing HTML table with omitted closing tags misparsed


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [d92e446b](https://git.openjdk.org/jdk/pull/11355/files/d92e446ba3050cfede8ba12746a7bb547d7b8664)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**) ⚠️ Review applies to [d92e446b](https://git.openjdk.org/jdk/pull/11355/files/d92e446ba3050cfede8ba12746a7bb547d7b8664)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11355/head:pull/11355` \
`$ git checkout pull/11355`

Update a local copy of the PR: \
`$ git checkout pull/11355` \
`$ git pull https://git.openjdk.org/jdk pull/11355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11355`

View PR using the GUI difftool: \
`$ git pr show -t 11355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11355.diff">https://git.openjdk.org/jdk/pull/11355.diff</a>

</details>
