### PR TITLE
8297556: Parse::check_interpreter_type fails with assert "must constrain OSR typestate"

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -2314,16 +2314,14 @@ bool TypeAry::ary_must_be_exact() const {
     toop = _elem->isa_oopptr();
   }
   if (!toop)                return true;   // a primitive type, like int
-  ciKlass* tklass = toop->klass();
-  if (tklass == NULL)       return false;  // unloaded class
-  if (!tklass->is_loaded()) return false;  // unloaded class
+  if (!toop->is_loaded())   return false;  // unloaded class
   const TypeInstPtr* tinst;
   if (_elem->isa_narrowoop())
     tinst = _elem->make_ptr()->isa_instptr();
   else
     tinst = _elem->isa_instptr();
   if (tinst)
-    return tklass->as_instance_klass()->is_final();
+    return tinst->instance_klass()->is_final();
   const TypeAryPtr*  tap;
   if (_elem->isa_narrowoop())
     tap = _elem->make_ptr()->isa_aryptr();

--- a/test/hotspot/jtreg/compiler/types/TestExactArrayOfBasicType.java
+++ b/test/hotspot/jtreg/compiler/types/TestExactArrayOfBasicType.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8297556
+ * @summary Parse::check_interpreter_type fails with assert "must constrain OSR typestate"
+ *
+ * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:CompileOnly=TestExactArrayOfBasicType::test TestExactArrayOfBasicType
+ *
+ */
+
+
+public class TestExactArrayOfBasicType {
+    public static void test() {
+        int[][][][][] array = new int[1][2][3][4][5];
+
+        for (int i = 0; i < 50_000; ++i) {
+            array[0] = new int[0][1][2][3];
+        }
+    }
+
+    public static void main(String args[]) {
+        test();
+    }
+}


### PR DESCRIPTION
With 6312651 (Compiler should only use verified interface types for
optimization), I changed when the _klass field for an array in the
type system would be null. Before, there was an assumption that any
type (other than top, bottom) could be represented with a non null
_klass field. With 6312651, there are types that are impossible to
represent with a single klass pointer so now, the _klass field is only
guaranteed non null for an array of basic type. When I made that
change, I went over uses of the _klass field for anything other than
an array of basic type and fixed the code so it uses something other
than the _klass field. This is a place I missed.

(I made some of the changes for the _klass field after Vladimir I ran
extensive testing for the patch so that could explain why this issue
was missed)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297556](https://bugs.openjdk.org/browse/JDK-8297556): Parse::check_interpreter_type fails with assert "must constrain OSR typestate"


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11356/head:pull/11356` \
`$ git checkout pull/11356`

Update a local copy of the PR: \
`$ git checkout pull/11356` \
`$ git pull https://git.openjdk.org/jdk pull/11356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11356`

View PR using the GUI difftool: \
`$ git pr show -t 11356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11356.diff">https://git.openjdk.org/jdk/pull/11356.diff</a>

</details>
