### PR TITLE
8297343: TestStress*.java fail with "got different traces for the same seed"

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -3183,7 +3183,7 @@ void TypePtr::InterfaceSet::compute_hash() {
 }
 
 static int compare_interfaces(ciKlass** k1, ciKlass** k2) {
-return (int)((*k1)->ident() - (*k2)->ident());
+  return (int)((*k1)->ident() - (*k2)->ident());
 }
 
 void TypePtr::InterfaceSet::dump(outputStream *st) const {

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -3182,16 +3182,24 @@ void TypePtr::InterfaceSet::compute_hash() {
   _hash = hash;
 }
 
+static int compare_interfaces(ciKlass** k1, ciKlass** k2) {
+return (int)((*k1)->ident() - (*k2)->ident());
+}
+
 void TypePtr::InterfaceSet::dump(outputStream *st) const {
   if (_list.length() == 0) {
     return;
   }
+  ResourceMark rm;
   st->print(" (");
-  for (int i = 0; i < _list.length(); i++) {
+  GrowableArray<ciKlass*> interfaces;
+  interfaces.appendAll(&_list);
+  interfaces.sort(compare_interfaces);
+  for (int i = 0; i < interfaces.length(); i++) {
     if (i > 0) {
       st->print(",");
     }
-    ciKlass* k = _list.at(i);
+    ciKlass* k = interfaces.at(i);
     k->print_name_on(st);
   }
   st->print(")");

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -3194,7 +3194,7 @@ void TypePtr::InterfaceSet::dump(outputStream *st) const {
   st->print(" (");
   GrowableArray<ciKlass*> interfaces;
   interfaces.appendAll(&_list);
-  // Sort the interfaces so there's listed in the same order from one run to the other of the same compilation
+  // Sort the interfaces so they are listed in the same order from one run to the other of the same compilation
   interfaces.sort(compare_interfaces);
   for (int i = 0; i < interfaces.length(); i++) {
     if (i > 0) {

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -3194,6 +3194,7 @@ void TypePtr::InterfaceSet::dump(outputStream *st) const {
   st->print(" (");
   GrowableArray<ciKlass*> interfaces;
   interfaces.appendAll(&_list);
+  // Sort the interfaces so there's listed in the same order from one run to the other of the same compilation
   interfaces.sort(compare_interfaces);
   for (int i = 0; i < interfaces.length(); i++) {
     if (i > 0) {

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -68,9 +68,6 @@ compiler/c2/Test8004741.java 8235801 generic-all
 
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-all
 
-compiler/debug/TestStressCM.java 8297343 generic-all
-compiler/debug/TestStressIGVNAndCCP.java 8297343 generic-all
-
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
Root cause from Roberto's analysis:

"The regression seems to be due to the introduction of non-determinism
in the node dumps of otherwise identical compilations."

"The problem seems to be that JDK-6312651 dumps interface sets in an
order that is determined by the raw pointers of the set elements. This
is unstable across different runs and leads to different node dumps
for otherwise identical compilations."

"Stable node dumps are useful for debugging (e.g. when diffing
compiler traces from two different runs), so the solution is probably
dumping interface sets in some order (e.g. lexicographic order of each
interface dump) that does not depend on raw pointer values."

This patch implements Roberto's recommendation by sorting interfaces
on their ciBaseObject::_ident.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297343](https://bugs.openjdk.org/browse/JDK-8297343): TestStress*.java fail with "got different traces for the same seed"


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11357/head:pull/11357` \
`$ git checkout pull/11357`

Update a local copy of the PR: \
`$ git checkout pull/11357` \
`$ git pull https://git.openjdk.org/jdk pull/11357/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11357`

View PR using the GUI difftool: \
`$ git pr show -t 11357`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11357.diff">https://git.openjdk.org/jdk/pull/11357.diff</a>

</details>
