### PR TITLE
JDK-8297660: x86: Redundant test+jump in C1 allocateArray

### DIFF
--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -176,7 +176,6 @@ void C1_MacroAssembler::initialize_body(Register obj, Register len_in_bytes, int
 
   // len_in_bytes is positive and ptr sized
   subptr(len_in_bytes, hdr_size_in_bytes);
-  jcc(Assembler::zero, done);
   zero_memory(obj, len_in_bytes, hdr_size_in_bytes, t1);
   bind(done);
 }

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -4130,16 +4130,20 @@ void MacroAssembler::pop_set(RegSet set, int offset) {
 
 // Preserves the contents of address, destroys the contents length_in_bytes and temp.
 void MacroAssembler::zero_memory(Register address, Register length_in_bytes, int offset_in_bytes, Register temp) {
-  assert(address != length_in_bytes && address != temp && temp != length_in_bytes, "registers must be different");
+  assert_different_registers(address, length_in_bytes, temp);
   assert((offset_in_bytes & (BytesPerWord - 1)) == 0, "offset must be a multiple of BytesPerWord");
   Label done;
-
-  testptr(length_in_bytes, length_in_bytes);
-  jcc(Assembler::zero, done);
 
   // initialize topmost word, divide index by 2, check if odd and test if zero
   // note: for the remaining code to work, index must be a multiple of BytesPerWord
 #ifdef ASSERT
+  {
+    Label L;
+    testptr(length_in_bytes, length_in_bytes);
+    jcc(Assembler::notZero, L);
+    stop("length must be non-zero");
+    bind(L);
+  }
   {
     Label L;
     testptr(length_in_bytes, BytesPerWord - 1);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -4130,20 +4130,16 @@ void MacroAssembler::pop_set(RegSet set, int offset) {
 
 // Preserves the contents of address, destroys the contents length_in_bytes and temp.
 void MacroAssembler::zero_memory(Register address, Register length_in_bytes, int offset_in_bytes, Register temp) {
-  assert_different_registers(address, length_in_bytes, temp);
+  assert(address != length_in_bytes && address != temp && temp != length_in_bytes, "registers must be different");
   assert((offset_in_bytes & (BytesPerWord - 1)) == 0, "offset must be a multiple of BytesPerWord");
   Label done;
+
+  testptr(length_in_bytes, length_in_bytes);
+  jcc(Assembler::zero, done);
 
   // initialize topmost word, divide index by 2, check if odd and test if zero
   // note: for the remaining code to work, index must be a multiple of BytesPerWord
 #ifdef ASSERT
-  {
-    Label L;
-    testptr(length_in_bytes, length_in_bytes);
-    jcc(Assembler::notZero, L);
-    stop("length must be non-zero");
-    bind(L);
-  }
   {
     Label L;
     testptr(length_in_bytes, BytesPerWord - 1);


### PR DESCRIPTION
In `C1_MacroAssembler::initialize_body()` we test the input array length for 0. We do this again in `MacroAssembler::zero_memory()`. This results in a redundant test+jump instruction:

```
 13442   0x00007f58a8ca2f02:   sub    $0x10,%rsi                 
 13443   0x00007f58a8ca2f06:   je     0x00007f58a8ca2f26   <<
 13444   0x00007f58a8ca2f0c:   test   %rsi,%rsi                     
 13445   0x00007f58a8ca2f0f:   je     0x00007f58a8ca2f26    <<
 13446   0x00007f58a8ca2f15:   xor    %rbx,%rbx
 13447   0x00007f58a8ca2f18:   shr    $0x3,%rsi
 13448   0x00007f58a8ca2f1c:   mov    %rbx,0x8(%rax,%rsi,8)
 13449   0x00007f58a8ca2f21:   dec    %rsi
 13450   0x00007f58a8ca2f24:   jne    0x00007f58a8ca2f1c           ;*anewarray {reexecute=0 rethrow=0 return_oop=0}
 13451                                                             ; - java.lang.invoke.MethodHandles::<clinit>@24 (line 5109)
```

Since `MacroAssembler::zero_memory()` is only ever called from `C1_MacroAssembler::initialize_body()`, it does not need to test for len=0, since its caller already does.

---

Patch removes one test+jump and adds an assertion for len>0 to zero_memory.

Patch ran through SAP nightlies and GHAs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297660](https://bugs.openjdk.org/browse/JDK-8297660): x86: Redundant test+jump in C1 allocateArray


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**) ⚠️ Review applies to [3372e965](https://git.openjdk.org/jdk/pull/11372/files/3372e965626390d8bef75466b5ab4c001256b8f3)
 * [Yi Yang](https://openjdk.org/census#yyang) (@y1yang0 - Committer) ⚠️ Review applies to [3372e965](https://git.openjdk.org/jdk/pull/11372/files/3372e965626390d8bef75466b5ab4c001256b8f3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11372/head:pull/11372` \
`$ git checkout pull/11372`

Update a local copy of the PR: \
`$ git checkout pull/11372` \
`$ git pull https://git.openjdk.org/jdk pull/11372/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11372`

View PR using the GUI difftool: \
`$ git pr show -t 11372`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11372.diff">https://git.openjdk.org/jdk/pull/11372.diff</a>

</details>
