### PR TITLE
8271519: java/awt/event/SequencedEvent/MultipleContextsFunctionalTest.java failed with "Total [200] - Expected [400]"

### DIFF
--- a/test/jdk/java/awt/event/SequencedEvent/MultipleContextsFunctionalTest.java
+++ b/test/jdk/java/awt/event/SequencedEvent/MultipleContextsFunctionalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,8 +35,8 @@ import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.swing.JButton;
 import javax.swing.JFrame;
@@ -55,7 +55,7 @@ public final class MultipleContextsFunctionalTest {
     private static final int CHECK_LAPSE = 100;
     private static final int MAX_COUNT = MAX_TIME / INTERVAL;
     private static final int EXPECTED = MAX_COUNT * NUM_WINDOW;
-    private static final List<TestWindow> WINDOWS = new ArrayList<TestWindow>();
+    private static final List<TestWindow> WINDOWS = new CopyOnWriteArrayList<>();
 
     public static void main(String[] args) {
         for (int i = 0; i < NUM_WINDOW; i++) {
@@ -126,7 +126,7 @@ public final class MultipleContextsFunctionalTest {
     private static final class TestWindow extends JFrame implements ActionListener {
 
         private final JButton btn;
-        private int counter = 0;
+        private volatile int counter = 0;
         private final Timer t;
 
         TestWindow(final int num) {


### PR DESCRIPTION
This test was trying to add windows to `ArrayList` instance from two different threads without any synchronization. 

So the reported test failure happens when the `WINDOWS` list contains only one windows instead of expected two.

Another possible failure is:
```
Exception in thread "AWT-EventQueue-1" java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 0
        at java.base/java.util.ArrayList.add(ArrayList.java:455)
        at java.base/java.util.ArrayList.add(ArrayList.java:467)
        at MultipleContextsFunctionalTest$1$1.run(MultipleContextsFunctionalTest.java:107)
        at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
        at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:773)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:720)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:714)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
        at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:742)
        at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
Total [200] - Expected [400]
Test FAILED
```

The test fails in about 8 out of 100 runs in a cycle for me.

Changing `ArrayList` to `CopyOnWriteArrayList` solves the issue. Didn't fail once after modification and 300 runs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271519](https://bugs.openjdk.org/browse/JDK-8271519): java/awt/event/SequencedEvent/MultipleContextsFunctionalTest.java failed with "Total [200] - Expected [400]"


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11423/head:pull/11423` \
`$ git checkout pull/11423`

Update a local copy of the PR: \
`$ git checkout pull/11423` \
`$ git pull https://git.openjdk.org/jdk pull/11423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11423`

View PR using the GUI difftool: \
`$ git pr show -t 11423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11423.diff">https://git.openjdk.org/jdk/pull/11423.diff</a>

</details>
