### PR TITLE
8297784: Optimize @Stable field for Method.isCallerSensitive

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -609,6 +609,7 @@ public final class Method extends Executable {
     //  1 = initialized, CS
     // -1 = initialized, not CS
     @Stable private byte callerSensitive;
+
     private boolean isCallerSensitive() {
         byte cs = callerSensitive;
         if (cs == 0) {

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -605,13 +605,16 @@ public final class Method extends Executable {
         return callerSensitive ? ma.invoke(obj, args, caller) : ma.invoke(obj, args);
     }
 
-    @Stable private Boolean callerSensitive;       // lazily initialize
+    //  0 = not initialized (@Stable contract)
+    //  1 = initialized, CS
+    // -1 = initialized, not CS
+    @Stable private byte callerSensitive;
     private boolean isCallerSensitive() {
-        Boolean cs = callerSensitive;
-        if (cs == null) {
-            callerSensitive = cs = Reflection.isCallerSensitive(this);
+        byte cs = callerSensitive;
+        if (cs == 0) {
+            callerSensitive = cs = (byte)(Reflection.isCallerSensitive(this) ? 1 : -1);
         }
-        return cs;
+        return (cs > 0);
     }
 
     /**


### PR DESCRIPTION
[JDK-8271820](https://bugs.openjdk.org/browse/JDK-8271820) introduced the `@Stable private Boolean callerSensitive;` cache in `Method`. That field is essentially a tri-state `Boolean` that relies on its `null` value to serve as "not initialized" value for `@Stable`.

This works well when the holder `Method` instance is constant: JIT compilers fold `@Stable` well. But if such folding fails, we always dereference the full-blown reference to "boxed" `Boolean` from the field on every access. We can instead do a more lean tri-state primitive field to improve that non-optimized case without sacrificing optimized case.

I chose `byte` and `-1`, `0`, `1` to let the fastpath encode well on most (all?) architectures.

On adhoc benchmark like:

```
@State(Scope.Thread)
public class WrapperConstness {
    static final Method CONST;
    static Method NON_CONST;

    static {
        try {
            CONST = WrapperConstness.class.getDeclaredMethod("target");
            NON_CONST = CONST;
        } catch (NoSuchMethodException e) {
            throw new RuntimeException(e);
        }
    }

    public void target() {}

    @Benchmark
    public void nonConstant() throws Exception {
        NON_CONST.invoke(this);
    }

    @Benchmark
    public void constant() throws Exception {
        CONST.invoke(this);
    }
}
```

We have a minor improvement for non-const case, confirmed due to better `isCallerSensitive` access:

```
Benchmark                     Mode  Cnt  Score   Error  Units

# Baseline
WrapperConstness.constant     avgt   25  0.410 ± 0.010  ns/op
WrapperConstness.nonConstant  avgt   25  7.283 ± 0.025  ns/op

# Patched
WrapperConstness.constant     avgt    5  0.407 ± 0.008  ns/op
WrapperConstness.nonConstant  avgt    5  7.054 ± 0.027  ns/op  ; -3%
```

Additional testing:
 - [x] Ad-hoc benchmarks
 - [x] Linux x86_64 fastdebug `java/lang/reflect`
 - [x] Linux x86_64 fastdebug `tier1`, `tier2`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297784](https://bugs.openjdk.org/browse/JDK-8297784): Optimize @Stable field for Method.isCallerSensitive


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to [51ccc4b9](https://git.openjdk.org/jdk/pull/11422/files/51ccc4b9f9daf7f5cdb42415c38255f2ad467fc1)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**) ⚠️ Review applies to [51ccc4b9](https://git.openjdk.org/jdk/pull/11422/files/51ccc4b9f9daf7f5cdb42415c38255f2ad467fc1)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11422/head:pull/11422` \
`$ git checkout pull/11422`

Update a local copy of the PR: \
`$ git checkout pull/11422` \
`$ git pull https://git.openjdk.org/jdk pull/11422/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11422`

View PR using the GUI difftool: \
`$ git pr show -t 11422`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11422.diff">https://git.openjdk.org/jdk/pull/11422.diff</a>

</details>
