### PR TITLE
8297715: RISC-V: C2: Use single-bit instructions from the Zbs extension

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1670,7 +1670,7 @@ enum Nf {
 
 // ====================================
 // RISC-V Bit-Manipulation Extension
-// Currently only support Zba and Zbb bitmanip extensions.
+// Currently only support Zba, Zbb and Zbs bitmanip extensions.
 // ====================================
 #define INSN(NAME, op, funct3, funct7)                  \
   void NAME(Register Rd, Register Rs1, Register Rs2) {  \
@@ -1745,6 +1745,7 @@ enum Nf {
 
   INSN(rori,    0b0010011, 0b101, 0b011000);
   INSN(slli_uw, 0b0011011, 0b001, 0b000010);
+  INSN(bexti,   0b0010011, 0b101, 0b010010);
 
 #undef INSN
 

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -102,6 +102,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, UseRVV, false, EXPERIMENTAL, "Use RVV instructions")             \
   product(bool, UseZba, false, EXPERIMENTAL, "Use Zba instructions")             \
   product(bool, UseZbb, false, EXPERIMENTAL, "Use Zbb instructions")             \
+  product(bool, UseZbs, false, EXPERIMENTAL, "Use Zbs instructions")             \
   product(bool, UseZic64b, false, EXPERIMENTAL, "Use Zic64b instructions")       \
   product(bool, UseZicbom, false, EXPERIMENTAL, "Use Zicbom instructions")       \
   product(bool, UseZicbop, false, EXPERIMENTAL, "Use Zicbop instructions")       \

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2982,6 +2982,14 @@ operand immI_16bits()
   interface(CONST_INTER);
 %}
 
+operand immIpowerOf2() %{
+  predicate(is_power_of_2((juint)(n->get_int())));
+  match(ConI);
+  op_cost(0);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
 // Long Immediate: low 32-bit mask
 operand immL_32bits()
 %{

--- a/src/hotspot/cpu/riscv/riscv_b.ad
+++ b/src/hotspot/cpu/riscv/riscv_b.ad
@@ -525,3 +525,17 @@ instruct ornL_reg_reg_b(iRegLNoSp dst, iRegL src1, iRegL src2, immL_M1 m1) %{
 
   ins_pipe(ialu_reg_reg);
 %}
+
+// AndI 0b0..010..0 + ConvI2B
+instruct convI2Bool_andI_reg_immIpowerOf2(iRegINoSp dst, iRegIorL2I src, immIpowerOf2 mask) %{
+  predicate(UseZbs);
+  match(Set dst (Conv2B (AndI src mask)));
+  ins_cost(ALU_COST);
+
+  format %{ "bexti  $dst, $src, $mask\t#@convI2Bool_andI_reg_immIpowerOf2" %}
+  ins_encode %{
+    __ bexti($dst$$Register, $src$$Register, exact_log2((juint)($mask$$constant)));
+  %}
+
+  ins_pipe(ialu_reg_reg);
+%}


### PR DESCRIPTION
The single-bit instructions from the Zbs extension provide a mechanism to set, clear,
invert, or extract a single bit in a register. The bit is specified by its index.

Especially, the single-bit extract (immediate) instruction 'bexti rd, rs1, shamt' [1] performs:
```
  let index = shamt & (XLEN - 1);
  X(rd) = (X(rs1) >> index) & 1;
```

This instruction is a perfect match for following C2 sub-graph when integer immediate 'mask' is power of 2:
```
  Set dst (Conv2B (AndI src mask))
```

The effect is that we could then optimize C2 JIT code for methods like [2]:
Before:
```
  lhu  R28, [R11, #12]    # short, #@loadUS ! Field: com/sun/org/apache/xerces/internal/dom/NodeImpl.flags
  andi  R7, R28, #8       #@andI_reg_imm
  snez  R10, R7           #@convI2Bool
```

After:
```
  lhu  R28, [R11, #12]    # short, #@loadUS ! Field: com/sun/org/apache/xerces/internal/dom/NodeImpl.flags
  bexti  R10, R28, 3      #
```
Note that I am not adding a matching rule for long->bool case as I see C2 compiler currently only catches and builds int->bool conversions [3]. I guess there might be no such use cases for long->bool conversion in the real-world.

Testing: Tier1-3 hotspot & jdk tested with QEMU (JTREG="VM_OPTIONS=-XX:+UnlockExperimentalVMOptions -XX:+UseZbs").

[1] https://github.com/riscv/riscv-bitmanip/blob/main/bitmanip/insns/bexti.adoc

[2] https://github.com/openjdk/jdk/blob/master/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/NodeImpl.java#L1936

[3] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/cfgnode.cpp#L1435

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297715](https://bugs.openjdk.org/browse/JDK-8297715): RISC-V: C2: Use single-bit instructions from the Zbs extension


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author)
 * [Yadong Wang](https://openjdk.org/census#yadongwang) (@yadongw - Author)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11406/head:pull/11406` \
`$ git checkout pull/11406`

Update a local copy of the PR: \
`$ git checkout pull/11406` \
`$ git pull https://git.openjdk.org/jdk pull/11406/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11406`

View PR using the GUI difftool: \
`$ git pr show -t 11406`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11406.diff">https://git.openjdk.org/jdk/pull/11406.diff</a>

</details>
