### PR TITLE
8298249: Excessive memory allocation in CipherInputStream AEAD decryption

### DIFF
--- a/test/micro/org/openjdk/bench/javax/crypto/full/AESGCMCipherInputStream.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/full/AESGCMCipherInputStream.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.javax.crypto.full;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+
+import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+
+/**
+ * This performance test runs AES/GCM encryption and decryption using CipherInputStream.
+ *
+ * This test rotates the IV and creates a new GCMParameterSpec for each encrypt
+ * benchmark operation
+ */
+
+public class AESGCMCipherInputStream extends CryptoBase {
+
+    @Param({"128"})
+    private int keyLength;
+
+    @Param({"16384", "1048576"})
+    private int dataSize;
+
+    byte[] encryptedData;
+    byte[] in;
+    ByteArrayOutputStream out;
+    private Cipher encryptCipher;
+    private Cipher decryptCipher;
+    SecretKeySpec ks;
+    GCMParameterSpec gcm_spec;
+    byte[] iv;
+
+    private static final int IV_BUFFER_SIZE = 32;
+    private static final int IV_MODULO = IV_BUFFER_SIZE - 16;
+    int iv_index = 0;
+
+    private int next_iv_index() {
+        int r = iv_index;
+        iv_index = (iv_index + 1) % IV_MODULO;
+        return r;
+    }
+
+    @Setup
+    public void setup() throws Exception {
+        setupProvider();
+
+        // Setup key material
+        byte[] keystring = fillSecureRandom(new byte[keyLength / 8]);
+        ks = new SecretKeySpec(keystring, "AES");
+        iv = fillSecureRandom(new byte[IV_BUFFER_SIZE]);
+        gcm_spec = new GCMParameterSpec(96, iv, next_iv_index(), 16);
+
+        // Setup Cipher classes
+        encryptCipher = makeCipher(prov, "AES/GCM/NoPadding");
+        encryptCipher.init(Cipher.ENCRYPT_MODE, ks, gcm_spec);
+        decryptCipher = makeCipher(prov, "AES/GCM/NoPadding");
+        decryptCipher.init(Cipher.DECRYPT_MODE, ks,
+            encryptCipher.getParameters().
+                getParameterSpec(GCMParameterSpec.class));
+
+        // Setup input/output buffers
+        in = fillRandom(new byte[dataSize]);
+        encryptedData = new byte[encryptCipher.getOutputSize(in.length)];
+        out = new ByteArrayOutputStream(encryptedData.length);
+        encryptCipher.doFinal(in, 0, in.length, encryptedData, 0);
+    }
+
+    @Benchmark
+    public byte[] encrypt() throws Exception {
+        out.reset();
+        gcm_spec = new GCMParameterSpec(96, iv, next_iv_index(), 16);
+        encryptCipher.init(Cipher.ENCRYPT_MODE, ks, gcm_spec);
+        ByteArrayInputStream fin = new ByteArrayInputStream(in);
+        InputStream cin = new CipherInputStream(fin, encryptCipher);
+
+        cin.transferTo(out);
+        return out.toByteArray();
+    }
+
+    @Benchmark
+    public byte[] decrypt() throws Exception {
+        out.reset();
+        decryptCipher.init(Cipher.DECRYPT_MODE, ks,
+                encryptCipher.getParameters().
+                        getParameterSpec(GCMParameterSpec.class));
+        ByteArrayInputStream fin = new ByteArrayInputStream(encryptedData);
+        InputStream cin = new CipherInputStream(fin, decryptCipher);
+
+        cin.transferTo(out);
+        return out.toByteArray();
+    }
+}


### PR DESCRIPTION
This patch modifies `CipherInputStream` to avoid pointless memory allocations when decrypting data using AEAD ciphers.

`Cipher.update` on AEAD decryption does not output any data; instead, all data is buffered and returned in one shot from `doFinal` call. On the other hand, the value returned by `getOutputSize` increases after every `update` call, which triggers multiple allocations in the existing implementation.

This patch addresses the issue by calling the `update` overload that returns the output buffer until one of the `update` calls returns some data. When that happens, we know that the cipher does not buffer everything until `doFinal`, and revert to original behavior.

As long as `doUpdate` returns no data, the new implementation doesn't allocate any memory. As a result, for AEAD ciphers it will only allocate once in the `doFinal` invocation.

There's a similar issue in CipherOutputStream that manifests when doing many small writes; I'll file a separate bug for that.

The PR adds a new benchmark for AES/GCM encryption and decryption using CipherInputStream. That benchmark shows a nice improvement on decryption and comparable results on encryption.

Benchmark results before:
```
Benchmark                        (dataSize)  (keyLength)  (provider)   Mode  Cnt       Score      Error  Units
AESGCMCipherInputStream.decrypt       16384          128              thrpt   40   24590,604 ± 1169,075  ops/s
AESGCMCipherInputStream.decrypt     1048576          128              thrpt   40      19,159 ±    0,219  ops/s
AESGCMCipherInputStream.encrypt       16384          128              thrpt   40  127135,615 ± 2322,957  ops/s
AESGCMCipherInputStream.encrypt     1048576          128              thrpt   40    2138,727 ±   16,400  ops/s
```

After:
```
Benchmark                        (dataSize)  (keyLength)  (provider)   Mode  Cnt       Score      Error  Units
AESGCMCipherInputStream.decrypt       16384          128              thrpt   40   43419,355 ± 3265,238  ops/s
AESGCMCipherInputStream.decrypt     1048576          128              thrpt   40     789,463 ±   89,384  ops/s
AESGCMCipherInputStream.encrypt       16384          128              thrpt   40  123014,294 ± 3302,102  ops/s
AESGCMCipherInputStream.encrypt     1048576          128              thrpt   40    2007,224 ±   88,347  ops/s
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298249](https://bugs.openjdk.org/browse/JDK-8298249): Excessive memory allocation in CipherInputStream AEAD decryption


### Reviewers
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11597/head:pull/11597` \
`$ git checkout pull/11597`

Update a local copy of the PR: \
`$ git checkout pull/11597` \
`$ git pull https://git.openjdk.org/jdk pull/11597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11597`

View PR using the GUI difftool: \
`$ git pr show -t 11597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11597.diff">https://git.openjdk.org/jdk/pull/11597.diff</a>

</details>
