### PR TITLE
8297953: Fix several C2 IR matching tests for RISC-V

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/RotateLeftNodeIntIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/RotateLeftNodeIntIdealizationTests.java
@@ -31,7 +31,7 @@ import compiler.lib.ir_framework.*;
  * @summary Test that Ideal transformations of RotateLeftNode* are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.RotateLeftNodeIntIdealizationTests
- * @requires os.arch == "x86_64" | os.arch == "aarch64" | os.arch == "riscv64"
+ * @requires os.arch == "x86_64" | os.arch == "aarch64" | (os.arch == "riscv64" & vm.opt.UseZbb == true)
  */
 public class RotateLeftNodeIntIdealizationTests {
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/RotateLeftNodeLongIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/RotateLeftNodeLongIdealizationTests.java
@@ -31,7 +31,7 @@ import compiler.lib.ir_framework.*;
  * @summary Test that Ideal transformations of RotateLeftNode* are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.RotateLeftNodeLongIdealizationTests
- * @requires os.arch == "x86_64" | os.arch == "aarch64" | os.arch == "riscv64"
+ * @requires os.arch == "x86_64" | os.arch == "aarch64" | (os.arch == "riscv64" & vm.opt.UseZbb == true)
  */
 public class RotateLeftNodeLongIdealizationTests {
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestFPComparison.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestFPComparison.java
@@ -31,6 +31,7 @@ import jdk.test.lib.Asserts;
  * @summary Test that code generation for fp comparison works as intended
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestFPComparison
+ * @requires os.arch != "riscv64"
  */
 public class TestFPComparison {
     static final double[] DOUBLES = new double[] {

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -139,6 +139,7 @@ public class TestFramework {
                     "UseAVX",
                     "UseSSE",
                     "UseSVE",
+                    "UseZbb",
                     "Xlog",
                     "LogCompilation"
             )


### PR DESCRIPTION
Fix several IR matching tests that failed on RISC-V.

Rotate Node will be matched only when UseZbb is enabled:
- test/hotspot/jtreg/compiler/c2/irTests/RotateLeftNodeIntIdealizationTests.java
- test/hotspot/jtreg/compiler/c2/irTests/RotateLeftNodeLongIdealizationTests.java

RISC-V does not provide float branch instruction, so we do not match CMOVEI for two floating-point comparisons:
- test/hotspot/jtreg/compiler/c2/irTests/TestFPComparison.java

Testing:
- test/hotspot/jtreg/compiler/c2/irTests/TestFPComparison.java -- no tests selected as expected.

- With `-XX:+UseZbb`:
  - test/hotspot/jtreg/compiler/c2/irTests/RotateLeftNodeIntIdealizationTests.java -- passed
  - test/hotspot/jtreg/compiler/c2/irTests/RotateLeftNodeLongIdealizationTests.java -- passed

- With `-XX:-UseZbb`:
  - test/hotspot/jtreg/compiler/c2/irTests/RotateLeftNodeIntIdealizationTests.java -- no tests selected as expected
  - test/hotspot/jtreg/compiler/c2/irTests/RotateLeftNodeLongIdealizationTests.java -- no tests selected as expected

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297953](https://bugs.openjdk.org/browse/JDK-8297953): Fix several C2 IR matching tests for RISC-V


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11453/head:pull/11453` \
`$ git checkout pull/11453`

Update a local copy of the PR: \
`$ git checkout pull/11453` \
`$ git pull https://git.openjdk.org/jdk pull/11453/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11453`

View PR using the GUI difftool: \
`$ git pr show -t 11453`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11453.diff">https://git.openjdk.org/jdk/pull/11453.diff</a>

</details>
