### PR TITLE
8296084: javax/swing/JSpinner/4788637/bug4788637.java fails intermittently on a VM

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -649,7 +649,6 @@ javax/swing/JWindow/ShapedAndTranslucentWindows/TranslucentJComboBox.java 802462
 # The next test below is an intermittent failure
 javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all
 javax/swing/JTree/4633594/JTreeFocusTest.java 7105441 macosx-all
-javax/swing/JSpinner/4788637/bug4788637.java 8296084 linux-all
 javax/swing/AbstractButton/6711682/bug6711682.java 8060765 windows-all,macosx-all
 javax/swing/JFileChooser/6396844/TwentyThousandTest.java 8198003 generic-all
 javax/swing/JPopupMenu/6800513/bug6800513.java 7184956 macosx-all


### PR DESCRIPTION
Test seems to fail intermittently in ubuntu OCI VM although it passes locally and in other physical system. 
Although I am not able to reproduce it on VM, tried some robot safeguards used in other tests.
Modified tests passed several iterations in couple of OCI VM hosts and other physical systems , link of whose jobs are in JBS
so we can deproblemlist it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296084](https://bugs.openjdk.org/browse/JDK-8296084): javax/swing/JSpinner/4788637/bug4788637.java fails intermittently on a VM


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11455/head:pull/11455` \
`$ git checkout pull/11455`

Update a local copy of the PR: \
`$ git checkout pull/11455` \
`$ git pull https://git.openjdk.org/jdk pull/11455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11455`

View PR using the GUI difftool: \
`$ git pr show -t 11455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11455.diff">https://git.openjdk.org/jdk/pull/11455.diff</a>

</details>
