### PR TITLE
8298277: Replace "session" with "scope" for FFM access

### DIFF
--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -141,10 +141,10 @@ public:
 
 /*
  * This function performs a thread-local handshake against all threads running at the time
- * the given session (deopt) was closed. If the handshake for a given thread is processed while
+ * the given scope (deopt) was closed. If the handshake for a given thread is processed while
  * one or more threads is found inside a scoped method (that is, a method inside the ScopedMemoryAccess
- * class annotated with the '@Scoped' annotation), and whose local variables mention the session being
- * closed (deopt), this method returns false, signalling that the session cannot be closed safely.
+ * class annotated with the '@Scoped' annotation), and whose local variables mention the scope being
+ * closed (deopt), this method returns false, signalling that the scope cannot be closed safely.
  */
 JVM_ENTRY(jboolean, ScopedMemoryAccess_closeScope(JNIEnv *env, jobject receiver, jobject deopt, jobject exception))
   CloseScopedMemoryClosure cl(deopt, exception);
@@ -158,7 +158,7 @@ JVM_END
 #define PKG_FOREIGN "Ljdk/internal/foreign/"
 
 #define MEMACCESS "ScopedMemoryAccess"
-#define SCOPE PKG_FOREIGN "MemorySessionImpl;"
+#define SCOPE PKG_FOREIGN "MemoryScopeImpl;"
 
 #define CC (char*)  /*cast a literal from (const char*)*/
 #define FN_PTR(f) CAST_FROM_FN_PTR(void*, &f)

--- a/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
@@ -1632,13 +1632,13 @@ abstract class GaloisCounterMode extends CipherSpi {
                         Arrays.fill(dst.array(), ofs, ofs + len,
                             (byte) 0);
                     } else {
-                        NIO_ACCESS.acquireSession(dst);
+                        NIO_ACCESS.acquireScope(dst);
                         try {
                             Unsafe.getUnsafe().setMemory(
                                 ((DirectBuffer)dst).address(),
                                 len + dst.position(), (byte) 0);
                         } finally {
-                            NIO_ACCESS.releaseSession(dst);
+                            NIO_ACCESS.releaseScope(dst);
                         }
                     }
                 }

--- a/src/java.base/share/classes/java/lang/foreign/Arena.java
+++ b/src/java.base/share/classes/java/lang/foreign/Arena.java
@@ -25,7 +25,7 @@
 
 package java.lang.foreign;
 
