### PR TITLE
8298050: Add links to graph output for javadoc

### DIFF
--- a/make/jdk/src/classes/build/tools/taglet/SealedGraph.java
+++ b/make/jdk/src/classes/build/tools/taglet/SealedGraph.java
@@ -204,7 +204,7 @@ public final class SealedGraph implements Taglet {
             // This implies the module is always the same.
             private static String relativeLink(TypeElement rootNode, TypeElement node) {
                 var backNavigator = rootNode.getQualifiedName().toString().chars()
-                        .filter(c -> '.' == c)
+                        .filter(c -> c == '.')
                         .mapToObj(c -> "../")
                         .collect(joining());
                 var forwardNavigator = node.getQualifiedName().toString()

--- a/make/jdk/src/classes/build/tools/taglet/SealedGraph.java
+++ b/make/jdk/src/classes/build/tools/taglet/SealedGraph.java
@@ -33,7 +33,6 @@ import jdk.javadoc.doclet.Taglet;
 import javax.lang.model.element.*;
 import javax.lang.model.type.DeclaredType;
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;


### PR DESCRIPTION
This PR proposes adding hyperlinks to the sealed graphic layout making navigation much simpler via the image.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298050](https://bugs.openjdk.org/browse/JDK-8298050): Add links to graph output for javadoc


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11580/head:pull/11580` \
`$ git checkout pull/11580`

Update a local copy of the PR: \
`$ git checkout pull/11580` \
`$ git pull https://git.openjdk.org/jdk pull/11580/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11580`

View PR using the GUI difftool: \
`$ git pr show -t 11580`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11580.diff">https://git.openjdk.org/jdk/pull/11580.diff</a>

</details>
