### PR TITLE
8298353: C2 fails with assert(opaq->outcnt() == 1 && opaq->in(1) == limit) failed

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1733,7 +1733,7 @@ Node* PhaseIdealLoop::compute_early_ctrl(Node* n, Node* n_ctrl) {
 bool PhaseIdealLoop::ctrl_of_all_uses_out_of_loop(const Node* n, Node* n_ctrl, IdealLoopTree* n_loop) {
   for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
     Node* u = n->fast_out(i);
-    if (u->Opcode() == Op_Opaque1) {
+    if (u->is_Opaque1()) {
       return false;  // Found loop limit, bugfix for 4677003
     }
     // We can't reuse tags in PhaseIdealLoop::dom_lca_for_get_late_ctrl_internal() so make sure calls to

--- a/test/hotspot/jtreg/compiler/loopopts/TestBadCountedLoopLimit.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestBadCountedLoopLimit.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8298353
+ * @summary C2 fails with assert(opaq->outcnt() == 1 && opaq->in(1) == limit) failed
+ *
+ * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation TestBadCountedLoopLimit
+ *
+ */
+
+import java.util.Arrays;
+
+public class TestBadCountedLoopLimit {
+    private static volatile int barrier;
+    private static int field;
+
+    public static void main(String[] args) {
+        boolean[] flag1 = new boolean[100];
+        boolean[] flag2 = new boolean[100];
+        Arrays.fill(flag2, true);
+        for (int i = 0; i < 20_000; i++) {
+            test(0, flag1, flag1);
+            test(0, flag2, flag2);
+            testHelper(true, 0, 0);
+            testHelper(false, 0, 0);
+        }
+    }
+
+    private static int test(int v, boolean[] flag, boolean[] flag2) {
+        int j = testHelper(flag2[0], 0, 1);
+        int i = 1;
+        int limit = 0;
+        for (;;) {
+            synchronized (new Object()) {
+            }
+            limit = j;
+            if (i >= 100) {
+                break;
+            }
+
+            if (flag[i]) {
+                return limit - 3;
+            }
+
+            j = testHelper(flag2[i], 100, 101);
+            i *= 2;
+        };
+        for (int k = 0; k < limit; k++) {
+            barrier = 0x42;
+        }
+        return j;
+    }
+
+    private static int testHelper(boolean flag2, int x, int x1) {
+        return flag2 ? x : x1;
+    }
+}


### PR DESCRIPTION
After some unrolling, when C2 runs loop opts with split if enabled
after CCP, the limit of the main loop of the counted loop (the second
loop in the test) is: limit - 3

That commons with the limit - 3 returned from the first loop. limit -
3 is thus in the first loop's body but only used outside of the
loop. It has 3 uses: The return in the first loop, the
OpaqueZeroTripGuard and loop exit conditionof the main loop. In the
same pass of loop opts, limit-3 is cloned out of the loop 3 times for
its 3 uses and unrolling is attempted. Because the OpaqueZeroTripGuard
and the loop exit condition now use 2 different nodes (until they
common at next igvn), the assert fires.

The fix I propose restores the behavior before the introduction of
OpaqueZeroTripGuard which is to not sink a node if it has an Opaque1
use.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298353](https://bugs.openjdk.org/browse/JDK-8298353): C2 fails with assert(opaq->outcnt() == 1 && opaq->in(1) == limit) failed


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11596/head:pull/11596` \
`$ git checkout pull/11596`

Update a local copy of the PR: \
`$ git checkout pull/11596` \
`$ git pull https://git.openjdk.org/jdk pull/11596/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11596`

View PR using the GUI difftool: \
`$ git pr show -t 11596`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11596.diff">https://git.openjdk.org/jdk/pull/11596.diff</a>

</details>
