### PR TITLE
8295116: C2: assert(dead->outcnt() == 0 && !dead->is_top()) failed: node must be dead

### DIFF
--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -733,6 +733,7 @@ bool IfNode::is_ctrl_folds(Node* ctrl, PhaseIterGVN* igvn) {
     ctrl->in(0)->as_If()->cmpi_folds(igvn, true) &&
     // Must compare same value
     ctrl->in(0)->in(1)->in(1)->in(1) != NULL &&
+    ctrl->in(0)->in(1)->in(1)->in(1) != igvn->C->top() &&
     ctrl->in(0)->in(1)->in(1)->in(1) == in(1)->in(1)->in(1);
 }
 


### PR DESCRIPTION
In `IfNode::fold_compares_helper()`, we merge two immediately following `If` nodes with a `CmpI` that share the left input into a single `If` with `CmpU`.

In this case here, a graph is currently dying. The `If` nodes are not yet removed but data was already folded in such a way that the graph currently looks like this when trying to apply `IfNode::fold_compares()`:

![image](https://user-images.githubusercontent.com/17833009/206415585-083c6558-84d1-4787-b766-01be8b64bf10.png)

In `IfNode::is_ctrl_folds()` we check if the dominating `If` is suited to apply this optimization. Here we check if the left inputs of the `CmpI` nodes are the same which is indeed the case because both `CmpI` have `top` as left input:
https://github.com/openjdk/jdk/blob/46cd457b0f78996a3f26e44452de8f8a66041f58/src/hotspot/share/opto/ifnode.cpp#L734-L736

We start merging `1641 If` and `1657 If`. During this process, we try to remove dead nodes that are no longer used:
https://github.com/openjdk/jdk/blob/46cd457b0f78996a3f26e44452de8f8a66041f58/src/hotspot/share/opto/ifnode.cpp#L1042-L1044

But in this specific setup, `adjusted_val` is `top` and we try to remove it because `outcnt()` for `top` is zero. This results in the assertion failure.

The fix I propose is to not only check for equality of the left inputs in `IfNode::is_ctrl_folds()` but also check if one of them is `top`.

I was only able to reproduce this bug with a replay file and a very specific seed when using `-XX:+StressIGVN`.

Thanks,
Christian
