### PR TITLE
8298375: Bad copyright header in test/jdk/java/lang/Character/Supplementary.java

### DIFF
--- a/test/jdk/java/lang/Character/Supplementary.java
+++ b/test/jdk/java/lang/Character/Supplementary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Can I get a review of this change which fixes the copyright header on the test file?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298375](https://bugs.openjdk.org/browse/JDK-8298375): Bad copyright header in test/jdk/java/lang/Character/Supplementary.java


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11583/head:pull/11583` \
`$ git checkout pull/11583`

Update a local copy of the PR: \
`$ git checkout pull/11583` \
`$ git pull https://git.openjdk.org/jdk pull/11583/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11583`

View PR using the GUI difftool: \
`$ git pr show -t 11583`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11583.diff">https://git.openjdk.org/jdk/pull/11583.diff</a>

</details>
