### PR TITLE
8298221: Problem list gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java on macosx-aarch64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -81,8 +81,9 @@ gc/stress/gclocker/TestExcessGCLockerCollections.java 8229120 generic-all
 gc/stress/gclocker/TestGCLockerWithParallel.java 8180622 generic-all
 gc/stress/gclocker/TestGCLockerWithG1.java 8180622 generic-all
 gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java 8192647 generic-all
-gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8241293 macosx-x64
+gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8241293,8298073 macosx-x64,macosx-aarch64
 gc/stress/TestStressG1Humongous.java 8286554 windows-x64
+
 
 #############################################################################
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -84,7 +84,6 @@ gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java 8192647 generic-all
 gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8241293,8298073 macosx-x64,macosx-aarch64
 gc/stress/TestStressG1Humongous.java 8286554 windows-x64
 
-
 #############################################################################
 
 # :hotspot_runtime


### PR DESCRIPTION
Problem list gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java on macosx-aarch64. It's causing the hosts to take 2 days or more to finish up the test task.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298221](https://bugs.openjdk.org/browse/JDK-8298221): Problem list gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java on macosx-aarch64


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11549/head:pull/11549` \
`$ git checkout pull/11549`

Update a local copy of the PR: \
`$ git checkout pull/11549` \
`$ git pull https://git.openjdk.org/jdk pull/11549/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11549`

View PR using the GUI difftool: \
`$ git pr show -t 11549`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11549.diff">https://git.openjdk.org/jdk/pull/11549.diff</a>

</details>
