### PR TITLE
8297687: new URI(S,S,S,S) throws exception with incorrect index position reported in the error message

### DIFF
--- a/src/java.base/share/classes/java/net/URI.java
+++ b/src/java.base/share/classes/java/net/URI.java
@@ -3239,6 +3239,7 @@ public final class URI
         {
             int p = start;
             int q = p;
+            int qreg = p;
             URISyntaxException ex = null;
 
             boolean serverChars;
@@ -3250,7 +3251,7 @@ public final class URI
             } else {
                 serverChars = (scan(p, n, L_SERVER, H_SERVER) == n);
             }
-            regChars = (scan(p, n, L_REG_NAME, H_REG_NAME) == n);
+            regChars = ((qreg = scan(p, n, L_REG_NAME, H_REG_NAME)) == n);
 
             if (regChars && !serverChars) {
                 // Must be a registry-based authority
@@ -3294,7 +3295,7 @@ public final class URI
                     // a malformed IPv6 address
                     throw ex;
                 } else {
-                    fail("Illegal character in authority", q);
+                    fail("Illegal character in authority", serverChars ? q : qreg);
                 }
             }
 

--- a/test/jdk/java/net/URI/Test.java
+++ b/test/jdk/java/net/URI/Test.java
@@ -24,7 +24,7 @@
 /* @test
  * @summary Unit test for java.net.URI
  * @bug 4464135 4505046 4503239 4438319 4991359 4866303 7023363 7041800
- *      7171415 6339649 6933879 8037396 8272072 8051627
+ *      7171415 6339649 6933879 8037396 8272072 8051627 8297687
  * @author Mark Reinhold
  */
 
@@ -1619,6 +1619,53 @@ public class Test {
         b8037396();
         b8051627();
         b8272072();
+        b8297687();
+    }
+
+    private static void b8297687() {
+        // constructors that take a hostname should fail
+        test("ftps", "p.e.local|SIT@p.e.local", "/path", null)
+                .x().z();
+        test("ftps", null,"p.e.local|SIT@p.e.local", -1, "/path", null, null)
+                .x().z();
+        // constructors that take an authority component should succeed
+        test("ftps", "p.e.local|SIT@p.e.local", "/path", null,null)
+                .s("ftps")
+                .sp("//p.e.local%7CSIT@p.e.local/path")
+                .spd("//p.e.local|SIT@p.e.local/path")
+                .u("p.e.local%7CSIT")
+                .ud("p.e.local|SIT")
+                .h("p.e.local")
+                .n(-1)
+                .p("/path")
+                .pd("/path")
+                .z();
+
+        // check index in exception for constructors that should fail
+        try {
+            URI uri = new URI("ftps", "p.e.local|SIT@p.e.local", "/path", null);
+            throw new AssertionError("Expected URISyntaxException not thrown for " + uri);
+        } catch (URISyntaxException ex) {
+            if (ex.getMessage().contains("at index 16")) {
+                 System.out.println("Got expected exception: " + ex);
+            } else {
+                throw new AssertionError("Exception does not point at index 16", ex);
+            }
+        }
+        testCount++;
+
+        // check index in exception for constructors that should fail
+        try {
+            URI uri = new URI("ftps", null, "p.e.local|SIT@p.e.local", -1, "/path", null, null);
+            throw new AssertionError("Expected URISyntaxException not thrown for " + uri);
+        } catch (URISyntaxException ex) {
+            if (ex.getMessage().contains("at index 16")) {
+                System.out.println("Got expected exception: " + ex);
+            } else {
+                throw new AssertionError("Exception does not point at index 16", ex);
+            }
+        }
+        testCount++;
     }
 
     // 6339649 - include detail message from nested exception


### PR DESCRIPTION
In some circumstance, when using a constructor that expects a hostname and the hostname contains an illegal character, the URISyntaxException which is thrown might contain a misleading index pointing at the start of the authority component, instead of pointing at the illegal character that was found.

This change fixes the misreported index, and adds corresponding tests to the URI/Test.java infrastructure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297687](https://bugs.openjdk.org/browse/JDK-8297687): new URI(S,S,S,S) throws exception with incorrect index position reported in the error message


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11518/head:pull/11518` \
`$ git checkout pull/11518`

Update a local copy of the PR: \
`$ git checkout pull/11518` \
`$ git pull https://git.openjdk.org/jdk pull/11518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11518`

View PR using the GUI difftool: \
`$ git pr show -t 11518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11518.diff">https://git.openjdk.org/jdk/pull/11518.diff</a>

</details>
