### PR TITLE
8297528: java/io/File/TempDirDoesNotExist.java test failing on windows-x64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -499,7 +499,6 @@ java/lang/instrument/RetransformBigClass.sh                     8065756 generic-
 
 java/io/pathNames/GeneralWin32.java                             8180264 windows-all
 java/io/File/createTempFile/SpecialTempFile.java                8274122 windows11
-java/io/File/TempDirDoesNotExist.java                           8297528 windows-all
 
 ############################################################################
 

--- a/test/jdk/java/io/File/TempDirDoesNotExist.java
+++ b/test/jdk/java/io/File/TempDirDoesNotExist.java
@@ -42,7 +42,7 @@ public class TempDirDoesNotExist {
     public static void main(String... args) throws Exception {
 
         String userDir = System.getProperty("user.home");
-        String timeStamp = java.time.Instant.now().toString();
+        String timeStamp = System.currentTimeMillis() + "";
         String tempDir = Path.of(userDir,"non-existing-", timeStamp).toString();
 
         for (String arg : args) {


### PR DESCRIPTION
fix the illegal characters of directory names in Windows

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297528](https://bugs.openjdk.org/browse/JDK-8297528): java/io/File/TempDirDoesNotExist.java test failing on windows-x64


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11393/head:pull/11393` \
`$ git checkout pull/11393`

Update a local copy of the PR: \
`$ git checkout pull/11393` \
`$ git pull https://git.openjdk.org/jdk pull/11393/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11393`

View PR using the GUI difftool: \
`$ git pr show -t 11393`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11393.diff">https://git.openjdk.org/jdk/pull/11393.diff</a>

</details>
