### PR TITLE
JDK-8298170 : Introduce a macro for exception check, free and return

### DIFF
--- a/src/java.base/share/native/libjava/jni_util.h
+++ b/src/java.base/share/native/libjava/jni_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -259,9 +259,25 @@ JNU_GetStaticFieldByName(JNIEnv *env,
         }                                       \
     } while (0)                                 \
 
+#define JNU_CHECK_EXCEPTION_FREE(env, x)        \
+    do {                                        \
+        if ((env)->ExceptionCheck()) {          \
+            free (x);                           \
+            return;                             \
+        }                                       \
+    } while (0)                                 \
+
 #define JNU_CHECK_EXCEPTION_RETURN(env, y)      \
     do {                                        \
         if ((env)->ExceptionCheck()) {          \
+            return (y);                         \
+        }                                       \
+    } while (0)
+
+#define JNU_CHECK_EXCEPTION_FREE_RETURN(env, x, y) \
+    do {                                        \
+        if ((env)->ExceptionCheck()) {          \
+            free (x);                           \
             return (y);                         \
         }                                       \
     } while (0)
@@ -273,9 +289,25 @@ JNU_GetStaticFieldByName(JNIEnv *env,
         }                                       \
     } while (0)                                 \
 
+#define JNU_CHECK_EXCEPTION_FREE(env, x)        \
+    do {                                        \
+        if ((*env)->ExceptionCheck(env)) {      \
+            free (x);                           \
+            return;                             \
+        }                                       \
+    } while (0)                                 \
+
 #define JNU_CHECK_EXCEPTION_RETURN(env, y)      \
     do {                                        \
         if ((*env)->ExceptionCheck(env)) {      \
+            return (y);                         \
+        }                                       \
+    } while (0)
+
+#define JNU_CHECK_EXCEPTION_FREE_RETURN(env, x, y) \
+    do {                                        \
+        if ((*env)->ExceptionCheck(env)) {      \
+            free (x);                           \
             return (y);                         \
         }                                       \
     } while (0)

