### PR TITLE
8297964: Jetty.java fails "assert(_no_handle_mark_nesting == 0) failed: allocating handle inside NoHandleMark"

### DIFF
--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.cpp
@@ -274,7 +274,10 @@ bool JfrStackTrace::record(JavaThread* jt, const frame& frame, int skip) {
   assert(jt != NULL, "invariant");
   assert(jt == Thread::current(), "invariant");
   assert(!_lineno, "invariant");
-  HandleMark hm(jt); // RegisterMap uses Handles to support continuations.
+  // Must use ResetNoHandleMark here to bypass if any NoHandleMark exist on stack.
+  // This is because RegisterMap uses Handles to support continuations.
+  ResetNoHandleMark rnhm;
+  HandleMark hm(jt);
   JfrVframeStream vfs(jt, frame, false, false);
   u4 count = 0;
   _reached_root = true;


### PR DESCRIPTION
Greetings,

this small change resolves the assertions on no_handle_mark_nesting, a problem resulting from continuations requiring handles for stack walking. Issue only in debug builds.

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297964](https://bugs.openjdk.org/browse/JDK-8297964): Jetty.java fails "assert(_no_handle_mark_nesting == 0) failed: allocating handle inside NoHandleMark"


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11534/head:pull/11534` \
`$ git checkout pull/11534`

Update a local copy of the PR: \
`$ git checkout pull/11534` \
`$ git pull https://git.openjdk.org/jdk pull/11534/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11534`

View PR using the GUI difftool: \
`$ git pr show -t 11534`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11534.diff">https://git.openjdk.org/jdk/pull/11534.diff</a>

</details>
