### PR TITLE
4365952: Cannot disable JFileChooser

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JFileChooser.java
+++ b/src/java.desktop/share/classes/javax/swing/JFileChooser.java
@@ -416,6 +416,21 @@ public class JFileChooser extends JComponent implements Accessible {
         }
     }
 
+    @Override
+    public void setEnabled(boolean enabled) {
+        super.setEnabled(enabled);
+        setEnabled(this, enabled);
+    }
+
+    private static void setEnabled(Container container, boolean enabled) {
+        for (Component component : container.getComponents()) {
+            component.setEnabled(enabled);
+            if (component instanceof Container) {
+                setEnabled((Container) component, enabled);
+            }
+        }
+    }
+
     /**
      * Sets the <code>dragEnabled</code> property,
      * which must be <code>true</code> to enable

--- a/test/jdk/javax/swing/JFileChooser/FileChooserDisableTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileChooserDisableTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+
+import javax.swing.AbstractButton;
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.WindowConstants;
+
+import java.util.function.Predicate;
+
+/*
+ * @test
+ * @bug 4365952
+ * @key headful
+ * @summary Test to check is File chooser can be Disabled
+ * @run main FileChooserDisableTest
+ */
+public class FileChooserDisableTest {
+    static Robot robot;
+    static JFrame frame;
+
+    static JFileChooser jfc;
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");
+        robot = new Robot();
+        try {
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    initialize();
+                }
+            });
+            String defaultDirectory = jfc.getCurrentDirectory().toString();
+            robot.delay(1000);
+            robot.waitForIdle();
+            final AbstractButton[] desktopBtn = new AbstractButton[1];
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    desktopBtn[0] = clickDetails();
+                }
+            });
+            Point movePoint = desktopBtn[0].getLocationOnScreen();
+            Dimension btnSize = desktopBtn[0].getSize();
+            robot.mouseMove(movePoint.x + btnSize.width/2, movePoint.y+btnSize.height/2);
+            robot.delay(2000);
+            robot.waitForIdle();
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(2000);
+            robot.waitForIdle();
+            String currentDirectory = jfc.getCurrentDirectory().toString();
+            if (!currentDirectory.equals(defaultDirectory)) {
+                throw new RuntimeException("File chooser disable failed");
+            }
+            System.out.println("Test Pass");
+        } finally {
+            frame.dispose();
+        }
+    }
+    private static AbstractButton clickDetails() {
+        AbstractButton details = findDetailsButton(jfc);
+        if (details == null) {
+            throw new Error("Didn't find 'Home' button in JFileChooser");
+        }
+        return details;
+    }
+    private static Component findComponent(final Container container,
+                                           final Predicate<Component> predicate) {
+        for (Component child : container.getComponents()) {
+            if (predicate.test(child)) {
+                return child;
+            }
+            if (child instanceof Container cont && cont.getComponentCount() > 0) {
+                Component result = findComponent(cont, predicate);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
+    private static AbstractButton findDetailsButton(final Container container) {
+        Component result = findComponent(container,
+                c -> c instanceof JButton button
+                        && "Home".equals(button.getToolTipText()));
+        return (AbstractButton) result;
+    }
+    static void initialize() {
+        frame = new JFrame("JFileChooser Disable test");
+        jfc = new JFileChooser();
+        jfc.setEnabled(false);
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+        frame.add(jfc, BorderLayout.CENTER);
+        frame.pack();
+        frame.setVisible(true);
+    }
+}


### PR DESCRIPTION
Disable functionality not working for JFileChooser. `public void setEnabled(boolean enabled)` functionality is overridden in JFileChooser class which enable/disable each sub-component of FileChooser. 
The added functionality is tested in mach5 and no regression found. The fix includes automated test which clicks _home_ directory and then compares which default selectedDirectory to check if JFileChooser is disabled. This is tested in mach5 for all platforms with multiple test runs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-4365952](https://bugs.openjdk.org/browse/JDK-4365952): Cannot disable JFileChooser


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11553/head:pull/11553` \
`$ git checkout pull/11553`

Update a local copy of the PR: \
`$ git checkout pull/11553` \
`$ git pull https://git.openjdk.org/jdk pull/11553/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11553`

View PR using the GUI difftool: \
`$ git pr show -t 11553`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11553.diff">https://git.openjdk.org/jdk/pull/11553.diff</a>

</details>
