### PR TITLE
8298588: WebSockets: HandshakeUrlEncodingTest unnecessarily depends on a response body

### DIFF
--- a/test/jdk/java/net/httpclient/websocket/HandshakeUrlEncodingTest.java
+++ b/test/jdk/java/net/httpclient/websocket/HandshakeUrlEncodingTest.java
@@ -123,12 +123,9 @@ public class HandshakeUrlEncodingTest {
                 final String rawQuery = wse.getResponse().uri().getRawQuery();
                 final String expectedRawQuery = "&raw=abc+def/ghi=xyz&encoded=abc%2Bdef%2Fghi%3Dxyz";
                 assertEquals(rawQuery, expectedRawQuery);
-                if (wse.getResponse().body() != null &&
-                        (wse.getResponse().body().getClass().equals(String.class))) {
-                    final String body = (String) wse.getResponse().body();
-                    final String expectedBody = "/?" + expectedRawQuery;
-                    assertEquals(body, expectedBody);
-                }
+                final String body = (String) wse.getResponse().body();
+                final String expectedBody = "/?" + expectedRawQuery;
+                assertEquals(body, expectedBody);
                 out.println("Status code is " + wse.getResponse().statusCode());
                 out.println("Response is " + wse.getResponse());
                 assertEquals(wse.getResponse().statusCode(), 400);

--- a/test/jdk/java/net/httpclient/websocket/HandshakeUrlEncodingTest.java
+++ b/test/jdk/java/net/httpclient/websocket/HandshakeUrlEncodingTest.java
@@ -116,17 +116,15 @@ public class HandshakeUrlEncodingTest {
                 if (!(t instanceof WebSocketHandshakeException)) {
                     throw new AssertionError("Unexpected exception", t);
                 }
-                WebSocketHandshakeException wse = (WebSocketHandshakeException) t;
+                final WebSocketHandshakeException wse = (WebSocketHandshakeException) t;
                 assertNotNull(wse.getResponse());
-                assertNotNull(wse.getResponse().body());
-                assertEquals(wse.getResponse().body().getClass(), String.class);
-                String body = (String)wse.getResponse().body();
-                String expectedBody = "/?&raw=abc+def/ghi=xyz&encoded=abc%2Bdef%2Fghi%3Dxyz";
-                assertEquals(body, expectedBody);
-                out.println("Status code is " + wse.getResponse().statusCode());
-                out.println("Response is " + body);
+                assertNotNull(wse.getResponse().uri());
                 assertNotNull(wse.getResponse().statusCode());
+                final String rawQuery = wse.getResponse().uri().getRawQuery();
+                final String expectedRawQuery = "&raw=abc+def/ghi=xyz&encoded=abc%2Bdef%2Fghi%3Dxyz";
+                assertEquals(rawQuery, expectedRawQuery);
                 out.println("Status code is " + wse.getResponse().statusCode());
+                out.println("Response is " + wse.getResponse());
                 assertEquals(wse.getResponse().statusCode(), 400);
             }
         }

--- a/test/jdk/java/net/httpclient/websocket/HandshakeUrlEncodingTest.java
+++ b/test/jdk/java/net/httpclient/websocket/HandshakeUrlEncodingTest.java
@@ -112,7 +112,7 @@ public class HandshakeUrlEncodingTest {
                     .join();
                 fail("Expected to throw");
             } catch (CompletionException ce) {
-                Throwable t = getCompletionCause(ce);
+                final Throwable t = getCompletionCause(ce);
                 if (!(t instanceof WebSocketHandshakeException)) {
                     throw new AssertionError("Unexpected exception", t);
                 }
@@ -123,6 +123,12 @@ public class HandshakeUrlEncodingTest {
                 final String rawQuery = wse.getResponse().uri().getRawQuery();
                 final String expectedRawQuery = "&raw=abc+def/ghi=xyz&encoded=abc%2Bdef%2Fghi%3Dxyz";
                 assertEquals(rawQuery, expectedRawQuery);
+                if (wse.getResponse().body() != null &&
+                        (wse.getResponse().body().getClass().equals(String.class))) {
+                    final String body = (String) wse.getResponse().body();
+                    final String expectedBody = "/?" + expectedRawQuery;
+                    assertEquals(body, expectedBody);
+                }
                 out.println("Status code is " + wse.getResponse().statusCode());
                 out.println("Response is " + wse.getResponse());
                 assertEquals(wse.getResponse().statusCode(), 400);


### PR DESCRIPTION
According to [rfc6455](https://www.rfc-editor.org/rfc/rfc6455.html#section-5.5.1), the close frame MAY contain a body, i.e. it is considered [optional](https://www.rfc-editor.org/rfc/rfc2119#section-5). It seems that the contemporary JDK HEAD (tip) does populate the body and thus enables `HandshakeUrlEncodingTest.java` to parse its contents. On the contrary, JDK 11 does not populate the body in the same case. I would like to backport JDK-8245245 all the way to JDK 11, so I would like to change the behavior of this test so as it works across JDK versions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298588](https://bugs.openjdk.org/browse/JDK-8298588): WebSockets: HandshakeUrlEncodingTest unnecessarily depends on a response body


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11486/head:pull/11486` \
`$ git checkout pull/11486`

Update a local copy of the PR: \
`$ git checkout pull/11486` \
`$ git pull https://git.openjdk.org/jdk pull/11486/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11486`

View PR using the GUI difftool: \
`$ git pr show -t 11486`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11486.diff">https://git.openjdk.org/jdk/pull/11486.diff</a>

</details>
