### PR TITLE
8291830: jvmti/RedefineClasses/StressRedefine failed: assert(!is_null(v)) failed: narrow klass value can never be zero

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -50,7 +50,7 @@
 #include "classfile/classLoaderData.inline.hpp"
 #include "classfile/classLoaderDataGraph.inline.hpp"
 #include "classfile/dictionary.hpp"
-#include "classfile/javaClasses.inline.hpp"
+#include "classfile/javaClasses.hpp"
 #include "classfile/moduleEntry.hpp"
 #include "classfile/packageEntry.hpp"
 #include "classfile/symbolTable.hpp"
@@ -1011,19 +1011,6 @@ void ClassLoaderData::print_on(outputStream* out) const {
 
 void ClassLoaderData::print() const { print_on(tty); }
 
-class VerifyHandleOops : public OopClosure {
- public:
-  virtual void do_oop(oop* p) {
-    if (p != nullptr && *p != nullptr) {
-      oop o = *p;
-      if (!java_lang_Class::is_instance(o)) {
-        guarantee(oopDesc::is_oop(o), "Should be some oop");
-      }
-    }
-  }
-  virtual void do_oop(narrowOop* o) { ShouldNotReachHere(); }
-};
-
 void ClassLoaderData::verify() {
   assert_locked_or_safepoint(_metaspace_lock);
   oop cl = class_loader();
@@ -1047,19 +1034,6 @@ void ClassLoaderData::verify() {
   if (_modules != NULL) {
     _modules->verify();
   }
-
-  if (_deallocate_list != nullptr) {
-    for (int i = _deallocate_list->length() - 1; i >= 0; i--) {
-      Metadata* m = _deallocate_list->at(i);
-      if (m->is_klass()) {
-        ((InstanceKlass*)m)->verify();
-      }
-    }
-  }
-
-  // Check the oops in the handles area
-  VerifyHandleOops vho;
-  oops_do(&vho, _claim_none, false);
 }
 
 bool ClassLoaderData::contains_klass(Klass* klass) {

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -27,7 +27,7 @@
 #include "cds/heapShared.hpp"
 #include "classfile/classLoaderData.inline.hpp"
 #include "classfile/classLoaderDataGraph.inline.hpp"
-#include "classfile/javaClasses.hpp"
+#include "classfile/javaClasses.inline.hpp"
 #include "classfile/moduleEntry.hpp"
 #include "classfile/systemDictionary.hpp"
 #include "classfile/systemDictionaryShared.hpp"
@@ -63,10 +63,6 @@ void Klass::set_java_mirror(Handle m) {
 
 oop Klass::java_mirror_no_keepalive() const {
   return _java_mirror.peek();
-}
-
-void Klass::replace_java_mirror(oop mirror) {
-  _java_mirror.replace(mirror);
 }
 
 bool Klass::is_cloneable() const {
@@ -788,7 +784,7 @@ void Klass::verify_on(outputStream* st) {
   }
 
   if (java_mirror_no_keepalive() != NULL) {
-    guarantee(oopDesc::is_oop(java_mirror_no_keepalive()), "should be instance");
+    guarantee(java_lang_Class::is_instance(java_mirror_no_keepalive()), "should be instance");
   }
 }
 

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -270,7 +270,7 @@ protected:
 
   // Temporary mirror switch used by RedefineClasses
   OopHandle java_mirror_handle() const { return _java_mirror; }
-  void replace_java_mirror_handle(OopHandle mirror) { _java_mirror.assign_handle(mirror); }
+  void swap_java_mirror_handle(OopHandle& mirror) { _java_mirror.swap(mirror); }
 
   // Set java mirror OopHandle to NULL for CDS
   // This leaves the OopHandle in the CLD, but that's ok, you can't release them.

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -269,7 +269,8 @@ protected:
   void set_archived_java_mirror(oop m) NOT_CDS_JAVA_HEAP_RETURN;
 
   // Temporary mirror switch used by RedefineClasses
-  void replace_java_mirror(oop mirror);
+  OopHandle java_mirror_handle() const { return _java_mirror; }
+  void replace_java_mirror_handle(OopHandle mirror) { _java_mirror.assign_handle(mirror); }
 
   // Set java mirror OopHandle to NULL for CDS
   // This leaves the OopHandle in the CLD, but that's ok, you can't release them.

--- a/src/hotspot/share/oops/oopHandle.hpp
+++ b/src/hotspot/share/oops/oopHandle.hpp
@@ -55,11 +55,8 @@ public:
     return *this;
   }
 
-  OopHandle& assign_handle(const OopHandle& copy) {
-    // Assignment is used by RedefineClasses for java_mirror to temporarily
-    // replace the mirror in the scratch class.
-    _obj = copy._obj;
-    return *this;
+  void swap(OopHandle& copy) {
+    ::swap(_obj, copy._obj);
   }
 
   inline oop resolve() const;

--- a/src/hotspot/share/oops/oopHandle.hpp
+++ b/src/hotspot/share/oops/oopHandle.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,6 +51,13 @@ public:
     // Allow "this" to be junk if copy is empty; needed by initialization of
     // raw memory in hashtables.
     assert(is_empty() || copy.is_empty(), "can only copy if empty");
+    _obj = copy._obj;
+    return *this;
+  }
+
+  OopHandle& assign_handle(const OopHandle& copy) {
+    // Assignment is used by RedefineClasses for java_mirror to temporarily
+    // replace the mirror in the scratch class.
     _obj = copy._obj;
     return *this;
   }

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -1324,7 +1324,7 @@ class RedefineVerifyMark : public StackObj {
  private:
   JvmtiThreadState* _state;
   Klass*            _scratch_class;
-  Handle            _scratch_mirror;
+  OopHandle         _scratch_mirror;
 
  public:
 
@@ -1332,14 +1332,14 @@ class RedefineVerifyMark : public StackObj {
                      JvmtiThreadState* state) : _state(state), _scratch_class(scratch_class)
   {
     _state->set_class_versions_map(the_class, scratch_class);
-    _scratch_mirror = Handle(_state->get_thread(), _scratch_class->java_mirror());
-    _scratch_class->replace_java_mirror(the_class->java_mirror());
+    _scratch_mirror = _scratch_class->java_mirror_handle();
+    _scratch_class->replace_java_mirror_handle(the_class->java_mirror_handle());
   }
 
   ~RedefineVerifyMark() {
     // Restore the scratch class's mirror, so when scratch_class is removed
     // the correct mirror pointing to it can be cleared.
-    _scratch_class->replace_java_mirror(_scratch_mirror());
+    _scratch_class->replace_java_mirror_handle(_scratch_mirror);
     _state->clear_class_versions_map();
   }
 };

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -1332,14 +1332,14 @@ class RedefineVerifyMark : public StackObj {
                      JvmtiThreadState* state) : _state(state), _scratch_class(scratch_class)
   {
     _state->set_class_versions_map(the_class, scratch_class);
-    _scratch_mirror = _scratch_class->java_mirror_handle();
-    _scratch_class->replace_java_mirror_handle(the_class->java_mirror_handle());
+    _scratch_mirror = the_class->java_mirror_handle();  // this is a copy that is swapped
+    _scratch_class->swap_java_mirror_handle(_scratch_mirror);
   }
 
   ~RedefineVerifyMark() {
     // Restore the scratch class's mirror, so when scratch_class is removed
     // the correct mirror pointing to it can be cleared.
-    _scratch_class->replace_java_mirror_handle(_scratch_mirror);
+    _scratch_class->swap_java_mirror_handle(_scratch_mirror);
     _state->clear_class_versions_map();
   }
 };


### PR DESCRIPTION
The code for RedefineVerifyMark in redefinition replaces the OopHandle mirror so that the verification has the right mirror, but it really should just copy it.  Replacing an OopHandle in the ClassLoaderData didn't set the has_modified_oops flag so GC wasn't noticing that this handle is old.

Tested with tier1-4 and tier6 in progress (linux-x64 and windows-x64 done).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291830](https://bugs.openjdk.org/browse/JDK-8291830): jvmti/RedefineClasses/StressRedefine failed: assert(!is_null(v)) failed: narrow klass value can never be zero


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [2f8d5517](https://git.openjdk.org/jdk/pull/11444/files/2f8d5517afef45f461bb789f659631f0d1cf7fbd)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to [2f8d5517](https://git.openjdk.org/jdk/pull/11444/files/2f8d5517afef45f461bb789f659631f0d1cf7fbd)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11444/head:pull/11444` \
`$ git checkout pull/11444`

Update a local copy of the PR: \
`$ git checkout pull/11444` \
`$ git pull https://git.openjdk.org/jdk pull/11444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11444`

View PR using the GUI difftool: \
`$ git pr show -t 11444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11444.diff">https://git.openjdk.org/jdk/pull/11444.diff</a>

</details>
