### PR TITLE
JDK-8297802: display of @spec tags should mimic that of @see tags

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
@@ -161,7 +161,7 @@ public class TagletWriterImpl extends TagletWriter {
     private final Context context;
 
     // Threshold for length of @see tag label for switching from inline to block layout.
-    private static final int SEE_TAG_MAX_INLINE_LENGTH = 30;
+    private static final int TAG_LIST_ITEM_MAX_INLINE_LENGTH = 30;
 
     /**
      * Creates a taglet writer.
@@ -386,7 +386,7 @@ public class TagletWriterImpl extends TagletWriter {
         }
         // Use a different style if any link label is longer than 30 chars or contains commas.
         boolean hasLongLabels = links.stream().anyMatch(this::isLongOrHasComma);
-        var seeList = HtmlTree.UL(hasLongLabels ? HtmlStyle.seeListLong : HtmlStyle.seeList);
+        var seeList = HtmlTree.UL(hasLongLabels ? HtmlStyle.tagListLong : HtmlStyle.tagList);
         links.stream()
                 .filter(Predicate.not(Content::isEmpty))
                 .forEach(item -> seeList.add(HtmlTree.LI(item)));
@@ -401,7 +401,7 @@ public class TagletWriterImpl extends TagletWriter {
                 .replaceAll("<.*?>", "")              // ignore HTML
                 .replaceAll("&#?[A-Za-z0-9]+;", " ")  // entities count as a single character
                 .replaceAll("\\R", "\n");             // normalize newlines
-        return s.length() > SEE_TAG_MAX_INLINE_LENGTH || s.contains(",");
+        return s.length() > TAG_LIST_ITEM_MAX_INLINE_LENGTH || s.contains(",");
     }
 
     String textOf(List<? extends DocTree> trees) {
@@ -754,7 +754,7 @@ public class TagletWriterImpl extends TagletWriter {
 
         // Use a different style if any link label is longer than 30 chars or contains commas.
         boolean hasLongLabels = links.stream().anyMatch(this::isLongOrHasComma);
-        var specList = HtmlTree.UL(hasLongLabels ? HtmlStyle.specListLong : HtmlStyle.specList);
+        var specList = HtmlTree.UL(hasLongLabels ? HtmlStyle.tagListLong : HtmlStyle.tagList);
         links.stream()
                 .filter(Predicate.not(Content::isEmpty))
                 .forEach(item -> specList.add(HtmlTree.LI(item)));

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlStyle.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlStyle.java
@@ -383,26 +383,15 @@ public enum HtmlStyle {
     previewLabel,
 
     /**
-     * The class for the list containing the {@code @see} tags of an element.
+     * The class for a list containing the tags of an element.
      */
-    seeList,
+    tagList,
 
     /**
-     * The class for the list containing the {@code @see} tags of an element
+     * The class for a list containing the tags of an element
      * when some tags have longer labels or contain commas.
      */
-    seeListLong,
-
-    /**
-     * The class for the list containing the {@code @spec} tags of an element.
-     */
-    specList,
-
-    /**
-     * The class for the list containing the {@code @spec} tags of an element
-     * when some tags have longer labels or contain commas.
-     */
-    specListLong,
+    tagListLong,
 
     //</editor-fold>
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlStyle.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlStyle.java
@@ -389,9 +389,20 @@ public enum HtmlStyle {
 
     /**
      * The class for the list containing the {@code @see} tags of an element
-     * when some of the tags have longer labels.
+     * when some tags have longer labels or contain commas.
      */
     seeListLong,
+
+    /**
+     * The class for the list containing the {@code @spec} tags of an element.
+     */
+    specList,
+
+    /**
+     * The class for the list containing the {@code @spec} tags of an element
+     * when some tags have longer labels or contain commas.
+     */
+    specListLong,
 
     //</editor-fold>
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
@@ -386,20 +386,16 @@ ul.ref-list > li {
     margin-top:0;
     margin-bottom:1px;
 }
-ul.see-list, ul.see-list-long,
-ul.spec-list, ul.spec-list-long {
+ul.tag-list, ul.tag-list-long {
     padding-left: 0;
     list-style: none;
 }
-ul.see-list li,
-ul.spec-list li {
+ul.tag-list li {
     display: inline;
 }
-ul.see-list li:not(:last-child):after,
-ul.see-list-long li:not(:last-child):after,
-ul.spec-list li:not(:last-child):after,
-ul.spec-list-long li:not(:last-child):after
- {
+ul.tag-list li:not(:last-child):after,
+ul.tag-list-long li:not(:last-child):after
+{
     content: ", ";
     white-space: pre-wrap;
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
@@ -386,15 +386,20 @@ ul.ref-list > li {
     margin-top:0;
     margin-bottom:1px;
 }
-ul.see-list, ul.see-list-long {
+ul.see-list, ul.see-list-long,
+ul.spec-list, ul.spec-list-long {
     padding-left: 0;
     list-style: none;
 }
-ul.see-list li {
+ul.see-list li,
+ul.spec-list li {
     display: inline;
 }
 ul.see-list li:not(:last-child):after,
-ul.see-list-long li:not(:last-child):after {
+ul.see-list-long li:not(:last-child):after,
+ul.spec-list li:not(:last-child):after,
+ul.spec-list-long li:not(:last-child):after
+ {
     content: ", ";
     white-space: pre-wrap;
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SpecTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SpecTaglet.java
@@ -63,15 +63,14 @@ public class SpecTaglet extends BaseTaglet implements InheritableTaglet {
             Optional<Documentation> result = docFinder.search((ExecutableElement) holder,
                     m -> Result.fromOptional(extract(utils, m))).toOptional();
             if (result.isPresent()) {
-                ExecutableElement m = result.get().method();
-                tags = utils.getSpecTrees(m);
-                e = m;
+                e = result.get().method();
+                tags = result.get().specTrees();
             }
         }
         return writer.specTagOutput(e, tags);
     }
 
-    private record Documentation(List<? extends SpecTree> seeTrees, ExecutableElement method) { }
+    private record Documentation(List<? extends SpecTree> specTrees, ExecutableElement method) { }
 
     private static Optional<Documentation> extract(Utils utils, ExecutableElement method) {
         List<? extends SpecTree> tags = utils.getSpecTrees(method);

--- a/test/langtools/jdk/javadoc/doclet/testConstructors/TestConstructors.java
+++ b/test/langtools/jdk/javadoc/doclet/testConstructors/TestConstructors.java
@@ -51,7 +51,7 @@ public class TestConstructors extends JavadocTester {
                 """
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="Outer.Inner.html#%3Cinit%3E()"><code>Inner()</code></a></li>
                     <li><a href="Outer.Inner.html#%3Cinit%3E(int)"><code>Inner(int)</code></a></li>
                     <li><a href="Outer.Inner.NestedInner.html#%3Cinit%3E()"><code>NestedInner()</code></a></li>

--- a/test/langtools/jdk/javadoc/doclet/testGenericTypeLink/TestGenericTypeLink.java
+++ b/test/langtools/jdk/javadoc/doclet/testGenericTypeLink/TestGenericTypeLink.java
@@ -70,7 +70,7 @@ public class TestGenericTypeLink extends JavadocTester {
                     <dl class="notes">
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list-long">
+                    <ul class="tag-list-long">
                     <li><code><a href="http://example.com/docs/api/java.base/java/util/Map.html" title="\
                     class or interface in java.util" class="external-link">Map</a>&lt;<a href="http://ex\
                     ample.com/docs/api/java.base/java/lang/String.html" title="class or interface in jav\
@@ -106,7 +106,7 @@ public class TestGenericTypeLink extends JavadocTester {
                     <dl class="notes">
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list-long">
+                    <ul class="tag-list-long">
                     <li><code><a href="A.html" title="class in pkg1">A</a>&lt;<a href="http://example.c\
                     om/docs/api/java.base/java/lang/String.html" title="class or interface in java.lang\
                     " class="external-link">String</a>,<wbr><a href="A.SomeException.html" title="class\
@@ -123,7 +123,7 @@ public class TestGenericTypeLink extends JavadocTester {
                     <dl class="notes">
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list-long">
+                    <ul class="tag-list-long">
                     <li><code><a href="A.html" title="class in pkg1">A</a>&lt;<a href="http://exampl\
                     e.com/docs/api/java.base/java/lang/String.html" title="class or interface in jav\
                     a.lang" class="external-link">String</a>,<wbr><a href="http://example.com/docs/a\
@@ -189,7 +189,7 @@ public class TestGenericTypeLink extends JavadocTester {
                     <dl class="notes">
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list-long">
+                    <ul class="tag-list-long">
                     <li>
                     <details class="invalid-tag">
                     <summary>invalid @see</summary>

--- a/test/langtools/jdk/javadoc/doclet/testHref/TestHref.java
+++ b/test/langtools/jdk/javadoc/doclet/testHref/TestHref.java
@@ -69,7 +69,7 @@ public class TestHref extends JavadocTester {
                 """
                     See Also:</dt>
                     <dd>
-                    <ul class="see-list-long">
+                    <ul class="tag-list-long">
                     <li><a href="C1.html#method(int,int,java.util.ArrayList)">"""
         );
 

--- a/test/langtools/jdk/javadoc/doclet/testHtmlDefinitionListTag/TestHtmlDefinitionListTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlDefinitionListTag/TestHtmlDefinitionListTag.java
@@ -160,7 +160,7 @@ public class TestHtmlDefinitionListTag extends JavadocTester {
                     <dd>JDK1.0</dd>
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="C2.html" title="class in pkg1"><code>C2</code></a></li>
                     <li><a href="../serialized-form.html#pkg1.C1">Serialized Form</a></li>
                     </ul>
@@ -172,7 +172,7 @@ public class TestHtmlDefinitionListTag extends JavadocTester {
                     <dd>1.4</dd>
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a></li>
                     </ul>
                     </dd>
@@ -197,7 +197,7 @@ public class TestHtmlDefinitionListTag extends JavadocTester {
                     <dd>1.4</dd>
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="#readObject()"><code>readObject()</code></a></li>
                     </ul>
                     </dd>
@@ -208,7 +208,7 @@ public class TestHtmlDefinitionListTag extends JavadocTester {
                     <dd><code>java.io.IOException</code></dd>
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a></li>
                     </ul>
                     </dd>
@@ -230,7 +230,7 @@ public class TestHtmlDefinitionListTag extends JavadocTester {
                     <dd><code>java.io.IOException</code></dd>
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="pkg1/C1.html#setUndecorated(boolean)"><code>C1.setUndecorated(boolean)</code></a></li>
                     </ul>
                     </dd>
@@ -246,7 +246,7 @@ public class TestHtmlDefinitionListTag extends JavadocTester {
                     <dd>1.4</dd>
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="pkg1/C1.html#setUndecorated(boolean)"><code>C1.setUndecorated(boolean)</code></a></li>
                     </ul>
                     </dd>
@@ -288,7 +288,7 @@ public class TestHtmlDefinitionListTag extends JavadocTester {
                     <dd>JDK1.0</dd>
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="C2.html" title="class in pkg1"><code>C2</code></a></li>
                     <li><a href="../serialized-form.html#pkg1.C1">Serialized Form</a></li>
                     </ul>
@@ -316,7 +316,7 @@ public class TestHtmlDefinitionListTag extends JavadocTester {
                     <dd>1.4</dd>
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="#readObject()"><code>readObject()</code></a></li>
                     </ul>
                     </dd>
@@ -327,7 +327,7 @@ public class TestHtmlDefinitionListTag extends JavadocTester {
                     <dd><code>java.io.IOException</code></dd>
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a></li>
                     </ul>
                     </dd>
@@ -340,7 +340,7 @@ public class TestHtmlDefinitionListTag extends JavadocTester {
                     <dd><code>java.io.IOException</code></dd>
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="pkg1/C1.html#setUndecorated(boolean)"><code>C1.setUndecorated(boolean)</code></a></li>
                     </ul>
                     </dd>
@@ -356,7 +356,7 @@ public class TestHtmlDefinitionListTag extends JavadocTester {
                     <dd>1.4</dd>
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="pkg1/C1.html#setUndecorated(boolean)"><code>C1.setUndecorated(boolean)</code></a></li>
                     </ul>
                     </dd>

--- a/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFX.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFX.java
@@ -63,7 +63,7 @@ public class TestJavaFX extends JavadocTester {
                 """
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="#getRate()"><code>getRate()</code></a></li>
                     <li><a href="#setRate(double)"><code>setRate(double)</code></a></li>
                     </ul>
@@ -268,7 +268,7 @@ public class TestJavaFX extends JavadocTester {
                         <dl class="notes">
                         <dt>See Also:</dt>
                         <dd>
-                        <ul class="see-list">
+                        <ul class="tag-list">
                         <li><a href="#betaProperty()"><code>betaProperty()</code></a></li>
                         </ul>
                         </dd>
@@ -284,7 +284,7 @@ public class TestJavaFX extends JavadocTester {
                         <dl class="notes">
                         <dt>See Also:</dt>
                         <dd>
-                        <ul class="see-list">
+                        <ul class="tag-list">
                         <li><a href="#gammaProperty()"><code>gammaProperty()</code></a></li>
                         </ul>
                         </dd>
@@ -300,7 +300,7 @@ public class TestJavaFX extends JavadocTester {
                         <dl class="notes">
                         <dt>See Also:</dt>
                         <dd>
-                        <ul class="see-list">
+                        <ul class="tag-list">
                         <li><a href="#deltaProperty()"><code>deltaProperty()</code></a></li>
                         </ul>
                         </dd>

--- a/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFXCombo.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFXCombo.java
@@ -329,7 +329,7 @@ public class TestJavaFXCombo extends JavadocTester {
         return sb.isEmpty() ? "" : """
                 <dt>See Also:</dt>
                 <dd>
-                <ul class="see-list">
+                <ul class="tag-list">
                 """ + sb + """
                 </ul>
                 </dd>""";

--- a/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFXMissingPropComments.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFXMissingPropComments.java
@@ -100,7 +100,7 @@ public class TestJavaFXMissingPropComments extends JavadocTester {
                     <dd>the value of the <code>value</code> property</dd>
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="#valueProperty()"><code>valueProperty()</code></a></li>
                     </ul>
                     </dd>
@@ -164,7 +164,7 @@ public class TestJavaFXMissingPropComments extends JavadocTester {
                     <dd>the value of the <code>value</code> property</dd>
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="#valueProperty()"><code>valueProperty()</code></a></li>
                     </ul>
                     </dd>

--- a/test/langtools/jdk/javadoc/doclet/testLinkOption/TestLinkOption.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkOption/TestLinkOption.java
@@ -102,7 +102,7 @@ public class TestLinkOption extends JavadocTester {
                 "<code>createTempFile(prefix,&nbsp;suffix,&nbsp;null)</code>",
                 """
                     <dd>
-                    <ul class="see-list-long">
+                    <ul class="tag-list-long">
                     <li><a href="http://www.ietf.org/rfc/rfc2279.txt"><i>RFC&nbsp;2279: UTF-8, a
                      transformation format of ISO 10646</i></a></li>
                     <li><a href="http://www.ietf.org/rfc/rfc2373.txt"><i>RFC&nbsp;2373: IPv6 Addressing

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
@@ -629,7 +629,7 @@ public class TestModules extends JavadocTester {
                 """
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li>"Test see tag"</li>
                     <li><a href="testpkgmdltags/TestClassInModuleTags.html" title="class in testpkgmdlta\
                     gs"><code>TestClassInModuleTags</code></a></li>

--- a/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/TestNewLanguageFeatures.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/TestNewLanguageFeatures.java
@@ -123,7 +123,7 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     <dl class="notes">
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="TypeParameters.html" title="class in pkg"><code>TypeParameters</code></a></li>
                     </ul>
                     </dd>

--- a/test/langtools/jdk/javadoc/doclet/testOverview/TestOverview.java
+++ b/test/langtools/jdk/javadoc/doclet/testOverview/TestOverview.java
@@ -76,7 +76,7 @@ public class TestOverview extends JavadocTester {
                     <dl class="notes">
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="%sp1/C.html" title="class in p1"><code>C</code></a></li>
                     </ul>
                     </dd>

--- a/test/langtools/jdk/javadoc/doclet/testProperty/TestProperty.java
+++ b/test/langtools/jdk/javadoc/doclet/testProperty/TestProperty.java
@@ -61,7 +61,7 @@ public class TestProperty extends JavadocTester {
                     <dl class="notes">
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="#getGood()"><code>getGood()</code></a></li>
                     <li><a href="#setGood(pkg.MyObj)"><code>setGood(MyObj)</code></a></li>
                     <li><a href="#goodProperty()"><code>goodProperty()</code></a></li>
@@ -78,7 +78,7 @@ public class TestProperty extends JavadocTester {
                     <dl class="notes">
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="#getBad()"><code>getBad()</code></a></li>
                     <li><a href="#setBad(pkg.MyObj%5B%5D)"><code>setBad(MyObj[])</code></a></li>
                     <li><a href="#badProperty()"><code>badProperty()</code></a></li>
@@ -117,7 +117,7 @@ public class TestProperty extends JavadocTester {
                     <dl class="notes">
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="#getList()"><code>getList()</code></a></li>
                     <li><a href="#setList(java.util.List)"><code>setList(List)</code></a></li>
                     <li><a href="#listProperty()"><code>listProperty()</code></a></li>

--- a/test/langtools/jdk/javadoc/doclet/testSeeTag/TestSeeTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSeeTag/TestSeeTag.java
@@ -58,7 +58,7 @@ public class TestSeeTag extends JavadocTester {
                 <dl class="notes">
                 <dt>See Also:</dt>
                 <dd>
-                <ul class="see-list-long">
+                <ul class="tag-list-long">
                 <li><a href="Test.InnerOne.html#foo()"><code>Test.InnerOne.foo()</code></a></li>
                 <li><a href="Test.InnerOne.html#bar(java.lang.Object)"><code>Test.InnerOne.bar(Object)</code></a></li>
                 <li><a href="http://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#see">Javadoc</a></li>
@@ -78,7 +78,7 @@ public class TestSeeTag extends JavadocTester {
                 <dl class="notes">
                 <dt>See Also:</dt>
                 <dd>
-                <ul class="see-list-long">
+                <ul class="tag-list-long">
                 <li><code>Serializable</code></li>
                 <li><a href="Test.html" title="class in pkg"><code>See tag with very long label text</code></a></li>
                 </ul>
@@ -102,7 +102,7 @@ public class TestSeeTag extends JavadocTester {
                     <dl class="notes">
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><code>Object</code></li>
                     <li>
                     <details class="invalid-tag">
@@ -142,7 +142,7 @@ public class TestSeeTag extends JavadocTester {
                     <dl class="notes">
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><span class="invalid-tag">invalid input: '&lt;'</span></li>
                     </ul>
                     </dd>
@@ -212,7 +212,7 @@ public class TestSeeTag extends JavadocTester {
         checkOrder("p/C.html",
                 "<section class=\"detail\" id=\"noComma()\">",
                 """
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="#noArgs()"><code>no args</code></a></li>
                     <li><a href="#oneArg(int)"><code>one arg</code></a></li>
                     <li><a href="#twoArgs(int,int)"><code>two args</code></a></li>
@@ -220,7 +220,7 @@ public class TestSeeTag extends JavadocTester {
 
                 "<section class=\"detail\" id=\"commaInDescription()\">",
                 """
-                    <ul class="see-list-long">
+                    <ul class="tag-list-long">
                     <li><a href="#noArgs()"><code>no args</code></a></li>
                     <li><a href="#oneArg(int)"><code>one arg</code></a></li>
                     <li><a href="#twoArgs(int,int)"><code>two args with a comma , in the description</code></a></li>
@@ -228,7 +228,7 @@ public class TestSeeTag extends JavadocTester {
 
                 "<section class=\"detail\" id=\"commaInDefaultDescription()\">",
                 """
-                    <ul class="see-list-long">
+                    <ul class="tag-list-long">
                     <li><a href="#noArgs()"><code>noArgs()</code></a></li>
                     <li><a href="#oneArg(int)"><code>oneArg(int)</code></a></li>
                     <li><a href="#twoArgs(int,int)"><code>twoArgs(int, int)</code></a></li>

--- a/test/langtools/jdk/javadoc/doclet/testSeeTag/TestSeeTagWithModule.java
+++ b/test/langtools/jdk/javadoc/doclet/testSeeTag/TestSeeTagWithModule.java
@@ -74,7 +74,7 @@ public class TestSeeTagWithModule extends JavadocTester {
                 """
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="../../../../m1/module-summary.html"><code>m1</code></a></li>
                     <li><a href="../../../../m1/module-summary.html"><code>m1</code></a></li>
                     <li><a href="../../../../m1/com/m1/lib/package-summary.html"><code>com.m1.lib</code></a></li>
@@ -109,7 +109,7 @@ public class TestSeeTagWithModule extends JavadocTester {
                 """
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="../../../../../out1/m1/module-summary.html" class="external-link"><code>m1</code></a></li>
                     <li><a href="../../../../../out1/m1/module-summary.html" class="external-link"><code>m1</code></a></li>
                     <li><a href="../../../../../out1/m1/com/m1/lib/package-summary.html" class="external-link"><code>m1/com.m1.lib</code></a></li>
@@ -142,7 +142,7 @@ public class TestSeeTagWithModule extends JavadocTester {
                 """
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="../../../com.ex1/com/ex1/package-summary.html"><code>com.ex1</code></a></li>
                     <li><a href="../../../com.ex1/module-summary.html"><code>com.ex1</code></a></li>
                     <li><a href="../../../com.ex1/com/ex1/package-summary.html"><code>com.ex1</code></a></li>
@@ -171,7 +171,7 @@ public class TestSeeTagWithModule extends JavadocTester {
                 """
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="../../../../out1/com.ex1/com/ex1/package-summary.html" class="external-link"><code>com.ex1</code></a></li>
                     <li><a href="../../../../out1/com.ex1/module-summary.html" class="external-link"><code>com.ex1</code></a></li>
                     <li><a href="../../../../out1/com.ex1/com/ex1/package-summary.html" class="external-link"><code>com.ex1/com.ex1</code></a></li>

--- a/test/langtools/jdk/javadoc/doclet/testSerializedForm/TestSerializedForm.java
+++ b/test/langtools/jdk/javadoc/doclet/testSerializedForm/TestSerializedForm.java
@@ -71,7 +71,7 @@ public class TestSerializedForm extends JavadocTester {
                     <dl class="notes">
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><code>TestSerializedForm</code></li>
                     </ul>
                     </dd>

--- a/test/langtools/jdk/javadoc/doclet/testSerializedFormDeprecationInfo/TestSerializedFormDeprecationInfo.java
+++ b/test/langtools/jdk/javadoc/doclet/testSerializedFormDeprecationInfo/TestSerializedFormDeprecationInfo.java
@@ -99,7 +99,7 @@ public class TestSerializedFormDeprecationInfo extends JavadocTester {
                     <dd><code>java.io.IOException</code> - on error</dd>
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="pkg1/C1.html#setUndecorated(boolean)"><code>C1.setUndecorated(boolean)</code></a></li>
                     </ul>
                     </dd>
@@ -115,7 +115,7 @@ public class TestSerializedFormDeprecationInfo extends JavadocTester {
                     <dd>1.4</dd>
                     <dt>See Also:</dt>
                     <dd>
-                    <ul class="see-list">
+                    <ul class="tag-list">
                     <li><a href="pkg1/C1.html#setUndecorated(boolean)"><code>C1.setUndecorated(boolean)</code></a></li>
                     </ul>
                     </dd>

--- a/test/langtools/jdk/javadoc/doclet/testSingletonLists/TestSingletonLists.java
+++ b/test/langtools/jdk/javadoc/doclet/testSingletonLists/TestSingletonLists.java
@@ -270,7 +270,7 @@ public class TestSingletonLists extends JavadocTester {
             switch (name) {
                 case "ul": case "ol": case "dl":
                     counts.push(new TreeMap<>());
-                    if ("see-list".equals(attrs.get("class"))) {
+                    if ("tag-list".equals(attrs.get("class"))) {
                         inSeeList = true;
                     }
                     break;

--- a/test/langtools/jdk/javadoc/doclet/testSpecTag/TestSpecTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSpecTag/TestSpecTag.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6251738 8226279
+ * @bug 6251738 8226279 8297802
  * @summary JDK-8226279 javadoc should support a new at-spec tag
  * @library /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -79,11 +79,15 @@ public class TestSpecTag extends JavadocTester {
 
         checkOutput("p/C.html", true,
                 """
-                    <dl class="notes">
-                    <dt>External Specifications</dt>
-                    <dd><span id="label" class="search-tag-result">label</span></dd>
-                    </dl>
-                    """);
+                        <dl class="notes">
+                        <dt>External Specifications</dt>
+                        <dd>
+                        <ul class="spec-list">
+                        <li><span id="label" class="search-tag-result">label</span></li>
+                        </ul>
+                        </dd>
+                        </dl>
+                        """);
 
         checkOutput("external-specs.html", true,
                 """
@@ -155,14 +159,18 @@ public class TestSpecTag extends JavadocTester {
 
         checkOutput("p/C.html", true,
                 """
-                    <dl class="notes">
-                    <dt>External Specifications</dt>
-                    <dd><a href="http://example.com/a+b"><span id="space:plus" class="search-tag-result">space: plus</span></a>,\s
-                    <a href="http://example.com/a%20b"><span id="space:percent" class="search-tag-result">space: percent</span></a>,\s
-                    <a href="http://example.com/a%C2%A7b"><span id="other:section;U+00A7,UTF-8c2a7" class="search-tag-result">other: section; U+00A7, UTF-8 c2 a7</span></a>,\s
-                    <a href="http://example.com/a%C2%B1b"><span id="unicode:plusorminus;U+00B1,UTF-8c2b1" class="search-tag-result">unicode: plus or minus; U+00B1, UTF-8 c2 b1</span></a></dd>
-                    </dl>
-                    """);
+                        <dl class="notes">
+                        <dt>External Specifications</dt>
+                        <dd>
+                        <ul class="spec-list-long">
+                        <li><a href="http://example.com/a+b"><span id="space:plus" class="search-tag-result">space: plus</span></a></li>
+                        <li><a href="http://example.com/a%20b"><span id="space:percent" class="search-tag-result">space: percent</span></a></li>
+                        <li><a href="http://example.com/a%C2%A7b"><span id="other:section;U+00A7,UTF-8c2a7" class="search-tag-result">other: section; U+00A7, UTF-8 c2 a7</span></a></li>
+                        <li><a href="http://example.com/a%C2%B1b"><span id="unicode:plusorminus;U+00B1,UTF-8c2b1" class="search-tag-result">unicode: plus or minus; U+00B1, UTF-8 c2 b1</span></a></li>
+                        </ul>
+                        </dd>
+                        </dl>
+                        """);
 
         checkOutput("external-specs.html", true,
                 """
@@ -223,17 +231,29 @@ public class TestSpecTag extends JavadocTester {
                 "<h1 title=\"Class C\" class=\"title\">Class C</h1>",
                 """
                     <dt>External Specifications</dt>
-                    <dd><a href="http://example.com/"><span id="example" class="search-tag-result">example</span></a></dd>
+                    <dd>
+                    <ul class="spec-list">
+                    <li><a href="http://example.com/"><span id="example" class="search-tag-result">example</span></a></li>
+                    </ul>
+                    </dd>                                                                                                     
                     """,
                 "<section class=\"field-details\" id=\"field-detail\">",
                 """
                     <dt>External Specifications</dt>
-                    <dd><a href="http://example.com/"><span id="example-1" class="search-tag-result">example</span></a></dd>
+                    <dd>
+                    <ul class="spec-list">
+                    <li><a href="http://example.com/"><span id="example-1" class="search-tag-result">example</span></a></li>
+                    </ul>
+                    </dd>
                     """,
                 "<section class=\"detail\" id=\"m()\">",
                 """
                     <dt>External Specifications</dt>
-                    <dd><a href="http://example.com/"><span id="example-2" class="search-tag-result">example</span></a></dd>
+                    <dd>
+                    <ul class="spec-list">
+                    <li><a href="http://example.com/"><span id="example-2" class="search-tag-result">example</span></a></li>
+                    </ul>
+                    </dd>
                     """);
 
         checkOutput("external-specs.html", true,
@@ -270,8 +290,12 @@ public class TestSpecTag extends JavadocTester {
         checkOutput("p/C.html", true,
                 """
                     <dt>External Specifications</dt>
-                    <dd><a href="http://example.com/1"><span id="example-1" class="search-tag-result">example-1</span></a>,\s
-                    <a href="http://example.com/2"><span id="example-2" class="search-tag-result">example-2</span></a></dd>
+                    <dd>
+                    <ul class="spec-list">
+                    <li><a href="http://example.com/1"><span id="example-1" class="search-tag-result">example-1</span></a></li>
+                    <li><a href="http://example.com/2"><span id="example-2" class="search-tag-result">example-2</span></a></li>
+                    </ul>
+                    </dd>
                     """);
 
         checkOutput("external-specs.html", true,
@@ -311,8 +335,12 @@ public class TestSpecTag extends JavadocTester {
         checkOutput("p/C.html", true,
                 """
                     <dt>External Specifications</dt>
-                    <dd><a href="http://example.com/1"><span id="example-1" class="search-tag-result">example-1</span></a>,\s
-                    <a href="http://example.net/2"><span id="example-2" class="search-tag-result">example-2</span></a></dd>
+                    <dd>
+                    <ul class="spec-list">
+                    <li><a href="http://example.com/1"><span id="example-1" class="search-tag-result">example-1</span></a></li>
+                    <li><a href="http://example.net/2"><span id="example-2" class="search-tag-result">example-2</span></a></li>
+                    </ul>
+                    </dd>
                     """);
 
         checkOutput("external-specs.html", true,
@@ -447,11 +475,14 @@ public class TestSpecTag extends JavadocTester {
 
         checkOutput("p/C.html", true,
                 """
-                    <dl class="notes">
-                    <dt>External Specifications</dt>
-                    <dd><a href="http://example.com/#LK#"><span id="#LK#reference" \
-                    class="search-tag-result">#LK# reference</span></a></dd>
-                    </dl>"""
+                        <dl class="notes">
+                        <dt>External Specifications</dt>
+                        <dd>
+                        <ul class="spec-list">
+                        <li><a href="http://example.com/#LK#"><span id="#LK#reference" class="search-tag-result">#LK# reference</span></a></li>
+                        </ul>
+                        </dd>
+                        </dl>"""
                 .replaceAll("#LK#", lk.toString().toLowerCase()));
 
         checkOutput("external-specs.html", true,

--- a/test/langtools/jdk/javadoc/doclet/testSpecTag/TestSpecTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSpecTag/TestSpecTag.java
@@ -82,7 +82,7 @@ public class TestSpecTag extends JavadocTester {
                         <dl class="notes">
                         <dt>External Specifications</dt>
                         <dd>
-                        <ul class="spec-list">
+                        <ul class="tag-list">
                         <li><span id="label" class="search-tag-result">label</span></li>
                         </ul>
                         </dd>
@@ -162,7 +162,7 @@ public class TestSpecTag extends JavadocTester {
                         <dl class="notes">
                         <dt>External Specifications</dt>
                         <dd>
-                        <ul class="spec-list-long">
+                        <ul class="tag-list-long">
                         <li><a href="http://example.com/a+b"><span id="space:plus" class="search-tag-result">space: plus</span></a></li>
                         <li><a href="http://example.com/a%20b"><span id="space:percent" class="search-tag-result">space: percent</span></a></li>
                         <li><a href="http://example.com/a%C2%A7b"><span id="other:section;U+00A7,UTF-8c2a7" class="search-tag-result">other: section; U+00A7, UTF-8 c2 a7</span></a></li>
@@ -232,7 +232,7 @@ public class TestSpecTag extends JavadocTester {
                 """
                     <dt>External Specifications</dt>
                     <dd>
-                    <ul class="spec-list">
+                    <ul class="tag-list">
                     <li><a href="http://example.com/"><span id="example" class="search-tag-result">example</span></a></li>
                     </ul>
                     </dd>                                                                                                     
@@ -241,7 +241,7 @@ public class TestSpecTag extends JavadocTester {
                 """
                     <dt>External Specifications</dt>
                     <dd>
-                    <ul class="spec-list">
+                    <ul class="tag-list">
                     <li><a href="http://example.com/"><span id="example-1" class="search-tag-result">example</span></a></li>
                     </ul>
                     </dd>
@@ -250,7 +250,7 @@ public class TestSpecTag extends JavadocTester {
                 """
                     <dt>External Specifications</dt>
                     <dd>
-                    <ul class="spec-list">
+                    <ul class="tag-list">
                     <li><a href="http://example.com/"><span id="example-2" class="search-tag-result">example</span></a></li>
                     </ul>
                     </dd>
@@ -291,7 +291,7 @@ public class TestSpecTag extends JavadocTester {
                 """
                     <dt>External Specifications</dt>
                     <dd>
-                    <ul class="spec-list">
+                    <ul class="tag-list">
                     <li><a href="http://example.com/1"><span id="example-1" class="search-tag-result">example-1</span></a></li>
                     <li><a href="http://example.com/2"><span id="example-2" class="search-tag-result">example-2</span></a></li>
                     </ul>
@@ -336,7 +336,7 @@ public class TestSpecTag extends JavadocTester {
                 """
                     <dt>External Specifications</dt>
                     <dd>
-                    <ul class="spec-list">
+                    <ul class="tag-list">
                     <li><a href="http://example.com/1"><span id="example-1" class="search-tag-result">example-1</span></a></li>
                     <li><a href="http://example.net/2"><span id="example-2" class="search-tag-result">example-2</span></a></li>
                     </ul>
@@ -478,7 +478,7 @@ public class TestSpecTag extends JavadocTester {
                         <dl class="notes">
                         <dt>External Specifications</dt>
                         <dd>
-                        <ul class="spec-list">
+                        <ul class="tag-list">
                         <li><a href="http://example.com/#LK#"><span id="#LK#reference" class="search-tag-result">#LK# reference</span></a></li>
                         </ul>
                         </dd>

--- a/test/langtools/jdk/javadoc/doclet/testSpecTag/TestSpecTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSpecTag/TestSpecTag.java
@@ -235,7 +235,7 @@ public class TestSpecTag extends JavadocTester {
                     <ul class="tag-list">
                     <li><a href="http://example.com/"><span id="example" class="search-tag-result">example</span></a></li>
                     </ul>
-                    </dd>                                                                                                     
+                    </dd>
                     """,
                 "<section class=\"field-details\" id=\"field-detail\">",
                 """

--- a/test/langtools/jdk/javadoc/doclet/testTagOrder/TestTagOrder.java
+++ b/test/langtools/jdk/javadoc/doclet/testTagOrder/TestTagOrder.java
@@ -120,7 +120,7 @@ public class TestTagOrder extends JavadocTester {
         expectMethod.put("@see", """
                 <dt>See Also:</dt>
                 <dd>
-                <ul class="see-list">
+                <ul class="tag-list">
                 <li><a href="http://example.com">example</a></li>
                 </ul>
                 </dd>
@@ -144,7 +144,7 @@ public class TestTagOrder extends JavadocTester {
         expectClass.put("@see", """
                 <dt>See Also:</dt>
                 <dd>
-                <ul class="see-list">
+                <ul class="tag-list">
                 <li><a href="http://example.com">example</a></li>
                 </ul>
                 </dd>


### PR DESCRIPTION
Please review a simple change to model the list used to display `@spec` tags on the list used to display `@see` tags.

In both cases, the list uses an inline list if the items are short and do not contain commas, or a bulleted list if they are long or contain commas.

The test is updated for the new output.

For now, new CSS styles are introduced for `spec-list` and `spec-list-long`, duplicating `see-list` and `see-list-long`. We might want to merge these into `tag-list` and `tag-list-long`, or some other suitably-named pair.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297802](https://bugs.openjdk.org/browse/JDK-8297802): display of @spec tags should mimic that of @see tags


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11426/head:pull/11426` \
`$ git checkout pull/11426`

Update a local copy of the PR: \
`$ git checkout pull/11426` \
`$ git pull https://git.openjdk.org/jdk pull/11426/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11426`

View PR using the GUI difftool: \
`$ git pr show -t 11426`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11426.diff">https://git.openjdk.org/jdk/pull/11426.diff</a>

</details>
