### PR TITLE
8297644: RISC-V: Compilation error when shenandoah is disabled

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -960,11 +960,13 @@ definitions %{
 source_hpp %{
 
 #include "asm/macroAssembler.hpp"
+#include "gc/shared/barrierSetAssembler.hpp"
 #include "gc/shared/cardTable.hpp"
 #include "gc/shared/cardTableBarrierSet.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "opto/addnode.hpp"
 #include "opto/convertnode.hpp"
+#include "runtime/objectMonitor.hpp"
 
 extern RegMask _ANY_REG32_mask;
 extern RegMask _ANY_REG_mask;


### PR DESCRIPTION
If configuring with `--disable-jvm-feature-shenandoahgc`, the risc-v port fails to build.

It seems that the code is really dependent on two header files, that is not declared, and probably has "leaked in" somewhere, but only if shenandoah is enabled. I have tried to resolve it to the best of my knowledge, but if you're not happy with the solution, by all means suggest a better way or take over this bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297644](https://bugs.openjdk.org/browse/JDK-8297644): RISC-V: Compilation error when shenandoah is disabled


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Yadong Wang](https://openjdk.org/census#yadongwang) (@yadongw - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11370/head:pull/11370` \
`$ git checkout pull/11370`

Update a local copy of the PR: \
`$ git checkout pull/11370` \
`$ git pull https://git.openjdk.org/jdk pull/11370/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11370`

View PR using the GUI difftool: \
`$ git pr show -t 11370`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11370.diff">https://git.openjdk.org/jdk/pull/11370.diff</a>

</details>
