### PR TITLE
8296012: jshell crashes on mismatched record pattern

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -778,7 +778,10 @@ public class Flow {
                 }
             }
             for (Entry<Symbol, List<JCRecordPattern>> e : deconstructionPatternsBySymbol.entrySet()) {
-                if (coversDeconstructionFromComponent(pos, targetType, e.getValue(), 0)) {
+                if (e.getValue().stream().anyMatch(r -> r.nested.size() != r.record.getRecordComponents().size())) {
+                    coveredSymbols.add(syms.errSymbol);
+                }
+                else if (coversDeconstructionFromComponent(pos, targetType, e.getValue(), 0)) {
                     coveredSymbols.add(e.getKey());
                 }
             }

--- a/test/langtools/jdk/jshell/Test8296012.java
+++ b/test/langtools/jdk/jshell/Test8296012.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8296012
+ * @summary jshell crashes on mismatched record pattern
+ * @build KullaTesting TestingInputStream
+ * @run testng Test8296012
+ */
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+
+@Test
+public class Test8296012 extends KullaTesting {
+
+    public void test() {
+        assertEval("record Foo(int x, int y) {}");
+        assertEvalFail("switch (new Foo(1, 2)) { case Foo(int z) -> z; }");
+    }
+
+    @org.testng.annotations.BeforeMethod
+    public void setUp() {
+        super.setUp(bc -> bc.compilerOptions("--source", System.getProperty("java.specification.version"), "--enable-preview").remoteVMOptions("--enable-preview"));
+    }
+}


### PR DESCRIPTION
This bug prevents a crash in Flow while evaluating a switch expression in JShell. The error is successfully reported in Attr however entering an erroneous symbols prevents the crash.