--- a/src/java.desktop/share/native/libawt/awt/image/BufImgSurfaceData.c
+++ b/src/java.desktop/share/native/libawt/awt/image/BufImgSurfaceData.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -367,12 +367,7 @@ static ColorData *BufImg_SetupICM(JNIEnv *env,
         if (JNU_IsNull(env, colorData)) {
             jlong pData = ptr_to_jlong(cData);
             colorData = (*env)->NewObjectA(env, clsICMCD, initICMCDmID, (jvalue *)&pData);
-
-            if ((*env)->ExceptionCheck(env))
-            {
-                free(cData);
-                return (ColorData*)NULL;
-            }
+            JNU_CHECK_EXCEPTION_FREE_RETURN(env, cData, NULL);
 
             (*env)->SetObjectField(env, bisdo->icm, colorDataID, colorData);
             Disposer_AddRecord(env, colorData, BufImg_Dispose_ICMColorData, pData);

--- a/src/java.security.jgss/share/native/libj2gss/NativeUtil.c
+++ b/src/java.security.jgss/share/native/libj2gss/NativeUtil.c
@@ -606,13 +606,9 @@ void initGSSBuffer(JNIEnv *env, jbyteArray jbytes,
       return;
     } else {
       (*env)->GetByteArrayRegion(env, jbytes, 0, len, value);
-      if ((*env)->ExceptionCheck(env)) {
-        free(value);
-        return;
-      } else {
-        cbytes->length = len;
-        cbytes->value = value;
-      }
+      JNU_CHECK_EXCEPTION_FREE(env, value);
+      cbytes->length = len;
+      cbytes->value = value;
     }
   } else {
     cbytes->length = 0;

--- a/src/java.smartcardio/share/native/libj2pcsc/pcsc.c
+++ b/src/java.smartcardio/share/native/libj2pcsc/pcsc.c
@@ -160,15 +160,9 @@ jobjectArray pcsc_multi2jstring(JNIEnv *env, char *spec) {
     if (result != NULL) {
         while (cnt-- > 0) {
             js = (*env)->NewStringUTF(env, tab[cnt]);
-            if ((*env)->ExceptionCheck(env)) {
-                free(tab);
-                return NULL;
-            }
+            JNU_CHECK_EXCEPTION_FREE_RETURN(env, tab, NULL);
             (*env)->SetObjectArrayElement(env, result, cnt, js);
-            if ((*env)->ExceptionCheck(env)) {
-                free(tab);
-                return NULL;
-            }
+            JNU_CHECK_EXCEPTION_FREE_RETURN(env, tab, NULL);
             (*env)->DeleteLocalRef(env, js);
         }
     }

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_convert.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_convert.c
@@ -1622,10 +1622,7 @@ jRsaPkcsOaepParamToCKRsaPkcsOaepParamPtr(JNIEnv *env, jobject jParam, CK_ULONG *
     ckParamPtr->source = jLongToCKULong(jSource);
     jByteArrayToCKByteArray(env, jSourceData, (CK_BYTE_PTR*) &(ckParamPtr->pSourceData),
             &(ckParamPtr->ulSourceDataLen));
-    if ((*env)->ExceptionCheck(env)) {
-        free(ckParamPtr);
-        return NULL;
-    }
+    JNU_CHECK_EXCEPTION_FREE_RETURN(env, ckParamPtr, NULL);
 
     if (pLength!= NULL) {
         *pLength = sizeof(CK_RSA_PKCS_OAEP_PARAMS);

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_general.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_general.c
@@ -811,10 +811,7 @@ Java_sun_security_pkcs11_wrapper_PKCS11_C_1InitToken
     if ((*env)->ExceptionCheck(env)) { return; }
     /* ckLabelLength <= 32 !!! */
     jCharArrayToCKUTF8CharArray(env, jLabel, &ckpLabel, &ckLabelLength);
-    if ((*env)->ExceptionCheck(env)) {
-        free(ckpPin);
-        return;
-    }
+    JNU_CHECK_EXCEPTION_FREE(env, ckpPin);
 
     rv = (*ckpFunctions->C_InitToken)(ckSlotID, ckpPin, ckPinLength, ckpLabel);
     TRACE1("InitToken return code: %d", rv);
@@ -891,10 +888,7 @@ jcharArray jNewPin)
     jCharArrayToCKCharArray(env, jOldPin, &ckpOldPin, &ckOldPinLength);
     if ((*env)->ExceptionCheck(env)) { return; }
     jCharArrayToCKCharArray(env, jNewPin, &ckpNewPin, &ckNewPinLength);
-    if ((*env)->ExceptionCheck(env)) {
-        free(ckpOldPin);
-        return;
-    }
+    JNU_CHECK_EXCEPTION_FREE(env, ckpOldPin);
 
     rv = (*ckpFunctions->C_SetPIN)(ckSessionHandle, ckpOldPin, ckOldPinLength,
                                    ckpNewPin, ckNewPinLength);

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
@@ -528,10 +528,7 @@ void jBooleanArrayToCKBBoolArray(JNIEnv *env, const jbooleanArray jArray, CK_BBO
         return;
     }
     (*env)->GetBooleanArrayRegion(env, jArray, 0, *ckpLength, jpTemp);
-    if ((*env)->ExceptionCheck(env)) {
-        free(jpTemp);
-        return;
-    }
+    JNU_CHECK_EXCEPTION_FREE(env, jpTemp);
 
     *ckpArray = (CK_BBOOL*) calloc (*ckpLength, sizeof(CK_BBOOL));
     if (*ckpArray == NULL) {
@@ -570,10 +567,7 @@ void jByteArrayToCKByteArray(JNIEnv *env, const jbyteArray jArray, CK_BYTE_PTR *
         return;
     }
     (*env)->GetByteArrayRegion(env, jArray, 0, *ckpLength, jpTemp);
-    if ((*env)->ExceptionCheck(env)) {
-        free(jpTemp);
-        return;
-    }
+    JNU_CHECK_EXCEPTION_FREE(env, jpTemp);
 
     /* if CK_BYTE is the same size as jbyte, we save an additional copy */
     if (sizeof(CK_BYTE) == sizeof(jbyte)) {
@@ -617,10 +611,7 @@ void jLongArrayToCKULongArray(JNIEnv *env, const jlongArray jArray, CK_ULONG_PTR
         return;
     }
     (*env)->GetLongArrayRegion(env, jArray, 0, *ckpLength, jTemp);
-    if ((*env)->ExceptionCheck(env)) {
-        free(jTemp);
-        return;
-    }
+    JNU_CHECK_EXCEPTION_FREE(env, jTemp);
 
     *ckpArray = (CK_ULONG_PTR) calloc(*ckpLength, sizeof(CK_ULONG));
     if (*ckpArray == NULL) {
@@ -659,10 +650,7 @@ void jCharArrayToCKCharArray(JNIEnv *env, const jcharArray jArray, CK_CHAR_PTR *
         return;
     }
     (*env)->GetCharArrayRegion(env, jArray, 0, *ckpLength, jpTemp);
-    if ((*env)->ExceptionCheck(env)) {
-        free(jpTemp);
-        return;
-    }
+    JNU_CHECK_EXCEPTION_FREE(env, jpTemp);
 
     *ckpArray = (CK_CHAR_PTR) calloc (*ckpLength, sizeof(CK_CHAR));
     if (*ckpArray == NULL) {
@@ -701,10 +689,7 @@ void jCharArrayToCKUTF8CharArray(JNIEnv *env, const jcharArray jArray, CK_UTF8CH
         return;
     }
     (*env)->GetCharArrayRegion(env, jArray, 0, *ckpLength, jTemp);
-    if ((*env)->ExceptionCheck(env)) {
-        free(jTemp);
-        return;
-    }
+    JNU_CHECK_EXCEPTION_FREE(env, jTemp);
 
     *ckpArray = (CK_UTF8CHAR_PTR) calloc(*ckpLength, sizeof(CK_UTF8CHAR));
     if (*ckpArray == NULL) {


### PR DESCRIPTION
We have a number of places in the codebase  where a macro could help when we check an exception and afterwrads free something and return.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8298170](https://bugs.openjdk.org/browse/JDK-8298170): Introduce a macro for exception check, free and return


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11539/head:pull/11539` \
`$ git checkout pull/11539`

Update a local copy of the PR: \
`$ git checkout pull/11539` \
`$ git pull https://git.openjdk.org/jdk pull/11539/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11539`

View PR using the GUI difftool: \
`$ git pr show -t 11539`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11539.diff">https://git.openjdk.org/jdk/pull/11539.diff</a>

</details>
