### PR TITLE
8298177: Various java.lang.invoke cleanups

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/BoundMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/BoundMethodHandle.java
@@ -33,9 +33,6 @@ import java.util.List;
 
 import static java.lang.invoke.LambdaForm.BasicType;
 import static java.lang.invoke.LambdaForm.BasicType.*;
-import static java.lang.invoke.LambdaForm.BasicType.V_TYPE_NUM;
-import static java.lang.invoke.LambdaForm.BasicType.V_TYPE_NUM;
-import static java.lang.invoke.LambdaForm.BasicType.V_TYPE_NUM;
 import static java.lang.invoke.MethodHandles.Lookup.IMPL_LOOKUP;
 import static java.lang.invoke.MethodHandleNatives.Constants.*;
 import static java.lang.invoke.MethodHandleStatics.newInternalError;
@@ -60,22 +57,6 @@ abstract non-sealed class BoundMethodHandle extends MethodHandle {
     //
     // BMH API and internals
     //
-
-    static BoundMethodHandle bindSingle(MethodType type, LambdaForm form, BasicType xtype, Object x) {
-        // for some type signatures, there exist pre-defined concrete BMH classes
-        try {
-            return switch (xtype) {
-                case L_TYPE -> bindSingle(type, form, x);  // Use known fast path.
-                case I_TYPE -> (BoundMethodHandle) SPECIALIZER.topSpecies().extendWith(I_TYPE_NUM).factory().invokeBasic(type, form, ValueConversions.widenSubword(x));
-                case J_TYPE -> (BoundMethodHandle) SPECIALIZER.topSpecies().extendWith(J_TYPE_NUM).factory().invokeBasic(type, form, (long) x);
-                case F_TYPE -> (BoundMethodHandle) SPECIALIZER.topSpecies().extendWith(F_TYPE_NUM).factory().invokeBasic(type, form, (float) x);
-                case D_TYPE -> (BoundMethodHandle) SPECIALIZER.topSpecies().extendWith(D_TYPE_NUM).factory().invokeBasic(type, form, (double) x);
-                default -> throw newInternalError("unexpected xtype: " + xtype);
-            };
-        } catch (Throwable t) {
-            throw uncaughtException(t);
-        }
-    }
 
     /*non-public*/
     LambdaFormEditor editor() {

--- a/src/java.base/share/classes/java/lang/invoke/BoundMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/BoundMethodHandle.java
@@ -26,7 +26,6 @@
 package java.lang.invoke;
 
 import jdk.internal.vm.annotation.Stable;
-import sun.invoke.util.ValueConversions;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/java.base/share/classes/java/lang/invoke/BoundMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/BoundMethodHandle.java
@@ -356,15 +356,16 @@ abstract non-sealed class BoundMethodHandle extends MethodHandle {
 
         private boolean verifyTHAargs(MemberName transform, int whichtm, List<?> args, List<?> fields) {
             assert(transform == Specializer.BMH_TRANSFORMS.get(whichtm));
-            assert(args.size() == transform.getMethodType().parameterCount());
+            MethodType tType = transform.getMethodType();
+            assert(args.size() == tType.parameterCount());
             assert(fields.size() == this.fieldCount());
             final int MH_AND_LF = 2;
             if (whichtm == Specializer.TN_COPY_NO_EXTEND) {
-                assert(transform.getMethodType().parameterCount() == MH_AND_LF);
+                assert(tType.parameterCount() == MH_AND_LF);
             } else if (whichtm < ARG_TYPE_LIMIT) {
-                assert(transform.getMethodType().parameterCount() == MH_AND_LF+1);
+                assert(tType.parameterCount() == MH_AND_LF+1);
                 final BasicType type = basicType((byte) whichtm);
-                assert(transform.getParameterTypes()[MH_AND_LF] == type.basicTypeClass());
+                assert(tType.parameterType(MH_AND_LF) == type.basicTypeClass());
             } else {
                 return false;
             }

--- a/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
+++ b/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
@@ -328,12 +328,13 @@ abstract class ClassSpecializer<T,K,S extends ClassSpecializer<T,K,S>.SpeciesDat
 
         private final MethodType transformHelperType(int whichtm) {
             MemberName tm = transformMethods().get(whichtm);
+            MethodType tmt = tm.getMethodType();
             ArrayList<Class<?>> args = new ArrayList<>();
             ArrayList<Class<?>> fields = new ArrayList<>();
-            Collections.addAll(args, tm.getParameterTypes());
+            Collections.addAll(args, tmt.ptypes());
             fields.addAll(fieldTypes());
             List<Class<?>> helperArgs = deriveTransformHelperArguments(tm, whichtm, args, fields);
-            return MethodType.methodType(tm.getReturnType(), helperArgs);
+            return MethodType.methodType(tmt.returnType(), helperArgs);
         }
 
         // Hooks for subclasses:
@@ -432,7 +433,7 @@ abstract class ClassSpecializer<T,K,S extends ClassSpecializer<T,K,S>.SpeciesDat
             final Class<T> topc = topClass();
             if (!topClassIsSuper) {
                 try {
-                    final Constructor<T> con = reflectConstructor(topc, baseConstructorType().parameterArray());
+                    final Constructor<T> con = reflectConstructor(topc, baseConstructorType().ptypes());
                     if (!topc.isInterface() && !Modifier.isPrivate(con.getModifiers())) {
                         topClassIsSuper = true;
                     }

--- a/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
@@ -600,7 +600,7 @@ sealed class DirectMethodHandle extends MethodHandle {
     }
 
     Object checkCast(Object obj) {
-        return member.getReturnType().cast(obj);
+        return member.getMethodType().returnType().cast(obj);
     }
 
     // Caching machinery for field accessors:

--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -1043,7 +1043,7 @@ class InvokerBytecodeGenerator {
     private static boolean isStaticallyInvocableType(MethodType mtype) {
         if (!isStaticallyNameable(mtype.returnType()))
             return false;
-        for (Class<?> ptype : mtype.parameterArray())
+        for (Class<?> ptype : mtype.ptypes())
             if (!isStaticallyNameable(ptype))
                 return false;
         return true;

--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -25,7 +25,6 @@
 
 package java.lang.invoke;
 
-import sun.invoke.util.BytecodeDescriptor;
 import sun.invoke.util.VerifyAccess;
 
 import java.lang.reflect.Constructor;

--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -33,10 +33,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Objects;
 
 import static java.lang.invoke.MethodHandleNatives.Constants.*;
@@ -74,7 +70,7 @@ import static java.lang.invoke.MethodHandleStatics.newInternalError;
 final class ResolvedMethodName {
     //@Injected JVM_Method* vmtarget;
     //@Injected Class<?>    vmholder;
-};
+}
 
 /*non-public*/
 final class MemberName implements Member, Cloneable {
@@ -196,16 +192,6 @@ final class MemberName implements Member, Cloneable {
         if (!isStatic())
             return itype.insertParameterTypes(0, clazz);
         return itype;
-    }
-
-    /** Utility method producing the parameter types of the method type. */
-    public Class<?>[] getParameterTypes() {
-        return getMethodType().parameterArray();
-    }
-
-    /** Utility method producing the return type of the method type. */
-    public Class<?> getReturnType() {
-        return getMethodType().returnType();
     }
 
     /** Return the declared type of this member, which
@@ -356,20 +342,9 @@ final class MemberName implements Member, Cloneable {
     }
 
     private MemberName changeReferenceKind(byte refKind, byte oldKind) {
-        assert(getReferenceKind() == oldKind);
-        assert(MethodHandleNatives.refKindIsValid(refKind));
+        assert(getReferenceKind() == oldKind && MethodHandleNatives.refKindIsValid(refKind));
         flags += (((int)refKind - oldKind) << MN_REFERENCE_KIND_SHIFT);
         return this;
-    }
-
-    private boolean testFlags(int mask, int value) {
-        return (flags & mask) == value;
-    }
-    private boolean testAllFlags(int mask) {
-        return testFlags(mask, mask);
-    }
-    private boolean testAnyFlags(int mask) {
-        return !testFlags(mask, 0);
     }
 
     /** Utility method to query if this member is a method handle invocation (invoke or invokeExact).
@@ -377,25 +352,22 @@ final class MemberName implements Member, Cloneable {
     public boolean isMethodHandleInvoke() {
         final int bits = MH_INVOKE_MODS &~ Modifier.PUBLIC;
         final int negs = Modifier.STATIC;
-        if (testFlags(bits | negs, bits) &&
+        if ((flags & (bits | negs)) == bits &&
             clazz == MethodHandle.class) {
             return isMethodHandleInvokeName(name);
         }
         return false;
     }
     public static boolean isMethodHandleInvokeName(String name) {
-        switch (name) {
-        case "invoke":
-        case "invokeExact":
-            return true;
-        default:
-            return false;
-        }
+        return switch (name) {
+            case "invoke", "invokeExact" -> true;
+            default -> false;
+        };
     }
     public boolean isVarHandleMethodInvoke() {
         final int bits = MH_INVOKE_MODS &~ Modifier.PUBLIC;
         final int negs = Modifier.STATIC;
-        if (testFlags(bits | negs, bits) &&
+        if ((flags & (bits | negs)) == bits &&
             clazz == VarHandle.class) {
             return isVarHandleMethodInvokeName(name);
         }
@@ -457,15 +429,15 @@ final class MemberName implements Member, Cloneable {
     static final int ENUM      = 0x00004000;
     /** Utility method to query the modifier flags of this member; returns false if the member is not a method. */
     public boolean isBridge() {
-        return testAllFlags(IS_METHOD | BRIDGE);
+        return (flags & (IS_METHOD | BRIDGE)) == (IS_METHOD | BRIDGE);
     }
     /** Utility method to query the modifier flags of this member; returns false if the member is not a method. */
     public boolean isVarargs() {
-        return testAllFlags(VARARGS) && isInvocable();
+        return (flags & VARARGS) == VARARGS && isInvocable();
     }
     /** Utility method to query the modifier flags of this member; returns false if the member is not a method. */
     public boolean isSynthetic() {
-        return testAllFlags(SYNTHETIC);
+        return (flags & SYNTHETIC) == SYNTHETIC;
     }
 
     static final String CONSTRUCTOR_NAME = "<init>";  // the ever-popular
@@ -485,49 +457,38 @@ final class MemberName implements Member, Cloneable {
     static final int ALL_ACCESS = Modifier.PUBLIC | Modifier.PRIVATE | Modifier.PROTECTED;
     static final int ALL_KINDS = IS_METHOD | IS_CONSTRUCTOR | IS_FIELD | IS_TYPE;
     static final int IS_INVOCABLE = IS_METHOD | IS_CONSTRUCTOR;
-    static final int IS_FIELD_OR_METHOD = IS_METHOD | IS_FIELD;
-    static final int SEARCH_ALL_SUPERS = MN_SEARCH_SUPERCLASSES | MN_SEARCH_INTERFACES;
 
     /** Utility method to query whether this member is a method or constructor. */
     public boolean isInvocable() {
-        return testAnyFlags(IS_INVOCABLE);
-    }
-    /** Utility method to query whether this member is a method, constructor, or field. */
-    public boolean isFieldOrMethod() {
-        return testAnyFlags(IS_FIELD_OR_METHOD);
+        return (flags & IS_INVOCABLE) != 0;
     }
     /** Query whether this member is a method. */
     public boolean isMethod() {
-        return testAllFlags(IS_METHOD);
+        return (flags & IS_METHOD) == IS_METHOD;
     }
     /** Query whether this member is a constructor. */
     public boolean isConstructor() {
-        return testAllFlags(IS_CONSTRUCTOR);
+        return (flags & IS_CONSTRUCTOR) == IS_CONSTRUCTOR;
     }
     /** Query whether this member is a field. */
     public boolean isField() {
-        return testAllFlags(IS_FIELD);
+        return (flags & IS_FIELD) == IS_FIELD;
     }
     /** Query whether this member is a type. */
     public boolean isType() {
-        return testAllFlags(IS_TYPE);
+        return (flags & IS_TYPE) == IS_TYPE;
     }
     /** Utility method to query whether this member is neither public, private, nor protected. */
     public boolean isPackage() {
-        return !testAnyFlags(ALL_ACCESS);
+        return (flags & ALL_ACCESS) == 0;
     }
     /** Query whether this member has a CallerSensitive annotation. */
     public boolean isCallerSensitive() {
-        return testAllFlags(CALLER_SENSITIVE);
+        return (flags & CALLER_SENSITIVE) == CALLER_SENSITIVE;
     }
     /** Query whether this member is a trusted final field. */
-    public boolean isTrustedFinalField() { return testAllFlags(TRUSTED_FINAL|IS_FIELD); }
-
-    /** Utility method to query whether this member is accessible from a given lookup class. */
-    public boolean isAccessibleFrom(Class<?> lookupClass) {
-        int mode = (ALL_ACCESS|MethodHandles.Lookup.PACKAGE|MethodHandles.Lookup.MODULE);
-        return VerifyAccess.isMemberAccessible(this.getDeclaringClass(), this.getDeclaringClass(), flags,
-                                               lookupClass, null, mode);
+    public boolean isTrustedFinalField() {
+        return (flags & (TRUSTED_FINAL | IS_FIELD)) == (TRUSTED_FINAL | IS_FIELD);
     }
 
     /**
@@ -547,7 +508,7 @@ final class MemberName implements Member, Cloneable {
         this.name = name;
         this.type = type;
         this.flags = flags;
-        assert(testAnyFlags(ALL_KINDS));
+        assert((flags & ALL_KINDS) != 0);
         assert(this.resolution == null);  // nobody should have touched this yet
         //assert(referenceKindIsConsistent());  // do this after resolution
     }
@@ -568,9 +529,9 @@ final class MemberName implements Member, Cloneable {
 
     // Capturing information from the Core Reflection API:
     private static int flagsMods(int flags, int mods, byte refKind) {
-        assert((flags & RECOGNIZED_MODIFIERS) == 0);
-        assert((mods & ~RECOGNIZED_MODIFIERS) == 0);
-        assert((refKind & ~MN_REFERENCE_KIND_MASK) == 0);
+        assert((flags & RECOGNIZED_MODIFIERS) == 0
+                && (mods & ~RECOGNIZED_MODIFIERS) == 0
+                && (refKind & ~MN_REFERENCE_KIND_MASK) == 0);
         return flags | mods | (refKind << MN_REFERENCE_KIND_SHIFT);
     }
     /** Create a name for the given reflected method.  The resulting name will be in a resolved state. */
@@ -607,7 +568,7 @@ final class MemberName implements Member, Cloneable {
             }
             throw new LinkageError(m.toString());
         }
-        assert(isResolved() && this.clazz != null);
+        assert(isResolved());
         this.name = m.getName();
         if (this.type == null)
             this.type = new Object[] { m.getReturnType(), m.getParameterTypes() };
@@ -649,20 +610,16 @@ final class MemberName implements Member, Cloneable {
      *  undoes that change under the assumption that it occurred.)
      */
     public MemberName asNormalOriginal() {
-        byte normalVirtual = clazz.isInterface() ? REF_invokeInterface : REF_invokeVirtual;
         byte refKind = getReferenceKind();
-        byte newRefKind = refKind;
-        MemberName result = this;
-        switch (refKind) {
-        case REF_invokeInterface:
-        case REF_invokeVirtual:
-        case REF_invokeSpecial:
-            newRefKind = normalVirtual;
-            break;
-        }
+        byte newRefKind = switch (refKind) {
+            case REF_invokeInterface,
+                 REF_invokeVirtual,
+                 REF_invokeSpecial -> clazz.isInterface() ? REF_invokeInterface : REF_invokeVirtual;
+            default -> refKind;
+        };
         if (newRefKind == refKind)
             return this;
-        result = clone().changeReferenceKind(newRefKind, refKind);
+        MemberName result = clone().changeReferenceKind(newRefKind, refKind);
         assert(this.referenceKindIsConsistentWith(result.getReferenceKind()));
         return result;
     }
@@ -690,7 +647,7 @@ final class MemberName implements Member, Cloneable {
         assert(isResolved() && this.clazz != null);
         this.name = fld.getName();
         this.type = fld.getType();
-        assert((REF_putStatic - REF_getStatic) == (REF_putField - REF_getField));
+        // assert((REF_putStatic - REF_getStatic) == (REF_putField - REF_getField));
         byte refKind = this.getReferenceKind();
         assert(refKind == (isStatic() ? REF_getStatic : REF_getField));
         if (makeSetter) {
@@ -703,13 +660,7 @@ final class MemberName implements Member, Cloneable {
     public boolean isSetter() {
         return MethodHandleNatives.refKindIsSetter(getReferenceKind());
     }
-    public MemberName asSetter() {
-        byte refKind = getReferenceKind();
-        assert(MethodHandleNatives.refKindIsGetter(refKind));
-        assert((REF_putStatic - REF_getStatic) == (REF_putField - REF_getField));
-        byte setterRefKind = (byte)(refKind + (REF_putField - REF_getField));
-        return clone().changeReferenceKind(setterRefKind, refKind);
-    }
+
     /** Create a name for the given class.  The resulting name will be in a resolved state. */
     public MemberName(Class<?> type) {
         init(type.getDeclaringClass(), type.getSimpleName(), type,
@@ -844,11 +795,6 @@ final class MemberName implements Member, Cloneable {
         init(defClass, name, type, flagsMods(kindFlags, 0, refKind));
         initResolved(false);
     }
-    /** Query whether this member name is resolved to a non-static, non-final method.
-     */
-    public boolean hasReceiverTypeDispatch() {
-        return MethodHandleNatives.refKindDoesDispatch(getReferenceKind());
-    }
 
     /** Query whether this member name is resolved.
      *  A resolved member name is one for which the JVM has found
@@ -930,7 +876,7 @@ final class MemberName implements Member, Cloneable {
     }
 
     public IllegalAccessException makeAccessException(String message, Object from) {
-        message = message + ": "+ toString();
+        message = message + ": " + this;
         if (from != null)  {
             if (from == MethodHandles.publicLookup()) {
                 message += ", from public Lookup";
@@ -965,7 +911,7 @@ final class MemberName implements Member, Cloneable {
             return "no such field";
     }
     public ReflectiveOperationException makeAccessException() {
-        String message = message() + ": "+ toString();
+        String message = message() + ": " + this;
         ReflectiveOperationException ex;
         if (isResolved() || !(resolution instanceof NoSuchMethodError ||
                               resolution instanceof NoSuchFieldError))
@@ -992,70 +938,8 @@ final class MemberName implements Member, Cloneable {
     /*non-public*/
     static class Factory {
         private Factory() { } // singleton pattern
-        static Factory INSTANCE = new Factory();
+        static final Factory INSTANCE = new Factory();
 
-        private static int ALLOWED_FLAGS = ALL_KINDS;
-
-        /// Queries
-        List<MemberName> getMembers(Class<?> defc,
-                String matchName, Object matchType,
-                int matchFlags, Class<?> lookupClass) {
-            matchFlags &= ALLOWED_FLAGS;
-            String matchSig = null;
-            if (matchType != null) {
-                matchSig = BytecodeDescriptor.unparse(matchType);
-                if (matchSig.startsWith("("))
-                    matchFlags &= ~(ALL_KINDS & ~IS_INVOCABLE);
-                else
-                    matchFlags &= ~(ALL_KINDS & ~IS_FIELD);
-            }
-            final int BUF_MAX = 0x2000;
-            int len1 = matchName == null ? 10 : matchType == null ? 4 : 1;
-            MemberName[] buf = newMemberBuffer(len1);
-            int totalCount = 0;
-            ArrayList<MemberName[]> bufs = null;
-            int bufCount = 0;
-            for (;;) {
-                bufCount = MethodHandleNatives.getMembers(defc,
-                        matchName, matchSig, matchFlags,
-                        lookupClass,
-                        totalCount, buf);
-                if (bufCount <= buf.length) {
-                    if (bufCount < 0)  bufCount = 0;
-                    totalCount += bufCount;
-                    break;
-                }
-                // JVM returned to us with an intentional overflow!
-                totalCount += buf.length;
-                int excess = bufCount - buf.length;
-                if (bufs == null)  bufs = new ArrayList<>(1);
-                bufs.add(buf);
-                int len2 = buf.length;
-                len2 = Math.max(len2, excess);
-                len2 = Math.max(len2, totalCount / 4);
-                buf = newMemberBuffer(Math.min(BUF_MAX, len2));
-            }
-            ArrayList<MemberName> result = new ArrayList<>(totalCount);
-            if (bufs != null) {
-                for (MemberName[] buf0 : bufs) {
-                    Collections.addAll(result, buf0);
-                }
-            }
-            for (int i = 0; i < bufCount; i++) {
-                result.add(buf[i]);
-            }
-            // Signature matching is not the same as type matching, since
-            // one signature might correspond to several types.
-            // So if matchType is a Class or MethodType, refilter the results.
-            if (matchType != null && matchType != matchSig) {
-                for (Iterator<MemberName> it = result.iterator(); it.hasNext();) {
-                    MemberName m = it.next();
-                    if (!matchType.equals(m.getType()))
-                        it.remove();
-                }
-            }
-            return result;
-        }
         /** Produce a resolved version of the given member.
          *  Super types are searched (for inherited members) if {@code searchSupers} is true.
          *  Access checking is performed on behalf of the given {@code lookupClass}.
@@ -1130,70 +1014,6 @@ final class MemberName implements Member, Cloneable {
             if (result != null && result.isResolved())
                 return result;
             return null;
-        }
-        /** Return a list of all methods defined by the given class.
-         *  Super types are searched (for inherited members) if {@code searchSupers} is true.
-         *  Access checking is performed on behalf of the given {@code lookupClass}.
-         *  Inaccessible members are not added to the last.
-         */
-        public List<MemberName> getMethods(Class<?> defc, boolean searchSupers,
-                Class<?> lookupClass) {
-            return getMethods(defc, searchSupers, null, null, lookupClass);
-        }
-        /** Return a list of matching methods defined by the given class.
-         *  Super types are searched (for inherited members) if {@code searchSupers} is true.
-         *  Returned methods will match the name (if not null) and the type (if not null).
-         *  Access checking is performed on behalf of the given {@code lookupClass}.
-         *  Inaccessible members are not added to the last.
-         */
-        public List<MemberName> getMethods(Class<?> defc, boolean searchSupers,
-                String name, MethodType type, Class<?> lookupClass) {
-            int matchFlags = IS_METHOD | (searchSupers ? SEARCH_ALL_SUPERS : 0);
-            return getMembers(defc, name, type, matchFlags, lookupClass);
-        }
-        /** Return a list of all constructors defined by the given class.
-         *  Access checking is performed on behalf of the given {@code lookupClass}.
-         *  Inaccessible members are not added to the last.
-         */
-        public List<MemberName> getConstructors(Class<?> defc, Class<?> lookupClass) {
-            return getMembers(defc, null, null, IS_CONSTRUCTOR, lookupClass);
-        }
-        /** Return a list of all fields defined by the given class.
-         *  Super types are searched (for inherited members) if {@code searchSupers} is true.
-         *  Access checking is performed on behalf of the given {@code lookupClass}.
-         *  Inaccessible members are not added to the last.
-         */
-        public List<MemberName> getFields(Class<?> defc, boolean searchSupers,
-                Class<?> lookupClass) {
-            return getFields(defc, searchSupers, null, null, lookupClass);
-        }
-        /** Return a list of all fields defined by the given class.
-         *  Super types are searched (for inherited members) if {@code searchSupers} is true.
-         *  Returned fields will match the name (if not null) and the type (if not null).
-         *  Access checking is performed on behalf of the given {@code lookupClass}.
-         *  Inaccessible members are not added to the last.
-         */
-        public List<MemberName> getFields(Class<?> defc, boolean searchSupers,
-                String name, Class<?> type, Class<?> lookupClass) {
-            int matchFlags = IS_FIELD | (searchSupers ? SEARCH_ALL_SUPERS : 0);
-            return getMembers(defc, name, type, matchFlags, lookupClass);
-        }
-        /** Return a list of all nested types defined by the given class.
-         *  Super types are searched (for inherited members) if {@code searchSupers} is true.
-         *  Access checking is performed on behalf of the given {@code lookupClass}.
-         *  Inaccessible members are not added to the last.
-         */
-        public List<MemberName> getNestedTypes(Class<?> defc, boolean searchSupers,
-                Class<?> lookupClass) {
-            int matchFlags = IS_TYPE | (searchSupers ? SEARCH_ALL_SUPERS : 0);
-            return getMembers(defc, null, null, matchFlags, lookupClass);
-        }
-        private static MemberName[] newMemberBuffer(int length) {
-            MemberName[] buf = new MemberName[length];
-            // fill the buffer with dummy structs for the JVM to fill in
-            for (int i = 0; i < length; i++)
-                buf[i] = new MemberName();
-            return buf;
         }
     }
 }

--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -235,22 +235,6 @@ final class MemberName implements Member, Cloneable {
         return (isInvocable() ? getMethodType() : getFieldType());
     }
 
-    /** Utility method to produce the signature of this member,
-     *  used within the class file format to describe its type.
-     */
-    public String getSignature() {
-        if (type == null) {
-            expandFromVM();
-            if (type == null) {
-                return null;
-            }
-        }
-        if (isInvocable())
-            return BytecodeDescriptor.unparse(getMethodType());
-        else
-            return BytecodeDescriptor.unparse(getFieldType());
-    }
-
     /** Return the modifier flags of this member.
      *  @see java.lang.reflect.Modifier
      */
@@ -646,6 +630,10 @@ final class MemberName implements Member, Cloneable {
     public MemberName(Field fld) {
         this(fld, false);
     }
+    static {
+        // the following MemberName constructor relies on these ranges matching up
+        assert((REF_putStatic - REF_getStatic) == (REF_putField - REF_getField));
+    }
     @SuppressWarnings("LeakingThisInConstructor")
     public MemberName(Field fld, boolean makeSetter) {
         Objects.requireNonNull(fld);
@@ -654,7 +642,6 @@ final class MemberName implements Member, Cloneable {
         assert(isResolved() && this.clazz != null);
         this.name = fld.getName();
         this.type = fld.getType();
-        // assert((REF_putStatic - REF_getStatic) == (REF_putField - REF_getField));
         byte refKind = this.getReferenceKind();
         assert(refKind == (isStatic() ? REF_getStatic : REF_getField));
         if (makeSetter) {

--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -347,13 +347,22 @@ final class MemberName implements Member, Cloneable {
         return this;
     }
 
+    private boolean matchingFlagsSet(int mask, int flags) {
+        return (this.flags & mask) == flags;
+    }
+    private boolean allFlagsSet(int flags) {
+        return (this.flags & flags) == flags;
+    }
+    private boolean anyFlagSet(int flags) {
+        return (this.flags & flags) != 0;
+    }
+
     /** Utility method to query if this member is a method handle invocation (invoke or invokeExact).
      */
     public boolean isMethodHandleInvoke() {
         final int bits = MH_INVOKE_MODS &~ Modifier.PUBLIC;
         final int negs = Modifier.STATIC;
-        if ((flags & (bits | negs)) == bits &&
-            clazz == MethodHandle.class) {
+        if (matchingFlagsSet(bits | negs, bits) && clazz == MethodHandle.class) {
             return isMethodHandleInvokeName(name);
         }
         return false;
@@ -367,8 +376,7 @@ final class MemberName implements Member, Cloneable {
     public boolean isVarHandleMethodInvoke() {
         final int bits = MH_INVOKE_MODS &~ Modifier.PUBLIC;
         final int negs = Modifier.STATIC;
-        if ((flags & (bits | negs)) == bits &&
-            clazz == VarHandle.class) {
+        if (matchingFlagsSet(bits | negs, bits) && clazz == VarHandle.class) {
             return isVarHandleMethodInvokeName(name);
         }
         return false;
@@ -429,15 +437,15 @@ final class MemberName implements Member, Cloneable {
     static final int ENUM      = 0x00004000;
     /** Utility method to query the modifier flags of this member; returns false if the member is not a method. */
     public boolean isBridge() {
-        return (flags & (IS_METHOD | BRIDGE)) == (IS_METHOD | BRIDGE);
+        return allFlagsSet(IS_METHOD | BRIDGE);
     }
     /** Utility method to query the modifier flags of this member; returns false if the member is not a method. */
     public boolean isVarargs() {
-        return (flags & VARARGS) == VARARGS && isInvocable();
+        return allFlagsSet(VARARGS) && isInvocable();
     }
     /** Utility method to query the modifier flags of this member; returns false if the member is not a method. */
     public boolean isSynthetic() {
-        return (flags & SYNTHETIC) == SYNTHETIC;
+        return allFlagsSet(SYNTHETIC);
     }
 
     static final String CONSTRUCTOR_NAME = "<init>";  // the ever-popular
@@ -460,35 +468,35 @@ final class MemberName implements Member, Cloneable {
 
     /** Utility method to query whether this member is a method or constructor. */
     public boolean isInvocable() {
-        return (flags & IS_INVOCABLE) != 0;
+        return anyFlagSet(IS_INVOCABLE);
     }
     /** Query whether this member is a method. */
     public boolean isMethod() {
-        return (flags & IS_METHOD) == IS_METHOD;
+        return allFlagsSet(IS_METHOD);
     }
     /** Query whether this member is a constructor. */
     public boolean isConstructor() {
-        return (flags & IS_CONSTRUCTOR) == IS_CONSTRUCTOR;
+        return allFlagsSet(IS_CONSTRUCTOR);
     }
     /** Query whether this member is a field. */
     public boolean isField() {
-        return (flags & IS_FIELD) == IS_FIELD;
+        return allFlagsSet(IS_FIELD);
     }
     /** Query whether this member is a type. */
     public boolean isType() {
-        return (flags & IS_TYPE) == IS_TYPE;
+        return allFlagsSet(IS_TYPE);
     }
     /** Utility method to query whether this member is neither public, private, nor protected. */
     public boolean isPackage() {
-        return (flags & ALL_ACCESS) == 0;
+        return !anyFlagSet(ALL_ACCESS);
     }
     /** Query whether this member has a CallerSensitive annotation. */
     public boolean isCallerSensitive() {
-        return (flags & CALLER_SENSITIVE) == CALLER_SENSITIVE;
+        return allFlagsSet(CALLER_SENSITIVE);
     }
     /** Query whether this member is a trusted final field. */
     public boolean isTrustedFinalField() {
-        return (flags & (TRUSTED_FINAL | IS_FIELD)) == (TRUSTED_FINAL | IS_FIELD);
+        return allFlagsSet(TRUSTED_FINAL | IS_FIELD);
     }
 
     /**
@@ -508,8 +516,7 @@ final class MemberName implements Member, Cloneable {
         this.name = name;
         this.type = type;
         this.flags = flags;
-        assert((flags & ALL_KINDS) != 0);
-        assert(this.resolution == null);  // nobody should have touched this yet
+        assert(anyFlagSet(ALL_KINDS) && this.resolution == null);  // nobody should have touched this yet
         //assert(referenceKindIsConsistent());  // do this after resolution
     }
 

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -1005,7 +1005,8 @@ abstract class MethodHandleImpl {
     }
     static MethodHandle fakeVarHandleInvoke(MemberName method) {
         // TODO caching, is it necessary?
-        MethodType type = MethodType.methodType(method.getReturnType(), UnsupportedOperationException.class,
+        MethodType type = MethodType.methodType(method.getMethodType().returnType(),
+                                                UnsupportedOperationException.class,
                                                 VarHandle.class, Object[].class);
         MethodHandle mh = throwException(type);
         mh = mh.bindTo(new UnsupportedOperationException("cannot reflectively invoke VarHandle"));

--- a/src/java.base/share/classes/java/lang/invoke/NativeMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/NativeMethodHandle.java
@@ -64,7 +64,7 @@ import static java.lang.invoke.MethodHandleStatics.newInternalError;
         if (isIllegalType(type.returnType()))
             return true;
 
-        for (Class<?> pType : type.parameterArray()) {
+        for (Class<?> pType : type.ptypes()) {
             if (isIllegalType(pType))
                 return true;
         }

--- a/src/java.base/share/classes/sun/invoke/util/BytecodeDescriptor.java
+++ b/src/java.base/share/classes/sun/invoke/util/BytecodeDescriptor.java
@@ -113,15 +113,11 @@ public class BytecodeDescriptor {
         return type.descriptorString();
     }
 
-    public static String unparse(MethodType type) {
-        return type.toMethodDescriptorString();
-    }
-
     public static String unparse(Object type) {
         if (type instanceof Class<?>)
             return unparse((Class<?>) type);
         if (type instanceof MethodType)
-            return unparse((MethodType) type);
+            return ((MethodType) type).toMethodDescriptorString();
         return (String) type;
     }
 

--- a/src/java.base/share/classes/sun/invoke/util/BytecodeDescriptor.java
+++ b/src/java.base/share/classes/sun/invoke/util/BytecodeDescriptor.java
@@ -114,7 +114,7 @@ public class BytecodeDescriptor {
     }
 
     public static String unparse(MethodType type) {
-        return unparseMethod(type.returnType(), type.parameterArray());
+        return type.toMethodDescriptorString();
     }
 
     public static String unparse(Object type) {

--- a/test/jdk/sun/invoke/util/ValueConversionsTest.java
+++ b/test/jdk/sun/invoke/util/ValueConversionsTest.java
@@ -135,30 +135,6 @@ public class ValueConversionsTest {
     }
 
     @Test
-    public void testCast() throws Throwable {
-        Class<?>[] types = { Object.class, Serializable.class, String.class, Number.class, Integer.class };
-        Object[] objects = { new Object(), Boolean.FALSE,      "hello",      (Long)12L,    (Integer)6    };
-        for (Class<?> dst : types) {
-            MethodHandle caster = ValueConversions.cast().bindTo(dst);
-            assertEquals(caster.type(), MethodHandles.identity(Object.class).type());
-            for (Object obj : objects) {
-                Class<?> src = obj.getClass();
-                boolean canCast = dst.isAssignableFrom(src);
-                try {
-                    Object result = caster.invokeExact(obj);
-                    if (canCast)
-                        assertEquals(obj, result);
-                    else
-                        assertEquals("cast should not have succeeded", dst, obj);
-                } catch (ClassCastException ex) {
-                    if (canCast)
-                        throw ex;
-                }
-            }
-        }
-    }
-
-    @Test
     public void testConvert() throws Throwable {
         for (long tval = 0, ctr = 0;;) {
             if (++ctr > 99999)  throw new AssertionError("too many test values");


### PR DESCRIPTION
Various code cleanups around java.lang.invoke code. Started out with dead code removal in `jli.MemberName`, then piled on to fix a set of minor inefficiencies (excessive vararg array allocations, unnecessary defensive cloning of parameter arrays etc).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8298177](https://bugs.openjdk.org/browse/JDK-8298177): Various java.lang.invoke cleanups
 * [JDK-8284363](https://bugs.openjdk.org/browse/JDK-8284363): Redundant imports in BoundMethodHandle


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11540/head:pull/11540` \
`$ git checkout pull/11540`

Update a local copy of the PR: \
`$ git checkout pull/11540` \
`$ git pull https://git.openjdk.org/jdk pull/11540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11540`

View PR using the GUI difftool: \
`$ git pr show -t 11540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11540.diff">https://git.openjdk.org/jdk/pull/11540.diff</a>

</details>
