### PR TITLE
8297750: Unnecessary Vector usage in IIORegistry

### DIFF
--- a/src/java.desktop/share/classes/javax/imageio/spi/IIORegistry.java
+++ b/src/java.desktop/share/classes/javax/imageio/spi/IIORegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,12 +27,8 @@ package javax.imageio.spi;
 
 import java.security.PrivilegedAction;
 import java.security.AccessController;
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Set;
-import java.util.Vector;
 import com.sun.imageio.spi.FileImageInputStreamSpi;
 import com.sun.imageio.spi.FileImageOutputStreamSpi;
 import com.sun.imageio.spi.InputStreamImageInputStreamSpi;
@@ -87,10 +83,10 @@ import java.util.ServiceConfigurationError;
 public final class IIORegistry extends ServiceRegistry {
 
     /**
-     * A {@code Vector} containing the valid IIO registry
+     * An {@code ArrayList} containing the valid IIO registry
      * categories (superinterfaces) to be used in the constructor.
      */
-    private static final Vector<Class<?>> initialCategories = new Vector<>(5);
+    private static final ArrayList<Class<?>> initialCategories = new ArrayList<>(5);
 
     static {
         initialCategories.add(ImageReaderSpi.class);

--- a/src/java.desktop/share/classes/javax/imageio/spi/IIORegistry.java
+++ b/src/java.desktop/share/classes/javax/imageio/spi/IIORegistry.java
@@ -27,7 +27,6 @@ package javax.imageio.spi;
 
 import java.security.PrivilegedAction;
 import java.security.AccessController;
-import java.util.ArrayList;
 import java.util.Iterator;
 import com.sun.imageio.spi.FileImageInputStreamSpi;
 import com.sun.imageio.spi.FileImageOutputStreamSpi;
@@ -48,6 +47,7 @@ import com.sun.imageio.plugins.wbmp.WBMPImageWriterSpi;
 import com.sun.imageio.plugins.tiff.TIFFImageReaderSpi;
 import com.sun.imageio.plugins.tiff.TIFFImageWriterSpi;
 import sun.awt.AppContext;
+import java.util.List;
 import java.util.ServiceLoader;
 import java.util.ServiceConfigurationError;
 
@@ -83,18 +83,16 @@ import java.util.ServiceConfigurationError;
 public final class IIORegistry extends ServiceRegistry {
 
     /**
-     * An {@code ArrayList} containing the valid IIO registry
+     * A {@code List} containing the valid IIO registry
      * categories (superinterfaces) to be used in the constructor.
      */
-    private static final ArrayList<Class<?>> initialCategories = new ArrayList<>(5);
-
-    static {
-        initialCategories.add(ImageReaderSpi.class);
-        initialCategories.add(ImageWriterSpi.class);
-        initialCategories.add(ImageTranscoderSpi.class);
-        initialCategories.add(ImageInputStreamSpi.class);
-        initialCategories.add(ImageOutputStreamSpi.class);
-    }
+    private static final List<Class<?>> initialCategories = List.of(
+            ImageReaderSpi.class,
+            ImageWriterSpi.class,
+            ImageTranscoderSpi.class,
+            ImageInputStreamSpi.class,
+            ImageOutputStreamSpi.class
+    );
 
     /**
      * Set up the valid service provider categories and automatically


### PR DESCRIPTION
Field `javax.imageio.spi.IIORegistry#initialCategories` is modified only in `static {}` block, which makes it effectively final. Instead of legacy synchronized `Vector` we can use non-threadsafe `ArrayList` here.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297750](https://bugs.openjdk.org/browse/JDK-8297750): Unnecessary Vector usage in IIORegistry


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11379/head:pull/11379` \
`$ git checkout pull/11379`

Update a local copy of the PR: \
`$ git checkout pull/11379` \
`$ git pull https://git.openjdk.org/jdk pull/11379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11379`

View PR using the GUI difftool: \
`$ git pr show -t 11379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11379.diff">https://git.openjdk.org/jdk/pull/11379.diff</a>

</details>
