### PR TITLE
JDK-8298255: JFR provide information about dynamization of number of compiler threads

### DIFF
--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -924,6 +924,7 @@
   <Event name="CompilerConfiguration" category="Java Virtual Machine, Compiler" label="Compiler Configuration" thread="false" period="endChunk" startTime="false">
     <Field type="int" name="threadCount" label="Thread Count" />
     <Field type="boolean" name="tieredCompilation" label="Tiered Compilation" />
+    <Field type="boolean" name="usesDynamicNumberOfCompilerThreads" label="Uses Dynamic Compiler Threads" />
   </Event>
 
   <Event name="CodeCacheStatistics" category="Java Virtual Machine, Code Cache" label="Code Cache Statistics" thread="false" period="everyChunk" startTime="false">

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -924,7 +924,7 @@
   <Event name="CompilerConfiguration" category="Java Virtual Machine, Compiler" label="Compiler Configuration" thread="false" period="endChunk" startTime="false">
     <Field type="int" name="threadCount" label="Thread Count" />
     <Field type="boolean" name="tieredCompilation" label="Tiered Compilation" />
-    <Field type="boolean" name="usesDynamicNrOfCompilerThreads" label="Uses Dynamic Number of Compiler Threads" />
+    <Field type="boolean" name="dynamicCompilerThreadCount" label="Uses Dynamic Number of Compiler Threads" />
   </Event>
 
   <Event name="CodeCacheStatistics" category="Java Virtual Machine, Code Cache" label="Code Cache Statistics" thread="false" period="everyChunk" startTime="false">

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -924,7 +924,7 @@
   <Event name="CompilerConfiguration" category="Java Virtual Machine, Compiler" label="Compiler Configuration" thread="false" period="endChunk" startTime="false">
     <Field type="int" name="threadCount" label="Thread Count" />
     <Field type="boolean" name="tieredCompilation" label="Tiered Compilation" />
-    <Field type="boolean" name="usesDynamicNumberOfCompilerThreads" label="Uses Dynamic Compiler Threads" />
+    <Field type="boolean" name="usesDynamicNrOfCompilerThreads" label="Uses Dynamic Number of Compiler Threads" />
   </Event>
 
   <Event name="CodeCacheStatistics" category="Java Virtual Machine, Code Cache" label="Code Cache Statistics" thread="false" period="everyChunk" startTime="false">

--- a/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
@@ -572,6 +572,7 @@ TRACE_REQUEST_FUNC(CompilerConfiguration) {
   EventCompilerConfiguration event;
   event.set_threadCount(CICompilerCount);
   event.set_tieredCompilation(TieredCompilation);
+  event.set_usesDynamicNumberOfCompilerThreads(UseDynamicNumberOfCompilerThreads);
   event.commit();
 }
 

--- a/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
@@ -572,7 +572,7 @@ TRACE_REQUEST_FUNC(CompilerConfiguration) {
   EventCompilerConfiguration event;
   event.set_threadCount(CICompilerCount);
   event.set_tieredCompilation(TieredCompilation);
-  event.set_usesDynamicNumberOfCompilerThreads(UseDynamicNumberOfCompilerThreads);
+  event.set_usesDynamicNrOfCompilerThreads(UseDynamicNumberOfCompilerThreads);
   event.commit();
 }
 

--- a/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
@@ -572,7 +572,7 @@ TRACE_REQUEST_FUNC(CompilerConfiguration) {
   EventCompilerConfiguration event;
   event.set_threadCount(CICompilerCount);
   event.set_tieredCompilation(TieredCompilation);
-  event.set_usesDynamicNrOfCompilerThreads(UseDynamicNumberOfCompilerThreads);
+  event.set_dynamicCompilerThreadCount(UseDynamicNumberOfCompilerThreads);
   event.commit();
 }
 

