### PR TITLE
8296389: C2: PhaseCFG::convert_NeverBranch_to_Goto must handle both orders of successors

### DIFF
--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -620,10 +620,19 @@ static bool no_flip_branch(Block *b) {
 // fake exit path to infinite loops.  At this late stage they need to turn
 // into Goto's so that when you enter the infinite loop you indeed hang.
 void PhaseCFG::convert_NeverBranch_to_Goto(Block *b) {
-  // Find true target
+  // NeverBranch sits at end_idx, the two projections right after it
   int end_idx = b->end_idx();
-  int idx = b->get_node(end_idx+1)->as_Proj()->_con;
-  Block *succ = b->_succs[idx];
+  int taken_idx = b->get_node(end_idx+1)->as_Proj()->_con;
+  ProjNode* alwaysTaken = b->get_node(end_idx + 1 + taken_idx)->as_Proj();
+  ProjNode* neverTaken  = b->get_node(end_idx + 2 - taken_idx)->as_Proj();
+  assert(alwaysTaken->_con == 0 && neverTaken->_con == 1, "correct projection constants");
+  // if alwaysTaken projects into _succs[0], dead_idx == 1
+  int dead_idx = b->_succs[0]->get_node(0) == alwaysTaken->unique_ctrl_out_or_null();
+  Block* succ = b->_succs[1 - dead_idx];
+  Block* dead = b->_succs[dead_idx];
+  assert(alwaysTaken->unique_ctrl_out_or_null() == succ->get_node(0), "alwaysTaken leads to succ block");
+  assert(neverTaken->unique_ctrl_out_or_null() == dead->get_node(0), "neverTaken leads to dead block");
+
   Node* gto = _goto->clone(); // get a new goto node
   gto->set_req(0, b->head());
   Node *bp = b->get_node(end_idx);
@@ -642,7 +651,6 @@ void PhaseCFG::convert_NeverBranch_to_Goto(Block *b) {
     }
   }
   // Kill alternate exit path
-  Block* dead = b->_succs[1 - idx];
   for (j = 1; j < dead->num_preds(); j++) {
     if (dead->pred(j)->in(0) == bp) {
       break;

--- a/test/hotspot/jtreg/compiler/loopopts/TestPhaseCFGNeverBranchToGoto.jasm
+++ b/test/hotspot/jtreg/compiler/loopopts/TestPhaseCFGNeverBranchToGoto.jasm
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+super public class TestPhaseCFGNeverBranchToGoto
+{
+    public Method "<init>":"()V"
+    stack 2 locals 1
+    {
+        aload_0;
+        invokespecial  Method java/lang/Object."<init>":"()V";
+        return;
+    }
+    static Method test:"(III)V"
+    stack 200 locals 200
+    {
+        iload      2;
+        ifeq LEND; // at runtime avoid the infinite-loop
+
+        iload      0;
+        ifeq L20;
+        goto L10;
+    L10:
+        goto L11;
+    L11:
+        iinc 0, 1;
+        iload      1;
+        ifge L10;
+        goto L11;
+    L20:
+        iload      1;
+        ifle L21;
+        goto L10;
+    L21:
+        iconst_m1; // eventually false
+        ifge L11;
+        goto L20;
+
+    LEND:
+        return;
+    }
+    public static Method main:"([Ljava/lang/String;)V"
+    stack 100 locals 100
+    {
+        iconst_0;
+        iconst_m1;
+        iconst_0;
+        invokestatic    Method test:"(III)V";
+        return;
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/TestPhaseCFGNeverBranchToGotoMain.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestPhaseCFGNeverBranchToGotoMain.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8296389
+ * @summary Peeling of Irreducible loop can lead to NeverBranch being visited from either side
+ * @run main/othervm -Xcomp -Xbatch -XX:-TieredCompilation -XX:PerMethodTrapLimit=0
+ *      -XX:CompileCommand=compileonly,TestPhaseCFGNeverBranchToGotoMain::test
+ *      TestPhaseCFGNeverBranchToGotoMain
+ */
+
+/*
+ * @test
+ * @bug 8296389
+ * @compile TestPhaseCFGNeverBranchToGoto.jasm
+ * @summary Peeling of Irreducible loop can lead to NeverBranch being visited from either side
+ * @run main/othervm -Xcomp -Xbatch -XX:-TieredCompilation -XX:PerMethodTrapLimit=0
+ *      -XX:CompileCommand=compileonly,TestPhaseCFGNeverBranchToGoto::test
+ *      TestPhaseCFGNeverBranchToGoto
+ */
+
+
+public class TestPhaseCFGNeverBranchToGotoMain {
+    public static void main (String[] args) {
+        test(false, false);
+    }
+    public static void test(boolean flag1, boolean flag2) {
+        if (flag1) { // runtime check, avoid infinite loop
+            int a = 77;
+            int b = 0;
+            do { // empty loop
+                a--;
+                b++;
+            } while (a > 0);
+            // a == 0, b == 77 - after first loop-opts phase
+            int p = 0;
+            for (int i = 0; i < 4; i++) {
+                if ((i % 2) == 0) {
+                    p = 1;
+                }
+            }
+            // p == 1 - after second loop-opts phase (via unrolling)
+            // in first loop-opts phase we have 2x unrolling, 4x after second
+            int x = 1;
+            if (flag2) {
+                x = 3;
+            } // have region here, so that NeverBranch does not get removed
+            do { // infinite loop
+                do {
+                    // NeverBranch inserted here, during loop-opts 1
+                    x *= 2;
+                    if (p == 0) { // reason for peeling in loop-opts 1
+                        // after we know that p == 1, we lose this exit
+                        break;
+		    }
+                    // once we know that b == 77, we lose exit
+		} while (b == 77);
+                // after we lost both exits above, this loop gets cut off
+		int y = 5;
+                do {
+                    y *= 3;
+                } while (b == 77);
+            } while (true);
+        }
+    }
+}


### PR DESCRIPTION
The code in `PhaseCFG::convert_NeverBranch_to_Goto` looks like it is ready to have `idx == 1`, but it is not.

We would read `succ` from `_succs[1]`.
https://github.com/openjdk/jdk/blob/8c472e481676ed0ef475c4989477d5714880c59e/src/hotspot/share/opto/block.cpp#L626

Then overwrite `_succs[0]` with `succ`, and shorten the array.
https://github.com/openjdk/jdk/blob/8c472e481676ed0ef475c4989477d5714880c59e/src/hotspot/share/opto/block.cpp#L635-L636

And finally attempt to read `dead` from `_succs[1]` which is now out of bounds, and where `succ` used to be stored.
https://github.com/openjdk/jdk/blob/8c472e481676ed0ef475c4989477d5714880c59e/src/hotspot/share/opto/block.cpp#L645

**Why did we never hit this bug before?**
