### PR TITLE
JDK-8297959: Provide better descriptions for some Operating System JFR events

### DIFF
--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -733,7 +733,7 @@
      </Event>
 
   <Event name="OSInformation" category="Operating System" label="OS Information"
-         description="Description of the OS the JVM runs on, e.g. for example a uname-like output"
+         description="Description of the OS the JVM runs on, for example a uname-like output"
          period="endChunk">
     <Field type="string" name="osVersion" label="OS Version" />
   </Event>

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -733,7 +733,7 @@
      </Event>
 
   <Event name="OSInformation" category="Operating System" label="OS Information"
-         description="Description of the OS the JVM runs on, for example a uname-like output"
+         description="Description of the OS the JVM runs on, for example, a uname-like output"
          period="endChunk">
     <Field type="string" name="osVersion" label="OS Version" />
   </Event>
@@ -750,7 +750,7 @@
   </Event>
 
   <Event name="InitialEnvironmentVariable" category="Operating System" label="Initial Environment Variable"
-         description="Key and value pairs for environment variables at JVM startup"
+         description="Key-value pairs for environment variables at JVM startup"
          period="endChunk">
     <Field type="string" name="key" label="Key" />
     <Field type="string" name="value" label="Value" />

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -732,11 +732,15 @@
     <Field type="long" name="pid" label="Process Identifier" />
      </Event>
 
-  <Event name="OSInformation" category="Operating System" label="OS Information" period="endChunk">
+  <Event name="OSInformation" category="Operating System" label="OS Information"
+         description="Description of the OS the JVM runs on, e.g. for example a uname-like output"
+         period="endChunk">
     <Field type="string" name="osVersion" label="OS Version" />
   </Event>
 
-  <Event name="VirtualizationInformation" category="Operating System" label="Virtualization Information" period="endChunk">
+  <Event name="VirtualizationInformation" category="Operating System" label="Virtualization Information"
+         description="Description of the virtualization technology the JVM runs on"
+         period="endChunk">
     <Field type="string" name="name" label="Name" />
   </Event>
 
@@ -745,7 +749,9 @@
     <Field type="string" name="value" label="Value" />
   </Event>
 
-  <Event name="InitialEnvironmentVariable" category="Operating System" label="Initial Environment Variable" period="endChunk">
+  <Event name="InitialEnvironmentVariable" category="Operating System" label="Initial Environment Variable"
+         description="Key and value pairs for environment variables at JVM startup"
+         period="endChunk">
     <Field type="string" name="key" label="Key" />
     <Field type="string" name="value" label="Value" />
   </Event>


### PR DESCRIPTION
Some Operating System JFR events currently lack descriptions , this could be improved.
See for example https://sap.github.io/SapMachine/jfrevents/20.html#osinformation

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297959](https://bugs.openjdk.org/browse/JDK-8297959): Provide better descriptions for some Operating System JFR events


### Reviewers
 * @parttimenerd (no known github.com user name / role) ⚠️ Review applies to [ad17c78a](https://git.openjdk.org/jdk/pull/11478/files/ad17c78a9d977401243a16dfa5b93a4573fad2d5)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [8b1994a8](https://git.openjdk.org/jdk/pull/11478/files/8b1994a810ca4bf151d463a8fd1058b74e57efd3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11478/head:pull/11478` \
`$ git checkout pull/11478`

Update a local copy of the PR: \
`$ git checkout pull/11478` \
`$ git pull https://git.openjdk.org/jdk pull/11478/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11478`

View PR using the GUI difftool: \
`$ git pr show -t 11478`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11478.diff">https://git.openjdk.org/jdk/pull/11478.diff</a>

</details>
