### PR TITLE
8298345: Fix another two C2 IR matching tests for RISC-V

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestAutoVectorization2DArray.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestAutoVectorization2DArray.java
@@ -29,7 +29,9 @@ import compiler.lib.ir_framework.*;
  * @test
  * @bug 8279258
  * @summary Auto-vectorization enhancement for two-dimensional array operations
- * @requires (os.arch != "x86" & os.arch != "i386") | vm.opt.UseSSE == "null" | vm.opt.UseSSE >= 2
+ * @requires ((os.arch == "x86" | os.arch == "i386") & (vm.opt.UseSSE == "null" | vm.opt.UseSSE >= 2))
+ *           | (os.arch != "x86" & os.arch != "i386" & os.arch != "riscv64")
+ *           | (os.arch == "riscv64" & vm.opt.UseRVV == true)
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestAutoVectorization2DArray
  */

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -140,6 +140,7 @@ public class TestFramework {
                     "UseSSE",
                     "UseSVE",
                     "UseZbb",
+                    "UseRVV",
                     "Xlog",
                     "LogCompilation"
             )

--- a/test/hotspot/jtreg/compiler/vectorization/TestAutoVecIntMinMax.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestAutoVecIntMinMax.java
@@ -34,7 +34,7 @@ import jdk.test.lib.Utils;
  * @library /test/lib /
  * @requires vm.compiler2.enabled
  * @requires (os.simpleArch == "x64" & (vm.opt.UseSSE == "null" | vm.opt.UseSSE > 3))
- *           | os.arch == "aarch64" | os.arch == "riscv64"
+ *           | os.arch == "aarch64" | (os.arch == "riscv64" & vm.opt.UseRVV == true)
  * @run driver compiler.c2.irTests.TestAutoVecIntMinMax
  */
 


### PR DESCRIPTION
Fix two IR matching tests that failed on RISC-V.

Vector api Node will be matched only when UseRVV is enabled:
- test/hotspot/jtreg/compiler/c2/irTests/TestAutoVectorization2DArray.java
- test/hotspot/jtreg/compiler/vectorization/TestAutoVecIntMinMax.java

Please take a look and have some reviews. Thanks a lot.

## Testing:
-  fastdebug on unmatched board without support for RVV
- - test/hotspot/jtreg/compiler/c2/irTests/TestAutoVectorization2DArray.java - no tests selected as expected
- - test/hotspot/jtreg/compiler/vectorization/TestAutoVecIntMinMax.java -  no tests selected as expected
- fastdebug with -XX:+UseRVV on QEMU
- - test/hotspot/jtreg/compiler/c2/irTests/TestAutoVectorization2DArray.java - The C2 graph generated by the test is as expected
- -  test/hotspot/jtreg/compiler/vectorization/TestAutoVecIntMinMax.java  -The C2 graph generated by the test is as expected
- fastdebug with -XX:-UseRVV on QEMU
- - test/hotspot/jtreg/compiler/c2/irTests/TestAutoVectorization2DArray.java - no tests selected as expected
- -  test/hotspot/jtreg/compiler/vectorization/TestAutoVecIntMinMax.java  - no tests selected as expected

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298345](https://bugs.openjdk.org/browse/JDK-8298345): Fix another two C2 IR matching tests for RISC-V


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Author)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11577/head:pull/11577` \
`$ git checkout pull/11577`

Update a local copy of the PR: \
`$ git checkout pull/11577` \
`$ git pull https://git.openjdk.org/jdk pull/11577/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11577`

View PR using the GUI difftool: \
`$ git pr show -t 11577`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11577.diff">https://git.openjdk.org/jdk/pull/11577.diff</a>

</details>
