### PR TITLE
8291359: Specification of method j.l.foreign.VaList::skip still deserves clarification

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/VaList.java
+++ b/src/java.base/share/classes/java/lang/foreign/VaList.java
@@ -52,9 +52,13 @@ import jdk.internal.reflect.Reflection;
  * As such, this interface only supports reading {@code int}, {@code double},
  * and any other type that fits into a {@code long}.
  * <h2 id="safety">Safety considerations</h2>
- * The behavior of any attempts to access a value in the variable argument list, whether through one of the {@code nextVarg} overloads
- * or {@link #skip(MemoryLayout...)}, using a memory layout other than the layout of the accessed value, or any subsequent
- * accesses to the same variable argument list, is undefined.
+ * Accessing a value through a variable argument list using the wrong memory layout will result in undefined behavior.
+ * For instance, if a variable argument list currently points at a C {@code int} value, then accessing it using
+ * {@link #nextVarg(ValueLayout.OfLong)} is illegal, but, any such illegal accesses might not be detected by
+ * the implementation.
+ * This goes for accesses through one of the {@code nextVarg} overloads, and {@link #skip(MemoryLayout...)}.
+ * After an attempt to access a value using the wrong memory layout like this can result in the
+ * variable argument list being corrupted, and the behavior of any subsequent accesses is therefor undefined as well.
  * <p>
  * It is possible for clients to access elements outside the spatial bounds of a variable argument list.
  * Variable argument list implementations will try to detect out-of-bounds reads on a best-effort basis.

--- a/src/java.base/share/classes/java/lang/foreign/VaList.java
+++ b/src/java.base/share/classes/java/lang/foreign/VaList.java
@@ -52,9 +52,9 @@ import jdk.internal.reflect.Reflection;
  * As such, this interface only supports reading {@code int}, {@code double},
  * and any other type that fits into a {@code long}.
  * <h2 id="safety">Safety considerations</h2>
- * The behavior of any attempts to access a value in the va list, whether through one of the {@code nextVarg} overloads
+ * The behavior of any attempts to access a value in the variable argument list, whether through one of the {@code nextVarg} overloads
  * or {@link #skip(MemoryLayout...)}, using a memory layout other than the layout of the accessed value, or any subsequent
- * accesses to the same va list, is undefined.
+ * accesses to the same variable argument list, is undefined.
  * <p>
  * It is possible for clients to access elements outside the spatial bounds of a variable argument list.
  * Variable argument list implementations will try to detect out-of-bounds reads on a best-effort basis.

--- a/src/java.base/share/classes/java/lang/foreign/VaList.java
+++ b/src/java.base/share/classes/java/lang/foreign/VaList.java
@@ -57,8 +57,8 @@ import jdk.internal.reflect.Reflection;
  * {@link #nextVarg(ValueLayout.OfLong)} is illegal, but, any such illegal accesses might not be detected by
  * the implementation.
  * This goes for accesses through one of the {@code nextVarg} overloads, and {@link #skip(MemoryLayout...)}.
- * After an attempt to access a value using the wrong memory layout like this can result in the
- * variable argument list being corrupted, and the behavior of any subsequent accesses is therefor undefined as well.
+ * Any attempt to access a value using the wrong memory layout like this can result in the
+ * variable argument list being corrupted, and the behavior of any subsequent accesses is therefore undefined as well.
  * <p>
  * It is possible for clients to access elements outside the spatial bounds of a variable argument list.
  * Variable argument list implementations will try to detect out-of-bounds reads on a best-effort basis.

--- a/src/java.base/share/classes/java/lang/foreign/VaList.java
+++ b/src/java.base/share/classes/java/lang/foreign/VaList.java
@@ -52,6 +52,10 @@ import jdk.internal.reflect.Reflection;
  * As such, this interface only supports reading {@code int}, {@code double},
  * and any other type that fits into a {@code long}.
  * <h2 id="safety">Safety considerations</h2>
+ * The behavior of any attempts to access a value in the va list, whether through one of the {@code nextVarg} overloads
+ * or {@link #skip(MemoryLayout...)}, using a memory layout other than the layout of the accessed value, or any subsequent
+ * accesses to the same va list, is undefined.
+ * <p>
  * It is possible for clients to access elements outside the spatial bounds of a variable argument list.
  * Variable argument list implementations will try to detect out-of-bounds reads on a best-effort basis.
  * <p>

--- a/src/java.base/share/classes/java/lang/foreign/VaList.java
+++ b/src/java.base/share/classes/java/lang/foreign/VaList.java
@@ -54,11 +54,10 @@ import jdk.internal.reflect.Reflection;
  * <h2 id="safety">Safety considerations</h2>
  * Accessing a value through a variable argument list using the wrong memory layout will result in undefined behavior.
  * For instance, if a variable argument list currently points at a C {@code int} value, then accessing it using
- * {@link #nextVarg(ValueLayout.OfLong)} is illegal, but, any such illegal accesses might not be detected by
- * the implementation.
- * This goes for accesses through one of the {@code nextVarg} overloads, and {@link #skip(MemoryLayout...)}.
- * Any attempt to access a value using the wrong memory layout like this can result in the
- * variable argument list being corrupted, and the behavior of any subsequent accesses is therefore undefined as well.
+ * {@link #nextVarg(ValueLayout.OfLong)} is illegal. Similarly, accessing the variable argument list with
+ * {@link #skip(MemoryLayout...)}, and providing a layout other than {@link ValueLayout.OfInt} is illegal.
+ * Any such illegal accesses might not be detected by the implementation, and can corrupt the variable argument list,
+ * so that the behavior of subsequent accesses is also undefined.
  * <p>
  * It is possible for clients to access elements outside the spatial bounds of a variable argument list.
  * Variable argument list implementations will try to detect out-of-bounds reads on a best-effort basis.


### PR DESCRIPTION
A small clarification of the VaList spec to say that attempts to access elements through an incorrect memory layout result in undefined behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8291359](https://bugs.openjdk.org/browse/JDK-8291359): Specification of method j.l.foreign.VaList::skip still deserves clarification
 * [JDK-8297873](https://bugs.openjdk.org/browse/JDK-8297873): Specification of method j.l.foreign.VaList::skip still deserves clarification (**CSR**)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11440/head:pull/11440` \
`$ git checkout pull/11440`

Update a local copy of the PR: \
`$ git checkout pull/11440` \
`$ git pull https://git.openjdk.org/jdk pull/11440/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11440`

View PR using the GUI difftool: \
`$ git pr show -t 11440`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11440.diff">https://git.openjdk.org/jdk/pull/11440.diff</a>

</details>
