### PR TITLE
8298075: RISC-V: Implement post-call NOPs

### DIFF
--- a/src/hotspot/cpu/riscv/c1_CodeStubs_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_CodeStubs_riscv.cpp
@@ -43,7 +43,9 @@ void C1SafepointPollStub::emit_code(LIR_Assembler* ce) {
   __ bind(_entry);
   InternalAddress safepoint_pc(__ pc() - __ offset() + safepoint_offset());
   __ relocate(safepoint_pc.rspec(), [&] {
-    __ la(t0, safepoint_pc.target());
+    int32_t offset;
+    __ la_patchable(t0, safepoint_pc.target(), offset);
+    __ addi(t0, t0, offset);
   });
   __ sd(t0, Address(xthread, JavaThread::saved_exception_pc_offset()));
 

--- a/src/hotspot/cpu/riscv/c2_safepointPollStubTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_safepointPollStubTable_riscv.cpp
@@ -40,7 +40,9 @@ void C2SafepointPollStubTable::emit_stub_impl(MacroAssembler& masm, C2SafepointP
   __ bind(entry->_stub_label);
   InternalAddress safepoint_pc(__ pc() - __ offset() + entry->_safepoint_offset);
   __ relocate(safepoint_pc.rspec(), [&] {
-    __ la(t0, safepoint_pc.target());
+    int32_t offset;
+    __ la_patchable(t0, safepoint_pc.target(), offset);
+    __ addi(t0, t0, offset);
   });
   __ sd(t0, Address(xthread, JavaThread::saved_exception_pc_offset()));
   __ far_jump(callback_addr);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -210,6 +210,7 @@ void MacroAssembler::post_call_nop() {
   }
   relocate(post_call_nop_Relocation::spec(), [&] {
     nop();
+    li32(zr, 0);
   });
 }
 
@@ -1383,7 +1384,7 @@ static int patch_imm_in_li64(address branch, address target) {
   return LI64_INSTRUCTIONS_NUM * NativeInstruction::instruction_size;
 }
 
-static int patch_imm_in_li32(address branch, int32_t target) {
+int MacroAssembler::patch_imm_in_li32(address branch, int32_t target) {
   const int LI32_INSTRUCTIONS_NUM = 2;                                          // lui + addiw
   int64_t upper = (intptr_t)target;
   int32_t lower = (((int32_t)target) << 20) >> 20;
@@ -1447,7 +1448,7 @@ static address get_target_of_li64(address insn_addr) {
   return (address)target_address;
 }
 
-static address get_target_of_li32(address insn_addr) {
+address MacroAssembler::get_target_of_li32(address insn_addr) {
   assert_cond(insn_addr != NULL);
   intptr_t target_address = (((int64_t)Assembler::sextract(((unsigned*)insn_addr)[0], 31, 12)) & 0xfffff) << 12;    // Lui.
   target_address += ((int64_t)Assembler::sextract(((unsigned*)insn_addr)[1], 31, 20));                              // Addiw.

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -387,6 +387,9 @@ class MacroAssembler: public Assembler {
 
   static int patch_oop(address insn_addr, address o);
 
+  static address get_target_of_li32(address insn_addr);
+  static int patch_imm_in_li32(address branch, int32_t target);
+
   // Return whether code is emitted to a scratch blob.
   virtual bool in_scratch_emit_size() {
     return false;

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -444,8 +444,18 @@ void NativePostCallNop::make_deopt() {
   NativeDeoptInstruction::insert(addr_at(0));
 }
 
+int NativePostCallNop::displacement() const {
+  // discard the high 32-bit
+  return (int)(intptr_t)MacroAssembler::get_target_of_li32(addr_at(4));
+}
+
 void NativePostCallNop::patch(jint diff) {
-  // unsupported for now
+#ifndef PRODUCT
+  assert(diff != 0, "must be");
+  assert(is_lui_to_zr_at(addr_at(4)) && is_addiw_to_zr_at(addr_at(8)), "must be");
+#endif
+
+  MacroAssembler::patch_imm_in_li32(addr_at(4), diff);
 }
 
 void NativeDeoptInstruction::verify() {

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -445,7 +445,7 @@ void NativePostCallNop::make_deopt() {
 }
 
 int NativePostCallNop::displacement() const {
-  // Discard the high 32 bit
+  // Discard the high 32 bits
   return (int)(intptr_t)MacroAssembler::get_target_of_li32(addr_at(4));
 }
 

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -445,7 +445,7 @@ void NativePostCallNop::make_deopt() {
 }
 
 int NativePostCallNop::displacement() const {
-  // Discard the high 32-bit
+  // Discard the high 32 bit
   return (int)(intptr_t)MacroAssembler::get_target_of_li32(addr_at(4));
 }
 

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -450,7 +450,7 @@ int NativePostCallNop::displacement() const {
 }
 
 void NativePostCallNop::patch(jint diff) {
-#ifndef PRODUCT
+#ifdef ASSERT
   assert(diff != 0, "must be");
   assert(is_lui_to_zr_at(addr_at(4)) && is_addiw_to_zr_at(addr_at(8)), "must be");
 #endif

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -445,7 +445,7 @@ void NativePostCallNop::make_deopt() {
 }
 
 int NativePostCallNop::displacement() const {
-  // discard the high 32-bit
+  // Discard the high 32-bit
   return (int)(intptr_t)MacroAssembler::get_target_of_li32(addr_at(4));
 }
 

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -450,10 +450,8 @@ int NativePostCallNop::displacement() const {
 }
 
 void NativePostCallNop::patch(jint diff) {
-#ifdef ASSERT
   assert(diff != 0, "must be");
   assert(is_lui_to_zr_at(addr_at(4)) && is_addiw_to_zr_at(addr_at(8)), "must be");
-#endif
 
   MacroAssembler::patch_imm_in_li32(addr_at(4), diff);
 }


### PR DESCRIPTION
Same as [JDK-8287567](https://bugs.openjdk.org/browse/JDK-8287567), we need to implement post-call NOPs in the RISC-V backend.

We use `li32` to implement it. `li32` will signed-extend the loaded imm32 to a 64-bit register. However, our reader `NativePostCallNop::displacement()` only needs the low 32 bits value so we are safe.

The current post-call NOP is like:
```
nop                    (always 4-byte, used for deoptimization, please see `NativePostCallNop::make_deopt()`)
lui zr, <imm20>        (always 4-byte)
addiw zr, zr, <imm12>  (always 4-byte)
```

The code size here is the same as the AArch64 counterpart, 12 bytes.

The logic of setting the post-call NOP displacement is at `install_post_call_nop_displacement()` [1] when nmethods are being installed, so no one is running post-call NOPs when we are patching them.

One can check them by directly using `java --enable-preview -XX:+UnlockDiagnosticVMOptions -XX:+PrintAssembly`.

Tested hotspot tier1\~4 and jdk tier1\~4 using fastdebug by force turning on `--enable-preview`; SPECjbb2015 and dacapo were tested without regressions found. Skynet JMH benchmark seems to have an improvement from `8662ms/op -> 8495ms/op`.

Thanks,
Xiaolin

[1] https://github.com/openjdk/jdk/blob/b49fd920b6690a8b828c85e45c10e5c4c54d2022/src/hotspot/share/code/nmethod.cpp#L1078-L1107

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298075](https://bugs.openjdk.org/browse/JDK-8298075): RISC-V: Implement post-call NOPs


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11502/head:pull/11502` \
`$ git checkout pull/11502`

Update a local copy of the PR: \
`$ git checkout pull/11502` \
`$ git pull https://git.openjdk.org/jdk pull/11502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11502`

View PR using the GUI difftool: \
`$ git pr show -t 11502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11502.diff">https://git.openjdk.org/jdk/pull/11502.diff</a>

</details>
