### PR TITLE
8298267: Too many conversion specifiers in CgroupV1Subsystem::pids_max_val

### DIFF
--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -286,7 +286,7 @@ int CgroupV1Subsystem::cpu_shares() {
 
 char* CgroupV1Subsystem::pids_max_val() {
   GET_CONTAINER_INFO_CPTR(cptr, _pids, "/pids.max",
-                     "Maximum number of tasks is: %s", "%s %*d", pidsmax, 1024);
+                     "Maximum number of tasks is: %s", "%*d", pidsmax, 1024);
   if (pidsmax == NULL) {
     return NULL;
   }


### PR DESCRIPTION
Trivial fix.

This code:

```c++
  GET_CONTAINER_INFO_CPTR(cptr, _pids, "/pids.max",
                     "Maximum number of tasks is: %s", "%s %*d", pidsmax, 1024);
```

Expands to this call:

```c++
    // matchline = NULL
    err = subsystem_file_line_contents(_pids, "/pids.max", NULL, "%s %*d", pidsmax);
```

Which in turn hits this branch:

```c++
      if (matchline == NULL) {
        // single-line file case
        int matched = sscanf(p, scan_fmt, returnval);
        found_match = (matched == 1);
      } 
```

Now we're calling `sscanf()` with `scan_fmt = "%s %*d"`, this is undefined behavior as the number of conversion specifiers are larger than the number of pointers provided.

This is the correct fix, because the file `pids.max` only contains a number. This is supported by:

1. Checking my own `pids.max` and
2. This [documentation](https://www.kernel.org/doc/Documentation/cgroup-v1/pids.txt) suggests that it only consists of a number by recommending altering the file through `echo 2 > /sys/fs/cgroup/pids/parent/pids.max`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298267](https://bugs.openjdk.org/browse/JDK-8298267): Too many conversion specifiers in CgroupV1Subsystem::pids_max_val


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11557/head:pull/11557` \
`$ git checkout pull/11557`

Update a local copy of the PR: \
`$ git checkout pull/11557` \
`$ git pull https://git.openjdk.org/jdk pull/11557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11557`

View PR using the GUI difftool: \
`$ git pr show -t 11557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11557.diff">https://git.openjdk.org/jdk/pull/11557.diff</a>

</details>
