### PR TITLE
8297740: runtime/ClassUnload/UnloadTest.java failed with "Test failed: should still be live"

### DIFF
--- a/test/hotspot/jtreg/runtime/ClassUnload/UnloadTest.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/UnloadTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test UnloadTest
- * @bug 8210559
+ * @bug 8210559 8297740
  * @requires vm.opt.final.ClassUnloading
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
@@ -48,8 +48,8 @@ import java.lang.reflect.Array;
  *    and verifies the class is unloaded.
  */
 public class UnloadTest {
-    // JDK-8297740: using a global static field to keep the object live in -Xcomp mode.
-    private static Object global_o;
+    // Using a global static field to keep the object live in -Xcomp mode.
+    private static Object o;
 
     public static void main(String... args) throws Exception {
        test_unload_instance_klass();
@@ -63,8 +63,7 @@ public class UnloadTest {
         ClassUnloadCommon.failIf(wb.isClassAlive(className), "is not expected to be alive yet");
 
         ClassLoader cl = ClassUnloadCommon.newClassLoader();
-        Object o = cl.loadClass(className).newInstance();
-        global_o = o;
+        o = cl.loadClass(className).newInstance();
 
         ClassUnloadCommon.failIf(!wb.isClassAlive(className), "should be live here");
 
@@ -77,7 +76,7 @@ public class UnloadTest {
 
         ClassUnloadCommon.failIf(!wb.isClassAlive(className), "should still be live");
 
-        global_o = o = null;
+        o = null;
         ClassUnloadCommon.triggerUnloading();
 
 
@@ -92,8 +91,7 @@ public class UnloadTest {
         final WhiteBox wb = WhiteBox.getWhiteBox();
 
         ClassLoader cl = ClassUnloadCommon.newClassLoader();
-        Object o = Array.newInstance(cl.loadClass("test.Empty"), 1);
-        global_o = o;
+        o = Array.newInstance(cl.loadClass("test.Empty"), 1);
         final String className = o.getClass().getName();
 
         ClassUnloadCommon.failIf(!wb.isClassAlive(className), "should be live here");
@@ -106,7 +104,7 @@ public class UnloadTest {
         ClassUnloadCommon.triggerUnloading();
         ClassUnloadCommon.failIf(!wb.isClassAlive(className), "should still be live");
 
-        global_o = o = null;
+        o = null;
         ClassUnloadCommon.triggerUnloading();
 
         ClassUnloadCommon.failIf(wb.isClassAlive(className), "should have been unloaded");

--- a/test/hotspot/jtreg/runtime/ClassUnload/UnloadTest.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/UnloadTest.java
@@ -48,6 +48,8 @@ import java.lang.reflect.Array;
  *    and verifies the class is unloaded.
  */
 public class UnloadTest {
+    // JDK-8297740: using a global static field to keep the object live in -Xcomp mode.
+    private static Object global_o;
 
     public static void main(String... args) throws Exception {
        test_unload_instance_klass();
@@ -62,6 +64,7 @@ public class UnloadTest {
 
         ClassLoader cl = ClassUnloadCommon.newClassLoader();
         Object o = cl.loadClass(className).newInstance();
+        global_o = o;
 
         ClassUnloadCommon.failIf(!wb.isClassAlive(className), "should be live here");
 
@@ -74,7 +77,7 @@ public class UnloadTest {
 
         ClassUnloadCommon.failIf(!wb.isClassAlive(className), "should still be live");
 
-        o = null;
+        global_o = o = null;
         ClassUnloadCommon.triggerUnloading();
 
 
@@ -90,6 +93,7 @@ public class UnloadTest {
 
         ClassLoader cl = ClassUnloadCommon.newClassLoader();
         Object o = Array.newInstance(cl.loadClass("test.Empty"), 1);
+        global_o = o;
         final String className = o.getClass().getName();
 
         ClassUnloadCommon.failIf(!wb.isClassAlive(className), "should be live here");
@@ -102,7 +106,7 @@ public class UnloadTest {
         ClassUnloadCommon.triggerUnloading();
         ClassUnloadCommon.failIf(!wb.isClassAlive(className), "should still be live");
 
-        o = null;
+        global_o = o = null;
         ClassUnloadCommon.triggerUnloading();
 
         ClassUnloadCommon.failIf(wb.isClassAlive(className), "should have been unloaded");


### PR DESCRIPTION
Fix the failure in `-Xcomp` mode. Thanks to David's analysis that a local variable is not enough to keep the object live; using a global variable now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297740](https://bugs.openjdk.org/browse/JDK-8297740): runtime/ClassUnload/UnloadTest.java failed with "Test failed: should still be live"


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to [fd1e1618](https://git.openjdk.org/jdk/pull/11409/files/fd1e161816b5f597d70817ac369d4d37f7158384)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11409/head:pull/11409` \
`$ git checkout pull/11409`

Update a local copy of the PR: \
`$ git checkout pull/11409` \
`$ git pull https://git.openjdk.org/jdk pull/11409/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11409`

View PR using the GUI difftool: \
`$ git pr show -t 11409`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11409.diff">https://git.openjdk.org/jdk/pull/11409.diff</a>

</details>
