### PR TITLE
8297794: Deprecate JMX Management Applets for Removal

### DIFF
--- a/src/java.management/share/classes/javax/management/loading/MLet.java
+++ b/src/java.management/share/classes/javax/management/loading/MLet.java
@@ -164,6 +164,8 @@ import javax.management.ServiceNotFoundException;
  *
  * @since 1.5
  */
+@Deprecated(since="20", forRemoval=true)
+@SuppressWarnings("removal")
 public class MLet extends java.net.URLClassLoader
      implements MLetMBean, MBeanRegistration, Externalizable {
 

--- a/src/java.management/share/classes/javax/management/loading/MLet.java
+++ b/src/java.management/share/classes/javax/management/loading/MLet.java
@@ -162,6 +162,10 @@ import javax.management.ServiceNotFoundException;
  * <p><STRONG>Note - </STRONG> The <CODE>MLet</CODE> class loader uses the {@link javax.management.MBeanServerFactory#getClassLoaderRepository(javax.management.MBeanServer)}
  * to load classes that could not be found in the loaded jar files.
  *
+ * @deprecated This API is part of Management Applets (m-lets), which is a legacy feature that allows loading
+ * of remote MBeans. This feature is not usable without a Security Manager, which is deprecated and subject to
+ * removal in a future release. Consequently, this API is also deprecated and subject to removal. There is no replacement.
+ *
  * @since 1.5
  */
 @Deprecated(since="20", forRemoval=true)

--- a/src/java.management/share/classes/javax/management/loading/MLetContent.java
+++ b/src/java.management/share/classes/javax/management/loading/MLetContent.java
@@ -39,11 +39,14 @@ import java.util.Map;
  * It can be consulted by a subclass of {@link MLet} that overrides
  * the {@link MLet#check MLet.check} method.
  *
+ * @deprecated This API is part of Management Applets (m-lets), which is a legacy feature that allows loading
+ * of remote MBeans. This feature is not usable without a Security Manager, which is deprecated and subject to
+ * removal in a future release. Consequently, this API is also deprecated and subject to removal. There is no replacement.
+ *
  * @since 1.6
  */
 @Deprecated(since="20", forRemoval=true)
 public class MLetContent {
-
 
     /**
      * A map of the attributes of the <CODE>MLET</CODE> tag

--- a/src/java.management/share/classes/javax/management/loading/MLetContent.java
+++ b/src/java.management/share/classes/javax/management/loading/MLetContent.java
@@ -41,6 +41,7 @@ import java.util.Map;
  *
  * @since 1.6
  */
+@Deprecated(since="20", forRemoval=true)
 public class MLetContent {
 
 

--- a/src/java.management/share/classes/javax/management/loading/MLetMBean.java
+++ b/src/java.management/share/classes/javax/management/loading/MLetMBean.java
@@ -39,6 +39,10 @@ import javax.management.*;
  * Exposes the remote management interface of the MLet
  * MBean.
  *
+ * @deprecated This API is part of Management Applets (m-lets), which is a legacy feature that allows loading
+ * of remote MBeans. This feature is not usable without a Security Manager, which is deprecated and subject to
+ * removal in a future release. Consequently, this API is also deprecated and subject to removal. There is no replacement.
+ *
  * @since 1.5
  */
 @Deprecated(since="20", forRemoval=true)

--- a/src/java.management/share/classes/javax/management/loading/MLetMBean.java
+++ b/src/java.management/share/classes/javax/management/loading/MLetMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,8 +41,8 @@ import javax.management.*;
  *
  * @since 1.5
  */
+@Deprecated(since="20", forRemoval=true)
 public interface MLetMBean   {
-
 
     /**
      * Loads a text file containing MLET tags that define the MBeans

--- a/src/java.management/share/classes/javax/management/loading/MLetObjectInputStream.java
+++ b/src/java.management/share/classes/javax/management/loading/MLetObjectInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,11 +40,13 @@ import java.lang.reflect.Array;
  */
 class MLetObjectInputStream extends ObjectInputStream {
 
+    @SuppressWarnings("removal")
     private MLet loader;
 
     /**
      * Loader must be non-null;
      */
+    @SuppressWarnings("removal")
     public MLetObjectInputStream(InputStream in, MLet loader)
         throws IOException, StreamCorruptedException {
 

--- a/src/java.management/share/classes/javax/management/loading/MLetObjectInputStream.java
+++ b/src/java.management/share/classes/javax/management/loading/MLetObjectInputStream.java
@@ -38,6 +38,7 @@ import java.lang.reflect.Array;
  *
  * @since 1.5
  */
+@Deprecated(since="20", forRemoval=true)
 class MLetObjectInputStream extends ObjectInputStream {
 
     @SuppressWarnings("removal")

--- a/src/java.management/share/classes/javax/management/loading/MLetParser.java
+++ b/src/java.management/share/classes/javax/management/loading/MLetParser.java
@@ -251,7 +251,7 @@ class MLetParser {
     /**
      * Parse the document pointed by the URL urlname
      */
-    @SuppressWarnings({"deprecation", "removal"})
+    @SuppressWarnings("removal")
     public List<MLetContent> parseURL(String urlname) throws IOException {
         // Parse the document
         //

--- a/src/java.management/share/classes/javax/management/loading/MLetParser.java
+++ b/src/java.management/share/classes/javax/management/loading/MLetParser.java
@@ -47,6 +47,7 @@ import java.lang.System.Logger.Level;
  *
  * @since 1.5
  */
+@Deprecated(since="20", forRemoval=true)
 class MLetParser {
 
 /*

--- a/src/java.management/share/classes/javax/management/loading/MLetParser.java
+++ b/src/java.management/share/classes/javax/management/loading/MLetParser.java
@@ -153,6 +153,7 @@ class MLetParser {
     /**
      * Scan an html file for {@literal <mlet>} tags.
      */
+    @SuppressWarnings("removal")
     public List<MLetContent> parse(URL url) throws IOException {
         // Warning Messages
         String requiresTypeWarning = "<arg type=... value=...> tag requires type parameter.";
@@ -249,7 +250,7 @@ class MLetParser {
     /**
      * Parse the document pointed by the URL urlname
      */
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     public List<MLetContent> parseURL(String urlname) throws IOException {
         // Parse the document
         //

--- a/src/java.management/share/classes/javax/management/loading/PrivateMLet.java
+++ b/src/java.management/share/classes/javax/management/loading/PrivateMLet.java
@@ -36,6 +36,10 @@ import java.net.URLStreamHandlerFactory;
  * ClassLoaderRepository}.  This is true because this class implements
  * the interface {@link PrivateClassLoader}.
  *
+ * @deprecated This API is part of Management Applets (m-lets), which is a legacy feature that allows loading
+ * of remote MBeans. This feature is not usable without a Security Manager, which is deprecated and subject to
+ * removal in a future release. Consequently, this API is also deprecated and subject to removal. There is no replacement.
+ *
  * @since 1.5
  */
 @Deprecated(since="20", forRemoval=true)

--- a/src/java.management/share/classes/javax/management/loading/PrivateMLet.java
+++ b/src/java.management/share/classes/javax/management/loading/PrivateMLet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,8 @@ import java.net.URLStreamHandlerFactory;
  *
  * @since 1.5
  */
-@SuppressWarnings("serial") // Externalizable class w/o no-arg c'tor
+@Deprecated(since="20", forRemoval=true)
+@SuppressWarnings({"serial", "removal"}) // Externalizable class w/o no-arg c'tor
 public class PrivateMLet extends MLet implements PrivateClassLoader {
     private static final long serialVersionUID = 2503458973393711979L;
 

--- a/test/jdk/javax/management/Introspector/ClassLeakTest.java
+++ b/test/jdk/javax/management/Introspector/ClassLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,6 +56,7 @@ public class ClassLeakTest {
             urls[i] = Paths.get(cpaths[i]).toUri().toURL();
         }
 
+        @SuppressWarnings("removal")
         PrivateMLet mlet = new PrivateMLet(urls, null, false);
         Class<?> shadowClass = mlet.loadClass(TestMBean.class.getName());
         if (shadowClass == TestMBean.class) {

--- a/test/jdk/javax/management/MBeanServer/PostExceptionTest.java
+++ b/test/jdk/javax/management/MBeanServer/PostExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -432,6 +432,7 @@ public class PostExceptionTest {
             if (server.isRegistered(name)) {
                 return name;
             }
+            @SuppressWarnings("removal")
             final MLet mlet = new MLet(new URL[0],
                     ClassLoader.getSystemClassLoader());
             return server.registerMBean(mlet, name).getObjectName();

--- a/test/jdk/javax/management/loading/DocumentRootTest.java
+++ b/test/jdk/javax/management/loading/DocumentRootTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import javax.management.loading.MLetContent;
 
+@SuppressWarnings("removal")
 public class DocumentRootTest {
     public static int test(URL documentBase, URL codeBase) {
         int error = 0;

--- a/test/jdk/javax/management/loading/GetMBeansFromURLTest.java
+++ b/test/jdk/javax/management/loading/GetMBeansFromURLTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,7 @@ import javax.management.ObjectName;
 import javax.management.ServiceNotFoundException;
 import javax.management.loading.MLet;
 
+@SuppressWarnings("removal")
 public class GetMBeansFromURLTest {
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/javax/management/loading/MLetCLR/MLetCommand.java
+++ b/test/jdk/javax/management/loading/MLetCLR/MLetCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ import javax.management.MBeanServerFactory;
 import javax.management.ObjectName;
 import java.io.File;
 
+@SuppressWarnings("removal")
 public class MLetCommand {
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/javax/management/loading/MLetContentTest.java
+++ b/test/jdk/javax/management/loading/MLetContentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import java.net.*;
 
 import javax.management.loading.*;
 
+@SuppressWarnings("removal")
 public class MLetContentTest {
     public static void main(String[] args) throws Exception {
         System.out.println(">>> General test for the public class MLetContent.");

--- a/test/jdk/javax/management/loading/MLetInternalsTest.java
+++ b/test/jdk/javax/management/loading/MLetInternalsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ import static org.testng.Assert.*;
  * @modules java.management/javax.management.loading:open
  * @run testng MLetInternalsTest
  */
+@SuppressWarnings("removal")
 public class MLetInternalsTest {
     private final static String CONSTRUCT_PARAMETER = "constructParameter";
 

--- a/test/jdk/javax/management/loading/MletParserLocaleTest.java
+++ b/test/jdk/javax/management/loading/MletParserLocaleTest.java
@@ -39,6 +39,7 @@ import javax.management.MBeanServerFactory;
 import javax.management.ObjectName;
 import javax.management.loading.MLet;
 
+@SuppressWarnings("removal")
 public class MletParserLocaleTest {
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/javax/management/loading/ParserInfiniteLoopTest.java
+++ b/test/jdk/javax/management/loading/ParserInfiniteLoopTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,7 @@ import javax.management.ObjectName;
 import javax.management.ServiceNotFoundException;
 import javax.management.loading.MLet;
 
+@SuppressWarnings("removal")
 public class ParserInfiniteLoopTest {
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/javax/management/mxbean/MXBeanLoadingTest1.java
+++ b/test/jdk/javax/management/mxbean/MXBeanLoadingTest1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,6 +81,7 @@ public class MXBeanLoadingTest1 {
                             + ".class", "");
 
             URL[] urls = new URL[]{new URL(clsLoadPath)};
+            @SuppressWarnings("removal")
             PrivateMLet mlet = new PrivateMLet(urls, null, false);
             Class<?> shadowClass = mlet.loadClass(TestMXBean.class.getName());
 
@@ -266,6 +267,7 @@ public class MXBeanLoadingTest1 {
             mbs.unregisterMBean(testName);
             mbs.unregisterMBean(mletName);
 
+            @SuppressWarnings("removal")
             WeakReference<PrivateMLet> mletRef =
                     new WeakReference<PrivateMLet>(mlet);
             mlet = null;

--- a/test/jdk/javax/management/relation/NonArrayListTest.java
+++ b/test/jdk/javax/management/relation/NonArrayListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,8 @@ import javax.management.relation.*;
 import javax.management.loading.MLet;
 
 public class NonArrayListTest {
+
+    @SuppressWarnings("removal") // use of MLet
     public static void main(String[] args) throws Exception {
         MBeanServer mbs = MBeanServerFactory.createMBeanServer();
         RelationService rs = new RelationService(true);

--- a/test/jdk/javax/management/remote/mandatory/loading/TargetMBeanTest.java
+++ b/test/jdk/javax/management/remote/mandatory/loading/TargetMBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,6 +101,7 @@ public class TargetMBeanTest {
 
         URLClassLoader jrcl = (URLClassLoader) jmxRemoteClassLoader;
         URL[] urls = jrcl.getURLs();
+        @SuppressWarnings("removal")
         PrivateMLet mlet = new PrivateMLet(urls, null, false);
         Class shadowClass = mlet.loadClass(JMXServiceURL.class.getName());
         if (shadowClass == JMXServiceURL.class) {

--- a/test/jdk/javax/management/remote/mandatory/notif/NotificationBufferTest.java
+++ b/test/jdk/javax/management/remote/mandatory/notif/NotificationBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,6 +80,7 @@ public class NotificationBufferTest {
         }
     }
 
+    @SuppressWarnings("removal") // use of MLet
     private static boolean test() throws Exception {
         MBeanServer mbs = MBeanServerFactory.createMBeanServer();
 


### PR DESCRIPTION
Deprecate the Java Management Extension (JMX) Management Applet (m-let) feature for removal.

This deprecation will have no impact on users of other JMX features, the JDK's built-in instrumentation, or any of the observability tools.

More details in bug, and CSR JDK-8297795

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8297794](https://bugs.openjdk.org/browse/JDK-8297794): Deprecate JMX Management Applets for Removal
 * [JDK-8297795](https://bugs.openjdk.org/browse/JDK-8297795): Deprecate JMX Management Applets for Removal (**CSR**)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11430/head:pull/11430` \
`$ git checkout pull/11430`

Update a local copy of the PR: \
`$ git checkout pull/11430` \
`$ git pull https://git.openjdk.org/jdk pull/11430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11430`

View PR using the GUI difftool: \
`$ git pr show -t 11430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11430.diff">https://git.openjdk.org/jdk/pull/11430.diff</a>

</details>
