### PR TITLE
8281214: Unsafe use of long in VMThread::setup_periodic_safepoint_if_needed

### DIFF
--- a/src/hotspot/share/runtime/vmThread.cpp
+++ b/src/hotspot/share/runtime/vmThread.cpp
@@ -323,7 +323,7 @@ void VMThread::setup_periodic_safepoint_if_needed() {
   assert(_cur_vm_operation  == NULL, "Already have an op");
   assert(_next_vm_operation == NULL, "Already have an op");
   // Check for a cleanup before SafepointALot to keep stats correct.
-  long interval_ms = SafepointTracing::time_since_last_safepoint_ms();
+  jlong interval_ms = SafepointTracing::time_since_last_safepoint_ms();
   bool max_time_exceeded = GuaranteedSafepointInterval != 0 &&
                            (interval_ms >= GuaranteedSafepointInterval);
   if (!max_time_exceeded) {


### PR DESCRIPTION
### Description 
In VMThread::setup_periodic_safepoint_if_needed there is an unsafe use of long:

long interval_ms = SafepointTracing::time_since_last_safepoint_ms();

because SafepointTracing::time_since_last_safepoint_ms returns jlong which can be bigger than long.

### Patch
Changed `long` to `jlong`.

### Test
local:  make test TEST=runtime/Thread
mach5: tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281214](https://bugs.openjdk.org/browse/JDK-8281214): Unsafe use of long in VMThread::setup_periodic_safepoint_if_needed


### Reviewers
 * [Evgeny Astigeevich](https://openjdk.org/census#eastigeevich) (@eastig - Committer)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11476/head:pull/11476` \
`$ git checkout pull/11476`

Update a local copy of the PR: \
`$ git checkout pull/11476` \
`$ git pull https://git.openjdk.org/jdk pull/11476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11476`

View PR using the GUI difftool: \
`$ git pr show -t 11476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11476.diff">https://git.openjdk.org/jdk/pull/11476.diff</a>

</details>
