### PR TITLE
4677581: ColorModel.getComponentSize()-wrong conditions for ArrayIndexOutOfBoundsExceptio

### DIFF
--- a/src/java.desktop/share/classes/java/awt/image/ColorModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/ColorModel.java
@@ -465,9 +465,8 @@ public abstract class ColorModel implements Transparency{
      * @param componentIdx the index of the color/alpha component
      * @return the number of bits for the color/alpha component at the
      *          specified index.
-     * @throws ArrayIndexOutOfBoundsException if {@code componentIdx}
-     *         is greater than the number of components or
-     *         less than zero
+     * @throws ArrayIndexOutOfBoundsException if {@code componentIdx} is greater
+     *         than or equal to the number of components or less than zero
      * @throws NullPointerException if the number of bits array is
      *         {@code null}
      */

--- a/test/jdk/java/awt/image/ColorModel/GetComponentSizeAIOBE.java
+++ b/test/jdk/java/awt/image/ColorModel/GetComponentSizeAIOBE.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.image.ColorModel;
+
+/**
+ * @test
+ * @bug 4677581
+ * @summary checks when the ColorModel#getComponentSize() throws AIOBE
+ */
+public final class GetComponentSizeAIOBE {
+
+    public static void main(String[] args) {
+        ColorModel cm = ColorModel.getRGBdefault();
+        for (int i = 0; i < cm.getNumComponents(); ++i) {
+            cm.getComponentSize(i);
+        }
+
+        testAIOBE(cm, Integer.MIN_VALUE);
+        testAIOBE(cm, -1);
+        testAIOBE(cm, cm.getNumComponents());
+        testAIOBE(cm, cm.getNumComponents() + 1);
+        testAIOBE(cm, Integer.MAX_VALUE);
+    }
+
+    private static void testAIOBE(ColorModel cm, int componentIdx) {
+        try {
+            cm.getComponentSize(componentIdx);
+            throw new RuntimeException("AIOBE is not thrown");
+        } catch (ArrayIndexOutOfBoundsException ignore) {
+            // expected
+        }
+    }
+}


### PR DESCRIPTION
The specification for `java.awt.image.ColorModel#getComponentSize(int)` states that an ArrayIndexOutOfBoundsException is thrown "if componentIdx is greater than the number of components or less than zero". The condition should actually be "if componentIdx is greater than OR EQUAL TO the number of components or less than zero."

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-4677581](https://bugs.openjdk.org/browse/JDK-4677581): ColorModel.getComponentSize()-wrong conditions for ArrayIndexOutOfBoundsExceptio
 * [JDK-8297998](https://bugs.openjdk.org/browse/JDK-8297998): ColorModel.getComponentSize()-wrong conditions for ArrayIndexOutOfBoundsExceptio (**CSR**)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11470/head:pull/11470` \
`$ git checkout pull/11470`

Update a local copy of the PR: \
`$ git checkout pull/11470` \
`$ git pull https://git.openjdk.org/jdk pull/11470/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11470`

View PR using the GUI difftool: \
`$ git pr show -t 11470`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11470.diff">https://git.openjdk.org/jdk/pull/11470.diff</a>

</details>
