### PR TITLE
8298266: "java.home property not set" error in Graal when sun.awt.fontconfig java property is set on Windows

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
+++ b/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
@@ -175,15 +175,17 @@ public abstract class FontConfiguration {
     private void findFontConfigFile() {
 
         foundOsSpecificFile = true; // default assumption.
+        String javaHome = System.getProperty("java.home");
+        if (javaHome != null) {
+            javaLib = javaHome + File.separator + "lib";
+        }
         String userConfigFile = System.getProperty("sun.awt.fontconfig");
         if (userConfigFile != null) {
             fontConfigFile = new File(userConfigFile);
         } else {
-            String javaHome = System.getProperty("java.home");
             if (javaHome == null) {
                 throw new Error("java.home property not set");
             }
-            javaLib = javaHome + File.separator + "lib";
             String javaConfFonts = javaHome +
                     File.separator + "conf" +
                     File.separator + "fonts";

--- a/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
+++ b/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
@@ -175,18 +175,18 @@ public abstract class FontConfiguration {
     private void findFontConfigFile() {
 
         foundOsSpecificFile = true; // default assumption.
-        String javaHome = System.getProperty("java.home");
-        if (javaHome == null) {
-            throw new Error("java.home property not set");
-        }
-        javaLib = javaHome + File.separator + "lib";
-        String javaConfFonts = javaHome +
-                               File.separator + "conf" +
-                               File.separator + "fonts";
         String userConfigFile = System.getProperty("sun.awt.fontconfig");
         if (userConfigFile != null) {
             fontConfigFile = new File(userConfigFile);
         } else {
+            String javaHome = System.getProperty("java.home");
+            if (javaHome == null) {
+                throw new Error("java.home property not set");
+            }
+            javaLib = javaHome + File.separator + "lib";
+            String javaConfFonts = javaHome +
+                    File.separator + "conf" +
+                    File.separator + "fonts";
             fontConfigFile = findFontConfigFile(javaConfFonts);
             if (fontConfigFile == null) {
                 fontConfigFile = findFontConfigFile(javaLib);


### PR DESCRIPTION
**Environment**: 
GraalVM 22.3.0 with  jdk 19, Windows OS.

**Description**:
Create a native image of Swing application using GraalVM and run it with ` -Dsun.awt.fontconfig=fontconfig.properties.src` java property.
`java.lang.Error: java.home property not set` error is thrown.

For more details see https://github.com/oracle/graal/issues/4875.

**Solution**:
The error is thrown by the code from [FontConfiguration.findFontConfigFile()](https://github.com/openjdk/jdk19u/blob/c9d485792b99233f381dcdfd69838e7b973909bd/src/java.desktop/share/classes/sun/awt/FontConfiguration.java#L175) method.
GraalVM does not set `java.home`  property, that is why the `java.lang.Error: java.home property not set` is thrown.
`FontConfiguration.findFontConfigFile()` method compares `java.home` property to null before checking user provided `sun.awt.fontconfig` java property.

The proposed fix swaps the order of `java.home` and `sun.awt.fontconfig` properties checking to avoid using `java.home` property in case `sun.awt.fontconfig` is set.


**Steps to reproduce**:
- Download graal 22.3.0 jdk 19 for Windows from [GraalVM Community Edition 22.3.0](https://github.com/graalvm/graalvm-ce-builds/releases/tag/vm-22.3.0) page.
- Install native-image
```
graalvm-ce-java19-22.3.0\bin\gu.cmd install native-image
```
- Create and compile `SwingSample.java` sample
```
import java.awt.*;
import javax.swing.*;

public class SwingSample {
    public static void main(String[] args) throws Exception {
        SwingUtilities.invokeAndWait(() -> {

            JFrame frame = new JFrame("Hello World");

            JButton button = new JButton("Hello");
            button.addActionListener(e -> {
                System.out.printf("Hello, World!%n");
            });

            JPanel panel = new JPanel(new FlowLayout());
            panel.add(button);

            frame.add(panel);
            frame.setSize(400, 300);
            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
            frame.setVisible(true);
        });
    }
}
```
- Run native-image-agent to generate configuration files
```
graalvm-ce-java19-22.3.0\bin\java.cmd -agentlib:native-image-agent=config-output-dir=conf-dir SwingSample
```
- Copy `graalvm-ce-java19-22.3.0\lib\fontconfig.properties.src` file to the sample dir
- Generate native image with configuration files and `-Djava.awt.headless=false `, `-Dsun.awt.fontconfig=fontconfig.properties.src` java properties
```
call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64"
graalvm-ce-java19-22.3.0\bin\native-image.cmd --no-fallback -Djava.awt.headless=false -Dsun.awt.fontconfig=fontconfig.properties.src -H:ResourceConfigurationFiles=conf-dir/resource-config.json -H:SerializationConfigurationFiles=conf-dir/serialization-config.json -H:ReflectionConfigurationFiles=conf-dir/reflect-config.json -H:JNIConfigurationFiles=conf-dir/jni-config.json SwingSample
```
- Run the native image with `-Dsun.awt.fontconfig=fontconfig.properties.src` java property.
```
swingsample.exe  -Dsun.awt.fontconfig=fontconfig.properties.src

Exception in thread "main" java.lang.reflect.InvocationTargetException
        at java.desktop@19.0.1/java.awt.EventQueue.invokeAndWait(EventQueue.java:1371)
        at java.desktop@19.0.1/java.awt.EventQueue.invokeAndWait(EventQueue.java:1346)
        at java.desktop@19.0.1/javax.swing.SwingUtilities.invokeAndWait(SwingUtilities.java:1480)
        at SwingSample.main(SwingSample.java:7)
Caused by: java.lang.Error: java.home property not set
        at java.desktop@19.0.1/sun.awt.FontConfiguration.findFontConfigFile(FontConfiguration.java:180)
        at java.desktop@19.0.1/sun.awt.FontConfiguration.<init>(FontConfiguration.java:97)
        at java.desktop@19.0.1/sun.awt.windows.WFontConfiguration.<init>(WFontConfiguration.java:41)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8298266](https://bugs.openjdk.org/browse/JDK-8298266): "java.home property not set" error in Graal when sun.awt.fontconfig java property is set on Windows


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11559/head:pull/11559` \
`$ git checkout pull/11559`

Update a local copy of the PR: \
`$ git checkout pull/11559` \
`$ git pull https://git.openjdk.org/jdk pull/11559/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11559`

View PR using the GUI difftool: \
`$ git pr show -t 11559`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11559.diff">https://git.openjdk.org/jdk/pull/11559.diff</a>

</details>
