### PR TITLE
8294278: ForkJoinPool.getAndAddPoolIds should use Unsafe.staticFieldBase

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -25,6 +25,7 @@
 
 package java.lang;
 
+import java.lang.reflect.Field;
 import java.security.AccessController;
 import java.security.AccessControlContext;
 import java.security.Permission;
@@ -1107,14 +1108,21 @@ public class Thread implements Runnable {
      */
     private static class ThreadNumbering {
         private static final Unsafe U;
-        private static final long NEXT;
+        private static final Object NEXT_BASE;
+        private static final long NEXT_OFFSET;
         static {
             U = Unsafe.getUnsafe();
-            NEXT = U.objectFieldOffset(ThreadNumbering.class, "next");
+            try {
+                Field nextField = ThreadNumbering.class.getDeclaredField("next");
+                NEXT_BASE = U.staticFieldBase(nextField);
+                NEXT_OFFSET = U.staticFieldOffset(nextField);
+            } catch (NoSuchFieldException e) {
+                throw new ExceptionInInitializerError(e);
+            }
         }
         private static volatile int next;
         static int next() {
-            return U.getAndAddInt(ThreadNumbering.class, NEXT, 1);
+            return U.getAndAddInt(NEXT_BASE, NEXT_OFFSET, 1);
         }
     }
 


### PR DESCRIPTION
Two (since 19) usages of Unsafe.getAndAddInt to update a static field provide the Class object as the base instead of the base object returned by Unsafe.staticFieldBase. This doesn't change anything on the HotSpot VM.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294278](https://bugs.openjdk.org/browse/JDK-8294278): ForkJoinPool.getAndAddPoolIds should use Unsafe.staticFieldBase


### Reviewers
 * [Bernhard Urban-Forster](https://openjdk.org/census#burban) (@lewurm - Author)
 * [Chris Hegarty](https://openjdk.org/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Martin Buchholz](https://openjdk.org/census#martin) (@Martin-Buchholz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11369/head:pull/11369` \
`$ git checkout pull/11369`

Update a local copy of the PR: \
`$ git checkout pull/11369` \
`$ git pull https://git.openjdk.org/jdk pull/11369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11369`

View PR using the GUI difftool: \
`$ git pr show -t 11369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11369.diff">https://git.openjdk.org/jdk/pull/11369.diff</a>

</details>
