### PR TITLE
8297294: compiler/c2/irTests/TestMulNodeIdealization.java failed compilation

### DIFF
--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -60,6 +60,7 @@
 #include "runtime/javaCalls.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/jniHandles.inline.hpp"
+#include "runtime/keepStackGCProcessed.hpp"
 #include "runtime/objectMonitor.hpp"
 #include "runtime/objectMonitor.inline.hpp"
 #include "runtime/os.hpp"
@@ -1964,6 +1965,11 @@ void JvmtiExport::post_exception_throw(JavaThread *thread, Method* method, addre
   HandleMark hm(thread);
   methodHandle mh(thread, method);
   Handle exception_handle(thread, exception);
+  // The KeepStackGCProcessedMark below keeps the target thread and its stack fully
+  // GC processed across this scope. This is needed because there is a stack walk
+  // below with safepoint polls inside of it. After such safepoints, we have to
+  // ensure the stack is sufficiently processed.
+  KeepStackGCProcessedMark ksgcpm(thread);
 
   JvmtiThreadState *state = thread->jvmti_thread_state();
   if (state == NULL) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
@@ -57,8 +57,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -1145,7 +1144,7 @@ public class Infer {
     }
 
     /** an incorporation cache keeps track of all executed incorporation-related operations */
-    Map<IncorporationBinaryOp, Boolean> incorporationCache = new HashMap<>();
+    Map<IncorporationBinaryOp, Boolean> incorporationCache = new LinkedHashMap<>();
 
     protected static class BoundFilter implements Predicate<Type> {
 
@@ -1307,7 +1306,7 @@ public class Infer {
         }
 
         /** cache used to avoid redundant computation of tree costs */
-        final Map<Node, Pair<List<Node>, Integer>> treeCache = new HashMap<>();
+        final Map<Node, Pair<List<Node>, Integer>> treeCache = new LinkedHashMap<>();
 
         /** constant value used to mark non-existent paths */
         final Pair<List<Node>, Integer> noPath = new Pair<>(null, Integer.MAX_VALUE);
@@ -1635,7 +1634,7 @@ public class Infer {
                  * through all its dependencies.
                  */
                 protected Set<Node> closure() {
-                    Set<Node> closure = new HashSet<>();
+                    Set<Node> closure = new LinkedHashSet<>();
                     closureInternal(closure);
                     return closure;
                 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/InferenceContext.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/InferenceContext.java
@@ -27,7 +27,6 @@ package com.sun.tools.javac.comp;
 
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -551,7 +550,7 @@ public class InferenceContext {
      * This is why the tree is used as the key of the map below. This map
      * stores a Type per AST.
      */
-    Map<JCTree, Type> captureTypeCache = new HashMap<>();
+    Map<JCTree, Type> captureTypeCache = new LinkedHashMap<>();
 
     Type cachedCapture(JCTree tree, Type t, boolean readOnly) {
         Type captured = captureTypeCache.get(tree);


### PR DESCRIPTION
Given that the reported issue is intermittent I think we have two options here:

1 - change the most probable use of a non-deterministic data structure that could be provoking this bug, to a deterministic one
2 - change all uses of non-deterministic data structures

I first tried option `1` but TBH after going again to the code I can't find a clear suspect. I thought we had reduced the options for non-determinism in the inference engine to zero, rien, niente. But it seems like that's not the case. So I have gone for option `2`.

Comments?
TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297294](https://bugs.openjdk.org/browse/JDK-8297294): compiler/c2/irTests/TestMulNodeIdealization.java failed compilation


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11437/head:pull/11437` \
`$ git checkout pull/11437`

Update a local copy of the PR: \
`$ git checkout pull/11437` \
`$ git pull https://git.openjdk.org/jdk pull/11437/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11437`

View PR using the GUI difftool: \
`$ git pr show -t 11437`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11437.diff">https://git.openjdk.org/jdk/pull/11437.diff</a>

</details>
