### PR TITLE
JDK-8266245: AWT Test FullScreenInsets.java fails due to incorrect pixel color and wrong window bounds

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -180,7 +180,6 @@ java/awt/Toolkit/RealSync/Test.java 6849383 linux-all
 java/awt/LightweightComponent/LightweightEventTest/LightweightEventTest.java 8159252 windows-all
 java/awt/EventDispatchThread/HandleExceptionOnEDT/HandleExceptionOnEDT.java 8072110 macosx-all
 java/awt/EventDispatchThread/LoopRobustness/LoopRobustness.java 8073636 macosx-all
-java/awt/FullScreen/FullScreenInsets/FullScreenInsets.java 7019055,8266245 windows-all,linux-all,macosx-all
 java/awt/Focus/8013611/JDK8013611.java 8175366 windows-all,macosx-all
 java/awt/Focus/6981400/Test1.java 8029675 windows-all,macosx-all
 java/awt/Focus/6981400/Test3.java 8173264 generic-all


### PR DESCRIPTION
The above test was failing due to incorrect pixel color and wrong window bounds on Mac-ARM, Windows and Linux platforms.

The following changes have been made:
- Correct window bounds are obtained using the current ScreenDevice's DefaultConfig bounds (this test checks FullScreen functionality on multiple screen devices).
- Color tolerance has been added for color check
- Instead of scanning the full screen to check pixel color, vertical and horizontal scans are done at the far right and bottom end to ensure that window is in full screen mode w.r.t to screen device and the window bounds are as expected.

CI testing passes on all platforms (tested 50 times per platform).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266245](https://bugs.openjdk.org/browse/JDK-8266245): AWT Test FullScreenInsets.java fails due to incorrect pixel color and wrong window bounds


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/11462/head:pull/11462` \
`$ git checkout pull/11462`

Update a local copy of the PR: \
`$ git checkout pull/11462` \
`$ git pull https://git.openjdk.org/jdk.git pull/11462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11462`

View PR using the GUI difftool: \
`$ git pr show -t 11462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11462.diff">https://git.openjdk.org/jdk/pull/11462.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/11462#issuecomment-1334160624)