### PR TITLE
8297875: jar should not compress the manifest directory entry

### DIFF
--- a/src/jdk.jartool/share/classes/sun/tools/jar/Main.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/Main.java
@@ -875,6 +875,7 @@ public class Main {
                 }
                 ZipEntry e = new ZipEntry(MANIFEST_DIR);
                 setZipEntryTime(e);
+                e.setMethod(ZipEntry.STORED);
                 e.setSize(0);
                 e.setCrc(0);
                 zos.putNextEntry(e);

--- a/test/jdk/tools/jar/ManifestDirectoryCompression.java
+++ b/test/jdk/tools/jar/ManifestDirectoryCompression.java
@@ -24,9 +24,15 @@
 /**
  * @test
  * @bug 8297875
- * @modules jdk.jartool
  * @summary jar should not compress the manifest directory entry
+ * @modules jdk.jartool
+ * @run testng ManifestDirectoryCompression
  */
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+import org.testng.annotations.Test;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -56,7 +62,8 @@ public class ManifestDirectoryCompression {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    @Test
+    public void run() throws Throwable {
         Path topDir = Files.createTempDirectory("delete");
         try {
             Path entry = Files.writeString(topDir.resolve("test.txt"), "Some text...");
@@ -69,18 +76,13 @@ public class ManifestDirectoryCompression {
     private static void doTest(Path jar, Path entry) throws Throwable {
         String[] jarArgs = new String[] {"cf", jar.toString(), entry.toString()};
         if (JAR_TOOL.run(System.out, System.err, jarArgs) != 0) {
-            throw new AssertionError("Could not create jar file: " + List.of(jarArgs));
+            fail("Could not create jar file: " + List.of(jarArgs));
         }
         try (JarFile jarFile = new JarFile(jar.toFile())) {
             ZipEntry zipEntry = jarFile.getEntry("META-INF/");
+            assertEquals(zipEntry.getMethod(), ZipEntry.STORED);
             assertEquals(zipEntry.getSize(), 0);
             assertEquals(zipEntry.getCompressedSize(), 0);
-        }
-    }
-
-    private static void assertEquals(long actual, long expected) {
-        if (actual != expected) {
-            throw new AssertionError(String.format("actual: %s, expected: %s", actual, expected));
         }
     }
 }

--- a/test/jdk/tools/jar/ManifestDirectoryCompression.java
+++ b/test/jdk/tools/jar/ManifestDirectoryCompression.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2022, Alphabet LLC. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8297875
+ * @modules jdk.jartool
+ * @summary jar should not compress the manifest directory entry
+ */
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.jar.JarFile;
+import java.util.spi.ToolProvider;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+
+public class ManifestDirectoryCompression {
+    private static final ToolProvider JAR_TOOL =
+            ToolProvider.findFirst("jar")
+                    .orElseThrow(() -> new RuntimeException("jar tool not found"));
+
+    /** Remove dirs & files needed for test. */
+    private static void cleanup(Path dir) {
+        try {
+            if (Files.isDirectory(dir)) {
+                try (Stream<Path> s = Files.list(dir)) {
+                    s.forEach(p -> cleanup(p));
+                }
+            }
+            Files.delete(dir);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static void main(String[] args) throws Throwable {
+        Path topDir = Files.createTempDirectory("delete");
+        try {
+            Path entry = Files.writeString(topDir.resolve("test.txt"), "Some text...");
+            doTest(topDir.resolve("test.jar"), entry);
+        } finally {
+            cleanup(topDir);
+        }
+    }
+
+    private static void doTest(Path jar, Path entry) throws Throwable {
+        String[] jarArgs = new String[] {"cf", jar.toString(), entry.toString()};
+        if (JAR_TOOL.run(System.out, System.err, jarArgs) != 0) {
+            throw new AssertionError("Could not create jar file: " + List.of(jarArgs));
+        }
+        try (JarFile jarFile = new JarFile(jar.toFile())) {
+            ZipEntry zipEntry = jarFile.getEntry("META-INF/");
+            assertEquals(zipEntry.getSize(), 0);
+            assertEquals(zipEntry.getCompressedSize(), 0);
+        }
+    }
+
+    private static void assertEquals(long actual, long expected) {
+        if (actual != expected) {
+            throw new AssertionError(String.format("actual: %s, expected: %s", actual, expected));
+        }
+    }
+}


### PR DESCRIPTION
This causes jar to not compress the `META-INF/` directory entry, for consistency with the handling of other directory entries and compliance with `APPNOTE.TXT`, and for compatibility with other zip implementations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297875](https://bugs.openjdk.org/browse/JDK-8297875): jar should not compress the manifest directory entry


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11441/head:pull/11441` \
`$ git checkout pull/11441`

Update a local copy of the PR: \
`$ git checkout pull/11441` \
`$ git pull https://git.openjdk.org/jdk pull/11441/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11441`

View PR using the GUI difftool: \
`$ git pr show -t 11441`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11441.diff">https://git.openjdk.org/jdk/pull/11441.diff</a>

</details>
