### PR TITLE
8297640: Increase buffer size for buf (insert_features_names) in Abstract_VM_Version::insert_features_names

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -989,7 +989,7 @@ void VM_Version::get_processor_features() {
     _has_intel_jcc_erratum = IntelJccErratumMitigation;
   }
 
-  char buf[512];
+  char buf[1024];
   int res = jio_snprintf(
               buf, sizeof(buf),
               "(%u cores per cpu, %u threads per core) family %d model %d stepping %d microcode 0x%x",


### PR DESCRIPTION
As described in [JDK-8297640](https://bugs.openjdk.org/browse/JDK-8297640), the buffer is too small, I increased the size from 512 to 1024.

The string needs to be a few characters larger, now that we have the additional feature `avx512_ifma`, added in [JDK-8288047](https://bugs.openjdk.org/browse/JDK-8288047).

I manually tested it with `./java --version`, used to crash, now works.
Running larger test suite now...

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297640](https://bugs.openjdk.org/browse/JDK-8297640): Increase buffer size for buf (insert_features_names) in Abstract_VM_Version::insert_features_names


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11366/head:pull/11366` \
`$ git checkout pull/11366`

Update a local copy of the PR: \
`$ git checkout pull/11366` \
`$ git pull https://git.openjdk.org/jdk pull/11366/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11366`

View PR using the GUI difftool: \
`$ git pr show -t 11366`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11366.diff">https://git.openjdk.org/jdk/pull/11366.diff</a>

</details>
