### PR TITLE
8296489: tools/jpackage/windows/WinL10nTest.java fails with timeout

### DIFF
--- a/test/jdk/tools/jpackage/windows/WinL10nTest.java
+++ b/test/jdk/tools/jpackage/windows/WinL10nTest.java
@@ -48,7 +48,7 @@ import static jdk.jpackage.test.WindowsHelper.getTempDirectory;
  * @requires (os.family == "windows")
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @compile WinL10nTest.java
- * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=1440 -Xmx512m jdk.jpackage.test.Main
  *  --jpt-run=WinL10nTest
  */
 


### PR DESCRIPTION
Simply increase timeout limit to make test pass on slower/loaded hosts

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296489](https://bugs.openjdk.org/browse/JDK-8296489): tools/jpackage/windows/WinL10nTest.java fails with timeout


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11522/head:pull/11522` \
`$ git checkout pull/11522`

Update a local copy of the PR: \
`$ git checkout pull/11522` \
`$ git pull https://git.openjdk.org/jdk pull/11522/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11522`

View PR using the GUI difftool: \
`$ git pr show -t 11522`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11522.diff">https://git.openjdk.org/jdk/pull/11522.diff</a>

</details>
