### PR TITLE
8298068: ProblemList tests failing due to JDK-8297235

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -38,3 +38,5 @@ serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64
 serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java 8288430 generic-all
 
 gc/cslocker/TestCSLocker.java 8293289 generic-x64
+
+compiler/c1/TestPrintC1Statistics.java 8298053 generic-x64

--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -39,4 +39,4 @@ serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java 8288430 generic-all
 
 gc/cslocker/TestCSLocker.java 8293289 generic-x64
 
-compiler/c1/TestPrintC1Statistics.java 8298053 generic-x64
+compiler/c1/TestPrintC1Statistics.java 8298053 linux-aarch64

--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -83,3 +83,6 @@ vmTestbase/nsk/monitoring/stress/lowmem/lowmem033/TestDescription.java 8297979 g
 vmTestbase/nsk/monitoring/stress/lowmem/lowmem034/TestDescription.java 8297979 generic-all
 vmTestbase/nsk/monitoring/stress/lowmem/lowmem035/TestDescription.java 8297979 generic-all
 vmTestbase/nsk/monitoring/stress/lowmem/lowmem036/TestDescription.java 8297979 generic-all
+
+vmTestbase/nsk/jdi/ExceptionRequest/addInstanceFilter/instancefilter001/TestDescription.java 8298059 generic-x64
+vmTestbase/nsk/jdi/ExceptionRequest/addInstanceFilter/instancefilter004/TestDescription.java 8298059 generic-x64

--- a/test/jdk/ProblemList-zgc.txt
+++ b/test/jdk/ProblemList-zgc.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -27,3 +27,68 @@
 #
 #############################################################################
 
+java/lang/StackWalker/AcrossThreads.java 8297235 generic-x64
+java/math/BigInteger/BigIntegerParallelMultiplyTest.java 8297235 generic-x64
+java/util/Arrays/SetAllTest.java 8297235 generic-x64
+java/util/Arrays/Sorting.java 8297235 generic-x64
+java/util/Arrays/largeMemory/ParallelPrefix.java 8297235 generic-x64
+java/util/BitSet/stream/BitSetStreamTest.java 8297235 generic-x64
+java/util/Collection/IteratorMicroBenchmark.java 8297235 generic-x64
+java/util/Collections/UnmodifiableMapEntrySet.java 8297235 generic-x64
+java/util/DoubleStreamSums/CompensatedSums.java 8297235 generic-x64
+java/util/Random/RandomTest.java 8297235 generic-x64
+java/util/Scanner/ScannerStreamTest.java 8297235 generic-x64
+java/util/concurrent/forkjoin/AsyncShutdownNow.java 8297235 generic-x64
+java/util/concurrent/forkjoin/AsyncShutdownNowInvokeAny.java 8297235 generic-x64
+java/util/concurrent/forkjoin/AsyncShutdownNowInvokeAnyRace.java 8297235 generic-x64
+java/util/concurrent/forkjoin/Integrate.java 8297235 generic-x64
+java/util/concurrent/forkjoin/NQueensCS.java 8297235 generic-x64
+java/util/concurrent/tck/JSR166TestCase.java 8297235 generic-x64
+java/util/regex/PatternStreamTest.java 8297235 generic-x64
+java/util/stream/CustomFJPoolTest.java 8297235 generic-x64
+java/util/stream/boottest/java.base/java/util/stream/DoubleNodeTest.java 8297235 generic-x64
+java/util/stream/boottest/java.base/java/util/stream/FlagOpTest.java 8297235 generic-x64
+java/util/stream/boottest/java.base/java/util/stream/IntNodeTest.java 8297235 generic-x64
+java/util/stream/boottest/java.base/java/util/stream/LongNodeTest.java 8297235 generic-x64
+java/util/stream/boottest/java.base/java/util/stream/NodeTest.java 8297235 generic-x64
+java/util/stream/boottest/java.base/java/util/stream/StreamReuseTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/CollectAndSummaryStatisticsTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/CollectorsTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/ConcatOpTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/CountTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/DistinctOpTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/DoublePrimitiveOpsTests.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/FilterOpTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/FindAnyOpTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/FindFirstOpTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/FlatMapOpTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/ForEachOpTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/GroupByOpTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/InfiniteStreamWithLimitOpTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/IntPrimitiveOpsTests.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/IntReduceTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/IntSliceOpTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/IntUniqOpTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/IterateTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/LongPrimitiveOpsTests.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/MapOpTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/MatchOpTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/MinMaxTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/PrimitiveAverageOpTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/PrimitiveSumTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/RangeTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/ReduceByOpTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/ReduceTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/SequentialOpTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/SliceOpTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/SortedOpTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/StreamBuilderTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/StreamLinkTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/StreamSpliteratorTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/TeeOpTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/ToListOpTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/WhileOpStatefulTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/WhileOpTest.java 8297235 generic-x64
+java/util/stream/test/org/openjdk/tests/java/util/stream/mapMultiOpTest.java 8297235 generic-x64

--- a/test/jdk/ProblemList-zgc.txt
+++ b/test/jdk/ProblemList-zgc.txt
@@ -92,3 +92,5 @@ java/util/stream/test/org/openjdk/tests/java/util/stream/ToListOpTest.java 82972
 java/util/stream/test/org/openjdk/tests/java/util/stream/WhileOpStatefulTest.java 8297235 generic-x64
 java/util/stream/test/org/openjdk/tests/java/util/stream/WhileOpTest.java 8297235 generic-x64
 java/util/stream/test/org/openjdk/tests/java/util/stream/mapMultiOpTest.java 8297235 generic-x64
+
+jdk/internal/vm/Continuation/Fuzz.java#default 8298058 generic-x64


### PR DESCRIPTION
Batch of ProblemListings to reduce the noise in the JDK20 CI:

[JDK-8298068](https://bugs.openjdk.org/browse/JDK-8298068) ProblemList tests failing due to JDK-8297235
[JDK-8298070](https://bugs.openjdk.org/browse/JDK-8298070) ProblemList jdk/internal/vm/Continuation/Fuzz.java#default with ZGC on X64
[JDK-8298071](https://bugs.openjdk.org/browse/JDK-8298071) ProblemList tests failing due to JDK-8298059
[JDK-8298072](https://bugs.openjdk.org/browse/JDK-8298072) ProblemList compiler/c1/TestPrintC1Statistics.java in Xcomp mode on linux-aarch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8298068](https://bugs.openjdk.org/browse/JDK-8298068): ProblemList tests failing due to JDK-8297235
 * [JDK-8298070](https://bugs.openjdk.org/browse/JDK-8298070): ProblemList jdk/internal/vm/Continuation/Fuzz.java#default with ZGC on X64
 * [JDK-8298071](https://bugs.openjdk.org/browse/JDK-8298071): ProblemList tests failing due to JDK-8298059
 * [JDK-8298072](https://bugs.openjdk.org/browse/JDK-8298072): ProblemList compiler/c1/TestPrintC1Statistics.java in Xcomp mode on linux-aarch64


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11501/head:pull/11501` \
`$ git checkout pull/11501`

Update a local copy of the PR: \
`$ git checkout pull/11501` \
`$ git pull https://git.openjdk.org/jdk pull/11501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11501`

View PR using the GUI difftool: \
`$ git pr show -t 11501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11501.diff">https://git.openjdk.org/jdk/pull/11501.diff</a>

</details>
