### PR TITLE
JDK-8298147: Clang warns about pointless comparisons

### DIFF
--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -287,9 +287,6 @@ int CgroupV1Subsystem::cpu_shares() {
 char* CgroupV1Subsystem::pids_max_val() {
   GET_CONTAINER_INFO_CPTR(cptr, _pids, "/pids.max",
                      "Maximum number of tasks is: %s", "%s %*d", pidsmax, 1024);
-  if (pidsmax == NULL) {
-    return NULL;
-  }
   return os::strdup(pidsmax);
 }
 

--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
@@ -92,27 +92,18 @@ int CgroupV2Subsystem::cpu_quota() {
 char * CgroupV2Subsystem::cpu_cpuset_cpus() {
   GET_CONTAINER_INFO_CPTR(cptr, _unified, "/cpuset.cpus",
                      "cpuset.cpus is: %s", "%1023s", cpus, 1024);
-  if (cpus == NULL) {
-    return NULL;
-  }
   return os::strdup(cpus);
 }
 
 char* CgroupV2Subsystem::cpu_quota_val() {
   GET_CONTAINER_INFO_CPTR(cptr, _unified, "/cpu.max",
                      "Raw value for CPU quota is: %s", "%s %*d", quota, 1024);
-  if (quota == NULL) {
-    return NULL;
-  }
   return os::strdup(quota);
 }
 
 char * CgroupV2Subsystem::cpu_cpuset_memory_nodes() {
   GET_CONTAINER_INFO_CPTR(cptr, _unified, "/cpuset.mems",
                      "cpuset.mems is: %s", "%1023s", mems, 1024);
-  if (mems == NULL) {
-    return NULL;
-  }
   return os::strdup(mems);
 }
 
@@ -151,9 +142,6 @@ jlong CgroupV2Subsystem::memory_max_usage_in_bytes() {
 char* CgroupV2Subsystem::mem_soft_limit_val() {
   GET_CONTAINER_INFO_CPTR(cptr, _unified, "/memory.low",
                          "Memory Soft Limit is: %s", "%s", mem_soft_limit_str, 1024);
-  if (mem_soft_limit_str == NULL) {
-    return NULL;
-  }
   return os::strdup(mem_soft_limit_str);
 }
 
@@ -176,9 +164,6 @@ jlong CgroupV2Subsystem::memory_and_swap_limit_in_bytes() {
 char* CgroupV2Subsystem::mem_swp_limit_val() {
   GET_CONTAINER_INFO_CPTR(cptr, _unified, "/memory.swap.max",
                          "Memory and Swap Limit is: %s", "%s", mem_swp_limit_str, 1024);
-  if (mem_swp_limit_str == NULL) {
-    return NULL;
-  }
   return os::strdup(mem_swp_limit_str);
 }
 
@@ -186,9 +171,6 @@ char* CgroupV2Subsystem::mem_swp_limit_val() {
 char* CgroupV2Subsystem::mem_swp_current_val() {
   GET_CONTAINER_INFO_CPTR(cptr, _unified, "/memory.swap.current",
                          "Swap currently used is: %s", "%s", mem_swp_current_str, 1024);
-  if (mem_swp_current_str == NULL) {
-    return NULL;
-  }
   return os::strdup(mem_swp_current_str);
 }
 
@@ -216,9 +198,6 @@ jlong CgroupV2Subsystem::read_memory_limit_in_bytes() {
 char* CgroupV2Subsystem::mem_limit_val() {
   GET_CONTAINER_INFO_CPTR(cptr, _unified, "/memory.max",
                          "Raw value for memory limit is: %s", "%s", mem_limit_str, 1024);
-  if (mem_limit_str == NULL) {
-    return NULL;
-  }
   return os::strdup(mem_limit_str);
 }
 
@@ -245,9 +224,6 @@ char* CgroupV2Controller::construct_path(char* mount_path, char *cgroup_path) {
 char* CgroupV2Subsystem::pids_max_val() {
   GET_CONTAINER_INFO_CPTR(cptr, _unified, "/pids.max",
                      "Maximum number of tasks is: %s", "%s %*d", pidsmax, 1024);
-  if (pidsmax == NULL) {
-    return NULL;
-  }
   return os::strdup(pidsmax);
 }
 


### PR DESCRIPTION
Trivial fix for clang warnings. GET_CONTAINER_INFO_CPTR creates local buffers of the given size; comparing them with NULL will always yield the same result.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298147](https://bugs.openjdk.org/browse/JDK-8298147): Clang warns about pointless comparisons


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11544/head:pull/11544` \
`$ git checkout pull/11544`

Update a local copy of the PR: \
`$ git checkout pull/11544` \
`$ git pull https://git.openjdk.org/jdk pull/11544/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11544`

View PR using the GUI difftool: \
`$ git pr show -t 11544`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11544.diff">https://git.openjdk.org/jdk/pull/11544.diff</a>

</details>
