### PR TITLE
8297729: Replace GrowableArray in ComputeMoveOrder with hash table

### DIFF
--- a/src/hotspot/share/prims/foreignGlobals.cpp
+++ b/src/hotspot/share/prims/foreignGlobals.cpp
@@ -184,12 +184,19 @@ int JavaCallingConvention::calling_convention(const BasicType* sig_bt, VMStorage
 class ComputeMoveOrder: public StackObj {
   class MoveOperation;
 
+  static inline unsigned hash(const VMStorage& vms) {
+    // segment_mask_or_size is not taken into account since
+    // VMStorages that differ only in mask or size can still
+    // conflict
+    return static_cast<unsigned int>(vms.type()) ^ vms.index_or_offset();
+  }
+
   using KillerTable = ResourceHashtable<
     VMStorage, MoveOperation*,
     32, // doesn't need to be big. don't have that many argument registers (in known ABIs)
-    ResourceObj::RESOURCE_AREA,
+    AnyObj::RESOURCE_AREA,
     mtInternal,
-    ::hash,
+    ComputeMoveOrder::hash,
     ::operator==
     >;
 

--- a/src/hotspot/share/prims/foreignGlobals.cpp
+++ b/src/hotspot/share/prims/foreignGlobals.cpp
@@ -27,6 +27,7 @@
 #include "memory/resourceArea.hpp"
 #include "prims/foreignGlobals.inline.hpp"
 #include "runtime/jniHandles.inline.hpp"
+#include "utilities/resourceHash.hpp"
 
 StubLocations::StubLocations() {
   for (uint32_t i = 0; i < LOCATION_LIMIT; i++) {
@@ -116,11 +117,10 @@ void ArgumentShuffle::print_on(outputStream* os) const {
   os->print_cr("Argument shuffle {");
   for (int i = 0; i < _moves.length(); i++) {
     Move move = _moves.at(i);
-    BasicType arg_bt   = move.bt;
     VMStorage from_reg = move.from;
     VMStorage to_reg   = move.to;
 
-    os->print("Move a %s from ", null_safe_string(type2name(arg_bt)));
+    os->print("Move from ");
     from_reg.print_on(os);
     os->print(" to ");
     to_reg.print_on(os);
@@ -182,44 +182,48 @@ int JavaCallingConvention::calling_convention(const BasicType* sig_bt, VMStorage
 }
 
 class ComputeMoveOrder: public StackObj {
+  class MoveOperation;
+
+  using KillerTable = ResourceHashtable<
+    VMStorage, MoveOperation*,
+    32, // doesn't need to be big. don't have that many argument registers (in known ABIs)
+    ResourceObj::RESOURCE_AREA,
+    mtInternal,
+    ::hash,
+    ::operator==
+    >;
+
   class MoveOperation: public ResourceObj {
     friend class ComputeMoveOrder;
    private:
-    VMStorage        _src;
-    VMStorage        _dst;
-    bool             _processed;
+    VMStorage       _src;
+    VMStorage       _dst;
+    bool            _processed;
     MoveOperation*  _next;
     MoveOperation*  _prev;
-    BasicType       _bt;
-
-    static int get_id(VMStorage r) {
-      assert((r.index_or_offset() & 0xFF000000) == 0, "index or offset too large");
-      // assuming mask and size doesn't matter for now
-      return ((int) r.type()) | (r.index_or_offset() << 8);
-    }
 
    public:
-    MoveOperation(VMStorage src, VMStorage dst, BasicType bt):
-      _src(src), _dst(dst), _processed(false), _next(NULL), _prev(NULL), _bt(bt) {}
+    MoveOperation(VMStorage src, VMStorage dst):
+      _src(src), _dst(dst), _processed(false), _next(nullptr), _prev(nullptr) {}
 
-    int src_id() const          { return get_id(_src); }
-    int dst_id() const          { return get_id(_dst); }
-    MoveOperation* next() const { return _next; }
-    MoveOperation* prev() const { return _prev; }
-    void set_processed()        { _processed = true; }
-    bool is_processed() const   { return _processed; }
+    const VMStorage& src() const { return _src; }
+    const VMStorage& dst() const { return _dst; }
+    MoveOperation* next()  const { return _next; }
+    MoveOperation* prev()  const { return _prev; }
+    void set_processed()         { _processed = true; }
+    bool is_processed()    const { return _processed; }
 
     // insert
     void break_cycle(VMStorage temp_register) {
       // create a new store following the last store
       // to move from the temp_register to the original
-      MoveOperation* new_store = new MoveOperation(temp_register, _dst, _bt);
+      MoveOperation* new_store = new MoveOperation(temp_register, _dst);
 
       // break the cycle of links and insert new_store at the end
       // break the reverse link.
       MoveOperation* p = prev();
       assert(p->next() == this, "must be");
-      _prev = NULL;
+      _prev = nullptr;
       p->_next = new_store;
       new_store->_prev = p;
 
@@ -227,18 +231,19 @@ class ComputeMoveOrder: public StackObj {
       _dst = temp_register;
     }
 
-    void link(GrowableArray<MoveOperation*>& killer) {
+    void link(KillerTable& killer) {
       // link this store in front the store that it depends on
-      MoveOperation* n = killer.at_grow(src_id(), NULL);
-      if (n != NULL) {
-        assert(_next == NULL && n->_prev == NULL, "shouldn't have been set yet");
-        _next = n;
-        n->_prev = this;
+      MoveOperation** n = killer.get(_src);
+      if (n != nullptr) {
+        MoveOperation* src_killer = *n;
+        assert(_next == nullptr && src_killer->_prev == nullptr, "shouldn't have been set yet");
+        _next = src_killer;
+        src_killer->_prev = this;
       }
     }
 
     Move as_move() {
-      return {_bt, _src, _dst};
+      return {_src, _dst};
     }
   };
 
@@ -280,11 +285,11 @@ class ComputeMoveOrder: public StackObj {
       VMStorage in_reg = _in_regs[in_idx];
       VMStorage out_reg = _out_regs[out_idx];
 
-      if (out_reg.is_stack()) {
+      if (out_reg.is_stack() || out_reg.is_frame_data()) {
         // Move operations where the dest is the stack can all be
         // scheduled first since they can't interfere with the other moves.
         // The input and output stack spaces are distinct from each other.
-        Move move{bt, in_reg, out_reg};
+        Move move{in_reg, out_reg};
         _moves.push(move);
       } else if (in_reg == out_reg
                  || bt == T_VOID) {
@@ -294,7 +299,7 @@ class ComputeMoveOrder: public StackObj {
         //    Don't need to do anything.
         continue;
       } else {
-        _edges.append(new MoveOperation(in_reg, out_reg, bt));
+        _edges.append(new MoveOperation(in_reg, out_reg));
       }
     }
     // Break any cycles in the register moves and emit the in the
@@ -305,16 +310,15 @@ class ComputeMoveOrder: public StackObj {
   // Walk the edges breaking cycles between moves.  The result list
   // can be walked in order to produce the proper set of loads
   void compute_store_order(VMStorage temp_register) {
-    // Record which moves kill which values
-    // FIXME should be a map
-    GrowableArray<MoveOperation*> killer; // essentially a map of register id -> MoveOperation*
+    // Record which moves kill which registers
+    KillerTable killer; // a map of VMStorage -> MoveOperation*
     for (int i = 0; i < _edges.length(); i++) {
       MoveOperation* s = _edges.at(i);
-      assert(killer.at_grow(s->dst_id(), NULL) == NULL,
+      assert(!killer.contains(s->dst()),
              "multiple moves with the same register as destination");
-      killer.at_put_grow(s->dst_id(), s, NULL);
+      killer.put(s->dst(), s);
     }
-    assert(killer.at_grow(MoveOperation::get_id(temp_register), NULL) == NULL,
+    assert(!killer.contains(temp_register),
            "make sure temp isn't in the registers that are killed");
 
     // create links between loads and stores
@@ -332,14 +336,14 @@ class ComputeMoveOrder: public StackObj {
       if (!s->is_processed()) {
         MoveOperation* start = s;
         // search for the beginning of the chain or cycle
-        while (start->prev() != NULL && start->prev() != s) {
+        while (start->prev() != nullptr && start->prev() != s) {
           start = start->prev();
         }
         if (start->prev() == s) {
           start->break_cycle(temp_register);
         }
         // walk the chain forward inserting to store list
-        while (start != NULL) {
+        while (start != nullptr) {
           _moves.push(start->as_move());
 
           start->set_processed();

--- a/src/hotspot/share/prims/foreignGlobals.cpp
+++ b/src/hotspot/share/prims/foreignGlobals.cpp
@@ -184,11 +184,14 @@ int JavaCallingConvention::calling_convention(const BasicType* sig_bt, VMStorage
 class ComputeMoveOrder: public StackObj {
   class MoveOperation;
 
+  // segment_mask_or_size is not taken into account since
+  // VMStorages that differ only in mask or size can still
+  // conflict
   static inline unsigned hash(const VMStorage& vms) {
-    // segment_mask_or_size is not taken into account since
-    // VMStorages that differ only in mask or size can still
-    // conflict
     return static_cast<unsigned int>(vms.type()) ^ vms.index_or_offset();
+  }
+  static inline bool equals(const VMStorage& a, const VMStorage& b) {
+    return a.type() == b.type() && a.index_or_offset() == b.index_or_offset();
   }
 
   using KillerTable = ResourceHashtable<
@@ -197,7 +200,7 @@ class ComputeMoveOrder: public StackObj {
     AnyObj::RESOURCE_AREA,
     mtInternal,
     ComputeMoveOrder::hash,
-    ::operator==
+    ComputeMoveOrder::equals
     >;
 
   class MoveOperation: public ResourceObj {

--- a/src/hotspot/share/prims/foreignGlobals.hpp
+++ b/src/hotspot/share/prims/foreignGlobals.hpp
@@ -116,7 +116,6 @@ private:
 };
 
 struct Move {
-  BasicType bt;
   VMStorage from;
   VMStorage to;
 };

--- a/src/hotspot/share/prims/vmstorage.hpp
+++ b/src/hotspot/share/prims/vmstorage.hpp
@@ -90,12 +90,6 @@ public:
   void print_on(outputStream* os) const;
 };
 
-inline unsigned hash(const VMStorage& vms) {
-  return static_cast<unsigned int>(vms._type)
-    ^ vms._index_or_offset
-    ^ vms._segment_mask_or_size;
-}
-
 inline bool operator==(const VMStorage& a, const VMStorage& b) {
   return a._type == b._type
     && a._index_or_offset == b._index_or_offset

--- a/src/hotspot/share/prims/vmstorage.hpp
+++ b/src/hotspot/share/prims/vmstorage.hpp
@@ -41,6 +41,7 @@ private:
   uint16_t _segment_mask_or_size;
   uint32_t _index_or_offset; // stack offset in bytes for stack storage
 
+  friend unsigned hash(const VMStorage& vms);
   friend bool operator==(const VMStorage& a, const VMStorage& b);
 
   constexpr inline static bool is_reg(StorageType type);
@@ -88,6 +89,12 @@ public:
 
   void print_on(outputStream* os) const;
 };
+
+inline unsigned hash(const VMStorage& vms) {
+  return static_cast<unsigned int>(vms._type)
+    ^ vms._index_or_offset
+    ^ vms._segment_mask_or_size;
+}
 
 inline bool operator==(const VMStorage& a, const VMStorage& b) {
   return a._type == b._type

--- a/src/hotspot/share/prims/vmstorage.hpp
+++ b/src/hotspot/share/prims/vmstorage.hpp
@@ -41,7 +41,6 @@ private:
   uint16_t _segment_mask_or_size;
   uint32_t _index_or_offset; // stack offset in bytes for stack storage
 
-  friend unsigned hash(const VMStorage& vms);
   friend bool operator==(const VMStorage& a, const VMStorage& b);
 
   constexpr inline static bool is_reg(StorageType type);


### PR DESCRIPTION
Replaces the GrowableArray 'table' in ComputeMoveOrder with a real hash table.

Through testing, I found that sometimes this array is blown up to several thousand elements, most of which are `NULL`. Using a hash table prevents this large wastage.

I've touched up some of the surrounding code as well. Mostly style changes, but I've also removed the `BasicType` field from the `Move` and `MoveOperation` structs, since it was unused, and added frame data storages to the fast path for stack args as well, since both are allocated on the stack.

Testing: `jdk_foreign` test suite.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297729](https://bugs.openjdk.org/browse/JDK-8297729): Replace GrowableArray in ComputeMoveOrder with hash table


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [40e66a7c](https://git.openjdk.org/jdk/pull/11392/files/40e66a7c29b302b787c0b97bb12c37c07772950e)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11392/head:pull/11392` \
`$ git checkout pull/11392`

Update a local copy of the PR: \
`$ git checkout pull/11392` \
`$ git pull https://git.openjdk.org/jdk pull/11392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11392`

View PR using the GUI difftool: \
`$ git pr show -t 11392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11392.diff">https://git.openjdk.org/jdk/pull/11392.diff</a>

</details>
