### PR TITLE
8297967: Make frame::safe_for_sender safer

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -135,7 +135,6 @@ bool frame::safe_for_sender(JavaThread *thread) {
       }
       // check that the accessed stack slots are safe too
       if (SafeFetchN(this->fp() + return_addr_offset, 0) == 0 ||
-          SafeFetchN(this->fp() + sender_sp_offset, 0) == 0 ||
           SafeFetchN(this->fp() + interpreter_frame_sender_sp_offset, 0) == 0 ||
           SafeFetchN(this->fp() + link_offset, 0) == 0
          ) return false;

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -133,6 +133,12 @@ bool frame::safe_for_sender(JavaThread *thread) {
       if (!fp_safe) {
         return false;
       }
+      // check that the accessed stack slots are safe too
+      if (SafeFetchN(this->fp() + return_addr_offset, 0) == 0 ||
+          SafeFetchN(this->fp() + sender_sp_offset, 0) == 0 ||
+          SafeFetchN(this->fp() + interpreter_frame_sender_sp_offset, 0) == 0 ||
+          SafeFetchN(this->fp() + link_offset, 0) == 0
+         ) return false;
 
       // for interpreted frames, the value below is the sender "raw" sp,
       // which can be different from the sender unextended sp (the sp seen

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -37,6 +37,7 @@
 #include "runtime/javaCalls.hpp"
 #include "runtime/monitorChunk.hpp"
 #include "runtime/os.inline.hpp"
+#include "runtime/safefetch.hpp"
 #include "runtime/signature.hpp"
 #include "runtime/stackWatermarkSet.hpp"
 #include "runtime/stubCodeGenerator.hpp"
@@ -262,10 +263,9 @@ bool frame::safe_for_sender(JavaThread *thread) {
     return false;
   }
 
-  // Will the pc we fetch be non-zero (which we'll find at the oldest frame)
+  // Will the pc we fetch be non-zero (which we'll find at the oldest frame) and readable
 
-  if ( (address) this->fp()[return_addr_offset] == NULL) return false;
-
+  if (SafeFetchN(this->fp() + return_addr_offset, 0) == 0) return false;
 
   // could try and do some more potential verification of native frame if we could think of some...
 

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -268,9 +268,9 @@ bool frame::safe_for_sender(JavaThread *thread) {
     return false;
   }
 
-  // Will the pc we fetch be non-zero (which we'll find at the oldest frame) and readable
+  // Will the pc we fetch be non-zero (which we'll find at the oldest frame)
 
-  if (SafeFetchN(this->fp() + return_addr_offset, 0) == 0) return false;
+  if ((address) this->fp()[return_addr_offset] == NULL) return false;
 
   // could try and do some more potential verification of native frame if we could think of some...
 

--- a/src/hotspot/cpu/arm/frame_arm.cpp
+++ b/src/hotspot/cpu/arm/frame_arm.cpp
@@ -107,7 +107,6 @@ bool frame::safe_for_sender(JavaThread *thread) {
       }
       // check that the accessed stack slots are safe too
       if (SafeFetchN(this->fp() + return_addr_offset, 0) == 0 ||
-          SafeFetchN(this->fp() + sender_sp_offset, 0) == 0 ||
           SafeFetchN(this->fp() + interpreter_frame_sender_sp_offset, 0) == 0 ||
           SafeFetchN(this->fp() + link_offset, 0) == 0
          ) return false;

--- a/src/hotspot/cpu/arm/frame_arm.cpp
+++ b/src/hotspot/cpu/arm/frame_arm.cpp
@@ -105,6 +105,12 @@ bool frame::safe_for_sender(JavaThread *thread) {
       if (!fp_safe) {
         return false;
       }
+      // check that the accessed stack slots are safe too
+      if (SafeFetchN(this->fp() + return_addr_offset, 0) == 0 ||
+          SafeFetchN(this->fp() + sender_sp_offset, 0) == 0 ||
+          SafeFetchN(this->fp() + interpreter_frame_sender_sp_offset, 0) == 0 ||
+          SafeFetchN(this->fp() + link_offset, 0) == 0
+         ) return false;
 
       sender_pc = (address) this->fp()[return_addr_offset];
       sender_sp = (intptr_t*) addr_at(sender_sp_offset);

--- a/src/hotspot/cpu/arm/frame_arm.cpp
+++ b/src/hotspot/cpu/arm/frame_arm.cpp
@@ -214,9 +214,9 @@ bool frame::safe_for_sender(JavaThread *thread) {
     return false;
   }
 
-  // Will the pc we fetch be non-zero (which we'll find at the oldest frame) and readable?
+  // Will the pc we fetch be non-zero (which we'll find at the oldest frame)
 
-  if (SafeFetchN(this->fp() + return_addr_offset, 0) == 0) return false;
+  if ((address) this->fp()[return_addr_offset] == NULL) return false;
 
   // could try and do some more potential verification of native frame if we could think of some...
 

--- a/src/hotspot/cpu/arm/frame_arm.cpp
+++ b/src/hotspot/cpu/arm/frame_arm.cpp
@@ -36,6 +36,7 @@
 #include "runtime/javaCalls.hpp"
 #include "runtime/monitorChunk.hpp"
 #include "runtime/os.inline.hpp"
+#include "runtime/safefetch.hpp"
 #include "runtime/signature.hpp"
 #include "runtime/stubCodeGenerator.hpp"
 #include "runtime/stubRoutines.hpp"
@@ -208,10 +209,9 @@ bool frame::safe_for_sender(JavaThread *thread) {
     return false;
   }
 
-  // Will the pc we fetch be non-zero (which we'll find at the oldest frame)
+  // Will the pc we fetch be non-zero (which we'll find at the oldest frame) and readable?
 
-  if ((address) this->fp()[return_addr_offset] == nullptr) return false;
-
+  if (SafeFetchN(this->fp() + return_addr_offset, 0) == 0) return false;
 
   // could try and do some more potential verification of native frame if we could think of some...
 

--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -130,6 +130,12 @@ bool frame::safe_for_sender(JavaThread *thread) {
       if (!fp_safe) {
         return false;
       }
+      // check that the accessed stack slots are safe too
+      if (SafeFetchN(this->fp() + return_addr_offset, 0) == 0 ||
+          SafeFetchN(this->fp() + sender_sp_offset, 0) == 0 ||
+          SafeFetchN(this->fp() + interpreter_frame_sender_sp_offset, 0) == 0 ||
+          SafeFetchN(this->fp() + link_offset, 0) == 0
+         ) return false;
 
       sender_pc = (address)this->fp()[return_addr_offset];
       // for interpreted frames, the value below is the sender "raw" sp,

--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -132,7 +132,6 @@ bool frame::safe_for_sender(JavaThread *thread) {
       }
       // check that the accessed stack slots are safe too
       if (SafeFetchN(this->fp() + return_addr_offset, 0) == 0 ||
-          SafeFetchN(this->fp() + sender_sp_offset, 0) == 0 ||
           SafeFetchN(this->fp() + interpreter_frame_sender_sp_offset, 0) == 0 ||
           SafeFetchN(this->fp() + link_offset, 0) == 0
          ) return false;

--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -38,6 +38,7 @@
 #include "runtime/javaCalls.hpp"
 #include "runtime/monitorChunk.hpp"
 #include "runtime/os.inline.hpp"
+#include "runtime/safefetch.hpp"
 #include "runtime/signature.hpp"
 #include "runtime/stackWatermarkSet.hpp"
 #include "runtime/stubCodeGenerator.hpp"
@@ -249,8 +250,9 @@ bool frame::safe_for_sender(JavaThread *thread) {
     return false;
   }
 
-  // Will the pc we fetch be non-zero (which we'll find at the oldest frame)
-  if ((address)this->fp()[return_addr_offset] == nullptr) { return false; }
+  // Will the pc we fetch be non-zero (which we'll find at the oldest frame) and readable?
+
+  if (SafeFetchN(this->fp() + return_addr_offset, 0) == 0) return false;
 
   return true;
 }

--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -255,9 +255,9 @@ bool frame::safe_for_sender(JavaThread *thread) {
     return false;
   }
 
-  // Will the pc we fetch be non-zero (which we'll find at the oldest frame) and readable?
+  // Will the pc we fetch be non-zero (which we'll find at the oldest frame)
 
-  if (SafeFetchN(this->fp() + return_addr_offset, 0) == 0) return false;
+  if ((address) this->fp()[return_addr_offset] == NULL) return false;
 
   return true;
 }

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -36,6 +36,7 @@
 #include "runtime/handles.inline.hpp"
 #include "runtime/javaCalls.hpp"
 #include "runtime/monitorChunk.hpp"
+#include "runtime/safefetch.hpp"
 #include "runtime/signature.hpp"
 #include "runtime/stackWatermarkSet.hpp"
 #include "runtime/stubCodeGenerator.hpp"
@@ -254,9 +255,9 @@ bool frame::safe_for_sender(JavaThread *thread) {
     return false;
   }
 
-  // Will the pc we fetch be non-zero (which we'll find at the oldest frame)
+  // Will the pc we fetch be non-zero (which we'll find at the oldest frame) and readable?
 
-  if ( (address) this->fp()[return_addr_offset] == nullptr) return false;
+  if (SafeFetchN(this->fp() + return_addr_offset, 0) == 0) return false;
 
 
   // could try and do some more potential verification of native frame if we could think of some...

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -124,6 +124,12 @@ bool frame::safe_for_sender(JavaThread *thread) {
       if (!fp_safe) {
         return false;
       }
+      // check that the accessed stack slots are safe too
+      if (SafeFetchN(this->fp() + return_addr_offset, 0) == 0 ||
+          SafeFetchN(this->fp() + sender_sp_offset, 0) == 0 ||
+          SafeFetchN(this->fp() + interpreter_frame_sender_sp_offset, 0) == 0 ||
+          SafeFetchN(this->fp() + link_offset, 0) == 0
+         ) return false;
 
       sender_pc = (address) this->fp()[return_addr_offset];
       // for interpreted frames, the value below is the sender "raw" sp,

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -260,9 +260,9 @@ bool frame::safe_for_sender(JavaThread *thread) {
     return false;
   }
 
-  // Will the pc we fetch be non-zero (which we'll find at the oldest frame) and readable?
+  // Will the pc we fetch be non-zero (which we'll find at the oldest frame)
 
-  if (SafeFetchN(this->fp() + return_addr_offset, 0) == 0) return false;
+  if ((address) this->fp()[return_addr_offset] == NULL) return false;
 
 
   // could try and do some more potential verification of native frame if we could think of some...

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -126,7 +126,6 @@ bool frame::safe_for_sender(JavaThread *thread) {
       }
       // check that the accessed stack slots are safe too
       if (SafeFetchN(this->fp() + return_addr_offset, 0) == 0 ||
-          SafeFetchN(this->fp() + sender_sp_offset, 0) == 0 ||
           SafeFetchN(this->fp() + interpreter_frame_sender_sp_offset, 0) == 0 ||
           SafeFetchN(this->fp() + link_offset, 0) == 0
          ) return false;


### PR DESCRIPTION
Makes `frame::safe_for_sender` safer by checking that the location of the return address, sender stack pointer, and link address is accessible. This makes the method safer in the case of broken frames.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Too few reviewers with at least role reviewer found (have 0, need at least 1) (failed with the updated jcheck configuration)

### Issue
 * [JDK-8297967](https://bugs.openjdk.org/browse/JDK-8297967): Make frame::safe_for_sender safer (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/11461/head:pull/11461` \
`$ git checkout pull/11461`

Update a local copy of the PR: \
`$ git checkout pull/11461` \
`$ git pull https://git.openjdk.org/jdk.git pull/11461/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11461`

View PR using the GUI difftool: \
`$ git pr show -t 11461`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11461.diff">https://git.openjdk.org/jdk/pull/11461.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/11461#issuecomment-1334067777)