### PR TITLE
8298055: AArch64: fastdebug build fails after JDK-8247645

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -2435,6 +2435,7 @@ public:
       break;
     default:
       ShouldNotReachHere();
+      Rm = 0;  // unreachable
     }
 
     starti;


### PR DESCRIPTION
Please review this trivial change fixing a fastdebug build failure due to warnings being treated as errors after JDK-8247645.

Testing: fastdebug build fine with this change on linux-aarch64 platform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298055](https://bugs.openjdk.org/browse/JDK-8298055): AArch64: fastdebug build fails after JDK-8247645


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Hao Sun](https://openjdk.org/census#haosun) (@shqking - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11496/head:pull/11496` \
`$ git checkout pull/11496`

Update a local copy of the PR: \
`$ git checkout pull/11496` \
`$ git pull https://git.openjdk.org/jdk pull/11496/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11496`

View PR using the GUI difftool: \
`$ git pr show -t 11496`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11496.diff">https://git.openjdk.org/jdk/pull/11496.diff</a>

</details>
