### PR TITLE
8298371: monitors_on_stack extracts unprocessed oops

### DIFF
--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -1461,7 +1461,7 @@ static bool monitors_on_stack(JavaThread* thread) {
   ContinuationEntry* ce = thread->last_continuation();
   RegisterMap map(thread,
                   RegisterMap::UpdateMap::include,
-                  RegisterMap::ProcessFrames::skip,
+                  RegisterMap::ProcessFrames::include,
                   RegisterMap::WalkContinuation::skip);
   map.set_include_argument_oops(false);
   for (frame f = thread->last_frame(); Continuation::is_frame_in_continuation(ce, f); f = f.sender(&map)) {


### PR DESCRIPTION
While investigating JDK-8298058 we've found that monitors_on_stack extracts oops without setting up the RegisterMap to process oops. This then leaks out stale oops.

A simple fix is to change the RegisterMap to perform oops processing. However, monitors_on_stack is only used in an assert, so this means that we'll get a difference in behavior between release builds and debug builds. This has the potential to hide bugs in debug builds. It has been suggested to me that it might be better to simply remove the assert:
```
  assert(monitors_on_stack(current) == ((current->held_monitor_count() - current->jni_monitor_count()) > 0),
         "Held monitor count and locks on stack invariant: " INT64_FORMAT " JNI: " INT64_FORMAT, (int64_t)current->held_monitor_count(), (int64_t)current->jni_monitor_count());
```

The suggested patch just turns on processing, but I'm also fine with removing the assert if that seems to be a better solution.

Tested with reproducer using Fuzz.java + ZGC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298371](https://bugs.openjdk.org/browse/JDK-8298371): monitors_on_stack extracts unprocessed oops


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11582/head:pull/11582` \
`$ git checkout pull/11582`

Update a local copy of the PR: \
`$ git checkout pull/11582` \
`$ git pull https://git.openjdk.org/jdk pull/11582/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11582`

View PR using the GUI difftool: \
`$ git pr show -t 11582`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11582.diff">https://git.openjdk.org/jdk/pull/11582.diff</a>

</details>
