### PR TITLE
8297767: Assert JNICritical_lock/safepoint-1 and AdapterHandlerLibrary_lock/safepoint-1

### DIFF
--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -374,7 +374,7 @@ void mutex_init() {
   defl(OopMapCacheAlloc_lock       , PaddedMutex ,  Threads_lock, true);
   defl(Module_lock                 , PaddedMutex ,  ClassLoaderDataGraph_lock);
   defl(SystemDictionary_lock       , PaddedMonitor, Module_lock);
-  defl(JNICritical_lock            , PaddedMonitor, MultiArray_lock); // used for JNI critical regions
+  defl(JNICritical_lock            , PaddedMonitor, AdapterHandlerLibrary_lock); // used for JNI critical regions
 #if INCLUDE_JVMCI
   // JVMCIRuntime_lock must be acquired before JVMCI_lock to avoid deadlock
   defl(JVMCI_lock                  , PaddedMonitor, JVMCIRuntime_lock);


### PR DESCRIPTION
Fixed the ranking of JNICritical_lock to be below the AdapterHandlerLibrary_lock.
Tested with a temporary inserted MutexLocker (JNICritical_lock) in the adapter path, and tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297767](https://bugs.openjdk.org/browse/JDK-8297767): Assert JNICritical_lock/safepoint-1 and AdapterHandlerLibrary_lock/safepoint-1


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11484/head:pull/11484` \
`$ git checkout pull/11484`

Update a local copy of the PR: \
`$ git checkout pull/11484` \
`$ git pull https://git.openjdk.org/jdk pull/11484/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11484`

View PR using the GUI difftool: \
`$ git pr show -t 11484`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11484.diff">https://git.openjdk.org/jdk/pull/11484.diff</a>

</details>
