### PR TITLE
JDK-8298003: NMT: fatal block printout does not show the correct corruption address

### DIFF
--- a/src/hotspot/share/services/mallocHeader.inline.hpp
+++ b/src/hotspot/share/services/mallocHeader.inline.hpp
@@ -55,9 +55,7 @@ inline void MallocHeader::assert_block_integrity() const {
   char msg[256];
   address corruption = NULL;
   if (!check_block_integrity(msg, sizeof(msg), &corruption)) {
-    if (corruption != NULL) {
-      print_block_on_error(tty, (address)this);
-    }
+    print_block_on_error(tty, corruption != NULL ? corruption : (address)this);
     fatal("NMT corruption: Block at " PTR_FORMAT ": %s", p2i(this), msg);
   }
 }


### PR DESCRIPTION
Simple fix for a printout regression.

If NMT encounters a corrupted block, it is supposed to print a report about block and corruption. This includes hex dumps from both header and corruption point, as well as corruption address. Corruption address can be far away, if the block footer had been overwritten. In that case we also want to see two hex dumps (header and corruption location).

This was introduced with [JDK-8275320](https://bugs.openjdk.org/browse/JDK-8275320), and worked, but regressed in the course of a code revamp with [JDK-8292071](https://bugs.openjdk.org/browse/JDK-8292071).

Fix fixes the printout.

before: wrong corruption address was printed:

```
[ RUN      ] NMT.test_overwrite_back_long_unaligned_distance_vm_assert
NMT overwrite death test, please ignore subsequent error dump.
NMT Block at 0x00005587f87632b0, corruption at: 0x00005587f87632b0: 
0x00005587f8763230:   ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab
0x00005587f8763240:   ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab
0x00005587f8763250:   ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab
0x00005587f8763260:   ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab
0x00005587f8763270:   ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab
0x00005587f8763280:   ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab
0x00005587f8763290:   ab ab ab ab ab ab ab ab e8 8e 00 00 00 00 00 00
0x00005587f87632a0:   00 00 00 00 00 00 00 00 21 20 00 00 00 00 00 00
0x00005587f87632b0:   01 20 00 00 00 00 00 00 00 00 00 00 0f 00 9e e9
0x00005587f87632c0:   f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1
0x00005587f87632d0:   f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1
0x00005587f87632e0:   f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1
0x00005587f87632f0:   f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1
0x00005587f8763300:   f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1
0x00005587f8763310:   f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1
0x00005587f8763320:   f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 
[       OK ] NMT.test_overwrite_back_long_unaligned_distance_vm_assert (101 ms)
```

With fix: correct corruption address is printed, and we have a second hexdump around the far corruption point:

```
[ RUN      ] NMT.test_overwrite_back_long_unaligned_distance_vm_assert
NMT overwrite death test, please ignore subsequent error dump.
NMT Block at 0x0000559090583020, corruption at: 0x0000559090585031: 
0x0000559090582fa0:   00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
0x0000559090582fb0:   20 00 00 00 00 00 00 00 21 00 00 00 00 00 00 00
0x0000559090582fc0:   00 00 00 00 01 00 00 00 02 00 00 00 ab ab ab ab
0x0000559090582fd0:   ab ab ab ab ab ab ab ab 21 00 00 00 00 00 00 00
0x0000559090582fe0:   00 00 00 00 02 00 00 00 ab ab ab ab ab ab ab ab
0x0000559090582ff0:   ab ab ab ab ab ab ab ab 21 00 00 00 00 00 00 00
0x0000559090583000:   60 2f 58 90 90 55 00 00 ab ab ab ab ab ab ab ab
0x0000559090583010:   ab ab ab ab ab ab ab ab 21 20 00 00 00 00 00 00
0x0000559090583020:   01 20 00 00 00 00 00 00 00 00 00 00 0f 00 9e e9
0x0000559090583030:   f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1
0x0000559090583040:   f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1
0x0000559090583050:   f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1
0x0000559090583060:   f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1
0x0000559090583070:   f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1
0x0000559090583080:   f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1
0x0000559090583090:   f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 
...
0x0000559090584fb0:   f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1
0x0000559090584fc0:   f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1
0x0000559090584fd0:   f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1
0x0000559090584fe0:   f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1
0x0000559090584ff0:   f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1
0x0000559090585000:   f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1
0x0000559090585010:   f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1
0x0000559090585020:   f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1 f1
0x0000559090585030:   f1 61 8e ab ab ab ab ab d1 2f 01 00 00 00 00 00
0x0000559090585040:   ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab
0x0000559090585050:   ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab
0x0000559090585060:   ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab
0x0000559090585070:   ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab
0x0000559090585080:   ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab
0x0000559090585090:   ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab
0x00005590905850a0:   ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab 
[       OK ] NMT.test_overwrite_back_long_unaligned_distance_vm_assert (101 ms)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298003](https://bugs.openjdk.org/browse/JDK-8298003): NMT: fatal block printout does not show the correct corruption address


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11472/head:pull/11472` \
`$ git checkout pull/11472`

Update a local copy of the PR: \
`$ git checkout pull/11472` \
`$ git pull https://git.openjdk.org/jdk pull/11472/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11472`

View PR using the GUI difftool: \
`$ git pr show -t 11472`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11472.diff">https://git.openjdk.org/jdk/pull/11472.diff</a>

</details>
