### PR TITLE
8297311: Improve exception message thrown by java.net.HostPortrange::toLowerCase(String s)

### DIFF
--- a/src/java.base/share/classes/java/net/HostPortrange.java
+++ b/src/java.base/share/classes/java/net/HostPortrange.java
@@ -186,7 +186,8 @@ class HostPortrange {
                 }
                 sb.append((char)(c - CASE_DIFF));
             } else {
-                throw new IllegalArgumentException("Invalid characters in hostname");
+                final String invalidChar = String.format("\\u%04x", (int) c);
+                throw new IllegalArgumentException("Invalid character " + invalidChar + " in hostname");
             }
         }
         return sb == null ? s : sb.toString();

--- a/src/java.base/share/classes/java/net/HostPortrange.java
+++ b/src/java.base/share/classes/java/net/HostPortrange.java
@@ -186,8 +186,8 @@ class HostPortrange {
                 }
                 sb.append((char)(c - CASE_DIFF));
             } else {
-                final String invalidChar = String.format("\\u%04x", (int) c);
-                throw new IllegalArgumentException("Invalid character " + invalidChar + " in hostname");
+                final String message = String.format("Invalid character \\u%04x in hostname", (int) c);
+                throw new IllegalArgumentException(message);
             }
         }
         return sb == null ? s : sb.toString();

--- a/test/jdk/java/net/URLPermission/InvalidCharacterTest.java
+++ b/test/jdk/java/net/URLPermission/InvalidCharacterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.net.URLPermission;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @test
+ * @bug 8297311
+ * @summary Verify that the exception thrown by URLPermission class, for invalid host name,
+ * contains expected exception message
+ * @run testng InvalidCharacterTest
+ */
+public class InvalidCharacterTest {
+
+    /**
+     * Creates an instance of URLPermission with a string containing invalid character
+     * and verifies that the construction fails with IllegalArgumentException
+     */
+    @Test
+    public void testIllegalArgException() throws Exception {
+        final char invalidChar = '%';
+        // we expect this string in the exception message
+        final String expectedStringInMessage = String.format("\\u%04x", (int) invalidChar);
+        final String url = "http://foo" + invalidChar + "bar.com:12345";
+        final IllegalArgumentException iae = Assert.expectThrows(IllegalArgumentException.class,
+                () -> new URLPermission(url));
+        // additionally check the error message contains the invalid char
+        final String exMessage = iae.getMessage();
+        System.out.println("Got exception message: " + exMessage);
+        Assert.assertNotNull(exMessage, "Exception message is null");
+        Assert.assertTrue(exMessage.contains(expectedStringInMessage),
+                expectedStringInMessage + " missing from exception message: " + exMessage);
+    }
+}


### PR DESCRIPTION
Can I please get a review of this change which proposes to enhance an exception message in `java.net.HostPortrange::toLowerCase`, as requested in https://bugs.openjdk.org/browse/JDK-8297311?

The commit here includes (only) the character, which was found to be invalid, in the exception message. The character will be printed out in `\uXXXX` format to take into account any unprintable characters.

A new test has been introduced to verify that the introduction of this change doesn't introduce any regression and does indeed include the expected exception message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297311](https://bugs.openjdk.org/browse/JDK-8297311): Improve exception message thrown by java.net.HostPortrange::toLowerCase(String s)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11407/head:pull/11407` \
`$ git checkout pull/11407`

Update a local copy of the PR: \
`$ git checkout pull/11407` \
`$ git pull https://git.openjdk.org/jdk pull/11407/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11407`

View PR using the GUI difftool: \
`$ git pr show -t 11407`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11407.diff">https://git.openjdk.org/jdk/pull/11407.diff</a>

</details>
