### PR TITLE
8297697: RISC-V: Add support for SATP mode detection

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -37,8 +37,8 @@ uint32_t VM_Version::_initial_vector_length = 0;
 void VM_Version::initialize() {
   get_os_cpu_info();
 
-  // check if satp.mode is supported, currently supports up to SV48(RV64)/SV32(RV32)
-  if (get_satp_mode() > RISCV64_ONLY(VM_SV48) RISCV32_ONLY(VM_SV32)) {
+  // check if satp.mode is supported, currently supports up to SV48(RV64)
+  if (get_satp_mode() > VM_SV48) {
     vm_exit_during_initialization(err_msg("Unsupported satp mode: %s", _vm_mode));
   }
 

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -37,10 +37,9 @@ uint32_t VM_Version::_initial_vector_length = 0;
 void VM_Version::initialize() {
   get_os_cpu_info();
 
-  // check if satp.mode is supported, currently supports up to SV48(rv64)/SV32(rv32)
-  VM_MODE mode = get_satp_mode();
-  if (mode > RISCV64_ONLY(VM_SV48) RISCV32_ONLY(VM_SV32)) {
-    vm_exit_during_initialization(err_msg("Unsupported satp mode: %d", mode));
+  // check if satp.mode is supported, currently supports up to SV48(RV64)/SV32(RV32)
+  if (get_satp_mode() > RISCV64_ONLY(VM_SV48) RISCV32_ONLY(VM_SV32)) {
+    vm_exit_during_initialization(err_msg("Unsupported satp mode: %s", _vm_mode));
   }
 
   // https://github.com/riscv/riscv-profiles/blob/main/profiles.adoc#rva20-profiles

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -31,10 +31,17 @@
 #include "utilities/macros.hpp"
 
 const char* VM_Version::_uarch = "";
+const char* VM_Version::_vm_mode = "";
 uint32_t VM_Version::_initial_vector_length = 0;
 
 void VM_Version::initialize() {
   get_os_cpu_info();
+
+  // check if satp.mode is supported, currently supports up to SV48(rv64)/SV32(rv32)
+  VM_MODE mode = get_satp_mode();
+  if (mode > RISCV64_ONLY(VM_SV48) RISCV32_ONLY(VM_SV32)) {
+    vm_exit_during_initialization(err_msg("Unsupported satp mode: %d", mode));
+  }
 
   // https://github.com/riscv/riscv-profiles/blob/main/profiles.adoc#rva20-profiles
   if (UseRVA20U64) {

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -41,7 +41,6 @@ private:
 // VM modes (satp.mode) privileged ISA 1.10
 enum VM_MODE {
   VM_MBARE = 0,
-  VM_SV32  = 1,
   VM_SV39  = 8,
   VM_SV48  = 9,
   VM_SV57  = 10,

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -38,11 +38,23 @@ private:
   static void c2_initialize();
 #endif // COMPILER2
 
+// VM modes (satp.mode) privileged ISA 1.10
+enum VM_MODE {
+  VM_MBARE = 0,
+  VM_SV32  = 1,
+  VM_SV39  = 8,
+  VM_SV48  = 9,
+  VM_SV57  = 10,
+  VM_SV64  = 11
+};
+
 protected:
   static const char* _uarch;
+  static const char* _vm_mode;
   static uint32_t _initial_vector_length;
   static void get_os_cpu_info();
   static uint32_t get_current_vector_length();
+  static VM_MODE get_satp_mode();
 
 public:
   // Initialization

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -76,9 +76,7 @@ uint32_t VM_Version::get_current_vector_length() {
 }
 
 VM_Version::VM_MODE VM_Version::get_satp_mode() {
-  if (!strcmp(_vm_mode, "sv32")) {
-    return VM_SV32;
-  } else if (!strcmp(_vm_mode, "sv39")) {
+  if (!strcmp(_vm_mode, "sv39")) {
     return VM_SV39;
   } else if (!strcmp(_vm_mode, "sv48")) {
     return VM_SV48;

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -75,6 +75,22 @@ uint32_t VM_Version::get_current_vector_length() {
   return (uint32_t)read_csr(CSR_VLENB);
 }
 
+VM_Version::VM_MODE VM_Version::get_satp_mode() {
+  if (!strcmp(_vm_mode, "sv32")) {
+    return VM_SV32;
+  } else if (!strcmp(_vm_mode, "sv39")) {
+    return VM_SV39;
+  } else if (!strcmp(_vm_mode, "sv48")) {
+    return VM_SV48;
+  } else if (!strcmp(_vm_mode, "sv57")) {
+    return VM_SV57;
+  } else if (!strcmp(_vm_mode, "sv64")) {
+    return VM_SV64;
+  } else {
+    return VM_MBARE;
+  }
+}
+
 void VM_Version::get_os_cpu_info() {
 
   uint64_t auxv = getauxval(AT_HWCAP);
@@ -103,7 +119,14 @@ void VM_Version::get_os_cpu_info() {
     char buf[512], *p;
     while (fgets(buf, sizeof (buf), f) != NULL) {
       if ((p = strchr(buf, ':')) != NULL) {
-        if (strncmp(buf, "uarch", sizeof "uarch" - 1) == 0) {
+        if (strncmp(buf, "mmu", sizeof "mmu" - 1) == 0) {
+          if (_vm_mode[0] != '\0') {
+            continue;
+          }
+          char* vm_mode = os::strdup(p + 2);
+          vm_mode[strcspn(vm_mode, "\n")] = '\0';
+          _vm_mode = vm_mode;
+        } else if (strncmp(buf, "uarch", sizeof "uarch" - 1) == 0) {
           char* uarch = os::strdup(p + 2);
           uarch[strcspn(uarch, "\n")] = '\0';
           _uarch = uarch;


### PR DESCRIPTION
RISC-V gets sv57-based virtual memory support since Linux 5.18 [1]. There are some reports of the OpenJDK RISC-V port crashing on Linux 5.18+ with QEMU-system 7.10+ when sv57 was enabled [2][3] as currently RISC-V port only supports up to sv48.
As discussed in [3], given the fact that there are no existing boards or hardware even support anything more than sv48,
we decide to add detection for SATP (Supervisor Address Translation and Protection) mode at JVM startup time if possible and explicitly issue a warning and stop early when sv57 is enabled.

When sv57 is enabled, the output of java -version would be:

```
root@qemuriscv64:~# jdk/bin/java -version
Error occurred during initialization of VM
Unsupported satp mode: sv57
```

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=aa5b537b0ecc16992577b013f11112d54c7ce869
[2] https://mail.openjdk.org/pipermail/riscv-port-dev/2022-September/000639.html
[3] https://mail.openjdk.org/pipermail/riscv-port-dev/2022-November/000681.html

Testing:

- QEMU-system with sv48/sv57-enabled Linux image `-version` test
- HiFive Unmatched board (sv39) `-version` test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297697](https://bugs.openjdk.org/browse/JDK-8297697): RISC-V: Add support for SATP mode detection


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11388/head:pull/11388` \
`$ git checkout pull/11388`

Update a local copy of the PR: \
`$ git checkout pull/11388` \
`$ git pull https://git.openjdk.org/jdk pull/11388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11388`

View PR using the GUI difftool: \
`$ git pr show -t 11388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11388.diff">https://git.openjdk.org/jdk/pull/11388.diff</a>

</details>
