### PR TITLE
[PATCH] Cleanup custom split implementation in sun.awt.FontConfiguration

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
+++ b/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
@@ -45,7 +45,6 @@ import java.util.Locale;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
-import java.util.Vector;
 import sun.font.CompositeFontDescriptor;
 import sun.font.SunFontManager;
 import sun.font.FontUtilities;
@@ -835,26 +834,6 @@ public abstract class FontConfiguration {
                 }
             }
         }
-    }
-
-    private static Vector<String> splitSequence(String sequence) {
-        //String.split would be more convenient, but incurs big performance penalty
-        Vector<String> parts = new Vector<>();
-        int start = 0;
-        int end;
-        while ((end = sequence.indexOf(',', start)) >= 0) {
-            parts.add(sequence.substring(start, end));
-            start = end + 1;
-        }
-        if (sequence.length() > start) {
-            parts.add(sequence.substring(start));
-        }
-        return parts;
-    }
-
-    protected String[] split(String sequence) {
-        Vector<String> v = splitSequence(sequence);
-        return v.toArray(new String[0]);
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -1753,7 +1732,6 @@ public abstract class FontConfiguration {
 
     //utility "empty" objects
     private static final int[] EMPTY_INT_ARRAY = new int[0];
-    private static final String[] EMPTY_STRING_ARRAY = new String[0];
     private static final short[] EMPTY_SHORT_ARRAY = new short[0];
     private static final String UNDEFINED_COMPONENT_FONT = "unknown";
 
@@ -2120,7 +2098,7 @@ public abstract class FontConfiguration {
                 boolean has1252 = false;
 
                 //get the scriptID list
-                String[] ss = splitSequence(value).toArray(EMPTY_STRING_ARRAY);
+                String[] ss = value.split(",");
                 short [] sa = new short[ss.length];
                 for (int i = 0; i < ss.length; i++) {
                     if ("alphabetic/default".equals(ss[i])) {

--- a/src/java.desktop/unix/classes/sun/font/MFontConfiguration.java
+++ b/src/java.desktop/unix/classes/sun/font/MFontConfiguration.java
@@ -74,8 +74,7 @@ public class MFontConfiguration extends FontConfiguration {
         reorderMap.put("UTF-8.zh.TW", "chinese-tw-iso10646");
         reorderMap.put("UTF-8.zh.HK", "chinese-tw-iso10646");
         reorderMap.put("UTF-8.zh.CN", "chinese-cn-iso10646");
-        reorderMap.put("x-euc-jp-linux",
-                        split("japanese-x0201,japanese-x0208"));
+        reorderMap.put("x-euc-jp-linux", new String[]{"japanese-x0201", "japanese-x0208"});
         reorderMap.put("GB2312", "chinese-gb18030");
         reorderMap.put("Big5", "chinese-big5");
         reorderMap.put("EUC-KR", "korean");

--- a/src/java.desktop/windows/classes/sun/awt/windows/WFontConfiguration.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WFontConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,8 +79,7 @@ public final class WFontConfiguration extends FontConfiguration {
         reorderMap.put("GBK", "chinese-ms936");
         reorderMap.put("GB18030", "chinese-gb18030");
         reorderMap.put("x-windows-950", "chinese-ms950");
-        reorderMap.put("x-MS950-HKSCS", split("chinese-ms950,chinese-hkscs"));
-//      reorderMap.put("windows-1252", "alphabetic");
+        reorderMap.put("x-MS950-HKSCS", new String[] {"chinese-ms950", "chinese-hkscs"});
     }
 
     @Override


### PR DESCRIPTION
`FontConfiguration.splitSequence` reimplements `String.split` in attempt to achieve better performance. But this custom implementation is not needed anymore after https://bugs.openjdk.org/browse/JDK-6840246 was implemented. Moreover, the method uses synchronized `Vector` to store intermediate result which is not great, because Biased Locking is gone and each lock costs something.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11380/head:pull/11380` \
`$ git checkout pull/11380`

Update a local copy of the PR: \
`$ git checkout pull/11380` \
`$ git pull https://git.openjdk.org/jdk pull/11380/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11380`

View PR using the GUI difftool: \
`$ git pr show -t 11380`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11380.diff">https://git.openjdk.org/jdk/pull/11380.diff</a>

</details>
