### PR TITLE
8298340: java/net/httpclient/CancelRequestTest.java fails with AssertionError: Found some subscribers for testPostInterrupt

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -1008,6 +1008,7 @@ class Http2Connection  {
     // This method is called when the HTTP/2 client is being
     // stopped. Do not call it from anywhere else.
     void closeAllStreams() {
+        if (debug.on()) debug.log("Close all streams");
         for (var streamId : streams.keySet()) {
             // safe to call without locking - see Stream::deRegister
             decrementStreamsCount(streamId);

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -273,6 +273,7 @@ class Stream<T> extends ExchangeImpl<T> {
         if (debug.on()) debug.log("nullBody: streamid=%d", streamid);
         // We should have an END_STREAM data frame waiting in the inputQ.
         // We need a subscriber to force the scheduler to process it.
+        assert pendingResponseSubscriber == null;
         pendingResponseSubscriber = HttpResponse.BodySubscribers.replacing(null);
         sched.runOrSchedule();
     }
@@ -472,8 +473,14 @@ class Stream<T> extends ExchangeImpl<T> {
                 receiveDataFrame(new DataFrame(streamid, DataFrame.END_STREAM, List.of()));
             }
         } else if (frame instanceof DataFrame) {
-            if (cancelled) connection.dropDataFrame((DataFrame) frame);
-            else receiveDataFrame((DataFrame) frame);
+            if (cancelled) {
+                if (debug.on()) {
+                    debug.log("request cancelled or stream closed: dropping data frame");
+                }
+                connection.dropDataFrame((DataFrame) frame);
+            } else {
+                receiveDataFrame((DataFrame) frame);
+            }
         } else {
             if (!cancelled) otherFrame(frame);
         }
@@ -1283,10 +1290,24 @@ class Stream<T> extends ExchangeImpl<T> {
                 }
             }
         }
+
         if (closing) { // true if the stream has not been closed yet
-            if (responseSubscriber != null || pendingResponseSubscriber != null)
+            if (responseSubscriber != null || pendingResponseSubscriber != null) {
+                if (debug.on())
+                    debug.log("stream %s closing due to %s", streamid, (Object)errorRef.get());
                 sched.runOrSchedule();
+            } else {
+                if (debug.on())
+                    debug.log("stream %s closing due to %s before subscriber registered",
+                        streamid, (Object)errorRef.get());
+            }
+        } else {
+            if (debug.on()) {
+                debug.log("stream %s already closed due to %s",
+                        streamid, (Object)errorRef.get());
+            }
         }
+
         completeResponseExceptionally(e);
         if (!requestBodyCF.isDone()) {
             requestBodyCF.completeExceptionally(errorRef.get()); // we may be sending the body..
@@ -1330,6 +1351,14 @@ class Stream<T> extends ExchangeImpl<T> {
         if (debug.on()) debug.log("close stream %d", streamid);
         Log.logTrace("Closing stream {0}", streamid);
         connection.closeStream(streamid);
+        var s = responseSubscriber == null
+                ? pendingResponseSubscriber
+                : responseSubscriber;
+        if (debug.on()) debug.log("subscriber is %s", s);
+        if (s instanceof Http2StreamResponseSubscriber<?> sw) {
+            if (debug.on()) debug.log("closing response subscriber stream %s", streamid);
+            sw.streamClosed(errorRef.get());
+        }
         Log.logTrace("Stream {0} closed", streamid);
     }
 
@@ -1554,10 +1583,29 @@ class Stream<T> extends ExchangeImpl<T> {
                 super.complete(t);
             }
         }
+
         @Override
         protected void onCancel() {
             unregisterResponseSubscriber(this);
         }
+
+        /**
+         * Make sure the subscriber gets completed if the stream gets closed
+         * asynchronously outside of cancelImpl.
+         * @param cause the error cause, if any
+         */
+        public void streamClosed(Throwable cause) {
+            // if the subscriber has already completed,
+            // there is nothing to do...
+            if (!completed()) {
+                // otherwise makes sur it will be completed
+                var ex = cause == null
+                        ? new IOException("stream closed")
+                        : cause;
+                complete(ex);
+            }
+        }
+
     }
 
     private static final VarHandle STREAM_STATE;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -1598,7 +1598,7 @@ class Stream<T> extends ExchangeImpl<T> {
             // if the subscriber has already completed,
             // there is nothing to do...
             if (!completed()) {
-                // otherwise makes sur it will be completed
+                // otherwise make sure it will be completed
                 var ex = cause == null
                         ? new IOException("stream closed")
                         : cause;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/HttpBodySubscriberWrapper.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/HttpBodySubscriberWrapper.java
@@ -30,7 +30,6 @@ import java.nio.ByteBuffer;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Flow;
 import java.util.concurrent.Flow.Subscription;
@@ -174,6 +173,14 @@ public class HttpBodySubscriberWrapper<T> implements TrustedSubscriber<T> {
                 propagateError(t);
             }
         }
+    }
+
+    /**
+     * {@return true if this subscriber has already completed, either normally
+     * or abnormally}
+     */
+    public boolean completed() {
+        return completed.get();
     }
 
     @Override

--- a/test/jdk/java/net/httpclient/CancelRequestTest.java
+++ b/test/jdk/java/net/httpclient/CancelRequestTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8245462 8229822 8254786 8297075 8297149
+ * @bug 8245462 8229822 8254786 8297075 8297149 8298340
  * @summary Tests cancelling the request.
  * @library /test/lib http2/server
  * @key randomness


### PR DESCRIPTION
There are several ways by which an HTTP/2  stream can be closed. Due to the built-in asynchronous behavior, and to avoid unnecessary churn when a request is cancelled/aborted there are two places where the boolean stream's state `closed` can be set to true: `cancelImpl` and `close`. The current code completes the subscriber in `cancelImpl`, but the subscriber should also be completed in `close`. The intermittent failure happens if `close` gets ever called before `cancelImpl`.
This patch fixes that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298340](https://bugs.openjdk.org/browse/JDK-8298340): java/net/httpclient/CancelRequestTest.java fails with AssertionError: Found some subscribers for testPostInterrupt


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11595/head:pull/11595` \
`$ git checkout pull/11595`

Update a local copy of the PR: \
`$ git checkout pull/11595` \
`$ git pull https://git.openjdk.org/jdk pull/11595/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11595`

View PR using the GUI difftool: \
`$ git pr show -t 11595`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11595.diff">https://git.openjdk.org/jdk/pull/11595.diff</a>

</details>
