### PR TITLE
8298067: Persistent test failures after 8296012

### DIFF
--- a/test/langtools/jdk/jshell/Test8296012.java
+++ b/test/langtools/jdk/jshell/Test8296012.java
@@ -42,6 +42,6 @@ public class Test8296012 extends KullaTesting {
 
     @org.testng.annotations.BeforeMethod
     public void setUp() {
-        super.setUp(bc -> bc.compilerOptions("--source", System.getProperty("java.specification.version"), "--enable-preview").remoteVMOptions("--enable-preview"));
+        super.setUp(bc -> bc.compilerOptions("--source", System.getProperty("java.specification.version"), "--enable-preview").remoteVMOptions("-XX:+UnlockExperimentalVMOptions", "-XX:+VMContinuations", "--enable-preview"));
     }
 }

--- a/test/langtools/jdk/jshell/Test8296012.java
+++ b/test/langtools/jdk/jshell/Test8296012.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8296012
  * @summary jshell crashes on mismatched record pattern
+ * @requires vm.continuations
  * @build KullaTesting TestingInputStream
  * @run testng Test8296012
  */
@@ -42,6 +43,6 @@ public class Test8296012 extends KullaTesting {
 
     @org.testng.annotations.BeforeMethod
     public void setUp() {
-        super.setUp(bc -> bc.compilerOptions("--source", System.getProperty("java.specification.version"), "--enable-preview").remoteVMOptions("-XX:+UnlockExperimentalVMOptions", "-XX:+VMContinuations", "--enable-preview"));
+        super.setUp(bc -> bc.compilerOptions("--source", System.getProperty("java.specification.version"), "--enable-preview").remoteVMOptions("--enable-preview"));
     }
 }


### PR DESCRIPTION
After JDK-8296012 a langtools test consistently fails on x86 Linux. This is due to said test needing JVMTI and --enable-preview, but for both to be compatible VMContinuations needs to be manually enabled, since it is off by default on certain platforms. HotSpot otherwise rejects the JVMTI request if VMContinuations is not enabled

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298067](https://bugs.openjdk.org/browse/JDK-8298067): Persistent test failures after 8296012


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11500/head:pull/11500` \
`$ git checkout pull/11500`

Update a local copy of the PR: \
`$ git checkout pull/11500` \
`$ git pull https://git.openjdk.org/jdk pull/11500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11500`

View PR using the GUI difftool: \
`$ git pr show -t 11500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11500.diff">https://git.openjdk.org/jdk/pull/11500.diff</a>

</details>
