### PR TITLE
8298083: The "CheckBox/RadioButton[Enabled/Disabled].textForeground" stoped working

### DIFF
--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKStyle.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKStyle.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKStyle.java
@@ -286,18 +286,6 @@ class GTKStyle extends SynthStyle implements GTKConstants {
                 }
             }
         }
-
-        if ((c instanceof JCheckBox) && (state & SynthConstants.DISABLED) != 0) {
-            if (UIManager.getColor("CheckBox.disabledText") != null) {
-                return UIManager.getColor("CheckBox.disabledText");
-            }
-        } else if ((c instanceof JRadioButton) &&
-                (state & SynthConstants.DISABLED) != 0) {
-            if (UIManager.getColor("RadioButton.disabledText") != null) {
-                return UIManager.getColor("RadioButton.disabledText");
-            }
-        }
-
         return getColorForState(context, type);
     }
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthStyle.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -779,14 +779,6 @@ public abstract class SynthStyle {
                             (type == ColorType.FOREGROUND ||
                              type == ColorType.TEXT_FOREGROUND)) {
                 return getColorForState(context, type);
-            } else if (c instanceof JCheckBox) {
-                if (UIManager.getColor("CheckBox.disabledText") != null) {
-                    return UIManager.getColor("CheckBox.disabledText");
-                }
-            } else if (c instanceof JRadioButton) {
-                if (UIManager.getColor("RadioButton.disabledText") != null) {
-                    return UIManager.getColor("RadioButton.disabledText");
-                }
             }
         }
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -661,7 +661,7 @@ javax/swing/JFileChooser/6798062/bug6798062.java 8146446 windows-all
 javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all,linux-all
 javax/swing/dnd/8139050/NativeErrorsInTableDnD.java 8202765  macosx-all,linux-all
 javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
-javax/swing/JRadioButton/4314194/bug4314194.java 8295006 linux-all
+javax/swing/JRadioButton/4314194/bug4314194.java 8298153 linux-all
 
 # Several tests which fail on some hidpi systems/macosx12-aarch64 system
 java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -661,6 +661,7 @@ javax/swing/JFileChooser/6798062/bug6798062.java 8146446 windows-all
 javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all,linux-all
 javax/swing/dnd/8139050/NativeErrorsInTableDnD.java 8202765  macosx-all,linux-all
 javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
+javax/swing/JRadioButton/4314194/bug4314194.java 8295006 linux-all
 
 # Several tests which fail on some hidpi systems/macosx12-aarch64 system
 java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64

--- a/test/jdk/javax/swing/JRadioButton/4314194/bug4314194.java
+++ b/test/jdk/javax/swing/JRadioButton/4314194/bug4314194.java
@@ -23,7 +23,7 @@
 /*
  * @test
  * @key headful
- * @bug 4314194 8075916
+ * @bug 4314194 8075916 8298083
  * @summary  Verifies disabled color for JCheckbox and JRadiobutton is honored in all L&F
  * @run main bug4314194
  */
@@ -40,13 +40,14 @@ import javax.swing.JRadioButton;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
+import javax.swing.plaf.synth.SynthLookAndFeel;
 
 public class bug4314194 {
-    private static JFrame frame;
-    private static JRadioButton radioButton;
-    private static JCheckBox checkBox;
-    private static Point point;
-    private static Rectangle rect;
+    private static volatile JFrame frame;
+    private static volatile JRadioButton radioButton;
+    private static volatile JCheckBox checkBox;
+    private static volatile Point point;
+    private static volatile Rectangle rect;
     private static Robot robot;
     private static final Color radioButtonColor = Color.RED;
     private static final Color checkboxColor = Color.GREEN;
@@ -87,9 +88,24 @@ public class bug4314194 {
         }
     }
 