--- a/test/jdk/jdk/jfr/event/compiler/TestCompilerConfig.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCompilerConfig.java
@@ -52,7 +52,7 @@ public class TestCompilerConfig {
             System.out.println("Event:" + event);
             Events.assertField(event, "threadCount").atLeast(0);
             Events.assertField(event, "tieredCompilation");
-            Events.assertField(event, "usesDynamicNumberOfCompilerThreads");
+            Events.assertField(event, "usesDynamicNrOfCompilerThreads");
         }
     }
 }

--- a/test/jdk/jdk/jfr/event/compiler/TestCompilerConfig.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCompilerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,7 @@ public class TestCompilerConfig {
             System.out.println("Event:" + event);
             Events.assertField(event, "threadCount").atLeast(0);
             Events.assertField(event, "tieredCompilation");
+            Events.assertField(event, "usesDynamicNumberOfCompilerThreads");
         }
     }
 }

--- a/test/jdk/jdk/jfr/event/compiler/TestCompilerConfig.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCompilerConfig.java
@@ -52,7 +52,7 @@ public class TestCompilerConfig {
             System.out.println("Event:" + event);
             Events.assertField(event, "threadCount").atLeast(0);
             Events.assertField(event, "tieredCompilation");
-            Events.assertField(event, "usesDynamicNrOfCompilerThreads");
+            Events.assertField(event, "dynamicCompilerThreadCount");
         }
     }
 }

--- a/test/jdk/jdk/jfr/event/metadata/TestEventMetadata.java
+++ b/test/jdk/jdk/jfr/event/metadata/TestEventMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,7 +98,7 @@ public class TestEventMetadata {
         Set<String> eventNames= new HashSet<>();
         for (EventType eventType : eventTypes) {
             verifyEventType(eventType);
-            verifyValueDesscriptors(eventType.getFields(), types);
+            verifyValueDescriptors(eventType.getFields(), types);
             System.out.println();
             String eventName = eventType.getName();
             if (eventNames.contains(eventName)) {
@@ -116,11 +116,11 @@ public class TestEventMetadata {
         }
     }
 
-    private static void verifyValueDesscriptors(List<ValueDescriptor> fields, Set<String> visitedTypes) {
+    private static void verifyValueDescriptors(List<ValueDescriptor> fields, Set<String> visitedTypes) {
         for (ValueDescriptor v : fields) {
             if (!visitedTypes.contains(v.getTypeName())) {
                 visitedTypes.add(v.getTypeName());
-                verifyValueDesscriptors(v.getFields(), visitedTypes);
+                verifyValueDescriptors(v.getFields(), visitedTypes);
             }
             verifyValueDescriptor(v);
         }


### PR DESCRIPTION
The JVM supports both dynamic GC threads, and dynamic Compiler threads.
While the GCConfiguration JFR event (see https://sap.github.io/SapMachine/jfrevents/#gcconfiguration ) seems to have at least some info about dynamization of GC threads ( field usesDynamicGCThreads), the JIT CompilerConfiguration event seems to miss this info (about JIT compiler threads dynamization), this should be added; currently the impression is given that the number is static but this is often not the case.
As an extension, the dynamization process of adding / removing threads could be added as well to the JFR events but I am not sure if this is desired so I just started with a very simple patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298255](https://bugs.openjdk.org/browse/JDK-8298255): JFR provide information about dynamization of number of compiler threads


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [42ff5021](https://git.openjdk.org/jdk/pull/11563/files/42ff502113a6a68a23960b506cf9df06191143ae)
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**) ⚠️ Review applies to [42ff5021](https://git.openjdk.org/jdk/pull/11563/files/42ff502113a6a68a23960b506cf9df06191143ae)
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11563/head:pull/11563` \
`$ git checkout pull/11563`

Update a local copy of the PR: \
`$ git checkout pull/11563` \
`$ git pull https://git.openjdk.org/jdk pull/11563/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11563`

View PR using the GUI difftool: \
`$ git pr show -t 11563`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11563.diff">https://git.openjdk.org/jdk/pull/11563.diff</a>

</details>
