### PR TITLE
8297590: [TESTBUG] HotSpotResolvedJavaFieldTest does not run

### DIFF
--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/HotSpotResolvedJavaFieldTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/HotSpotResolvedJavaFieldTest.java
@@ -47,7 +47,15 @@ import jdk.vm.ci.meta.ResolvedJavaType;
 import jdk.vm.ci.runtime.JVMCI;
 
 /**
- * Tests {@link HotSpotResolvedJavaField} functionality.
+ *
+ * @test
+ * @requires vm.jvmci
+ * @summary Tests HotSpotResolvedJavaField functionality
+ * @library ../../../../../
+ * @modules jdk.internal.vm.ci/jdk.vm.ci.meta
+ *          jdk.internal.vm.ci/jdk.vm.ci.runtime
+ *          jdk.internal.vm.ci/jdk.vm.ci.hotspot
+ * @run junit/othervm --add-opens=jdk.internal.vm.ci/jdk.vm.ci.hotspot=ALL-UNNAMED -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseJVMCICompiler jdk.vm.ci.hotspot.test.HotSpotResolvedJavaFieldTest
  */
 public class HotSpotResolvedJavaFieldTest {
 
@@ -61,7 +69,7 @@ public class HotSpotResolvedJavaFieldTest {
         Field f = null;
         try {
             Class<?> typeImpl = Class.forName("jdk.vm.ci.hotspot.HotSpotResolvedObjectTypeImpl");
-            m = typeImpl.getDeclaredMethod("createField", JavaType.class, long.class, int.class, int.class);
+            m = typeImpl.getDeclaredMethod("createField", JavaType.class, int.class, int.class, int.class);
             m.setAccessible(true);
             Class<?> fieldImpl = Class.forName("jdk.vm.ci.hotspot.HotSpotResolvedJavaFieldImpl");
             f = fieldImpl.getDeclaredField("index");


### PR DESCRIPTION
Simple test fix. Test now also runs when running the JVMCI test set.

Testing: jvmci tests. Includes the test now and passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297590](https://bugs.openjdk.org/browse/JDK-8297590): [TESTBUG] HotSpotResolvedJavaFieldTest does not run


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11358/head:pull/11358` \
`$ git checkout pull/11358`

Update a local copy of the PR: \
`$ git checkout pull/11358` \
`$ git pull https://git.openjdk.org/jdk pull/11358/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11358`

View PR using the GUI difftool: \
`$ git pr show -t 11358`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11358.diff">https://git.openjdk.org/jdk/pull/11358.diff</a>

</details>
