### PR TITLE
8297718: Make NMT free:ing protocol more granular

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -726,7 +726,7 @@ void* os::realloc(void *memblock, size_t size, MEMFLAGS memflags, const NativeCa
     if (new_outer_ptr == NULL) {
       // realloc(3) failed and the block still exists.
       // We have however marked it as dead, revert this change.
-      header->mark_block_as_alive();
+      header->revive();
       return nullptr;
     }
     // realloc(3) succeeded, variable header now points to invalid memory and we need to record the free:ing

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -731,7 +731,7 @@ void* os::realloc(void *memblock, size_t size, MEMFLAGS memflags, const NativeCa
       header->revive();
       return nullptr;
     }
-    // realloc(3) succeeded, variable header now points to invalid memory and we need to de-account the old block.
+    // realloc(3) succeeded, variable header now points to invalid memory and we need to deaccount the old block.
     MemTracker::deaccount(free_info);
 
     // After a successful realloc(3), we account the resized block with its new size
@@ -776,8 +776,8 @@ void  os::free(void *memblock) {
 
   DEBUG_ONLY(break_if_ptr_caught(memblock);)
 
-  // When NMT is enabled this checks for heap overwrites, then de-accounts the old block.
-  void* const old_outer_ptr = MemTracker::enabled() ? MemTracker::record_free(memblock) : memblock;
+  // When NMT is enabled this checks for heap overwrites, then deaccounts the old block.
+  void* const old_outer_ptr = MemTracker::record_free(memblock);
 
   ALLOW_C_FUNCTION(::free, ::free(old_outer_ptr);)
 }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -730,7 +730,7 @@ void* os::realloc(void *memblock, size_t size, MEMFLAGS memflags, const NativeCa
       return nullptr;
     }
     // realloc(3) succeeded, variable header now points to invalid memory and we need to record the free:ing
-    MemTracker::record_free(free_info);
+    MemTracker::deaccount(free_info);
 
     // After a successful realloc(3), we re-account the resized block with its new size
     // to NMT. This re-instantiates the NMT header.

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -730,7 +730,7 @@ void* os::realloc(void *memblock, size_t size, MEMFLAGS memflags, const NativeCa
       return nullptr;
     }
     // realloc(3) succeeded, variable header now points to invalid memory and we need to record the free:ing
-    MallocTracker::record_free(free_package);
+    MemTracker::record_free(free_package);
 
     // After a successful realloc(3), we re-account the resized block with its new size
     // to NMT. This re-instantiates the NMT header.
@@ -775,7 +775,7 @@ void  os::free(void *memblock) {
   DEBUG_ONLY(break_if_ptr_caught(memblock);)
 
   // When NMT is enabled this checks for heap overwrites, then de-accounts the old block.
-  void* const old_outer_ptr = MemTracker::enabled() ? MemTracker::record_free(memblock) : memblock;
+  void* const old_outer_ptr = MemTracker::enabled() ? MemTracker::record_free_block(memblock) : memblock;
 
   ALLOW_C_FUNCTION(::free, ::free(old_outer_ptr);)
 }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -723,7 +723,7 @@ void* os::realloc(void *memblock, size_t size, MEMFLAGS memflags, const NativeCa
     header->mark_block_as_dead();
 
     // the real realloc
-    ALLOW_C_FUNCTION(::realloc, void* const new_outer_ptr = ::realloc((void*)header, new_outer_size);)
+    ALLOW_C_FUNCTION(::realloc, void* const new_outer_ptr = ::realloc(header, new_outer_size);)
 
     if (new_outer_ptr == NULL) {
       // realloc(3) failed and the block still exists.

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -731,11 +731,11 @@ void* os::realloc(void *memblock, size_t size, MEMFLAGS memflags, const NativeCa
       header->revive();
       return nullptr;
     }
-    // realloc(3) succeeded, variable header now points to invalid memory and we need to record the free:ing
+    // realloc(3) succeeded, variable header now points to invalid memory and we need to de-account the old block.
     MemTracker::deaccount(free_info);
 
-    // After a successful realloc(3), we re-account the resized block with its new size
-    // to NMT. This re-instantiates the NMT header.
+    // After a successful realloc(3), we account the resized block with its new size
+    // to NMT.
     void* const new_inner_ptr = MemTracker::record_malloc(new_outer_ptr, size, memflags, stack);
 
 #ifdef ASSERT

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -717,7 +717,7 @@ void* os::realloc(void *memblock, size_t size, MEMFLAGS memflags, const NativeCa
 
     MallocHeader* header = MallocTracker::malloc_header(memblock);
     header->assert_block_integrity(); // Assert block hasn't been tampered with.
-    const FreePackage free_package = header->free_recording_data();
+    const FreePackage free_package = header->free_package();
     header->mark_block_as_dead();
 
     // the real realloc

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -730,7 +730,7 @@ void* os::realloc(void *memblock, size_t size, MEMFLAGS memflags, const NativeCa
       return nullptr;
     }
     // realloc(3) succeeded, variable header now points to invalid memory and we need to record the free:ing
-    MallocTracker::record_free_header(free_package);
+    MallocTracker::record_free(free_package);
 
     // After a successful realloc(3), we re-account the resized block with its new size
     // to NMT. This re-instantiates the NMT header.

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -775,7 +775,7 @@ void  os::free(void *memblock) {
   DEBUG_ONLY(break_if_ptr_caught(memblock);)
 
   // When NMT is enabled this checks for heap overwrites, then de-accounts the old block.
-  void* const old_outer_ptr = MemTracker::enabled() ? MemTracker::record_free_block(memblock) : memblock;
+  void* const old_outer_ptr = MemTracker::enabled() ? MemTracker::record_free(memblock) : memblock;
 
   ALLOW_C_FUNCTION(::free, ::free(old_outer_ptr);)
 }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -774,8 +774,8 @@ void  os::free(void *memblock) {
 
   DEBUG_ONLY(break_if_ptr_caught(memblock);)
 
-  // If NMT is enabled, this checks for heap overwrites, then de-accounts the old block.
-  void* const old_outer_ptr = MemTracker::record_free(memblock);
+  // When NMT is enabled this checks for heap overwrites, then de-accounts the old block.
+  void* const old_outer_ptr = MemTracker::enabled() ? MemTracker::record_free(memblock) : memblock;
 
   ALLOW_C_FUNCTION(::free, ::free(old_outer_ptr);)
 }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -715,6 +715,8 @@ void* os::realloc(void *memblock, size_t size, MEMFLAGS memflags, const NativeCa
       return NULL;
     }
 
+    // Perform integrity checks on and mark the old block as dead *before* calling the real realloc(3) since it
+    // may invalidate the old block, including its header.
     MallocHeader* header = MallocTracker::malloc_header(memblock);
     header->assert_block_integrity(); // Assert block hasn't been tampered with.
     const MallocHeader::FreeInfo free_info = header->free_info();

--- a/src/hotspot/share/services/mallocHeader.hpp
+++ b/src/hotspot/share/services/mallocHeader.hpp
@@ -87,6 +87,13 @@ class outputStream;
  *   the bytes are stored individually.
  */
 
+// Contains all of the necessary data to record a free().
+struct FreePackage {
+  const size_t size;
+  const MEMFLAGS flags;
+  const uint32_t mst_marker;
+};
+
 class MallocHeader {
 
   NOT_LP64(uint32_t _alt_canary);
@@ -115,7 +122,7 @@ class MallocHeader {
   void set_footer(uint16_t v)       { footer_address()[0] = v >> 8; footer_address()[1] = (uint8_t)v; }
 
  public:
-
+  MallocHeader(const MallocHeader&) = default;
   inline MallocHeader(size_t size, MEMFLAGS flags, uint32_t mst_marker);
 
   inline size_t   size()  const { return _size; }
@@ -123,7 +130,11 @@ class MallocHeader {
   inline uint32_t mst_marker() const { return _mst_marker; }
   bool get_stack(NativeCallStack& stack) const;
 
+  FreePackage free_recording_data() {
+    return FreePackage{this->size(), this->flags(), this->mst_marker()};
+  }
   inline void mark_block_as_dead();
+  inline void mark_block_as_alive();
 
   // If block is broken, fill in a short descriptive text in out,
   // an option pointer to the corruption in p_corruption, and return false.

--- a/src/hotspot/share/services/mallocHeader.hpp
+++ b/src/hotspot/share/services/mallocHeader.hpp
@@ -88,7 +88,7 @@ class outputStream;
  */
 
 class MallocHeader {
-
+  NONCOPYABLE(MallocHeader);
   NOT_LP64(uint32_t _alt_canary);
   const size_t _size;
   const uint32_t _mst_marker;

--- a/src/hotspot/share/services/mallocHeader.hpp
+++ b/src/hotspot/share/services/mallocHeader.hpp
@@ -129,7 +129,7 @@ class MallocHeader {
   inline uint32_t mst_marker() const { return _mst_marker; }
   bool get_stack(NativeCallStack& stack) const;
 
-  // Return the necessary data to record the block this belongs to as freed
+  // Return the necessary data to deaccount the block with NMT.
   FreeInfo free_info() {
     return FreeInfo{this->size(), this->flags(), this->mst_marker()};
   }

--- a/src/hotspot/share/services/mallocHeader.hpp
+++ b/src/hotspot/share/services/mallocHeader.hpp
@@ -122,7 +122,6 @@ class MallocHeader {
   void set_footer(uint16_t v)       { footer_address()[0] = v >> 8; footer_address()[1] = (uint8_t)v; }
 
  public:
-  MallocHeader(const MallocHeader&) = default;
   inline MallocHeader(size_t size, MEMFLAGS flags, uint32_t mst_marker);
 
   inline size_t   size()  const { return _size; }
@@ -135,7 +134,7 @@ class MallocHeader {
     return FreePackage{this->size(), this->flags(), this->mst_marker()};
   }
   inline void mark_block_as_dead();
-  inline void mark_block_as_alive();
+  inline void revive();
 
   // If block is broken, fill in a short descriptive text in out,
   // an option pointer to the corruption in p_corruption, and return false.

--- a/src/hotspot/share/services/mallocHeader.hpp
+++ b/src/hotspot/share/services/mallocHeader.hpp
@@ -87,13 +87,6 @@ class outputStream;
  *   the bytes are stored individually.
  */
 
-// Contains all of the necessary data to record a free().
-struct FreePackage {
-  const size_t size;
-  const MEMFLAGS flags;
-  const uint32_t mst_marker;
-};
-
 class MallocHeader {
 
   NOT_LP64(uint32_t _alt_canary);
@@ -122,6 +115,13 @@ class MallocHeader {
   void set_footer(uint16_t v)       { footer_address()[0] = v >> 8; footer_address()[1] = (uint8_t)v; }
 
  public:
+  // Contains all of the necessary data to to deaccount block with NMT.
+  struct FreeInfo {
+    const size_t size;
+    const MEMFLAGS flags;
+    const uint32_t mst_marker;
+  };
+
   inline MallocHeader(size_t size, MEMFLAGS flags, uint32_t mst_marker);
 
   inline size_t   size()  const { return _size; }
@@ -130,8 +130,8 @@ class MallocHeader {
   bool get_stack(NativeCallStack& stack) const;
 
   // Return the necessary data to record the block this belongs to as freed
-  FreePackage free_package() {
-    return FreePackage{this->size(), this->flags(), this->mst_marker()};
+  FreeInfo free_info() {
+    return FreeInfo{this->size(), this->flags(), this->mst_marker()};
   }
   inline void mark_block_as_dead();
   inline void revive();

--- a/src/hotspot/share/services/mallocHeader.hpp
+++ b/src/hotspot/share/services/mallocHeader.hpp
@@ -130,7 +130,8 @@ class MallocHeader {
   inline uint32_t mst_marker() const { return _mst_marker; }
   bool get_stack(NativeCallStack& stack) const;
 
-  FreePackage free_recording_data() {
+  // Return the necessary data to record the block this belongs to as freed
+  FreePackage free_package() {
     return FreePackage{this->size(), this->flags(), this->mst_marker()};
   }
   inline void mark_block_as_dead();

--- a/src/hotspot/share/services/mallocHeader.inline.hpp
+++ b/src/hotspot/share/services/mallocHeader.inline.hpp
@@ -45,6 +45,12 @@ inline MallocHeader::MallocHeader(size_t size, MEMFLAGS flags, uint32_t mst_mark
   set_footer(_footer_canary_life_mark); // set after initializing _size
 }
 
+inline void MallocHeader::mark_block_as_alive() {
+  _canary = _header_canary_life_mark;
+  NOT_LP64(_alt_canary = _header_alt_canary_life_mark);
+  set_footer(_footer_canary_life_mark);
+}
+
 inline void MallocHeader::mark_block_as_dead() {
   _canary = _header_canary_dead_mark;
   NOT_LP64(_alt_canary = _header_alt_canary_dead_mark);

--- a/src/hotspot/share/services/mallocHeader.inline.hpp
+++ b/src/hotspot/share/services/mallocHeader.inline.hpp
@@ -45,7 +45,10 @@ inline MallocHeader::MallocHeader(size_t size, MEMFLAGS flags, uint32_t mst_mark
   set_footer(_footer_canary_life_mark); // set after initializing _size
 }
 
-inline void MallocHeader::mark_block_as_alive() {
+inline void MallocHeader::revive() {
+  assert(_canary == _header_canary_dead_mark, "must be dead");
+  assert(get_footer() == _footer_canary_dead_mark, "must be dead");
+  NOT_LP64(assert(_alt_canary == _header_alt_canary_dead_mark, "must be dead"));
   _canary = _header_canary_life_mark;
   NOT_LP64(_alt_canary = _header_alt_canary_life_mark);
   set_footer(_footer_canary_life_mark);

--- a/src/hotspot/share/services/mallocHeader.inline.hpp
+++ b/src/hotspot/share/services/mallocHeader.inline.hpp
@@ -54,6 +54,7 @@ inline void MallocHeader::revive() {
   set_footer(_footer_canary_life_mark);
 }
 
+// The effects of this method must be reversible with MallocHeader::revive()
 inline void MallocHeader::mark_block_as_dead() {
   _canary = _header_canary_dead_mark;
   NOT_LP64(_alt_canary = _header_alt_canary_dead_mark);

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -199,14 +199,18 @@ void* MallocTracker::record_free(void* memblock) {
   MallocHeader* const header = malloc_header(memblock);
   header->assert_block_integrity();
 
-  MallocMemorySummary::record_free(header->size(), header->flags());
-  if (MemTracker::tracking_level() == NMT_detail) {
-    MallocSiteTable::deallocation_at(header->size(), header->mst_marker());
-  }
+  record_free_header(header->free_recording_data());
 
   header->mark_block_as_dead();
 
   return (void*)header;
+}
+
+void MallocTracker::record_free_header(FreePackage pkg) {
+  MallocMemorySummary::record_free(pkg.size, pkg.flags);
+  if (MemTracker::tracking_level() == NMT_detail) {
+    MallocSiteTable::deallocation_at(pkg.size, pkg.mst_marker);
+  }
 }
 
 // Given a pointer, if it seems to point to the start of a valid malloced block,

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -199,17 +199,17 @@ void* MallocTracker::record_free_block(void* memblock) {
   MallocHeader* const header = malloc_header(memblock);
   header->assert_block_integrity();
 
-  record_free(header->free_package());
+  record_free(header->free_info());
 
   header->mark_block_as_dead();
 
   return (void*)header;
 }
 
-void MallocTracker::record_free(FreePackage free_package) {
-  MallocMemorySummary::record_free(free_package.size, free_package.flags);
+void MallocTracker::record_free(MallocHeader::FreeInfo free_info) {
+  MallocMemorySummary::record_free(free_info.size, free_info.flags);
   if (MemTracker::tracking_level() == NMT_detail) {
-    MallocSiteTable::deallocation_at(free_package.size, free_package.mst_marker);
+    MallocSiteTable::deallocation_at(free_info.size, free_info.mst_marker);
   }
 }
 

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -199,7 +199,7 @@ void* MallocTracker::record_free(void* memblock) {
   MallocHeader* const header = malloc_header(memblock);
   header->assert_block_integrity();
 
-  record_free_header(header->free_recording_data());
+  record_free_header(header->free_package());
 
   header->mark_block_as_dead();
 

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -199,14 +199,14 @@ void* MallocTracker::record_free_block(void* memblock) {
   MallocHeader* const header = malloc_header(memblock);
   header->assert_block_integrity();
 
-  record_free(header->free_info());
+  deaccount(header->free_info());
 
   header->mark_block_as_dead();
 
   return (void*)header;
 }
 
-void MallocTracker::record_free(MallocHeader::FreeInfo free_info) {
+void MallocTracker::deaccount(MallocHeader::FreeInfo free_info) {
   MallocMemorySummary::record_free(free_info.size, free_info.flags);
   if (MemTracker::tracking_level() == NMT_detail) {
     MallocSiteTable::deallocation_at(free_info.size, free_info.mst_marker);

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -192,7 +192,7 @@ void* MallocTracker::record_malloc(void* malloc_base, size_t size, MEMFLAGS flag
   return memblock;
 }
 
-void* MallocTracker::record_free(void* memblock) {
+void* MallocTracker::record_free_block(void* memblock) {
   assert(MemTracker::enabled(), "Sanity");
   assert(memblock != NULL, "precondition");
 

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -199,14 +199,14 @@ void* MallocTracker::record_free_block(void* memblock) {
   MallocHeader* const header = malloc_header(memblock);
   header->assert_block_integrity();
 
-  record_free_header(header->free_package());
+  record_free(header->free_package());
 
   header->mark_block_as_dead();
 
   return (void*)header;
 }
 
-void MallocTracker::record_free_header(FreePackage pkg) {
+void MallocTracker::record_free(FreePackage pkg) {
   MallocMemorySummary::record_free(pkg.size, pkg.flags);
   if (MemTracker::tracking_level() == NMT_detail) {
     MallocSiteTable::deallocation_at(pkg.size, pkg.mst_marker);

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -206,10 +206,10 @@ void* MallocTracker::record_free_block(void* memblock) {
   return (void*)header;
 }
 
-void MallocTracker::record_free(FreePackage pkg) {
-  MallocMemorySummary::record_free(pkg.size, pkg.flags);
+void MallocTracker::record_free(FreePackage free_package) {
+  MallocMemorySummary::record_free(free_package.size, free_package.flags);
   if (MemTracker::tracking_level() == NMT_detail) {
-    MallocSiteTable::deallocation_at(pkg.size, pkg.mst_marker);
+    MallocSiteTable::deallocation_at(free_package.size, free_package.mst_marker);
   }
 }
 

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -293,6 +293,8 @@ class MallocTracker : AllStatic {
 
   // Record free on specified memory block
   static void* record_free(void* memblock);
+  // Record free given the relevant data.
+  static void record_free_header(FreePackage pkg);
 
   static inline void record_new_arena(MEMFLAGS flags) {
     MallocMemorySummary::record_new_arena(flags);

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -295,7 +295,7 @@ class MallocTracker : AllStatic {
   // Returns the outer pointer to this block.
   static void* record_free_block(void* memblock);
   // Record a free.
-  static void record_free(FreePackage free_package);
+  static void record_free(MallocHeader::FreeInfo free_info);
 
   static inline void record_new_arena(MEMFLAGS flags) {
     MallocMemorySummary::record_new_arena(flags);

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -291,11 +291,11 @@ class MallocTracker : AllStatic {
   static void* record_malloc(void* malloc_base, size_t size, MEMFLAGS flags,
     const NativeCallStack& stack);
 
-  // Record free on specified memory block.
-  // Returns the outer pointer to this block.
+  // Given a block returned by os::malloc() or os::realloc():
+  // deaccount block from NMT, mark its header as dead and return pointer to header.
   static void* record_free_block(void* memblock);
-  // Record a free.
-  static void record_free(MallocHeader::FreeInfo free_info);
+  // Given the free info from a block, de-account block from NMT.
+  static void deaccount(MallocHeader::FreeInfo free_info);
 
   static inline void record_new_arena(MEMFLAGS flags) {
     MallocMemorySummary::record_new_arena(flags);

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -291,8 +291,9 @@ class MallocTracker : AllStatic {
   static void* record_malloc(void* malloc_base, size_t size, MEMFLAGS flags,
     const NativeCallStack& stack);
 
-  // Record free on specified memory block
-  static void* record_free(void* memblock);
+  // Record free on specified memory block.
+  // Returns the outer pointer to this block.
+  static void* record_free_block(void* memblock);
   // Record free given the relevant data.
   static void record_free_header(FreePackage pkg);
 

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -294,8 +294,8 @@ class MallocTracker : AllStatic {
   // Record free on specified memory block.
   // Returns the outer pointer to this block.
   static void* record_free_block(void* memblock);
-  // Record free given the relevant data.
-  static void record_free_header(FreePackage pkg);
+  // Record a free.
+  static void record_free(FreePackage pkg);
 
   static inline void record_new_arena(MEMFLAGS flags) {
     MallocMemorySummary::record_new_arena(flags);

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -295,7 +295,7 @@ class MallocTracker : AllStatic {
   // Returns the outer pointer to this block.
   static void* record_free_block(void* memblock);
   // Record a free.
-  static void record_free(FreePackage pkg);
+  static void record_free(FreePackage free_package);
 
   static inline void record_new_arena(MEMFLAGS flags) {
     MallocMemorySummary::record_new_arena(flags);

--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -106,12 +106,14 @@ class MemTracker : AllStatic {
   static inline void* record_free(void* memblock) {
     // Never turned on
     assert(memblock != NULL, "caller should handle NULL");
-    assert(enabled(), "NMT must be enabled");
+    if(!enabled()) {
+      return memblock;
+    }
     return MallocTracker::record_free_block(memblock);
   }
   static inline void deaccount(MallocHeader::FreeInfo free_info) {
     assert(enabled(), "NMT must be enabled");
-    MallocTracker::record_free(free_info);
+    MallocTracker::deaccount(free_info);
   }
 
   // Record creation of an arena

--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -109,9 +109,9 @@ class MemTracker : AllStatic {
     assert(enabled(), "NMT must be enabled");
     return MallocTracker::record_free_block(memblock);
   }
-  static inline void record_free(FreePackage free_package) {
+  static inline void record_free(MallocHeader::FreeInfo free_info) {
     assert(enabled(), "NMT must be enabled");
-    MallocTracker::record_free(free_package);
+    MallocTracker::record_free(free_info);
   }
 
   // Record creation of an arena

--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -109,7 +109,7 @@ class MemTracker : AllStatic {
     assert(enabled(), "NMT must be enabled");
     return MallocTracker::record_free_block(memblock);
   }
-  static inline void record_free(MallocHeader::FreeInfo free_info) {
+  static inline void deaccount(MallocHeader::FreeInfo free_info) {
     assert(enabled(), "NMT must be enabled");
     MallocTracker::record_free(free_info);
   }

--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -103,11 +103,15 @@ class MemTracker : AllStatic {
   }
 
   // Record malloc free and return malloc base address
-  static inline void* record_free(void* memblock) {
+  static inline void* record_free_block(void* memblock) {
     // Never turned on
     assert(memblock != NULL, "caller should handle NULL");
     assert(enabled(), "NMT must be enabled");
     return MallocTracker::record_free_block(memblock);
+  }
+  static inline void record_free(FreePackage free_package) {
+    assert(enabled(), "NMT must be enabled");
+    MallocTracker::record_free(free_package);
   }
 
   // Record creation of an arena

--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -106,9 +106,7 @@ class MemTracker : AllStatic {
   static inline void* record_free(void* memblock) {
     // Never turned on
     assert(memblock != NULL, "caller should handle NULL");
-    if (!enabled()) {
-      return memblock;
-    }
+    assert(enabled(), "NMT must be enabled");
     return MallocTracker::record_free(memblock);
   }
 

--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -103,7 +103,7 @@ class MemTracker : AllStatic {
   }
 
   // Record malloc free and return malloc base address
-  static inline void* record_free_block(void* memblock) {
+  static inline void* record_free(void* memblock) {
     // Never turned on
     assert(memblock != NULL, "caller should handle NULL");
     assert(enabled(), "NMT must be enabled");

--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -107,7 +107,7 @@ class MemTracker : AllStatic {
     // Never turned on
     assert(memblock != NULL, "caller should handle NULL");
     assert(enabled(), "NMT must be enabled");
-    return MallocTracker::record_free(memblock);
+    return MallocTracker::record_free_block(memblock);
   }
 
   // Record creation of an arena

--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -106,7 +106,7 @@ class MemTracker : AllStatic {
   static inline void* record_free(void* memblock) {
     // Never turned on
     assert(memblock != NULL, "caller should handle NULL");
-    if(!enabled()) {
+    if (!enabled()) {
       return memblock;
     }
     return MallocTracker::record_free_block(memblock);

--- a/test/hotspot/gtest/nmt/test_nmt_cornercases.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_cornercases.cpp
@@ -141,3 +141,16 @@ TEST_VM(NMT, random_reallocs) {
 
   os::free(p);
 }
+
+TEST_VM(NMT, HeaderKeepsIntegrityAfterRevival) {
+  if (!MemTracker::enabled()) {
+    return;
+  }
+  size_t some_size = 16;
+  void* p = os::malloc(some_size, mtTest);
+  ASSERT_NOT_NULL(p) << "Failed to malloc()";
+  MallocHeader* hdr = MallocTracker::malloc_header(p);
+  hdr->mark_block_as_dead();
+  hdr->revive();
+  check_expected_malloc_header(p, mtTest, some_size);
+}


### PR DESCRIPTION
This PR avoids the double registration of a failed `os::realloc` in NMT by doing the NMT free protocol steps inline (asserting block integrity, marking of MallocHeader, and registrering results to statistics). This is done by creating a new struct `FreePackage` which includes all of the necessary data for registrering results.

I also did some light refactoring which I think makes the protocol clearer, these are done piece wise as separate commits for the reviewers' convenience.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297718](https://bugs.openjdk.org/browse/JDK-8297718): Make NMT free:ing protocol more granular


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [e704c024](https://git.openjdk.org/jdk/pull/11390/files/e704c0245192abf64ee441eac92b13fc074ffb99)
 * [Gerard Ziemski](https://openjdk.org/census#gziemski) (@gerard-ziemski - Committer) ⚠️ Review applies to [e704c024](https://git.openjdk.org/jdk/pull/11390/files/e704c0245192abf64ee441eac92b13fc074ffb99)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11390/head:pull/11390` \
`$ git checkout pull/11390`

Update a local copy of the PR: \
`$ git checkout pull/11390` \
`$ git pull https://git.openjdk.org/jdk pull/11390/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11390`

View PR using the GUI difftool: \
`$ git pr show -t 11390`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11390.diff">https://git.openjdk.org/jdk/pull/11390.diff</a>

</details>
