### PR TITLE
8298379: JFR: Some UNTIMED events only sets endTime

### DIFF
--- a/src/hotspot/share/gc/shared/gcTraceSend.cpp
+++ b/src/hotspot/share/gc/shared/gcTraceSend.cpp
@@ -389,6 +389,7 @@ void GCLockerTracer::report_gc_locker() {
     EventGCLocker event(UNTIMED);
     if (event.should_commit()) {
       event.set_starttime(_needs_gc_start_timestamp);
+      event.set_endtime(_needs_gc_start_timestamp);
       event.set_lockCount(_jni_lock_count);
       event.set_stallCount(_stall_count);
       event.commit();

--- a/src/hotspot/share/gc/shared/objectCountEventSender.cpp
+++ b/src/hotspot/share/gc/shared/objectCountEventSender.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,11 +54,12 @@ template <typename T>
 void ObjectCountEventSender::send_event_if_enabled(Klass* klass, jlong count, julong size, const Ticks& timestamp) {
   T event(UNTIMED);
   if (event.should_commit()) {
+    event.set_endtime(timestamp);
+    event.set_endtime(timestamp);
     event.set_gcId(GCId::current());
     event.set_objectClass(klass);
     event.set_count(count);
     event.set_totalSize(size);
-    event.set_endtime(timestamp);
     event.commit();
   }
 }

--- a/src/hotspot/share/gc/shared/objectCountEventSender.cpp
+++ b/src/hotspot/share/gc/shared/objectCountEventSender.cpp
@@ -54,7 +54,7 @@ template <typename T>
 void ObjectCountEventSender::send_event_if_enabled(Klass* klass, jlong count, julong size, const Ticks& timestamp) {
   T event(UNTIMED);
   if (event.should_commit()) {
-    event.set_endtime(timestamp);
+    event.set_starttime(timestamp);
     event.set_endtime(timestamp);
     event.set_gcId(GCId::current());
     event.set_objectClass(klass);

--- a/src/hotspot/share/jfr/periodic/jfrFinalizerStatisticsEvent.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrFinalizerStatisticsEvent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,7 @@ static void send_event(const FinalizerEntry* fe, const InstanceKlass* ik, const 
   const char* const url = fe != nullptr ? fe->codesource() : nullptr;
   const traceid url_symbol_id = url != NULL ? JfrSymbolTable::add(url) : 0;
   EventFinalizerStatistics event(UNTIMED);
+  event.set_starttime(timestamp);
   event.set_endtime(timestamp);
   event.set_finalizableClass(ik);
   event.set_codeSource(url_symbol_id);

--- a/src/hotspot/share/jfr/periodic/jfrModuleEvent.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrModuleEvent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,7 @@ class ModuleExportClosure : public ModuleEventCallbackClosure {
 
 static void write_module_dependency_event(const void* from_module, const ModuleEntry* to_module) {
   EventModuleRequire event(UNTIMED);
+  event.set_starttime(invocation_time);
   event.set_endtime(invocation_time);
   event.set_source((const ModuleEntry* const)from_module);
   event.set_requiredModule(to_module);
@@ -68,6 +69,7 @@ static void write_module_dependency_event(const void* from_module, const ModuleE
 
 static void write_module_export_event(const void* package, const ModuleEntry* qualified_export) {
   EventModuleExport event(UNTIMED);
+  event.set_starttime(invocation_time);
   event.set_endtime(invocation_time);
   event.set_exportedPackage((const PackageEntry*)package);
   event.set_targetModule(qualified_export);

--- a/src/hotspot/share/jfr/periodic/jfrOSInterface.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrOSInterface.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/periodic/jfrOSInterface.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrOSInterface.cpp
@@ -292,7 +292,7 @@ int JfrOSInterface::generate_initial_environment_variable_events() {
         strncpy(key, variable, key_length);
         key[key_length] = '\0';
         EventInitialEnvironmentVariable event(UNTIMED);
-        event.set_startime(time_stamp);
+        event.set_starttime(time_stamp);
         event.set_endtime(time_stamp);
         event.set_key(key);
         event.set_value(value);

--- a/src/hotspot/share/jfr/periodic/jfrOSInterface.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrOSInterface.cpp
@@ -292,6 +292,7 @@ int JfrOSInterface::generate_initial_environment_variable_events() {
         strncpy(key, variable, key_length);
         key[key_length] = '\0';
         EventInitialEnvironmentVariable event(UNTIMED);
+        event.set_startime(time_stamp);
         event.set_endtime(time_stamp);
         event.set_key(key);
         event.set_value(value);

--- a/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
@@ -151,6 +151,7 @@ static int _native_library_callback(const char* name, address base, address top,
   event.set_name(name);
   event.set_baseAddress((u8)base);
   event.set_topAddress((u8)top);
+  event.set_starttime(*(JfrTicks*)param);
   event.set_endtime(*(JfrTicks*) param);
   event.commit();
   return 0;
@@ -425,6 +426,7 @@ TRACE_REQUEST_FUNC(InitialSystemProperty) {
       EventInitialSystemProperty event(UNTIMED);
       event.set_key(p->key());
       event.set_value(p->value());
+      event.set_starttime(time_stamp);
       event.set_endtime(time_stamp);
       event.commit();
     }
@@ -451,6 +453,7 @@ TRACE_REQUEST_FUNC(ThreadAllocationStatistics) {
     EventThreadAllocationStatistics event(UNTIMED);
     event.set_allocated(allocated.at(i));
     event.set_thread(thread_ids.at(i));
+    event.set_starttime(time_stamp);
     event.set_endtime(time_stamp);
     event.commit();
   }

--- a/src/hotspot/share/jfr/periodic/jfrThreadCPULoadEvent.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrThreadCPULoadEvent.cpp
@@ -120,6 +120,7 @@ void JfrThreadCPULoadEvent::send_events() {
     EventThreadCPULoad event(UNTIMED);
     if (JfrThreadCPULoadEvent::update_event(event, jt, cur_wallclock_time, processor_count)) {
       event.set_starttime(event_time);
+      event.set_endtime(event_time);
       if (jt != periodic_thread) {
         // Commit reads the thread id from this thread's trace data, so put it there temporarily
         JfrThreadLocal::impersonate(periodic_thread, JFR_JVM_THREAD_ID(jt));


### PR DESCRIPTION
Greetings,

It was pointed out that some UNTIMED events only call set_endtime(), and not the corresponding set_starttime(), for example some events in jfrPeriodic.cpp. UNTIMED events need to have both timestamps set, because the UNTIMED parameter denotes that the user takes on the responsibility for controlling time stamping.

This change rectifies a few places by adding the corresponding set_starttime() call.

Test: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298379](https://bugs.openjdk.org/browse/JDK-8298379): JFR: Some UNTIMED events only sets endTime


### Reviewers
 * [Erik Helin](https://openjdk.org/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to [f1acc1f5](https://git.openjdk.org/jdk/pull/11592/files/f1acc1f58a3f93e7242b7b567333e8da6e745fbc)
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**) ⚠️ Review applies to [f1acc1f5](https://git.openjdk.org/jdk/pull/11592/files/f1acc1f58a3f93e7242b7b567333e8da6e745fbc)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11592/head:pull/11592` \
`$ git checkout pull/11592`

Update a local copy of the PR: \
`$ git checkout pull/11592` \
`$ git pull https://git.openjdk.org/jdk pull/11592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11592`

View PR using the GUI difftool: \
`$ git pr show -t 11592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11592.diff">https://git.openjdk.org/jdk/pull/11592.diff</a>

</details>
