### PR TITLE
8298202: [AIX] Dead code elimination removed jfr constructor used by AIX

### DIFF
--- a/src/hotspot/share/runtime/os_perf.hpp
+++ b/src/hotspot/share/runtime/os_perf.hpp
@@ -106,6 +106,14 @@ class SystemProcess : public CHeapObj<mtInternal> {
     _next = NULL;
   }
 
+  SystemProcess(int pid, char* name, char* path, char* command_line, SystemProcess* next) {
+    _pid = pid;
+    _name = name;
+    _path = path;
+    _command_line = command_line;
+    _next = next;
+  }
+
   void set_next(SystemProcess* sys_process) {
     _next = sys_process;
   }


### PR DESCRIPTION
A very simple change to restore the 5 argument SystemProcess constructor used by JFR on AIX which is currently blocking the AIX build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298202](https://bugs.openjdk.org/browse/JDK-8298202): [AIX] Dead code elimination removed jfr constructor used by AIX


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11546/head:pull/11546` \
`$ git checkout pull/11546`

Update a local copy of the PR: \
`$ git checkout pull/11546` \
`$ git pull https://git.openjdk.org/jdk pull/11546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11546`

View PR using the GUI difftool: \
`$ git pr show -t 11546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11546.diff">https://git.openjdk.org/jdk/pull/11546.diff</a>

</details>
