### PR TITLE
8293806: JDK_JAVA_OPTIONS picked up twice if launcher re-executes itself

### DIFF
--- a/src/java.base/share/native/launcher/main.c
+++ b/src/java.base/share/native/launcher/main.c
@@ -62,6 +62,11 @@ main(int argc, char **argv)
     char** jargv;
     const jboolean const_javaw = JNI_FALSE;
 #endif /* JAVAW */
+
+#if !defined(WINDOWS) && !defined(MACOSX)
+   JLI_ReExecLauncher(argc, argv);
+#endif
+
     {
         int i, main_jargc, extra_jargc;
         JLI_List list;
@@ -163,6 +168,7 @@ main(int argc, char **argv)
         margv = args->elements;
     }
 #endif /* WIN32 */
+
     return JLI_Launch(margc, margv,
                    jargc, (const char**) jargv,
                    0, NULL,

--- a/src/java.base/share/native/libjli/args.c
+++ b/src/java.base/share/native/libjli/args.c
@@ -77,7 +77,6 @@ static jboolean expectingNoDashArg = JNI_FALSE;
 // Initialize to 1, as the first argument is the app name and not preprocessed
 static size_t argsCount = 1;
 static jboolean stopExpansion = JNI_FALSE;
-static jboolean relaunch = JNI_FALSE;
 
 /*
  * Prototypes for internal functions.
@@ -86,15 +85,7 @@ static jboolean expand(JLI_List args, const char *str, const char *var_name);
 
 JNIEXPORT void JNICALL
 JLI_InitArgProcessing(jboolean hasJavaArgs, jboolean disableArgFile) {
-    // No expansion for relaunch
-    if (argsCount != 1) {
-        relaunch = JNI_TRUE;
-        stopExpansion = JNI_TRUE;
-        argsCount = 1;
-    } else {
-        stopExpansion = disableArgFile;
-    }
-
+    stopExpansion = disableArgFile;
     expectingNoDashArg = JNI_FALSE;
 
     // for tools, this value remains 0 all the time.
@@ -469,10 +460,6 @@ JLI_AddArgsFromEnvVar(JLI_List args, const char *var_name) {
 
     if (firstAppArgIndex == 0) {
         // Not 'java', return
-        return JNI_FALSE;
-    }
-
-    if (relaunch) {
         return JNI_FALSE;
     }
 

--- a/src/java.base/share/native/libjli/java.h
+++ b/src/java.base/share/native/libjli/java.h
@@ -100,6 +100,9 @@ JLI_Launch(int argc, char ** argv,              /* main argc, argc */
         jint     ergo_class                     /* ergnomics policy */
 );
 
+JNIEXPORT void JNICALL
+JLI_ReExecLauncher(int argc, char **argv);
+
 /*
  * Prototypes for launcher functions in the system specific java_md.c.
  */

