### PR TITLE
8298006: Build failure by maybe-uninitialized error on Linux s390x GCC8

### DIFF
--- a/src/java.desktop/share/native/libawt/awt/medialib/awt_ImagingLib.c
+++ b/src/java.desktop/share/native/libawt/awt/medialib/awt_ImagingLib.c
@@ -2912,10 +2912,8 @@ static int expandPackedBCR(JNIEnv *env, RasterS_t *rasterP, int component,
     jint   *inDataP;
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
 
-#if defined(LINUX) && defined(s390x)
     memset(loff, 0, sizeof(loff));
     memset(roff, 0, sizeof(roff));
-#endif
 
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;
@@ -3006,11 +3004,6 @@ static int expandPackedBCRdefault(JNIEnv *env, RasterS_t *rasterP,
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
     int numBands = rasterP->numBands - (forceAlpha ? 0 : 1);
     int a = numBands;
-
-#if defined(LINUX) && defined(s390x)
-    memset(loff, 0, sizeof(loff));
-    memset(roff, 0, sizeof(roff));
-#endif
 
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;
@@ -3103,10 +3096,8 @@ static int expandPackedSCR(JNIEnv *env, RasterS_t *rasterP, int component,
     jint   *inDataP;
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
 
-#if defined(LINUX) && defined(s390x)
     memset(loff, 0, sizeof(loff));
     memset(roff, 0, sizeof(roff));
-#endif
 
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;
@@ -3204,11 +3195,6 @@ static int expandPackedSCRdefault(JNIEnv *env, RasterS_t *rasterP,
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
     int numBands = rasterP->numBands - (forceAlpha ? 0 : 1);
     int a = numBands;
-
-#if defined(LINUX) && defined(s390x)
-    memset(loff, 0, sizeof(loff));
-    memset(roff, 0, sizeof(roff));
-#endif
 
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;
@@ -3310,11 +3296,6 @@ static int expandPackedICR(JNIEnv *env, RasterS_t *rasterP, int component,
     jint   *inDataP;
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
 
-#if defined(LINUX) && defined(s390x)
-    memset(loff, 0, sizeof(loff));
-    memset(roff, 0, sizeof(roff));
-#endif
-
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;
     }
@@ -3408,11 +3389,6 @@ static int expandPackedICRdefault(JNIEnv *env, RasterS_t *rasterP,
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
     int numBands = rasterP->numBands - (forceAlpha ? 0 : 1);
     int a = numBands;
-
-#if defined(LINUX) && defined(s390x)
-    memset(loff, 0, sizeof(loff));
-    memset(roff, 0, sizeof(roff));
-#endif
 
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;
@@ -3510,11 +3486,6 @@ static int setPackedBCR(JNIEnv *env, RasterS_t *rasterP, int component,
     unsigned char *outDataP;
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
 
-#if defined(LINUX) && defined(s390x)
-    memset(loff, 0, sizeof(loff));
-    memset(roff, 0, sizeof(roff));
-#endif
-
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;
     }
@@ -3591,11 +3562,6 @@ static int setPackedSCR(JNIEnv *env, RasterS_t *rasterP, int component,
     unsigned short *outDataP;
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
 
-#if defined(LINUX) && defined(s390x)
-    memset(loff, 0, sizeof(loff));
-    memset(roff, 0, sizeof(roff));
-#endif
-
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;
     }
@@ -3671,11 +3637,6 @@ static int setPackedICR(JNIEnv *env, RasterS_t *rasterP, int component,
     jsize dataArrayLength;
     unsigned int *outDataP;
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
-
-#if defined(LINUX) && defined(s390x)
-    memset(loff, 0, sizeof(loff));
-    memset(roff, 0, sizeof(roff));
-#endif
 
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;
@@ -3755,11 +3716,6 @@ static int setPackedBCRdefault(JNIEnv *env, RasterS_t *rasterP,
     unsigned char *outDataP;
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
     int a = rasterP->numBands - 1;
-
-#if defined(LINUX) && defined(s390x)
-    memset(loff, 0, sizeof(loff));
-    memset(roff, 0, sizeof(roff));
-#endif
 
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;
@@ -3859,11 +3815,6 @@ static int setPackedSCRdefault(JNIEnv *env, RasterS_t *rasterP,
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
     int a = rasterP->numBands - 1;
 
-#if defined(LINUX) && defined(s390x)
-    memset(loff, 0, sizeof(loff));
-    memset(roff, 0, sizeof(roff));
-#endif
-
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;
     }
@@ -3960,11 +3911,6 @@ static int setPackedICRdefault(JNIEnv *env, RasterS_t *rasterP,
     unsigned int *outDataP;
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
     int a = rasterP->numBands - 1;
-
-#if defined(LINUX) && defined(s390x)
-    memset(loff, 0, sizeof(loff));
-    memset(roff, 0, sizeof(roff));
-#endif
 
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;

--- a/src/java.desktop/share/native/libawt/awt/medialib/awt_ImagingLib.c
+++ b/src/java.desktop/share/native/libawt/awt/medialib/awt_ImagingLib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2912,6 +2912,11 @@ static int expandPackedBCR(JNIEnv *env, RasterS_t *rasterP, int component,
     jint   *inDataP;
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
 
+#if defined(LINUX) && defined(s390x)
+    memset(loff, 0, sizeof(loff));
+    memset(roff, 0, sizeof(roff));
+#endif
+
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;
     }
@@ -3001,6 +3006,11 @@ static int expandPackedBCRdefault(JNIEnv *env, RasterS_t *rasterP,
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
     int numBands = rasterP->numBands - (forceAlpha ? 0 : 1);
     int a = numBands;
+
+#if defined(LINUX) && defined(s390x)
+    memset(loff, 0, sizeof(loff));
+    memset(roff, 0, sizeof(roff));
+#endif
 
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;
@@ -3092,6 +3102,11 @@ static int expandPackedSCR(JNIEnv *env, RasterS_t *rasterP, int component,
     jarray jInDataP;
     jint   *inDataP;
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
+
+#if defined(LINUX) && defined(s390x)
+    memset(loff, 0, sizeof(loff));
+    memset(roff, 0, sizeof(roff));
+#endif
 
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;
@@ -3189,6 +3204,11 @@ static int expandPackedSCRdefault(JNIEnv *env, RasterS_t *rasterP,
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
     int numBands = rasterP->numBands - (forceAlpha ? 0 : 1);
     int a = numBands;
+
+#if defined(LINUX) && defined(s390x)
+    memset(loff, 0, sizeof(loff));
+    memset(roff, 0, sizeof(roff));
+#endif
 
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;
@@ -3290,6 +3310,11 @@ static int expandPackedICR(JNIEnv *env, RasterS_t *rasterP, int component,
     jint   *inDataP;
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
 
+#if defined(LINUX) && defined(s390x)
+    memset(loff, 0, sizeof(loff));
+    memset(roff, 0, sizeof(roff));
+#endif
+
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;
     }
@@ -3383,6 +3408,11 @@ static int expandPackedICRdefault(JNIEnv *env, RasterS_t *rasterP,
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
     int numBands = rasterP->numBands - (forceAlpha ? 0 : 1);
     int a = numBands;
+
+#if defined(LINUX) && defined(s390x)
+    memset(loff, 0, sizeof(loff));
+    memset(roff, 0, sizeof(roff));
+#endif
 
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;
@@ -3480,6 +3510,11 @@ static int setPackedBCR(JNIEnv *env, RasterS_t *rasterP, int component,
     unsigned char *outDataP;
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
 
+#if defined(LINUX) && defined(s390x)
+    memset(loff, 0, sizeof(loff));
+    memset(roff, 0, sizeof(roff));
+#endif
+
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;
     }
@@ -3556,6 +3591,11 @@ static int setPackedSCR(JNIEnv *env, RasterS_t *rasterP, int component,
     unsigned short *outDataP;
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
 
+#if defined(LINUX) && defined(s390x)
+    memset(loff, 0, sizeof(loff));
+    memset(roff, 0, sizeof(roff));
+#endif
+
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;
     }
@@ -3631,6 +3671,11 @@ static int setPackedICR(JNIEnv *env, RasterS_t *rasterP, int component,
     jsize dataArrayLength;
     unsigned int *outDataP;
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
+
+#if defined(LINUX) && defined(s390x)
+    memset(loff, 0, sizeof(loff));
+    memset(roff, 0, sizeof(roff));
+#endif
 
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;
@@ -3710,6 +3755,11 @@ static int setPackedBCRdefault(JNIEnv *env, RasterS_t *rasterP,
     unsigned char *outDataP;
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
     int a = rasterP->numBands - 1;
+
+#if defined(LINUX) && defined(s390x)
+    memset(loff, 0, sizeof(loff));
+    memset(roff, 0, sizeof(roff));
+#endif
 
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;
@@ -3809,6 +3859,11 @@ static int setPackedSCRdefault(JNIEnv *env, RasterS_t *rasterP,
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
     int a = rasterP->numBands - 1;
 
+#if defined(LINUX) && defined(s390x)
+    memset(loff, 0, sizeof(loff));
+    memset(roff, 0, sizeof(roff));
+#endif
+
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;
     }
@@ -3905,6 +3960,11 @@ static int setPackedICRdefault(JNIEnv *env, RasterS_t *rasterP,
     unsigned int *outDataP;
     int loff[MAX_NUMBANDS], roff[MAX_NUMBANDS];
     int a = rasterP->numBands - 1;
+
+#if defined(LINUX) && defined(s390x)
+    memset(loff, 0, sizeof(loff));
+    memset(roff, 0, sizeof(roff));
+#endif
 
     if (rasterP->numBands > MAX_NUMBANDS) {
         return -1;


### PR DESCRIPTION
I changed GCC toolchain from GCC6 to GCC8 on SLES12SP5 Linux s390x.
I could see following errors:
```
src/java.desktop/share/native/libawt/awt/medialib/awt_ImagingLib.c: In function 'allocateRasterArray':
src/java.desktop/share/native/libawt/awt/medialib/awt_ImagingLib.c:2944:73: error: 'roff[3]' may be used uninitialized in this function [-Werror=maybe-uninitialized]
                             (((*inP&rasterP->sppsm.maskArray[c]) >> roff[c])
                                                                     ~~~~^~~
```

```
src/java.desktop/share/native/libawt/awt/medialib/awt_ImagingLib.c:3129:73: error: 'roff[3]' may be used uninitialized in this function [-Werror=maybe-uninitialized]
                             (((*inP&rasterP->sppsm.maskArray[c]) >> roff[c])
                                                                     ~~~~^~~
```

According to error messages,
roff and loff may not be initialized.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298006](https://bugs.openjdk.org/browse/JDK-8298006): Build failure by maybe-uninitialized error on Linux s390x GCC8


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11475/head:pull/11475` \
`$ git checkout pull/11475`

Update a local copy of the PR: \
`$ git checkout pull/11475` \
`$ git pull https://git.openjdk.org/jdk pull/11475/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11475`

View PR using the GUI difftool: \
`$ git pr show -t 11475`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11475.diff">https://git.openjdk.org/jdk/pull/11475.diff</a>

</details>
