### PR TITLE
JDK-8298093: improve cleanup and error handling of awt_parseColorModel in awt_parseImage.c

### DIFF
--- a/src/java.desktop/share/native/libawt/awt/image/awt_parseImage.c
+++ b/src/java.desktop/share/native/libawt/awt/image/awt_parseImage.c
@@ -97,9 +97,8 @@ int awt_parseImage(JNIEnv *env, jobject jimage, BufImageS_t **imagePP,
     }
 
     /* Parse the color model */
-    ColorModelS_t *cmP = &imageP->cmodel;
     if ((status = awt_parseColorModel(env, jcmodel, imageP->imageType,
-                                      cmP)) <= 0) {
+                                      &imageP->cmodel)) <= 0) {
         awt_freeParsedRaster(&imageP->raster, FALSE);
         free((void *)imageP);
         return 0;


### PR DESCRIPTION
The cleanup and error handling in function awt_parseColorModel in awt_parseImage.c could be improved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298093](https://bugs.openjdk.org/browse/JDK-8298093): improve cleanup and error handling of awt_parseColorModel in awt_parseImage.c


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11508/head:pull/11508` \
`$ git checkout pull/11508`

Update a local copy of the PR: \
`$ git checkout pull/11508` \
`$ git pull https://git.openjdk.org/jdk pull/11508/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11508`

View PR using the GUI difftool: \
`$ git pr show -t 11508`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11508.diff">https://git.openjdk.org/jdk/pull/11508.diff</a>

</details>