-import jdk.internal.foreign.MemorySessionImpl;
+import jdk.internal.foreign.MemoryScopeImpl;
 import jdk.internal.javac.PreviewFeature;
 
 /**
@@ -154,13 +154,13 @@ public interface Arena extends SegmentAllocator, AutoCloseable {
      * {@return a new confined arena, owned by the current thread}
      */
     static Arena openConfined() {
-        return MemorySessionImpl.createConfined(Thread.currentThread()).asArena();
+        return MemoryScopeImpl.createConfined(Thread.currentThread()).asArena();
     }
 
     /**
      * {@return a new shared arena}
      */
     static Arena openShared() {
-        return MemorySessionImpl.createShared().asArena();
+        return MemoryScopeImpl.createShared().asArena();
     }
 }

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1361,11 +1361,11 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
         srcImpl.checkAccess(srcOffset, size, true);
         dstImpl.checkAccess(dstOffset, size, false);
         if (srcElementLayout.byteSize() == 1 || srcElementLayout.order() == dstElementLayout.order()) {
-            ScopedMemoryAccess.getScopedMemoryAccess().copyMemory(srcImpl.sessionImpl(), dstImpl.sessionImpl(),
+            ScopedMemoryAccess.getScopedMemoryAccess().copyMemory(srcImpl.scopeImpl(), dstImpl.scopeImpl(),
                     srcImpl.unsafeGetBase(), srcImpl.unsafeGetOffset() + srcOffset,
                     dstImpl.unsafeGetBase(), dstImpl.unsafeGetOffset() + dstOffset, size);
         } else {
-            ScopedMemoryAccess.getScopedMemoryAccess().copySwapMemory(srcImpl.sessionImpl(), dstImpl.sessionImpl(),
+            ScopedMemoryAccess.getScopedMemoryAccess().copySwapMemory(srcImpl.scopeImpl(), dstImpl.scopeImpl(),
                     srcImpl.unsafeGetBase(), srcImpl.unsafeGetOffset() + srcOffset,
                     dstImpl.unsafeGetBase(), dstImpl.unsafeGetOffset() + dstOffset, size, srcElementLayout.byteSize());
         }

--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -32,7 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.function.Function;
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
-import jdk.internal.foreign.MemorySessionImpl;
+import jdk.internal.foreign.MemoryScopeImpl;
 import jdk.internal.foreign.SlicingAllocator;
 import jdk.internal.foreign.Utils;
 import jdk.internal.javac.PreviewFeature;
@@ -409,6 +409,6 @@ public interface SegmentAllocator {
      */
     static SegmentAllocator nativeAllocator(SegmentScope scope) {
         Objects.requireNonNull(scope);
-        return (MemorySessionImpl)scope;
+        return (MemoryScopeImpl)scope;
     }
 }

--- a/src/java.base/share/classes/java/lang/foreign/SegmentScope.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentScope.java
@@ -25,7 +25,7 @@
  */
 package java.lang.foreign;
 
-import jdk.internal.foreign.MemorySessionImpl;
+import jdk.internal.foreign.MemoryScopeImpl;
 import jdk.internal.javac.PreviewFeature;
 import jdk.internal.ref.CleanerFactory;
 
@@ -86,7 +86,7 @@ import jdk.internal.ref.CleanerFactory;
  * @since 20
  */
 @PreviewFeature(feature =PreviewFeature.Feature.FOREIGN)
-sealed public interface SegmentScope permits MemorySessionImpl {
+sealed public interface SegmentScope permits MemoryScopeImpl {
 
     /**
      * Creates a new scope that is managed, automatically, by the garbage collector.
@@ -96,7 +96,7 @@ sealed public interface SegmentScope permits MemorySessionImpl {
      * @return a new scope that is managed, automatically, by the garbage collector.
      */
     static SegmentScope auto() {
-        return MemorySessionImpl.createImplicit(CleanerFactory.cleaner());
+        return MemoryScopeImpl.createImplicit(CleanerFactory.cleaner());
     }
 
     /**
@@ -106,7 +106,7 @@ sealed public interface SegmentScope permits MemorySessionImpl {
      * @return the global scope.
      */
     static SegmentScope global() {
-        return MemorySessionImpl.GLOBAL;
+        return MemoryScopeImpl.GLOBAL;
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
+++ b/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
@@ -27,7 +27,7 @@ package java.lang.foreign;
 
 import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.SharedSecrets;
-import jdk.internal.foreign.MemorySessionImpl;
+import jdk.internal.foreign.MemoryScopeImpl;
 import jdk.internal.javac.PreviewFeature;
 import jdk.internal.loader.BuiltinClassLoader;
 import jdk.internal.loader.NativeLibrary;
@@ -160,7 +160,7 @@ public interface SymbolLookup {
                 ClassLoader.getSystemClassLoader();
         SegmentScope loaderScope = (loader == null || loader instanceof BuiltinClassLoader) ?
                 SegmentScope.global() : // builtin loaders never go away
-                MemorySessionImpl.heapSession(loader);
+                MemoryScopeImpl.heapScope(loader);
         return name -> {
             Objects.requireNonNull(name);
             JavaLangAccess javaLangAccess = SharedSecrets.getJavaLangAccess();
@@ -235,7 +235,7 @@ public interface SymbolLookup {
             throw new IllegalArgumentException("Cannot open library: " + libDesc);
         }
         // register hook to unload library when 'libScope' becomes not alive
-        ((MemorySessionImpl) libScope).addOrCleanupIfFail(new MemorySessionImpl.ResourceList.ResourceCleanup() {
+        ((MemoryScopeImpl) libScope).addOrCleanupIfFail(new MemoryScopeImpl.ResourceList.ResourceCleanup() {
             @Override
             public void cleanup() {
                 nativeLibraries.unload(library);

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandleByteArrayView.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandleByteArrayView.java.template
@@ -27,7 +27,7 @@ package java.lang.invoke;
 import jdk.internal.access.JavaNioAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
-import jdk.internal.foreign.MemorySessionImpl;
+import jdk.internal.foreign.MemoryScopeImpl;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.util.Preconditions;
@@ -613,10 +613,10 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static MemorySessionImpl session(ByteBuffer bb) {
+        static MemoryScopeImpl scope(ByteBuffer bb) {
             MemorySegment segment = NIO_ACCESS.bufferSegment(bb);
             return segment != null ?
-                    ((AbstractMemorySegmentImpl)segment).sessionImpl() : null;
+                    ((AbstractMemorySegmentImpl)segment).scopeImpl() : null;
         }
 
         @ForceInline
@@ -639,13 +639,13 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
 #if[floatingPoint]
-            $rawType$ rawValue = SCOPED_MEMORY_ACCESS.get$RawType$Unaligned(session(bb),
+            $rawType$ rawValue = SCOPED_MEMORY_ACCESS.get$RawType$Unaligned(scope(bb),
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                     ((long) index(bb, index)) + UNSAFE.getLong(bb, BUFFER_ADDRESS),
                     handle.be);
             return $Type$.$rawType$BitsTo$Type$(rawValue);
 #else[floatingPoint]
-            return SCOPED_MEMORY_ACCESS.get$Type$Unaligned(session(bb),
+            return SCOPED_MEMORY_ACCESS.get$Type$Unaligned(scope(bb),
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                     ((long) index(bb, index)) + UNSAFE.getLong(bb, BUFFER_ADDRESS),
                     handle.be);
@@ -657,13 +657,13 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
 #if[floatingPoint]
-            SCOPED_MEMORY_ACCESS.put$RawType$Unaligned(session(bb),
+            SCOPED_MEMORY_ACCESS.put$RawType$Unaligned(scope(bb),
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                     ((long) indexRO(bb, index)) + UNSAFE.getLong(bb, BUFFER_ADDRESS),
                     $Type$.$type$ToRaw$RawType$Bits(value),
                     handle.be);
 #else[floatingPoint]
-            SCOPED_MEMORY_ACCESS.put$Type$Unaligned(session(bb),
+            SCOPED_MEMORY_ACCESS.put$Type$Unaligned(scope(bb),
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                     ((long) indexRO(bb, index)) + UNSAFE.getLong(bb, BUFFER_ADDRESS),
                     value,
@@ -676,7 +676,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             return convEndian(handle.be,
-                              SCOPED_MEMORY_ACCESS.get$RawType$Volatile(session(bb),
+                              SCOPED_MEMORY_ACCESS.get$RawType$Volatile(scope(bb),
                                       UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                                       address(bb, index(bb, index))));
         }
@@ -685,7 +685,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         static void setVolatile(VarHandle ob, Object obb, int index, $type$ value) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
-            SCOPED_MEMORY_ACCESS.put$RawType$Volatile(session(bb),
+            SCOPED_MEMORY_ACCESS.put$RawType$Volatile(scope(bb),
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                     address(bb, indexRO(bb, index)),
                     convEndian(handle.be, value));
@@ -696,7 +696,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             return convEndian(handle.be,
-                              SCOPED_MEMORY_ACCESS.get$RawType$Acquire(session(bb),
+                              SCOPED_MEMORY_ACCESS.get$RawType$Acquire(scope(bb),
                                       UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                                       address(bb, index(bb, index))));
         }
@@ -705,7 +705,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         static void setRelease(VarHandle ob, Object obb, int index, $type$ value) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
-            SCOPED_MEMORY_ACCESS.put$RawType$Release(session(bb),
+            SCOPED_MEMORY_ACCESS.put$RawType$Release(scope(bb),
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                     address(bb, indexRO(bb, index)),
                     convEndian(handle.be, value));
@@ -716,7 +716,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             return convEndian(handle.be,
-                              SCOPED_MEMORY_ACCESS.get$RawType$Opaque(session(bb),
+                              SCOPED_MEMORY_ACCESS.get$RawType$Opaque(scope(bb),
                                       UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                                       address(bb, index(bb, index))));
         }
@@ -725,7 +725,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         static void setOpaque(VarHandle ob, Object obb, int index, $type$ value) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
-            SCOPED_MEMORY_ACCESS.put$RawType$Opaque(session(bb),
+            SCOPED_MEMORY_ACCESS.put$RawType$Opaque(scope(bb),
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                     address(bb, indexRO(bb, index)),
                     convEndian(handle.be, value));
@@ -737,12 +737,12 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
 #if[Object]
-            return SCOPED_MEMORY_ACCESS.compareAndSetReference(session(bb),
+            return SCOPED_MEMORY_ACCESS.compareAndSetReference(scope(bb),
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                     address(bb, indexRO(bb, index)),
                     convEndian(handle.be, expected), convEndian(handle.be, value));
 #else[Object]
-            return SCOPED_MEMORY_ACCESS.compareAndSet$RawType$(session(bb),
+            return SCOPED_MEMORY_ACCESS.compareAndSet$RawType$(scope(bb),
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                     address(bb, indexRO(bb, index)),
                     convEndian(handle.be, expected), convEndian(handle.be, value));
@@ -754,7 +754,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             return convEndian(handle.be,
-                              SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$(session(bb),
+                              SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$(scope(bb),
                                       UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                                       address(bb, indexRO(bb, index)),
                                       convEndian(handle.be, expected), convEndian(handle.be, value)));
@@ -765,7 +765,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             return convEndian(handle.be,
-                              SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Acquire(session(bb),
+                              SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Acquire(scope(bb),
                                       UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                                       address(bb, indexRO(bb, index)),
                                       convEndian(handle.be, expected), convEndian(handle.be, value)));
@@ -776,7 +776,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             return convEndian(handle.be,
-                              SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Release(session(bb),
+                              SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Release(scope(bb),
                                       UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                                       address(bb, indexRO(bb, index)),
                                       convEndian(handle.be, expected), convEndian(handle.be, value)));
@@ -786,7 +786,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         static boolean weakCompareAndSetPlain(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
-            return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Plain(session(bb),
+            return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Plain(scope(bb),
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                     address(bb, indexRO(bb, index)),
                     convEndian(handle.be, expected), convEndian(handle.be, value));
@@ -796,7 +796,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         static boolean weakCompareAndSet(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
-            return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(session(bb),
+            return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(scope(bb),
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                     address(bb, indexRO(bb, index)),
                     convEndian(handle.be, expected), convEndian(handle.be, value));
@@ -806,7 +806,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         static boolean weakCompareAndSetAcquire(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
-            return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Acquire(session(bb),
+            return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Acquire(scope(bb),
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                     address(bb, indexRO(bb, index)),
                     convEndian(handle.be, expected), convEndian(handle.be, value));
@@ -816,7 +816,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         static boolean weakCompareAndSetRelease(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
-            return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Release(session(bb),
+            return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Release(scope(bb),
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                     address(bb, indexRO(bb, index)),
                     convEndian(handle.be, expected), convEndian(handle.be, value));
@@ -828,13 +828,13 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
 #if[Object]
             return convEndian(handle.be,
-                              SCOPED_MEMORY_ACCESS.getAndSetReference(session(bb),
+                              SCOPED_MEMORY_ACCESS.getAndSetReference(scope(bb),
                                       UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                                       address(bb, indexRO(bb, index)),
                                       convEndian(handle.be, value)));
 #else[Object]
             return convEndian(handle.be,
-                              SCOPED_MEMORY_ACCESS.getAndSet$RawType$(session(bb),
+                              SCOPED_MEMORY_ACCESS.getAndSet$RawType$(scope(bb),
                                       UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                                       address(bb, indexRO(bb, index)),
                                       convEndian(handle.be, value)));
@@ -846,7 +846,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             return convEndian(handle.be,
-                              SCOPED_MEMORY_ACCESS.getAndSet$RawType$Acquire(session(bb),
+                              SCOPED_MEMORY_ACCESS.getAndSet$RawType$Acquire(scope(bb),
                                       UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                                       address(bb, indexRO(bb, index)),
                                       convEndian(handle.be, value)));
@@ -857,7 +857,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             return convEndian(handle.be,
-                              SCOPED_MEMORY_ACCESS.getAndSet$RawType$Release(session(bb),
+                              SCOPED_MEMORY_ACCESS.getAndSet$RawType$Release(scope(bb),
                                       UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                                       address(bb, indexRO(bb, index)),
                                       convEndian(handle.be, value)));
@@ -870,7 +870,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
-                return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$(session(bb),
+                return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$(scope(bb),
                         UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                         address(bb, indexRO(bb, index)),
                         delta);
@@ -884,7 +884,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
-                return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Acquire(session(bb),
+                return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Acquire(scope(bb),
                         UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                         address(bb, indexRO(bb, index)),
                         delta);
@@ -898,7 +898,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
-                return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Release(session(bb),
+                return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Release(scope(bb),
                         UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                         address(bb, indexRO(bb, index)),
                         delta);
@@ -913,7 +913,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             Object base = UNSAFE.getReference(bb, BYTE_BUFFER_HB);
             long offset = address(bb, indexRO(bb, index));
             do {
-                nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(session(bb), base, offset);
+                nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(scope(bb), base, offset);
                 expectedValue = $RawBoxType$.reverseBytes(nativeExpectedValue);
             } while (!UNSAFE.weakCompareAndSet$RawType$(base, offset,
                     nativeExpectedValue, $RawBoxType$.reverseBytes(expectedValue + delta)));
@@ -927,7 +927,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
-                return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$(session(bb),
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$(scope(bb),
                         UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                         address(bb, indexRO(bb, index)),
                         value);
@@ -941,7 +941,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
-                return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Release(session(bb),
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Release(scope(bb),
                         UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                         address(bb, indexRO(bb, index)),
                         value);
@@ -955,7 +955,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
-                return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Acquire(session(bb),
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Acquire(scope(bb),
                         UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                         address(bb, indexRO(bb, index)),
                         value);
@@ -970,7 +970,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             Object base = UNSAFE.getReference(bb, BYTE_BUFFER_HB);
             long offset = address(bb, indexRO(bb, index));
             do {
-                nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(session(bb), base, offset);
+                nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(scope(bb), base, offset);
                 expectedValue = $RawBoxType$.reverseBytes(nativeExpectedValue);
             } while (!UNSAFE.weakCompareAndSet$RawType$(base, offset,
                     nativeExpectedValue, $RawBoxType$.reverseBytes(expectedValue | value)));
@@ -982,7 +982,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
-                return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$(session(bb),
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$(scope(bb),
                         UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                         address(bb, indexRO(bb, index)),
                         value);
@@ -996,7 +996,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
-                return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Release(session(bb),
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Release(scope(bb),
                         UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                         address(bb, indexRO(bb, index)),
                         value);
@@ -1010,7 +1010,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
-                return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Acquire(session(bb),
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Acquire(scope(bb),
                         UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                         address(bb, indexRO(bb, index)),
                         value);
@@ -1025,7 +1025,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             Object base = UNSAFE.getReference(bb, BYTE_BUFFER_HB);
             long offset = address(bb, indexRO(bb, index));
             do {
-                nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(session(bb), base, offset);
+                nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(scope(bb), base, offset);
                 expectedValue = $RawBoxType$.reverseBytes(nativeExpectedValue);
             } while (!UNSAFE.weakCompareAndSet$RawType$(base, offset,
                     nativeExpectedValue, $RawBoxType$.reverseBytes(expectedValue & value)));
@@ -1038,7 +1038,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
-                return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$(session(bb),
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$(scope(bb),
                         UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                         address(bb, indexRO(bb, index)),
                         value);
@@ -1052,7 +1052,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
-                return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Release(session(bb),
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Release(scope(bb),
                         UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                         address(bb, indexRO(bb, index)),
                         value);
@@ -1066,7 +1066,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
-                return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Acquire(session(bb),
+                return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Acquire(scope(bb),
                         UNSAFE.getReference(bb, BYTE_BUFFER_HB),
                         address(bb, indexRO(bb, index)),
                         value);
@@ -1081,7 +1081,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
             Object base = UNSAFE.getReference(bb, BYTE_BUFFER_HB);
             long offset = address(bb, indexRO(bb, index));
             do {
-                nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(session(bb), base, offset);
+                nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(scope(bb), base, offset);
                 expectedValue = $RawBoxType$.reverseBytes(nativeExpectedValue);
             } while (!UNSAFE.weakCompareAndSet$RawType$(base, offset,
                     nativeExpectedValue, $RawBoxType$.reverseBytes(expectedValue ^ value)));

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
@@ -128,18 +128,18 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, true);
 #if[floatingPoint]
-        $rawType$ rawValue = SCOPED_MEMORY_ACCESS.get$RawType$Unaligned(bb.sessionImpl(),
+        $rawType$ rawValue = SCOPED_MEMORY_ACCESS.get$RawType$Unaligned(bb.scopeImpl(),
                 bb.unsafeGetBase(),
                 offsetNoVMAlignCheck(bb, base, handle.alignmentMask),
                 handle.be);
         return $Type$.$rawType$BitsTo$Type$(rawValue);
 #else[floatingPoint]
 #if[byte]
-        return SCOPED_MEMORY_ACCESS.get$Type$(bb.sessionImpl(),
+        return SCOPED_MEMORY_ACCESS.get$Type$(bb.scopeImpl(),
                 bb.unsafeGetBase(),
                 offsetNoVMAlignCheck(bb, base, handle.alignmentMask));
 #else[byte]
-        return SCOPED_MEMORY_ACCESS.get$Type$Unaligned(bb.sessionImpl(),
+        return SCOPED_MEMORY_ACCESS.get$Type$Unaligned(bb.scopeImpl(),
                 bb.unsafeGetBase(),
                 offsetNoVMAlignCheck(bb, base, handle.alignmentMask),
                 handle.be);
@@ -152,19 +152,19 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
 #if[floatingPoint]
-        SCOPED_MEMORY_ACCESS.put$RawType$Unaligned(bb.sessionImpl(),
+        SCOPED_MEMORY_ACCESS.put$RawType$Unaligned(bb.scopeImpl(),
                 bb.unsafeGetBase(),
                 offsetNoVMAlignCheck(bb, base, handle.alignmentMask),
                 $Type$.$type$ToRaw$RawType$Bits(value),
                 handle.be);
 #else[floatingPoint]
 #if[byte]
-        SCOPED_MEMORY_ACCESS.put$Type$(bb.sessionImpl(),
+        SCOPED_MEMORY_ACCESS.put$Type$(bb.scopeImpl(),
                 bb.unsafeGetBase(),
                 offsetNoVMAlignCheck(bb, base, handle.alignmentMask),
                 value);
 #else[byte]
-        SCOPED_MEMORY_ACCESS.put$Type$Unaligned(bb.sessionImpl(),
+        SCOPED_MEMORY_ACCESS.put$Type$Unaligned(bb.scopeImpl(),
                 bb.unsafeGetBase(),
                 offsetNoVMAlignCheck(bb, base, handle.alignmentMask),
                 value,
@@ -178,7 +178,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, true);
         return convEndian(handle.be,
-                          SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.sessionImpl(),
+                          SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.scopeImpl(),
                                   bb.unsafeGetBase(),
                                   offset(bb, base, handle.alignmentMask)));
     }
@@ -187,7 +187,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     static void setVolatile(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
-        SCOPED_MEMORY_ACCESS.put$RawType$Volatile(bb.sessionImpl(),
+        SCOPED_MEMORY_ACCESS.put$RawType$Volatile(bb.scopeImpl(),
                 bb.unsafeGetBase(),
                 offset(bb, base, handle.alignmentMask),
                 convEndian(handle.be, value));
@@ -198,7 +198,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, true);
         return convEndian(handle.be,
-                          SCOPED_MEMORY_ACCESS.get$RawType$Acquire(bb.sessionImpl(),
+                          SCOPED_MEMORY_ACCESS.get$RawType$Acquire(bb.scopeImpl(),
                                   bb.unsafeGetBase(),
                                   offset(bb, base, handle.alignmentMask)));
     }
@@ -207,7 +207,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     static void setRelease(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
-        SCOPED_MEMORY_ACCESS.put$RawType$Release(bb.sessionImpl(),
+        SCOPED_MEMORY_ACCESS.put$RawType$Release(bb.scopeImpl(),
                 bb.unsafeGetBase(),
                 offset(bb, base, handle.alignmentMask),
                 convEndian(handle.be, value));
@@ -218,7 +218,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, true);
         return convEndian(handle.be,
-                          SCOPED_MEMORY_ACCESS.get$RawType$Opaque(bb.sessionImpl(),
+                          SCOPED_MEMORY_ACCESS.get$RawType$Opaque(bb.scopeImpl(),
                                   bb.unsafeGetBase(),
                                   offset(bb, base, handle.alignmentMask)));
     }
@@ -227,7 +227,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     static void setOpaque(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
-        SCOPED_MEMORY_ACCESS.put$RawType$Opaque(bb.sessionImpl(),
+        SCOPED_MEMORY_ACCESS.put$RawType$Opaque(bb.scopeImpl(),
                 bb.unsafeGetBase(),
                 offset(bb, base, handle.alignmentMask),
                 convEndian(handle.be, value));
@@ -238,7 +238,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     static boolean compareAndSet(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
-        return SCOPED_MEMORY_ACCESS.compareAndSet$RawType$(bb.sessionImpl(),
+        return SCOPED_MEMORY_ACCESS.compareAndSet$RawType$(bb.scopeImpl(),
                 bb.unsafeGetBase(),
                 offset(bb, base, handle.alignmentMask),
                 convEndian(handle.be, expected), convEndian(handle.be, value));
@@ -249,7 +249,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
-                          SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$(bb.sessionImpl(),
+                          SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$(bb.scopeImpl(),
                                   bb.unsafeGetBase(),
                                   offset(bb, base, handle.alignmentMask),
                                   convEndian(handle.be, expected), convEndian(handle.be, value)));
@@ -260,7 +260,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
-                          SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Acquire(bb.sessionImpl(),
+                          SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Acquire(bb.scopeImpl(),
                                   bb.unsafeGetBase(),
                                   offset(bb, base, handle.alignmentMask),
                                   convEndian(handle.be, expected), convEndian(handle.be, value)));
@@ -271,7 +271,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
-                          SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Release(bb.sessionImpl(),
+                          SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Release(bb.scopeImpl(),
                                   bb.unsafeGetBase(),
                                   offset(bb, base, handle.alignmentMask),
                                   convEndian(handle.be, expected), convEndian(handle.be, value)));
@@ -281,7 +281,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     static boolean weakCompareAndSetPlain(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
-        return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Plain(bb.sessionImpl(),
+        return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Plain(bb.scopeImpl(),
                 bb.unsafeGetBase(),
                 offset(bb, base, handle.alignmentMask),
                 convEndian(handle.be, expected), convEndian(handle.be, value));
@@ -291,7 +291,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     static boolean weakCompareAndSet(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
-        return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.sessionImpl(),
+        return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.scopeImpl(),
                 bb.unsafeGetBase(),
                 offset(bb, base, handle.alignmentMask),
                 convEndian(handle.be, expected), convEndian(handle.be, value));
@@ -301,7 +301,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     static boolean weakCompareAndSetAcquire(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
-        return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Acquire(bb.sessionImpl(),
+        return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Acquire(bb.scopeImpl(),
                 bb.unsafeGetBase(),
                 offset(bb, base, handle.alignmentMask),
                 convEndian(handle.be, expected), convEndian(handle.be, value));
@@ -311,7 +311,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     static boolean weakCompareAndSetRelease(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
-        return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Release(bb.sessionImpl(),
+        return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Release(bb.scopeImpl(),
                 bb.unsafeGetBase(),
                 offset(bb, base, handle.alignmentMask),
                 convEndian(handle.be, expected), convEndian(handle.be, value));
@@ -322,7 +322,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
-                          SCOPED_MEMORY_ACCESS.getAndSet$RawType$(bb.sessionImpl(),
+                          SCOPED_MEMORY_ACCESS.getAndSet$RawType$(bb.scopeImpl(),
                                   bb.unsafeGetBase(),
                                   offset(bb, base, handle.alignmentMask),
                                   convEndian(handle.be, value)));
@@ -333,7 +333,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
-                          SCOPED_MEMORY_ACCESS.getAndSet$RawType$Acquire(bb.sessionImpl(),
+                          SCOPED_MEMORY_ACCESS.getAndSet$RawType$Acquire(bb.scopeImpl(),
                                   bb.unsafeGetBase(),
                                   offset(bb, base, handle.alignmentMask),
                                   convEndian(handle.be, value)));
@@ -344,7 +344,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
-                          SCOPED_MEMORY_ACCESS.getAndSet$RawType$Release(bb.sessionImpl(),
+                          SCOPED_MEMORY_ACCESS.getAndSet$RawType$Release(bb.scopeImpl(),
                                   bb.unsafeGetBase(),
                                   offset(bb, base, handle.alignmentMask),
                                   convEndian(handle.be, value)));
@@ -357,7 +357,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
-            return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$(bb.sessionImpl(),
+            return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$(bb.scopeImpl(),
                     bb.unsafeGetBase(),
                     offset(bb, base, handle.alignmentMask),
                     delta);
@@ -371,7 +371,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
-            return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Acquire(bb.sessionImpl(),
+            return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Acquire(bb.scopeImpl(),
                     bb.unsafeGetBase(),
                     offset(bb, base, handle.alignmentMask),
                     delta);
@@ -385,7 +385,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
-            return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Release(bb.sessionImpl(),
+            return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Release(bb.scopeImpl(),
                     bb.unsafeGetBase(),
                     offset(bb, base, handle.alignmentMask),
                     delta);
@@ -399,9 +399,9 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         $type$ nativeExpectedValue, expectedValue;
         Object base = bb.unsafeGetBase();
         do {
-            nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.sessionImpl(),base, offset);
+            nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.scopeImpl(),base, offset);
             expectedValue = $RawBoxType$.reverseBytes(nativeExpectedValue);
-        } while (!SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.sessionImpl(),base, offset,
+        } while (!SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.scopeImpl(),base, offset,
                 nativeExpectedValue, $RawBoxType$.reverseBytes(expectedValue + delta)));
         return expectedValue;
     }
@@ -413,7 +413,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
-            return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$(bb.sessionImpl(),
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$(bb.scopeImpl(),
                     bb.unsafeGetBase(),
                     offset(bb, base, handle.alignmentMask),
                     value);
@@ -427,7 +427,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
-            return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Release(bb.sessionImpl(),
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Release(bb.scopeImpl(),
                     bb.unsafeGetBase(),
                     offset(bb, base, handle.alignmentMask),
                     value);
@@ -441,7 +441,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
-            return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Acquire(bb.sessionImpl(),
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Acquire(bb.scopeImpl(),
                     bb.unsafeGetBase(),
                     offset(bb, base, handle.alignmentMask),
                     value);
@@ -455,9 +455,9 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         $type$ nativeExpectedValue, expectedValue;
         Object base = bb.unsafeGetBase();
         do {
-            nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.sessionImpl(),base, offset);
+            nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.scopeImpl(),base, offset);
             expectedValue = $RawBoxType$.reverseBytes(nativeExpectedValue);
-        } while (!SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.sessionImpl(),base, offset,
+        } while (!SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.scopeImpl(),base, offset,
                 nativeExpectedValue, $RawBoxType$.reverseBytes(expectedValue | value)));
         return expectedValue;
     }
@@ -467,7 +467,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
-            return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$(bb.sessionImpl(),
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$(bb.scopeImpl(),
                     bb.unsafeGetBase(),
                     offset(bb, base, handle.alignmentMask),
                     value);
@@ -481,7 +481,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
-            return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Release(bb.sessionImpl(),
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Release(bb.scopeImpl(),
                     bb.unsafeGetBase(),
                     offset(bb, base, handle.alignmentMask),
                     value);
@@ -495,7 +495,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
-            return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Acquire(bb.sessionImpl(),
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Acquire(bb.scopeImpl(),
                     bb.unsafeGetBase(),
                     offset(bb, base, handle.alignmentMask),
                     value);
@@ -509,9 +509,9 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         $type$ nativeExpectedValue, expectedValue;
         Object base = bb.unsafeGetBase();
         do {
-            nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.sessionImpl(),base, offset);
+            nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.scopeImpl(),base, offset);
             expectedValue = $RawBoxType$.reverseBytes(nativeExpectedValue);
-        } while (!SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.sessionImpl(),base, offset,
+        } while (!SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.scopeImpl(),base, offset,
                 nativeExpectedValue, $RawBoxType$.reverseBytes(expectedValue & value)));
         return expectedValue;
     }
@@ -522,7 +522,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
-            return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$(bb.sessionImpl(),
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$(bb.scopeImpl(),
                     bb.unsafeGetBase(),
                     offset(bb, base, handle.alignmentMask),
                     value);
@@ -536,7 +536,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
-            return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Release(bb.sessionImpl(),
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Release(bb.scopeImpl(),
                     bb.unsafeGetBase(),
                     offset(bb, base, handle.alignmentMask),
                     value);
@@ -550,7 +550,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
-            return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Acquire(bb.sessionImpl(),
+            return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Acquire(bb.scopeImpl(),
                     bb.unsafeGetBase(),
                     offset(bb, base, handle.alignmentMask),
                     value);
@@ -564,9 +564,9 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         $type$ nativeExpectedValue, expectedValue;
         Object base = bb.unsafeGetBase();
         do {
-            nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.sessionImpl(),base, offset);
+            nativeExpectedValue = SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.scopeImpl(),base, offset);
             expectedValue = $RawBoxType$.reverseBytes(nativeExpectedValue);
-        } while (!SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.sessionImpl(),base, offset,
+        } while (!SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.scopeImpl(),base, offset,
                 nativeExpectedValue, $RawBoxType$.reverseBytes(expectedValue ^ value)));
         return expectedValue;
     }

--- a/src/java.base/share/classes/java/nio/Buffer.java
+++ b/src/java.base/share/classes/java/nio/Buffer.java
@@ -29,7 +29,7 @@ import jdk.internal.access.JavaNioAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.access.foreign.UnmapperProxy;
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
-import jdk.internal.foreign.MemorySessionImpl;
+import jdk.internal.foreign.MemoryScopeImpl;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.misc.VM.BufferPool;
@@ -761,18 +761,18 @@ public abstract sealed class Buffer
     }
 
     @ForceInline
-    final MemorySessionImpl session() {
+    final MemoryScopeImpl scope() {
         if (segment != null) {
-            return ((AbstractMemorySegmentImpl)segment).sessionImpl();
+            return ((AbstractMemorySegmentImpl)segment).scopeImpl();
         } else {
             return null;
         }
     }
 
-    final void checkSession() {
-        MemorySessionImpl session = session();
-        if (session != null) {
-            session.checkValidState();
+    final void checkScope() {
+        MemoryScopeImpl scope = scope();
+        if (scope != null) {
+            scope.checkValidState();
         }
     }
 
@@ -826,17 +826,17 @@ public abstract sealed class Buffer
                 }
 
                 @Override
-                public void acquireSession(Buffer buffer) {
-                    var scope = buffer.session();
+                public void acquireScope(Buffer buffer) {
+                    var scope = buffer.scope();
                     if (scope != null) {
                         scope.acquire0();
                     }
                 }
 
                 @Override
-                public void releaseSession(Buffer buffer) {
+                public void releaseScope(Buffer buffer) {
                     try {
-                        var scope = buffer.session();
+                        var scope = buffer.scope();
                         if (scope != null) {
                             scope.release0();
                         }
@@ -847,13 +847,13 @@ public abstract sealed class Buffer
 
                 @Override
                 public boolean isThreadConfined(Buffer buffer) {
-                    var scope = buffer.session();
+                    var scope = buffer.scope();
                     return scope != null && scope.ownerThread() != null;
                 }
 
                 @Override
-                public boolean hasSession(Buffer buffer) {
-                    return buffer.session() != null;
+                public boolean hasScope(Buffer buffer) {
+                    return buffer.scope() != null;
                 }
 
                 @Override

--- a/src/java.base/share/classes/java/nio/BufferMismatch.java
+++ b/src/java.base/share/classes/java/nio/BufferMismatch.java
@@ -39,7 +39,7 @@ final class BufferMismatch {
         if (length > 7) {
             if (a.get(aOff) != b.get(bOff))
                 return 0;
-            i = SCOPED_MEMORY_ACCESS.vectorizedMismatch(a.session(), b.session(),
+            i = SCOPED_MEMORY_ACCESS.vectorizedMismatch(a.scope(), b.scope(),
                     a.base(), a.address + aOff,
                     b.base(), b.address + bOff,
                     length,
@@ -63,7 +63,7 @@ final class BufferMismatch {
             && a.charRegionOrder() != null && b.charRegionOrder() != null) {
             if (a.get(aOff) != b.get(bOff))
                 return 0;
-            i = SCOPED_MEMORY_ACCESS.vectorizedMismatch(a.session(), b.session(),
+            i = SCOPED_MEMORY_ACCESS.vectorizedMismatch(a.scope(), b.scope(),
                     a.base(), a.address + (aOff << ArraysSupport.LOG2_ARRAY_CHAR_INDEX_SCALE),
                     b.base(), b.address + (bOff << ArraysSupport.LOG2_ARRAY_CHAR_INDEX_SCALE),
                     length,
@@ -83,7 +83,7 @@ final class BufferMismatch {
         if (length > 3 && a.order() == b.order()) {
             if (a.get(aOff) != b.get(bOff))
                 return 0;
-            i = SCOPED_MEMORY_ACCESS.vectorizedMismatch(a.session(), b.session(),
+            i = SCOPED_MEMORY_ACCESS.vectorizedMismatch(a.scope(), b.scope(),
                     a.base(), a.address + (aOff << ArraysSupport.LOG2_ARRAY_SHORT_INDEX_SCALE),
                     b.base(), b.address + (bOff << ArraysSupport.LOG2_ARRAY_SHORT_INDEX_SCALE),
                     length,
@@ -103,7 +103,7 @@ final class BufferMismatch {
         if (length > 1 && a.order() == b.order()) {
             if (a.get(aOff) != b.get(bOff))
                 return 0;
-            i = SCOPED_MEMORY_ACCESS.vectorizedMismatch(a.session(), b.session(),
+            i = SCOPED_MEMORY_ACCESS.vectorizedMismatch(a.scope(), b.scope(),
                     a.base(), a.address + (aOff << ArraysSupport.LOG2_ARRAY_INT_INDEX_SCALE),
                     b.base(), b.address + (bOff << ArraysSupport.LOG2_ARRAY_INT_INDEX_SCALE),
                     length,
@@ -122,7 +122,7 @@ final class BufferMismatch {
         int i = 0;
         if (length > 1 && a.order() == b.order()) {
             if (Float.floatToRawIntBits(a.get(aOff)) == Float.floatToRawIntBits(b.get(bOff))) {
-                i = SCOPED_MEMORY_ACCESS.vectorizedMismatch(a.session(), b.session(),
+                i = SCOPED_MEMORY_ACCESS.vectorizedMismatch(a.scope(), b.scope(),
                         a.base(), a.address + (aOff << ArraysSupport.LOG2_ARRAY_FLOAT_INDEX_SCALE),
                         b.base(), b.address + (bOff << ArraysSupport.LOG2_ARRAY_FLOAT_INDEX_SCALE),
                         length,
@@ -161,7 +161,7 @@ final class BufferMismatch {
         if (length > 0 && a.order() == b.order()) {
             if (a.get(aOff) != b.get(bOff))
                 return 0;
-            i = SCOPED_MEMORY_ACCESS.vectorizedMismatch(a.session(), b.session(),
+            i = SCOPED_MEMORY_ACCESS.vectorizedMismatch(a.scope(), b.scope(),
                     a.base(), a.address + (aOff << ArraysSupport.LOG2_ARRAY_LONG_INDEX_SCALE),
                     b.base(), b.address + (bOff << ArraysSupport.LOG2_ARRAY_LONG_INDEX_SCALE),
                     length,
@@ -179,7 +179,7 @@ final class BufferMismatch {
         int i = 0;
         if (length > 0 && a.order() == b.order()) {
             if (Double.doubleToRawLongBits(a.get(aOff)) == Double.doubleToRawLongBits(b.get(bOff))) {
-                i = SCOPED_MEMORY_ACCESS.vectorizedMismatch(a.session(), b.session(),
+                i = SCOPED_MEMORY_ACCESS.vectorizedMismatch(a.scope(), b.scope(),
                         a.base(), a.address + (aOff << ArraysSupport.LOG2_ARRAY_DOUBLE_INDEX_SCALE),
                         b.base(), b.address + (bOff << ArraysSupport.LOG2_ARRAY_DOUBLE_INDEX_SCALE),
                         length,

--- a/src/java.base/share/classes/java/nio/ByteBufferAs-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/ByteBufferAs-X-Buffer.java.template
@@ -138,13 +138,13 @@ class ByteBufferAs$Type$Buffer$RW$$BO$                  // package-private
     }
 
     public $type$ get() {
-        $memtype$ x = SCOPED_MEMORY_ACCESS.get$Memtype$Unaligned(session(), bb.hb, byteOffset(nextGetIndex()),
+        $memtype$ x = SCOPED_MEMORY_ACCESS.get$Memtype$Unaligned(scope(), bb.hb, byteOffset(nextGetIndex()),
             {#if[boB]?true:false});
         return $fromBits$(x);
     }
 
     public $type$ get(int i) {
-        $memtype$ x = SCOPED_MEMORY_ACCESS.get$Memtype$Unaligned(session(), bb.hb, byteOffset(checkIndex(i)),
+        $memtype$ x = SCOPED_MEMORY_ACCESS.get$Memtype$Unaligned(scope(), bb.hb, byteOffset(checkIndex(i)),
             {#if[boB]?true:false});
         return $fromBits$(x);
     }
@@ -162,7 +162,7 @@ class ByteBufferAs$Type$Buffer$RW$$BO$                  // package-private
     public $Type$Buffer put($type$ x) {
 #if[rw]
         $memtype$ y = $toBits$(x);
-        SCOPED_MEMORY_ACCESS.put$Memtype$Unaligned(session(), bb.hb, byteOffset(nextPutIndex()), y,
+        SCOPED_MEMORY_ACCESS.put$Memtype$Unaligned(scope(), bb.hb, byteOffset(nextPutIndex()), y,
             {#if[boB]?true:false});
         return this;
 #else[rw]
@@ -173,7 +173,7 @@ class ByteBufferAs$Type$Buffer$RW$$BO$                  // package-private
     public $Type$Buffer put(int i, $type$ x) {
 #if[rw]
         $memtype$ y = $toBits$(x);
-        SCOPED_MEMORY_ACCESS.put$Memtype$Unaligned(session(), bb.hb, byteOffset(checkIndex(i)), y,
+        SCOPED_MEMORY_ACCESS.put$Memtype$Unaligned(scope(), bb.hb, byteOffset(checkIndex(i)), y,
             {#if[boB]?true:false});
         return this;
 #else[rw]

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer-bin.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer-bin.java.template
@@ -33,7 +33,7 @@ class XXX {
 
     private $type$ get$Type$(long a) {
         try {
-            $memtype$ x = SCOPED_MEMORY_ACCESS.get$Memtype$Unaligned(session(), null, a, bigEndian);
+            $memtype$ x = SCOPED_MEMORY_ACCESS.get$Memtype$Unaligned(scope(), null, a, bigEndian);
             return $fromBits$(x);
         } finally {
             Reference.reachabilityFence(this);
@@ -62,7 +62,7 @@ class XXX {
 #if[rw]
         try {
             $memtype$ y = $toBits$(x);
-            SCOPED_MEMORY_ACCESS.put$Memtype$Unaligned(session(), null, a, y, bigEndian);
+            SCOPED_MEMORY_ACCESS.put$Memtype$Unaligned(scope(), null, a, y, bigEndian);
         } finally {
             Reference.reachabilityFence(this);
         }

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -31,7 +31,7 @@ import java.io.FileDescriptor;
 import java.lang.foreign.MemorySegment;
 import java.lang.ref.Reference;
 import java.util.Objects;
-import jdk.internal.foreign.MemorySessionImpl;
+import jdk.internal.foreign.MemoryScopeImpl;
 import jdk.internal.misc.ScopedMemoryAccess.ScopedAccessError;
 import jdk.internal.misc.VM;
 import jdk.internal.ref.Cleaner;
@@ -314,12 +314,12 @@ class Direct$Type$Buffer$RW$$BO$
 #if[rw]
 
     public long address() {
-        MemorySessionImpl session = session();
-        if (session != null) {
-            if (session.ownerThread() == null && session.isCloseable()) {
-                throw new UnsupportedOperationException("ByteBuffer derived from closeable shared sessions not supported");
+        MemoryScopeImpl scope = scope();
+        if (scope != null) {
+            if (scope.ownerThread() == null && scope.isCloseable()) {
+                throw new UnsupportedOperationException("ByteBuffer derived from closeable shared scopes not supported");
             }
-            session.checkValidState();
+            scope.checkValidState();
         }
         return address;
     }
@@ -330,7 +330,7 @@ class Direct$Type$Buffer$RW$$BO$
 
     public $type$ get() {
         try {
-            return $fromBits$($swap$(SCOPED_MEMORY_ACCESS.get$Swaptype$(session(), null, ix(nextGetIndex()))));
+            return $fromBits$($swap$(SCOPED_MEMORY_ACCESS.get$Swaptype$(scope(), null, ix(nextGetIndex()))));
         } finally {
             Reference.reachabilityFence(this);
         }
@@ -338,7 +338,7 @@ class Direct$Type$Buffer$RW$$BO$
 
     public $type$ get(int i) {
         try {
-            return $fromBits$($swap$(SCOPED_MEMORY_ACCESS.get$Swaptype$(session(), null, ix(checkIndex(i)))));
+            return $fromBits$($swap$(SCOPED_MEMORY_ACCESS.get$Swaptype$(scope(), null, ix(checkIndex(i)))));
         } finally {
             Reference.reachabilityFence(this);
         }
@@ -358,7 +358,7 @@ class Direct$Type$Buffer$RW$$BO$
     public $Type$Buffer put($type$ x) {
 #if[rw]
         try {
-            SCOPED_MEMORY_ACCESS.put$Swaptype$(session(), null, ix(nextPutIndex()), $swap$($toBits$(x)));
+            SCOPED_MEMORY_ACCESS.put$Swaptype$(scope(), null, ix(nextPutIndex()), $swap$($toBits$(x)));
         } finally {
             Reference.reachabilityFence(this);
         }
@@ -371,7 +371,7 @@ class Direct$Type$Buffer$RW$$BO$
     public $Type$Buffer put(int i, $type$ x) {
 #if[rw]
         try {
-            SCOPED_MEMORY_ACCESS.put$Swaptype$(session(), null, ix(checkIndex(i)), $swap$($toBits$(x)));
+            SCOPED_MEMORY_ACCESS.put$Swaptype$(scope(), null, ix(checkIndex(i)), $swap$($toBits$(x)));
         } finally {
             Reference.reachabilityFence(this);
         }
@@ -388,8 +388,8 @@ class Direct$Type$Buffer$RW$$BO$
         assert (pos <= lim);
         int rem = (pos <= lim ? lim - pos : 0);
         try {
-            // null is passed as destination MemorySession to avoid checking session() twice
-            SCOPED_MEMORY_ACCESS.copyMemory(session(), null, null,
+            // null is passed as destination MemoryScope to avoid checking scope() twice
+            SCOPED_MEMORY_ACCESS.copyMemory(scope(), null, null,
                     ix(pos), null, ix(0), (long)rem << $LG_BYTES_PER_VALUE$);
         } finally {
             Reference.reachabilityFence(this);

--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -183,7 +183,7 @@ class Heap$Type$Buffer$RW$
 #end[streamableType]
 
     public $Type$Buffer get($type$[] dst, int offset, int length) {
-        checkSession();
+        checkScope();
         Objects.checkFromIndexSize(offset, length, dst.length);
         int pos = position();
         if (length > limit() - pos)
@@ -194,7 +194,7 @@ class Heap$Type$Buffer$RW$
     }
 
     public $Type$Buffer get(int index, $type$[] dst, int offset, int length) {
-        checkSession();
+        checkScope();
         Objects.checkFromIndexSize(index, length, limit());
         Objects.checkFromIndexSize(offset, length, dst.length);
         System.arraycopy(hb, ix(index), dst, offset, length);
@@ -231,7 +231,7 @@ class Heap$Type$Buffer$RW$
 
     public $Type$Buffer put($type$[] src, int offset, int length) {
 #if[rw]
-        checkSession();
+        checkScope();
         Objects.checkFromIndexSize(offset, length, src.length);
         int pos = position();
         if (length > limit() - pos)
@@ -246,7 +246,7 @@ class Heap$Type$Buffer$RW$
 
     public $Type$Buffer put($Type$Buffer src) {
 #if[rw]
-        checkSession();
+        checkScope();
         super.put(src);
         return this;
 #else[rw]
@@ -256,7 +256,7 @@ class Heap$Type$Buffer$RW$
 
     public $Type$Buffer put(int index, $Type$Buffer src, int offset, int length) {
 #if[rw]
-        checkSession();
+        checkScope();
         super.put(index, src, offset, length);
         return this;
 #else[rw]
@@ -266,7 +266,7 @@ class Heap$Type$Buffer$RW$
 
     public $Type$Buffer put(int index, $type$[] src, int offset, int length) {
 #if[rw]
-        checkSession();
+        checkScope();
         Objects.checkFromIndexSize(index, length, limit());
         Objects.checkFromIndexSize(offset, length, src.length);
         System.arraycopy(src, offset, hb, ix(index), length);
@@ -280,7 +280,7 @@ class Heap$Type$Buffer$RW$
 
     public $Type$Buffer put(String src, int start, int end) {
 #if[rw]
-        checkSession();
+        checkScope();
         int length = end - start;
         Objects.checkFromIndexSize(start, length, src.length());
         int pos = position();
@@ -335,18 +335,18 @@ class Heap$Type$Buffer$RW$
 #if[rw]
 
     public char getChar() {
-        return SCOPED_MEMORY_ACCESS.getCharUnaligned(session(), hb, byteOffset(nextGetIndex(2)), bigEndian);
+        return SCOPED_MEMORY_ACCESS.getCharUnaligned(scope(), hb, byteOffset(nextGetIndex(2)), bigEndian);
     }
 
     public char getChar(int i) {
-        return SCOPED_MEMORY_ACCESS.getCharUnaligned(session(), hb, byteOffset(checkIndex(i, 2)), bigEndian);
+        return SCOPED_MEMORY_ACCESS.getCharUnaligned(scope(), hb, byteOffset(checkIndex(i, 2)), bigEndian);
     }
 
 #end[rw]
 
     public $Type$Buffer putChar(char x) {
 #if[rw]
-        SCOPED_MEMORY_ACCESS.putCharUnaligned(session(), hb, byteOffset(nextPutIndex(2)), x, bigEndian);
+        SCOPED_MEMORY_ACCESS.putCharUnaligned(scope(), hb, byteOffset(nextPutIndex(2)), x, bigEndian);
         return this;
 #else[rw]
         throw new ReadOnlyBufferException();
@@ -355,7 +355,7 @@ class Heap$Type$Buffer$RW$
 
     public $Type$Buffer putChar(int i, char x) {
 #if[rw]
-        SCOPED_MEMORY_ACCESS.putCharUnaligned(session(), hb, byteOffset(checkIndex(i, 2)), x, bigEndian);
+        SCOPED_MEMORY_ACCESS.putCharUnaligned(scope(), hb, byteOffset(checkIndex(i, 2)), x, bigEndian);
         return this;
 #else[rw]
         throw new ReadOnlyBufferException();
@@ -387,18 +387,18 @@ class Heap$Type$Buffer$RW$
 #if[rw]
 
     public short getShort() {
-        return SCOPED_MEMORY_ACCESS.getShortUnaligned(session(), hb, byteOffset(nextGetIndex(2)), bigEndian);
+        return SCOPED_MEMORY_ACCESS.getShortUnaligned(scope(), hb, byteOffset(nextGetIndex(2)), bigEndian);
     }
 
     public short getShort(int i) {
-        return SCOPED_MEMORY_ACCESS.getShortUnaligned(session(), hb, byteOffset(checkIndex(i, 2)), bigEndian);
+        return SCOPED_MEMORY_ACCESS.getShortUnaligned(scope(), hb, byteOffset(checkIndex(i, 2)), bigEndian);
     }
 
 #end[rw]
 
     public $Type$Buffer putShort(short x) {
 #if[rw]
-        SCOPED_MEMORY_ACCESS.putShortUnaligned(session(), hb, byteOffset(nextPutIndex(2)), x, bigEndian);
+        SCOPED_MEMORY_ACCESS.putShortUnaligned(scope(), hb, byteOffset(nextPutIndex(2)), x, bigEndian);
         return this;
 #else[rw]
         throw new ReadOnlyBufferException();
@@ -407,7 +407,7 @@ class Heap$Type$Buffer$RW$
 
     public $Type$Buffer putShort(int i, short x) {
 #if[rw]
-        SCOPED_MEMORY_ACCESS.putShortUnaligned(session(), hb, byteOffset(checkIndex(i, 2)), x, bigEndian);
+        SCOPED_MEMORY_ACCESS.putShortUnaligned(scope(), hb, byteOffset(checkIndex(i, 2)), x, bigEndian);
         return this;
 #else[rw]
         throw new ReadOnlyBufferException();
@@ -439,18 +439,18 @@ class Heap$Type$Buffer$RW$
 #if[rw]
 
     public int getInt() {
-        return SCOPED_MEMORY_ACCESS.getIntUnaligned(session(), hb, byteOffset(nextGetIndex(4)), bigEndian);
+        return SCOPED_MEMORY_ACCESS.getIntUnaligned(scope(), hb, byteOffset(nextGetIndex(4)), bigEndian);
     }
 
     public int getInt(int i) {
-        return SCOPED_MEMORY_ACCESS.getIntUnaligned(session(), hb, byteOffset(checkIndex(i, 4)), bigEndian);
+        return SCOPED_MEMORY_ACCESS.getIntUnaligned(scope(), hb, byteOffset(checkIndex(i, 4)), bigEndian);
     }
 
 #end[rw]
 
     public $Type$Buffer putInt(int x) {
 #if[rw]
-        SCOPED_MEMORY_ACCESS.putIntUnaligned(session(), hb, byteOffset(nextPutIndex(4)), x, bigEndian);
+        SCOPED_MEMORY_ACCESS.putIntUnaligned(scope(), hb, byteOffset(nextPutIndex(4)), x, bigEndian);
         return this;
 #else[rw]
         throw new ReadOnlyBufferException();
@@ -459,7 +459,7 @@ class Heap$Type$Buffer$RW$
 
     public $Type$Buffer putInt(int i, int x) {
 #if[rw]
-        SCOPED_MEMORY_ACCESS.putIntUnaligned(session(), hb, byteOffset(checkIndex(i, 4)), x, bigEndian);
+        SCOPED_MEMORY_ACCESS.putIntUnaligned(scope(), hb, byteOffset(checkIndex(i, 4)), x, bigEndian);
         return this;
 #else[rw]
         throw new ReadOnlyBufferException();
@@ -491,18 +491,18 @@ class Heap$Type$Buffer$RW$
 #if[rw]
 
     public long getLong() {
-        return SCOPED_MEMORY_ACCESS.getLongUnaligned(session(), hb, byteOffset(nextGetIndex(8)), bigEndian);
+        return SCOPED_MEMORY_ACCESS.getLongUnaligned(scope(), hb, byteOffset(nextGetIndex(8)), bigEndian);
     }
 
     public long getLong(int i) {
-        return SCOPED_MEMORY_ACCESS.getLongUnaligned(session(), hb, byteOffset(checkIndex(i, 8)), bigEndian);
+        return SCOPED_MEMORY_ACCESS.getLongUnaligned(scope(), hb, byteOffset(checkIndex(i, 8)), bigEndian);
     }
 
 #end[rw]
 
     public $Type$Buffer putLong(long x) {
 #if[rw]
-        SCOPED_MEMORY_ACCESS.putLongUnaligned(session(), hb, byteOffset(nextPutIndex(8)), x, bigEndian);
+        SCOPED_MEMORY_ACCESS.putLongUnaligned(scope(), hb, byteOffset(nextPutIndex(8)), x, bigEndian);
         return this;
 #else[rw]
         throw new ReadOnlyBufferException();
@@ -511,7 +511,7 @@ class Heap$Type$Buffer$RW$
 
     public $Type$Buffer putLong(int i, long x) {
 #if[rw]
-        SCOPED_MEMORY_ACCESS.putLongUnaligned(session(), hb, byteOffset(checkIndex(i, 8)), x, bigEndian);
+        SCOPED_MEMORY_ACCESS.putLongUnaligned(scope(), hb, byteOffset(checkIndex(i, 8)), x, bigEndian);
         return this;
 #else[rw]
         throw new ReadOnlyBufferException();
@@ -543,12 +543,12 @@ class Heap$Type$Buffer$RW$
 #if[rw]
 
     public float getFloat() {
-        int x = SCOPED_MEMORY_ACCESS.getIntUnaligned(session(), hb, byteOffset(nextGetIndex(4)), bigEndian);
+        int x = SCOPED_MEMORY_ACCESS.getIntUnaligned(scope(), hb, byteOffset(nextGetIndex(4)), bigEndian);
         return Float.intBitsToFloat(x);
     }
 
     public float getFloat(int i) {
-        int x = SCOPED_MEMORY_ACCESS.getIntUnaligned(session(), hb, byteOffset(checkIndex(i, 4)), bigEndian);
+        int x = SCOPED_MEMORY_ACCESS.getIntUnaligned(scope(), hb, byteOffset(checkIndex(i, 4)), bigEndian);
         return Float.intBitsToFloat(x);
     }
 
@@ -557,7 +557,7 @@ class Heap$Type$Buffer$RW$
     public $Type$Buffer putFloat(float x) {
 #if[rw]
         int y = Float.floatToRawIntBits(x);
-        SCOPED_MEMORY_ACCESS.putIntUnaligned(session(), hb, byteOffset(nextPutIndex(4)), y, bigEndian);
+        SCOPED_MEMORY_ACCESS.putIntUnaligned(scope(), hb, byteOffset(nextPutIndex(4)), y, bigEndian);
         return this;
 #else[rw]
         throw new ReadOnlyBufferException();
@@ -567,7 +567,7 @@ class Heap$Type$Buffer$RW$
     public $Type$Buffer putFloat(int i, float x) {
 #if[rw]
         int y = Float.floatToRawIntBits(x);
-        SCOPED_MEMORY_ACCESS.putIntUnaligned(session(), hb, byteOffset(checkIndex(i, 4)), y, bigEndian);
+        SCOPED_MEMORY_ACCESS.putIntUnaligned(scope(), hb, byteOffset(checkIndex(i, 4)), y, bigEndian);
         return this;
 #else[rw]
         throw new ReadOnlyBufferException();
@@ -599,12 +599,12 @@ class Heap$Type$Buffer$RW$
 #if[rw]
 
     public double getDouble() {
-        long x = SCOPED_MEMORY_ACCESS.getLongUnaligned(session(), hb, byteOffset(nextGetIndex(8)), bigEndian);
+        long x = SCOPED_MEMORY_ACCESS.getLongUnaligned(scope(), hb, byteOffset(nextGetIndex(8)), bigEndian);
         return Double.longBitsToDouble(x);
     }
 
     public double getDouble(int i) {
-        long x = SCOPED_MEMORY_ACCESS.getLongUnaligned(session(), hb, byteOffset(checkIndex(i, 8)), bigEndian);
+        long x = SCOPED_MEMORY_ACCESS.getLongUnaligned(scope(), hb, byteOffset(checkIndex(i, 8)), bigEndian);
         return Double.longBitsToDouble(x);
     }
 
@@ -613,7 +613,7 @@ class Heap$Type$Buffer$RW$
     public $Type$Buffer putDouble(double x) {
 #if[rw]
         long y = Double.doubleToRawLongBits(x);
-        SCOPED_MEMORY_ACCESS.putLongUnaligned(session(), hb, byteOffset(nextPutIndex(8)), y, bigEndian);
+        SCOPED_MEMORY_ACCESS.putLongUnaligned(scope(), hb, byteOffset(nextPutIndex(8)), y, bigEndian);
         return this;
 #else[rw]
         throw new ReadOnlyBufferException();
@@ -623,7 +623,7 @@ class Heap$Type$Buffer$RW$
     public $Type$Buffer putDouble(int i, double x) {
 #if[rw]
         long y = Double.doubleToRawLongBits(x);
-        SCOPED_MEMORY_ACCESS.putLongUnaligned(session(), hb, byteOffset(checkIndex(i, 8)), y, bigEndian);
+        SCOPED_MEMORY_ACCESS.putLongUnaligned(scope(), hb, byteOffset(checkIndex(i, 8)), y, bigEndian);
         return this;
 #else[rw]
         throw new ReadOnlyBufferException();

--- a/src/java.base/share/classes/java/nio/MappedByteBuffer.java
+++ b/src/java.base/share/classes/java/nio/MappedByteBuffer.java
@@ -189,7 +189,7 @@ public abstract sealed class MappedByteBuffer
         if (fd == null) {
             return true;
         }
-        return SCOPED_MEMORY_ACCESS.isLoaded(session(), address, isSync, capacity());
+        return SCOPED_MEMORY_ACCESS.isLoaded(scope(), address, isSync, capacity());
     }
 
     /**
@@ -207,7 +207,7 @@ public abstract sealed class MappedByteBuffer
             return this;
         }
         try {
-            SCOPED_MEMORY_ACCESS.load(session(), address, isSync, capacity());
+            SCOPED_MEMORY_ACCESS.load(scope(), address, isSync, capacity());
         } finally {
             Reference.reachabilityFence(this);
         }
@@ -307,7 +307,7 @@ public abstract sealed class MappedByteBuffer
         if ((address != 0) && (capacity != 0)) {
             // check inputs
             Objects.checkFromIndexSize(index, length, capacity);
-            SCOPED_MEMORY_ACCESS.force(session(), fd, address, isSync, index, length);
+            SCOPED_MEMORY_ACCESS.force(scope(), fd, address, isSync, index, length);
         }
         return this;
     }

--- a/src/java.base/share/classes/java/nio/X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/X-Buffer.java.template
@@ -936,12 +936,12 @@ public abstract sealed class $Type$Buffer
 #if[!byte]
                 if (order() != ByteOrder.nativeOrder())
                     SCOPED_MEMORY_ACCESS.copySwapMemory(
-                            session(), null, base(), bufAddr,
+                            scope(), null, base(), bufAddr,
                             dst, dstOffset, len, $Fulltype$.BYTES);
                 else
 #end[!byte]
                     SCOPED_MEMORY_ACCESS.copyMemory(
-                            session(), null, base(), bufAddr,
+                            scope(), null, base(), bufAddr,
                             dst, dstOffset, len);
             } finally {
                 Reference.reachabilityFence(this);
@@ -1106,12 +1106,12 @@ public abstract sealed class $Type$Buffer
 #if[!byte]
                 if (this.order() != src.order())
                     SCOPED_MEMORY_ACCESS.copySwapMemory(
-                            src.session(), session(), srcBase, srcAddr,
+                            src.scope(), scope(), srcBase, srcAddr,
                             base, addr, len, $Fulltype$.BYTES);
                 else
 #end[!byte]
                     SCOPED_MEMORY_ACCESS.copyMemory(
-                            src.session(), session(), srcBase, srcAddr,
+                            src.scope(), scope(), srcBase, srcAddr,
                             base, addr, len);
             } finally {
                 Reference.reachabilityFence(src);
@@ -1326,12 +1326,12 @@ public abstract sealed class $Type$Buffer
 #if[!byte]
                 if (order() != ByteOrder.nativeOrder())
                     SCOPED_MEMORY_ACCESS.copySwapMemory(
-                            null, session(), src, srcOffset,
+                            null, scope(), src, srcOffset,
                             base(), bufAddr, len, $Fulltype$.BYTES);
                 else
 #end[!byte]
                     SCOPED_MEMORY_ACCESS.copyMemory(
-                            null, session(), src, srcOffset,
+                            null, scope(), src, srcOffset,
                             base(), bufAddr, len);
             } finally {
                 Reference.reachabilityFence(this);

--- a/src/java.base/share/classes/java/util/zip/Adler32.java
+++ b/src/java.base/share/classes/java/util/zip/Adler32.java
@@ -98,11 +98,11 @@ public class Adler32 implements Checksum {
         if (rem <= 0)
             return;
         if (buffer.isDirect()) {
-            NIO_ACCESS.acquireSession(buffer);
+            NIO_ACCESS.acquireScope(buffer);
             try {
                 adler = updateByteBuffer(adler, ((DirectBuffer)buffer).address(), pos, rem);
             } finally {
-                NIO_ACCESS.releaseSession(buffer);
+                NIO_ACCESS.releaseScope(buffer);
             }
         } else if (buffer.hasArray()) {
             adler = updateBytes(adler, buffer.array(), pos + buffer.arrayOffset(), rem);

--- a/src/java.base/share/classes/java/util/zip/CRC32.java
+++ b/src/java.base/share/classes/java/util/zip/CRC32.java
@@ -97,11 +97,11 @@ public class CRC32 implements Checksum {
         if (rem <= 0)
             return;
         if (buffer.isDirect()) {
-            NIO_ACCESS.acquireSession(buffer);
+            NIO_ACCESS.acquireScope(buffer);
             try {
                 crc = updateByteBuffer(crc, ((DirectBuffer)buffer).address(), pos, rem);
             } finally {
-                NIO_ACCESS.releaseSession(buffer);
+                NIO_ACCESS.releaseScope(buffer);
             }
         } else if (buffer.hasArray()) {
             crc = updateBytes(crc, buffer.array(), pos + buffer.arrayOffset(), rem);

--- a/src/java.base/share/classes/java/util/zip/CRC32C.java
+++ b/src/java.base/share/classes/java/util/zip/CRC32C.java
@@ -172,12 +172,12 @@ public final class CRC32C implements Checksum {
         }
 
         if (buffer.isDirect()) {
-            NIO_ACCESS.acquireSession(buffer);
+            NIO_ACCESS.acquireScope(buffer);
             try {
                 crc = updateDirectByteBuffer(crc, ((DirectBuffer)buffer).address(),
                         pos, limit);
             } finally {
-                NIO_ACCESS.releaseSession(buffer);
+                NIO_ACCESS.releaseScope(buffer);
             }
         } else if (buffer.hasArray()) {
             crc = updateBytes(crc, buffer.array(), pos + buffer.arrayOffset(),

--- a/src/java.base/share/classes/java/util/zip/Deflater.java
+++ b/src/java.base/share/classes/java/util/zip/Deflater.java
@@ -338,12 +338,12 @@ public class Deflater {
             int remaining = Math.max(dictionary.limit() - position, 0);
             ensureOpen();
             if (dictionary.isDirect()) {
-                NIO_ACCESS.acquireSession(dictionary);
+                NIO_ACCESS.acquireScope(dictionary);
                 try {
                     long address = ((DirectBuffer) dictionary).address();
                     setDictionaryBuffer(zsRef.address(), address + position, remaining);
                 } finally {
-                    NIO_ACCESS.releaseSession(dictionary);
+                    NIO_ACCESS.releaseScope(dictionary);
                 }
             } else {
                 byte[] array = ZipUtils.getBufferArray(dictionary);
@@ -589,7 +589,7 @@ public class Deflater {
                 inputPos = input.position();
                 int inputRem = Math.max(input.limit() - inputPos, 0);
                 if (input.isDirect()) {
-                    NIO_ACCESS.acquireSession(input);
+                    NIO_ACCESS.acquireScope(input);
                     try {
                         long inputAddress = ((DirectBuffer) input).address();
                         result = deflateBufferBytes(zsRef.address(),
@@ -597,7 +597,7 @@ public class Deflater {
                             output, off, len,
                             flush, params);
                     } finally {
-                        NIO_ACCESS.releaseSession(input);
+                        NIO_ACCESS.releaseScope(input);
                     }
                 } else {
                     byte[] inputArray = ZipUtils.getBufferArray(input);
@@ -712,7 +712,7 @@ public class Deflater {
             if (input == null) {
                 inputPos = this.inputPos;
                 if (output.isDirect()) {
-                    NIO_ACCESS.acquireSession(output);
+                    NIO_ACCESS.acquireScope(output);
                     try {
                         long outputAddress = ((DirectBuffer) output).address();
                         result = deflateBytesBuffer(zsRef.address(),
@@ -720,7 +720,7 @@ public class Deflater {
                             outputAddress + outputPos, outputRem,
                             flush, params);
                     } finally {
-                        NIO_ACCESS.releaseSession(output);
+                        NIO_ACCESS.releaseScope(output);
                     }
                 } else {
                     byte[] outputArray = ZipUtils.getBufferArray(output);
@@ -734,11 +734,11 @@ public class Deflater {
                 inputPos = input.position();
                 int inputRem = Math.max(input.limit() - inputPos, 0);
                 if (input.isDirect()) {
-                    NIO_ACCESS.acquireSession(input);
+                    NIO_ACCESS.acquireScope(input);
                     try {
                         long inputAddress = ((DirectBuffer) input).address();
                         if (output.isDirect()) {
-                            NIO_ACCESS.acquireSession(output);
+                            NIO_ACCESS.acquireScope(output);
                             try {
                                 long outputAddress = outputPos + ((DirectBuffer) output).address();
                                 result = deflateBufferBuffer(zsRef.address(),
@@ -746,7 +746,7 @@ public class Deflater {
                                     outputAddress, outputRem,
                                     flush, params);
                             } finally {
-                                NIO_ACCESS.releaseSession(output);
+                                NIO_ACCESS.releaseScope(output);
                             }
                         } else {
                             byte[] outputArray = ZipUtils.getBufferArray(output);
@@ -757,13 +757,13 @@ public class Deflater {
                                 flush, params);
                         }
                     } finally {
-                        NIO_ACCESS.releaseSession(input);
+                        NIO_ACCESS.releaseScope(input);
                     }
                 } else {
                     byte[] inputArray = ZipUtils.getBufferArray(input);
                     int inputOffset = ZipUtils.getBufferOffset(input);
                     if (output.isDirect()) {
-                        NIO_ACCESS.acquireSession(output);
+                        NIO_ACCESS.acquireScope(output);
                         try {
                             long outputAddress = ((DirectBuffer) output).address();
                             result = deflateBytesBuffer(zsRef.address(),
@@ -771,7 +771,7 @@ public class Deflater {
                                 outputAddress + outputPos, outputRem,
                                 flush, params);
                         } finally {
-                            NIO_ACCESS.releaseSession(output);
+                            NIO_ACCESS.releaseScope(output);
                         }
                     } else {
                         byte[] outputArray = ZipUtils.getBufferArray(output);

--- a/src/java.base/share/classes/java/util/zip/Inflater.java
+++ b/src/java.base/share/classes/java/util/zip/Inflater.java
@@ -260,12 +260,12 @@ public class Inflater {
             int remaining = Math.max(dictionary.limit() - position, 0);
             ensureOpen();
             if (dictionary.isDirect()) {
-                NIO_ACCESS.acquireSession(dictionary);
+                NIO_ACCESS.acquireScope(dictionary);
                 try {
                     long address = ((DirectBuffer) dictionary).address();
                     setDictionaryBuffer(zsRef.address(), address + position, remaining);
                 } finally {
-                    NIO_ACCESS.releaseSession(dictionary);
+                    NIO_ACCESS.releaseScope(dictionary);
                 }
             } else {
                 byte[] array = ZipUtils.getBufferArray(dictionary);
@@ -385,14 +385,14 @@ public class Inflater {
                     try {
                         int inputRem = Math.max(input.limit() - inputPos, 0);
                         if (input.isDirect()) {
-                            NIO_ACCESS.acquireSession(input);
+                            NIO_ACCESS.acquireScope(input);
                             try {
                                 long inputAddress = ((DirectBuffer) input).address();
                                 result = inflateBufferBytes(zsRef.address(),
                                     inputAddress + inputPos, inputRem,
                                     output, off, len);
                             } finally {
-                                NIO_ACCESS.releaseSession(input);
+                                NIO_ACCESS.releaseScope(input);
                             }
                         } else {
                             byte[] inputArray = ZipUtils.getBufferArray(input);
@@ -520,14 +520,14 @@ public class Inflater {
                     inputPos = this.inputPos;
                     try {
                         if (output.isDirect()) {
-                            NIO_ACCESS.acquireSession(output);
+                            NIO_ACCESS.acquireScope(output);
                             try {
                                 long outputAddress = ((DirectBuffer) output).address();
                                 result = inflateBytesBuffer(zsRef.address(),
                                     inputArray, inputPos, inputLim - inputPos,
                                     outputAddress + outputPos, outputRem);
                             } finally {
-                                NIO_ACCESS.releaseSession(output);
+                                NIO_ACCESS.releaseScope(output);
                             }
                         } else {
                             byte[] outputArray = ZipUtils.getBufferArray(output);
@@ -545,18 +545,18 @@ public class Inflater {
                     int inputRem = Math.max(input.limit() - inputPos, 0);
                     try {
                         if (input.isDirect()) {
-                            NIO_ACCESS.acquireSession(input);
+                            NIO_ACCESS.acquireScope(input);
                             try {
                                 long inputAddress = ((DirectBuffer) input).address();
                                 if (output.isDirect()) {
-                                    NIO_ACCESS.acquireSession(output);
+                                    NIO_ACCESS.acquireScope(output);
                                     try {
                                         long outputAddress = ((DirectBuffer) output).address();
                                         result = inflateBufferBuffer(zsRef.address(),
                                             inputAddress + inputPos, inputRem,
                                             outputAddress + outputPos, outputRem);
                                     } finally {
-                                        NIO_ACCESS.releaseSession(output);
+                                        NIO_ACCESS.releaseScope(output);
                                     }
                                 } else {
                                     byte[] outputArray = ZipUtils.getBufferArray(output);
@@ -566,20 +566,20 @@ public class Inflater {
                                         outputArray, outputOffset + outputPos, outputRem);
                                 }
                             } finally {
-                                NIO_ACCESS.releaseSession(input);
+                                NIO_ACCESS.releaseScope(input);
                             }
                         } else {
                             byte[] inputArray = ZipUtils.getBufferArray(input);
                             int inputOffset = ZipUtils.getBufferOffset(input);
                             if (output.isDirect()) {
-                                NIO_ACCESS.acquireSession(output);
+                                NIO_ACCESS.acquireScope(output);
                                 try {
                                     long outputAddress = ((DirectBuffer) output).address();
                                     result = inflateBytesBuffer(zsRef.address(),
                                         inputArray, inputOffset + inputPos, inputRem,
                                         outputAddress + outputPos, outputRem);
                                 } finally {
-                                    NIO_ACCESS.releaseSession(output);
+                                    NIO_ACCESS.releaseScope(output);
                                 }
                             } else {
                                 byte[] outputArray = ZipUtils.getBufferArray(output);

--- a/src/java.base/share/classes/jdk/internal/access/JavaNioAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaNioAccess.java
@@ -86,26 +86,26 @@ public interface JavaNioAccess {
     MemorySegment bufferSegment(Buffer buffer);
 
     /**
-     * Used by operations to make a buffer's session non-closeable
-     * (for the duration of the operation) by acquiring the session.
+     * Used by operations to make a buffer's scope non-closeable
+     * (for the duration of the operation) by acquiring the scope.
      * {@snippet lang = java:
-     * acquireSession(buffer);
+     * acquireScope(buffer);
      * try {
      *     performOperation(buffer);
      * } finally {
-     *     releaseSession(buffer);
+     *     releaseScope(buffer);
      * }
      *}
      *
-     * @see #releaseSession(Buffer)
+     * @see #releaseScope(Buffer)
      */
-    void acquireSession(Buffer buffer);
+    void acquireScope(Buffer buffer);
 
-    void releaseSession(Buffer buffer);
+    void releaseScope(Buffer buffer);
 
     boolean isThreadConfined(Buffer buffer);
 
-    boolean hasSession(Buffer buffer);
+    boolean hasScope(Buffer buffer);
 
     /**
      * Used by {@code jdk.internal.foreign.MappedMemorySegmentImpl} and byte buffer var handle views.

--- a/src/java.base/share/classes/jdk/internal/foreign/GlobalScope.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/GlobalScope.java
@@ -28,15 +28,15 @@ package jdk.internal.foreign;
 import jdk.internal.vm.annotation.ForceInline;
 
 /**
- * The global, non-closeable, shared session. Similar to a shared session, but its {@link #close()} method throws unconditionally.
- * Adding new resources to the global session, does nothing: as the session can never become not-alive, there is nothing to track.
- * Acquiring and or releasing a memory session similarly does nothing.
+ * The global, non-closeable, shared scope. Similar to a shared scope, but its {@link #close()} method throws unconditionally.
+ * Adding new resources to the global scope, does nothing: as the scope can never become not-alive, there is nothing to track.
+ * Acquiring and or releasing a memory scope similarly does nothing.
  */
-final class GlobalSession extends MemorySessionImpl {
+final class GlobalScope extends MemoryScopeImpl {
 
     final Object ref;
 
-    public GlobalSession(Object ref) {
+    public GlobalScope(Object ref) {
         super(null, null);
         this.ref = ref;
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
@@ -79,7 +79,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
     }
 
     @Override
-    abstract HeapMemorySegmentImpl dup(long offset, long size, boolean readOnly, SegmentScope session);
+    abstract HeapMemorySegmentImpl dup(long offset, long size, boolean readOnly, SegmentScope scope);
 
     @Override
     ByteBuffer makeByteBuffer() {
@@ -99,7 +99,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
         }
 
         @Override
-        OfByte dup(long offset, long size, boolean readOnly, SegmentScope session) {
+        OfByte dup(long offset, long size, boolean readOnly, SegmentScope scope) {
             return new OfByte(this.offset + offset, base, size, readOnly);
         }
 
@@ -132,7 +132,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
         }
 
         @Override
-        OfChar dup(long offset, long size, boolean readOnly, SegmentScope session) {
+        OfChar dup(long offset, long size, boolean readOnly, SegmentScope scope) {
             return new OfChar(this.offset + offset, base, size, readOnly);
         }
 
@@ -165,7 +165,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
         }
 
         @Override
-        OfShort dup(long offset, long size, boolean readOnly, SegmentScope session) {
+        OfShort dup(long offset, long size, boolean readOnly, SegmentScope scope) {
             return new OfShort(this.offset + offset, base, size, readOnly);
         }
 
@@ -198,7 +198,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
         }
 
         @Override
-        OfInt dup(long offset, long size, boolean readOnly, SegmentScope session) {
+        OfInt dup(long offset, long size, boolean readOnly, SegmentScope scope) {
             return new OfInt(this.offset + offset, base, size, readOnly);
         }
 
@@ -231,7 +231,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
         }
 
         @Override
-        OfLong dup(long offset, long size, boolean readOnly, SegmentScope session) {
+        OfLong dup(long offset, long size, boolean readOnly, SegmentScope scope) {
             return new OfLong(this.offset + offset, base, size, readOnly);
         }
 
@@ -264,7 +264,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
         }
 
         @Override
-        OfFloat dup(long offset, long size, boolean readOnly, SegmentScope session) {
+        OfFloat dup(long offset, long size, boolean readOnly, SegmentScope scope) {
             return new OfFloat(this.offset + offset, base, size, readOnly);
         }
 
@@ -297,7 +297,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
         }
 
         @Override
-        OfDouble dup(long offset, long size, boolean readOnly, SegmentScope session) {
+        OfDouble dup(long offset, long size, boolean readOnly, SegmentScope scope) {
             return new OfDouble(this.offset + offset, base, size, readOnly);
         }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/ImplicitScope.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/ImplicitScope.java
@@ -31,16 +31,16 @@ import java.lang.ref.Cleaner;
 import java.lang.ref.Reference;
 
 /**
- * This is an implicit, GC-backed memory session. Implicit sessions cannot be closed explicitly.
- * While it would be possible to model an implicit session as a non-closeable view of a shared
- * session, it is better to capture the fact that an implicit session is not just a non-closeable
- * view of some session which might be closeable. This is useful e.g. in the implementations of
+ * This is an implicit, GC-backed memory scope. Implicit scopes cannot be closed explicitly.
+ * While it would be possible to model an implicit scope as a non-closeable view of a shared
+ * scope, it is better to capture the fact that an implicit scope is not just a non-closeable
+ * view of some scope which might be closeable. This is useful e.g. in the implementations of
  * {@link DirectBuffer#address()}, where obtaining an address of a buffer instance associated
- * with a potentially closeable session is forbidden.
+ * with a potentially closeable scope is forbidden.
  */
-final class ImplicitSession extends SharedSession {
+final class ImplicitScope extends SharedScope {
 
-    public ImplicitSession(Cleaner cleaner) {
+    public ImplicitScope(Cleaner cleaner) {
         super();
         cleaner.register(this, resourceList);
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
@@ -43,20 +43,20 @@ public sealed class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
 
     static final ScopedMemoryAccess SCOPED_MEMORY_ACCESS = ScopedMemoryAccess.getScopedMemoryAccess();
 
-    public MappedMemorySegmentImpl(long min, UnmapperProxy unmapper, long length, boolean readOnly, SegmentScope session) {
-        super(min, length, readOnly, session);
+    public MappedMemorySegmentImpl(long min, UnmapperProxy unmapper, long length, boolean readOnly, SegmentScope scope) {
+        super(min, length, readOnly, scope);
         this.unmapper = unmapper;
     }
 
     @Override
     ByteBuffer makeByteBuffer() {
         return NIO_ACCESS.newMappedByteBuffer(unmapper, min, (int)length, null,
-                session == MemorySessionImpl.GLOBAL ? null : this);
+                scope == MemoryScopeImpl.GLOBAL ? null : this);
     }
 
     @Override
-    MappedMemorySegmentImpl dup(long offset, long size, boolean readOnly, SegmentScope session) {
-        return new MappedMemorySegmentImpl(min + offset, unmapper, size, readOnly, session);
+    MappedMemorySegmentImpl dup(long offset, long size, boolean readOnly, SegmentScope scope) {
+        return new MappedMemorySegmentImpl(min + offset, unmapper, size, readOnly, scope);
     }
 
     // mapped segment methods
@@ -78,25 +78,25 @@ public sealed class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
     }
 
     public void load() {
-        SCOPED_MEMORY_ACCESS.load(sessionImpl(), min, unmapper.isSync(), length);
+        SCOPED_MEMORY_ACCESS.load(scopeImpl(), min, unmapper.isSync(), length);
     }
 
     public void unload() {
-        SCOPED_MEMORY_ACCESS.unload(sessionImpl(), min, unmapper.isSync(), length);
+        SCOPED_MEMORY_ACCESS.unload(scopeImpl(), min, unmapper.isSync(), length);
     }
 
     public boolean isLoaded() {
-        return SCOPED_MEMORY_ACCESS.isLoaded(sessionImpl(), min, unmapper.isSync(), length);
+        return SCOPED_MEMORY_ACCESS.isLoaded(scopeImpl(), min, unmapper.isSync(), length);
     }
 
     public void force() {
-        SCOPED_MEMORY_ACCESS.force(sessionImpl(), unmapper.fileDescriptor(), min, unmapper.isSync(), 0, length);
+        SCOPED_MEMORY_ACCESS.force(scopeImpl(), unmapper.fileDescriptor(), min, unmapper.isSync(), 0, length);
     }
 
     public static final class EmptyMappedMemorySegmentImpl extends MappedMemorySegmentImpl {
 
-        public EmptyMappedMemorySegmentImpl(boolean readOnly, MemorySessionImpl session) {
-            super(0, null, 0, readOnly, session);
+        public EmptyMappedMemorySegmentImpl(boolean readOnly, MemoryScopeImpl scope) {
+            super(0, null, 0, readOnly, scope);
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -52,8 +52,8 @@ public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl pe
     final long min;
 
     @ForceInline
-    NativeMemorySegmentImpl(long min, long length, boolean readOnly, SegmentScope session) {
-        super(length, readOnly, session);
+    NativeMemorySegmentImpl(long min, long length, boolean readOnly, SegmentScope scope) {
+        super(length, readOnly, scope);
         this.min = min;
     }
 
@@ -69,14 +69,14 @@ public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl pe
 
     @ForceInline
     @Override
-    NativeMemorySegmentImpl dup(long offset, long size, boolean readOnly, SegmentScope session) {
-        return new NativeMemorySegmentImpl(min + offset, size, readOnly, session);
+    NativeMemorySegmentImpl dup(long offset, long size, boolean readOnly, SegmentScope scope) {
+        return new NativeMemorySegmentImpl(min + offset, size, readOnly, scope);
     }
 
     @Override
     ByteBuffer makeByteBuffer() {
         return NIO_ACCESS.newDirectByteBuffer(min, (int) this.length, null,
-                session == MemorySessionImpl.GLOBAL ? null : this);
+                scope == MemoryScopeImpl.GLOBAL ? null : this);
     }
 
     @Override
@@ -101,9 +101,9 @@ public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl pe
 
     // factories
 
-    public static MemorySegment makeNativeSegment(long byteSize, long byteAlignment, SegmentScope session) {
-        MemorySessionImpl sessionImpl = (MemorySessionImpl) session;
-        sessionImpl.checkValidState();
+    public static MemorySegment makeNativeSegment(long byteSize, long byteAlignment, SegmentScope scope) {
+        MemoryScopeImpl scopeImpl = (MemoryScopeImpl) scope;
+        scopeImpl.checkValidState();
         if (VM.isDirectMemoryPageAligned()) {
             byteAlignment = Math.max(byteAlignment, NIO_ACCESS.pageSize());
         }
@@ -119,8 +119,8 @@ public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl pe
         }
         long alignedBuf = Utils.alignUp(buf, byteAlignment);
         AbstractMemorySegmentImpl segment = new NativeMemorySegmentImpl(buf, alignedSize,
-                false, session);
-        sessionImpl.addOrCleanupIfFail(new MemorySessionImpl.ResourceList.ResourceCleanup() {
+                false, scope);
+        scopeImpl.addOrCleanupIfFail(new MemoryScopeImpl.ResourceList.ResourceCleanup() {
             @Override
             public void cleanup() {
                 UNSAFE.freeMemory(buf);
@@ -138,21 +138,21 @@ public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl pe
     // associated with MemorySegment::ofAddress.
 
     @ForceInline
-    public static MemorySegment makeNativeSegmentUnchecked(long min, long byteSize, SegmentScope session, Runnable action) {
-        MemorySessionImpl sessionImpl = (MemorySessionImpl) session;
+    public static MemorySegment makeNativeSegmentUnchecked(long min, long byteSize, SegmentScope scope, Runnable action) {
+        MemoryScopeImpl scopeImpl = (MemoryScopeImpl) scope;
         if (action == null) {
-            sessionImpl.checkValidState();
+            scopeImpl.checkValidState();
         } else {
-            sessionImpl.addCloseAction(action);
+            scopeImpl.addCloseAction(action);
         }
-        return new NativeMemorySegmentImpl(min, byteSize, false, session);
+        return new NativeMemorySegmentImpl(min, byteSize, false, scope);
     }
 
     @ForceInline
-    public static MemorySegment makeNativeSegmentUnchecked(long min, long byteSize, SegmentScope session) {
-        MemorySessionImpl sessionImpl = (MemorySessionImpl) session;
-        sessionImpl.checkValidState();
-        return new NativeMemorySegmentImpl(min, byteSize, false, session);
+    public static MemorySegment makeNativeSegmentUnchecked(long min, long byteSize, SegmentScope scope) {
+        MemoryScopeImpl scopeImpl = (MemoryScopeImpl) scope;
+        scopeImpl.checkValidState();
+        return new NativeMemorySegmentImpl(min, byteSize, false, scope);
     }
 
     @ForceInline

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -202,19 +202,19 @@ public interface Binding {
      */
     class Context implements AutoCloseable {
         private final SegmentAllocator allocator;
-        private final SegmentScope session;
+        private final SegmentScope scope;
 
-        private Context(SegmentAllocator allocator, SegmentScope session) {
+        private Context(SegmentAllocator allocator, SegmentScope scope) {
             this.allocator = allocator;
-            this.session = session;
+            this.scope = scope;
         }
 
         public SegmentAllocator allocator() {
             return allocator;
         }
 
-        public SegmentScope session() {
-            return session;
+        public SegmentScope scope() {
+            return scope;
         }
 
         @Override
@@ -242,7 +242,7 @@ public interface Binding {
         public static Context ofAllocator(SegmentAllocator allocator) {
             return new Context(allocator, null) {
                 @Override
-                public SegmentScope session() {
+                public SegmentScope scope() {
                     throw new UnsupportedOperationException();
                 }
             };
@@ -252,7 +252,7 @@ public interface Binding {
          * Create a binding context from given scope. The resulting context will throw when
          * the context's allocator is accessed.
          */
-        public static Context ofSession() {
+        public static Context ofScope() {
             Arena arena = Arena.openConfined();
             return new Context(null, arena.scope()) {
                 @Override
@@ -276,7 +276,7 @@ public interface Binding {
             }
 
             @Override
-            public SegmentScope session() {
+            public SegmentScope scope() {
                 throw new UnsupportedOperationException();
             }
 
@@ -678,10 +678,10 @@ public interface Binding {
 
     /**
      * BOX_ADDRESS()
-     * Pops a 'long' from the operand stack, converts it to a 'MemorySegment', with the given size and memory session
-     * (either the context session, or the global session), and pushes that onto the operand stack.
+     * Pops a 'long' from the operand stack, converts it to a 'MemorySegment', with the given size and memory scope
+     * (either the context scope, or the global scope), and pushes that onto the operand stack.
      */
-    record BoxAddress(long size, boolean needsSession) implements Binding {
+    record BoxAddress(long size, boolean needsScope) implements Binding {
 
         @Override
         public Tag tag() {
@@ -698,9 +698,9 @@ public interface Binding {
         @Override
         public void interpret(Deque<Object> stack, BindingInterpreter.StoreFunc storeFunc,
                               BindingInterpreter.LoadFunc loadFunc, Context context) {
-            SegmentScope session = needsSession ?
-                    context.session() : SegmentScope.global();
-            stack.push(NativeMemorySegmentImpl.makeNativeSegmentUnchecked((long) stack.pop(), size, session));
+            SegmentScope scope = needsScope ?
+                    context.scope() : SegmentScope.global();
+            stack.push(NativeMemorySegmentImpl.makeNativeSegmentUnchecked((long) stack.pop(), size, scope));
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -288,21 +288,21 @@ public final class SharedUtils {
             throw new IllegalArgumentException("Symbol is NULL: " + symbol);
     }
 
-    public static VaList newVaList(Consumer<VaList.Builder> actions, SegmentScope session) {
+    public static VaList newVaList(Consumer<VaList.Builder> actions, SegmentScope scope) {
         return switch (CABI.current()) {
-            case WIN_64 -> Windowsx64Linker.newVaList(actions, session);
-            case SYS_V -> SysVx64Linker.newVaList(actions, session);
-            case LINUX_AARCH_64 -> LinuxAArch64Linker.newVaList(actions, session);
-            case MAC_OS_AARCH_64 -> MacOsAArch64Linker.newVaList(actions, session);
+            case WIN_64 -> Windowsx64Linker.newVaList(actions, scope);
+            case SYS_V -> SysVx64Linker.newVaList(actions, scope);
+            case LINUX_AARCH_64 -> LinuxAArch64Linker.newVaList(actions, scope);
+            case MAC_OS_AARCH_64 -> MacOsAArch64Linker.newVaList(actions, scope);
         };
     }
 
-    public static VaList newVaListOfAddress(long address, SegmentScope session) {
+    public static VaList newVaListOfAddress(long address, SegmentScope scope) {
         return switch (CABI.current()) {
-            case WIN_64 -> Windowsx64Linker.newVaListOfAddress(address, session);
-            case SYS_V -> SysVx64Linker.newVaListOfAddress(address, session);
-            case LINUX_AARCH_64 -> LinuxAArch64Linker.newVaListOfAddress(address, session);
-            case MAC_OS_AARCH_64 -> MacOsAArch64Linker.newVaListOfAddress(address, session);
+            case WIN_64 -> Windowsx64Linker.newVaListOfAddress(address, scope);
+            case SYS_V -> SysVx64Linker.newVaListOfAddress(address, scope);
+            case LINUX_AARCH_64 -> LinuxAArch64Linker.newVaListOfAddress(address, scope);
+            case MAC_OS_AARCH_64 -> MacOsAArch64Linker.newVaListOfAddress(address, scope);
         };
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallLinker.java
@@ -61,7 +61,7 @@ public class UpcallLinker {
         }
     }
 
-    public static MemorySegment make(ABIDescriptor abi, MethodHandle target, CallingSequence callingSequence, SegmentScope session) {
+    public static MemorySegment make(ABIDescriptor abi, MethodHandle target, CallingSequence callingSequence, SegmentScope scope) {
         assert callingSequence.forUpcall();
         Binding.VMLoad[] argMoves = argMoveBindings(callingSequence);
         Binding.VMStore[] retMoves = retMoveBindings(callingSequence);
@@ -93,7 +93,7 @@ public class UpcallLinker {
         CallRegs conv = new CallRegs(args, rets);
         long entryPoint = makeUpcallStub(doBindings, abi, conv,
                 callingSequence.needsReturnBuffer(), callingSequence.returnBufferSize());
-        return UpcallStubs.makeUpcall(entryPoint, session);
+        return UpcallStubs.makeUpcall(entryPoint, scope);
     }
 
     private static void checkPrimitive(MethodType type) {
@@ -130,7 +130,7 @@ public class UpcallLinker {
     private static Object invokeInterpBindings(Object[] lowLevelArgs, InvocationData invData) throws Throwable {
         Binding.Context allocator = invData.callingSequence.allocationSize() != 0
                 ? Binding.Context.ofBoundedAllocator(invData.callingSequence.allocationSize())
-                : Binding.Context.ofSession();
+                : Binding.Context.ofScope();
         try (allocator) {
             /// Invoke interpreter, got array of high-level arguments back
             Object[] highLevelArgs = new Object[invData.callingSequence.calleeMethodType().parameterCount()];

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallStubs.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallStubs.java
@@ -27,7 +27,7 @@ package jdk.internal.foreign.abi;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SegmentScope;
 
-import jdk.internal.foreign.MemorySessionImpl;
+import jdk.internal.foreign.MemoryScopeImpl;
 
 public final class UpcallStubs {
 
@@ -50,13 +50,13 @@ public final class UpcallStubs {
         registerNatives();
     }
 
-    static MemorySegment makeUpcall(long entry, SegmentScope session) {
-        ((MemorySessionImpl) session).addOrCleanupIfFail(new MemorySessionImpl.ResourceList.ResourceCleanup() {
+    static MemorySegment makeUpcall(long entry, SegmentScope scope) {
+        ((MemoryScopeImpl) scope).addOrCleanupIfFail(new MemoryScopeImpl.ResourceList.ResourceCleanup() {
             @Override
             public void cleanup() {
                 freeUpcallStub(entry);
             }
         });
-        return MemorySegment.ofAddress(entry, 0, session);
+        return MemorySegment.ofAddress(entry, 0, scope);
     }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -158,14 +158,14 @@ public abstract class CallArranger {
         return handle;
     }
 
-    public MemorySegment arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc, SegmentScope session) {
+    public MemorySegment arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc, SegmentScope scope) {
         Bindings bindings = getBindings(mt, cDesc, true);
 
         if (bindings.isInMemoryReturn) {
             target = SharedUtils.adaptUpcallForIMR(target, true /* drop return, since we don't have bindings for it */);
         }
 
-        return UpcallLinker.make(C, target, bindings.callingSequence, session);
+        return UpcallLinker.make(C, target, bindings.callingSequence, scope);
     }
 
     private static boolean isInMemoryReturn(Optional<MemoryLayout> returnLayout) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64Linker.java
@@ -65,14 +65,14 @@ public final class LinuxAArch64Linker extends AbstractLinker {
         return CallArranger.LINUX.arrangeUpcall(target, targetType, function, scope);
     }
 
-    public static VaList newVaList(Consumer<VaList.Builder> actions, SegmentScope session) {
-        LinuxAArch64VaList.Builder builder = LinuxAArch64VaList.builder(session);
+    public static VaList newVaList(Consumer<VaList.Builder> actions, SegmentScope scope) {
+        LinuxAArch64VaList.Builder builder = LinuxAArch64VaList.builder(scope);
         actions.accept(builder);
         return builder.build();
     }
 
-    public static VaList newVaListOfAddress(long address, SegmentScope session) {
-        return LinuxAArch64VaList.ofAddress(address, session);
+    public static VaList newVaListOfAddress(long address, SegmentScope scope) {
+        return LinuxAArch64VaList.ofAddress(address, scope);
     }
 
     public static VaList emptyVaList() {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64Linker.java
@@ -65,14 +65,14 @@ public final class MacOsAArch64Linker extends AbstractLinker {
         return CallArranger.MACOS.arrangeUpcall(target, targetType, function, scope);
     }
 
-    public static VaList newVaList(Consumer<VaList.Builder> actions, SegmentScope session) {
-        MacOsAArch64VaList.Builder builder = MacOsAArch64VaList.builder(session);
+    public static VaList newVaList(Consumer<VaList.Builder> actions, SegmentScope scope) {
+        MacOsAArch64VaList.Builder builder = MacOsAArch64VaList.builder(scope);
         actions.accept(builder);
         return builder.build();
     }
 
-    public static VaList newVaListOfAddress(long address, SegmentScope session) {
-        return MacOsAArch64VaList.ofAddress(address, session);
+    public static VaList newVaListOfAddress(long address, SegmentScope scope) {
+        return MacOsAArch64VaList.ofAddress(address, scope);
     }
 
     public static VaList emptyVaList() {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -132,14 +132,14 @@ public class CallArranger {
         return handle;
     }
 
-    public static MemorySegment arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc, SegmentScope session) {
+    public static MemorySegment arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc, SegmentScope scope) {
         Bindings bindings = getBindings(mt, cDesc, true);
 
         if (bindings.isInMemoryReturn) {
             target = SharedUtils.adaptUpcallForIMR(target, true /* drop return, since we don't have bindings for it */);
         }
 
-        return UpcallLinker.make(CSysV, target, bindings.callingSequence, session);
+        return UpcallLinker.make(CSysV, target, bindings.callingSequence, scope);
     }
 
     private static boolean isInMemoryReturn(Optional<MemoryLayout> returnLayout) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
@@ -33,7 +33,7 @@ import java.lang.foreign.SegmentAllocator;
 import java.lang.foreign.VaList;
 import java.lang.foreign.ValueLayout;
 
-import jdk.internal.foreign.MemorySessionImpl;
+import jdk.internal.foreign.MemoryScopeImpl;
 import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.SharedUtils;
 
@@ -130,8 +130,8 @@ public non-sealed class SysVVaList implements VaList {
         this.fpLimit = fpLimit;
     }
 
-    private static SysVVaList readFromAddress(long address, SegmentScope session) {
-        MemorySegment segment = MemorySegment.ofAddress(address, LAYOUT.byteSize(), session);
+    private static SysVVaList readFromAddress(long address, SegmentScope scope) {
+        MemorySegment segment = MemorySegment.ofAddress(address, LAYOUT.byteSize(), scope);
         MemorySegment regSaveArea = getRegSaveArea(segment);
         MemorySegment overflowArgArea = getArgOverflowArea(segment);
         return new SysVVaList(segment, overflowArgArea, regSaveArea, MAX_GP_OFFSET, MAX_FP_OFFSET);
@@ -306,7 +306,7 @@ public non-sealed class SysVVaList implements VaList {
     @Override
     public void skip(MemoryLayout... layouts) {
         Objects.requireNonNull(layouts);
-        ((MemorySessionImpl) segment.scope()).checkValidState();
+        ((MemoryScopeImpl) segment.scope()).checkValidState();
         for (MemoryLayout layout : layouts) {
             Objects.requireNonNull(layout);
             TypeClass typeClass = TypeClass.classifyLayout(layout);
@@ -322,12 +322,12 @@ public non-sealed class SysVVaList implements VaList {
         }
     }
 
-    static SysVVaList.Builder builder(SegmentScope session) {
-        return new SysVVaList.Builder(session);
+    static SysVVaList.Builder builder(SegmentScope scope) {
+        return new SysVVaList.Builder(scope);
     }
 
-    public static VaList ofAddress(long address, SegmentScope session) {
-        return readFromAddress(address, session);
+    public static VaList ofAddress(long address, SegmentScope scope) {
+        return readFromAddress(address, scope);
     }
 
     @Override
@@ -359,15 +359,15 @@ public non-sealed class SysVVaList implements VaList {
     }
 
     public static non-sealed class Builder implements VaList.Builder {
-        private final SegmentScope session;
+        private final SegmentScope scope;
         private final MemorySegment reg_save_area;
         private long currentGPOffset = 0;
         private long currentFPOffset = FP_OFFSET;
         private final List<SimpleVaArg> stackArgs = new ArrayList<>();
 
-        public Builder(SegmentScope session) {
-            this.session = session;
-            this.reg_save_area = MemorySegment.allocateNative(LAYOUT_REG_SAVE_AREA, session);
+        public Builder(SegmentScope scope) {
+            this.scope = scope;
+            this.reg_save_area = MemorySegment.allocateNative(LAYOUT_REG_SAVE_AREA, scope);
         }
 
         @Override
@@ -446,12 +446,12 @@ public non-sealed class SysVVaList implements VaList {
                 return EMPTY;
             }
 
-            MemorySegment vaListSegment = MemorySegment.allocateNative(LAYOUT, session);
+            MemorySegment vaListSegment = MemorySegment.allocateNative(LAYOUT, scope);
             MemorySegment stackArgsSegment;
             if (!stackArgs.isEmpty()) {
                 long stackArgsSize = stackArgs.stream().reduce(0L,
                         (acc, e) -> acc + Utils.alignUp(e.layout.byteSize(), STACK_SLOT_SIZE), Long::sum);
-                stackArgsSegment = MemorySegment.allocateNative(stackArgsSize, 16, session);
+                stackArgsSegment = MemorySegment.allocateNative(stackArgsSize, 16, scope);
                 MemorySegment writeCursor = stackArgsSegment;
                 for (SimpleVaArg arg : stackArgs) {
                     if (arg.layout.byteSize() > 8) {
@@ -472,7 +472,7 @@ public non-sealed class SysVVaList implements VaList {
             VH_fp_offset.set(vaListSegment, (int) FP_OFFSET);
             VH_overflow_arg_area.set(vaListSegment, stackArgsSegment);
             VH_reg_save_area.set(vaListSegment, reg_save_area);
-            assert MemorySessionImpl.sameOwnerThread(reg_save_area.scope(), vaListSegment.scope());
+            assert MemoryScopeImpl.sameOwnerThread(reg_save_area.scope(), vaListSegment.scope());
             return new SysVVaList(vaListSegment, stackArgsSegment, reg_save_area, currentGPOffset, currentFPOffset);
         }
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
@@ -68,8 +68,8 @@ public final class SysVx64Linker extends AbstractLinker {
         return builder.build();
     }
 
-    public static VaList newVaListOfAddress(long address, SegmentScope session) {
-        return SysVVaList.ofAddress(address, session);
+    public static VaList newVaListOfAddress(long address, SegmentScope scope) {
+        return SysVVaList.ofAddress(address, scope);
     }
 
     public static VaList emptyVaList() {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -131,14 +131,14 @@ public class CallArranger {
         return handle;
     }
 
-    public static MemorySegment arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc, SegmentScope session) {
+    public static MemorySegment arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc, SegmentScope scope) {
         Bindings bindings = getBindings(mt, cDesc, true);
 
         if (bindings.isInMemoryReturn) {
             target = SharedUtils.adaptUpcallForIMR(target, false /* need the return value as well */);
         }
 
-        return UpcallLinker.make(CWindows, target, bindings.callingSequence, session);
+        return UpcallLinker.make(CWindows, target, bindings.callingSequence, scope);
     }
 
     private static boolean isInMemoryReturn(Optional<MemoryLayout> returnLayout) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
@@ -68,8 +68,8 @@ public final class Windowsx64Linker extends AbstractLinker {
         return builder.build();
     }
 
-    public static VaList newVaListOfAddress(long address, SegmentScope session) {
-        return WinVaList.ofAddress(address, session);
+    public static VaList newVaListOfAddress(long address, SegmentScope scope) {
+        return WinVaList.ofAddress(address, scope);
     }
 
     public static VaList emptyVaList() {

--- a/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess-bin.java.template
+++ b/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess-bin.java.template
@@ -1,698 +1,698 @@
     @ForceInline
-    public $type$ get$Type$(MemorySessionImpl session, Object base, long offset) {
+    public $type$ get$Type$(MemoryScopeImpl scope, Object base, long offset) {
         try {
-            return get$Type$Internal(session, base, offset);
+            return get$Type$Internal(scope, base, offset);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ get$Type$Internal(MemorySessionImpl session, Object base, long offset) {
+    private $type$ get$Type$Internal(MemoryScopeImpl scope, Object base, long offset) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.get$Type$(base, offset);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public void put$Type$(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    public void put$Type$(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            put$Type$Internal(session, base, offset, value);
+            put$Type$Internal(scope, base, offset, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private void put$Type$Internal(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    private void put$Type$Internal(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             UNSAFE.put$Type$(base, offset, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
 #if[Unaligned]
     @ForceInline
-    public $type$ get$Type$Unaligned(MemorySessionImpl session, Object base, long offset, boolean be) {
+    public $type$ get$Type$Unaligned(MemoryScopeImpl scope, Object base, long offset, boolean be) {
         try {
-            return get$Type$UnalignedInternal(session, base, offset, be);
+            return get$Type$UnalignedInternal(scope, base, offset, be);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ get$Type$UnalignedInternal(MemorySessionImpl session, Object base, long offset, boolean be) {
+    private $type$ get$Type$UnalignedInternal(MemoryScopeImpl scope, Object base, long offset, boolean be) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.get$Type$Unaligned(base, offset, be);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public void put$Type$Unaligned(MemorySessionImpl session, Object base, long offset, $type$ value, boolean be) {
+    public void put$Type$Unaligned(MemoryScopeImpl scope, Object base, long offset, $type$ value, boolean be) {
         try {
-            put$Type$UnalignedInternal(session, base, offset, value, be);
+            put$Type$UnalignedInternal(scope, base, offset, value, be);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private void put$Type$UnalignedInternal(MemorySessionImpl session, Object base, long offset, $type$ value, boolean be) {
+    private void put$Type$UnalignedInternal(MemoryScopeImpl scope, Object base, long offset, $type$ value, boolean be) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             UNSAFE.put$Type$Unaligned(base, offset, value, be);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 #end[Unaligned]
 
     @ForceInline
-    public $type$ get$Type$Volatile(MemorySessionImpl session, Object base, long offset) {
+    public $type$ get$Type$Volatile(MemoryScopeImpl scope, Object base, long offset) {
         try {
-            return get$Type$VolatileInternal(session, base, offset);
+            return get$Type$VolatileInternal(scope, base, offset);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ get$Type$VolatileInternal(MemorySessionImpl session, Object base, long offset) {
+    private $type$ get$Type$VolatileInternal(MemoryScopeImpl scope, Object base, long offset) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.get$Type$Volatile(base, offset);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public void put$Type$Volatile(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    public void put$Type$Volatile(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            put$Type$VolatileInternal(session, base, offset, value);
+            put$Type$VolatileInternal(scope, base, offset, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private void put$Type$VolatileInternal(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    private void put$Type$VolatileInternal(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             UNSAFE.put$Type$Volatile(base, offset, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public $type$ get$Type$Acquire(MemorySessionImpl session, Object base, long offset) {
+    public $type$ get$Type$Acquire(MemoryScopeImpl scope, Object base, long offset) {
         try {
-            return get$Type$AcquireInternal(session, base, offset);
+            return get$Type$AcquireInternal(scope, base, offset);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ get$Type$AcquireInternal(MemorySessionImpl session, Object base, long offset) {
+    private $type$ get$Type$AcquireInternal(MemoryScopeImpl scope, Object base, long offset) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.get$Type$Acquire(base, offset);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public void put$Type$Release(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    public void put$Type$Release(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            put$Type$ReleaseInternal(session, base, offset, value);
+            put$Type$ReleaseInternal(scope, base, offset, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private void put$Type$ReleaseInternal(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    private void put$Type$ReleaseInternal(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             UNSAFE.put$Type$Release(base, offset, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public $type$ get$Type$Opaque(MemorySessionImpl session, Object base, long offset) {
+    public $type$ get$Type$Opaque(MemoryScopeImpl scope, Object base, long offset) {
         try {
-            return get$Type$OpaqueInternal(session, base, offset);
+            return get$Type$OpaqueInternal(scope, base, offset);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ get$Type$OpaqueInternal(MemorySessionImpl session, Object base, long offset) {
+    private $type$ get$Type$OpaqueInternal(MemoryScopeImpl scope, Object base, long offset) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.get$Type$Opaque(base, offset);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
     @ForceInline
-    public void put$Type$Opaque(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    public void put$Type$Opaque(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            put$Type$OpaqueInternal(session, base, offset, value);
+            put$Type$OpaqueInternal(scope, base, offset, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private void put$Type$OpaqueInternal(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    private void put$Type$OpaqueInternal(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             UNSAFE.put$Type$Opaque(base, offset, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 #if[CAS]
     @ForceInline
-    public boolean compareAndSet$Type$(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
+    public boolean compareAndSet$Type$(MemoryScopeImpl scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
-            return compareAndSet$Type$Internal(session, base, offset, expected, value);
+            return compareAndSet$Type$Internal(scope, base, offset, expected, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private boolean compareAndSet$Type$Internal(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
+    private boolean compareAndSet$Type$Internal(MemoryScopeImpl scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.compareAndSet$Type$(base, offset, expected, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public $type$ compareAndExchange$Type$(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
+    public $type$ compareAndExchange$Type$(MemoryScopeImpl scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
-            return compareAndExchange$Type$Internal(session, base, offset, expected, value);
+            return compareAndExchange$Type$Internal(scope, base, offset, expected, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ compareAndExchange$Type$Internal(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
+    private $type$ compareAndExchange$Type$Internal(MemoryScopeImpl scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.compareAndExchange$Type$(base, offset, expected, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public $type$ compareAndExchange$Type$Acquire(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
+    public $type$ compareAndExchange$Type$Acquire(MemoryScopeImpl scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
-            return compareAndExchange$Type$AcquireInternal(session, base, offset, expected, value);
+            return compareAndExchange$Type$AcquireInternal(scope, base, offset, expected, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ compareAndExchange$Type$AcquireInternal(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
+    private $type$ compareAndExchange$Type$AcquireInternal(MemoryScopeImpl scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.compareAndExchange$Type$Acquire(base, offset, expected, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public $type$ compareAndExchange$Type$Release(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
+    public $type$ compareAndExchange$Type$Release(MemoryScopeImpl scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
-            return compareAndExchange$Type$ReleaseInternal(session, base, offset, expected, value);
+            return compareAndExchange$Type$ReleaseInternal(scope, base, offset, expected, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ compareAndExchange$Type$ReleaseInternal(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
+    private $type$ compareAndExchange$Type$ReleaseInternal(MemoryScopeImpl scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.compareAndExchange$Type$Release(base, offset, expected, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public boolean weakCompareAndSet$Type$Plain(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
+    public boolean weakCompareAndSet$Type$Plain(MemoryScopeImpl scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
-            return weakCompareAndSet$Type$PlainInternal(session, base, offset, expected, value);
+            return weakCompareAndSet$Type$PlainInternal(scope, base, offset, expected, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private boolean weakCompareAndSet$Type$PlainInternal(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
+    private boolean weakCompareAndSet$Type$PlainInternal(MemoryScopeImpl scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.weakCompareAndSet$Type$Plain(base, offset, expected, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public boolean weakCompareAndSet$Type$(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
+    public boolean weakCompareAndSet$Type$(MemoryScopeImpl scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
-            return weakCompareAndSet$Type$Internal(session, base, offset, expected, value);
+            return weakCompareAndSet$Type$Internal(scope, base, offset, expected, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private boolean weakCompareAndSet$Type$Internal(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
+    private boolean weakCompareAndSet$Type$Internal(MemoryScopeImpl scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.weakCompareAndSet$Type$(base, offset, expected, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public boolean weakCompareAndSet$Type$Acquire(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
+    public boolean weakCompareAndSet$Type$Acquire(MemoryScopeImpl scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
-            return weakCompareAndSet$Type$AcquireInternal(session, base, offset, expected, value);
+            return weakCompareAndSet$Type$AcquireInternal(scope, base, offset, expected, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private boolean weakCompareAndSet$Type$AcquireInternal(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
+    private boolean weakCompareAndSet$Type$AcquireInternal(MemoryScopeImpl scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.weakCompareAndSet$Type$Acquire(base, offset, expected, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public boolean weakCompareAndSet$Type$Release(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
+    public boolean weakCompareAndSet$Type$Release(MemoryScopeImpl scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
-            return weakCompareAndSet$Type$ReleaseInternal(session, base, offset, expected, value);
+            return weakCompareAndSet$Type$ReleaseInternal(scope, base, offset, expected, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private boolean weakCompareAndSet$Type$ReleaseInternal(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
+    private boolean weakCompareAndSet$Type$ReleaseInternal(MemoryScopeImpl scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.weakCompareAndSet$Type$Release(base, offset, expected, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public $type$ getAndSet$Type$(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    public $type$ getAndSet$Type$(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            return getAndSet$Type$Internal(session, base, offset, value);
+            return getAndSet$Type$Internal(scope, base, offset, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ getAndSet$Type$Internal(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    private $type$ getAndSet$Type$Internal(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.getAndSet$Type$(base, offset, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public $type$ getAndSet$Type$Acquire(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    public $type$ getAndSet$Type$Acquire(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            return getAndSet$Type$AcquireInternal(session, base, offset, value);
+            return getAndSet$Type$AcquireInternal(scope, base, offset, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ getAndSet$Type$AcquireInternal(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    private $type$ getAndSet$Type$AcquireInternal(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.getAndSet$Type$Acquire(base, offset, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public $type$ getAndSet$Type$Release(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    public $type$ getAndSet$Type$Release(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            return getAndSet$Type$ReleaseInternal(session, base, offset, value);
+            return getAndSet$Type$ReleaseInternal(scope, base, offset, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ getAndSet$Type$ReleaseInternal(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    private $type$ getAndSet$Type$ReleaseInternal(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.getAndSet$Type$Release(base, offset, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 #end[CAS]
 
 #if[AtomicAdd]
     @ForceInline
-    public $type$ getAndAdd$Type$(MemorySessionImpl session, Object base, long offset, $type$ delta) {
+    public $type$ getAndAdd$Type$(MemoryScopeImpl scope, Object base, long offset, $type$ delta) {
         try {
-            return getAndAdd$Type$Internal(session, base, offset, delta);
+            return getAndAdd$Type$Internal(scope, base, offset, delta);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ getAndAdd$Type$Internal(MemorySessionImpl session, Object base, long offset, $type$ delta) {
+    private $type$ getAndAdd$Type$Internal(MemoryScopeImpl scope, Object base, long offset, $type$ delta) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.getAndAdd$Type$(base, offset, delta);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public $type$ getAndAdd$Type$Acquire(MemorySessionImpl session, Object base, long offset, $type$ delta) {
+    public $type$ getAndAdd$Type$Acquire(MemoryScopeImpl scope, Object base, long offset, $type$ delta) {
         try {
-            return getAndAdd$Type$AcquireInternal(session, base, offset, delta);
+            return getAndAdd$Type$AcquireInternal(scope, base, offset, delta);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ getAndAdd$Type$AcquireInternal(MemorySessionImpl session, Object base, long offset, $type$ delta) {
+    private $type$ getAndAdd$Type$AcquireInternal(MemoryScopeImpl scope, Object base, long offset, $type$ delta) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.getAndAdd$Type$Acquire(base, offset, delta);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public $type$ getAndAdd$Type$Release(MemorySessionImpl session, Object base, long offset, $type$ delta) {
+    public $type$ getAndAdd$Type$Release(MemoryScopeImpl scope, Object base, long offset, $type$ delta) {
         try {
-            return getAndAdd$Type$ReleaseInternal(session, base, offset, delta);
+            return getAndAdd$Type$ReleaseInternal(scope, base, offset, delta);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ getAndAdd$Type$ReleaseInternal(MemorySessionImpl session, Object base, long offset, $type$ delta) {
+    private $type$ getAndAdd$Type$ReleaseInternal(MemoryScopeImpl scope, Object base, long offset, $type$ delta) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.getAndAdd$Type$Release(base, offset, delta);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 #end[AtomicAdd]
 
 #if[Bitwise]
     @ForceInline
-    public $type$ getAndBitwiseOr$Type$(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    public $type$ getAndBitwiseOr$Type$(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            return getAndBitwiseOr$Type$Internal(session, base, offset, value);
+            return getAndBitwiseOr$Type$Internal(scope, base, offset, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ getAndBitwiseOr$Type$Internal(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    private $type$ getAndBitwiseOr$Type$Internal(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.getAndBitwiseOr$Type$(base, offset, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public $type$ getAndBitwiseOr$Type$Acquire(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    public $type$ getAndBitwiseOr$Type$Acquire(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            return getAndBitwiseOr$Type$AcquireInternal(session, base, offset, value);
+            return getAndBitwiseOr$Type$AcquireInternal(scope, base, offset, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ getAndBitwiseOr$Type$AcquireInternal(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    private $type$ getAndBitwiseOr$Type$AcquireInternal(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.getAndBitwiseOr$Type$Acquire(base, offset, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public $type$ getAndBitwiseOr$Type$Release(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    public $type$ getAndBitwiseOr$Type$Release(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            return getAndBitwiseOr$Type$ReleaseInternal(session, base, offset, value);
+            return getAndBitwiseOr$Type$ReleaseInternal(scope, base, offset, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ getAndBitwiseOr$Type$ReleaseInternal(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    private $type$ getAndBitwiseOr$Type$ReleaseInternal(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.getAndBitwiseOr$Type$Release(base, offset, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public $type$ getAndBitwiseAnd$Type$(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    public $type$ getAndBitwiseAnd$Type$(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            return getAndBitwiseAnd$Type$Internal(session, base, offset, value);
+            return getAndBitwiseAnd$Type$Internal(scope, base, offset, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ getAndBitwiseAnd$Type$Internal(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    private $type$ getAndBitwiseAnd$Type$Internal(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.getAndBitwiseAnd$Type$(base, offset, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public $type$ getAndBitwiseAnd$Type$Acquire(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    public $type$ getAndBitwiseAnd$Type$Acquire(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            return getAndBitwiseAnd$Type$AcquireInternal(session, base, offset, value);
+            return getAndBitwiseAnd$Type$AcquireInternal(scope, base, offset, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ getAndBitwiseAnd$Type$AcquireInternal(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    private $type$ getAndBitwiseAnd$Type$AcquireInternal(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.getAndBitwiseAnd$Type$Acquire(base, offset, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public $type$ getAndBitwiseAnd$Type$Release(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    public $type$ getAndBitwiseAnd$Type$Release(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            return getAndBitwiseAnd$Type$ReleaseInternal(session, base, offset, value);
+            return getAndBitwiseAnd$Type$ReleaseInternal(scope, base, offset, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ getAndBitwiseAnd$Type$ReleaseInternal(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    private $type$ getAndBitwiseAnd$Type$ReleaseInternal(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.getAndBitwiseAnd$Type$Release(base, offset, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public $type$ getAndBitwiseXor$Type$(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    public $type$ getAndBitwiseXor$Type$(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            return getAndBitwiseXor$Type$Internal(session, base, offset, value);
+            return getAndBitwiseXor$Type$Internal(scope, base, offset, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ getAndBitwiseXor$Type$Internal(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    private $type$ getAndBitwiseXor$Type$Internal(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.getAndBitwiseXor$Type$(base, offset, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public $type$ getAndBitwiseXor$Type$Acquire(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    public $type$ getAndBitwiseXor$Type$Acquire(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            return getAndBitwiseXor$Type$AcquireInternal(session, base, offset, value);
+            return getAndBitwiseXor$Type$AcquireInternal(scope, base, offset, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ getAndBitwiseXor$Type$AcquireInternal(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    private $type$ getAndBitwiseXor$Type$AcquireInternal(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.getAndBitwiseXor$Type$Acquire(base, offset, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public $type$ getAndBitwiseXor$Type$Release(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    public $type$ getAndBitwiseXor$Type$Release(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            return getAndBitwiseXor$Type$ReleaseInternal(session, base, offset, value);
+            return getAndBitwiseXor$Type$ReleaseInternal(scope, base, offset, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private $type$ getAndBitwiseXor$Type$ReleaseInternal(MemorySessionImpl session, Object base, long offset, $type$ value) {
+    private $type$ getAndBitwiseXor$Type$ReleaseInternal(MemoryScopeImpl scope, Object base, long offset, $type$ value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return UNSAFE.getAndBitwiseXor$Type$Release(base, offset, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 #end[Bitwise]

--- a/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
+++ b/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
@@ -37,7 +37,7 @@ import java.util.function.Supplier;
 import jdk.internal.access.JavaNioAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
-import jdk.internal.foreign.MemorySessionImpl;
+import jdk.internal.foreign.MemoryScopeImpl;
 import jdk.internal.util.ArraysSupport;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.vector.VectorSupport;
@@ -46,7 +46,7 @@ import jdk.internal.vm.vector.VectorSupport;
 /**
  * This class defines low-level methods to access on-heap and off-heap memory. The methods in this class
  * can be thought of as thin wrappers around methods provided in the {@link Unsafe} class. All the methods in this
- * class accept one or more {@link MemorySessionImpl} parameter, which is used to validate as to whether access to memory
+ * class accept one or more {@link MemoryScopeImpl} parameter, which is used to validate as to whether access to memory
  * can be performed in a safe fashion - more specifically, to ensure that the memory being accessed has not
  * already been released (which would result in a hard VM crash).
  * <p>
@@ -56,17 +56,17 @@ import jdk.internal.vm.vector.VectorSupport;
  * a memory region while another thread is releasing it.
  * <p>
  * This class provides tools to manage races when multiple threads are accessing and/or releasing the same memory
- * session concurrently. More specifically, when a thread wants to release a memory session, it should call the
- * {@link ScopedMemoryAccess#closeScope(MemorySessionImpl)} method. This method initiates thread-local handshakes with all the other VM threads,
- * which are then stopped one by one. If any thread is found accessing a resource associated to the very memory session
- * being closed, the handshake fails, and the session will not be closed.
+ * scope concurrently. More specifically, when a thread wants to release a memory scope, it should call the
+ * {@link ScopedMemoryAccess#closeScope(MemoryScopeImpl)} method. This method initiates thread-local handshakes with all the other VM threads,
+ * which are then stopped one by one. If any thread is found accessing a resource associated to the very memory scope
+ * being closed, the handshake fails, and the scope will not be closed.
  * <p>
  * This synchronization strategy relies on the idea that accessing memory is atomic with respect to checking the
- * validity of the session associated with that memory region - that is, a thread that wants to perform memory access will be
+ * validity of the scope associated with that memory region - that is, a thread that wants to perform memory access will be
  * suspended either <em>before</em> a liveness check or <em>after</em> the memory access. To ensure this atomicity,
  * all methods in this class are marked with the special {@link Scoped} annotation, which is recognized by the VM,
  * and used during the thread-local handshake to detect (and stop) threads performing potentially problematic memory access
- * operations. Additionally, to make sure that the session object(s) of the memory being accessed is always
+ * operations. Additionally, to make sure that the scope object(s) of the memory being accessed is always
  * reachable during an access operation, all the methods in this class add reachability fences around the underlying
  * unsafe access.
  * <p>
@@ -83,11 +83,11 @@ public class ScopedMemoryAccess {
         registerNatives();
     }
 
-    public boolean closeScope(MemorySessionImpl session) {
-        return closeScope0(session);
+    public boolean closeScope(MemoryScopeImpl scope) {
+        return closeScope0(scope);
     }
 
-    native boolean closeScope0(MemorySessionImpl session);
+    native boolean closeScope0(MemoryScopeImpl scope);
 
     private ScopedMemoryAccess() {}
 
@@ -121,202 +121,202 @@ public class ScopedMemoryAccess {
     // bulk ops
 
     @ForceInline
-    public void copyMemory(MemorySessionImpl srcSession, MemorySessionImpl dstSession,
+    public void copyMemory(MemoryScopeImpl srcScope, MemoryScopeImpl dstScope,
                                    Object srcBase, long srcOffset,
                                    Object destBase, long destOffset,
                                    long bytes) {
           try {
-              copyMemoryInternal(srcSession, dstSession, srcBase, srcOffset, destBase, destOffset, bytes);
+              copyMemoryInternal(srcScope, dstScope, srcBase, srcOffset, destBase, destOffset, bytes);
           } catch (ScopedAccessError ex) {
               throw ex.newRuntimeException();
           }
     }
 
     @ForceInline @Scoped
-    private void copyMemoryInternal(MemorySessionImpl srcSession, MemorySessionImpl dstSession,
+    private void copyMemoryInternal(MemoryScopeImpl srcScope, MemoryScopeImpl dstScope,
                                Object srcBase, long srcOffset,
                                Object destBase, long destOffset,
                                long bytes) {
         try {
-            if (srcSession != null) {
-                srcSession.checkValidStateRaw();
+            if (srcScope != null) {
+                srcScope.checkValidStateRaw();
             }
-            if (dstSession != null) {
-                dstSession.checkValidStateRaw();
+            if (dstScope != null) {
+                dstScope.checkValidStateRaw();
             }
             UNSAFE.copyMemory(srcBase, srcOffset, destBase, destOffset, bytes);
         } finally {
-            Reference.reachabilityFence(srcSession);
-            Reference.reachabilityFence(dstSession);
+            Reference.reachabilityFence(srcScope);
+            Reference.reachabilityFence(dstScope);
         }
     }
 
     @ForceInline
-    public void copySwapMemory(MemorySessionImpl srcSession, MemorySessionImpl dstSession,
+    public void copySwapMemory(MemoryScopeImpl srcScope, MemoryScopeImpl dstScope,
                                    Object srcBase, long srcOffset,
                                    Object destBase, long destOffset,
                                    long bytes, long elemSize) {
           try {
-              copySwapMemoryInternal(srcSession, dstSession, srcBase, srcOffset, destBase, destOffset, bytes, elemSize);
+              copySwapMemoryInternal(srcScope, dstScope, srcBase, srcOffset, destBase, destOffset, bytes, elemSize);
           } catch (ScopedAccessError ex) {
               throw ex.newRuntimeException();
           }
     }
 
     @ForceInline @Scoped
-    private void copySwapMemoryInternal(MemorySessionImpl srcSession, MemorySessionImpl dstSession,
+    private void copySwapMemoryInternal(MemoryScopeImpl srcScope, MemoryScopeImpl dstScope,
                                Object srcBase, long srcOffset,
                                Object destBase, long destOffset,
                                long bytes, long elemSize) {
         try {
-            if (srcSession != null) {
-                srcSession.checkValidStateRaw();
+            if (srcScope != null) {
+                srcScope.checkValidStateRaw();
             }
-            if (dstSession != null) {
-                dstSession.checkValidStateRaw();
+            if (dstScope != null) {
+                dstScope.checkValidStateRaw();
             }
             UNSAFE.copySwapMemory(srcBase, srcOffset, destBase, destOffset, bytes, elemSize);
         } finally {
-            Reference.reachabilityFence(srcSession);
-            Reference.reachabilityFence(dstSession);
+            Reference.reachabilityFence(srcScope);
+            Reference.reachabilityFence(dstScope);
         }
     }
 
     @ForceInline
-    public void setMemory(MemorySessionImpl session, Object o, long offset, long bytes, byte value) {
+    public void setMemory(MemoryScopeImpl scope, Object o, long offset, long bytes, byte value) {
         try {
-            setMemoryInternal(session, o, offset, bytes, value);
+            setMemoryInternal(scope, o, offset, bytes, value);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private void setMemoryInternal(MemorySessionImpl session, Object o, long offset, long bytes, byte value) {
+    private void setMemoryInternal(MemoryScopeImpl scope, Object o, long offset, long bytes, byte value) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             UNSAFE.setMemory(o, offset, bytes, value);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public int vectorizedMismatch(MemorySessionImpl aSession, MemorySessionImpl bSession,
+    public int vectorizedMismatch(MemoryScopeImpl aScope, MemoryScopeImpl bScope,
                                              Object a, long aOffset,
                                              Object b, long bOffset,
                                              int length,
                                              int log2ArrayIndexScale) {
         try {
-            return vectorizedMismatchInternal(aSession, bSession, a, aOffset, b, bOffset, length, log2ArrayIndexScale);
+            return vectorizedMismatchInternal(aScope, bScope, a, aOffset, b, bOffset, length, log2ArrayIndexScale);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    private int vectorizedMismatchInternal(MemorySessionImpl aSession, MemorySessionImpl bSession,
+    private int vectorizedMismatchInternal(MemoryScopeImpl aScope, MemoryScopeImpl bScope,
                                              Object a, long aOffset,
                                              Object b, long bOffset,
                                              int length,
                                              int log2ArrayIndexScale) {
         try {
-            if (aSession != null) {
-                aSession.checkValidStateRaw();
+            if (aScope != null) {
+                aScope.checkValidStateRaw();
             }
-            if (bSession != null) {
-                bSession.checkValidStateRaw();
+            if (bScope != null) {
+                bScope.checkValidStateRaw();
             }
             return ArraysSupport.vectorizedMismatch(a, aOffset, b, bOffset, length, log2ArrayIndexScale);
         } finally {
-            Reference.reachabilityFence(aSession);
-            Reference.reachabilityFence(bSession);
+            Reference.reachabilityFence(aScope);
+            Reference.reachabilityFence(bScope);
         }
     }
 
     @ForceInline
-    public boolean isLoaded(MemorySessionImpl session, long address, boolean isSync, long size) {
+    public boolean isLoaded(MemoryScopeImpl scope, long address, boolean isSync, long size) {
         try {
-            return isLoadedInternal(session, address, isSync, size);
+            return isLoadedInternal(scope, address, isSync, size);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    public boolean isLoadedInternal(MemorySessionImpl session, long address, boolean isSync, long size) {
+    public boolean isLoadedInternal(MemoryScopeImpl scope, long address, boolean isSync, long size) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             return SharedSecrets.getJavaNioAccess().isLoaded(address, isSync, size);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public void load(MemorySessionImpl session, long address, boolean isSync, long size) {
+    public void load(MemoryScopeImpl scope, long address, boolean isSync, long size) {
         try {
-            loadInternal(session, address, isSync, size);
+            loadInternal(scope, address, isSync, size);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    public void loadInternal(MemorySessionImpl session, long address, boolean isSync, long size) {
+    public void loadInternal(MemoryScopeImpl scope, long address, boolean isSync, long size) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             SharedSecrets.getJavaNioAccess().load(address, isSync, size);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public void unload(MemorySessionImpl session, long address, boolean isSync, long size) {
+    public void unload(MemoryScopeImpl scope, long address, boolean isSync, long size) {
         try {
-            unloadInternal(session, address, isSync, size);
+            unloadInternal(scope, address, isSync, size);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    public void unloadInternal(MemorySessionImpl session, long address, boolean isSync, long size) {
+    public void unloadInternal(MemoryScopeImpl scope, long address, boolean isSync, long size) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             SharedSecrets.getJavaNioAccess().unload(address, isSync, size);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
     @ForceInline
-    public void force(MemorySessionImpl session, FileDescriptor fd, long address, boolean isSync, long index, long length) {
+    public void force(MemoryScopeImpl scope, FileDescriptor fd, long address, boolean isSync, long index, long length) {
         try {
-            forceInternal(session, fd, address, isSync, index, length);
+            forceInternal(scope, fd, address, isSync, index, length);
         } catch (ScopedAccessError ex) {
             throw ex.newRuntimeException();
         }
     }
 
     @ForceInline @Scoped
-    public void forceInternal(MemorySessionImpl session, FileDescriptor fd, long address, boolean isSync, long index, long length) {
+    public void forceInternal(MemoryScopeImpl scope, FileDescriptor fd, long address, boolean isSync, long index, long length) {
         try {
-            if (session != null) {
-                session.checkValidStateRaw();
+            if (scope != null) {
+                scope.checkValidStateRaw();
             }
             SharedSecrets.getJavaNioAccess().force(fd, address, isSync, index, length);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
@@ -336,7 +336,7 @@ public class ScopedMemoryAccess {
 
         try {
             return loadFromMemorySegmentScopedInternal(
-                    msp.sessionImpl(),
+                    msp.scopeImpl(),
                     vmClass, e, length,
                     msp, offset,
                     s,
@@ -350,20 +350,20 @@ public class ScopedMemoryAccess {
     @ForceInline
     private static
     <V extends VectorSupport.Vector<E>, E, S extends VectorSupport.VectorSpecies<E>>
-    V loadFromMemorySegmentScopedInternal(MemorySessionImpl session,
+    V loadFromMemorySegmentScopedInternal(MemoryScopeImpl scope,
                                           Class<? extends V> vmClass, Class<E> e, int length,
                                           AbstractMemorySegmentImpl msp, long offset,
                                           S s,
                                           VectorSupport.LoadOperation<AbstractMemorySegmentImpl, V, S> defaultImpl) {
         try {
-            session.checkValidStateRaw();
+            scope.checkValidStateRaw();
 
             return VectorSupport.load(vmClass, e, length,
                     msp.unsafeGetBase(), msp.unsafeGetOffset() + offset,
                     msp, offset, s,
                     defaultImpl);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
@@ -381,7 +381,7 @@ public class ScopedMemoryAccess {
 
         try {
             return loadFromMemorySegmentMaskedScopedInternal(
-                    msp.sessionImpl(),
+                    msp.scopeImpl(),
                     vmClass, maskClass, e, length,
                     msp, offset, m,
                     s, offsetInRange,
@@ -396,20 +396,20 @@ public class ScopedMemoryAccess {
     private static
     <V extends VectorSupport.Vector<E>, E, S extends VectorSupport.VectorSpecies<E>,
      M extends VectorSupport.VectorMask<E>>
-    V loadFromMemorySegmentMaskedScopedInternal(MemorySessionImpl session, Class<? extends V> vmClass,
+    V loadFromMemorySegmentMaskedScopedInternal(MemoryScopeImpl scope, Class<? extends V> vmClass,
                                                 Class<M> maskClass, Class<E> e, int length,
                                                 AbstractMemorySegmentImpl msp, long offset, M m,
                                                 S s, int offsetInRange,
                                                 VectorSupport.LoadVectorMaskedOperation<AbstractMemorySegmentImpl, V, S, M> defaultImpl) {
         try {
-            session.checkValidStateRaw();
+            scope.checkValidStateRaw();
 
             return VectorSupport.loadMasked(vmClass, maskClass, e, length,
                     msp.unsafeGetBase(), msp.unsafeGetOffset() + offset, m, offsetInRange,
                     msp, offset, s,
                     defaultImpl);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
@@ -427,7 +427,7 @@ public class ScopedMemoryAccess {
 
         try {
             storeIntoMemorySegmentScopedInternal(
-                    msp.sessionImpl(),
+                    msp.scopeImpl(),
                     vmClass, e, length,
                     v,
                     msp, offset,
@@ -441,13 +441,13 @@ public class ScopedMemoryAccess {
     @ForceInline
     private static
     <V extends VectorSupport.Vector<E>, E>
-    void storeIntoMemorySegmentScopedInternal(MemorySessionImpl session,
+    void storeIntoMemorySegmentScopedInternal(MemoryScopeImpl scope,
                                               Class<? extends V> vmClass, Class<E> e, int length,
                                               V v,
                                               AbstractMemorySegmentImpl msp, long offset,
                                               VectorSupport.StoreVectorOperation<AbstractMemorySegmentImpl, V> defaultImpl) {
         try {
-            session.checkValidStateRaw();
+            scope.checkValidStateRaw();
 
             VectorSupport.store(vmClass, e, length,
                     msp.unsafeGetBase(), msp.unsafeGetOffset() + offset,
@@ -455,7 +455,7 @@ public class ScopedMemoryAccess {
                     msp, offset,
                     defaultImpl);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 
@@ -473,7 +473,7 @@ public class ScopedMemoryAccess {
 
         try {
             storeIntoMemorySegmentMaskedScopedInternal(
-                    msp.sessionImpl(),
+                    msp.scopeImpl(),
                     vmClass, maskClass, e, length,
                     v, m,
                     msp, offset,
@@ -487,13 +487,13 @@ public class ScopedMemoryAccess {
     @ForceInline
     private static
     <V extends VectorSupport.Vector<E>, E, M extends VectorSupport.VectorMask<E>>
-    void storeIntoMemorySegmentMaskedScopedInternal(MemorySessionImpl session,
+    void storeIntoMemorySegmentMaskedScopedInternal(MemoryScopeImpl scope,
                                                     Class<? extends V> vmClass, Class<M> maskClass,
                                                     Class<E> e, int length, V v, M m,
                                                     AbstractMemorySegmentImpl msp, long offset,
                                                     VectorSupport.StoreVectorMaskedOperation<AbstractMemorySegmentImpl, V, M> defaultImpl) {
         try {
-            session.checkValidStateRaw();
+            scope.checkValidStateRaw();
 
             VectorSupport.storeMasked(vmClass, maskClass, e, length,
                     msp.unsafeGetBase(), msp.unsafeGetOffset() + offset,
@@ -501,7 +501,7 @@ public class ScopedMemoryAccess {
                     msp, offset,
                     defaultImpl);
         } finally {
-            Reference.reachabilityFence(session);
+            Reference.reachabilityFence(scope);
         }
     }
 

--- a/src/java.base/share/classes/sun/nio/ch/DatagramChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/DatagramChannelImpl.java
@@ -784,7 +784,7 @@ class DatagramChannelImpl
                                         boolean connected)
         throws IOException
     {
-        NIO_ACCESS.acquireSession(bb);
+        NIO_ACCESS.acquireScope(bb);
         try {
             int n = receive0(fd,
                             ((DirectBuffer)bb).address() + pos, rem,
@@ -794,7 +794,7 @@ class DatagramChannelImpl
                 bb.position(pos + n);
             return n;
         } finally {
-            NIO_ACCESS.releaseSession(bb);
+            NIO_ACCESS.releaseScope(bb);
         }
     }
 
@@ -939,7 +939,7 @@ class DatagramChannelImpl
         int rem = (pos <= lim ? lim - pos : 0);
 
         int written;
-        NIO_ACCESS.acquireSession(bb);
+        NIO_ACCESS.acquireScope(bb);
         try {
             int addressLen = targetSocketAddress(target);
             written = send0(fd, ((DirectBuffer)bb).address() + pos, rem,
@@ -949,7 +949,7 @@ class DatagramChannelImpl
                 throw pue;
             written = rem;
         } finally {
-            NIO_ACCESS.releaseSession(bb);
+            NIO_ACCESS.releaseScope(bb);
         }
         if (written > 0)
             bb.position(pos + written);

--- a/src/java.base/share/classes/sun/nio/ch/DirectBuffer.java
+++ b/src/java.base/share/classes/sun/nio/ch/DirectBuffer.java
@@ -31,7 +31,7 @@ import jdk.internal.ref.Cleaner;
 public interface DirectBuffer {
 
     // Use of the returned address must be guarded if this DirectBuffer
-    // is backed by a memory session that is explicitly closeable.
+    // is backed by a memory scope that is explicitly closeable.
     //
     // Failure to do this means the outcome is undefined including
     // silent unrelated memory mutation and JVM crashes.

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -50,7 +50,7 @@ import jdk.internal.access.JavaIOFileDescriptorAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.foreign.MappedMemorySegmentImpl;
-import jdk.internal.foreign.MemorySessionImpl;
+import jdk.internal.foreign.MemoryScopeImpl;
 import jdk.internal.misc.Blocker;
 import jdk.internal.misc.ExtendedMapMode;
 import jdk.internal.misc.Unsafe;
@@ -1208,13 +1208,13 @@ public class FileChannelImpl
 
     @Override
     public MemorySegment map(MapMode mode, long offset, long size,
-                             SegmentScope session)
+                             SegmentScope scope)
             throws IOException
     {
         Objects.requireNonNull(mode,"Mode is null");
-        Objects.requireNonNull(session, "Session is null");
-        MemorySessionImpl sessionImpl = (MemorySessionImpl) session;
-        sessionImpl.checkValidState();
+        Objects.requireNonNull(scope, "Scope is null");
+        MemoryScopeImpl scopeImpl = (MemoryScopeImpl) scope;
+        scopeImpl.checkValidState();
         if (offset < 0)
             throw new IllegalArgumentException("Requested bytes offset must be >= 0.");
         if (size < 0)
@@ -1230,18 +1230,18 @@ public class FileChannelImpl
         if (unmapper != null) {
             AbstractMemorySegmentImpl segment =
                 new MappedMemorySegmentImpl(unmapper.address(), unmapper, size,
-                                            readOnly, session);
-            MemorySessionImpl.ResourceList.ResourceCleanup resource =
-                new MemorySessionImpl.ResourceList.ResourceCleanup() {
+                                            readOnly, scope);
+            MemoryScopeImpl.ResourceList.ResourceCleanup resource =
+                new MemoryScopeImpl.ResourceList.ResourceCleanup() {
                     @Override
                     public void cleanup() {
                         unmapper.unmap();
                     }
                 };
-            sessionImpl.addOrCleanupIfFail(resource);
+            scopeImpl.addOrCleanupIfFail(resource);
             return segment;
         } else {
-            return new MappedMemorySegmentImpl.EmptyMappedMemorySegmentImpl(readOnly, sessionImpl);
+            return new MappedMemorySegmentImpl.EmptyMappedMemorySegmentImpl(readOnly, scopeImpl);
         }
     }
 

--- a/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
@@ -179,14 +179,14 @@ abstract class UnixUserDefinedFileAttributeView
         int rem = (pos <= lim ? lim - pos : 0);
 
         if (dst instanceof sun.nio.ch.DirectBuffer ddst) {
-            NIO_ACCESS.acquireSession(dst);
+            NIO_ACCESS.acquireScope(dst);
             try {
                 long address = ddst.address() + pos;
                 int n = read(name, address, rem);
                 dst.position(pos + n);
                 return n;
             } finally {
-                NIO_ACCESS.releaseSession(dst);
+                NIO_ACCESS.releaseScope(dst);
             }
         } else {
             try (NativeBuffer nb = NativeBuffers.getNativeBuffer(rem)) {
@@ -242,14 +242,14 @@ abstract class UnixUserDefinedFileAttributeView
         int rem = (pos <= lim ? lim - pos : 0);
 
         if (src instanceof sun.nio.ch.DirectBuffer buf) {
-            NIO_ACCESS.acquireSession(src);
+            NIO_ACCESS.acquireScope(src);
             try {
                 long address = buf.address() + pos;
                 write(name, address, rem);
                 src.position(pos + rem);
                 return rem;
             } finally {
-                NIO_ACCESS.releaseSession(src);
+                NIO_ACCESS.releaseScope(src);
             }
         } else {
             try (NativeBuffer nb = NativeBuffers.getNativeBuffer(rem)) {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
@@ -709,9 +709,9 @@ final class P11AEADCipher extends CipherSpi {
         }
 
         boolean doCancel = true;
-        NIO_ACCESS.acquireSession(inBuffer);
+        NIO_ACCESS.acquireScope(inBuffer);
         try {
-            NIO_ACCESS.acquireSession(outBuffer);
+            NIO_ACCESS.acquireScope(outBuffer);
             try {
                 try {
                     ensureInitialized();
@@ -793,10 +793,10 @@ final class P11AEADCipher extends CipherSpi {
                     reset(doCancel);
                 }
             } finally {
-                NIO_ACCESS.releaseSession(outBuffer);
+                NIO_ACCESS.releaseScope(outBuffer);
             }
         } finally {
-            NIO_ACCESS.releaseSession(inBuffer);
+            NIO_ACCESS.releaseScope(inBuffer);
         }
     }
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
@@ -682,9 +682,9 @@ final class P11Cipher extends CipherSpi {
             throw new ShortBufferException();
         }
         int origPos = inBuffer.position();
-        NIO_ACCESS.acquireSession(inBuffer);
+        NIO_ACCESS.acquireScope(inBuffer);
         try {
-            NIO_ACCESS.acquireSession(outBuffer);
+            NIO_ACCESS.acquireScope(outBuffer);
             try {
                 ensureInitialized();
 
@@ -795,10 +795,10 @@ final class P11Cipher extends CipherSpi {
                 reset(true);
                 throw new ProviderException("update() failed", e);
             } finally {
-                NIO_ACCESS.releaseSession(outBuffer);
+                NIO_ACCESS.releaseScope(outBuffer);
             }
         } finally {
-            NIO_ACCESS.releaseSession(inBuffer);
+            NIO_ACCESS.releaseScope(inBuffer);
         }
     }
 
@@ -889,7 +889,7 @@ final class P11Cipher extends CipherSpi {
         }
 
         boolean doCancel = true;
-        NIO_ACCESS.acquireSession(outBuffer);
+        NIO_ACCESS.acquireScope(outBuffer);
         try {
             try {
                 ensureInitialized();
@@ -986,7 +986,7 @@ final class P11Cipher extends CipherSpi {
                 reset(doCancel);
             }
         } finally {
-            NIO_ACCESS.releaseSession(outBuffer);
+            NIO_ACCESS.releaseScope(outBuffer);
         }
     }
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Digest.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Digest.java
@@ -287,11 +287,11 @@ final class P11Digest extends MessageDigestSpi implements Cloneable,
                 token.p11.C_DigestUpdate(session.id(), 0, buffer, 0, bufOfs);
                 bufOfs = 0;
             }
-            NIO_ACCESS.acquireSession(byteBuffer);
+            NIO_ACCESS.acquireScope(byteBuffer);
             try {
                 token.p11.C_DigestUpdate(session.id(), dByteBuffer.address() + ofs, null, 0, len);
             } finally {
-                NIO_ACCESS.releaseSession(byteBuffer);
+                NIO_ACCESS.releaseScope(byteBuffer);
             }
             byteBuffer.position(ofs + len);
         } catch (PKCS11Exception e) {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyWrapCipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyWrapCipher.java
@@ -555,9 +555,9 @@ final class P11KeyWrapCipher extends CipherSpi {
 
         boolean doCancel = true;
         int k = 0;
-        NIO_ACCESS.acquireSession(inBuffer);
+        NIO_ACCESS.acquireScope(inBuffer);
         try {
-            NIO_ACCESS.acquireSession(outBuffer);
+            NIO_ACCESS.acquireScope(outBuffer);
             try {
                 try {
                     ensureInitialized();
@@ -633,10 +633,10 @@ final class P11KeyWrapCipher extends CipherSpi {
                     reset(doCancel);
                 }
             } finally {
-                NIO_ACCESS.releaseSession(outBuffer);
+                NIO_ACCESS.releaseScope(outBuffer);
             }
         } finally {
-            NIO_ACCESS.releaseSession(inBuffer);
+            NIO_ACCESS.releaseScope(inBuffer);
         }
         return k;
     }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
@@ -255,11 +255,11 @@ final class P11Mac extends MacSpi {
                 return;
             }
             int ofs = byteBuffer.position();
-            NIO_ACCESS.acquireSession(byteBuffer);
+            NIO_ACCESS.acquireScope(byteBuffer);
             try  {
                 token.p11.C_SignUpdate(session.id(), dByteBuffer.address() + ofs, null, 0, len);
             } finally {
-                NIO_ACCESS.releaseSession(byteBuffer);
+                NIO_ACCESS.releaseScope(byteBuffer);
             }
             byteBuffer.position(ofs + len);
         } catch (PKCS11Exception e) {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PSSSignature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PSSSignature.java
@@ -621,7 +621,7 @@ final class P11PSSSignature extends SignatureSpi {
                     return;
                 }
                 int ofs = byteBuffer.position();
-                NIO_ACCESS.acquireSession(byteBuffer);
+                NIO_ACCESS.acquireScope(byteBuffer);
                 try {
                     long addr = dByteBuffer.address();
                     if (mode == M_SIGN) {
@@ -639,7 +639,7 @@ final class P11PSSSignature extends SignatureSpi {
                     reset(false);
                     throw new ProviderException("Update failed", e);
                 } finally {
-                    NIO_ACCESS.releaseSession(byteBuffer);
+                    NIO_ACCESS.releaseScope(byteBuffer);
                 }
             }
             case T_DIGEST -> {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
@@ -585,7 +585,7 @@ final class P11Signature extends SignatureSpi {
                     return;
                 }
                 int ofs = byteBuffer.position();
-                NIO_ACCESS.acquireSession(byteBuffer);
+                NIO_ACCESS.acquireScope(byteBuffer);
                 try {
                     long addr = dByteBuffer.address();
                     if (mode == M_SIGN) {
@@ -601,7 +601,7 @@ final class P11Signature extends SignatureSpi {
                     reset(false);
                     throw new ProviderException("Update failed", e);
                 } finally {
-                    NIO_ACCESS.releaseSession(byteBuffer);
+                    NIO_ACCESS.releaseScope(byteBuffer);
                 }
             }
             case T_DIGEST -> {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -3283,8 +3283,8 @@ public abstract class ByteVector extends AbstractVector<Byte> {
      *         for any lane {@code N} in the vector
      * @throws IllegalArgumentException if the memory segment is a heap segment that is
      *         not backed by a {@code byte[]} array.
-     * @throws IllegalStateException if the memory segment's session is not alive,
-     *         or if access occurs from a thread other than the thread owning the session.
+     * @throws IllegalStateException if the memory segment's scope is not alive,
+     *         or if access occurs from a thread other than the thread owning the scope.
      * @since 19
      */
     @ForceInline
@@ -3335,8 +3335,8 @@ public abstract class ByteVector extends AbstractVector<Byte> {
      *         where the mask is set
      * @throws IllegalArgumentException if the memory segment is a heap segment that is
      *         not backed by a {@code byte[]} array.
-     * @throws IllegalStateException if the memory segment's session is not alive,
-     *         or if access occurs from a thread other than the thread owning the session.
+     * @throws IllegalStateException if the memory segment's scope is not alive,
+     *         or if access occurs from a thread other than the thread owning the scope.
      * @since 19
      */
     @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -2966,8 +2966,8 @@ public abstract class DoubleVector extends AbstractVector<Double> {
      *         for any lane {@code N} in the vector
      * @throws IllegalArgumentException if the memory segment is a heap segment that is
      *         not backed by a {@code byte[]} array.
-     * @throws IllegalStateException if the memory segment's session is not alive,
-     *         or if access occurs from a thread other than the thread owning the session.
+     * @throws IllegalStateException if the memory segment's scope is not alive,
+     *         or if access occurs from a thread other than the thread owning the scope.
      * @since 19
      */
     @ForceInline
@@ -3023,8 +3023,8 @@ public abstract class DoubleVector extends AbstractVector<Double> {
      *         where the mask is set
      * @throws IllegalArgumentException if the memory segment is a heap segment that is
      *         not backed by a {@code byte[]} array.
-     * @throws IllegalStateException if the memory segment's session is not alive,
-     *         or if access occurs from a thread other than the thread owning the session.
+     * @throws IllegalStateException if the memory segment's scope is not alive,
+     *         or if access occurs from a thread other than the thread owning the scope.
      * @since 19
      */
     @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -2972,8 +2972,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
      *         for any lane {@code N} in the vector
      * @throws IllegalArgumentException if the memory segment is a heap segment that is
      *         not backed by a {@code byte[]} array.
-     * @throws IllegalStateException if the memory segment's session is not alive,
-     *         or if access occurs from a thread other than the thread owning the session.
+     * @throws IllegalStateException if the memory segment's scope is not alive,
+     *         or if access occurs from a thread other than the thread owning the scope.
      * @since 19
      */
     @ForceInline
@@ -3029,8 +3029,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
      *         where the mask is set
      * @throws IllegalArgumentException if the memory segment is a heap segment that is
      *         not backed by a {@code byte[]} array.
-     * @throws IllegalStateException if the memory segment's session is not alive,
-     *         or if access occurs from a thread other than the thread owning the session.
+     * @throws IllegalStateException if the memory segment's scope is not alive,
+     *         or if access occurs from a thread other than the thread owning the scope.
      * @since 19
      */
     @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -3128,8 +3128,8 @@ public abstract class IntVector extends AbstractVector<Integer> {
      *         for any lane {@code N} in the vector
      * @throws IllegalArgumentException if the memory segment is a heap segment that is
      *         not backed by a {@code byte[]} array.
-     * @throws IllegalStateException if the memory segment's session is not alive,
-     *         or if access occurs from a thread other than the thread owning the session.
+     * @throws IllegalStateException if the memory segment's scope is not alive,
+     *         or if access occurs from a thread other than the thread owning the scope.
      * @since 19
      */
     @ForceInline
@@ -3185,8 +3185,8 @@ public abstract class IntVector extends AbstractVector<Integer> {
      *         where the mask is set
      * @throws IllegalArgumentException if the memory segment is a heap segment that is
      *         not backed by a {@code byte[]} array.
-     * @throws IllegalStateException if the memory segment's session is not alive,
-     *         or if access occurs from a thread other than the thread owning the session.
+     * @throws IllegalStateException if the memory segment's scope is not alive,
+     *         or if access occurs from a thread other than the thread owning the scope.
      * @since 19
      */
     @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -3007,8 +3007,8 @@ public abstract class LongVector extends AbstractVector<Long> {
      *         for any lane {@code N} in the vector
      * @throws IllegalArgumentException if the memory segment is a heap segment that is
      *         not backed by a {@code byte[]} array.
-     * @throws IllegalStateException if the memory segment's session is not alive,
-     *         or if access occurs from a thread other than the thread owning the session.
+     * @throws IllegalStateException if the memory segment's scope is not alive,
+     *         or if access occurs from a thread other than the thread owning the scope.
      * @since 19
      */
     @ForceInline
@@ -3064,8 +3064,8 @@ public abstract class LongVector extends AbstractVector<Long> {
      *         where the mask is set
      * @throws IllegalArgumentException if the memory segment is a heap segment that is
      *         not backed by a {@code byte[]} array.
-     * @throws IllegalStateException if the memory segment's session is not alive,
-     *         or if access occurs from a thread other than the thread owning the session.
+     * @throws IllegalStateException if the memory segment's scope is not alive,
+     *         or if access occurs from a thread other than the thread owning the scope.
      * @since 19
      */
     @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -3277,8 +3277,8 @@ public abstract class ShortVector extends AbstractVector<Short> {
      *         for any lane {@code N} in the vector
      * @throws IllegalArgumentException if the memory segment is a heap segment that is
      *         not backed by a {@code byte[]} array.
-     * @throws IllegalStateException if the memory segment's session is not alive,
-     *         or if access occurs from a thread other than the thread owning the session.
+     * @throws IllegalStateException if the memory segment's scope is not alive,
+     *         or if access occurs from a thread other than the thread owning the scope.
      * @since 19
      */
     @ForceInline
@@ -3334,8 +3334,8 @@ public abstract class ShortVector extends AbstractVector<Short> {
      *         where the mask is set
      * @throws IllegalArgumentException if the memory segment is a heap segment that is
      *         not backed by a {@code byte[]} array.
-     * @throws IllegalStateException if the memory segment's session is not alive,
-     *         or if access occurs from a thread other than the thread owning the session.
+     * @throws IllegalStateException if the memory segment's scope is not alive,
+     *         or if access occurs from a thread other than the thread owning the scope.
      * @since 19
      */
     @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Vector.java
@@ -3392,8 +3392,8 @@ public abstract class Vector<E> extends jdk.internal.vm.vector.VectorSupport.Vec
      *         if the memory segment is read-only
      * @throws IllegalArgumentException if the memory segment is a heap segment that is
      *         not backed by a {@code byte[]} array.
-     * @throws IllegalStateException if the memory segment's session is not alive,
-     *         or if access occurs from a thread other than the thread owning the session.
+     * @throws IllegalStateException if the memory segment's scope is not alive,
+     *         or if access occurs from a thread other than the thread owning the scope.
      * @since 19
      */
     public abstract void intoMemorySegment(MemorySegment ms, long offset, ByteOrder bo);
@@ -3445,8 +3445,8 @@ public abstract class Vector<E> extends jdk.internal.vm.vector.VectorSupport.Vec
      *         if the memory segment is read-only
      * @throws IllegalArgumentException if the memory segment is a heap segment that is
      *         not backed by a {@code byte[]} array.
-     * @throws IllegalStateException if the memory segment's session is not alive,
-     *         or if access occurs from a thread other than the thread owning the session.
+     * @throws IllegalStateException if the memory segment's scope is not alive,
+     *         or if access occurs from a thread other than the thread owning the scope.
      * @since 19
      */
     public abstract void intoMemorySegment(MemorySegment ms, long offset,

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -4079,8 +4079,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      *         for any lane {@code N} in the vector
      * @throws IllegalArgumentException if the memory segment is a heap segment that is
      *         not backed by a {@code byte[]} array.
-     * @throws IllegalStateException if the memory segment's session is not alive,
-     *         or if access occurs from a thread other than the thread owning the session.
+     * @throws IllegalStateException if the memory segment's scope is not alive,
+     *         or if access occurs from a thread other than the thread owning the scope.
      * @since 19
      */
     @ForceInline
@@ -4140,8 +4140,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      *         where the mask is set
      * @throws IllegalArgumentException if the memory segment is a heap segment that is
      *         not backed by a {@code byte[]} array.
-     * @throws IllegalStateException if the memory segment's session is not alive,
-     *         or if access occurs from a thread other than the thread owning the session.
+     * @throws IllegalStateException if the memory segment's scope is not alive,
+     *         or if access occurs from a thread other than the thread owning the scope.
      * @since 19
      */
     @ForceInline

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpChannelImpl.java
@@ -844,7 +844,7 @@ public class SctpChannelImpl extends SctpChannel
                                         boolean peek)
         throws IOException
     {
-        NIO_ACCESS.acquireSession(bb);
+        NIO_ACCESS.acquireScope(bb);
         try {
             int n = receive0(fd, resultContainer, ((DirectBuffer)bb).address() + pos, rem, peek);
 
@@ -852,7 +852,7 @@ public class SctpChannelImpl extends SctpChannel
                 bb.position(pos + n);
             return n;
         } finally {
-            NIO_ACCESS.releaseSession(bb);
+            NIO_ACCESS.releaseScope(bb);
         }
     }
 
@@ -1038,7 +1038,7 @@ public class SctpChannelImpl extends SctpChannel
         assert (pos <= lim);
         int rem = (pos <= lim ? lim - pos : 0);
 
-        NIO_ACCESS.acquireSession(bb);
+        NIO_ACCESS.acquireScope(bb);
         try {
             int written = send0(fd, ((DirectBuffer)bb).address() + pos, rem, addr,
                     port, -1 /*121*/, streamNumber, unordered, ppid);
@@ -1046,7 +1046,7 @@ public class SctpChannelImpl extends SctpChannel
                 bb.position(pos + written);
             return written;
         } finally {
-            NIO_ACCESS.releaseSession(bb);
+            NIO_ACCESS.releaseScope(bb);
         }
     }
 

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpMultiChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpMultiChannelImpl.java
@@ -587,14 +587,14 @@ public class SctpMultiChannelImpl extends SctpMultiChannel
                                         int rem,
                                         int pos)
             throws IOException {
-        NIO_ACCESS.acquireSession(bb);
+        NIO_ACCESS.acquireScope(bb);
         try {
             int n = receive0(fd, resultContainer, ((DirectBuffer)bb).address() + pos, rem);
             if (n > 0)
                 bb.position(pos + n);
             return n;
         } finally {
-            NIO_ACCESS.releaseSession(bb);
+            NIO_ACCESS.releaseScope(bb);
         }
     }
 
@@ -917,7 +917,7 @@ public class SctpMultiChannelImpl extends SctpMultiChannel
         assert (pos <= lim);
         int rem = (pos <= lim ? lim - pos : 0);
 
-        NIO_ACCESS.acquireSession(bb);
+        NIO_ACCESS.acquireScope(bb);
         try {
             int written = send0(fd, ((DirectBuffer)bb).address() + pos, rem, addr,
                     port, assocId, streamNumber, unordered, ppid);
@@ -925,7 +925,7 @@ public class SctpMultiChannelImpl extends SctpMultiChannel
                 bb.position(pos + written);
             return written;
         } finally {
-            NIO_ACCESS.releaseSession(bb);
+            NIO_ACCESS.releaseScope(bb);
         }
     }
 

--- a/test/jdk/java/foreign/LibraryLookupTest.java
+++ b/test/jdk/java/foreign/LibraryLookupTest.java
@@ -71,10 +71,10 @@ public class LibraryLookupTest {
         callFunc(addr);
     }
 
-    private static MemorySegment loadLibrary(SegmentScope session) {
-        SymbolLookup lib = SymbolLookup.libraryLookup(LIB_PATH, session);
+    private static MemorySegment loadLibrary(SegmentScope scope) {
+        SymbolLookup lib = SymbolLookup.libraryLookup(LIB_PATH, scope);
         MemorySegment addr = lib.find("inc").get();
-        assertEquals(addr.scope(), session);
+        assertEquals(addr.scope(), scope);
         return addr;
     }
 

--- a/test/jdk/java/foreign/SafeFunctionAccessTest.java
+++ b/test/jdk/java/foreign/SafeFunctionAccessTest.java
@@ -151,7 +151,7 @@ public class SafeFunctionAccessTest extends NativeTestHelper {
 
         try (Arena arena = Arena.openConfined()) {
             VaList list = VaList.make(b -> b.addVarg(C_INT, 42), arena.scope());
-            handle.invokeExact(list.segment(), sessionChecker(arena));
+            handle.invokeExact(list.segment(), scopeChecker(arena));
         }
     }
 
@@ -163,7 +163,7 @@ public class SafeFunctionAccessTest extends NativeTestHelper {
 
         try (Arena arena = Arena.openConfined()) {
             MemorySegment segment = arena.allocate(POINT);
-            handle.invokeExact(segment, sessionChecker(arena));
+            handle.invokeExact(segment, scopeChecker(arena));
         }
     }
 
@@ -176,13 +176,13 @@ public class SafeFunctionAccessTest extends NativeTestHelper {
         try (Arena arena = Arena.openConfined()) {
             MethodHandle dummy = MethodHandles.lookup().findStatic(SafeFunctionAccessTest.class, "dummy", MethodType.methodType(void.class));
             MemorySegment upcall = Linker.nativeLinker().upcallStub(dummy, FunctionDescriptor.ofVoid(), arena.scope());
-            handle.invokeExact(upcall, sessionChecker(arena));
+            handle.invokeExact(upcall, scopeChecker(arena));
         }
     }
 
-    MemorySegment sessionChecker(Arena arena) {
+    MemorySegment scopeChecker(Arena arena) {
         try {
-            MethodHandle handle = MethodHandles.lookup().findStatic(SafeFunctionAccessTest.class, "checkSession",
+            MethodHandle handle = MethodHandles.lookup().findStatic(SafeFunctionAccessTest.class, "checkScope",
                     MethodType.methodType(void.class, Arena.class));
             handle = handle.bindTo(arena);
             return Linker.nativeLinker().upcallStub(handle, FunctionDescriptor.ofVoid(), SegmentScope.auto());
@@ -191,10 +191,10 @@ public class SafeFunctionAccessTest extends NativeTestHelper {
         }
     }
 
-    static void checkSession(Arena arena) {
+    static void checkScope(Arena arena) {
         try {
             arena.close();
-            fail("Session closed unexpectedly!");
+            fail("Scope closed unexpectedly!");
         } catch (IllegalStateException ex) {
             assertTrue(ex.getMessage().contains("acquired")); //if acquired, fine
         }

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -364,14 +364,14 @@ public class TestByteBuffer {
             MemorySegment segment = MemorySegment.allocateNative(bytes, arena.scope());;
             bb = bufferFactory.apply(segment.asByteBuffer());
         }
-        //outside of session!!
+        //outside of scope!!
         try {
             method.invoke(bb, args);
             fail("Exception expected");
         } catch (InvocationTargetException ex) {
             Throwable cause = ex.getCause();
             if (cause instanceof IllegalStateException) {
-                //all get/set buffer operation should fail because of the session check
+                //all get/set buffer operation should fail because of the scope check
                 assertTrue(ex.getCause().getMessage().contains("Already closed"));
             } else {
                 //all other exceptions were unexpected - fail
@@ -480,7 +480,7 @@ public class TestByteBuffer {
     }
 
     @Test(expectedExceptions = IllegalStateException.class)
-    public void testBufferOnClosedSession() {
+    public void testBufferOnClosedScope() {
         MemorySegment leaked;
         try (Arena arena = Arena.openConfined()) {
             leaked = MemorySegment.allocateNative(bytes, arena.scope());;

--- a/test/jdk/java/foreign/TestMemoryAccess.java
+++ b/test/jdk/java/foreign/TestMemoryAccess.java
@@ -115,9 +115,9 @@ public class TestMemoryAccess {
         }
         try {
             checker.check(handle, outer_segment);
-            throw new AssertionError(); //not ok, session is closed
+            throw new AssertionError(); //not ok, scope is closed
         } catch (IllegalStateException ex) {
-            //ok, should fail (session is closed)
+            //ok, should fail (scope is closed)
         }
     }
 
@@ -149,9 +149,9 @@ public class TestMemoryAccess {
         }
         try {
             checker.check(handle, outer_segment, 0);
-            throw new AssertionError(); //not ok, session is closed
+            throw new AssertionError(); //not ok, scope is closed
         } catch (IllegalStateException ex) {
-            //ok, should fail (session is closed)
+            //ok, should fail (scope is closed)
         }
     }
 
@@ -221,9 +221,9 @@ public class TestMemoryAccess {
         }
         try {
             checker.check(handle, outer_segment, 0, 0);
-            throw new AssertionError(); //not ok, session is closed
+            throw new AssertionError(); //not ok, scope is closed
         } catch (IllegalStateException ex) {
-            //ok, should fail (session is closed)
+            //ok, should fail (scope is closed)
         }
     }
 

--- a/test/jdk/java/foreign/TestNulls.java
+++ b/test/jdk/java/foreign/TestNulls.java
@@ -108,8 +108,8 @@ public class TestNulls {
 
     static final Set<String> EXCLUDE_LIST = Set.of(
             "java.lang.foreign.MemorySegment/ofAddress(long,long,java.lang.foreign.SegmentScope,java.lang.Runnable)/3/0",
-            "java.lang.foreign.MemorySegment.MemorySession/openConfined(java.lang.ref.Cleaner)/0/0",
-            "java.lang.foreign.MemorySegment.MemorySession/openShared(java.lang.ref.Cleaner)/0/0",
+            "java.lang.foreign.MemorySegment.MemoryScope/openConfined(java.lang.ref.Cleaner)/0/0",
+            "java.lang.foreign.MemorySegment.MemoryScope/openShared(java.lang.ref.Cleaner)/0/0",
             "java.lang.foreign.MemoryLayout/withAttribute(java.lang.String,java.lang.constant.Constable)/1/0",
             "java.lang.foreign.SequenceLayout/withAttribute(java.lang.String,java.lang.constant.Constable)/1/0",
             "java.lang.foreign.ValueLayout/withAttribute(java.lang.String,java.lang.constant.Constable)/1/0",

--- a/test/jdk/java/foreign/TestScopedOperations.java
+++ b/test/jdk/java/foreign/TestScopedOperations.java
@@ -110,17 +110,17 @@ public class TestScopedOperations {
     static List<ScopedOperation> scopedOperations = new ArrayList<>();
 
     static {
-        // session operations
-        ScopedOperation.ofScope(session -> MemorySegment.allocateNative(100, session), "MemorySession::allocate");;
-        ScopedOperation.ofScope(session -> {
+        // scope operations
+        ScopedOperation.ofScope(scope -> MemorySegment.allocateNative(100, scope), "MemoryScope::allocate");;
+        ScopedOperation.ofScope(scope -> {
             try (FileChannel fileChannel = FileChannel.open(tempPath, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
-                fileChannel.map(FileChannel.MapMode.READ_WRITE, 0L, 10L, session);
+                fileChannel.map(FileChannel.MapMode.READ_WRITE, 0L, 10L, scope);
             } catch (IOException ex) {
                 fail();
             }
         }, "FileChannel::map");
-        ScopedOperation.ofScope(session -> VaList.make(b -> b.addVarg(JAVA_INT, 42), session), "VaList::make");
-        ScopedOperation.ofScope(session -> VaList.ofAddress(42, session), "VaList::make");
+        ScopedOperation.ofScope(scope -> VaList.make(b -> b.addVarg(JAVA_INT, 42), scope), "VaList::make");
+        ScopedOperation.ofScope(scope -> VaList.ofAddress(42, scope), "VaList::make");
         // segment operations
         ScopedOperation.ofSegment(s -> s.toArray(JAVA_BYTE), "MemorySegment::toArray(BYTE)");
         ScopedOperation.ofSegment(s -> s.copyFrom(s), "MemorySegment::copyFrom");
@@ -179,8 +179,8 @@ public class TestScopedOperations {
         }
 
         @Override
-        public X apply(SegmentScope session) {
-            return factory.apply(session);
+        public X apply(SegmentScope scope) {
+            return factory.apply(scope);
         }
 
         static <Z> void of(Function<SegmentScope, Z> factory, Consumer<Z> consumer, String name) {
@@ -192,7 +192,7 @@ public class TestScopedOperations {
         }
 
         static void ofVaList(Consumer<VaList> vaListConsumer, String name) {
-            scopedOperations.add(new ScopedOperation<>(session -> VaList.make(builder -> builder.addVarg(JAVA_LONG, 42), session),
+            scopedOperations.add(new ScopedOperation<>(scope -> VaList.make(builder -> builder.addVarg(JAVA_LONG, 42), scope),
                     vaListConsumer, name));
         }
 
@@ -216,15 +216,15 @@ public class TestScopedOperations {
 
         enum SegmentFactory {
 
-            NATIVE(session -> MemorySegment.allocateNative(10, session)),
-            MAPPED(session -> {
+            NATIVE(scope -> MemorySegment.allocateNative(10, scope)),
+            MAPPED(scope -> {
                 try (FileChannel fileChannel = FileChannel.open(Path.of("foo.txt"), StandardOpenOption.READ, StandardOpenOption.WRITE)) {
-                    return fileChannel.map(FileChannel.MapMode.READ_WRITE, 0L, 10L, session);
+                    return fileChannel.map(FileChannel.MapMode.READ_WRITE, 0L, 10L, scope);
                 } catch (IOException ex) {
                     throw new AssertionError(ex);
                 }
             }),
-            UNSAFE(session -> MemorySegment.ofAddress(0, 10, session));
+            UNSAFE(scope -> MemorySegment.ofAddress(0, 10, scope));
 
             static {
                 try {

--- a/test/jdk/java/foreign/TestSegmentAllocators.java
+++ b/test/jdk/java/foreign/TestSegmentAllocators.java
@@ -102,7 +102,7 @@ public class TestSegmentAllocators {
     static final int SIZE_256M = 1024 * 1024 * 256;
 
     @Test
-    public void testBigAllocationInUnboundedSession() {
+    public void testBigAllocationInUnboundedScope() {
         try (Arena arena = Arena.openConfined()) {
             for (int i = 8 ; i < SIZE_256M ; i *= 8) {
                 SegmentAllocator allocator = SegmentAllocator.slicingAllocator(arena.allocate(i * 2 + 1));

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -56,17 +56,17 @@ public class TestSegments {
     @Test
     public void testZeroLengthNativeSegment() {
         try (Arena arena = Arena.openConfined()) {
-            SegmentScope session = arena.scope();
-            var segment = MemorySegment.allocateNative(0, session);
+            SegmentScope scope = arena.scope();
+            var segment = MemorySegment.allocateNative(0, scope);
             assertEquals(segment.byteSize(), 0);
             MemoryLayout seq = MemoryLayout.sequenceLayout(0, JAVA_INT);
-            segment = MemorySegment.allocateNative(seq, session);
+            segment = MemorySegment.allocateNative(seq, scope);
             assertEquals(segment.byteSize(), 0);
             assertEquals(segment.address() % seq.byteAlignment(), 0);
-            segment = MemorySegment.allocateNative(0, 4, session);
+            segment = MemorySegment.allocateNative(0, 4, scope);
             assertEquals(segment.byteSize(), 0);
             assertEquals(segment.address() % 4, 0);
-            MemorySegment rawAddress = MemorySegment.ofAddress(segment.address(), 0, session);
+            MemorySegment rawAddress = MemorySegment.ofAddress(segment.address(), 0, scope);
             assertEquals(rawAddress.byteSize(), 0);
             assertEquals(rawAddress.address() % 4, 0);
         }

--- a/test/jdk/java/foreign/TestUpcallBase.java
+++ b/test/jdk/java/foreign/TestUpcallBase.java
@@ -81,11 +81,11 @@ public abstract class TestUpcallBase extends CallGeneratorHelper {
                 FunctionDescriptor.of(layouts[prefix.size()], layouts);
     }
 
-    static Object[] makeArgs(SegmentScope session, Ret ret, List<ParamType> params, List<StructFieldType> fields, List<Consumer<Object>> checks, List<Consumer<Object[]>> argChecks) throws ReflectiveOperationException {
-        return makeArgs(session, ret, params, fields, checks, argChecks, List.of());
+    static Object[] makeArgs(SegmentScope scope, Ret ret, List<ParamType> params, List<StructFieldType> fields, List<Consumer<Object>> checks, List<Consumer<Object[]>> argChecks) throws ReflectiveOperationException {
+        return makeArgs(scope, ret, params, fields, checks, argChecks, List.of());
     }
 
-    static Object[] makeArgs(SegmentScope session, Ret ret, List<ParamType> params, List<StructFieldType> fields, List<Consumer<Object>> checks, List<Consumer<Object[]>> argChecks, List<MemoryLayout> prefix) throws ReflectiveOperationException {
+    static Object[] makeArgs(SegmentScope scope, Ret ret, List<ParamType> params, List<StructFieldType> fields, List<Consumer<Object>> checks, List<Consumer<Object[]>> argChecks, List<MemoryLayout> prefix) throws ReflectiveOperationException {
         Object[] args = new Object[prefix.size() + params.size() + 1];
         int argNum = 0;
         for (MemoryLayout layout : prefix) {
@@ -94,11 +94,11 @@ public abstract class TestUpcallBase extends CallGeneratorHelper {
         for (int i = 0 ; i < params.size() ; i++) {
             args[argNum++] = makeArg(params.get(i).layout(fields), checks, i == 0);
         }
-        args[argNum] = makeCallback(session, ret, params, fields, checks, argChecks, prefix);
+        args[argNum] = makeCallback(scope, ret, params, fields, checks, argChecks, prefix);
         return args;
     }
 
-    static MemorySegment makeCallback(SegmentScope session, Ret ret, List<ParamType> params, List<StructFieldType> fields, List<Consumer<Object>> checks, List<Consumer<Object[]>> argChecks, List<MemoryLayout> prefix) {
+    static MemorySegment makeCallback(SegmentScope scope, Ret ret, List<ParamType> params, List<StructFieldType> fields, List<Consumer<Object>> checks, List<Consumer<Object[]>> argChecks, List<MemoryLayout> prefix) {
         if (params.isEmpty()) {
             return DUMMY_STUB;
         }
@@ -145,7 +145,7 @@ public abstract class TestUpcallBase extends CallGeneratorHelper {
         FunctionDescriptor func = ret != Ret.VOID
                 ? FunctionDescriptor.of(firstlayout, paramLayouts)
                 : FunctionDescriptor.ofVoid(paramLayouts);
-        return ABI.upcallStub(mh, func, session);
+        return ABI.upcallStub(mh, func, scope);
     }
 
     static Object passAndSave(Object[] o, AtomicReference<Object[]> ref, int retArg, List<MemoryLayout> layouts) {

--- a/test/jdk/java/foreign/TestUpcallStack.java
+++ b/test/jdk/java/foreign/TestUpcallStack.java
@@ -71,8 +71,8 @@ public class TestUpcallStack extends TestUpcallBase {
         return function(ret, params, fields, STACK_PREFIX_LAYOUTS);
     }
 
-    static Object[] makeArgsStack(SegmentScope session, Ret ret, List<ParamType> params, List<StructFieldType> fields, List<Consumer<Object>> checks, List<Consumer<Object[]>> argChecks) throws ReflectiveOperationException {
-        return makeArgs(session, ret, params, fields, checks, argChecks, STACK_PREFIX_LAYOUTS);
+    static Object[] makeArgsStack(SegmentScope scope, Ret ret, List<ParamType> params, List<StructFieldType> fields, List<Consumer<Object>> checks, List<Consumer<Object[]>> argChecks) throws ReflectiveOperationException {
+        return makeArgs(scope, ret, params, fields, checks, argChecks, STACK_PREFIX_LAYOUTS);
     }
 
 }

--- a/test/jdk/java/foreign/channels/AbstractChannelsTest.java
+++ b/test/jdk/java/foreign/channels/AbstractChannelsTest.java
@@ -68,29 +68,29 @@ public class AbstractChannelsTest {
 
     static final Random RANDOM = RandomFactory.getRandom();
 
-    static ByteBuffer segmentBufferOfSize(SegmentScope session, int size) {
-        var segment = MemorySegment.allocateNative(size, 1, session);
+    static ByteBuffer segmentBufferOfSize(SegmentScope scope, int size) {
+        var segment = MemorySegment.allocateNative(size, 1, scope);
         for (int i = 0; i < size; i++) {
             segment.set(JAVA_BYTE, i, ((byte)RANDOM.nextInt()));
         }
         return segment.asByteBuffer();
     }
 
-    static ByteBuffer[] segmentBuffersOfSize(int len, SegmentScope session, int size) {
+    static ByteBuffer[] segmentBuffersOfSize(int len, SegmentScope scope, int size) {
         ByteBuffer[] bufs = new ByteBuffer[len];
         for (int i = 0; i < len; i++)
-            bufs[i] = segmentBufferOfSize(session, size);
+            bufs[i] = segmentBufferOfSize(scope, size);
         return bufs;
     }
 
     /**
      * Returns an array of mixed source byte buffers; both heap and direct,
-     * where heap can be from the global session or session-less, and direct are
-     * associated with the given session.
+     * where heap can be from the global scope or scope-less, and direct are
+     * associated with the given scope.
      */
-    static ByteBuffer[] mixedBuffersOfSize(int len, SegmentScope session, int size) {
+    static ByteBuffer[] mixedBuffersOfSize(int len, SegmentScope scope, int size) {
         ByteBuffer[] bufs;
-        boolean atLeastOneSessionBuffer = false;
+        boolean atLeastOneScopeBuffer = false;
         do {
             bufs = new ByteBuffer[len];
             for (int i = 0; i < len; i++) {
@@ -101,12 +101,12 @@ public class AbstractChannelsTest {
                     case 1 -> { byte[] b = new byte[size];
                                 RANDOM.nextBytes(b);
                                 yield MemorySegment.ofArray(b).asByteBuffer(); }
-                    case 2 -> { atLeastOneSessionBuffer = true;
-                                yield segmentBufferOfSize(session, size); }
+                    case 2 -> { atLeastOneScopeBuffer = true;
+                                yield segmentBufferOfSize(scope, size); }
                     default -> throw new AssertionError("cannot happen");
                 };
             }
-        } while (!atLeastOneSessionBuffer);
+        } while (!atLeastOneScopeBuffer);
         return bufs;
     }
 

--- a/test/jdk/java/foreign/channels/TestSocketChannels.java
+++ b/test/jdk/java/foreign/channels/TestSocketChannels.java
@@ -116,7 +116,7 @@ public class TestSocketChannels extends AbstractChannelsTest {
     }
 
     @Test
-    public void testBasicHeapIOWithGlobalSession() throws Exception {
+    public void testBasicHeapIOWithGlobalScope() throws Exception {
         try (var sc1 = SocketChannel.open();
              var ssc = ServerSocketChannel.open();
              var sc2 = connectChannels(ssc, sc1)) {
@@ -181,7 +181,7 @@ public class TestSocketChannels extends AbstractChannelsTest {
     }
 
     @Test(dataProvider = "closeableArenas")
-    public void testBasicIOWithDifferentSessions(Supplier<Arena> arenaSupplier)
+    public void testBasicIOWithDifferentScopes(Supplier<Arena> arenaSupplier)
          throws Exception
     {
         try (var sc1 = SocketChannel.open();

--- a/test/jdk/java/foreign/dontrelease/TestDontRelease.java
+++ b/test/jdk/java/foreign/dontrelease/TestDontRelease.java
@@ -70,7 +70,7 @@ public class TestDontRelease extends NativeTestHelper  {
                     throw new RuntimeException(e);
                 }
 
-                // the downcall above should not have called release on the session
+                // the downcall above should not have called release on the scope
                 // so doing it here should succeed without error
             });
         }

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -600,9 +600,9 @@ public class VaListTest extends NativeTestHelper {
                 assertEquals((int) VH_Point_y.get(pointOut), 6);
                 assertTrue(pointOut.scope().isAlive()); // after VaList freed
             }
-            assertTrue(pointOut.scope().isAlive()); // after inner session freed
+            assertTrue(pointOut.scope().isAlive()); // after inner scope freed
         }
-        assertFalse(pointOut.scope().isAlive()); // after outer session freed
+        assertFalse(pointOut.scope().isAlive()); // after outer scope freed
     }
 
     @DataProvider

--- a/test/micro/org/openjdk/bench/java/lang/foreign/BulkMismatchAcquire.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/BulkMismatchAcquire.java
@@ -51,13 +51,13 @@ import java.util.function.Supplier;
 @Fork(value = 3, jvmArgsAppend = "--enable-preview")
 public class BulkMismatchAcquire {
 
-    public enum SessionKind {
+    public enum ScopeKind {
         CONFINED(Arena::openConfined),
         SHARED(Arena::openShared);
 
         final Supplier<Arena> arenaFactory;
 
-        SessionKind(Supplier<Arena> arenaFactory) {
+        ScopeKind(Supplier<Arena> arenaFactory) {
             this.arenaFactory = arenaFactory;
         }
 
@@ -67,7 +67,7 @@ public class BulkMismatchAcquire {
     }
 
     @Param({"CONFINED", "SHARED"})
-    public BulkMismatchAcquire.SessionKind sessionKind;
+    public BulkMismatchAcquire.ScopeKind scopeKind;
 
     // large(ish) segments/buffers with same content, 0, for mismatch, non-multiple-of-8 sized
     static final int SIZE_WITH_TAIL = (1024 * 1024) + 7;
@@ -84,7 +84,7 @@ public class BulkMismatchAcquire {
 
     @Setup
     public void setup() {
-        arena = sessionKind.makeArena();
+        arena = scopeKind.makeArena();
         mismatchSegmentLarge1 = arena.allocate(SIZE_WITH_TAIL);
         mismatchSegmentLarge2 = arena.allocate(SIZE_WITH_TAIL);
         mismatchBufferLarge1 = ByteBuffer.allocateDirect(SIZE_WITH_TAIL);

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNew.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNew.java
@@ -119,7 +119,7 @@ public class LoopOverNew extends JavaLayouts {
     // act under significant native memory pressure, and here the ByteBuffer API has more juice, since it features
     // a complex exponential back off with multiple GC retries (see ByteBuffer::allocateDirect). Of course, we
     // don't care about those cases with segments, as if clients need to allocate/free very frequently
-    // they should just use deterministic deallocation (with confined session) instead, which delivers much
+    // they should just use deterministic deallocation (with confined scope) instead, which delivers much
     // better performances anyway.
     static byte gcCount = 0;
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverOfAddress.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverOfAddress.java
@@ -67,7 +67,7 @@ public class LoopOverOfAddress extends JavaLayouts {
     }
 
     @Benchmark
-    public long segment_loop_addr_size_session() {
+    public long segment_loop_addr_size_scope() {
         long res = 0;
         for (int i = 0; i < ITERATIONS; i++) {
             res += MemorySegment.ofAddress(i, i % 100, SegmentScope.global()).address();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/MemoryScopeClose.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/MemoryScopeClose.java
@@ -48,7 +48,7 @@ import java.util.concurrent.TimeUnit;
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @Fork(value = 3, jvmArgsAppend = "--enable-preview")
-public class MemorySessionClose {
+public class MemoryScopeClose {
 
     static final int ALLOC_SIZE = 1024;
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
@@ -148,8 +148,8 @@ public class StrLenTest extends CLayouts {
         SegmentAllocator current;
         long rem;
 
-        public RingAllocator(SegmentScope session) {
-            this.segment = MemorySegment.allocateNative(1024, session);
+        public RingAllocator(SegmentScope scope) {
+            this.segment = MemorySegment.allocateNative(1024, scope);
             reset();
         }
 


### PR DESCRIPTION
This PR suggests renaming various names from "session" to "scope" in accordance with https://openjdk.org/jeps/434

The PRs contains changes for several sub-components.