### PR TITLE
8297689: Fix incorrect result of Short.reverseBytes() call in loops

### DIFF
--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -169,10 +169,18 @@ int VectorNode::opcode(int sopc, BasicType bt) {
   case Op_ReverseL:
     return (is_integral_type(bt) ? Op_ReverseV : 0);
   case Op_ReverseBytesS:
-  case Op_ReverseBytesI:
-  case Op_ReverseBytesL:
   case Op_ReverseBytesUS:
-    return (is_integral_type(bt) ? Op_ReverseBytesV : 0);
+    // Subword operations in superword usually don't have precise info
+    // about signedness. But the behavior of reverseBytes for short and
+    // char are exactly the same.
+    return ((bt == T_SHORT || bt == T_CHAR) ? Op_ReverseBytesV : 0);
+  case Op_ReverseBytesI:
+    // There is no reverseBytes() in Byte class but T_BYTE may appear
+    // in VectorAPI calls. We still use ReverseBytesI for T_BYTE to
+    // ensure vector intrinsification succeeds.
+    return ((bt == T_INT || bt == T_BYTE) ? Op_ReverseBytesV : 0);
+  case Op_ReverseBytesL:
+    return (bt == T_LONG ? Op_ReverseBytesV : 0);
   case Op_CompressBits:
     // Not implemented. Returning 0 temporarily
     return 0;

--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -520,8 +520,13 @@ int VectorSupport::vop2ideal(jint id, BasicType bt) {
     }
     case VECTOR_OP_REVERSE_BYTES: {
       switch (bt) {
-        case T_BYTE:
-        case T_SHORT:
+        case T_SHORT: return Op_ReverseBytesS;
+        // Superword requires type consistency between the ReverseBytes*
+        // node and the data. But there's no ReverseBytesB node because
+        // no reverseBytes() method in Java Byte class. T_BYTE can only
+        // appear in VectorAPI calls. We reuse Op_ReverseBytesI for this
+        // to ensure vector intrinsification succeeds.
+        case T_BYTE:  // Intentionally fall-through
         case T_INT:   return Op_ReverseBytesI;
         case T_LONG:  return Op_ReverseBytesL;
         default: fatal("REVERSE_BYTES: %s", type2name(bt));

--- a/test/hotspot/jtreg/compiler/vectorization/TestReverseBytes.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestReverseBytes.java
@@ -25,8 +25,7 @@
  * @bug 8288112
  * @summary Auto-vectorization of ReverseBytes operations.
  * @requires vm.compiler2.enabled
- * @requires vm.cpu.features ~= ".*avx2.*"
- * @requires os.simpleArch == "x64"
+ * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") | os.simpleArch == "AArch64"
  * @library /test/lib /
  * @run driver compiler.vectorization.TestReverseBytes
  */

--- a/test/hotspot/jtreg/compiler/vectorization/TestSubwordReverseBytes.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestSubwordReverseBytes.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorization;
+
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8297689
+ * @summary Test miscompilation of reverseBytes call from subword types
+ * @library /test/lib /
+ * @requires vm.compiler2.enabled
+ * @run driver compiler.vectorization.TestSubwordReverseBytes
+ */
+
+public class TestSubwordReverseBytes {
+    private static final int SIZE = 32000;
+
+    private static   int[] idx = new int[SIZE];
+    private static short[] rbs = new short[SIZE];
+    private static  char[] rbc = new char[SIZE];
+
+    static {
+        for (int i = 0; i < SIZE; i++) {
+            idx[i] = i;
+        }
+        for (short s = 0; s < SIZE; s++) {
+            rbs[s] = Short.reverseBytes(s);
+        }
+        for (char c = 0; c < SIZE; c++) {
+            rbc[c] = Character.reverseBytes(c);
+        }
+    }
+
+    @Test
+    @IR(failOn = {IRNode.REVERSE_BYTES_V})
+    public static int[] testShortReverseBytes() {
+        int[] res = new int[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+           res[i] = Short.reverseBytes((short) idx[i]);
+        }
+        return res;
+    }
+
+    @Run(test = "testShortReverseBytes")
+    public static void testShort() {
+        int[] res = testShortReverseBytes();
+        for (int i = 0; i < SIZE; i++) {
+            if (res[i] != rbs[i]) {
+                throw new RuntimeException("Wrong result: expected = " +
+                        (int) rbs[i] + ", actual = " + res[i]);
+            }
+        }
+    }
+
+    @Test
+    @IR(failOn = {IRNode.REVERSE_BYTES_V})
+    public static int[] testCharacterReverseBytes() {
+        int[] res = new int[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+           res[i] = Character.reverseBytes((char) idx[i]);
+        }
+        return res;
+    }
+
+    @Run(test = "testCharacterReverseBytes")
+    public static void testChar() {
+        int[] res = testCharacterReverseBytes();
+        for (int i = 0; i < SIZE; i++) {
+            if (res[i] != rbc[i]) {
+                throw new RuntimeException("Wrong result: expected = " +
+                        (int) rbc[i] + ", actual = " + res[i]);
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+}
+

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicCharOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicCharOpTest.java
@@ -47,15 +47,18 @@ public class BasicCharOpTest extends VectorizationTestRunner {
     private char[] a;
     private char[] b;
     private char[] c;
+    private int[] idx;
 
     public BasicCharOpTest() {
         a = new char[SIZE];
         b = new char[SIZE];
         c = new char[SIZE];
+        idx = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
             a[i] = (char) (20 * i);
             b[i] = (char) (i + 44444);
             c[i] = (char) 10000;
+            idx[i] = i;
         }
     }
 
@@ -186,6 +189,25 @@ public class BasicCharOpTest extends VectorizationTestRunner {
         char[] res = new char[SIZE];
         for (int i = 0; i < SIZE; i++) {
             res[i] = (char) (a[i] >>> 5);
+        }
+        return res;
+    }
+
+    // ------------- ReverseBytes -------------
+    @Test
+    public char[] reverseBytesWithChar() {
+        char[] res = new char[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            res[i] = Character.reverseBytes(a[i]);
+        }
+        return res;
+    }
+
+    @Test
+    public int[] reverseBytesWithInt() {
+        int[] res = new int[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            res[i] = Character.reverseBytes((char) idx[i]);
         }
         return res;
     }

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicShortOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicShortOpTest.java
@@ -47,15 +47,18 @@ public class BasicShortOpTest extends VectorizationTestRunner {
     private short[] a;
     private short[] b;
     private short[] c;
+    private int[] idx;
 
     public BasicShortOpTest() {
         a = new short[SIZE];
         b = new short[SIZE];
         c = new short[SIZE];
+        idx = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
             a[i] = (short) (-12 * i);
             b[i] = (short) (9 * i + 8888);
             c[i] = (short) -32323;
+            idx[i] = i;
         }
     }
 
@@ -184,6 +187,25 @@ public class BasicShortOpTest extends VectorizationTestRunner {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {
             res[i] = (short) (a[i] >>> 5);
+        }
+        return res;
+    }
+
+    // ------------- ReverseBytes -------------
+    @Test
+    public short[] reverseBytesWithShort() {
+        short[] res = new short[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            res[i] = Short.reverseBytes(a[i]);
+        }
+        return res;
+    }
+
+    @Test
+    public int[] reverseBytesWithInt() {
+        int[] res = new int[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            res[i] = Short.reverseBytes((short) idx[i]);
         }
         return res;
     }


### PR DESCRIPTION
Recently, we find calling `Short.reverseBytes()` in loops may generate incorrect result if the code is compiled by C2. Below is a simple case to reproduce.

```
class Foo {
  static final int SIZE = 50;
  static int a[] = new int[SIZE];

  static void test() {
    for (int i = 0; i < SIZE; i++) {
      a[i] = Short.reverseBytes((short) a[i]);
    }
  }

  public static void main(String[] args) throws Exception {
    Class.forName("java.lang.Short");
    a[25] = 16;
    test();
    System.out.println(a[25]);
  }
}

// $ java -Xint Foo
// 4096
// $ java -Xcomp -XX:-TieredCompilation -XX:CompileOnly=Foo.test Foo
// 268435456
```

In this case, the `reverseBytes()` call is intrinsified and transformed into a `ReverseBytesS` node. But then C2 compiler incorrectly vectorizes it into `ReverseBytesV` with int type. C2 `Op_ReverseBytes*` has short, char, int and long versions. Their behaviors are different for different data sizes. In superword, subword operation itself doesn't have precise data size info. Instead, the data size info comes from memory operations in its use-def chain. Hence, vectorization of `reverseBytes()` is valid only if the data size is consistent with the type size of the caller's class. But current C2 compiler code lacks fine-grained type checks for `ReverseBytes*` in vector transformation. It results in `reverseBytes()` call from Short or Character class with int load/store gets vectorized incorrectly in above case.

To fix the issue, this patch adds more checks in `VectorNode::opcode()`. T_BYTE is a special case for `Op_ReverseBytes*`. As the Java Byte class doesn't have `reverseBytes()` method so there's no `Op_ReverseBytesB`. But T_BYTE may still appear in VectorAPI calls. In this patch we still use `Op_ReverseBytesI` for T_BYTE to ensure vector intrinsification succeeds.

Tested with hotspot::hotspot_all_no_apps, jdk tier1~3 and langtools tier1 on x86 and AArch64, no issue is found.