### PR TITLE
8297974: ClassCastException in com.sun.tools.javac.comp.AttrRecover.doRecovery

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/AttrRecover.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/AttrRecover.java
@@ -156,7 +156,7 @@ public class AttrRecover {
                                     //do not touch nested classes
                                 }
                             }.translate(lambda.body);
-                            if (!voidCompatible) {
+                            if (!voidCompatible && lambda.body.hasTag(Tag.BLOCK)) {
                                 JCReturn ret = make.Return(make.Erroneous().setType(syms.errType));
                                 ((JCBlock) lambda.body).stats = ((JCBlock) lambda.body).stats.append(ret);
                                 rollback.append(() -> {

--- a/test/langtools/tools/javac/recovery/LambdaRecovery.java
+++ b/test/langtools/tools/javac/recovery/LambdaRecovery.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8297974
+ * @summary Verify error recovery w.r.t. lambdas
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.jdeps/com.sun.tools.classfile
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main LambdaRecovery
+ */
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+
+import toolbox.JavacTask;
+import toolbox.Task.Expect;
+import toolbox.Task.OutputKind;
+import toolbox.TestRunner;
+import toolbox.ToolBox;
+
+public class LambdaRecovery extends TestRunner {
+
+    ToolBox tb;
+
+    public LambdaRecovery() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public static void main(String[] args) throws Exception {
+        LambdaRecovery t = new LambdaRecovery();
+        t.runTests();
+    }
+
+    @Test
+    public void testRecoveryExpressionLambda() throws Exception {
+        String code = """
+                      class Test {
+                          interface I {
+                              int convert(int i);
+                          }
+                          interface O {
+                              Object convert(Object o);
+                          }
+                          void t1(I f, String e) {
+                              t1(param -> param);
+                              t1(param -> voidMethod(param));
+                          }
+                          void t2(O f, String e) {
+                              t2(param -> param);
+                              t2(param -> voidMethod(param));
+                          }
+                          void voidMethod(Object o) {}
+                      }
+                      """;
+        Path curPath = Path.of(".");
+        List<String> actual = new JavacTask(tb)
+                .options("-XDrawDiagnostics", "-XDdev")
+                .sources(code)
+                .outdir(curPath)
+                .run(Expect.FAIL)
+                .getOutputLines(OutputKind.DIRECT);
+
+        List<String> expected = List.of(
+                "Test.java:9:9: compiler.err.cant.apply.symbol: kindname.method, t1, Test.I,java.lang.String, @12, kindname.class, Test, (compiler.misc.arg.length.mismatch)",
+                "Test.java:10:9: compiler.err.cant.apply.symbol: kindname.method, t1, Test.I,java.lang.String, @12, kindname.class, Test, (compiler.misc.arg.length.mismatch)",
+                "Test.java:10:11: compiler.err.cant.apply.symbol: kindname.method, t1, Test.I,java.lang.String, @12,<any>, kindname.class, Test, (compiler.misc.no.conforming.assignment.exists: (compiler.misc.incompatible.ret.type.in.lambda: (compiler.misc.inconvertible.types: void, int)))",
+                "Test.java:13:9: compiler.err.cant.apply.symbol: kindname.method, t2, Test.O,java.lang.String, @12, kindname.class, Test, (compiler.misc.arg.length.mismatch)",
+                "Test.java:14:9: compiler.err.cant.apply.symbol: kindname.method, t2, Test.O,java.lang.String, @12, kindname.class, Test, (compiler.misc.arg.length.mismatch)",
+                "Test.java:14:11: compiler.err.cant.apply.symbol: kindname.method, t2, Test.O,java.lang.String, @12,<any>, kindname.class, Test, (compiler.misc.no.conforming.assignment.exists: (compiler.misc.incompatible.ret.type.in.lambda: (compiler.misc.inconvertible.types: void, java.lang.Object)))",
+                "6 errors"
+        );
+
+        if (!Objects.equals(actual, expected)) {
+            error("Expected: " + expected + ", but got: " + actual);
+        }
+
+    }
+}


### PR DESCRIPTION
Considering code like:
```
class RecoveryTest {

    interface I {
        int convert(int i);
    }

    void t(I f, String e) {
        t(param -> param); //a parameter missing here
    }

}
```

This is clearly wrong (the invocation of `t` is missing a parameter). But, running this crashes the compiler in addition to reporting the error:
```
$ javac -XDdev RecoveryTest.java 
/tmp/RecoveryTest.java:8: error: method t in class RecoveryTest cannot be applied to given types;
        t(param -> param);
        ^
  required: I,String
  found:    (param)->param
  reason: actual and formal argument lists differ in length
1 error
An exception has occurred in the compiler (20-internal). Please file a bug against the Java compiler via the Java bug reporting page (https://bugreport.java.com) after checking the Bug Database (https://bugs.java.com) for duplicates. Include your program, the following diagnostic, and the parameters passed to the Java compiler in your report. Thank you.
java.lang.ClassCastException: class com.sun.tools.javac.tree.JCTree$JCIdent cannot be cast to class com.sun.tools.javac.tree.JCTree$JCBlock (com.sun.tools.javac.tree.JCTree$JCIdent and com.sun.tools.javac.tree.JCTree$JCBlock are in module jdk.compiler of loader 'app')
        at jdk.compiler/com.sun.tools.javac.comp.AttrRecover.doRecovery(AttrRecover.java:161)
        at jdk.compiler/com.sun.tools.javac.comp.Attr.attribStat(Attr.java:738)
...
```

The reason is that `AttrRecovery` will try to temporarily tweak the AST, so that it can be more correctly attributed. In particular, it will try to add a `return` statement into the lambda - but as the lambda is not a block lambda, and it crashes.

It seems it is enough to avoid adding the `return` statement into the expression lambdas, the recovery should still be reasonable, and the crash will be avoided. So, this is what the patch is doing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297974](https://bugs.openjdk.org/browse/JDK-8297974): ClassCastException in com.sun.tools.javac.comp.AttrRecover.doRecovery


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11479/head:pull/11479` \
`$ git checkout pull/11479`

Update a local copy of the PR: \
`$ git checkout pull/11479` \
`$ git pull https://git.openjdk.org/jdk pull/11479/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11479`

View PR using the GUI difftool: \
`$ git pr show -t 11479`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11479.diff">https://git.openjdk.org/jdk/pull/11479.diff</a>

</details>
