### PR TITLE
8297992: Tests fail after JDK-8297215 due to lack of @enablePreview

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/HoldsLock.java
+++ b/test/jdk/java/lang/Thread/virtual/HoldsLock.java
@@ -35,6 +35,7 @@
  * @summary Test Thread.holdsLock when lock held by carrier thread
  * @requires vm.continuations & vm.debug
  * @modules java.base/java.lang:+open
+ * @enablePreview
  * @run testng/othervm -XX:+UseHeavyMonitors HoldsLock
  */
 

--- a/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALot.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALot.java
@@ -35,6 +35,7 @@
  * @test
  * @requires vm.debug == true & vm.continuations
  * @modules java.base/java.lang:+open
+ * @enablePreview
  * @compile GetStackTraceALot.java ../ThreadBuilders.java
  * @run main/timeout=300 GetStackTraceALot 1000
  */

--- a/test/jdk/jdk/internal/vm/Continuation/Basic.java
+++ b/test/jdk/jdk/internal/vm/Continuation/Basic.java
@@ -47,6 +47,7 @@
 * @modules java.base/jdk.internal.vm
 * @build java.base/java.lang.StackWalkerHelper
 *
+* @enablePreview
 * @run testng/othervm -XX:+VerifyStack -Xint Basic
 * @run testng/othervm -XX:+VerifyStack -Xcomp -XX:TieredStopAtLevel=3 -XX:CompileOnly=jdk/internal/vm/Continuation,Basic Basic
 * @run testng/othervm -XX:+VerifyStack -Xcomp -XX:-TieredCompilation -XX:CompileOnly=jdk/internal/vm/Continuation,Basic Basic


### PR DESCRIPTION
Hi all,

The following 3 tests fail with debug VMs due to lack of @enablePreview after JDK-8297215.

```
* jtreg:test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALot.java
* jtreg:test/jdk/java/lang/Thread/virtual/HoldsLock.java
* jtreg:test/jdk/jdk/internal/vm/Continuation/Basic.java
```

Let's fix them.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297992](https://bugs.openjdk.org/browse/JDK-8297992): Tests fail after JDK-8297215 due to lack of @enablePreview


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11469/head:pull/11469` \
`$ git checkout pull/11469`

Update a local copy of the PR: \
`$ git checkout pull/11469` \
`$ git pull https://git.openjdk.org/jdk pull/11469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11469`

View PR using the GUI difftool: \
`$ git pr show -t 11469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11469.diff">https://git.openjdk.org/jdk/pull/11469.diff</a>

</details>
