### PR TITLE
JDK-8297679: InvocationTargetException field named target is not declared final

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/InvocationTargetException.java
+++ b/src/java.base/share/classes/java/lang/reflect/InvocationTargetException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class InvocationTargetException extends ReflectiveOperationException {
      * @serial
      *
      */
-    private Throwable target;
+    private final Throwable target;
 
     /**
      * Constructs an {@code InvocationTargetException} with
@@ -56,6 +56,7 @@ public class InvocationTargetException extends ReflectiveOperationException {
      */
     protected InvocationTargetException() {
         super((Throwable)null);  // Disallow initCause
+        this.target = null;
     }
 
     /**


### PR DESCRIPTION
Should be an innocuous change of a private field to final; I'll run an internal round of sanity tests before any push to make sure there isn't any unexpected interaction.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297679](https://bugs.openjdk.org/browse/JDK-8297679): InvocationTargetException field named target is not declared final


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11599/head:pull/11599` \
`$ git checkout pull/11599`

Update a local copy of the PR: \
`$ git checkout pull/11599` \
`$ git pull https://git.openjdk.org/jdk pull/11599/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11599`

View PR using the GUI difftool: \
`$ git pr show -t 11599`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11599.diff">https://git.openjdk.org/jdk/pull/11599.diff</a>

</details>
