### PR TITLE
8298144: Remove Space::new_dcto_cl

### DIFF
--- a/src/hotspot/share/gc/shared/cardTableRS.cpp
+++ b/src/hotspot/share/gc/shared/cardTableRS.cpp
@@ -111,7 +111,7 @@ void ClearNoncleanCardWrapper::do_MemRegion(MemRegion mr) {
   }
 }
 
-void CardTableRS::younger_refs_in_space_iterate(Space* sp,
+void CardTableRS::younger_refs_in_space_iterate(ContiguousSpace* sp,
                                                 HeapWord* gen_boundary,
                                                 OopIterateClosure* cl) {
   verify_used_region_at_save_marks(sp);
@@ -440,7 +440,7 @@ void CardTableRS::initialize() {
   CardTable::initialize();
 }
 
-void CardTableRS::non_clean_card_iterate(Space* sp,
+void CardTableRS::non_clean_card_iterate(ContiguousSpace* sp,
                                          HeapWord* gen_boundary,
                                          MemRegion mr,
                                          OopIterateClosure* cl,

--- a/src/hotspot/share/gc/shared/cardTableRS.hpp
+++ b/src/hotspot/share/gc/shared/cardTableRS.hpp
@@ -32,7 +32,7 @@
 class DirtyCardToOopClosure;
 class Generation;
 class Space;
-
+class ContiguousSpace;
 // This RemSet uses a card table both as shared data structure
 // for a mod ref barrier set and for the rem set information.
 
@@ -47,7 +47,7 @@ class CardTableRS : public CardTable {
 public:
   CardTableRS(MemRegion whole_heap);
 
-  void younger_refs_in_space_iterate(Space* sp, HeapWord* gen_boundary, OopIterateClosure* cl);
+  void younger_refs_in_space_iterate(ContiguousSpace* sp, HeapWord* gen_boundary, OopIterateClosure* cl);
 
   virtual void verify_used_region_at_save_marks(Space* sp) const NOT_DEBUG_RETURN;
 
@@ -70,7 +70,7 @@ public:
   // Iterate over the portion of the card-table which covers the given
   // region mr in the given space and apply cl to any dirty sub-regions
   // of mr. Clears the dirty cards as they are processed.
-  void non_clean_card_iterate(Space* sp,
+  void non_clean_card_iterate(ContiguousSpace* sp,
                               HeapWord* gen_boundary,
                               MemRegion mr,
                               OopIterateClosure* cl,

--- a/src/hotspot/share/gc/shared/cardTableRS.hpp
+++ b/src/hotspot/share/gc/shared/cardTableRS.hpp
@@ -29,10 +29,10 @@
 #include "memory/memRegion.hpp"
 #include "oops/oop.hpp"
 
+class ContiguousSpace;
 class DirtyCardToOopClosure;
 class Generation;
 class Space;
-class ContiguousSpace;
 // This RemSet uses a card table both as shared data structure
 // for a mod ref barrier set and for the rem set information.
 

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -161,12 +161,6 @@ void DirtyCardToOopClosure::do_MemRegion(MemRegion mr) {
   _min_done = bottom;
 }
 
-DirtyCardToOopClosure* Space::new_dcto_cl(OopIterateClosure* cl,
-                                          CardTable::PrecisionStyle precision,
-                                          HeapWord* boundary) {
-  return new DirtyCardToOopClosure(this, cl, precision, boundary);
-}
-
 HeapWord* ContiguousSpaceDCTOC::get_actual_top(HeapWord* top,
                                                HeapWord* top_obj) {
   if (top_obj != NULL && top_obj < (_sp->toContiguousSpace())->top()) {

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -174,14 +174,6 @@ class Space: public CHeapObj<mtGC> {
   // included in the iteration.
   virtual void object_iterate(ObjectClosure* blk) = 0;
 
-  // Create and return a new dirty card to oop closure. Can be
-  // overridden to return the appropriate type of closure
-  // depending on the type of space in which the closure will
-  // operate. ResourceArea allocated.
-  virtual DirtyCardToOopClosure* new_dcto_cl(OopIterateClosure* cl,
-                                             CardTable::PrecisionStyle precision,
-                                             HeapWord* boundary);
-
   // If "p" is in the space, returns the address of the start of the
   // "block" that contains "p".  We say "block" instead of "object" since
   // some heaps may not pack objects densely; a chunk may either be an
@@ -492,10 +484,9 @@ class ContiguousSpace: public CompactibleSpace {
     set_top(compaction_top());
   }
 
-  // Override.
   DirtyCardToOopClosure* new_dcto_cl(OopIterateClosure* cl,
                                      CardTable::PrecisionStyle precision,
-                                     HeapWord* boundary) override;
+                                     HeapWord* boundary);
 
   // Apply "blk->do_oop" to the addresses of all reference fields in objects
   // starting with the _saved_mark_word, which was noted during a generation's


### PR DESCRIPTION
Simple change of removing effectively unused code.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298144](https://bugs.openjdk.org/browse/JDK-8298144): Remove Space::new_dcto_cl


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to [34bc3aca](https://git.openjdk.org/jdk/pull/11527/files/34bc3aca4c37527ba261c9cb779b2ef8aac303cc)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11527/head:pull/11527` \
`$ git checkout pull/11527`

Update a local copy of the PR: \
`$ git checkout pull/11527` \
`$ git pull https://git.openjdk.org/jdk pull/11527/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11527`

View PR using the GUI difftool: \
`$ git pr show -t 11527`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11527.diff">https://git.openjdk.org/jdk/pull/11527.diff</a>

</details>
