### PR TITLE
8297676: DataBuffer.TYPE_SHORT/TYPE_FLOAT/TYPE_DOUBLE are not placeholders

### DIFF
--- a/src/java.desktop/share/classes/java/awt/image/DataBuffer.java
+++ b/src/java.desktop/share/classes/java/awt/image/DataBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,13 +35,13 @@
 
 package java.awt.image;
 
-import sun.java2d.StateTrackable.State;
-import static sun.java2d.StateTrackable.State.*;
-import sun.java2d.StateTrackableDelegate;
+import java.lang.annotation.Native;
 
 import sun.awt.image.SunWritableRaster;
+import sun.java2d.StateTrackable.State;
+import sun.java2d.StateTrackableDelegate;
 
-import java.lang.annotation.Native;
+import static sun.java2d.StateTrackable.State.UNTRACKABLE;
 
 /**
  * This class exists to wrap one or more data arrays.  Each data array in
@@ -75,16 +75,16 @@ public abstract class DataBuffer {
     /** Tag for unsigned short data. */
     @Native public static final int TYPE_USHORT = 1;
 
-    /** Tag for signed short data.  Placeholder for future use. */
+    /** Tag for signed short data. */
     @Native public static final int TYPE_SHORT = 2;
 
     /** Tag for int data. */
     @Native public static final int TYPE_INT   = 3;
 
-    /** Tag for float data.  Placeholder for future use. */
+    /** Tag for float data. */
     @Native public static final int TYPE_FLOAT  = 4;
 
-    /** Tag for double data.  Placeholder for future use. */
+    /** Tag for double data. */
     @Native public static final int TYPE_DOUBLE  = 5;
 
     /** Tag for undefined data. */


### PR DESCRIPTION
The specification for the DataBuffer.TYPE_SHORT/TYPE_FLOAT/TYPE_DOUBLE mentioned that all of them are "Placeholder for future use" which is not true.

They are used and it is possible to create the ComponentColorModel for each of this transferType. Also, there is a specific data buffer for each: [DataBufferFloat](https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/java/awt/image/DataBufferFloat.java#L67), [DataBufferDouble](https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/java/awt/image/DataBufferDouble.java#L67), and [DataBufferShort](https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/java/awt/image/DataBufferShort.java#L74).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8297676](https://bugs.openjdk.org/browse/JDK-8297676): DataBuffer.TYPE_SHORT/TYPE_FLOAT/TYPE_DOUBLE are not placeholders
 * [JDK-8297677](https://bugs.openjdk.org/browse/JDK-8297677): DataBuffer.TYPE_SHORT/TYPE_FLOAT/TYPE_DOUBLE are not placeholders (**CSR**)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11374/head:pull/11374` \
`$ git checkout pull/11374`

Update a local copy of the PR: \
`$ git checkout pull/11374` \
`$ git pull https://git.openjdk.org/jdk pull/11374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11374`

View PR using the GUI difftool: \
`$ git pr show -t 11374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11374.diff">https://git.openjdk.org/jdk/pull/11374.diff</a>

</details>
