### PR TITLE
8298184: Incorrect record component type in record patterns

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4204,13 +4204,15 @@ public class Attr extends JCTree.Visitor {
             }
         }
         tree.type = tree.deconstructor.type = type;
-        Type site = types.removeWildcards(tree.type);
+        Type site = types.capture(tree.type);
         List<Type> expectedRecordTypes;
         if (site.tsym.kind == Kind.TYP && ((ClassSymbol) site.tsym).isRecord()) {
             ClassSymbol record = (ClassSymbol) site.tsym;
             expectedRecordTypes = record.getRecordComponents()
                                         .stream()
-                                        .map(rc -> types.memberType(site, rc)).collect(List.collector());
+                                        .map(rc -> types.memberType(site, rc))
+                                        .map(t -> types.upward(t, types.captures(t)).baseType())
+                                        .collect(List.collector());
             tree.record = record;
         } else {
             log.error(tree.pos(), Errors.DeconstructionPatternOnlyRecords(site.tsym));

--- a/test/langtools/tools/javac/patterns/GenericRecordDeconstructionPattern.java
+++ b/test/langtools/tools/javac/patterns/GenericRecordDeconstructionPattern.java
@@ -23,7 +23,10 @@
 
 /**
  * @test
+ * @bug 8298184
  * @enablePreview
+ * @compile GenericRecordDeconstructionPattern.java
+ * @run main GenericRecordDeconstructionPattern
  */
 import java.util.List;
 import java.util.Objects;
@@ -46,6 +49,8 @@ public class GenericRecordDeconstructionPattern {
         testInference3();
         assertEquals(0, forEachInference(List.of(new Box(""))));
         assertEquals(1, forEachInference(List.of(new Box(null))));
+        assertEquals(1, runIfSuperBound(new Box<>(new StringBuilder())));
+        assertEquals(1, runIfSuperBound(new Box<>(0)));
     }
 
     void runTest(Function<Box<String>, Integer> test) {
@@ -118,6 +123,11 @@ public class GenericRecordDeconstructionPattern {
             case Box(Box(var s)): return s == null ? 1 : s.length();
             default: return -1;
         }
+    }
+
+    int runIfSuperBound(I<? super String> b) {
+        if (b instanceof Box(var v)) return 1;
+        return -1;
     }
 
     sealed interface I<T> {}


### PR DESCRIPTION
When a type of a record type is a generic type with wildcards, per specification[1] we should do upward projection on the component type. But the current code removes wildcards. As a consequence, for record type e.g. `Box<? super String>` the type of the record component is determined to be `String`, instead of `Object`, and as a consequence code like this:
```
    int runIfSuperBound(I<? super String> b) {
        if (b instanceof Box(var v)) return 1;
        return -1;
    }
```

will return `-1` for `new Box<>(new StringBuilder())`.

The proposed fix is to use upward projections as per specification to compute the type of the record components.

[1] http://cr.openjdk.java.net/~gbierman/jep432%2b433/jep432+433-20221115/specs/patterns-switch-record-patterns-jls.html#jls-14.30.1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298184](https://bugs.openjdk.org/browse/JDK-8298184): Incorrect record component type in record patterns


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11543/head:pull/11543` \
`$ git checkout pull/11543`

Update a local copy of the PR: \
`$ git checkout pull/11543` \
`$ git pull https://git.openjdk.org/jdk pull/11543/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11543`

View PR using the GUI difftool: \
`$ git pr show -t 11543`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11543.diff">https://git.openjdk.org/jdk/pull/11543.diff</a>

</details>
