### PR TITLE
8297285: Shenandoah pacing causes assertion failure during VM initialization

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
@@ -29,6 +29,7 @@
 #include "gc/shenandoah/shenandoahPacer.hpp"
 #include "gc/shenandoah/shenandoahPhaseTimings.hpp"
 #include "runtime/atomic.hpp"
+#include "runtime/javaThread.inline.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/threadSMR.hpp"
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
@@ -241,7 +241,13 @@ void ShenandoahPacer::pace_for_alloc(size_t words) {
   // Threads that are attaching should not block at all: they are not
   // fully initialized yet. Blocking them would be awkward.
   // This is probably the path that allocates the thread oop itself.
-  if (JavaThread::current()->is_attaching_via_jni()) {
+  //
+  // Thread which is not an active Java thread should also not block.
+  // This can happen during VM init when main thread is still not an
+  // active Java thread.
+  JavaThread* current = JavaThread::current();
+  if (current->is_attaching_via_jni() ||
+      current->is_active_Java_thread()) {
     return;
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
@@ -248,7 +248,7 @@ void ShenandoahPacer::pace_for_alloc(size_t words) {
   // active Java thread.
   JavaThread* current = JavaThread::current();
   if (current->is_attaching_via_jni() ||
-      current->is_active_Java_thread()) {
+      !current->is_active_Java_thread()) {
     return;
   }
 


### PR DESCRIPTION
Please review the fix for the assertion failure seen during VM init due to pacing in shenandoah gc.
The fix is to avoid pacing during VM initialization as the main thread is not yet an active java thread.

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297285](https://bugs.openjdk.org/browse/JDK-8297285): Shenandoah pacing causes assertion failure during VM initialization


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11360/head:pull/11360` \
`$ git checkout pull/11360`

Update a local copy of the PR: \
`$ git checkout pull/11360` \
`$ git pull https://git.openjdk.org/jdk pull/11360/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11360`

View PR using the GUI difftool: \
`$ git pr show -t 11360`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11360.diff">https://git.openjdk.org/jdk/pull/11360.diff</a>

</details>
