### PR TITLE
8298323: trivial typo in JOptionPane.OK_OPTION

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JOptionPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JOptionPane.java
@@ -353,7 +353,7 @@ public class JOptionPane extends JComponent implements Accessible
     public static final int         NO_OPTION = 1;
     /** Return value from class method if CANCEL is chosen. */
     public static final int         CANCEL_OPTION = 2;
-    /** Return value form class method if OK is chosen. */
+    /** Return value from class method if OK is chosen. */
     public static final int         OK_OPTION = 0;
     /** Return value from class method if user closes window without selecting
      * anything, more than likely this should be treated as either a


### PR DESCRIPTION
Typo rectified

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298323](https://bugs.openjdk.org/browse/JDK-8298323): trivial typo in JOptionPane.OK_OPTION


### Reviewers
 * @SWinxy (no known github.com user name / role)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11578/head:pull/11578` \
`$ git checkout pull/11578`

Update a local copy of the PR: \
`$ git checkout pull/11578` \
`$ git pull https://git.openjdk.org/jdk pull/11578/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11578`

View PR using the GUI difftool: \
`$ git pr show -t 11578`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11578.diff">https://git.openjdk.org/jdk/pull/11578.diff</a>

</details>
