### PR TITLE
8298342: RISC-V: RoundDoubleModeV does not use dynamic rounding mode correctly

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -1123,15 +1123,15 @@ instruct vroundD(vReg dst, vReg src, immI rmode) %{
     switch ($rmode$$constant) {
       case RoundDoubleModeNode::rmode_rint:
         __ csrwi(CSR_FRM, C2_MacroAssembler::rne);
-        __ vfcvt_rtz_x_f_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
+        __ vfcvt_x_f_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
         break;
       case RoundDoubleModeNode::rmode_floor:
         __ csrwi(CSR_FRM, C2_MacroAssembler::rdn);
-        __ vfcvt_rtz_x_f_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
+        __ vfcvt_x_f_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
         break;
       case RoundDoubleModeNode::rmode_ceil:
         __ csrwi(CSR_FRM, C2_MacroAssembler::rup);
-        __ vfcvt_rtz_x_f_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
+        __ vfcvt_x_f_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
         break;
       default:
         ShouldNotReachHere();


### PR DESCRIPTION
Currently, the `vfcvt_rtz_x_f_v` operand is being used in `RoundDoubleModeV`. We use the `csrwi` instruction to set frm for different rounding mode, which is similar to scalar calculations. But `vfcvt_rtz_x_f_v` will not use dynamic rounding mode.

We can see the note in RVV v1.0[1]:

> The conversions follow the same rules on exceptional conditions as the scalar conversion instructions. The conversions use the dynamic rounding mode in frm, except for the rtz variants, which round towards zero.

The test `TestDoubleVect.java`[2] can be used to cover the test of RoundDoubleModeV on aarch64, and a similar jit code will be generated:

```
  0x000000550d4dd4bc:   ldr	d16, [sp, #40]
  0x000000550d4dd4c0:   frintn	d16, d16                    ;*daload {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - compiler.c2.cr6340864.TestDoubleVect::test@3325 (line 316)
  0x000000550d4dd4c4:   str	d16, [sp, #80]
  0x000000550d4dd4c8:   ldr	d16, [sp, #112]
  0x000000550d4dd4cc:   frintn	d16, d16                    ;*daload {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - compiler.c2.cr6340864.TestDoubleVect::test@3342 (line 317)
  0x000000550d4dd4d0:   str	d16, [sp, #88]
  0x000000550d4dd4d4:   ldr	d16, [sp, #56]
  0x000000550d4dd4d8:   frintn	d16, d16                    ;*if_icmpge {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - compiler.c2.cr6340864.TestDoubleVect::test@2286 (line 248)
```

However, the test on RISC-V will not cover `RoundDoubleModeV` as expected, I'm continuing to debug or write new test cases, but maybe that will be another issue.



[1] https://github.com/riscv/riscv-v-spec/blob/v1.0/v-spec.adoc
[2] https://github.com/openjdk/jdk/blob/master/test/hotspot/jtreg/compiler/c2/cr6340864/TestDoubleVect.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298342](https://bugs.openjdk.org/browse/JDK-8298342): RISC-V: RoundDoubleModeV does not use dynamic rounding mode correctly


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11575/head:pull/11575` \
`$ git checkout pull/11575`

Update a local copy of the PR: \
`$ git checkout pull/11575` \
`$ git pull https://git.openjdk.org/jdk pull/11575/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11575`

View PR using the GUI difftool: \
`$ git pr show -t 11575`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11575.diff">https://git.openjdk.org/jdk/pull/11575.diff</a>

</details>
