### PR TITLE
8297602: Compiler crash with type annotation and generic record during pattern matching

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
@@ -1086,7 +1086,11 @@ public class TypeAnnotations {
                                         newPath, currentLambda,
                                         outer_type_index, location);
                 }
-
+                case DECONSTRUCTION_PATTERN: {
+                    // TODO: Treat case labels as full type contexts for complete type annotation support in Record Patterns
+                    //    https://bugs.openjdk.org/browse/JDK-8298154
+                    return TypeAnnotationPosition.unknown;
+                }
                 default:
                     throw new AssertionError("Unresolved frame: " + frame +
                                              " of kind: " + frame.getKind() +

--- a/test/langtools/tools/javac/T8297602.java
+++ b/test/langtools/tools/javac/T8297602.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8297602
+ * @summary Compiler crash with type annotation and generic record during pattern matching
+ * @enablePreview
+ * @compile --enable-preview -source ${jdk.version} -XDrawDiagnostics T8297602.java
+ */
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+public class T8297602
+{
+    void meth(Foo<Integer> p) {
+        switch(p) {
+            case Foo<@Annot(field = "") Integer>(): {}
+        };
+
+        if (p instanceof Foo<@Annot(field = "") Integer>()) {
+
+        }
+    }
+
+    @Target({ElementType.TYPE_USE})
+    @interface Annot {
+        String field();
+    }
+
+    record Foo<T>() { }
+}


### PR DESCRIPTION
In this PR we erase the annotation in the unhandled case of deconstruction patterns.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297602](https://bugs.openjdk.org/browse/JDK-8297602): Compiler crash with type annotation and generic record during pattern matching


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11532/head:pull/11532` \
`$ git checkout pull/11532`

Update a local copy of the PR: \
`$ git checkout pull/11532` \
`$ git pull https://git.openjdk.org/jdk pull/11532/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11532`

View PR using the GUI difftool: \
`$ git pr show -t 11532`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11532.diff">https://git.openjdk.org/jdk/pull/11532.diff</a>

</details>
