### PR TITLE
8298380: Clean up redundant array length checks in JDK code base

### DIFF
--- a/src/java.base/linux/classes/sun/nio/fs/LinuxWatchService.java
+++ b/src/java.base/linux/classes/sun/nio/fs/LinuxWatchService.java
@@ -226,15 +226,13 @@ class LinuxWatchService
             }
 
             // no modifiers supported at this time
-            if (modifiers.length > 0) {
-                for (WatchEvent.Modifier modifier: modifiers) {
-                    if (modifier == null)
-                        return new NullPointerException();
-                    if (!ExtendedOptions.SENSITIVITY_HIGH.matches(modifier) &&
-                            !ExtendedOptions.SENSITIVITY_MEDIUM.matches(modifier) &&
-                            !ExtendedOptions.SENSITIVITY_LOW.matches(modifier)) {
-                        return new UnsupportedOperationException("Modifier not supported");
-                    }
+            for (WatchEvent.Modifier modifier : modifiers) {
+                if (modifier == null)
+                    return new NullPointerException();
+                if (!ExtendedOptions.SENSITIVITY_HIGH.matches(modifier) &&
+                        !ExtendedOptions.SENSITIVITY_MEDIUM.matches(modifier) &&
+                        !ExtendedOptions.SENSITIVITY_LOW.matches(modifier)) {
+                    return new UnsupportedOperationException("Modifier not supported");
                 }
             }
 

--- a/src/java.base/share/classes/java/nio/file/spi/FileSystemProvider.java
+++ b/src/java.base/share/classes/java/nio/file/spi/FileSystemProvider.java
@@ -411,13 +411,11 @@ public abstract class FileSystemProvider {
     public InputStream newInputStream(Path path, OpenOption... options)
         throws IOException
     {
-        if (options.length > 0) {
-            for (OpenOption opt: options) {
-                // All OpenOption values except for APPEND and WRITE are allowed
-                if (opt == StandardOpenOption.APPEND ||
-                    opt == StandardOpenOption.WRITE)
-                    throw new UnsupportedOperationException("'" + opt + "' not allowed");
-            }
+        for (OpenOption opt : options) {
+            // All OpenOption values except for APPEND and WRITE are allowed
+            if (opt == StandardOpenOption.APPEND ||
+                opt == StandardOpenOption.WRITE)
+                throw new UnsupportedOperationException("'" + opt + "' not allowed");
         }
         ReadableByteChannel rbc = Files.newByteChannel(path, options);
         if (rbc instanceof FileChannelImpl) {

--- a/src/java.base/share/classes/jdk/internal/jrtfs/JrtPath.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/JrtPath.java
@@ -627,11 +627,9 @@ final class JrtPath implements Path {
     }
 
     final InputStream newInputStream(OpenOption... options) throws IOException {
-        if (options.length > 0) {
-            for (OpenOption opt : options) {
-                if (opt != READ) {
-                    throw new UnsupportedOperationException("'" + opt + "' not allowed");
-                }
+        for (OpenOption opt : options) {
+            if (opt != READ) {
+                throw new UnsupportedOperationException("'" + opt + "' not allowed");
             }
         }
         return jrtfs.newInputStream(this);

--- a/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
+++ b/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
@@ -119,20 +119,18 @@ class PollingWatchService
 
         // Extended modifiers may be used to specify the sensitivity level
         int sensitivity = DEFAULT_POLLING_INTERVAL;
-        if (modifiers.length > 0) {
-            for (WatchEvent.Modifier modifier: modifiers) {
-                if (modifier == null)
-                    throw new NullPointerException();
+        for (WatchEvent.Modifier modifier : modifiers) {
+            if (modifier == null)
+                throw new NullPointerException();
 
-                if (ExtendedOptions.SENSITIVITY_HIGH.matches(modifier)) {
-                    sensitivity = ExtendedOptions.SENSITIVITY_HIGH.parameter();
-                } else if (ExtendedOptions.SENSITIVITY_MEDIUM.matches(modifier)) {
-                    sensitivity = ExtendedOptions.SENSITIVITY_MEDIUM.parameter();
-                } else if (ExtendedOptions.SENSITIVITY_LOW.matches(modifier)) {
-                    sensitivity = ExtendedOptions.SENSITIVITY_LOW.parameter();
-                } else {
-                    throw new UnsupportedOperationException("Modifier not supported");
-                }
+            if (ExtendedOptions.SENSITIVITY_HIGH.matches(modifier)) {
+                sensitivity = ExtendedOptions.SENSITIVITY_HIGH.parameter();
+            } else if (ExtendedOptions.SENSITIVITY_MEDIUM.matches(modifier)) {
+                sensitivity = ExtendedOptions.SENSITIVITY_MEDIUM.parameter();
+            } else if (ExtendedOptions.SENSITIVITY_LOW.matches(modifier)) {
+                sensitivity = ExtendedOptions.SENSITIVITY_LOW.parameter();
+            } else {
+                throw new UnsupportedOperationException("Modifier not supported");
             }
         }
 

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaFileChooserUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaFileChooserUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -653,10 +653,8 @@ public class AquaFileChooserUI extends FileChooserUI {
                 int selectableCount = 0;
                 // Double-check that all the list selections are valid for this mode
                 // Directories can be selected in the list regardless of mode
-                if (rows.length > 0) {
-                    for (final int element : rows) {
-                        if (isSelectableForMode(chooser, (File)fFileList.getValueAt(element, 0))) selectableCount++;
-                    }
+                for (final int element : rows) {
+                    if (isSelectableForMode(chooser, (File) fFileList.getValueAt(element, 0))) selectableCount++;
                 }
                 if (selectableCount > 0) {
                     final File[] files = new File[selectableCount];

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/Assumptions.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/Assumptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,10 +89,8 @@ public final class Assumptions implements Iterable<Assumptions.Assumption> {
         public void recordTo(Assumptions target) {
             assert canRecordTo(target);
 
-            if (assumptions.length > 0) {
-                for (Assumption assumption : assumptions) {
-                    target.record(assumption);
-                }
+            for (Assumption assumption : assumptions) {
+                target.record(assumption);
             }
         }
 

--- a/src/jdk.jconsole/share/classes/sun/tools/jconsole/inspector/XTree.java
+++ b/src/jdk.jconsole/share/classes/sun/tools/jconsole/inspector/XTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -649,7 +649,7 @@ public class XTree extends JTree {
                         Messages.NOTIFICATIONS, null);
                 notifications.setUserObject(notificationsUO);
                 node.insert(notifications, childIndex++);
-                if (ni != null && ni.length > 0) {
+                if (ni != null) {
                     for (MBeanNotificationInfo mbni : ni) {
                         DefaultMutableTreeNode notification =
                                 new DefaultMutableTreeNode();

--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipPath.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipPath.java
@@ -744,11 +744,9 @@ final class ZipPath implements Path {
 
     InputStream newInputStream(OpenOption... options) throws IOException
     {
-        if (options.length > 0) {
-            for (OpenOption opt : options) {
-                if (opt != READ)
-                    throw new UnsupportedOperationException("'" + opt + "' not allowed");
-            }
+        for (OpenOption opt : options) {
+            if (opt != READ)
+                throw new UnsupportedOperationException("'" + opt + "' not allowed");
         }
         return zfs.newInputStream(getResolvedPath());
     }


### PR DESCRIPTION
Newer version of IntelliJ IDEA introduces new [inspection](https://youtrack.jetbrains.com/issue/IDEA-301797/IDEA-should-report-redundant-array-length-check-in-certain-cases) detecting redundant array length check in snippets like
```java
<T> void iterate(T[] items) {
  if (items.length == 0) {
    return;
  }
  for (T item : items) {
    //...
  }
}
```
Here
```java
if (items.length == 0) {
  return;
}
```
is redundant and can be removed as length check is performed by for-each loop.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298380](https://bugs.openjdk.org/browse/JDK-8298380): Clean up redundant array length checks in JDK code base


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11589/head:pull/11589` \
`$ git checkout pull/11589`

Update a local copy of the PR: \
`$ git checkout pull/11589` \
`$ git pull https://git.openjdk.org/jdk pull/11589/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11589`

View PR using the GUI difftool: \
`$ git pr show -t 11589`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11589.diff">https://git.openjdk.org/jdk/pull/11589.diff</a>

</details>
