### PR TITLE
8297941: Add override modifier in space.hpp

### DIFF
--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -286,7 +286,7 @@ public:
     NOT_PRODUCT(_last_explicit_min_done = NULL);
   }
 
-  void do_MemRegion(MemRegion mr);
+  void do_MemRegion(MemRegion mr) override;
 
   void set_min_done(HeapWord* min_done) {
     _min_done = min_done;
@@ -330,8 +330,8 @@ public:
   CompactibleSpace() :
    _compaction_top(NULL), _next_compaction_space(NULL) {}
 
-  virtual void initialize(MemRegion mr, bool clear_space, bool mangle_space);
-  virtual void clear(bool mangle_space);
+  void initialize(MemRegion mr, bool clear_space, bool mangle_space) override;
+  void clear(bool mangle_space) override;
 
   // Used temporarily during a compaction phase to hold the value
   // top should have when compaction is complete.
@@ -372,7 +372,7 @@ public:
   // indicates when the next such action should be taken.
   virtual void prepare_for_compaction(CompactPoint* cp) = 0;
   // MarkSweep support phase3
-  virtual void adjust_pointers();
+  void adjust_pointers() override;
   // MarkSweep support phase4
   virtual void compact();
 #endif // INCLUDE_SERIALGC
@@ -438,8 +438,8 @@ class ContiguousSpace: public CompactibleSpace {
   ContiguousSpace();
   ~ContiguousSpace();
 
-  virtual void initialize(MemRegion mr, bool clear_space, bool mangle_space);
-  virtual void clear(bool mangle_space);
+  void initialize(MemRegion mr, bool clear_space, bool mangle_space) override;
+  void clear(bool mangle_space) override;
 
   // Accessors
   HeapWord* top() const            { return _top;    }
@@ -460,9 +460,9 @@ class ContiguousSpace: public CompactibleSpace {
 
   // Mangle regions in the space from the current top up to the
   // previously mangled part of the space.
-  void mangle_unused_area() PRODUCT_RETURN;
+  void mangle_unused_area() override PRODUCT_RETURN;
   // Mangle [top, end)
-  void mangle_unused_area_complete() PRODUCT_RETURN;
+  void mangle_unused_area_complete() override PRODUCT_RETURN;
 
   // Do some sparse checking on the area that should have been mangled.
   void check_mangled_unused_area(HeapWord* limit) PRODUCT_RETURN;
@@ -472,25 +472,25 @@ class ContiguousSpace: public CompactibleSpace {
 
   // Size computations: sizes in bytes.
   size_t capacity() const        { return byte_size(bottom(), end()); }
-  size_t used() const            { return byte_size(bottom(), top()); }
-  size_t free() const            { return byte_size(top(),    end()); }
+  size_t used() const override            { return byte_size(bottom(), top()); }
+  size_t free() const override            { return byte_size(top(),    end()); }
 
-  virtual bool is_free_block(const HeapWord* p) const;
+  bool is_free_block(const HeapWord* p) const override;
 
   // In a contiguous space we have a more obvious bound on what parts
   // contain objects.
-  MemRegion used_region() const { return MemRegion(bottom(), top()); }
+  MemRegion used_region() const override { return MemRegion(bottom(), top()); }
 
   // Allocation (return NULL if full)
-  virtual HeapWord* allocate(size_t word_size);
-  virtual HeapWord* par_allocate(size_t word_size);
+  HeapWord* allocate(size_t word_size) override;
+  HeapWord* par_allocate(size_t word_size) override;
 
   // Iteration
-  void oop_iterate(OopIterateClosure* cl);
-  void object_iterate(ObjectClosure* blk);
+  void oop_iterate(OopIterateClosure* cl) override;
+  void object_iterate(ObjectClosure* blk) override;
 
   // Compaction support
-  virtual void reset_after_compaction() {
+  void reset_after_compaction() override {
     assert(compaction_top() >= bottom() && compaction_top() <= end(), "should point inside space");
     set_top(compaction_top());
   }
@@ -498,7 +498,7 @@ class ContiguousSpace: public CompactibleSpace {
   // Override.
   DirtyCardToOopClosure* new_dcto_cl(OopIterateClosure* cl,
                                      CardTable::PrecisionStyle precision,
-                                     HeapWord* boundary);
+                                     HeapWord* boundary) override;
 
   // Apply "blk->do_oop" to the addresses of all reference fields in objects
   // starting with the _saved_mark_word, which was noted during a generation's
@@ -516,10 +516,10 @@ class ContiguousSpace: public CompactibleSpace {
   virtual void object_iterate_from(HeapWord* mark, ObjectClosure* blk);
 
   // Very inefficient implementation.
-  virtual HeapWord* block_start_const(const void* p) const;
-  size_t block_size(const HeapWord* p) const;
+  HeapWord* block_start_const(const void* p) const override;
+  size_t block_size(const HeapWord* p) const override;
   // If a block is in the allocated area, it is an object.
-  bool block_is_obj(const HeapWord* p) const { return p < top(); }
+  bool block_is_obj(const HeapWord* p) const override { return p < top(); }
 
   // Addresses for inlined allocation
   HeapWord** top_addr() { return &_top; }
@@ -527,18 +527,18 @@ class ContiguousSpace: public CompactibleSpace {
 
 #if INCLUDE_SERIALGC
   // Overrides for more efficient compaction support.
-  void prepare_for_compaction(CompactPoint* cp);
+  void prepare_for_compaction(CompactPoint* cp) override;
 #endif
 
-  virtual void print_on(outputStream* st) const;
+  void print_on(outputStream* st) const override;
 
   // Checked dynamic downcasts.
-  virtual ContiguousSpace* toContiguousSpace() {
+  ContiguousSpace* toContiguousSpace() override {
     return this;
   }
 
   // Debugging
-  virtual void verify() const;
+  void verify() const override;
 };
 
 // A dirty card to oop closure for contiguous spaces (ContiguousSpace and
@@ -554,9 +554,9 @@ class ContiguousSpace: public CompactibleSpace {
 class ContiguousSpaceDCTOC : public DirtyCardToOopClosure {
   // Overrides.
   void walk_mem_region(MemRegion mr,
-                       HeapWord* bottom, HeapWord* top);
+                       HeapWord* bottom, HeapWord* top) override;
 
-  HeapWord* get_actual_top(HeapWord* top, HeapWord* top_obj);
+  HeapWord* get_actual_top(HeapWord* top, HeapWord* top_obj) override;
 
   // Walk the given memory region, from bottom to top, applying
   // the given oop closure to (possibly) all objects found. The
@@ -597,25 +597,25 @@ class OffsetTableContigSpace: public ContiguousSpace {
   OffsetTableContigSpace(BlockOffsetSharedArray* sharedOffsetArray,
                          MemRegion mr);
 
-  void set_bottom(HeapWord* value);
-  void set_end(HeapWord* value);
+  void set_bottom(HeapWord* value) override;
+  void set_end(HeapWord* value) override;
 
-  void clear(bool mangle_space);
+  void clear(bool mangle_space) override;
 
-  inline HeapWord* block_start_const(const void* p) const;
+  inline HeapWord* block_start_const(const void* p) const override;
 
   // Add offset table update.
-  virtual inline HeapWord* allocate(size_t word_size);
-  inline HeapWord* par_allocate(size_t word_size);
+  inline HeapWord* allocate(size_t word_size) override;
+  inline HeapWord* par_allocate(size_t word_size) override;
 
   // MarkSweep support phase3
-  virtual void initialize_threshold();
-  virtual void alloc_block(HeapWord* start, HeapWord* end);
+  void initialize_threshold() override;
+  void alloc_block(HeapWord* start, HeapWord* end) override;
 
-  virtual void print_on(outputStream* st) const;
+  void print_on(outputStream* st) const override;
 
   // Debugging
-  void verify() const;
+  void verify() const override;
 };
 
 
@@ -625,7 +625,7 @@ class TenuredSpace: public OffsetTableContigSpace {
   friend class VMStructs;
  protected:
   // Mark sweep support
-  size_t allowed_dead_ratio() const;
+  size_t allowed_dead_ratio() const override;
  public:
   // Constructor
   TenuredSpace(BlockOffsetSharedArray* sharedOffsetArray,

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -472,8 +472,8 @@ class ContiguousSpace: public CompactibleSpace {
 
   // Size computations: sizes in bytes.
   size_t capacity() const        { return byte_size(bottom(), end()); }
-  size_t used() const override            { return byte_size(bottom(), top()); }
-  size_t free() const override            { return byte_size(top(),    end()); }
+  size_t used() const override   { return byte_size(bottom(), top()); }
+  size_t free() const override   { return byte_size(top(),    end()); }
 
   bool is_free_block(const HeapWord* p) const override;
 


### PR DESCRIPTION
Simple patch generated using `clang-tidy`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297941](https://bugs.openjdk.org/browse/JDK-8297941): Add override modifier in space.hpp


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to [1aafddfb](https://git.openjdk.org/jdk/pull/11451/files/1aafddfb23f6dc2bfe4d4f15f45e6c6f4a5786b0)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11451/head:pull/11451` \
`$ git checkout pull/11451`

Update a local copy of the PR: \
`$ git checkout pull/11451` \
`$ git pull https://git.openjdk.org/jdk pull/11451/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11451`

View PR using the GUI difftool: \
`$ git pr show -t 11451`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11451.diff">https://git.openjdk.org/jdk/pull/11451.diff</a>

</details>
