### PR TITLE
8297821: jdk/jshell/Test8294583.java fails on some platforms

### DIFF
--- a/test/langtools/jdk/jshell/Test8294583.java
+++ b/test/langtools/jdk/jshell/Test8294583.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8294583
  * @summary JShell: NPE in switch with non existing record pattern
+ * @requires vm.continuations
  * @build KullaTesting TestingInputStream
  * @run testng Test8294583
  */


### PR DESCRIPTION
[JDK-8294583](https://bugs.openjdk.org/browse/JDK-8294583) added a new test that does `--enable-preview` to access new language constructs. Unfortunately, this test also enables Loom, which on some platforms like x86_32 uses the 1:1 fallback emulation, which does not support JVMTI. JShell apparently uses JDI -> JDWP -> JVMTI to work, and thus the test fails.

More logs in the bug.

Additional testing:
 - [x] Linux x86_64 fastdebug, test still passes
 - [x] Linux x86_32 fastdebug, test is now skipped

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297821](https://bugs.openjdk.org/browse/JDK-8297821): jdk/jshell/Test8294583.java fails on some platforms


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11428/head:pull/11428` \
`$ git checkout pull/11428`

Update a local copy of the PR: \
`$ git checkout pull/11428` \
`$ git pull https://git.openjdk.org/jdk pull/11428/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11428`

View PR using the GUI difftool: \
`$ git pr show -t 11428`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11428.diff">https://git.openjdk.org/jdk/pull/11428.diff</a>

</details>
