### PR TITLE
8297717: Remove jdk/internal/misc/TerminatingThreadLocal/TestTerminatingThreadLocal.java from ProblemList

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -485,7 +485,6 @@ java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java        8151492 generic-
 java/lang/invoke/LFCaching/LFGarbageCollectedTest.java          8078602 generic-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java    8249079 linux-x64
 java/lang/invoke/RicochetTest.java                              8251969 generic-all
-jdk/internal/misc/TerminatingThreadLocal/TestTerminatingThreadLocal.java 8292051 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
JDK-8291760 removed java/lang/ProcessBuilder/PipelineLeaksFD.java from test/jdk/ProblemList.txt but accidentally added jdk/internal/misc/TerminatingThreadLocal/TestTerminatingThreadLocal.java, presumably there was a merge at the time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297717](https://bugs.openjdk.org/browse/JDK-8297717): Remove jdk/internal/misc/TerminatingThreadLocal/TestTerminatingThreadLocal.java from ProblemList


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11389/head:pull/11389` \
`$ git checkout pull/11389`

Update a local copy of the PR: \
`$ git checkout pull/11389` \
`$ git pull https://git.openjdk.org/jdk pull/11389/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11389`

View PR using the GUI difftool: \
`$ git pr show -t 11389`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11389.diff">https://git.openjdk.org/jdk/pull/11389.diff</a>

</details>
