### PR TITLE
8298173: GarbageCollectionNotificationContentTest test failed: no decrease in Eden usage

### DIFF
--- a/test/jdk/com/sun/management/GarbageCollectorMXBean/GarbageCollectionNotificationContentTest.java
+++ b/test/jdk/com/sun/management/GarbageCollectorMXBean/GarbageCollectionNotificationContentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,8 +52,8 @@ import gc.testlibrary.g1.MixedGCProvoker;
 public class GarbageCollectionNotificationContentTest {
     private static HashMap<String,GarbageCollectionNotificationInfo> listenerInvoked
         = new HashMap<String,GarbageCollectionNotificationInfo>();
-    static volatile long count = 0;
-    static volatile long number = 0;
+    static volatile long notificationReceivedCount = 0;
+    static volatile long numberOfGCMBeans = 0;
     static Object synchronizer = new Object();
 
     static class GcListener implements NotificationListener {
@@ -64,12 +64,12 @@ public class GarbageCollectionNotificationContentTest {
                     GarbageCollectionNotificationInfo.from((CompositeData) notif.getUserData());
                 String source = ((ObjectName)notif.getSource()).getCanonicalName();
                 synchronized(synchronizer) {
-                    if(listenerInvoked.get(source) == null) {
-                            listenerInvoked.put(((ObjectName)notif.getSource()).getCanonicalName(),gcNotif);
-                            count++;
-                            if(count >= number) {
-                                synchronizer.notify();
-                            }
+                    if (listenerInvoked.get(source) == null) {
+                        listenerInvoked.put(((ObjectName)notif.getSource()).getCanonicalName(), gcNotif);
+                        notificationReceivedCount++;
+                        if (notificationReceivedCount >= numberOfGCMBeans) {
+                            synchronizer.notify();
+                        }
                     }
                 }
             }
@@ -85,16 +85,14 @@ public class GarbageCollectionNotificationContentTest {
             System.out.println("GC Notification not supported by the JVM, test skipped");
             return;
         }
-        final ObjectName gcMXBeanPattern =
-                new ObjectName("java.lang:type=GarbageCollector,*");
-        Set<ObjectName> names =
-                mbs.queryNames(gcMXBeanPattern, null);
+        final ObjectName gcMXBeanPattern = new ObjectName("java.lang:type=GarbageCollector,*");
+        Set<ObjectName> names = mbs.queryNames(gcMXBeanPattern, null);
         if (names.isEmpty())
             throw new Exception("Test incorrect: no GC MXBeans");
-        number = names.size();
+        numberOfGCMBeans = names.size();
         for (ObjectName n : names) {
-            if(mbs.isInstanceOf(n,"javax.management.NotificationEmitter")) {
-                listenerInvoked.put(n.getCanonicalName(),null);
+            if(mbs.isInstanceOf(n, "javax.management.NotificationEmitter")) {
+                listenerInvoked.put(n.getCanonicalName(), null);
                 GcListener listener = new GcListener();
                 mbs.addNotificationListener(n, listener, null, null);
             }
@@ -112,7 +110,7 @@ public class GarbageCollectionNotificationContentTest {
         }
         int wakeup = 0;
         synchronized(synchronizer) {
-            while(count != number) {
+            while(notificationReceivedCount != numberOfGCMBeans) {
                 synchronizer.wait(10000);
                 wakeup++;
                 if(wakeup > 10)
@@ -126,9 +124,9 @@ public class GarbageCollectionNotificationContentTest {
     }
 
     private static void checkGarbageCollectionNotificationInfoContent(GarbageCollectionNotificationInfo notif) throws Exception {
-        System.out.println("GC notification for "+notif.getGcName());
-        System.out.print("Action: "+notif.getGcAction());
-        System.out.println(" Cause: "+notif.getGcCause());
+        System.out.println("GC notification for " + notif.getGcName());
+        System.out.print("Action: " + notif.getGcAction());
+        System.out.println(" Cause: " + notif.getGcCause());
         GcInfo info = notif.getGcInfo();
         System.out.print("GC Info #" + info.getId());
         System.out.print(" start:" + info.getStartTime());
@@ -136,6 +134,12 @@ public class GarbageCollectionNotificationContentTest {
         System.out.println(" (" + info.getDuration() + "ms)");
         Map<String, MemoryUsage> usage = info.getMemoryUsageBeforeGc();
 
+        // Check MemoryUsage is present. For all but No GC events, check Eden usage decreases:
+        boolean doCheckMemoryUsage = true;
+        if (notif.getGcCause().equals("No GC")) {
+            System.out.println("(skip memory usage check for event with 'No GC' cause)");
+            doCheckMemoryUsage = false;
+        }
         List<String> pnames = new ArrayList<String>();
         for (Map.Entry entry : usage.entrySet() ) {
             String poolname = (String) entry.getKey();
@@ -143,22 +147,22 @@ public class GarbageCollectionNotificationContentTest {
             MemoryUsage busage = (MemoryUsage) entry.getValue();
             MemoryUsage ausage = (MemoryUsage) info.getMemoryUsageAfterGc().get(poolname);
             if (ausage == null) {
-                throw new RuntimeException("After Gc Memory does not exist" +
-                    " for " + poolname);
+                throw new RuntimeException("After Gc Memory does not exist for " + poolname);
             }
             System.out.println("Usage for pool " + poolname);
             System.out.println("   Before GC: " + busage);
             System.out.println("   After GC: " + ausage);
 
-            checkMemoryUsage(poolname, busage, ausage);
+            if (doCheckMemoryUsage) {
+                checkMemoryUsage(poolname, busage, ausage);
+            }
         }
 
         // check if memory usage for all memory pools are returned
         List<MemoryPoolMXBean> pools = ManagementFactory.getMemoryPoolMXBeans();
         for (MemoryPoolMXBean p : pools ) {
             if (!pnames.contains(p.getName())) {
-                throw new RuntimeException("GcInfo does not contain " +
-                    "memory usage for pool " + p.getName());
+                throw new RuntimeException("GcInfo does not contain memory usage for pool " + p.getName());
             }
         }
     }

--- a/test/jdk/com/sun/management/GarbageCollectorMXBean/GarbageCollectionNotificationContentTest.java
+++ b/test/jdk/com/sun/management/GarbageCollectorMXBean/GarbageCollectionNotificationContentTest.java
@@ -91,7 +91,7 @@ public class GarbageCollectionNotificationContentTest {
             throw new Exception("Test incorrect: no GC MXBeans");
         numberOfGCMBeans = names.size();
         for (ObjectName n : names) {
-            if(mbs.isInstanceOf(n, "javax.management.NotificationEmitter")) {
+            if (mbs.isInstanceOf(n, "javax.management.NotificationEmitter")) {
                 listenerInvoked.put(n.getCanonicalName(), null);
                 GcListener listener = new GcListener();
                 mbs.addNotificationListener(n, listener, null, null);


### PR DESCRIPTION
Test should not check that Eden has decreased in used size if the GCCause is "No GC".

These happen with the message "end of concurrent GC pause" which is logged by the GCMemoryManager _conc_gc_memory_manager (in G1MonitoringSupport).  This GCMemoryManager only interacts with the old gen memory pool, so it is expected that eden usage does not change.

Updated a few variable names to make it more obvious what count and number are recording, and some formatting.  The key  part of the change is at line 137 onwards.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298173](https://bugs.openjdk.org/browse/JDK-8298173): GarbageCollectionNotificationContentTest test failed: no decrease in Eden usage


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to [71607383](https://git.openjdk.org/jdk/pull/11572/files/716073838edb0b6fcf130fed5de685328f7b2a33)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [71607383](https://git.openjdk.org/jdk/pull/11572/files/716073838edb0b6fcf130fed5de685328f7b2a33)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [71607383](https://git.openjdk.org/jdk/pull/11572/files/716073838edb0b6fcf130fed5de685328f7b2a33)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11572/head:pull/11572` \
`$ git checkout pull/11572`

Update a local copy of the PR: \
`$ git checkout pull/11572` \
`$ git pull https://git.openjdk.org/jdk pull/11572/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11572`

View PR using the GUI difftool: \
`$ git pr show -t 11572`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11572.diff">https://git.openjdk.org/jdk/pull/11572.diff</a>

</details>
