### PR TITLE
8298320: Typo in the comment block of  catch_inline_exception

### DIFF
--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -894,7 +894,7 @@ void Parse::catch_call_exceptions(ciExceptionHandlerStream& handlers) {
 // Common case 1: we have no handler, so all exceptions merge right into
 // the rethrow case.
 // Case 2: we have some handlers, with loaded exception klasses that have
-// no subklasses.  We do a Deutsch-Shiffman style type-check on the incoming
+// no subklasses.  We do a Deutsch-Schiffman style type-check on the incoming
 // exception oop and branch to the handler directly.
 // Case 3: We have some handlers with subklasses or are not loaded at
 // compile-time.  We have to call the runtime to resolve the exception.


### PR DESCRIPTION
The following comment makes reference to 'Deutsch-Shiffman'. I believe it's a typo. It should be 'Schiffman' if the author intent to cite this paper:
> Deutsch, L. Peter, and Allan M. Schiffman. "Efficient implementation of the Smalltalk-80 system." Proceedings of the 11th ACM SIGACT-SIGPLAN symposium on Principles of programming languages. 1984.

I ask 'Deutsch-Shiffman' to google and this is what google answers me. seems reasonable.

```
// Case 2: we have some handlers, with loaded exception klasses that have
// no subklasses. We do a Deutsch-Shiffman style type-check on the incoming
// exception oop and branch to the handler directly.
...
void Parse::catch_inline_exceptions(SafePointNode* ex_map) { 
```