### PR TITLE
8298043: jdk/jfr/api/consumer/recordingstream/TestStop.java failed with "Expected outer stream to have 3 events"

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
@@ -166,18 +166,21 @@ public final class EventDirectoryStream extends AbstractEventStream {
                         processUnordered(disp);
                     }
                     currentParser.resetCache();
-                    barrier.check(); // block if recording is being stopped
                     long endNanos = currentParser.getStartNanos() + currentParser.getChunkDuration();
                     // same conversion as in RecordingInfo
-                    long endMillis = Instant.ofEpochSecond(0, endNanos).toEpochMilli();
-                    if (barrier.getStreamEnd() <= endMillis) {
-                        return;
-                    }
                     if (endNanos > filterEnd) {
                         return;
                     }
                 }
-                if (isLastChunk()) {
+                long endNanos = currentParser.getStartNanos() + currentParser.getChunkDuration();
+                long endMillis = Instant.ofEpochSecond(0, endNanos).toEpochMilli();
+
+                barrier.check(); // block if recording is being stopped
+                if (barrier.getStreamEnd() <= endMillis) {
+                    return;
+                }
+
+                if (!barrier.hasStreamEnd() && isLastChunk()) {
                     // Recording was stopped/closed externally, and no more data to process.
                     return;
                 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/management/StreamBarrier.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/management/StreamBarrier.java
@@ -62,6 +62,10 @@ public final class StreamBarrier implements Closeable {
         return end;
     }
 
+    public synchronized boolean hasStreamEnd() {
+        return end != Long.MAX_VALUE;
+    }
+
     public synchronized void activate() {
         activated = true;
     }
@@ -71,4 +75,5 @@ public final class StreamBarrier implements Closeable {
         activated = false;
         this.notifyAll();
     }
+
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/management/StreamBarrier.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/management/StreamBarrier.java
@@ -75,5 +75,4 @@ public final class StreamBarrier implements Closeable {
         activated = false;
         this.notifyAll();
     }
-
 }

--- a/test/jdk/jdk/jfr/api/consumer/recordingstream/TestStop.java
+++ b/test/jdk/jdk/jfr/api/consumer/recordingstream/TestStop.java
@@ -149,7 +149,7 @@ public class TestStop {
                 if (dumpOuter.size() != 3) {
                     throw new AssertionError("Expected outer dump to have 3 events");
                 }
-                if (outerCount.get() == 3) {
+                if (outerCount.get() != 3) {
                     throw new AssertionError("Expected outer stream to have 3 events");
                 }
                 if (dumpInner.size() != 1) {

--- a/test/jdk/jdk/jfr/jmx/streaming/TestStop.java
+++ b/test/jdk/jdk/jfr/jmx/streaming/TestStop.java
@@ -158,7 +158,7 @@ public class TestStop {
                 if (dumpOuter.size() != 3) {
                     throw new AssertionError("Expected outer dump to have 3 events");
                 }
-                if (outerCount.get() == 3) {
+                if (outerCount.get() != 3) {
                     throw new AssertionError("Expected outer stream to have 3 events");
                 }
                 if (dumpInner.size() != 1) {


### PR DESCRIPTION
Could I have a review of a test and product fix.

Testing: 100 * test/jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ 8298043 is used in problem lists: [test/jdk/ProblemList.txt]

### Issue
 * [JDK-8298043](https://bugs.openjdk.org/browse/JDK-8298043): jdk/jfr/api/consumer/recordingstream/TestStop.java failed with "Expected outer stream to have 3 events"


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11495/head:pull/11495` \
`$ git checkout pull/11495`

Update a local copy of the PR: \
`$ git checkout pull/11495` \
`$ git pull https://git.openjdk.org/jdk pull/11495/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11495`

View PR using the GUI difftool: \
`$ git pr show -t 11495`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11495.diff">https://git.openjdk.org/jdk/pull/11495.diff</a>

</details>
