### PR TITLE
8297928: Update jdk.internal.javac.PreviewFeature.Feature to reflect JEP 432 and JEP 433

### DIFF
--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -64,9 +64,9 @@ public @interface PreviewFeature {
      * Values should be annotated with the feature's {@code JEP}.
      */
     public enum Feature {
-        @JEP(number=427, title="Pattern Matching for switch", status="Third Preview")
+        @JEP(number=433, title="Pattern Matching for switch", status="Fourth Preview")
         SWITCH_PATTERN_MATCHING(),
-        @JEP(number=405, title="Record Patterns")
+        @JEP(number=432, title="Record Patterns", status="Second Preview")
         RECORD_PATTERNS,
         @JEP(number=425, title="Virtual Threads")
         VIRTUAL_THREADS,


### PR DESCRIPTION
The jdk.internal.javac.PreviewFeature.Feature needs to be updated to reflect JEP 432 and JEP 433 properly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297928](https://bugs.openjdk.org/browse/JDK-8297928): Update jdk.internal.javac.PreviewFeature.Feature to reflect JEP 432 and JEP 433


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11447/head:pull/11447` \
`$ git checkout pull/11447`

Update a local copy of the PR: \
`$ git checkout pull/11447` \
`$ git pull https://git.openjdk.org/jdk pull/11447/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11447`

View PR using the GUI difftool: \
`$ git pr show -t 11447`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11447.diff">https://git.openjdk.org/jdk/pull/11447.diff</a>

</details>
