### PR TITLE
8298073: gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java causes test task timeout on macosx

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -80,7 +80,6 @@ gc/stress/gclocker/TestExcessGCLockerCollections.java 8229120 generic-all
 gc/stress/gclocker/TestGCLockerWithParallel.java 8180622 generic-all
 gc/stress/gclocker/TestGCLockerWithG1.java 8180622 generic-all
 gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java 8192647 generic-all
-gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8241293,8298073 macosx-x64,macosx-aarch64
 gc/stress/TestStressG1Humongous.java 8286554 windows-x64
 
 #############################################################################

--- a/test/hotspot/jtreg/gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java
+++ b/test/hotspot/jtreg/gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java
@@ -32,7 +32,7 @@ package gc.metaspace;
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/timeout=240  gc.metaspace.CompressedClassSpaceSizeInJmapHeap
+ * @run main/timeout=240 gc.metaspace.CompressedClassSpaceSizeInJmapHeap
  */
 
 import jdk.test.lib.JDKToolLauncher;

--- a/test/hotspot/jtreg/gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java
+++ b/test/hotspot/jtreg/gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,10 +32,11 @@ package gc.metaspace;
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm -XX:CompressedClassSpaceSize=48m gc.metaspace.CompressedClassSpaceSizeInJmapHeap
+ * @run main/timeout=240  gc.metaspace.CompressedClassSpaceSizeInJmapHeap
  */
 
 import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.apps.LingeredApp;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.SA.SATestUtils;
@@ -49,7 +50,9 @@ public class CompressedClassSpaceSizeInJmapHeap {
     public static void main(String[] args) throws Exception {
         SATestUtils.skipIfCannotAttach(); // throws SkippedException if attach not expected to work.
 
-        String pid = Long.toString(ProcessTools.getProcessId());
+        LingeredApp  theApp = new LingeredApp();
+        LingeredApp.startApp(theApp, "-XX:CompressedClassSpaceSize=48m");
+        String pid = Long.toString(theApp.getPid());
 
         JDKToolLauncher jmap = JDKToolLauncher.create("jhsdb")
                                               .addToolArg("jmap")
@@ -69,7 +72,9 @@ public class CompressedClassSpaceSizeInJmapHeap {
         OutputAnalyzer output = new OutputAnalyzer(read(out));
         output.shouldContain("CompressedClassSpaceSize = 50331648 (48.0MB)");
         out.delete();
-    }
+
+        LingeredApp.stopApp(theApp);
+ }
 
     private static void run(ProcessBuilder pb) throws Exception {
         Process p = pb.start();

--- a/test/hotspot/jtreg/gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java
+++ b/test/hotspot/jtreg/gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java
@@ -74,7 +74,7 @@ public class CompressedClassSpaceSizeInJmapHeap {
         out.delete();
 
         LingeredApp.stopApp(theApp);
- }
+    }
 
     private static void run(ProcessBuilder pb) throws Exception {
         Process p = pb.start();

--- a/test/hotspot/jtreg/gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java
+++ b/test/hotspot/jtreg/gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java
@@ -50,7 +50,7 @@ public class CompressedClassSpaceSizeInJmapHeap {
     public static void main(String[] args) throws Exception {
         SATestUtils.skipIfCannotAttach(); // throws SkippedException if attach not expected to work.
 
-        LingeredApp  theApp = new LingeredApp();
+        LingeredApp theApp = new LingeredApp();
         LingeredApp.startApp(theApp, "-XX:CompressedClassSpaceSize=48m");
         String pid = Long.toString(theApp.getPid());
 


### PR DESCRIPTION
This fixes two separate CRs:

[JDK-8241293](https://bugs.openjdk.org/browse/JDK-8241293) CompressedClassSpaceSizeInJmapHeap.java time out after 8 minutes
[JDK-8298073](https://bugs.openjdk.org/browse/JDK-8298073) gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java causes test task timeout on macosx

For the first one the test was hitting an 8m timeout, but completing right after that. The test log said PASSED, but jtreg failed it anyway because it noticed the timeout. The fix is to double the default 120s timeout to 240s (which is 16m when the 4x timeoutfactor is applied.

For the second one the issue seemed to be with having the test process spawn a jhsdb process that attached back to the test process. OSX didn't seem to be too happy about this. The fix is to instead create a LingeredApp process to attach to like all the other SA tests do.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8298073](https://bugs.openjdk.org/browse/JDK-8298073): gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java causes test task timeout on macosx
 * [JDK-8241293](https://bugs.openjdk.org/browse/JDK-8241293): CompressedClassSpaceSizeInJmapHeap.java time out after 8 minutes


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [e1543d5a](https://git.openjdk.org/jdk/pull/11576/files/e1543d5adf8ffc25324067e1b043b980ecc3a1d6)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [b403e129](https://git.openjdk.org/jdk/pull/11576/files/b403e1291362c6559b9c143b2e71ea61b127c019)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11576/head:pull/11576` \
`$ git checkout pull/11576`

Update a local copy of the PR: \
`$ git checkout pull/11576` \
`$ git pull https://git.openjdk.org/jdk pull/11576/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11576`

View PR using the GUI difftool: \
`$ git pr show -t 11576`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11576.diff">https://git.openjdk.org/jdk/pull/11576.diff</a>

</details>
