### PR TITLE
JDK-8297968: Crash in PrintOptoAssembly

### DIFF
--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -276,6 +276,7 @@ void Matcher::match( ) {
     // Permit args to have no register
     _calling_convention_mask[i].Clear();
     if( !vm_parm_regs[i].first()->is_valid() && !vm_parm_regs[i].second()->is_valid() ) {
+      _parm_regs[i].set_bad();
       continue;
     }
     // calling_convention returns stack arguments as a count of


### PR DESCRIPTION
If PrintOptoAssembly is used in an optimized build, we have a crash in `PhaseChaitin::dump_frame()` due to reading from uninitialized memory in the _parm_regs array. The fix is trivial.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297968](https://bugs.openjdk.org/browse/JDK-8297968): Crash in PrintOptoAssembly


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11460/head:pull/11460` \
`$ git checkout pull/11460`

Update a local copy of the PR: \
`$ git checkout pull/11460` \
`$ git pull https://git.openjdk.org/jdk pull/11460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11460`

View PR using the GUI difftool: \
`$ git pr show -t 11460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11460.diff">https://git.openjdk.org/jdk/pull/11460.diff</a>

</details>
