### PR TITLE
8296924: C2: assert(is_valid_AArch64_address(dest.target())) failed: bad address

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3377,7 +3377,8 @@ encode %{
         __ mov_metadata(dst_reg, (Metadata*)con);
       } else {
         assert(rtype == relocInfo::none, "unexpected reloc type");
-        if (con < (address)(uintptr_t)os::vm_page_size()) {
+        if (!__ is_valid_AArch64_address(con) ||
+            con < (address)(uintptr_t)os::vm_page_size()) {
           __ mov(dst_reg, con);
         } else {
           uint64_t offset;

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3377,7 +3377,7 @@ encode %{
         __ mov_metadata(dst_reg, (Metadata*)con);
       } else {
         assert(rtype == relocInfo::none, "unexpected reloc type");
-        if (!__ is_valid_AArch64_address(con) ||
+        if (! __ is_valid_AArch64_address(con) ||
             con < (address)(uintptr_t)os::vm_page_size()) {
           __ mov(dst_reg, con);
         } else {

--- a/test/hotspot/jtreg/compiler/unsafe/TestBadBaseAddress.java
+++ b/test/hotspot/jtreg/compiler/unsafe/TestBadBaseAddress.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8296924
+ * @summary Tests compilation of an unreachable unsafe access with a bad base address.
+ * @modules java.base/jdk.internal.misc:+open
+ * @run main/othervm -XX:CompileCommand=compileonly,TestBadBaseAddress::test -XX:-TieredCompilation -Xcomp TestBadBaseAddress
+ */
+
+import java.lang.reflect.*;
+import sun.misc.*;
+
+public class TestBadBaseAddress {
+    private static Unsafe unsafe;
+
+    static {
+        try {
+            Field field = Unsafe.class.getDeclaredField("theUnsafe");
+            field.setAccessible(true);
+            unsafe = (Unsafe)field.get(null);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void test(boolean b) {
+        if (b) {
+            unsafe.putLong(-1, 42);
+        }
+    }
+
+    public static void main(String[] args) {
+        test(false);
+    }
+}


### PR DESCRIPTION
With (unreachable) unsafe accesses, it can happen that the base address is invalid. On AArch64, C2 will emit a `loadConP` for loading the constant address that is implemented by [aarch64_enc_mov_p](https://github.com/openjdk/jdk/blob/48017b1d9c3a7867984f54d61f17c7f034d213f5/src/hotspot/cpu/aarch64/aarch64.ad#L3366) calling [MacroAssembler::adrp](https://github.com/openjdk/jdk/blob/48017b1d9c3a7867984f54d61f17c7f034d213f5/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp#L4576). The `adrp` implementation then asserts in [is_valid_AArch64_address](https://github.com/openjdk/jdk/blob/48017b1d9c3a7867984f54d61f17c7f034d213f5/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp#L1321), assuming that we can only ever load constant pointers that are within the 48-bit AArch64 address space.

The fix, proposed by @theRealAph, is to emit a full-blown `mov` in case of a bad address.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296924](https://bugs.openjdk.org/browse/JDK-8296924): C2: assert(is_valid_AArch64_address(dest.target())) failed: bad address


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**) ⚠️ Review applies to [fa945fa3](https://git.openjdk.org/jdk/pull/11412/files/fa945fa333b91aa35bc05bad8cc5c5dbde9c3292)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Contributors
 * Andrew Haley `<aph@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11412/head:pull/11412` \
`$ git checkout pull/11412`

Update a local copy of the PR: \
`$ git checkout pull/11412` \
`$ git pull https://git.openjdk.org/jdk pull/11412/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11412`

View PR using the GUI difftool: \
`$ git pr show -t 11412`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11412.diff">https://git.openjdk.org/jdk/pull/11412.diff</a>

</details>
