### PR TITLE
8296198: JFileChooser throws InternalError java.lang.InternalError with Windows shortcuts

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicFileChooserUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicFileChooserUI.java
@@ -1409,41 +1409,28 @@ public class BasicFileChooserUI extends FileChooserUI {
         JFileChooser fc = getFileChooser();
         // Traverse shortcuts on Windows
         if (dir != null) {
-            if (FilePane.usesShellFolder(fc)) {
-                try {
+            try {
+                File linkedTo = null;
+                if (FilePane.usesShellFolder(fc)) {
                     ShellFolder shellFolder = ShellFolder.getShellFolder(dir);
-
                     if (shellFolder.isLink()) {
-                        File linkedTo = shellFolder.getLinkLocation();
-
-                        // If linkedTo is null we try to use dir
-                        if (linkedTo != null) {
-                            if (fc.isTraversable(linkedTo)) {
-                                dir = linkedTo;
-                            } else {
-                                return;
-                            }
-                        } else {
+                        linkedTo = shellFolder.getLinkLocation();
+                        if (linkedTo == null) {
                             dir = shellFolder;
                         }
                     }
-                } catch (FileNotFoundException ex) {
-                    return;
+                } else if ( fc.getFileSystemView().isLink(dir)){
+                    linkedTo = fc.getFileSystemView().getLinkLocation(dir);
                 }
-            } else if ( fc.getFileSystemView().isLink(dir)) {
-                try {
-                    File linkedTo = fc.getFileSystemView().getLinkLocation(dir);
-
-                    if (linkedTo != null) {
-                        if (fc.isTraversable(linkedTo)) {
-                            dir = linkedTo;
-                        } else {
-                            return;
-                        }
+                if (linkedTo != null) {
+                    if (fc.isTraversable(linkedTo)) {
+                        dir = linkedTo;
+                    } else {
+                        return;
                     }
-                } catch (FileNotFoundException ex) {
-                    return;
                 }
+            } catch (FileNotFoundException ex) {
+                return;
             }
         }
         fc.setCurrentDirectory(dir);

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicFileChooserUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicFileChooserUI.java
@@ -1408,26 +1408,42 @@ public class BasicFileChooserUI extends FileChooserUI {
     private void changeDirectory(File dir) {
         JFileChooser fc = getFileChooser();
         // Traverse shortcuts on Windows
-        if (dir != null && FilePane.usesShellFolder(fc)) {
-            try {
-                ShellFolder shellFolder = ShellFolder.getShellFolder(dir);
+        if (dir != null) {
+            if (FilePane.usesShellFolder(fc)) {
+                try {
+                    ShellFolder shellFolder = ShellFolder.getShellFolder(dir);
 
-                if (shellFolder.isLink()) {
-                    File linkedTo = shellFolder.getLinkLocation();
+                    if (shellFolder.isLink()) {
+                        File linkedTo = shellFolder.getLinkLocation();
 
-                    // If linkedTo is null we try to use dir
+                        // If linkedTo is null we try to use dir
+                        if (linkedTo != null) {
+                            if (fc.isTraversable(linkedTo)) {
+                                dir = linkedTo;
+                            } else {
+                                return;
+                            }
+                        } else {
+                            dir = shellFolder;
+                        }
+                    }
+                } catch (FileNotFoundException ex) {
+                    return;
+                }
+            } else if ( fc.getFileSystemView().isLink(dir)) {
+                try {
+                    File linkedTo = fc.getFileSystemView().getLinkLocation(dir);
+
                     if (linkedTo != null) {
                         if (fc.isTraversable(linkedTo)) {
                             dir = linkedTo;
                         } else {
                             return;
                         }
-                    } else {
-                        dir = shellFolder;
                     }
+                } catch (FileNotFoundException ex) {
+                    return;
                 }
-            } catch (FileNotFoundException ex) {
-                return;
             }
         }
         fc.setCurrentDirectory(dir);

--- a/test/jdk/javax/swing/JFileChooser/FileSystemView/CustomFSVLinkTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileSystemView/CustomFSVLinkTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+
+import javax.swing.*;
+import javax.swing.filechooser.FileSystemView;
+
+/*
+ * @test
+ * @bug 8296198
+ * @key headful
+ * @requires (os.family == "windows")
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Test to check if the Link to a folder is traversable with custom
+ * FileSystemView is valid on ValueChanged property listener.
+ * @run main/manual CustomFSVLinkTest
+ */
+public class CustomFSVLinkTest {
+    static JFrame frame;
+    static JFileChooser jfc;
+
+    static PassFailJFrame passFailJFrame;
+
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(new Runnable() {
+            public void run() {
+                try {
+                    initialize();
+                } catch (InterruptedException | InvocationTargetException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        passFailJFrame.awaitAndCheck();
+    }
+
+    static void initialize() throws InterruptedException, InvocationTargetException {
+        //Initialize the components
+        final String INSTRUCTIONS = """
+                Instructions to Test:
+                1. Create a link to a any valid folder.
+                2. Navigate to the linked folder through the link created
+                (From FileChooser).
+                3. If "link" can't be traversed or if its absolute path is null
+                   click FAIL. If "link" can be traversed then click PASS.
+                """;
+        frame = new JFrame("JFileChooser Link test");
+        jfc = new JFileChooser(new MyFileSystemView());
+        passFailJFrame = new PassFailJFrame("Test Instructions", INSTRUCTIONS, 5L, 8, 40);
+
+        PassFailJFrame.addTestWindow(frame);
+        PassFailJFrame.positionTestWindow(frame, PassFailJFrame.Position.HORIZONTAL);
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+        jfc.setDialogType(JFileChooser.CUSTOM_DIALOG);
+
+        frame.add(jfc, BorderLayout.CENTER);
+        frame.pack();
+        frame.setVisible(true);
+    }
+
+    private static class MyFileSystemView extends FileSystemView {
+        FileSystemView delegate;
+
+        MyFileSystemView() {
+            delegate = FileSystemView.getFileSystemView();
+        }
+
+        @Override
+        public File createNewFolder(File containingDir) throws IOException {
+            return delegate.createNewFolder(containingDir);
+        }
+
+        @Override
+        public boolean isRoot(File f) {
+            return delegate.isRoot(f);
+        }
+
+        @Override
+        public Boolean isTraversable(File f) {
+            return delegate.isTraversable(f);
+        }
+
+        @Override
+        public String getSystemDisplayName(File f) {
+            return delegate.getSystemDisplayName(f);
+        }
+
+        @Override
+        public String getSystemTypeDescription(File f) {
+            return delegate.getSystemTypeDescription(f);
+        }
+
+        @Override
+        public Icon getSystemIcon(File f) {
+            return delegate.getSystemIcon(f);
+        }
+        /*
+                @Override
+                public Icon getSystemIcon(File f, int width, int height) {
+                    return delegate.getSystemIcon(f, width, height);
+                }
+        */
+        @Override
+        public boolean isParent(File folder, File file) {
+            return delegate.isParent(folder, file);
+        }
+
+        @Override
+        public File getChild(File parent, String fileName) {
+            return delegate.getChild(parent, fileName);
+        }
+
+        @Override
+        public boolean isFileSystem(File f) {
+            return delegate.isFileSystem(f);
+        }
+
+        @Override
+        public boolean isHiddenFile(File f) {
+            return delegate.isHiddenFile(f);
+        }
+
+        @Override
+        public boolean isFileSystemRoot(File dir) {
+            return delegate.isFileSystemRoot(dir);
+        }
+
+        @Override
+        public boolean isDrive(File dir) {
+            return delegate.isDrive(dir);
+        }
+
+        @Override
+        public boolean isFloppyDrive(File dir) {
+            return delegate.isFloppyDrive(dir);
+        }
+
+        @Override
+        public boolean isComputerNode(File dir) {
+            return delegate.isComputerNode(dir);
+        }
+
+        @Override
+        public File[] getRoots() {
+            return delegate.getRoots();
+        }
+
+        @Override
+        public File getHomeDirectory() {
+            return delegate.getHomeDirectory();
+        }
+
+        @Override
+        public File getDefaultDirectory() {
+            return delegate.getDefaultDirectory();
+        }
+
+        @Override
+        public File createFileObject(File dir, String filename) {
+            return delegate.createFileObject(dir, filename);
+        }
+
+        @Override
+        public File createFileObject(String path) {
+            return delegate.createFileObject(path);
+        }
+
+        @Override
+        public File[] getFiles(File dir, boolean useFileHiding) {
+            return delegate.getFiles(dir, useFileHiding);
+        }
+
+        @Override
+        public File getParentDirectory(File dir) {
+            return delegate.getParentDirectory(dir);
+        }
+
+        @Override
+        public File[] getChooserComboBoxFiles() {
+            return delegate.getChooserComboBoxFiles();
+        }
+
+        @Override
+        public boolean isLink(File file) {
+            return delegate.isLink(file);
+        }
+
+        @Override
+        public File getLinkLocation(File file) throws FileNotFoundException {
+            return delegate.getLinkLocation(file);
+        }
+
+    }
+
+}

--- a/test/jdk/javax/swing/JFileChooser/FileSystemView/CustomFSVLinkTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileSystemView/CustomFSVLinkTest.java
@@ -220,7 +220,5 @@ public class CustomFSVLinkTest {
         public File getLinkLocation(File file) throws FileNotFoundException {
             return delegate.getLinkLocation(file);
         }
-
     }
-
 }

--- a/test/jdk/javax/swing/JFileChooser/FileSystemView/CustomFSVLinkTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileSystemView/CustomFSVLinkTest.java
@@ -125,12 +125,7 @@ public class CustomFSVLinkTest {
         public Icon getSystemIcon(File f) {
             return delegate.getSystemIcon(f);
         }
-        /*
-                @Override
-                public Icon getSystemIcon(File f, int width, int height) {
-                    return delegate.getSystemIcon(f, width, height);
-                }
-        */
+
         @Override
         public boolean isParent(File folder, File file) {
             return delegate.isParent(folder, file);

--- a/test/jdk/javax/swing/JFileChooser/FileSystemView/CustomFSVLinkTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileSystemView/CustomFSVLinkTest.java
@@ -22,17 +22,16 @@
  */
 
 import java.awt.BorderLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Arrays;
 
-import javax.swing.*;
+import javax.swing.JFrame;
+import javax.swing.JFileChooser;
+import javax.swing.SwingUtilities;
+import javax.swing.Icon;
+import javax.swing.WindowConstants;
 import javax.swing.filechooser.FileSystemView;
 
 /*


### PR DESCRIPTION
When `JFileChooser` uses custom `FileSystemView`, traversing to link/shortcut to a folder throw `InternalError java.lang.InternalError ` in Windows. The issue found out to be in BasicFileChooserUI class which was unable to resolve the link path during directory setting. The `UsesShellFolder` check expects the FileSystemView to be of WindowsFileSystemView, which fails when custom FileSystemView is used.
The fix includes resolving the link folder when custom File System View is used and has manual test. (Fix is test in CI system and no regression caused).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296198](https://bugs.openjdk.org/browse/JDK-8296198): JFileChooser throws InternalError java.lang.InternalError with Windows shortcuts


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to [4dd8cc71](https://git.openjdk.org/jdk/pull/11510/files/4dd8cc71c550b56e7eec04cabcf5892aeabd23fd)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11510/head:pull/11510` \
`$ git checkout pull/11510`

Update a local copy of the PR: \
`$ git checkout pull/11510` \
`$ git pull https://git.openjdk.org/jdk pull/11510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11510`

View PR using the GUI difftool: \
`$ git pr show -t 11510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11510.diff">https://git.openjdk.org/jdk/pull/11510.diff</a>

</details>
