### PR TITLE
8273357: SecurityManager deprecation warning from java/awt/regtesthelpers/Util.java

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/Util.java
+++ b/test/jdk/java/awt/regtesthelpers/Util.java
@@ -450,6 +450,7 @@ public final class Util {
             Method m_addExports = Class.forName("java.awt.Helper").getDeclaredMethod("addExports", String.class, java.lang.Module.class);
             // We may be called from non-X11 system, and this permission cannot be delegated to a test.
             m_addExports.invoke(null, "sun.awt.X11", Util.class.getModule());
+            @SuppressWarnings("removal")
             Method m_getWMID = (Method)AccessController.doPrivileged(new PrivilegedAction() {
                     public Object run() {
                         try {


### PR DESCRIPTION
The compilation of a number of tests that use regtesthelpers/Util.java are getting a warning about
the deprecation-for-removal of the SecurityManager.
This suppresses that warning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273357](https://bugs.openjdk.org/browse/JDK-8273357): SecurityManager deprecation warning from java/awt/regtesthelpers/Util.java


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11492/head:pull/11492` \
`$ git checkout pull/11492`

Update a local copy of the PR: \
`$ git checkout pull/11492` \
`$ git pull https://git.openjdk.org/jdk pull/11492/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11492`

View PR using the GUI difftool: \
`$ git pr show -t 11492`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11492.diff">https://git.openjdk.org/jdk/pull/11492.diff</a>

</details>
