### PR TITLE
8244400: MenuItem may cache the size and did not update it when the screen DPI is changed

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuItemUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuItemUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuItemUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuItemUI.java
@@ -1160,6 +1160,9 @@ public class BasicMenuItemUI extends MenuItemUI
                 // existed, and install a new one if the text installed
                 // into the JLabel is html source.
                 JMenuItem lbl = ((JMenuItem) e.getSource());
+                if (SwingUtilities2.isScaleChanged(e)) {
+                    MenuItemLayoutHelper.clearUsedParentClientProperties(lbl);
+                }
                 String text = lbl.getText();
                 BasicHTML.updateRenderer(lbl, text);
             } else if (name  == "iconTextGap") {

--- a/test/jdk/javax/swing/GraphicsConfigNotifier/StalePreferredSize.java
+++ b/test/jdk/javax/swing/GraphicsConfigNotifier/StalePreferredSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/GraphicsConfigNotifier/StalePreferredSize.java
+++ b/test/jdk/javax/swing/GraphicsConfigNotifier/StalePreferredSize.java
@@ -65,7 +65,6 @@ import static javax.swing.UIManager.getInstalledLookAndFeels;
  * @summary Initial layout of the component should use correct graphics config.
  *          It is checked by SwingUtilities.updateComponentTreeUI(), if layout
  *          was correct the call to updateComponentTreeUI() will be no-op.
- * @modules java.desktop/sun.swing
  * @compile -encoding utf-8 StalePreferredSize.java
  * @run main/othervm/timeout=600 StalePreferredSize
  * @run main/othervm/timeout=600 -Dsun.java2d.uiScale=1 StalePreferredSize

--- a/test/jdk/javax/swing/GraphicsConfigNotifier/StalePreferredSize.java
+++ b/test/jdk/javax/swing/GraphicsConfigNotifier/StalePreferredSize.java
@@ -56,22 +56,20 @@ import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.tree.DefaultMutableTreeNode;
 
-import sun.swing.MenuItemLayoutHelper;
-
 import static javax.swing.UIManager.getInstalledLookAndFeels;
 
 /**
  * @test
  * @key headful
- * @bug 8201552 8213843 8213535
+ * @bug 8201552 8213843 8213535 8244400
  * @summary Initial layout of the component should use correct graphics config.
  *          It is checked by SwingUtilities.updateComponentTreeUI(), if layout
  *          was correct the call to updateComponentTreeUI() will be no-op.
  * @modules java.desktop/sun.swing
  * @compile -encoding utf-8 StalePreferredSize.java
- * @run main/othervm/timeout=400 StalePreferredSize
- * @run main/othervm/timeout=400 -Dsun.java2d.uiScale=1 StalePreferredSize
- * @run main/othervm/timeout=400 -Dsun.java2d.uiScale=2.25 StalePreferredSize
+ * @run main/othervm/timeout=600 StalePreferredSize
+ * @run main/othervm/timeout=600 -Dsun.java2d.uiScale=1 StalePreferredSize
+ * @run main/othervm/timeout=600 -Dsun.java2d.uiScale=2.25 StalePreferredSize
  */
 public final class StalePreferredSize {
 
@@ -94,6 +92,11 @@ public final class StalePreferredSize {
 
     public static void main(final String[] args) throws Exception {
         for (final UIManager.LookAndFeelInfo laf : getInstalledLookAndFeels()) {
+            // Ignore obsolete/deprecated Motif
+            if (laf.getClassName().contains("Motif")) {
+                System.out.println("Skipped Motif");
+                continue;
+            }
             EventQueue.invokeAndWait(() -> setLookAndFeel(laf));
             for (typeFont = 0; typeFont < 3; typeFont++) {
                 System.err.println("typeFont = " + typeFont);
@@ -182,10 +185,6 @@ public final class StalePreferredSize {
                 int y = frame.getY() + 200;
                 PopupFactory factory = PopupFactory.getSharedInstance();
                 popup = factory.getPopup(frame, component, x, y);
-                if (component instanceof JMenuItem) {
-                    // TODO JDK-8244400
-                    MenuItemLayoutHelper.clearUsedParentClientProperties((JMenuItem)component);
-                }
             } else {
                 frame.add(new JScrollPane(component));
             }

--- a/test/jdk/javax/swing/GraphicsConfigNotifier/StalePreferredSize.java
+++ b/test/jdk/javax/swing/GraphicsConfigNotifier/StalePreferredSize.java
@@ -91,11 +91,6 @@ public final class StalePreferredSize {
 
     public static void main(final String[] args) throws Exception {
         for (final UIManager.LookAndFeelInfo laf : getInstalledLookAndFeels()) {
-            // Ignore obsolete/deprecated Motif
-            if (laf.getClassName().contains("Motif")) {
-                System.out.println("Skipped Motif");
-                continue;
-            }
             EventQueue.invokeAndWait(() -> setLookAndFeel(laf));
             for (typeFont = 0; typeFont < 3; typeFont++) {
                 System.err.println("typeFont = " + typeFont);


### PR DESCRIPTION
The MenuItemLayoutHelper.clearUsedParentClientProperties must be called automatically when the DPI was changed. 
Workaround added in the test for this bug is removed.

CI tests are ok.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8244400](https://bugs.openjdk.org/browse/JDK-8244400): MenuItem may cache the size and did not update it when the screen DPI is changed


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11551/head:pull/11551` \
`$ git checkout pull/11551`

Update a local copy of the PR: \
`$ git checkout pull/11551` \
`$ git pull https://git.openjdk.org/jdk pull/11551/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11551`

View PR using the GUI difftool: \
`$ git pr show -t 11551`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11551.diff">https://git.openjdk.org/jdk/pull/11551.diff</a>

</details>
