### PR TITLE
8297853: windows-x86 test build broken

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/foreign/libQSortJNI.c
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/libQSortJNI.c
@@ -28,7 +28,7 @@
 #include "jlong.h"
 #include "JNICB.h"
 
-#if defined(_WIN64) || defined(_WIN32)
+#ifdef _WIN32
 #define THREAD_LOCAL __declspec(thread)
 #else
 #define THREAD_LOCAL __thread

--- a/test/micro/org/openjdk/bench/java/lang/foreign/libQSortJNI.c
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/libQSortJNI.c
@@ -28,7 +28,7 @@
 #include "jlong.h"
 #include "JNICB.h"
 
-#ifdef _WIN64
+#if defined(_WIN64) || defined(_WIN32)
 #define THREAD_LOCAL __declspec(thread)
 #else
 #define THREAD_LOCAL __thread


### PR DESCRIPTION
test/micro/org/openjdk/bench/java/lang/foreign/libQSortJNI.c is missing the correct macro definition to compile on 32-bit Windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297853](https://bugs.openjdk.org/browse/JDK-8297853): windows-x86 test build broken


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11434/head:pull/11434` \
`$ git checkout pull/11434`

Update a local copy of the PR: \
`$ git checkout pull/11434` \
`$ git pull https://git.openjdk.org/jdk pull/11434/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11434`

View PR using the GUI difftool: \
`$ git pr show -t 11434`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11434.diff">https://git.openjdk.org/jdk/pull/11434.diff</a>

</details>
