### PR TITLE
8298341: Ensure heap growth in TestNativeMemoryUsageEvents.java

### DIFF
--- a/test/jdk/jdk/jfr/event/runtime/TestNativeMemoryUsageEvents.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestNativeMemoryUsageEvents.java
@@ -103,6 +103,15 @@ public class TestNativeMemoryUsageEvents {
         // Generate data to force heap to grow.
         generateHeapContents();
 
+        // To allow the two usage events to share a single NMTUsage snapshot
+        // there is an AgeThreshold set to 50ms and if the two events occur
+        // within this interval they will use the same snapshot. On fast
+        // machines it is possible that the whole heap contents generation
+        // take less than 50ms and therefor both beginChunk end endChunk
+        // events will use the same NMTUsage snapshot. To avoid this, do
+        // a short sleep.
+        Thread.sleep(100);
+
         recording.stop();
     }
 


### PR DESCRIPTION
Please review this test fix.

**Summary**
The new test TestNativeMemoryUsageEvents.java sometimes fail. The reason is that the _NativeMemoryUsage_ and _NativeMemoryUsageTotal_ events want to share a single `NMTUsage` snapshot. To achieve this there is an `AgeThreshold` set to 50ms that is considered when sending the events. If the usage snapshot is new enough we don't refresh it, but reuse it. In the test this becomes problematic if the recording is shorter than 50ms, then both the beginChunk event and the endChunk event will use the same NMT data. 

This could be solved by using the feature currently reviewed in #11541 and this is the plan, see: [JDK-8298276](https://bugs.openjdk.org/browse/JDK-8298276). But since this is not yet done, I propose to fix the test for now by just adding a short sleep during the recording to ensure the endChunk event is delayed enough to cause a new NMT snapshot to be taken.

**Testing**
* Local testing with a larger `AgeThreshold` to see that a sleep really helps the problem.
* Mach5 testing to verify the fix is good there as well, this is currently running.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298341](https://bugs.openjdk.org/browse/JDK-8298341): Ensure heap growth in TestNativeMemoryUsageEvents.java


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11579/head:pull/11579` \
`$ git checkout pull/11579`

Update a local copy of the PR: \
`$ git checkout pull/11579` \
`$ git pull https://git.openjdk.org/jdk pull/11579/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11579`

View PR using the GUI difftool: \
`$ git pr show -t 11579`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11579.diff">https://git.openjdk.org/jdk/pull/11579.diff</a>

</details>
