### PR TITLE
8298381: Improve handling of session tickets for multiple SSLContexts

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
@@ -130,10 +130,12 @@ public abstract class SSLContextImpl extends SSLContextSpi {
         if (SSLLogger.isOn && SSLLogger.isOn("ssl,sslctx")) {
             SSLLogger.finest("trigger seeding of SecureRandom");
         }
-        secureRandom.nextInt();
+        int keyID = secureRandom.nextInt();
         if (SSLLogger.isOn && SSLLogger.isOn("ssl,sslctx")) {
             SSLLogger.finest("done seeding of SecureRandom");
         }
+        // Use the "priming output" to initialize the FC 5077 session ticket key name
+        serverCache.initCurrentKeyID(keyID);
 
         isInitialized = true;
     }

--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionContextImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionContextImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionContextImpl.java
@@ -25,10 +25,13 @@
 
 package sun.security.ssl;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSessionContext;
 
@@ -68,6 +71,11 @@ final class SSLSessionContextImpl implements SSLSessionContext {
                                         // session cache, "host:port" as key
     private int cacheLimit;             // the max cache size
     private int timeout;                // timeout in seconds
+
+    private int currentKeyID = new SecureRandom().nextInt();
+                                        // RFC 5077 session ticket key name
+    private final Map<Integer,          // Maps session keys to session state
+            SessionTicketExtension.StatelessKey> keyHashMap = new ConcurrentHashMap<>();
 
     // Default setting for stateless session resumption support (RFC 5077)
     private boolean statelessSession = true;
@@ -168,6 +176,21 @@ final class SSLSessionContextImpl implements SSLSessionContext {
     @Override
     public int getSessionCacheSize() {
         return cacheLimit;
+    }
+
+    // package-private, used only by SSLContextImpl
+    int getKeyID() {
+        return currentKeyID;
+    }
+
+    // package-private, used only by SSLContextImpl
+    void setKeyID(int keyID) {
+        currentKeyID = keyID;
+    }
+
+    // package-private, used only by SSLContextImpl
+    Map<Integer, SessionTicketExtension.StatelessKey> getKeyHashMap() {
+        return keyHashMap;
     }
 
     // package-private method, used ONLY by ServerHandshaker

--- a/src/java.base/share/classes/sun/security/ssl/SessionTicketExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/SessionTicketExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/ssl/SessionTicketExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/SessionTicketExtension.java
@@ -116,11 +116,11 @@ final class SessionTicketExtension {
         final int num;
 
         // package-private, used only by SSLContextImpl
-        StatelessKey(int num) {
+        StatelessKey(HandshakeContext hc, int num) {
             SecretKey k = null;
             try {
                 KeyGenerator kg = KeyGenerator.getInstance("AES");
-                kg.init(KEYLEN);
+                kg.init(KEYLEN, hc.sslContext.getSecureRandom());
                 k = kg.generateKey();
             } catch (NoSuchAlgorithmException e) {
                 // should not happen;
@@ -160,7 +160,7 @@ final class SessionTicketExtension {
         static StatelessKey getCurrentKey(HandshakeContext hc) {
             SSLSessionContextImpl serverCache =
                 (SSLSessionContextImpl)hc.sslContext.engineGetServerSessionContext();
-            return serverCache.getKey();
+            return serverCache.getKey(hc);
         }
     }
 

--- a/src/java.base/share/classes/sun/security/ssl/SessionTicketExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/SessionTicketExtension.java
@@ -116,11 +116,11 @@ final class SessionTicketExtension {
         final int num;
 
         // package-private, used only by SSLContextImpl
-        StatelessKey(SecureRandom secRand, int num) {
+        StatelessKey(int num) {
             SecretKey k = null;
             try {
                 KeyGenerator kg = KeyGenerator.getInstance("AES");
-                kg.init(KEYLEN, secRand);
+                kg.init(KEYLEN);
                 k = kg.generateKey();
             } catch (NoSuchAlgorithmException e) {
                 // should not happen;
@@ -146,9 +146,11 @@ final class SessionTicketExtension {
 
         // Get a key with a specific key number
         static StatelessKey getKey(HandshakeContext hc, int num)  {
-            StatelessKey ssk = hc.sslContext.getKey(num);
+            SSLSessionContextImpl serverCache =
+                (SSLSessionContextImpl)hc.sslContext.engineGetServerSessionContext();
+            StatelessKey ssk = serverCache.getKey(num);
 
-            if (ssk == null || ssk.isInvalid(hc.sslContext.engineGetServerSessionContext())) {
+            if (ssk == null || ssk.isInvalid(serverCache)) {
                 return null;
             }
             return ssk;
@@ -156,7 +158,9 @@ final class SessionTicketExtension {
 
         // Get the current valid key, this will generate a new key if needed
         static StatelessKey getCurrentKey(HandshakeContext hc) {
-            return hc.sslContext.getKey();
+            SSLSessionContextImpl serverCache =
+                (SSLSessionContextImpl)hc.sslContext.engineGetServerSessionContext();
+            return serverCache.getKey();
         }
     }
 


### PR DESCRIPTION
Currently, TLS session tickets introduced by [JDK-8211018](https://bugs.openjdk.org/browse/JDK-8211018) in JDK 13 (i.e. `SessionTicketExtension$StatelessKey`) are generated in the class `SessionTicketExtension` and they use a single, global key ID (`currentKeyID`) for all `SSLContext`s.

This is problematic if more than one `SSLContext` is used, because every context which requests a session ticket will increment the global id `currentKeyID` when it creates a ticket. This means that in turn all the other contexts won't be able to find a ticket under the new id in their `SSLContextImpl` and create a new one (again incrementing `currentKeyID`). In fact, every time a ticket is requested from a different context, this will transitively trigger a new ticket creation in all the other contexts. We've observed millions of session ticket accumulating for some workloads.

Another issue with the curent implementation is that cleanup is racy because the underlying data structure (i.e. `keyHashMap` in `SSLContextImpl`) as well as the cleanup code itself are not threadsafe.

I therefor propose to move `currentKeyID` into the `SSLContextImpl` to solve these issues.

The following test program (contributed by Steven Collison (https://raycoll.com/)) can be used to demonstrate the current behaviour. It outputs the number of `StatelessKey` instances at the end of the program. Opening 1000 connections with a single `SSLContext` results in a single `StatelessKey` instance being created:
```
$ java -XX:+UseSerialGC -Xmx16m -cp ~/Java/ SSLSocketServerMultipleSSLContext 9999 1 1000
605:             1             32  sun.security.ssl.SessionTicketExtension$StatelessKey (java.base@20-internal)
```
The same example with the 1000 connections being opened alternatively on thwo different contexts will instead create 1000 `StatelessKey` instances:
```
$ java -XX:+UseSerialGC -Xmx16m -cp ~/Java/ SSLSocketServerMultipleSSLContext 9999 2 1000
  11:          1000          32000  sun.security.ssl.SessionTicketExtension$StatelessKey (java.base@20-internal)
```
With my proposed patch, the numbers goes back to two instances again:
```
$ java -XX:+UseSerialGC -Xmx16m -cp ~/Java/ SSLSocketServerMultipleSSLContext 9999 2 1000
611:             2             64  sun.security.ssl.SessionTicketExtension$StatelessKey (java.base@20-internal)
```

I've attached the test program to the [JBS issue](https://bugs.openjdk.org/browse/JDK-8298381). If you think it makes sense, I can probably convert it into a JTreg test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298381](https://bugs.openjdk.org/browse/JDK-8298381): Improve handling of session tickets for multiple SSLContexts


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**) ⚠️ Review applies to [68ed71dd](https://git.openjdk.org/jdk/pull/11590/files/68ed71dd7661eace65954ea21791ff2a49f09724)
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) - **Reviewer** ⚠️ Added manually
 * [Sergey Bylokhov](https://openjdk.org/census#serb) - **Reviewer** ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11590/head:pull/11590` \
`$ git checkout pull/11590`

Update a local copy of the PR: \
`$ git checkout pull/11590` \
`$ git pull https://git.openjdk.org/jdk pull/11590/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11590`

View PR using the GUI difftool: \
`$ git pr show -t 11590`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11590.diff">https://git.openjdk.org/jdk/pull/11590.diff</a>

</details>
