### PR TITLE
8298059: Linked stack watermarks don't support nesting

### DIFF
--- a/src/hotspot/share/runtime/keepStackGCProcessed.cpp
+++ b/src/hotspot/share/runtime/keepStackGCProcessed.cpp
@@ -44,7 +44,7 @@ KeepStackGCProcessedMark::KeepStackGCProcessedMark(JavaThread* jt) :
     return;
   }
   StackWatermark* their_watermark = StackWatermarkSet::get(jt, StackWatermarkKind::gc);
-  our_watermark->link_watermark(their_watermark);
+  our_watermark->push_linked_watermark(their_watermark);
 }
 
 KeepStackGCProcessedMark::~KeepStackGCProcessedMark() {
@@ -52,7 +52,7 @@ KeepStackGCProcessedMark::~KeepStackGCProcessedMark() {
     return;
   }
   StackWatermark* our_watermark = StackWatermarkSet::get(JavaThread::current(), StackWatermarkKind::gc);
-  our_watermark->link_watermark(NULL);
+  our_watermark->pop_linked_watermark();
 }
 
 void KeepStackGCProcessedMark::finish_processing() {

--- a/src/hotspot/share/runtime/stackWatermark.cpp
+++ b/src/hotspot/share/runtime/stackWatermark.cpp
@@ -36,7 +36,7 @@
 #include "utilities/macros.hpp"
 #include "utilities/preserveException.hpp"
 
-class StackWatermarkFramesIterator : public CHeapObj<mtInternal> {
+class StackWatermarkFramesIterator : public CHeapObj<mtThread> {
   JavaThread* _jt;
   uintptr_t _caller;
   uintptr_t _callee;
@@ -317,6 +317,7 @@ void StackWatermark::process_linked_watermarks() {
 
 void StackWatermark::on_safepoint() {
   start_processing();
+
   // If the thread waking up from a safepoint expected certain other
   // stack watermarks (potentially from different threads) are processed,
   // then we have to perform processing of said linked watermarks here.

--- a/src/hotspot/share/runtime/stackWatermark.cpp
+++ b/src/hotspot/share/runtime/stackWatermark.cpp
@@ -317,6 +317,9 @@ void StackWatermark::process_linked_watermarks() {
 
 void StackWatermark::on_safepoint() {
   start_processing();
+  // If the thread waking up from a safepoint expected certain other
+  // stack watermarks (potentially from different threads) are processed,
+  // then we have to perform processing of said linked watermarks here.
   process_linked_watermarks();
 }
 

--- a/src/hotspot/share/runtime/stackWatermark.hpp
+++ b/src/hotspot/share/runtime/stackWatermark.hpp
@@ -94,7 +94,7 @@ protected:
   StackWatermarkFramesIterator* _iterator;
   Mutex _lock;
   StackWatermarkKind _kind;
-  GrowableArrayCHeap<StackWatermark*, mtGC> _linked_watermarks;
+  GrowableArrayCHeap<StackWatermark*, mtInternal> _linked_watermarks;
 
   void process_one();
 
@@ -118,6 +118,7 @@ protected:
   virtual bool process_on_iteration() { return true; }
 
   void process_linked_watermarks();
+
   bool processing_started(uint32_t state) const;
   bool processing_completed(uint32_t state) const;
 

--- a/src/hotspot/share/runtime/stackWatermark.hpp
+++ b/src/hotspot/share/runtime/stackWatermark.hpp
@@ -84,7 +84,7 @@ public:
 //  ----------  <-- watermark (callee SP from the snapshot, SP at the
 //                             point of unwinding, might be above or below
 //                             due to frame resizing)
-class StackWatermark : public CHeapObj<mtInternal> {
+class StackWatermark : public CHeapObj<mtThread> {
   friend class StackWatermarkFramesIterator;
 protected:
   volatile uint32_t _state;
@@ -94,7 +94,7 @@ protected:
   StackWatermarkFramesIterator* _iterator;
   Mutex _lock;
   StackWatermarkKind _kind;
-  GrowableArrayCHeap<StackWatermark*, mtInternal> _linked_watermarks;
+  GrowableArrayCHeap<StackWatermark*, mtThread> _linked_watermarks;
 
   void process_one();
 

--- a/src/hotspot/share/runtime/stackWatermark.hpp
+++ b/src/hotspot/share/runtime/stackWatermark.hpp
@@ -28,6 +28,7 @@
 #include "memory/allStatic.hpp"
 #include "runtime/mutex.hpp"
 #include "runtime/stackWatermarkKind.hpp"
+#include "utilities/growableArray.hpp"
 
 class frame;
 class JavaThread;
@@ -93,7 +94,7 @@ protected:
   StackWatermarkFramesIterator* _iterator;
   Mutex _lock;
   StackWatermarkKind _kind;
-  StackWatermark* _linked_watermark;
+  GrowableArrayCHeap<StackWatermark*, mtGC> _linked_watermarks;
 
   void process_one();
 
@@ -116,6 +117,7 @@ protected:
   // opposed to due to frames being unwound by the owning thread.
   virtual bool process_on_iteration() { return true; }
 
+  void process_linked_watermarks();
   bool processing_started(uint32_t state) const;
   bool processing_completed(uint32_t state) const;
 
@@ -129,7 +131,8 @@ public:
   StackWatermark* next() const { return _next; }
   void set_next(StackWatermark* n) { _next = n; }
 
-  void link_watermark(StackWatermark* watermark);
+  void push_linked_watermark(StackWatermark* watermark);
+  void pop_linked_watermark();
 
   uintptr_t watermark();
   uintptr_t last_processed();

--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -83,6 +83,3 @@ vmTestbase/nsk/monitoring/stress/lowmem/lowmem033/TestDescription.java 8297979 g
 vmTestbase/nsk/monitoring/stress/lowmem/lowmem034/TestDescription.java 8297979 generic-all
 vmTestbase/nsk/monitoring/stress/lowmem/lowmem035/TestDescription.java 8297979 generic-all
 vmTestbase/nsk/monitoring/stress/lowmem/lowmem036/TestDescription.java 8297979 generic-all
-
-vmTestbase/nsk/jdi/ExceptionRequest/addInstanceFilter/instancefilter001/TestDescription.java 8298059 generic-x64
-vmTestbase/nsk/jdi/ExceptionRequest/addInstanceFilter/instancefilter004/TestDescription.java 8298059 generic-x64


### PR DESCRIPTION
The KeepStackGCProcessedMark facility used to ensure a thread (possibly remote) remains fully processed in its scope, has not yet had to support nesting. As it turns out, they can now nest after JDK-8294924. So this patch adds support for nesting. Tested ZGC specific tests tier 1-8, general testing 1-3 and manually tested the two tests that failed and got problem listed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298059](https://bugs.openjdk.org/browse/JDK-8298059): Linked stack watermarks don't support nesting


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to [39a4eea0](https://git.openjdk.org/jdk/pull/11530/files/39a4eea0b16154207ff6a50937d5e3336c5d3538)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [39a4eea0](https://git.openjdk.org/jdk/pull/11530/files/39a4eea0b16154207ff6a50937d5e3336c5d3538)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11530/head:pull/11530` \
`$ git checkout pull/11530`

Update a local copy of the PR: \
`$ git checkout pull/11530` \
`$ git pull https://git.openjdk.org/jdk pull/11530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11530`

View PR using the GUI difftool: \
`$ git pr show -t 11530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11530.diff">https://git.openjdk.org/jdk/pull/11530.diff</a>

</details>
