### PR TITLE
8297683: Use enhanced-for cycle instead of Enumeration in java.security.jgss

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/jgss/GSSCredentialImpl.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/GSSCredentialImpl.java
@@ -134,10 +134,7 @@ public class GSSCredentialImpl implements GSSCredential {
 
     public void dispose() throws GSSException {
         if (!destroyed) {
-            GSSCredentialSpi element;
-            Enumeration<GSSCredentialSpi> values = hashtable.elements();
-            while (values.hasMoreElements()) {
-                element = values.nextElement();
+            for (GSSCredentialSpi element : hashtable.values()) {
                 element.dispose();
             }
             destroyed = true;
@@ -211,14 +208,11 @@ public class GSSCredentialImpl implements GSSCredential {
                                         "no longer valid");
         }
 
-        SearchKey tempKey;
         GSSCredentialSpi tempCred;
         int tempLife, tempInitLife, tempAcceptLife;
         int min = INDEFINITE_LIFETIME;
 
-        for (Enumeration<SearchKey> e = hashtable.keys();
-                                        e.hasMoreElements(); ) {
-            tempKey = e.nextElement();
+        for (SearchKey tempKey : hashtable.keySet()) {
             tempCred = hashtable.get(tempKey);
             if (tempKey.getUsage() == INITIATE_ONLY)
                 tempLife = tempCred.getInitLifetime();
@@ -329,13 +323,10 @@ public class GSSCredentialImpl implements GSSCredential {
                                         "no longer valid");
         }
 
-        SearchKey tempKey;
         boolean initiate = false;
         boolean accept = false;
 
-        for (Enumeration<SearchKey> e = hashtable.keys();
-                                        e.hasMoreElements(); ) {
-            tempKey = e.nextElement();
+        for (SearchKey tempKey : hashtable.keySet()) {
             if (tempKey.getUsage() == INITIATE_ONLY)
                 initiate = true;
             else if (tempKey.getUsage() == ACCEPT_ONLY)
@@ -406,10 +397,7 @@ public class GSSCredentialImpl implements GSSCredential {
                                         "no longer valid");
         }
         ArrayList<Oid> result = new ArrayList<Oid>(hashtable.size());
-
-        for (Enumeration<SearchKey> e = hashtable.keys();
-                                                e.hasMoreElements(); ) {
-            SearchKey tempKey = e.nextElement();
+        for (SearchKey tempKey : hashtable.keySet()) {
             result.add(tempKey.getMech());
         }
         return result.toArray(new Oid[0]);
@@ -615,14 +603,7 @@ public class GSSCredentialImpl implements GSSCredential {
     }
 
     Set<GSSCredentialSpi> getElements() {
-        HashSet<GSSCredentialSpi> retVal =
-                new HashSet<>(hashtable.size());
-        Enumeration<GSSCredentialSpi> values = hashtable.elements();
-        while (values.hasMoreElements()) {
-            GSSCredentialSpi o = values.nextElement();
-            retVal.add(o);
-        }
-        return retVal;
+        return new HashSet<>(hashtable.values());
     }
 
     private static String getElementStr(Oid mechOid, int usage) {

--- a/src/java.security.jgss/share/classes/sun/security/jgss/ProviderList.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/ProviderList.java
@@ -32,7 +32,6 @@ import java.security.Security;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.HashMap;
-import java.util.Enumeration;
 import java.util.Iterator;
 import sun.security.jgss.spi.*;
 import sun.security.jgss.wrapper.NativeGSSFactory;
@@ -408,12 +407,9 @@ public final class ProviderList {
         String prop;
         boolean retVal = false;
 
-        // Get all props for this provider
-        Enumeration<Object> props = p.keys();
-
         // See if there are any GSS prop's
-        while (props.hasMoreElements()) {
-            prop = (String) props.nextElement();
+        for (Object o : p.keySet()) {
+            prop = (String) o;
             if (isMechFactoryProperty(prop)) {
                 // Ok! This is a GSS provider!
                 try {
@@ -428,7 +424,7 @@ public final class ProviderList {
                     }
                 }
             } // Processed GSS property
-        } // while loop
+        } // for loop
 
         return retVal;
 


### PR DESCRIPTION
java.util.Enumeration is a legacy interface from java 1.0.
There are a few places with cycles which use it to iterate over collections. We can replace this manual cycle with enchanced-for, which is shorter and easier to read.

sun.security.jgss.ProviderList#addAllMechsFromProvider
sun.security.jgss.GSSCredentialImpl#dispose
sun.security.jgss.GSSCredentialImpl#getRemainingLifetime
sun.security.jgss.GSSCredentialImpl#getUsage()
sun.security.jgss.GSSCredentialImpl#getElements

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297683](https://bugs.openjdk.org/browse/JDK-8297683): Use enhanced-for cycle instead of Enumeration in java.security.jgss


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11377/head:pull/11377` \
`$ git checkout pull/11377`

Update a local copy of the PR: \
`$ git checkout pull/11377` \
`$ git pull https://git.openjdk.org/jdk pull/11377/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11377`

View PR using the GUI difftool: \
`$ git pr show -t 11377`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11377.diff">https://git.openjdk.org/jdk/pull/11377.diff</a>

</details>
