### PR TITLE
8297608: JFR: Incorrect duration after chunk rotation

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventInstrumentation.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventInstrumentation.java
@@ -478,18 +478,20 @@ public final class EventInstrumentation {
                 methodVisitor.visitInsn(Opcodes.RETURN);
                 methodVisitor.visitLabel(l0);
                 methodVisitor.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
+                // long startTime = this.startTime
+                methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                methodVisitor.visitFieldInsn(Opcodes.GETFIELD, getInternalClassName(), FIELD_START_TIME, "J");
+                methodVisitor.visitVarInsn(Opcodes.LSTORE, 1);
                 // if (startTime == 0) {
                 // startTime = EventWriter.timestamp();
                 // } else {
-                methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
-                methodVisitor.visitFieldInsn(Opcodes.GETFIELD, getInternalClassName(), FIELD_START_TIME, "J");
+                methodVisitor.visitVarInsn(Opcodes.LLOAD, 1);
                 methodVisitor.visitInsn(Opcodes.LCONST_0);
                 methodVisitor.visitInsn(Opcodes.LCMP);
                 Label durationalEvent = new Label();
                 methodVisitor.visitJumpInsn(Opcodes.IFNE, durationalEvent);
-                methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
                 methodVisitor.visitMethodInsn(Opcodes.INVOKESTATIC, TYPE_EVENT_CONFIGURATION.getInternalName(), METHOD_TIME_STAMP.getName(), METHOD_TIME_STAMP.getDescriptor(), false);
-                methodVisitor.visitFieldInsn(Opcodes.PUTFIELD, getInternalClassName(), FIELD_START_TIME, "J");
+                methodVisitor.visitVarInsn(Opcodes.LSTORE, 1);
                 Label commit = new Label();
                 methodVisitor.visitJumpInsn(Opcodes.GOTO, commit);
                 // if (duration == 0) {
@@ -505,8 +507,7 @@ public final class EventInstrumentation {
                 methodVisitor.visitJumpInsn(Opcodes.IFNE, commit);
                 methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
                 methodVisitor.visitMethodInsn(Opcodes.INVOKESTATIC, TYPE_EVENT_CONFIGURATION.getInternalName(), METHOD_TIME_STAMP.getName(), METHOD_TIME_STAMP.getDescriptor(), false);
-                methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
-                methodVisitor.visitFieldInsn(Opcodes.GETFIELD, getInternalClassName(), FIELD_START_TIME, "J");
+                methodVisitor.visitVarInsn(Opcodes.LLOAD, 1);
                 methodVisitor.visitInsn(Opcodes.LSUB);
                 methodVisitor.visitFieldInsn(Opcodes.PUTFIELD, getInternalClassName(), FIELD_DURATION, "J");
                 methodVisitor.visitLabel(commit);
@@ -531,9 +532,7 @@ public final class EventInstrumentation {
                 int fieldIndex = 0;
                 methodVisitor.visitInsn(Opcodes.DUP);
                 // stack: [EW] [EW]
-                methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
-                // stack: [EW] [EW] [this]
-                methodVisitor.visitFieldInsn(Opcodes.GETFIELD, getInternalClassName(), FIELD_START_TIME, "J");
+                methodVisitor.visitVarInsn(Opcodes.LLOAD, 1);
                 // stack: [EW] [EW] [long]
                 invokeVirtual(methodVisitor, TYPE_EVENT_WRITER, EventWriterMethod.PUT_LONG.asmMethod);
                 // stack: [EW]

--- a/test/jdk/jdk/jfr/jvm/TestEventDuration.java
+++ b/test/jdk/jdk/jfr/jvm/TestEventDuration.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.jvm;
+
+import jdk.jfr.Event;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordingFile;
+import java.nio.file.Path;
+
+/**
+ * @test Checks that timestamp are correctly handled in case of a chunk rotation
+ * @key jfr
+ * @requires vm.hasJFR
+ * @library /test/lib
+ * @modules jdk.jfr/jdk.jfr.internal
+ * @run main/othervm jdk.jfr.jvm.TestEventDuration
+ */
+public class TestEventDuration {
+
+    static class InstantEvent extends Event {
+        long id;
+    }
+
+    public static void main(String... args) throws Exception {
+        try (Recording r1 = new Recording()) {
+            r1.start();
+            long counter = 0;
+            for (int i = 0; i < 10; i ++) {
+                try (Recording r2 = new Recording()) {
+                    r2.start();
+                    InstantEvent e1 = new InstantEvent();
+                    e1.id = counter++;
+                    e1.commit();
+                    InstantEvent e2 = new InstantEvent();
+                    e2.id = counter++;
+                    e2.commit();
+                }
+            }
+            Path p = Path.of("dump.jfr");
+            r1.dump(p);
+            var events = RecordingFile.readAllEvents(p);
+            if (events.isEmpty()) {
+                throw new AssertionError("Expected at least one event");
+            }
+            events.forEach(System.out::println);
+            for (var event : events) {
+                if (event.getDuration().toNanos() != 0) {
+                    throw new AssertionError("Expected all events to have zero duration");
+                }
+            }
+        }
+    }
+
+}

--- a/test/jdk/jdk/jfr/jvm/TestEventDuration.java
+++ b/test/jdk/jdk/jfr/jvm/TestEventDuration.java
@@ -29,7 +29,7 @@ import jdk.jfr.consumer.RecordingFile;
 import java.nio.file.Path;
 
 /**
- * @test Checks that timestamp are correctly handled in case of a chunk rotation
+ * @test Tests that the event duration is zero of length after a chunk rotation
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib
@@ -71,5 +71,4 @@ public class TestEventDuration {
             }
         }
     }
-
 }

--- a/test/jdk/jdk/jfr/jvm/TestEventDuration.java
+++ b/test/jdk/jdk/jfr/jvm/TestEventDuration.java
@@ -29,7 +29,7 @@ import jdk.jfr.consumer.RecordingFile;
 import java.nio.file.Path;
 
 /**
- * @test Tests that the event duration is zero of length after a chunk rotation
+ * @test Tests that the event duration is zero after a chunk rotation
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib


### PR DESCRIPTION
Could I have a review of PR that fixes a problem with the duration of instant events after a chunk rotation.

Testing: test/jdk/dk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297608](https://bugs.openjdk.org/browse/JDK-8297608): JFR: Incorrect duration after chunk rotation


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11364/head:pull/11364` \
`$ git checkout pull/11364`

Update a local copy of the PR: \
`$ git checkout pull/11364` \
`$ git pull https://git.openjdk.org/jdk pull/11364/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11364`

View PR using the GUI difftool: \
`$ git pr show -t 11364`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11364.diff">https://git.openjdk.org/jdk/pull/11364.diff</a>

</details>
