### PR TITLE
8298054: ProblemList jdk/jfr/api/consumer/recordingstream/TestStop.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -749,6 +749,7 @@ jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all
 jdk/jfr/api/consumer/recordingstream/TestOnEvent.java           8255404 linux-x64
 jdk/jfr/api/consumer/TestRecordingFileWrite.java                8287699 generic-all
+jdk/jfr/api/consumer/recordingstream/TestStop.java              8298043 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList jdk/jfr/api/consumer/recordingstream/TestStop.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298054](https://bugs.openjdk.org/browse/JDK-8298054): ProblemList jdk/jfr/api/consumer/recordingstream/TestStop.java


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11494/head:pull/11494` \
`$ git checkout pull/11494`

Update a local copy of the PR: \
`$ git checkout pull/11494` \
`$ git pull https://git.openjdk.org/jdk pull/11494/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11494`

View PR using the GUI difftool: \
`$ git pr show -t 11494`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11494.diff">https://git.openjdk.org/jdk/pull/11494.diff</a>

</details>