-    private static void createUI() {
-        UIManager.getDefaults().put("CheckBox.disabledText", checkboxColor);
-        UIManager.getDefaults().put("RadioButton.disabledText", radioButtonColor);
+    private static void createUI(String laf) {
+        if (UIManager.getLookAndFeel() instanceof SynthLookAndFeel) {
+            // reset "basic" properties
+            UIManager.getDefaults().put("CheckBox.disabledText", null);
+            UIManager.getDefaults().put("RadioButton.disabledText", null);
+            // set "synth" properties
+            UIManager.getDefaults().put("CheckBox[Disabled].textForeground", checkboxColor);
+            // for some reason the RadioButton[Disabled] does not work
+            //UIManager.getDefaults().put("RadioButton[Disabled].textForeground", radioButtonColor);
+            UIManager.getDefaults().put("RadioButton[Enabled].textForeground", radioButtonColor);
+        } else {
+            // reset "synth" properties
+            UIManager.getDefaults().put("CheckBox[Disabled].textForeground", null);
+            UIManager.getDefaults().put("RadioButton[Enabled].textForeground", null);
+            // set "basic" properties
+            UIManager.getDefaults().put("CheckBox.disabledText", checkboxColor);
+            UIManager.getDefaults().put("RadioButton.disabledText", radioButtonColor);
+        }
 
         checkBox = new JCheckBox("\u2588".repeat(5));
         radioButton = new JRadioButton("\u2588".repeat(5));
@@ -98,7 +114,7 @@ public class bug4314194 {
         checkBox.setEnabled(false);
         radioButton.setEnabled(false);
 
-        frame = new JFrame("bug4314194");
+        frame = new JFrame(laf);
         frame.getContentPane().add(radioButton, BorderLayout.SOUTH);
         frame.getContentPane().add(checkBox, BorderLayout.NORTH);
         frame.pack();
@@ -122,7 +138,7 @@ public class bug4314194 {
             System.out.println("Testing L&F: " + laf.getClassName());
             SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
             try {
-                SwingUtilities.invokeAndWait(() -> createUI());
+                SwingUtilities.invokeAndWait(() -> createUI(laf.getName()));
                 robot.waitForIdle();
                 robot.delay(1000);
 
@@ -141,4 +157,3 @@ public class bug4314194 {
         }
     }
 }
-

--- a/test/jdk/javax/swing/JRadioButton/4314194/bug4314194.java
+++ b/test/jdk/javax/swing/JRadioButton/4314194/bug4314194.java
@@ -96,6 +96,7 @@ public class bug4314194 {
             // set "synth" properties
             UIManager.getDefaults().put("CheckBox[Disabled].textForeground", checkboxColor);
             // for some reason the RadioButton[Disabled] does not work
+            // see https://bugs.openjdk.org/browse/JDK-8298149
             //UIManager.getDefaults().put("RadioButton[Disabled].textForeground", radioButtonColor);
             UIManager.getDefaults().put("RadioButton[Enabled].textForeground", radioButtonColor);
         } else {


### PR DESCRIPTION
We have two types of properties in Swing, the "basics": were implemented a long time ago. Some of that properties are tested by the bug4314194 test. And other properties implemented as part of the Synth L&F, and based on it - Nimbus/GTK. Attempt to fix the issue reported by bug4314194 added support of two "basic" options to the Nimbus/GTK but at the same time broke the Synth/Nimbus properties. It is unclear what is the root cause and how these properties should work together(should they? I assume each "basic"/"synth" should support its own) I suggest to revert the changes in 20 to prevent the regression and rethink the solution later.

In short, this is a request to revert the next fixes:
 * https://bugs.openjdk.org/browse/JDK-8075916 - for some reason broke the Synth/Nimbus properties
 * https://bugs.openjdk.org/browse/JDK-8295006 - This uses the same approach as the fix above
The next two issues created to redo both:
 * https://bugs.openjdk.org/browse/JDK-8298149
 * https://bugs.openjdk.org/browse/JDK-8298153

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298083](https://bugs.openjdk.org/browse/JDK-8298083): The "CheckBox/RadioButton[Enabled/Disabled].textForeground" stoped working


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11531/head:pull/11531` \
`$ git checkout pull/11531`

Update a local copy of the PR: \
`$ git checkout pull/11531` \
`$ git pull https://git.openjdk.org/jdk pull/11531/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11531`

View PR using the GUI difftool: \
`$ git pr show -t 11531`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11531.diff">https://git.openjdk.org/jdk/pull/11531.diff</a>

</details>
