### PR TITLE
8297733: Refactor Cast binding to enum

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
@@ -676,10 +676,9 @@ public class BindingSpecializer {
         Class<?> fromType = cast.fromType();
         Class<?> toType = cast.toType();
 
-        if (fromType == int.class) {
-            popType(int.class);
-
-            if (toType == boolean.class) {
+        popType(fromType);
+        switch (cast) {
+            case INT_TO_BOOLEAN -> {
                 // implement least significant byte non-zero test
 
                 // select first byte
@@ -688,28 +687,16 @@ public class BindingSpecializer {
 
                 // convert to boolean
                 emitInvokeStatic(Utils.class, "byteToBoolean", "(B)Z");
-            } else if (toType == byte.class) {
-                mv.visitInsn(I2B);
-            } else if (toType == short.class) {
-                mv.visitInsn(I2S);
-            } else {
-                assert toType == char.class;
-                mv.visitInsn(I2C);
             }
-
-            pushType(toType);
-        } else {
-            popType(fromType);
-
-            assert fromType == boolean.class
-                    || fromType == byte.class
-                    || fromType == short.class
-                    || fromType == char.class;
-            // no-op in bytecode
-
-            assert toType == int.class;
-            pushType(int.class);
+            case INT_TO_BYTE -> mv.visitInsn(I2B);
+            case INT_TO_CHAR -> mv.visitInsn(I2C);
+            case INT_TO_SHORT -> mv.visitInsn(I2S);
+            case BOOLEAN_TO_INT, BYTE_TO_INT, CHAR_TO_INT, SHORT_TO_INT -> {
+                // no-op in bytecode
+            }
+            default -> throw new IllegalStateException("Unknown cast: " + cast);
         }
+        pushType(toType);
     }
 
     private void emitUnboxAddress() {


### PR DESCRIPTION
Refactor the cast binding to an enum, which clearly enumerates all supported conversions.

This also fixes a bug where `java/foreign/normalize/TestNormalize` was failing when running in interpreted mode (`-Djdk.internal.foreign.DowncallLinker.USE_SPEC=false`), for conversions from `int` to `byte` because the `explicitCast` method handle that was used only considers the least significant bit, while we want to look at all of the least significant byte.

As mentioned in the JBS issue, doing this will also make it easier going forward to support multiple conversions with the same from and to types, but requiring different semantics.

Testing: jdk_foreign test suite.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297733](https://bugs.openjdk.org/browse/JDK-8297733): Refactor Cast binding to enum


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [a5576dee](https://git.openjdk.org/jdk/pull/11397/files/a5576deebd9a0a99fbe43d8949fe4f4e6a8a9687)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11397/head:pull/11397` \
`$ git checkout pull/11397`

Update a local copy of the PR: \
`$ git checkout pull/11397` \
`$ git pull https://git.openjdk.org/jdk pull/11397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11397`

View PR using the GUI difftool: \
`$ git pr show -t 11397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11397.diff">https://git.openjdk.org/jdk/pull/11397.diff</a>

</details>
