### PR TITLE
8297988: NPE in JavacTypes.getOverriddenMethods from doclint

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -608,13 +608,22 @@ public class JavaCompiler {
      *  @param content      The characters to be parsed.
      */
     protected JCCompilationUnit parse(JavaFileObject filename, CharSequence content) {
+        return parse(filename, content, false);
+    }
+
+    /** Parse contents of input stream.
+     *  @param filename     The name of the file from which input stream comes.
+     *  @param content      The characters to be parsed.
+     *  @param silent       true if TaskListeners should not be notified
+     */
+    private JCCompilationUnit parse(JavaFileObject filename, CharSequence content, boolean silent) {
         long msec = now();
         JCCompilationUnit tree = make.TopLevel(List.nil());
         if (content != null) {
             if (verbose) {
                 log.printVerbose("parsing.started", filename);
             }
-            if (!taskListener.isEmpty()) {
+            if (!taskListener.isEmpty() && !silent) {
                 TaskEvent e = new TaskEvent(TaskEvent.Kind.PARSE, filename);
                 taskListener.started(e);
                 keepComments = true;
@@ -630,7 +639,7 @@ public class JavaCompiler {
 
         tree.sourcefile = filename;
 
-        if (content != null && !taskListener.isEmpty()) {
+        if (content != null && !taskListener.isEmpty() && !silent) {
             TaskEvent e = new TaskEvent(TaskEvent.Kind.PARSE, tree);
             taskListener.finished(e);
         }
@@ -1800,7 +1809,7 @@ public class JavaCompiler {
         DiagnosticHandler dh = new DiscardDiagnosticHandler(log);
         JavaFileObject prevSource = log.useSource(fo);
         try {
-            JCTree.JCCompilationUnit t = parse(fo, fo.getCharContent(false));
+            JCTree.JCCompilationUnit t = parse(fo, fo.getCharContent(false), true);
             return tree2Name.apply(t);
         } catch (IOException e) {
             return null;

--- a/test/langtools/tools/javac/modules/EdgeCases.java
+++ b/test/langtools/tools/javac/modules/EdgeCases.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8154283 8167320 8171098 8172809 8173068 8173117 8176045 8177311 8241519
+ * @bug 8154283 8167320 8171098 8172809 8173068 8173117 8176045 8177311 8241519 8297988
  * @summary tests for multi-module mode compilation
  * @library /tools/lib
  * @modules
@@ -65,10 +65,13 @@ import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
 
 import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.util.TaskEvent;
+import com.sun.source.util.TaskListener;
 //import com.sun.source.util.JavacTask; // conflicts with toolbox.JavacTask
 import com.sun.tools.javac.api.JavacTaskImpl;
 import com.sun.tools.javac.code.Symbol.ModuleSymbol;
 import com.sun.tools.javac.code.Symtab;
+import java.util.ArrayList;
 
 import toolbox.JarTask;
 import toolbox.JavacTask;
@@ -1045,6 +1048,105 @@ public class EdgeCases extends ModuleTestBase {
 
         if (!expected.equals(log))
             throw new Exception("expected output not found: " + log);
+    }
+
+    @Test //JDK-8297988
+    public void testExportedNameCheckFromSourceNoEvent(Path base) throws Exception {
+        //when validating "exports", javac may parse source(s) from the package to check their
+        //package name. The AST produced by this parse are thrown away, so listeners should not
+        //be notified:
+        Path src = base.resolve("src");
+        Path m = src.resolve("m");
+        tb.writeJavaFiles(m,
+                          """
+                          module m {
+                              exports test;
+                          }
+                          """,
+                          """
+                          package test;
+                          public class Test {}
+                          """,
+                          """
+                          package impl;
+                          public class Impl {
+                              void t() {
+                                  test.Test t;
+                              }
+                          }
+                          """);
+        Path classes = base.resolve("classes");
+        tb.createDirectories(classes);
+
+        record TestCase(Path[] files, String... expectedLog){}
+
+        TestCase[] testCases = new TestCase[] {
+            new TestCase(new Path[] {m.resolve("module-info.java")},
+                         "COMPILATION:started:<none>",
+                         "PARSE:started:testExportedNameCheckFromSourceNoEvent/src/m/module-info.java",
+                         "PARSE:finished:testExportedNameCheckFromSourceNoEvent/src/m/module-info.java",
+                         "ENTER:started:testExportedNameCheckFromSourceNoEvent/src/m/module-info.java",
+                         "ENTER:finished:testExportedNameCheckFromSourceNoEvent/src/m/module-info.java",
+                         "ANALYZE:started:testExportedNameCheckFromSourceNoEvent/src/m/module-info.java",
+                         "ANALYZE:finished:testExportedNameCheckFromSourceNoEvent/src/m/module-info.java",
+                         "COMPILATION:finished:<none>"),
+            new TestCase(new Path[] {m.resolve("module-info.java"),
+                                     m.resolve("impl").resolve("Impl.java")},
+                         "COMPILATION:started:<none>",
+                         "PARSE:started:testExportedNameCheckFromSourceNoEvent/src/m/module-info.java",
+                         "PARSE:finished:testExportedNameCheckFromSourceNoEvent/src/m/module-info.java",
+                         "PARSE:started:testExportedNameCheckFromSourceNoEvent/src/m/impl/Impl.java",
+                         "PARSE:finished:testExportedNameCheckFromSourceNoEvent/src/m/impl/Impl.java",
+                         "ENTER:started:testExportedNameCheckFromSourceNoEvent/src/m/module-info.java",
+                         "ENTER:started:testExportedNameCheckFromSourceNoEvent/src/m/impl/Impl.java",
+                         "ENTER:finished:testExportedNameCheckFromSourceNoEvent/src/m/module-info.java",
+                         "ENTER:finished:testExportedNameCheckFromSourceNoEvent/src/m/impl/Impl.java",
+                         "ANALYZE:started:testExportedNameCheckFromSourceNoEvent/src/m/module-info.java",
+                         "ANALYZE:finished:testExportedNameCheckFromSourceNoEvent/src/m/module-info.java",
+                         "ANALYZE:started:testExportedNameCheckFromSourceNoEvent/src/m/impl/Impl.java",
+                         "PARSE:started:testExportedNameCheckFromSourceNoEvent/src/m/test/Test.java",
+                         "PARSE:finished:testExportedNameCheckFromSourceNoEvent/src/m/test/Test.java",
+                         "ENTER:started:testExportedNameCheckFromSourceNoEvent/src/m/test/Test.java",
+                         "ENTER:finished:testExportedNameCheckFromSourceNoEvent/src/m/test/Test.java",
+                         "ANALYZE:finished:testExportedNameCheckFromSourceNoEvent/src/m/impl/Impl.java",
+                         "ANALYZE:started:testExportedNameCheckFromSourceNoEvent/src/m/test/Test.java",
+                         "ANALYZE:finished:testExportedNameCheckFromSourceNoEvent/src/m/test/Test.java",
+                         "COMPILATION:finished:<none>")
+        };
+
+        for (TestCase tc : testCases) {
+            List<String> log = new ArrayList<>();
+
+            new JavacTask(tb)
+                    .outdir(classes)
+                    .options("--source-path", m.toString(),
+                             "-XDshould-stop.ifNoError=FLOW")
+                    .callback(task -> {
+                        task.addTaskListener(new TaskListener() {
+                            @Override
+                            public void started(TaskEvent e) {
+                                record(e, "started");
+                            }
+                            @Override
+                            public void finished(TaskEvent e) {
+                                record(e, "finished");
+                            }
+                            private void record(TaskEvent e, String phase) {
+                                JavaFileObject source = e.getSourceFile();
+                                String sourceName = source != null ? source.getName() : "<none>";
+                                log.add(e.getKind() + ":" + phase + ":" + sourceName);
+                            }
+                        });
+                    })
+                    .files(tc.files)
+                    .run()
+                    .writeAll();
+
+            if (!List.of(tc.expectedLog).equals(log)) {
+                throw new AssertionError("Unexpected log, got: " + log +
+                                         ", expected: " + List.of(tc.expectedLog));
+            }
+        }
     }
 
 }


### PR DESCRIPTION
There are a few cases where `javac` parses Java source code, reads some name from the AST, and throws it away. This is used e.g. when validating `exports` directive in the `module-info`, if there are no classfiles and no source files used in the current compilation from the given package, `javac` will peek into the sources in the package, looking at their package clause[1]. The ASTs produced by such parses are thrown away/not part of the upcoming compilation.

But, even parses like this are reported to the `TaskListener`s, and some of the listeners may expect that the AST is eventually attributed - but it is not, as it was used only to read some name from the source code. Specifically, for DocLint, this may lead to an NPE, but it may cause other issues as well.

The proposal here is to simply avoid sending the "parse" event for parses that are not part of the actual compilation.

[1] https://github.com/openjdk/jdk/blob/84b927a05bcb7bf32a12829070ffd3a5670066d2/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java#L1040

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297988](https://bugs.openjdk.org/browse/JDK-8297988): NPE in JavacTypes.getOverriddenMethods from doclint


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11535/head:pull/11535` \
`$ git checkout pull/11535`

Update a local copy of the PR: \
`$ git checkout pull/11535` \
`$ git pull https://git.openjdk.org/jdk pull/11535/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11535`

View PR using the GUI difftool: \
`$ git pr show -t 11535`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11535.diff">https://git.openjdk.org/jdk/pull/11535.diff</a>

</details>
