### PR TITLE
Javadoc: Use the correct parameter name 'locales' in Locale#lookup

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -3554,7 +3554,7 @@ public final class Locale implements Cloneable, Serializable {
      * @param locales {@code Locale} instances used for matching
      * @return the best matching {@code Locale} instance chosen based on
      *     priority or weight, or {@code null} if nothing matches.
-     * @throws NullPointerException if {@code priorityList} or {@code tags} is
+     * @throws NullPointerException if {@code priorityList} or {@code locales} is
      *     {@code null}
      *
      * @since 1.8


### PR DESCRIPTION
This is a minor error in Javadoc of Locale#lookup method, 'tags' is not a parameter name, it should be 'locales'.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11378/head:pull/11378` \
`$ git checkout pull/11378`

Update a local copy of the PR: \
`$ git checkout pull/11378` \
`$ git pull https://git.openjdk.org/jdk pull/11378/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11378`

View PR using the GUI difftool: \
`$ git pr show -t 11378`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11378.diff">https://git.openjdk.org/jdk/pull/11378.diff</a>

</details>
