### PR TITLE
JDK-8297688: libjli leaks memory related to options handling

### DIFF
--- a/src/java.base/share/native/libjli/java.h
+++ b/src/java.base/share/native/libjli/java.h
@@ -168,7 +168,6 @@ void SetJavaCommandLineProp(char* what, int argc, char** argv);
  */
 jint ReadKnownVMs(const char *jvmcfg, jboolean speculative);
 char *CheckJvmType(int *argc, char ***argv, jboolean speculative);
-void AddOption(char *str, void *info);
 jboolean IsWhiteSpaceOption(const char* name);
 jlong CurrentTimeMicros();
 


### PR DESCRIPTION
Fix memory leaks by making `AddOption` unconditionally duplicate passed in strings, taking ownership. Callers using dynamic memory free their storage after calling `AddOption`. This ensures no memory is dropped on the floor.