### PR TITLE
8298033: Character.codePointAt(char[], int, int) doesn't do JavaDoc-specified check

### DIFF
--- a/src/java.base/share/classes/java/lang/Character.java
+++ b/src/java.base/share/classes/java/lang/Character.java
@@ -39,7 +39,6 @@ import java.util.Optional;
 
 import static java.lang.constant.ConstantDescs.BSM_EXPLICIT_CAST;
 import static java.lang.constant.ConstantDescs.CD_char;
-import static java.lang.constant.ConstantDescs.CD_int;
 import static java.lang.constant.ConstantDescs.DEFAULT_NAME;
 
 /**
@@ -9375,7 +9374,7 @@ class Character implements java.io.Serializable, Comparable<Character>, Constabl
      * @since  1.5
      */
     public static int codePointAt(char[] a, int index, int limit) {
-        if (index >= limit || limit < 0 || limit > a.length) {
+        if (index >= limit || index < 0 || limit > a.length) {
             throw new IndexOutOfBoundsException();
         }
         return codePointAtImpl(a, index, limit);


### PR DESCRIPTION
I found out that this code
```java
public class Main {
    public static void main(String[] args) {
        String s = "Hello world!";
        char[] chars = s.toCharArray();
        int point = Character.codePointAt(chars, -1, 1);
    }
}
```
throws `ArrayIndexOutOfBoundsException` instead of JavaDoc-specified `IndexOutOfBoundsException`: 
```
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 12
	at java.base/java.lang.Character.codePointAtImpl(Character.java:9254)
	at java.base/java.lang.Character.codePointAt(Character.java:9249)
	at org.example.Main.main(Main.java:7)
```
and the method doesn't check whether `index` parameter is negative:
```java
public static int codePointAt(char[] a, int index, int limit) {
    if (index >= limit || limit < 0 || limit > a.length) {
        throw new IndexOutOfBoundsException();
    }
    return codePointAtImpl(a, index, limit);
}
```
I suggest to check the `index` parameter explicitly instead of relying on AIOOBE thrown from accessing the array with negative index.