### PR TITLE
JDK-8297958: NMT: Display peak values

### DIFF
--- a/src/hotspot/share/services/mallocSiteTable.hpp
+++ b/src/hotspot/share/services/mallocSiteTable.hpp
@@ -46,8 +46,12 @@ class MallocSite : public AllocationSite {
 
   // Memory allocated from this code path
   size_t size()  const { return _c.size(); }
+  // Peak memory ever allocated from this code path
+  size_t peak_size()  const { return _c.peak_size(); }
   // The number of calls were made
   size_t count() const { return _c.count(); }
+
+  const MemoryCounter* counter() const { return &_c; }
 };
 
 // Malloc site hashtable entry

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -47,7 +47,7 @@ void MemoryCounter::update_peak(size_t size, size_t cnt) {
   size_t peak_sz = peak_size();
   while (peak_sz < size) {
     size_t old_sz = Atomic::cmpxchg(&_peak_size, peak_sz, size, memory_order_relaxed);
-    if (old_sz == size) {
+    if (old_sz == peak_sz) {
       // I won
       _peak_count = cnt;
       break;

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -56,7 +56,7 @@ void MemoryCounter::update_peak(size_t size, size_t cnt) {
     }
   }
 }
-#endif
+#endif // ASSERT
 
 // Total malloc'd memory used by arenas
 size_t MallocMemorySnapshot::total_arena() const {

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -27,6 +27,7 @@
 #include "jvm_io.h"
 #include "logging/log.hpp"
 #include "runtime/arguments.hpp"
+#include "runtime/atomic.hpp"
 #include "runtime/os.hpp"
 #include "runtime/safefetch.hpp"
 #include "services/mallocHeader.inline.hpp"
@@ -42,32 +43,18 @@ size_t MallocMemorySummary::_limits_per_category[mt_number_of_types] = { 0 };
 size_t MallocMemorySummary::_total_limit = 0;
 
 #ifdef ASSERT
-void MemoryCounter::update_peak_count(size_t count) {
-  size_t peak_cnt = peak_count();
-  while (peak_cnt < count) {
-    size_t old_cnt = Atomic::cmpxchg(&_peak_count, peak_cnt, count, memory_order_relaxed);
-    if (old_cnt != peak_cnt) {
-      peak_cnt = old_cnt;
-    }
-  }
-}
-
-void MemoryCounter::update_peak_size(size_t sz) {
+void MemoryCounter::update_peak(size_t size, size_t cnt) {
   size_t peak_sz = peak_size();
-  while (peak_sz < sz) {
-    size_t old_sz = Atomic::cmpxchg(&_peak_size, peak_sz, sz, memory_order_relaxed);
-    if (old_sz != peak_sz) {
+  while (peak_sz < size) {
+    size_t old_sz = Atomic::cmpxchg(&_peak_size, peak_sz, size, memory_order_relaxed);
+    if (old_sz == size) {
+      // I won
+      _peak_count = cnt;
+      break;
+    } else {
       peak_sz = old_sz;
     }
   }
-}
-
-size_t MemoryCounter::peak_count() const {
-  return Atomic::load(&_peak_count);
-}
-
-size_t MemoryCounter::peak_size() const {
-  return Atomic::load(&_peak_size);
 }
 #endif
 

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -45,8 +45,13 @@ class MemoryCounter {
   volatile size_t   _count;
   volatile size_t   _size;
 
-  DEBUG_ONLY(volatile size_t   _peak_count;)
-  DEBUG_ONLY(volatile size_t   _peak_size; )
+#ifdef ASSERT
+  // Peak size and count. Note: Peak count is the count at the point
+  // peak size was reached, not the absolute highest peak count.
+  volatile size_t _peak_count;
+  volatile size_t _peak_size;
+  void update_peak(size_t size, size_t cnt);
+#endif // ASSERT
 
  public:
   MemoryCounter() : _count(0), _size(0) {
@@ -58,9 +63,8 @@ class MemoryCounter {
     size_t cnt = Atomic::add(&_count, size_t(1), memory_order_relaxed);
     if (sz > 0) {
       size_t sum = Atomic::add(&_size, sz, memory_order_relaxed);
-      DEBUG_ONLY(update_peak_size(sum);)
+      DEBUG_ONLY(update_peak(sum, cnt);)
     }
-    DEBUG_ONLY(update_peak_count(cnt);)
   }
 
   inline void deallocate(size_t sz) {
@@ -76,19 +80,20 @@ class MemoryCounter {
     if (sz != 0) {
       assert(sz >= 0 || size() >= size_t(-sz), "Must be");
       size_t sum = Atomic::add(&_size, size_t(sz), memory_order_relaxed);
-      DEBUG_ONLY(update_peak_size(sum);)
+      DEBUG_ONLY(update_peak(sum, _count);)
     }
   }
 
   inline size_t count() const { return Atomic::load(&_count); }
   inline size_t size()  const { return Atomic::load(&_size);  }
 
-#ifdef ASSERT
-  void update_peak_count(size_t cnt);
-  void update_peak_size(size_t sz);
-  size_t peak_count() const;
-  size_t peak_size()  const;
-#endif // ASSERT
+  inline size_t peak_count() const {
+    return DEBUG_ONLY(Atomic::load(&_peak_count)) NOT_DEBUG(0);
+  }
+
+  inline size_t peak_size() const {
+    return DEBUG_ONLY(Atomic::load(&_peak_size)) NOT_DEBUG(0);
+  }
 };
 
 /*
@@ -125,12 +130,14 @@ class MallocMemory {
   }
 
   inline size_t malloc_size()  const { return _malloc.size(); }
+  inline size_t malloc_peak_size()  const { return _malloc.peak_size(); }
   inline size_t malloc_count() const { return _malloc.count();}
   inline size_t arena_size()   const { return _arena.size();  }
+  inline size_t arena_peak_size()  const { return _arena.peak_size(); }
   inline size_t arena_count()  const { return _arena.count(); }
 
-  DEBUG_ONLY(inline const MemoryCounter& malloc_counter() const { return _malloc; })
-  DEBUG_ONLY(inline const MemoryCounter& arena_counter()  const { return _arena;  })
+  const MemoryCounter* malloc_counter() const { return &_malloc; }
+  const MemoryCounter* arena_counter()  const { return &_arena;  }
 };
 
 class MallocMemorySummary;

--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -70,7 +70,7 @@ void MemReporterBase::print_malloc(const MemoryCounter* c, MEMFLAGS flag) const 
 
   size_t pk_amount = c->peak_size();
   if (pk_amount == amount) {
-    out->print_raw(" (peak)");
+    out->print_raw(" (at peak)");
   } else if (pk_amount > amount) {
     size_t pk_count = c->peak_count();
     out->print(" (peak=" SIZE_FORMAT "%s #" SIZE_FORMAT ")",
@@ -108,7 +108,7 @@ void MemReporterBase::print_arena_line(const MemoryCounter* c) const {
 
   size_t pk_amount = c->peak_size();
   if (pk_amount == amount) {
-    out->print_raw(" (peak)");
+    out->print_raw(" (at peak)");
   } else if (pk_amount > amount) {
     size_t pk_count = c->peak_count();
     out->print(" (peak=" SIZE_FORMAT "%s #" SIZE_FORMAT ")",

--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -69,7 +69,9 @@ void MemReporterBase::print_malloc(const MemoryCounter* c, MEMFLAGS flag) const 
   out->print(")");
 
   size_t pk_amount = c->peak_size();
-  if (pk_amount > amount) { // Only print if historic peak is larger than what we see now
+  if (pk_amount == amount) {
+    out->print_raw(" (peak)");
+  } else if (pk_amount > amount) {
     size_t pk_count = c->peak_count();
     out->print(" (peak=" SIZE_FORMAT "%s #" SIZE_FORMAT ")",
         amount_in_current_scale(pk_amount), scale, pk_count);
@@ -105,7 +107,9 @@ void MemReporterBase::print_arena_line(const MemoryCounter* c) const {
     amount_in_current_scale(amount), scale, count);
 
   size_t pk_amount = c->peak_size();
-  if (pk_amount > amount) { // Only print if historic peak is larger than what we see now
+  if (pk_amount == amount) {
+    out->print_raw(" (peak)");
+  } else if (pk_amount > amount) {
     size_t pk_count = c->peak_count();
     out->print(" (peak=" SIZE_FORMAT "%s #" SIZE_FORMAT ")",
         amount_in_current_scale(pk_amount), scale, pk_count);

--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -226,7 +226,6 @@ void MemSummaryReporter::report_summary_of_type(MEMFLAGS flag,
      // report malloc'd memory
     if (amount_in_current_scale(malloc_memory->malloc_size()) > 0
         DEBUG_ONLY(|| amount_in_current_scale(malloc_memory->malloc_peak_size()) > 0)) {
-      // We don't know how many arena chunks are in used, so don't report the count
       print_malloc_line(malloc_memory->malloc_counter());
     }
 

--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -45,10 +45,13 @@ void MemReporterBase::print_total(size_t reserved, size_t committed) const {
     amount_in_current_scale(reserved), scale, amount_in_current_scale(committed), scale);
 }
 
-void MemReporterBase::print_malloc(size_t amount, size_t count, MEMFLAGS flag) const {
+void MemReporterBase::print_malloc(const MemoryCounter* c, MEMFLAGS flag) const {
   const char* scale = current_scale();
   outputStream* out = output();
   const char* alloc_type = (flag == mtThreadStack) ? "" : "malloc=";
+
+  const size_t amount = c->size();
+  const size_t count = c->count();
 
   if (flag != mtNone) {
     out->print("(%s" SIZE_FORMAT "%s type=%s", alloc_type,
@@ -58,11 +61,19 @@ void MemReporterBase::print_malloc(size_t amount, size_t count, MEMFLAGS flag) c
       amount_in_current_scale(amount), scale);
   }
 
+  // blends out mtChunk count number
   if (count > 0) {
     out->print(" #" SIZE_FORMAT "", count);
   }
 
   out->print(")");
+
+  size_t pk_amount = c->peak_size();
+  if (pk_amount > amount) { // Only print if historic peak is larger than what we see now
+    size_t pk_count = c->peak_count();
+    out->print(" (peak=" SIZE_FORMAT "%s #" SIZE_FORMAT ")",
+        amount_in_current_scale(pk_amount), scale, pk_count);
+  }
 }
 
 void MemReporterBase::print_virtual_memory(size_t reserved, size_t committed) const {
@@ -71,9 +82,9 @@ void MemReporterBase::print_virtual_memory(size_t reserved, size_t committed) co
     amount_in_current_scale(reserved), scale, amount_in_current_scale(committed), scale);
 }
 
-void MemReporterBase::print_malloc_line(size_t amount, size_t count) const {
+void MemReporterBase::print_malloc_line(const MemoryCounter* c) const {
   output()->print("%28s", " ");
-  print_malloc(amount, count);
+  print_malloc(c);
   output()->print_cr(" ");
 }
 
@@ -83,10 +94,24 @@ void MemReporterBase::print_virtual_memory_line(size_t reserved, size_t committe
   output()->print_cr(" ");
 }
 
-void MemReporterBase::print_arena_line(size_t amount, size_t count) const {
+void MemReporterBase::print_arena_line(const MemoryCounter* c) const {
   const char* scale = current_scale();
-  output()->print_cr("%27s (arena=" SIZE_FORMAT "%s #" SIZE_FORMAT ")", " ",
+  outputStream* out = output();
+
+  const size_t amount = c->size();
+  const size_t count = c->count();
+
+  out->print("%27s (arena=" SIZE_FORMAT "%s #" SIZE_FORMAT ")", "",
     amount_in_current_scale(amount), scale, count);
+
+  size_t pk_amount = c->peak_size();
+  if (pk_amount > amount) { // Only print if historic peak is larger than what we see now
+    size_t pk_count = c->peak_count();
+    out->print(" (peak=" SIZE_FORMAT "%s #" SIZE_FORMAT ")",
+        amount_in_current_scale(pk_amount), scale, pk_count);
+  }
+
+  out->cr();
 }
 
 void MemReporterBase::print_virtual_memory_region(const char* type, address base, size_t size) const {
@@ -195,18 +220,20 @@ void MemSummaryReporter::report_summary_of_type(MEMFLAGS flag,
     }
 
      // report malloc'd memory
-    if (amount_in_current_scale(malloc_memory->malloc_size()) > 0) {
+    if (amount_in_current_scale(malloc_memory->malloc_size()) > 0
+        DEBUG_ONLY(|| amount_in_current_scale(malloc_memory->malloc_peak_size()) > 0)) {
       // We don't know how many arena chunks are in used, so don't report the count
       size_t count = (flag == mtChunk) ? 0 : malloc_memory->malloc_count();
-      print_malloc_line(malloc_memory->malloc_size(), count);
+      print_malloc_line(malloc_memory->malloc_counter());
     }
 
     if (amount_in_current_scale(virtual_memory->reserved()) > 0) {
       print_virtual_memory_line(virtual_memory->reserved(), virtual_memory->committed());
     }
 
-    if (amount_in_current_scale(malloc_memory->arena_size()) > 0) {
-      print_arena_line(malloc_memory->arena_size(), malloc_memory->arena_count());
+    if (amount_in_current_scale(malloc_memory->arena_size()) > 0
+        DEBUG_ONLY(|| amount_in_current_scale(malloc_memory->arena_peak_size()) > 0)) {
+      print_arena_line(malloc_memory->arena_counter());
     }
 
     if (flag == mtNMT &&
@@ -271,12 +298,9 @@ int MemDetailReporter::report_malloc_sites() {
   const MallocSite* malloc_site;
   int num_omitted = 0;
   while ((malloc_site = malloc_itr.next()) != NULL) {
-    // Don't report free sites; does not count toward omitted count.
-    if (malloc_site->size() == 0) {
-      continue;
-    }
-    // Don't report if site has allocated less than one unit of whatever our scale is
-    if (scale() > 1 && amount_in_current_scale(malloc_site->size()) == 0) {
+    // Don't report if site has never allocated less than one unit of whatever our scale is
+    if (scale() > 1 && amount_in_current_scale(malloc_site->size()) == 0
+                       DEBUG_ONLY(&& amount_in_current_scale(malloc_site->peak_size()) == 0)) {
       num_omitted ++;
       continue;
     }
@@ -286,7 +310,7 @@ int MemDetailReporter::report_malloc_sites() {
     MEMFLAGS flag = malloc_site->flag();
     assert(NMTUtil::flag_is_valid(flag) && flag != mtNone,
       "Must have a valid memory type");
-    print_malloc(malloc_site->size(), malloc_site->count(),flag);
+    print_malloc(malloc_site->counter(), flag);
     out->print_cr("\n");
   }
   return num_omitted;

--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -227,7 +227,6 @@ void MemSummaryReporter::report_summary_of_type(MEMFLAGS flag,
     if (amount_in_current_scale(malloc_memory->malloc_size()) > 0
         DEBUG_ONLY(|| amount_in_current_scale(malloc_memory->malloc_peak_size()) > 0)) {
       // We don't know how many arena chunks are in used, so don't report the count
-      size_t count = (flag == mtChunk) ? 0 : malloc_memory->malloc_count();
       print_malloc_line(malloc_memory->malloc_counter());
     }
 

--- a/src/hotspot/share/services/memReporter.hpp
+++ b/src/hotspot/share/services/memReporter.hpp
@@ -80,12 +80,12 @@ class MemReporterBase : public StackObj {
 
   // Print summary total, malloc and virtual memory
   void print_total(size_t reserved, size_t committed) const;
-  void print_malloc(size_t amount, size_t count, MEMFLAGS flag = mtNone) const;
+  void print_malloc(const MemoryCounter* c, MEMFLAGS flag = mtNone) const;
   void print_virtual_memory(size_t reserved, size_t committed) const;
 
-  void print_malloc_line(size_t amount, size_t count) const;
+  void print_malloc_line(const MemoryCounter* c) const;
   void print_virtual_memory_line(size_t reserved, size_t committed) const;
-  void print_arena_line(size_t amount, size_t count) const;
+  void print_arena_line(const MemoryCounter* c) const;
 
   void print_virtual_memory_region(const char* type, address base, size_t size) const;
 };


### PR DESCRIPTION
Historical peak values can be very useful in analyzing memory footprint. 

For example, want to know how much memory the compiler needs during warmup? You have to get an NMT report at the exact time, with compile arenas at their largest combined extensions. But if we had peak values, you'd see how much the compiler needed by just looking at its arena peak size.

We already collect peak values in debug builds, but never actually display them. Since we already pay for them, we might just as well print them.

There is also a small issue that peak size and count are updated separately. It makes not much sense to treat these as independent values. Therefore this patch changes the meaning and implementation of peak count from today's "highest count" to "count at the point peak size was reached". 

How this looks like:

```
-                        GC (reserved=425748KB, committed=94868KB)
                            (malloc=38552KB #1086) (peak=38622KB #1409)   <<<<
                            (mmap: reserved=387196KB, committed=56316KB) 
 
-                 GCCardSet (reserved=29KB, committed=29KB)
                            (malloc=29KB #387) 
 
-                  Compiler (reserved=200KB, committed=200KB)
                            (malloc=36KB #59) (peak=37KB #74)    <<<<
                            (arena=165KB #5) (peak=6192KB #18)  <<<<
```

```
[0x00007f7e6b0866b0] Arena::grow(unsigned long, AllocFailStrategy::AllocFailEnum)+0x40
[0x00007f7e6c117a29] OopMap::OopMap(int, int)+0x69
[0x00007f7e6b2857a5] LinearScan::compute_oop_map(IntervalWalker*, LIR_Op*, CodeEmitInfo*, bool)+0x85
[0x00007f7e6b285f2a] LinearScan::compute_oop_map(IntervalWalker*, LIR_OpVisitState const&, LIR_Op*)+0x5a
                             (malloc=32KB type=Arena Chunk #1) (peak=288KB #9) <<<<
```

Notes:

- This RFE just adds peak to the *debug* VM. In debug, we already have all values, its just a matter of printing them. I would love to see peak values in release builds too, but collecting them does cost one or more CAS per malloc and therefore we must analyze performance before enabling. Having them in release would also remove the remaining #ifdef ASSERT.

- I omit printing peak values when we are at peak. So if "peak" is missing, current peak is implied.

- I only print peak values in summary and detail mode, not in any of the diff modes, to keep code complexity low and because diff modes are more about baseline compare.

- In detail mode, there is a small display issue that call sites will be omitted that have no current allocations. A hypothetical call site that allocated a zillion byte, then freed them all, will not be shown even though its peak value would be interesting. That is an issue for another RFE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297958](https://bugs.openjdk.org/browse/JDK-8297958): NMT: Display peak values


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - Committer) ⚠️ Review applies to [9c2daf50](https://git.openjdk.org/jdk/pull/11497/files/9c2daf501c1f7b46348bba277fb4d0c3d9b404d4)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11497/head:pull/11497` \
`$ git checkout pull/11497`

Update a local copy of the PR: \
`$ git checkout pull/11497` \
`$ git pull https://git.openjdk.org/jdk pull/11497/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11497`

View PR using the GUI difftool: \
`$ git pr show -t 11497`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11497.diff">https://git.openjdk.org/jdk/pull/11497.diff</a>

</details>
