### PR TITLE
8297584: G1 parallel phase event for scan heap roots is sent too often

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -683,8 +683,7 @@ class G1ScanHRForRegionClosure : public HeapRegionClosure {
     _blocks_scanned++;
   }
 
-   void scan_heap_roots(HeapRegion* r) {
-    EventGCPhaseParallel event;
+  void scan_heap_roots(HeapRegion* r) {
     uint const region_idx = r->hrm_index();
 
     ResourceMark rm;
@@ -725,8 +724,6 @@ class G1ScanHRForRegionClosure : public HeapRegionClosure {
       }
       _chunks_claimed++;
     }
-
-    event.commit(GCId::current(), _worker_id, G1GCPhaseTimes::phase_name(G1GCPhaseTimes::ScanHR));
   }
 
 public:
@@ -780,8 +777,11 @@ void G1RemSet::scan_heap_roots(G1ParScanThreadState* pss,
                                G1GCPhaseTimes::GCParPhases scan_phase,
                                G1GCPhaseTimes::GCParPhases objcopy_phase,
                                bool remember_already_scanned_cards) {
+  EventGCPhaseParallel event;
   G1ScanHRForRegionClosure cl(_scan_state, pss, worker_id, scan_phase, remember_already_scanned_cards);
   _scan_state->iterate_dirty_regions_from(&cl, worker_id);
+
+  event.commit(GCId::current(), worker_id, G1GCPhaseTimes::phase_name(scan_phase));
 
   G1GCPhaseTimes* p = _g1p->phase_times();
 
@@ -816,16 +816,12 @@ class G1ScanCollectionSetRegionClosure : public HeapRegionClosure {
   Tickspan _rem_set_opt_trim_partially_time;
 
   void scan_opt_rem_set_roots(HeapRegion* r) {
-    EventGCPhaseParallel event;
-
     G1OopStarChunkedList* opt_rem_set_list = _pss->oops_into_optional_region(r);
 
     G1ScanCardClosure scan_cl(G1CollectedHeap::heap(), _pss, _opt_roots_scanned);
     G1ScanRSForOptionalClosure cl(G1CollectedHeap::heap(), &scan_cl);
     _opt_refs_scanned += opt_rem_set_list->oops_do(&cl, _pss->closures()->strong_oops());
     _opt_refs_memory_used += opt_rem_set_list->used_memory();
-
-    event.commit(GCId::current(), _worker_id, G1GCPhaseTimes::phase_name(_scan_phase));
   }
 
 public:
@@ -853,13 +849,15 @@ public:
     // The individual references for the optional remembered set are per-worker, so we
     // always need to scan them.
     if (r->has_index_in_opt_cset()) {
+      EventGCPhaseParallel event;
       G1EvacPhaseWithTrimTimeTracker timer(_pss, _rem_set_opt_root_scan_time, _rem_set_opt_trim_partially_time);
       scan_opt_rem_set_roots(r);
+
+      event.commit(GCId::current(), _worker_id, G1GCPhaseTimes::phase_name(_scan_phase));
     }
 
     if (_scan_state->claim_collection_set_region(region_idx)) {
       EventGCPhaseParallel event;
-
       G1EvacPhaseWithTrimTimeTracker timer(_pss, _code_root_scan_time, _code_trim_partially_time);
       // Scan the code root list attached to the current region
       r->code_roots_do(_pss->closures()->weak_codeblobs());


### PR DESCRIPTION
Please review this enhancement to decrease the number of "GC Phase Parallel" events sent by G1.

**Summary**
The "GC Phase Parallel" event is used by multiple phases in G1 and for the "ScanHR" phase we currently get an excessive amount of events. In a recent recording of mine more then 75% of these events was of the "ScanHR" type. This event is sent from more than one place in the code and one reason for the excessive amount is that we send the event on a per region basis rather than once per worker.

The fix is to move where we send the event so instead of sending it inside `scan_heap_roots(HeapRegion* r)` in the closure we send it in the outer `scan_heap_roots(...)`. So instead of sending it once per region we send it once per worker. The way the event is sent is still not optimal because it will include a bit more than what the name suggests (but that was true before as well). 

I also move the other place where this event was sent to make it more consistent with the "Code Roots" events sent by the same closure.

**Testing**
* Local JFR testing and verification that we get a lower number of events.
* Mach5 testing of JFR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297584](https://bugs.openjdk.org/browse/JDK-8297584): G1 parallel phase event for scan heap roots is sent too often


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11362/head:pull/11362` \
`$ git checkout pull/11362`

Update a local copy of the PR: \
`$ git checkout pull/11362` \
`$ git pull https://git.openjdk.org/jdk pull/11362/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11362`

View PR using the GUI difftool: \
`$ git pr show -t 11362`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11362.diff">https://git.openjdk.org/jdk/pull/11362.diff</a>

</details>
