### PR TITLE
8297685: Typo in NullPointerException description specified by Locale.lookup

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -3554,7 +3554,7 @@ public final class Locale implements Cloneable, Serializable {
      * @param locales {@code Locale} instances used for matching
      * @return the best matching {@code Locale} instance chosen based on
      *     priority or weight, or {@code null} if nothing matches.
-     * @throws NullPointerException if {@code priorityList} or {@code tags} is
+     * @throws NullPointerException if {@code priorityList} or {@code locales} is
      *     {@code null}
      *
      * @since 1.8


### PR DESCRIPTION
Problem: Javadoc in Locale.lookup is incorrect. Javadoc should match the parameter arguments. See lines 3562-3563.

Fix: For `@throws NullPointerException` replace `if priorityList or tags is null` with `if priorityList or locales is null `. 