### PR TITLE
8298027: Remove SCCS id's from awt jtreg tests

### DIFF
--- a/test/jdk/java/awt/font/TextLayout/TestOldHangul.java
+++ b/test/jdk/java/awt/font/TextLayout/TestOldHangul.java
@@ -21,7 +21,7 @@
  *
  */
 
-/* @test @(#)TestOldHangul.java
+/* @test
  * @summary Verify Old Hangul display
  * @bug 6886358
  * @ignore Requires a special font installed.
@@ -80,4 +80,3 @@ public class TestOldHangul {
         frame.setVisible(true);
     }
 }
-

--- a/test/jdk/java/awt/font/TextLayout/TestTibetan.java
+++ b/test/jdk/java/awt/font/TextLayout/TestTibetan.java
@@ -21,7 +21,7 @@
  *
  */
 
-/* @test @(#)TestTibetan.java
+/* @test
  * @summary verify tibetan output
  * @bug 6886358
  * @ignore Requires a special font installed
@@ -84,4 +84,3 @@ public class TestTibetan {
         frame.setVisible(true);
     }
 }
-


### PR DESCRIPTION
Noticed SCCS jtreg id's in 2 open awt tests. After jtreg 7.1 update, jtreg doesn't parse SCCS id's and it causes the tests with SCCS id's to fail.

As of now these 2 tests are ignored, but it is good to remove these SCCS id's.
If we don't need these 2 tests since they are ignored, then i will update the PR base on the review comments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298027](https://bugs.openjdk.org/browse/JDK-8298027): Remove SCCS id's from awt jtreg tests


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11509/head:pull/11509` \
`$ git checkout pull/11509`

Update a local copy of the PR: \
`$ git checkout pull/11509` \
`$ git pull https://git.openjdk.org/jdk pull/11509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11509`

View PR using the GUI difftool: \
`$ git pr show -t 11509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11509.diff">https://git.openjdk.org/jdk/pull/11509.diff</a>

</details>
