### PR TITLE
8287400: Make BitMap range parameter names consistent

### DIFF
--- a/src/hotspot/share/utilities/bitMap.cpp
+++ b/src/hotspot/share/utilities/bitMap.cpp
@@ -320,11 +320,11 @@ bool BitMap::par_at_put(idx_t bit, bool value) {
   return value ? par_set_bit(bit) : par_clear_bit(bit);
 }
 
-void BitMap::at_put_range(idx_t start_offset, idx_t end_offset, bool value) {
+void BitMap::at_put_range(idx_t beg_offset, idx_t end_offset, bool value) {
   if (value) {
-    set_range(start_offset, end_offset);
+    set_range(beg_offset, end_offset);
   } else {
-    clear_range(start_offset, end_offset);
+    clear_range(beg_offset, end_offset);
   }
 }
 

--- a/src/hotspot/share/utilities/bitMap.cpp
+++ b/src/hotspot/share/utilities/bitMap.cpp
@@ -164,9 +164,9 @@ void BitMap::verify_limit(idx_t bit) const {
          bit, _size);
 }
 
-void BitMap::verify_range(idx_t start, idx_t end) const {
-  assert(start <= end,
-         "BitMap range error: " SIZE_FORMAT " > " SIZE_FORMAT, start, end);
+void BitMap::verify_range(idx_t beg, idx_t end) const {
+  assert(beg <= end,
+         "BitMap range error: " SIZE_FORMAT " > " SIZE_FORMAT, beg, end);
   verify_limit(end);
 }
 #endif // #ifdef ASSERT
@@ -175,32 +175,32 @@ void BitMap::pretouch() {
   os::pretouch_memory(word_addr(0), word_addr(size()));
 }
 
-void BitMap::set_range_within_word(idx_t start, idx_t end) {
-  // With a valid range (start <= end), this test ensures that end != 0, as
+void BitMap::set_range_within_word(idx_t beg, idx_t end) {
+  // With a valid range (beg <= end), this test ensures that end != 0, as
   // required by inverted_bit_mask_for_range.  Also avoids an unnecessary write.
-  if (start != end) {
-    bm_word_t mask = inverted_bit_mask_for_range(start, end);
-    *word_addr(start) |= ~mask;
+  if (beg != end) {
+    bm_word_t mask = inverted_bit_mask_for_range(beg, end);
+    *word_addr(beg) |= ~mask;
   }
 }
 
-void BitMap::clear_range_within_word(idx_t start, idx_t end) {
-  // With a valid range (start <= end), this test ensures that end != 0, as
+void BitMap::clear_range_within_word(idx_t beg, idx_t end) {
+  // With a valid range (beg <= end), this test ensures that end != 0, as
   // required by inverted_bit_mask_for_range.  Also avoids an unnecessary write.
-  if (start != end) {
-    bm_word_t mask = inverted_bit_mask_for_range(start, end);
-    *word_addr(start) &= mask;
+  if (beg != end) {
+    bm_word_t mask = inverted_bit_mask_for_range(beg, end);
+    *word_addr(beg) &= mask;
   }
 }
 
-void BitMap::par_put_range_within_word(idx_t start, idx_t end, bool value) {
+void BitMap::par_put_range_within_word(idx_t beg, idx_t end, bool value) {
   assert(value == 0 || value == 1, "0 for clear, 1 for set");
-  // With a valid range (start <= end), this test ensures that end != 0, as
+  // With a valid range (beg <= end), this test ensures that end != 0, as
   // required by inverted_bit_mask_for_range.  Also avoids an unnecessary write.
-  if (start != end) {
-    volatile bm_word_t* pw = word_addr(start);
+  if (beg != end) {
+    volatile bm_word_t* pw = word_addr(beg);
     bm_word_t w = Atomic::load(pw);
-    bm_word_t mr = inverted_bit_mask_for_range(start, end);
+    bm_word_t mr = inverted_bit_mask_for_range(beg, end);
     bm_word_t nw = value ? (w | ~mr) : (w & mr);
     while (true) {
       bm_word_t res = Atomic::cmpxchg(pw, w, nw);
@@ -211,85 +211,85 @@ void BitMap::par_put_range_within_word(idx_t start, idx_t end, bool value) {
   }
 }
 
-void BitMap::set_range(idx_t start, idx_t end) {
-  verify_range(start, end);
+void BitMap::set_range(idx_t beg, idx_t end) {
+  verify_range(beg, end);
 
-  idx_t start_full_word = to_words_align_up(start);
+  idx_t beg_full_word = to_words_align_up(beg);
   idx_t end_full_word = to_words_align_down(end);
 
-  if (start_full_word < end_full_word) {
+  if (beg_full_word < end_full_word) {
     // The range includes at least one full word.
-    set_range_within_word(start, bit_index(start_full_word));
-    set_range_of_words(start_full_word, end_full_word);
+    set_range_within_word(beg, bit_index(beg_full_word));
+    set_range_of_words(beg_full_word, end_full_word);
     set_range_within_word(bit_index(end_full_word), end);
   } else {
     // The range spans at most 2 partial words.
-    idx_t boundary = MIN2(bit_index(start_full_word), end);
-    set_range_within_word(start, boundary);
+    idx_t boundary = MIN2(bit_index(beg_full_word), end);
+    set_range_within_word(beg, boundary);
     set_range_within_word(boundary, end);
   }
 }
 
-void BitMap::clear_range(idx_t start, idx_t end) {
-  verify_range(start, end);
+void BitMap::clear_range(idx_t beg, idx_t end) {
+  verify_range(beg, end);
 
-  idx_t start_full_word = to_words_align_up(start);
+  idx_t beg_full_word = to_words_align_up(beg);
   idx_t end_full_word = to_words_align_down(end);
 
-  if (start_full_word < end_full_word) {
+  if (beg_full_word < end_full_word) {
     // The range includes at least one full word.
-    clear_range_within_word(start, bit_index(start_full_word));
-    clear_range_of_words(start_full_word, end_full_word);
+    clear_range_within_word(beg, bit_index(beg_full_word));
+    clear_range_of_words(beg_full_word, end_full_word);
     clear_range_within_word(bit_index(end_full_word), end);
   } else {
     // The range spans at most 2 partial words.
-    idx_t boundary = MIN2(bit_index(start_full_word), end);
-    clear_range_within_word(start, boundary);
+    idx_t boundary = MIN2(bit_index(beg_full_word), end);
+    clear_range_within_word(beg, boundary);
     clear_range_within_word(boundary, end);
   }
 }
 
-bool BitMap::is_small_range_of_words(idx_t start_full_word, idx_t end_full_word) {
+bool BitMap::is_small_range_of_words(idx_t beg_full_word, idx_t end_full_word) {
   // There is little point to call large version on small ranges.
   // Need to check carefully, keeping potential idx_t over/underflow in mind,
-  // because start_full_word > end_full_word can occur when start and end are in
+  // because beg_full_word > end_full_word can occur when beg and end are in
   // the same word.
   // The threshold should be at least one word.
   STATIC_ASSERT(small_range_words >= 1);
-  return start_full_word + small_range_words >= end_full_word;
+  return beg_full_word + small_range_words >= end_full_word;
 }
 
-void BitMap::set_large_range(idx_t start, idx_t end) {
-  verify_range(start, end);
+void BitMap::set_large_range(idx_t beg, idx_t end) {
+  verify_range(beg, end);
 
-  idx_t start_full_word = to_words_align_up(start);
+  idx_t beg_full_word = to_words_align_up(beg);
   idx_t end_full_word = to_words_align_down(end);
 
-  if (is_small_range_of_words(start_full_word, end_full_word)) {
-    set_range(start, end);
+  if (is_small_range_of_words(beg_full_word, end_full_word)) {
+    set_range(beg, end);
     return;
   }
 
   // The range includes at least one full word.
-  set_range_within_word(start, bit_index(start_full_word));
-  set_large_range_of_words(start_full_word, end_full_word);
+  set_range_within_word(beg, bit_index(beg_full_word));
+  set_large_range_of_words(beg_full_word, end_full_word);
   set_range_within_word(bit_index(end_full_word), end);
 }
 
-void BitMap::clear_large_range(idx_t start, idx_t end) {
-  verify_range(start, end);
+void BitMap::clear_large_range(idx_t beg, idx_t end) {
+  verify_range(beg, end);
 
-  idx_t start_full_word = to_words_align_up(start);
+  idx_t beg_full_word = to_words_align_up(beg);
   idx_t end_full_word = to_words_align_down(end);
 
-  if (is_small_range_of_words(start_full_word, end_full_word)) {
-    clear_range(start, end);
+  if (is_small_range_of_words(beg_full_word, end_full_word)) {
+    clear_range(beg, end);
     return;
   }
 
   // The range includes at least one full word.
-  clear_range_within_word(start, bit_index(start_full_word));
-  clear_large_range_of_words(start_full_word, end_full_word);
+  clear_range_within_word(beg, bit_index(beg_full_word));
+  clear_large_range_of_words(beg_full_word, end_full_word);
   clear_range_within_word(bit_index(end_full_word), end);
 }
 
@@ -328,55 +328,55 @@ void BitMap::at_put_range(idx_t start_offset, idx_t end_offset, bool value) {
   }
 }
 
-void BitMap::par_at_put_range(idx_t start, idx_t end, bool value) {
-  verify_range(start, end);
+void BitMap::par_at_put_range(idx_t beg, idx_t end, bool value) {
+  verify_range(beg, end);
 
-  idx_t start_full_word = to_words_align_up(start);
+  idx_t beg_full_word = to_words_align_up(beg);
   idx_t end_full_word = to_words_align_down(end);
 
-  if (start_full_word < end_full_word) {
+  if (beg_full_word < end_full_word) {
     // The range includes at least one full word.
-    par_put_range_within_word(start, bit_index(start_full_word), value);
+    par_put_range_within_word(beg, bit_index(beg_full_word), value);
     if (value) {
-      set_range_of_words(start_full_word, end_full_word);
+      set_range_of_words(beg_full_word, end_full_word);
     } else {
-      clear_range_of_words(start_full_word, end_full_word);
+      clear_range_of_words(beg_full_word, end_full_word);
     }
     par_put_range_within_word(bit_index(end_full_word), end, value);
   } else {
     // The range spans at most 2 partial words.
-    idx_t boundary = MIN2(bit_index(start_full_word), end);
-    par_put_range_within_word(start, boundary, value);
+    idx_t boundary = MIN2(bit_index(beg_full_word), end);
+    par_put_range_within_word(beg, boundary, value);
     par_put_range_within_word(boundary, end, value);
   }
 
 }
 
-void BitMap::at_put_large_range(idx_t start, idx_t end, bool value) {
+void BitMap::at_put_large_range(idx_t beg, idx_t end, bool value) {
   if (value) {
-    set_large_range(start, end);
+    set_large_range(beg, end);
   } else {
-    clear_large_range(start, end);
+    clear_large_range(beg, end);
   }
 }
 
-void BitMap::par_at_put_large_range(idx_t start, idx_t end, bool value) {
-  verify_range(start, end);
+void BitMap::par_at_put_large_range(idx_t beg, idx_t end, bool value) {
+  verify_range(beg, end);
 
-  idx_t start_full_word = to_words_align_up(start);
+  idx_t beg_full_word = to_words_align_up(beg);
   idx_t end_full_word = to_words_align_down(end);
 
-  if (is_small_range_of_words(start_full_word, end_full_word)) {
-    par_at_put_range(start, end, value);
+  if (is_small_range_of_words(beg_full_word, end_full_word)) {
+    par_at_put_range(beg, end, value);
     return;
   }
 
   // The range includes at least one full word.
-  par_put_range_within_word(start, bit_index(start_full_word), value);
+  par_put_range_within_word(beg, bit_index(beg_full_word), value);
   if (value) {
-    set_large_range_of_words(start_full_word, end_full_word);
+    set_large_range_of_words(beg_full_word, end_full_word);
   } else {
-    clear_large_range_of_words(start_full_word, end_full_word);
+    clear_large_range_of_words(beg_full_word, end_full_word);
   }
   par_put_range_within_word(bit_index(end_full_word), end, value);
 }
@@ -593,20 +593,20 @@ void BitMap::clear_large() {
   clear_large_range_of_words(0, size_in_words());
 }
 
-BitMap::idx_t BitMap::count_one_bits_in_range_of_words(idx_t start_full_word, idx_t end_full_word) const {
+BitMap::idx_t BitMap::count_one_bits_in_range_of_words(idx_t beg_full_word, idx_t end_full_word) const {
   idx_t sum = 0;
-  for (idx_t i = start_full_word; i < end_full_word; i++) {
+  for (idx_t i = beg_full_word; i < end_full_word; i++) {
     bm_word_t w = map()[i];
     sum += population_count(w);
   }
   return sum;
 }
 
-BitMap::idx_t BitMap::count_one_bits_within_word(idx_t start, idx_t end) const {
-  if (start != end) {
-    assert(end > start, "must be");
-    bm_word_t mask = ~inverted_bit_mask_for_range(start, end);
-    bm_word_t w = *word_addr(start);
+BitMap::idx_t BitMap::count_one_bits_within_word(idx_t beg, idx_t end) const {
+  if (beg != end) {
+    assert(end > beg, "must be");
+    bm_word_t mask = ~inverted_bit_mask_for_range(beg, end);
+    bm_word_t w = *word_addr(beg);
     w &= mask;
     return population_count(w);
   }
@@ -617,28 +617,28 @@ BitMap::idx_t BitMap::count_one_bits() const {
   return count_one_bits(0, size());
 }
 
-// Returns the number of bits set within  [start, end).
-BitMap::idx_t BitMap::count_one_bits(idx_t start, idx_t end) const {
-  verify_range(start, end);
+// Returns the number of bits set within  [beg, end).
+BitMap::idx_t BitMap::count_one_bits(idx_t beg, idx_t end) const {
+  verify_range(beg, end);
 
-  idx_t start_full_word = to_words_align_up(start);
+  idx_t beg_full_word = to_words_align_up(beg);
   idx_t end_full_word = to_words_align_down(end);
 
   idx_t sum = 0;
 
-  if (start_full_word < end_full_word) {
+  if (beg_full_word < end_full_word) {
     // The range includes at least one full word.
-    sum += count_one_bits_within_word(start, bit_index(start_full_word));
-    sum += count_one_bits_in_range_of_words(start_full_word, end_full_word);
+    sum += count_one_bits_within_word(beg, bit_index(beg_full_word));
+    sum += count_one_bits_in_range_of_words(beg_full_word, end_full_word);
     sum += count_one_bits_within_word(bit_index(end_full_word), end);
   } else {
     // The range spans at most 2 partial words.
-    idx_t boundary = MIN2(bit_index(start_full_word), end);
-    sum += count_one_bits_within_word(start, boundary);
+    idx_t boundary = MIN2(bit_index(beg_full_word), end);
+    sum += count_one_bits_within_word(beg, boundary);
     sum += count_one_bits_within_word(boundary, end);
   }
 
-  assert(sum <= (start - end), "must be");
+  assert(sum <= (beg - end), "must be");
 
   return sum;
 

--- a/src/hotspot/share/utilities/bitMap.hpp
+++ b/src/hotspot/share/utilities/bitMap.hpp
@@ -97,9 +97,9 @@ class BitMap {
   // Helper for get_next_{zero,one}_bit variants.
   // - flip designates whether searching for 1s or 0s.  Must be one of
   //   find_{zeros,ones}_flip.
-  // - aligned_right is true if r_index is a priori on a bm_word_t boundary.
+  // - aligned_right is true if end is a priori on a bm_word_t boundary.
   template<bm_word_t flip, bool aligned_right>
-  inline idx_t get_next_bit_impl(idx_t l_index, idx_t r_index) const;
+  inline idx_t get_next_bit_impl(idx_t beg, idx_t end) const;
 
   // Values for get_next_bit_impl flip parameter.
   static const bm_word_t find_ones_flip = 0;
@@ -262,11 +262,11 @@ class BitMap {
   template <class BitMapClosureType>
   bool iterate(BitMapClosureType* cl);
 
-  // Looking for 1's and 0's at indices equal to or greater than "l_index",
-  // stopping if none has been found before "r_index", and returning
-  // "r_index" (which must be at most "size") in that case.
-  idx_t get_next_one_offset (idx_t l_index, idx_t r_index) const;
-  idx_t get_next_zero_offset(idx_t l_index, idx_t r_index) const;
+  // Looking for 1's and 0's at indices equal to or greater than "beg",
+  // stopping if none has been found before "end", and returning
+  // "end" (which must be at most "size") in that case.
+  idx_t get_next_one_offset (idx_t beg, idx_t end) const;
+  idx_t get_next_zero_offset(idx_t beg, idx_t end) const;
 
   idx_t get_next_one_offset(idx_t offset) const {
     return get_next_one_offset(offset, size());
@@ -275,9 +275,9 @@ class BitMap {
     return get_next_zero_offset(offset, size());
   }
 
-  // Like "get_next_one_offset", except requires that "r_index" is
+  // Like "get_next_one_offset", except requires that "end" is
   // aligned to bitsizeof(bm_word_t).
-  idx_t get_next_one_offset_aligned_right(idx_t l_index, idx_t r_index) const;
+  idx_t get_next_one_offset_aligned_right(idx_t beg, idx_t end) const;
 
   // Returns the number of bits set in the bitmap.
   idx_t count_one_bits() const;

--- a/src/hotspot/share/utilities/bitMap.hpp
+++ b/src/hotspot/share/utilities/bitMap.hpp
@@ -97,9 +97,9 @@ class BitMap {
   // Helper for get_next_{zero,one}_bit variants.
   // - flip designates whether searching for 1s or 0s.  Must be one of
   //   find_{zeros,ones}_flip.
-  // - aligned_right is true if end is a priori on a bm_word_t boundary.
+  // - aligned_right is true if r_index is a priori on a bm_word_t boundary.
   template<bm_word_t flip, bool aligned_right>
-  inline idx_t get_next_bit_impl(idx_t start, idx_t end) const;
+  inline idx_t get_next_bit_impl(idx_t l_index, idx_t r_index) const;
 
   // Values for get_next_bit_impl flip parameter.
   static const bm_word_t find_ones_flip = 0;
@@ -109,7 +109,7 @@ class BitMap {
   // operation was requested. Measured in words.
   static const size_t small_range_words = 32;
 
-  static bool is_small_range_of_words(idx_t start_full_word, idx_t end_full_word);
+  static bool is_small_range_of_words(idx_t beg_full_word, idx_t end_full_word);
 
   // Return the position of bit within the word that contains it (e.g., if
   // bitmap words are 32 bits, return a number 0 <= n <= 31).
@@ -142,24 +142,24 @@ class BitMap {
 
   static inline const bm_word_t load_word_ordered(const volatile bm_word_t* const addr, atomic_memory_order memory_order);
 
-  // Utilities for ranges of bits.  Ranges are half-open [start, end).
+  // Utilities for ranges of bits.  Ranges are half-open [beg, end).
 
   // Ranges within a single word.
-  bm_word_t inverted_bit_mask_for_range(idx_t start, idx_t end) const;
-  void  set_range_within_word      (idx_t start, idx_t end);
-  void  clear_range_within_word    (idx_t start, idx_t end);
-  void  par_put_range_within_word  (idx_t start, idx_t end, bool value);
+  bm_word_t inverted_bit_mask_for_range(idx_t beg, idx_t end) const;
+  void  set_range_within_word      (idx_t beg, idx_t end);
+  void  clear_range_within_word    (idx_t beg, idx_t end);
+  void  par_put_range_within_word  (idx_t beg, idx_t end, bool value);
 
   // Ranges spanning entire words.
-  void      set_range_of_words         (idx_t start, idx_t end);
-  void      clear_range_of_words       (idx_t start, idx_t end);
-  void      set_large_range_of_words   (idx_t start, idx_t end);
-  void      clear_large_range_of_words (idx_t start, idx_t end);
+  void      set_range_of_words         (idx_t beg, idx_t end);
+  void      clear_range_of_words       (idx_t beg, idx_t end);
+  void      set_large_range_of_words   (idx_t beg, idx_t end);
+  void      clear_large_range_of_words (idx_t beg, idx_t end);
 
-  static void clear_range_of_words(bm_word_t* map, idx_t start, idx_t end);
+  static void clear_range_of_words(bm_word_t* map, idx_t beg, idx_t end);
 
-  idx_t count_one_bits_within_word(idx_t start, idx_t end) const;
-  idx_t count_one_bits_in_range_of_words(idx_t start_full_word, idx_t end_full_word) const;
+  idx_t count_one_bits_within_word(idx_t beg, idx_t end) const;
+  idx_t count_one_bits_in_range_of_words(idx_t beg_full_word, idx_t end_full_word) const;
 
   // Set the map and size.
   void update(bm_word_t* map, idx_t size) {
@@ -215,23 +215,23 @@ class BitMap {
   void at_put(idx_t index, bool value);
   bool par_at_put(idx_t index, bool value);
 
-  // Update a range of bits.  Ranges are half-open [start, end).
-  void set_range   (idx_t start, idx_t end);
-  void clear_range (idx_t start, idx_t end);
-  void set_large_range   (idx_t start, idx_t end);
-  void clear_large_range (idx_t start, idx_t end);
-  void at_put_range(idx_t start, idx_t end, bool value);
-  void par_at_put_range(idx_t start, idx_t end, bool value);
-  void at_put_large_range(idx_t start, idx_t end, bool value);
-  void par_at_put_large_range(idx_t start, idx_t end, bool value);
+  // Update a range of bits.  Ranges are half-open [beg, end).
+  void set_range   (idx_t beg, idx_t end);
+  void clear_range (idx_t beg, idx_t end);
+  void set_large_range   (idx_t beg, idx_t end);
+  void clear_large_range (idx_t beg, idx_t end);
+  void at_put_range(idx_t beg, idx_t end, bool value);
+  void par_at_put_range(idx_t beg, idx_t end, bool value);
+  void at_put_large_range(idx_t beg, idx_t end, bool value);
+  void par_at_put_large_range(idx_t beg, idx_t end, bool value);
 
   // Update a range of bits, using a hint about the size.  Currently only
   // inlines the predominant case of a 1-bit range.  Works best when hint is a
   // compile-time constant.
-  void set_range(idx_t start, idx_t end, RangeSizeHint hint);
-  void clear_range(idx_t start, idx_t end, RangeSizeHint hint);
-  void par_set_range(idx_t start, idx_t end, RangeSizeHint hint);
-  void par_clear_range  (idx_t start, idx_t end, RangeSizeHint hint);
+  void set_range(idx_t beg, idx_t end, RangeSizeHint hint);
+  void clear_range(idx_t beg, idx_t end, RangeSizeHint hint);
+  void par_set_range(idx_t beg, idx_t end, RangeSizeHint hint);
+  void par_clear_range  (idx_t beg, idx_t end, RangeSizeHint hint);
 
   // Clearing
   void clear_large();
@@ -245,8 +245,8 @@ class BitMap {
   void verify_index(idx_t bit) const NOT_DEBUG_RETURN;
   // Verify bit is not greater than size().
   void verify_limit(idx_t bit) const NOT_DEBUG_RETURN;
-  // Verify [start,end) is a valid range, e.g. start <= end <= size().
-  void verify_range(idx_t start, idx_t end) const NOT_DEBUG_RETURN;
+  // Verify [beg,end) is a valid range, e.g. beg <= end <= size().
+  void verify_range(idx_t beg, idx_t end) const NOT_DEBUG_RETURN;
 
   // Iteration support.  Applies the closure to the index for each set bit,
   // starting from the least index in the range to the greatest, in order.
@@ -255,18 +255,18 @@ class BitMap {
   // returned false.  If the closure modifies the bitmap, modifications to
   // bits at indices greater than the current index will affect which further
   // indices the closure will be applied to.
-  // precondition: start and end form a valid range.
+  // precondition: beg and end form a valid range.
   template <class BitMapClosureType>
-  bool iterate(BitMapClosureType* cl, idx_t start, idx_t end);
+  bool iterate(BitMapClosureType* cl, idx_t beg, idx_t end);
 
   template <class BitMapClosureType>
   bool iterate(BitMapClosureType* cl);
 
-  // Looking for 1's and 0's at indices equal to or greater than "start",
-  // stopping if none has been found before "end", and returning
-  // "end" (which must be at most "size") in that case.
-  idx_t get_next_one_offset (idx_t start, idx_t end) const;
-  idx_t get_next_zero_offset(idx_t start, idx_t end) const;
+  // Looking for 1's and 0's at indices equal to or greater than "l_index",
+  // stopping if none has been found before "r_index", and returning
+  // "r_index" (which must be at most "size") in that case.
+  idx_t get_next_one_offset (idx_t l_index, idx_t r_index) const;
+  idx_t get_next_zero_offset(idx_t l_index, idx_t r_index) const;
 
   idx_t get_next_one_offset(idx_t offset) const {
     return get_next_one_offset(offset, size());
@@ -275,15 +275,15 @@ class BitMap {
     return get_next_zero_offset(offset, size());
   }
 
-  // Like "get_next_one_offset", except requires that "end" is
+  // Like "get_next_one_offset", except requires that "r_index" is
   // aligned to bitsizeof(bm_word_t).
-  idx_t get_next_one_offset_aligned_right(idx_t start, idx_t end) const;
+  idx_t get_next_one_offset_aligned_right(idx_t l_index, idx_t r_index) const;
 
   // Returns the number of bits set in the bitmap.
   idx_t count_one_bits() const;
 
-  // Returns the number of bits set within  [start, end).
-  idx_t count_one_bits(idx_t start, idx_t end) const;
+  // Returns the number of bits set within  [beg, end).
+  idx_t count_one_bits(idx_t beg, idx_t end) const;
 
   // Set operations.
   void set_union(const BitMap& bits);


### PR DESCRIPTION
The ranges are determined by 'start' and 'end' all over the bitMap.hpp and bitMap.cpp. All instances of other names for start and end are replaced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287400](https://bugs.openjdk.org/browse/JDK-8287400): Make BitMap range parameter names consistent


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Leo Korinth](https://openjdk.org/census#lkorinth) (@lkorinth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11375/head:pull/11375` \
`$ git checkout pull/11375`

Update a local copy of the PR: \
`$ git checkout pull/11375` \
`$ git pull https://git.openjdk.org/jdk pull/11375/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11375`

View PR using the GUI difftool: \
`$ git pr show -t 11375`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11375.diff">https://git.openjdk.org/jdk/pull/11375.diff</a>

</details>
