### PR TITLE
JDK-8297731: Remove redundant check in MutableBigInteger.divide

### DIFF
--- a/src/java.base/share/classes/java/math/MutableBigInteger.java
+++ b/src/java.base/share/classes/java/math/MutableBigInteger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1532,12 +1532,10 @@ class MutableBigInteger {
         int[] q = quotient.value;
 
 
-        // Must insert leading 0 in rem if its length did not change
-        if (rem.intLen == nlen) {
-            rem.offset = 0;
-            rem.value[0] = 0;
-            rem.intLen++;
-        }
+        // Insert leading 0 in rem
+        rem.offset = 0;
+        rem.value[0] = 0;
+        rem.intLen++;
 
         int dh = divisor[0];
         long dhLong = dh & LONG_MASK;

--- a/src/java.base/share/classes/java/math/MutableBigInteger.java
+++ b/src/java.base/share/classes/java/math/MutableBigInteger.java
@@ -1531,7 +1531,6 @@ class MutableBigInteger {
         quotient.intLen = limit;
         int[] q = quotient.value;
 
-
         // Insert leading 0 in rem
         rem.offset = 0;
         rem.value[0] = 0;


### PR DESCRIPTION
Remove redundant code reported in

https://mail.openjdk.org/pipermail/core-libs-dev/2022-November/097163.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297731](https://bugs.openjdk.org/browse/JDK-8297731): Remove redundant check in MutableBigInteger.divide


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to [0e74b515](https://git.openjdk.org/jdk/pull/11395/files/0e74b51514ce5cf56037a22fc7fd1cc364f785e4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11395/head:pull/11395` \
`$ git checkout pull/11395`

Update a local copy of the PR: \
`$ git checkout pull/11395` \
`$ git pull https://git.openjdk.org/jdk pull/11395/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11395`

View PR using the GUI difftool: \
`$ git pr show -t 11395`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11395.diff">https://git.openjdk.org/jdk/pull/11395.diff</a>

</details>
