### PR TITLE
8287699: jdk/jfr/api/consumer/TestRecordingFileWrite.java fails with exception: java.lang.Exception: Found event that should not be there.

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -755,7 +755,6 @@ jdk/jfr/startupargs/TestStartName.java                          8214685 windows-
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all
 jdk/jfr/api/consumer/recordingstream/TestOnEvent.java           8255404 linux-x64
-jdk/jfr/api/consumer/TestRecordingFileWrite.java                8287699 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Greetings,

The missing thread information is a result of a race that was introduced in [JDK-8277131](https://bugs.openjdk.org/browse/JDK-8277131), a race that could result in lost thread metadata information. [JDK-8289692](https://bugs.openjdk.org/browse/JDK-8289692) closed the race a bit but was not a complete fix. The proper fix, removing the race entirely, was made as part of [JDK-8293864](https://bugs.openjdk.org/browse/JDK-8293864).

This change only removes the excluded test from ProblemList.txt.

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287699](https://bugs.openjdk.org/browse/JDK-8287699): jdk/jfr/api/consumer/TestRecordingFileWrite.java fails with exception: java.lang.Exception: Found event that should not be there.


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11588/head:pull/11588` \
`$ git checkout pull/11588`

Update a local copy of the PR: \
`$ git checkout pull/11588` \
`$ git pull https://git.openjdk.org/jdk pull/11588/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11588`

View PR using the GUI difftool: \
`$ git pr show -t 11588`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11588.diff">https://git.openjdk.org/jdk/pull/11588.diff</a>

</details>
