### PR TITLE
8297763: Fix missing stub code expansion before align() in shared trampolines

### DIFF
--- a/src/hotspot/cpu/aarch64/codeBuffer_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/codeBuffer_aarch64.cpp
@@ -52,6 +52,11 @@ static bool emit_shared_trampolines(CodeBuffer* cb, CodeBuffer::SharedTrampoline
   bool p_succeeded = true;
   auto emit = [&](address dest, const CodeBuffer::Offsets &offsets) {
     masm.set_code_section(cb->stubs());
+    if (cb->stubs()->maybe_expand_to_ensure_remaining(NativeInstruction::instruction_size) && cb->blob() == NULL) {
+      ciEnv::current()->record_failure("CodeCache is full");
+      p_succeeded = false;
+      return p_succeeded;
+    }
     masm.align(wordSize);
 
     LinkedListIterator<int> it(offsets.head());

--- a/src/hotspot/cpu/aarch64/codeBuffer_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/codeBuffer_aarch64.cpp
@@ -52,12 +52,14 @@ static bool emit_shared_trampolines(CodeBuffer* cb, CodeBuffer::SharedTrampoline
   bool p_succeeded = true;
   auto emit = [&](address dest, const CodeBuffer::Offsets &offsets) {
     masm.set_code_section(cb->stubs());
-    if (cb->stubs()->maybe_expand_to_ensure_remaining(NativeInstruction::instruction_size) && cb->blob() == NULL) {
-      ciEnv::current()->record_failure("CodeCache is full");
-      p_succeeded = false;
-      return p_succeeded;
+    if (!is_aligned(masm.offset(), wordSize)) {
+      if (cb->stubs()->maybe_expand_to_ensure_remaining(NativeInstruction::instruction_size) && cb->blob() == NULL) {
+        ciEnv::current()->record_failure("CodeCache is full");
+        p_succeeded = false;
+        return p_succeeded;
+      }
+      masm.align(wordSize);
     }
-    masm.align(wordSize);
 
     LinkedListIterator<int> it(offsets.head());
     int offset = *it.next();

--- a/src/hotspot/cpu/riscv/codeBuffer_riscv.cpp
+++ b/src/hotspot/cpu/riscv/codeBuffer_riscv.cpp
@@ -53,6 +53,11 @@ static bool emit_shared_trampolines(CodeBuffer* cb, CodeBuffer::SharedTrampoline
   bool p_succeeded = true;
   auto emit = [&](address dest, const CodeBuffer::Offsets &offsets) {
     masm.set_code_section(cb->stubs());
+    if (cb->stubs()->maybe_expand_to_ensure_remaining(NativeInstruction::instruction_size) && cb->blob() == NULL) {
+      ciEnv::current()->record_failure("CodeCache is full");
+      p_succeeded = false;
+      return p_succeeded;
+    }
     masm.align(wordSize, NativeCallTrampolineStub::data_offset);
 
     LinkedListIterator<int> it(offsets.head());

--- a/src/hotspot/cpu/riscv/codeBuffer_riscv.cpp
+++ b/src/hotspot/cpu/riscv/codeBuffer_riscv.cpp
@@ -53,12 +53,14 @@ static bool emit_shared_trampolines(CodeBuffer* cb, CodeBuffer::SharedTrampoline
   bool p_succeeded = true;
   auto emit = [&](address dest, const CodeBuffer::Offsets &offsets) {
     masm.set_code_section(cb->stubs());
-    if (cb->stubs()->maybe_expand_to_ensure_remaining(NativeInstruction::instruction_size) && cb->blob() == NULL) {
-      ciEnv::current()->record_failure("CodeCache is full");
-      p_succeeded = false;
-      return p_succeeded;
+    if (!is_aligned(masm.offset() + NativeCallTrampolineStub::data_offset, wordSize)) {
+      if (cb->stubs()->maybe_expand_to_ensure_remaining(NativeInstruction::instruction_size) && cb->blob() == NULL) {
+        ciEnv::current()->record_failure("CodeCache is full");
+        p_succeeded = false;
+        return p_succeeded;
+      }
+      masm.align(wordSize, NativeCallTrampolineStub::data_offset);
     }
-    masm.align(wordSize, NativeCallTrampolineStub::data_offset);
 
     LinkedListIterator<int> it(offsets.head());
     int offset = *it.next();

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -3128,6 +3128,9 @@ address MacroAssembler::emit_trampoline_stub(int insts_call_instruction_offset,
     return NULL;  // CodeBuffer::expand failed
   }
 
+  // We are always 4-byte aligned here.
+  assert_alignment(pc());
+
   // Create a trampoline stub relocation which relates this trampoline stub
   // with the call instruction at insts_call_instruction_offset in the
   // instructions code-section.


### PR DESCRIPTION
This patch fixes missing stub code expansion logic before `align()` for AArch64 and RISC-V.

The `align()` at most creates 4-byte padding, so a `NativeInstruction::instruction_size` is enough.

I am considering pre-calculating the total trampoline sizes and allocating them in batches, but maybe after this one, for this is a quick fix to unblock https://github.com/openjdk/jdk/pull/11188. Please see that thread.

The `assert_alignment(pc());` added in the RISC-V part shows that RVC doesn't change the trampoline stub / static stub logic, so there is no need to adjust the trampoline size for it. [1]

Tested AArch64 hotspot tier1\~3, and 4 is still running; tested RISC-V hotspot tier1\~2, and 3\~4 are still running.

Thanks,
Xiaolin

[1] https://github.com/openjdk/jdk/blob/2deb318c9f047ec5a4b160d66a4b52f93688ec42/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp#L3125-L3126

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297763](https://bugs.openjdk.org/browse/JDK-8297763): Fix missing stub code expansion before align() in shared trampolines


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11414/head:pull/11414` \
`$ git checkout pull/11414`

Update a local copy of the PR: \
`$ git checkout pull/11414` \
`$ git pull https://git.openjdk.org/jdk pull/11414/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11414`

View PR using the GUI difftool: \
`$ git pr show -t 11414`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11414.diff">https://git.openjdk.org/jdk/pull/11414.diff</a>

</details>
