### PR TITLE
8297984: Turn on warnings as errors for javadoc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,7 +149,9 @@ jobs:
       # Some multilib libraries do not have proper inter-dependencies, so we have to
       # install their dependencies manually.
       apt-extra-packages: 'libfreetype6-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386 libc6-i386'
-      extra-conf-options: '--with-target-bits=32'
+      # Let linux-x86 double as the platform which also builds docs
+      make-target: 'product-bundles test-bundles docs-bundles'
+      extra-conf-options: '--with-target-bits=32 --enable-full-docs'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-x86 == 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ on:
       platforms:
         description: 'Platform(s) to execute on (comma separated, e.g. "linux-x64, macos, aarch64")'
         required: true
-        default: 'linux-x64, linux-x86, linux-x64-variants, linux-cross-compile, macos-x64, macos-aarch64, windows-x64, windows-aarch64'
+        default: 'linux-x64, linux-x86, linux-x64-variants, linux-cross-compile, macos-x64, macos-aarch64, windows-x64, windows-aarch64, docs'
       configure-arguments:
         description: 'Additional configure arguments'
         required: false
@@ -65,6 +65,7 @@ jobs:
       macos-aarch64: ${{ steps.include.outputs.macos-aarch64 }}
       windows-x64: ${{ steps.include.outputs.windows-x64 }}
       windows-aarch64: ${{ steps.include.outputs.windows-aarch64 }}
+      docs: ${{ steps.include.outputs.docs }}
 
     steps:
         # This function must be inlined in main.yml, or we'd be forced to checkout the repo
@@ -118,6 +119,7 @@ jobs:
           echo "macos-aarch64=$(check_platform macos-aarch64 macos aarch64)" >> $GITHUB_OUTPUT
           echo "windows-x64=$(check_platform windows-x64 windows x64)" >> $GITHUB_OUTPUT
           echo "windows-aarch64=$(check_platform windows-aarch64 windows aarch64)" >> $GITHUB_OUTPUT
+          echo "docs=$(check_platform docs)" >> $GITHUB_OUTPUT
 
   ###
   ### Build jobs
@@ -149,9 +151,7 @@ jobs:
       # Some multilib libraries do not have proper inter-dependencies, so we have to
       # install their dependencies manually.
       apt-extra-packages: 'libfreetype6-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386 libc6-i386'
-      # Let linux-x86 double as the platform which also builds docs
-      make-target: 'product-bundles test-bundles docs-bundles'
-      extra-conf-options: '--with-target-bits=32 --enable-full-docs'
+      extra-conf-options: '--with-target-bits=32'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-x86 == 'true'
@@ -279,6 +279,22 @@ jobs:
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.windows-aarch64 == 'true'
+
+  build-docs:
+    name: docs
+    needs: select
+    uses: ./.github/workflows/build-linux.yml
+    with:
+      platform: linux-x64
+      debug-levels: '[ "release" ]'
+      make-target: 'docs-jdk-bundles'
+      # Creating full docs require us to build the entire JDK (for the module graphs)
+      extra-conf-options: '--disable-full-docs'
+      gcc-major-version: '10'
+      apt-gcc-version: '10.4.0-4ubuntu1~22.04'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
+    if: needs.select.outputs.docs == 'true'
 
   ###
   ### Test jobs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -286,7 +286,7 @@ jobs:
     uses: ./.github/workflows/build-linux.yml
     with:
       platform: linux-x64
-      debug-levels: '[ "release" ]'
+      debug-levels: '[ "debug" ]'
       make-target: 'docs-jdk-bundles'
       # Creating full docs require us to build the entire JDK (for the module graphs)
       extra-conf-options: '--disable-full-docs'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -288,7 +288,8 @@ jobs:
       platform: linux-x64
       debug-levels: '[ "debug" ]'
       make-target: 'docs-jdk-bundles'
-      # Creating full docs require us to build the entire JDK (for the module graphs)
+      # Make sure we never try to make full docs, since that would require a
+      # build JDK, and we do not need the additional testing of the graphs.
       extra-conf-options: '--disable-full-docs'
       gcc-major-version: '10'
       apt-gcc-version: '10.4.0-4ubuntu1~22.04'

--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -102,6 +102,10 @@ REFERENCE_TAGS := $(JAVADOC_TAGS)
 JAVADOC_DISABLED_DOCLINT_WARNINGS := missing
 JAVADOC_DISABLED_DOCLINT_PACKAGES := org.w3c.* javax.smartcardio
 
+# Allow overriding on the command line
+# (intentionally sharing name with the javac option)
+JAVA_WARNINGS_ARE_ERRORS ?= -Werror
+
 # The initial set of options for javadoc
 JAVADOC_OPTIONS := -use -keywords -notimestamp \
     -encoding ISO-8859-1 -docencoding UTF-8 -breakiterator \
@@ -333,6 +337,7 @@ define SetupApiDocsGenerationBody
   # Ignore the doclint warnings in certain packages
   $1_OPTIONS += -Xdoclint/package:$$(call CommaList, $$(addprefix -, \
       $$(JAVADOC_DISABLED_DOCLINT_PACKAGES)))
+  $1_OPTIONS += $$(JAVA_WARNINGS_ARE_ERRORS)
 
   $1_DOC_TITLE := $$($1_LONG_NAME)<br>Version $$(VERSION_SPECIFICATION) API \
       Specification

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
@@ -394,7 +394,7 @@ public final class RecordingStream implements AutoCloseable, EventStream {
      * The following code snippet illustrates how this method can be used in
      * conjunction with the {@link #startAsync()} method to monitor what happens
      * during a test method:
-     * <p>
+     *
      * {@snippet class="Snippets" region="RecordingStreamStop"}
      *
      * @return {@code true} if recording is stopped, {@code false} otherwise


### PR DESCRIPTION
For some reason, we never turned on `-Werror` for javadoc. It is high time to do so.

This PR also fixes a recent issue with the javadoc in JFR that caused a warning, and enables building of javadoc on GHA. (It takes about 3 minutes, as a separate build job.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297984](https://bugs.openjdk.org/browse/JDK-8297984): Turn on warnings as errors for javadoc


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to [20bc7222](https://git.openjdk.org/jdk/pull/11468/files/20bc7222a54a239a83ea7c514a83671ad9d6c378)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [20bc7222](https://git.openjdk.org/jdk/pull/11468/files/20bc7222a54a239a83ea7c514a83671ad9d6c378)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11468/head:pull/11468` \
`$ git checkout pull/11468`

Update a local copy of the PR: \
`$ git checkout pull/11468` \
`$ git pull https://git.openjdk.org/jdk pull/11468/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11468`

View PR using the GUI difftool: \
`$ git pr show -t 11468`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11468.diff">https://git.openjdk.org/jdk/pull/11468.diff</a>

</details>