--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -174,11 +174,13 @@ ContainsLibJVM(const char *env) {
     /* the usual suspects */
     char clientPattern[] = "lib/client";
     char serverPattern[] = "lib/server";
+    char minimalPattern[] = "lib/minimal";
     char *envpath;
     char *path;
     char* save_ptr = NULL;
     jboolean clientPatternFound;
     jboolean serverPatternFound;
+    jboolean minimalPatternFound;
 
     /* fastest path */
     if (env == NULL) {
@@ -188,7 +190,8 @@ ContainsLibJVM(const char *env) {
     /* to optimize for time, test if any of our usual suspects are present. */
     clientPatternFound = JLI_StrStr(env, clientPattern) != NULL;
     serverPatternFound = JLI_StrStr(env, serverPattern) != NULL;
-    if (clientPatternFound == JNI_FALSE && serverPatternFound == JNI_FALSE) {
+    minimalPatternFound = JLI_StrStr(env, serverPattern) != NULL;
+    if (clientPatternFound == JNI_FALSE && serverPatternFound == JNI_FALSE && minimalPatternFound == JNI_FALSE) {
         return JNI_FALSE;
     }
 
@@ -342,7 +345,6 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
 
     /**
      * Update execution environment and re-exec the launcher
-     *
      */
 
     /*
@@ -399,6 +401,7 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
                     (runpath[JLI_StrLen(newpath)] == 0 ||
                     runpath[JLI_StrLen(newpath)] == ':')) {
                 JLI_MemFree(new_runpath);
+                JLI_TraceLauncher("LD_LIBRARY_PATH is already correct, will not EXEC");
                 return;
             }
         }

--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -309,18 +309,24 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
 
     /* Check to see if the jvmpath exists */
     /* Find out where the JRE is that we will be using. */
-    if (!GetJREPath(jrepath, so_jrepath, JNI_FALSE)) {
-        JLI_ReportErrorMessage(JRE_ERROR1);
-        exit(2);
-    }
-    JLI_Snprintf(jvmcfg, so_jvmcfg, "%s%slib%sjvm.cfg",
-            jrepath, FILESEP, FILESEP);
-    /* Find the specified JVM type */
-    if (ReadKnownVMs(jvmcfg, JNI_FALSE) < 1) {
-        JLI_ReportErrorMessage(CFG_ERROR7);
-        exit(1);
+    if (jrepath[0] == '\0') {
+        if (!GetJREPath(jrepath, so_jrepath, JNI_FALSE)) {
+            JLI_ReportErrorMessage(JRE_ERROR1);
+            exit(2);
+        }
     }
 
+    if (jvmcfg[0] == '\0') {
+        JLI_Snprintf(jvmcfg, so_jvmcfg, "%s%slib%sjvm.cfg",
+                jrepath, FILESEP, FILESEP);
+        /* Find the specified JVM type */
+        if (ReadKnownVMs(jvmcfg, JNI_FALSE) < 1) {
+            JLI_ReportErrorMessage(CFG_ERROR7);
+            exit(1);
+        }
+    }
+
+    /* Always repeat this step because arguments can affect choice */
     jvmpath[0] = '\0';
     jvmtype = CheckJvmType(pargc, pargv, JNI_FALSE);
     if (JLI_StrCmp(jvmtype, "ERROR") == 0) {

--- a/test/jdk/tools/launcher/ArgsEnvVar.java
+++ b/test/jdk/tools/launcher/ArgsEnvVar.java
@@ -219,6 +219,24 @@ public class ArgsEnvVar extends TestHelper {
     }
 
     @Test
+    public void NoOptionsDuplication() {
+        if (System.getProperty("os.family") == "windows") {
+           /* This test has no value on windows */
+           return;
+        }
+        env.put(JDK_JAVA_OPTIONS, "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005");
+        String testJdk = System.getProperty("test.jdk");
+        String libraryPath = "/usr/bin:" + testJdk + "/lib/server:" + testJdk + "/lib/client";
+        env.put("LD_LIBRARY_PATH", libraryPath);
+        TestResult tr = doExec(env, javaCmd, "-version");
+        tr.notContains("ERROR: Cannot load this JVM TI agent twice");
+        if (!tr.testStatus) {
+            System.out.println(tr);
+            throw new RuntimeException("test fails");
+        }
+    }
+
+    @Test
     public void noWildcard() {
         env.put(JDK_JAVA_OPTIONS, "-cp *");
         TestResult tr = doExec(env, javaCmd, "-jar", "test.jar");


### PR DESCRIPTION
If the user has set LD_LIBRARY_PATH to use a particular libjvm.so, options from the JDK_JAVA_OPTIONS environment variable are picked up twice.

If an option cannot be accepted twice (e.g., -agentlib), the application fails to start.

The same happens on operating systems that doesn't support $RPATH/$ORIGIN and always have to set LD_LIBRARY_PATH and re-exec the launcher.

This fix takes the approach to re-launch as early as possible, as discussed here:

https://github.com/openjdk/jdk/pull/10430

This PR consists of three commits:
1. Cleanup of java_md.c
2. The implementation of early re-launch
3. Performance optimization

@AlanBateman, @dholmes-ora Alan, David - any comments are appreciated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293806](https://bugs.openjdk.org/browse/JDK-8293806): JDK_JAVA_OPTIONS picked up twice if launcher re-executes itself


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/11538/head:pull/11538` \
`$ git checkout pull/11538`

Update a local copy of the PR: \
`$ git checkout pull/11538` \
`$ git pull https://git.openjdk.org/jdk.git pull/11538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11538`

View PR using the GUI difftool: \
`$ git pr show -t 11538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11538.diff">https://git.openjdk.org/jdk/pull/11538.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/11538#issuecomment-1339450429)