### PR TITLE
8298187: (fs) BsdFileAttributeViews::setTimes does not support lastAccessTime on HFS+

### DIFF
--- a/src/java.base/macosx/classes/sun/nio/fs/BsdFileAttributeViews.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdFileAttributeViews.java
@@ -69,7 +69,7 @@ class BsdFileAttributeViews {
 
         try {
             // not all volumes support setattrlist(2), so set the last
-            // modified and last access times using futimens(2)
+            // modified and last access times using futimens(2)/lutimes(3)
             if (lastModifiedTime != null || lastAccessTime != null) {
                 // if not changing both attributes then need existing attributes
                 if (lastModifiedTime == null || lastAccessTime == null) {

--- a/src/java.base/macosx/classes/sun/nio/fs/BsdFileAttributeViews.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdFileAttributeViews.java
@@ -58,7 +58,7 @@ class BsdFileAttributeViews {
             }
 
             // not all volumes support fsetattrlist(2), so set the last
-            // modified and last access times using the Unix implementation
+            // modified and last access times using futimens(2)
             if (lastModifiedTime != null || lastAccessTime != null) {
                 // if not changing both attributes then need existing attributes
                 if (lastModifiedTime == null || lastAccessTime == null) {

--- a/src/java.base/macosx/classes/sun/nio/fs/BsdFileAttributeViews.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdFileAttributeViews.java
@@ -51,12 +51,12 @@ class BsdFileAttributeViews {
 
         int fd = -1;
         try {
-            try {
-                fd = path.openForAttributeAccess(followLinks);
-            } catch (UnixException x) {
-                x.rethrowAsIOException(path);
-            }
+            fd = path.openForAttributeAccess(followLinks);
+        } catch (UnixException x) {
+            x.rethrowAsIOException(path);
+        }
 
+        try {
             // not all volumes support fsetattrlist(2), so set the last
             // modified and last access times using futimens(2)
             if (lastModifiedTime != null || lastAccessTime != null) {

--- a/src/java.base/macosx/classes/sun/nio/fs/BsdNativeDispatcher.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdNativeDispatcher.java
@@ -95,7 +95,7 @@ class BsdNativeDispatcher extends UnixNativeDispatcher {
                           createTime, options);
         } finally {
             Blocker.end(comp);
-            }
+        }
     }
     private static native void fsetattrlist0(int fd, int commonattr,
                                              long modTime, long accTime,

--- a/src/java.base/macosx/classes/sun/nio/fs/BsdNativeDispatcher.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdNativeDispatcher.java
@@ -82,26 +82,24 @@ class BsdNativeDispatcher extends UnixNativeDispatcher {
                                          int flags);
 
     /**
-     * setattrlist(const char* path, struct attrlist* attrList, void* attrBuf,
-     *             size_t attrBufSize, unsigned long options)
+     * fsetattrlist(int fd, struct attrlist* attrList, void* attrBuf,
+     *              size_t attrBufSize, unsigned long options)
      */
-    static void setattrlist(UnixPath path, int commonattr, long modTime,
-                            long accTime, long createTime, long options)
+    static void fsetattrlist(int fd, int commonattr, long modTime,
+                             long accTime, long createTime, long options)
         throws UnixException
     {
-        try (NativeBuffer buffer = copyToNativeBuffer(path)) {
-            long comp = Blocker.begin();
-            try {
-                setattrlist0(buffer.address(), commonattr, modTime, accTime,
-                             createTime, options);
-            } finally {
-                Blocker.end(comp);
+        long comp = Blocker.begin();
+        try {
+            fsetattrlist0(fd, commonattr, modTime, accTime,
+                          createTime, options);
+        } finally {
+            Blocker.end(comp);
             }
-        }
     }
-    private static native void setattrlist0(long pathAddress, int commonattr,
-                                            long modTime, long accTime,
-                                            long createTime, long options)
+    private static native void fsetattrlist0(int fd, int commonattr,
+                                             long modTime, long accTime,
+                                             long createTime, long options)
         throws UnixException;
 
     // initialize field IDs

--- a/src/java.base/macosx/classes/sun/nio/fs/BsdNativeDispatcher.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdNativeDispatcher.java
@@ -82,6 +82,29 @@ class BsdNativeDispatcher extends UnixNativeDispatcher {
                                          int flags);
 
     /**
+     * setattrlist(const char* path, struct attrlist* attrList, void* attrBuf,
+     *             size_t attrBufSize, unsigned long options)
+     */
+    static void setattrlist(UnixPath path, int commonattr, long modTime,
+                            long accTime, long createTime, long options)
+        throws UnixException
+    {
+        try (NativeBuffer buffer = copyToNativeBuffer(path)) {
+            long comp = Blocker.begin();
+            try {
+                setattrlist0(buffer.address(), commonattr, modTime, accTime,
+                             createTime, options);
+            } finally {
+                Blocker.end(comp);
+            }
+        }
+    }
+    private static native void setattrlist0(long pathAddress, int commonattr,
+                                            long modTime, long accTime,
+                                            long createTime, long options)
+        throws UnixException;
+
+    /**
      * fsetattrlist(int fd, struct attrlist* attrList, void* attrBuf,
      *              size_t attrBufSize, unsigned long options)
      */

--- a/src/java.base/macosx/native/libnio/fs/BsdNativeDispatcher.c
+++ b/src/java.base/macosx/native/libnio/fs/BsdNativeDispatcher.c
@@ -244,11 +244,10 @@ Java_sun_nio_fs_BsdNativeDispatcher_clonefile0(JNIEnv* env, jclass this,
 }
 
 JNIEXPORT void JNICALL
-Java_sun_nio_fs_BsdNativeDispatcher_setattrlist0(JNIEnv* env, jclass this,
-    jlong pathAddress, int commonattr, jlong modTime, jlong accTime,
+Java_sun_nio_fs_BsdNativeDispatcher_fsetattrlist0(JNIEnv* env, jclass this,
+    jint fd, int commonattr, jlong modTime, jlong accTime,
     jlong createTime, jlong options)
 {
-    const char* path = (const char*)jlong_to_ptr(pathAddress);
     // attributes must align on 4-byte boundaries per the getattrlist(2) spec
     const int attrsize = ((sizeof(struct timespec) + 3)/4)*4;
     char buf[3*attrsize];
@@ -279,7 +278,7 @@ Java_sun_nio_fs_BsdNativeDispatcher_setattrlist0(JNIEnv* env, jclass this,
     attrList.bitmapcount = ATTR_BIT_MAP_COUNT;
     attrList.commonattr = commonattr;
 
-    if (setattrlist(path, &attrList, (void*)buf, count*attrsize, options) != 0) {
+    if (fsetattrlist(fd, &attrList, (void*)buf, count*attrsize, options) != 0) {
         throwUnixException(env, errno);
     }
 }

--- a/src/java.base/macosx/native/libnio/fs/BsdNativeDispatcher.c
+++ b/src/java.base/macosx/native/libnio/fs/BsdNativeDispatcher.c
@@ -39,6 +39,7 @@
 #define ISREADONLY MNT_RDONLY
 #endif
 #include <sys/attr.h>
+#include <unistd.h>
 
 #include <stdlib.h>
 #include <string.h>
@@ -243,16 +244,11 @@ Java_sun_nio_fs_BsdNativeDispatcher_clonefile0(JNIEnv* env, jclass this,
     return 0;
 }
 
-JNIEXPORT void JNICALL
-Java_sun_nio_fs_BsdNativeDispatcher_fsetattrlist0(JNIEnv* env, jclass this,
-    jint fd, int commonattr, jlong modTime, jlong accTime,
-    jlong createTime, jlong options)
+size_t initattrlist(jint commonattr, jlong modTime, jlong accTime,
+    jlong createTime, const int attrsize, char* buf, struct attrlist *attrList)
 {
-    // attributes must align on 4-byte boundaries per the getattrlist(2) spec
-    const int attrsize = ((sizeof(struct timespec) + 3)/4)*4;
-    char buf[3*attrsize];
-
     int count = 0;
+
     // attributes are ordered per the getattrlist(2) spec
     if ((commonattr & ATTR_CMN_CRTIME) != 0) {
         struct timespec* t = (struct timespec*)buf;
@@ -273,12 +269,46 @@ Java_sun_nio_fs_BsdNativeDispatcher_fsetattrlist0(JNIEnv* env, jclass this,
         count++;
     }
 
-    struct attrlist attrList;
-    memset(&attrList, 0, sizeof(struct attrlist));
-    attrList.bitmapcount = ATTR_BIT_MAP_COUNT;
-    attrList.commonattr = commonattr;
+    memset(attrList, 0, sizeof(struct attrlist));
+    attrList->bitmapcount = ATTR_BIT_MAP_COUNT;
+    attrList->commonattr = commonattr;
 
-    if (fsetattrlist(fd, &attrList, (void*)buf, count*attrsize, options) != 0) {
+    return count*attrsize;
+}
+
+JNIEXPORT void JNICALL
+Java_sun_nio_fs_BsdNativeDispatcher_setattrlist0(JNIEnv* env, jclass this,
+    jlong pathAddress, int commonattr, jlong modTime, jlong accTime,
+    jlong createTime, jlong options)
+{
+    const char* path = (const char*)jlong_to_ptr(pathAddress);
+    // attributes must align on 4-byte boundaries per the getattrlist(2) spec
+    const int attrsize = ((sizeof(struct timespec) + 3)/4)*4;
+    char buf[3*attrsize];
+
+    struct attrlist attrList;
+    size_t attrBufSize = initattrlist(commonattr, modTime, accTime, createTime,
+                                      attrsize, buf, &attrList);
+
+    if (setattrlist(path, &attrList, (void*)buf, attrBufSize, options) != 0) {
+        throwUnixException(env, errno);
+    }
+}
+
+JNIEXPORT void JNICALL
+Java_sun_nio_fs_BsdNativeDispatcher_fsetattrlist0(JNIEnv* env, jclass this,
+    jint fd, int commonattr, jlong modTime, jlong accTime,
+    jlong createTime, jlong options)
+{
+    // attributes must align on 4-byte boundaries per the getattrlist(2) spec
+    const int attrsize = ((sizeof(struct timespec) + 3)/4)*4;
+    char buf[3*attrsize];
+
+    struct attrlist attrList;
+    size_t attrBufSize = initattrlist(commonattr, modTime, accTime, createTime,
+                                      attrsize, buf, &attrList);
+
+    if (fsetattrlist(fd, &attrList, (void*)buf, attrBufSize, options) != 0) {
         throwUnixException(env, errno);
     }
 }

--- a/src/java.base/share/classes/java/nio/file/attribute/BasicFileAttributeView.java
+++ b/src/java.base/share/classes/java/nio/file/attribute/BasicFileAttributeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -134,7 +134,7 @@ public interface BasicFileAttributeView
      *
      * <p> This method updates the file's timestamp attributes. The values are
      * converted to the epoch and precision supported by the file system.
-     * Converting from finer to coarser granularities result in precision loss.
+     * Converting from finer to coarser granularities results in precision loss.
      * The behavior of this method when attempting to set a timestamp that is
      * not supported or to a value that is outside the range supported by the
      * underlying file store is not defined. It may or not fail by throwing an

--- a/src/java.base/unix/classes/sun/nio/fs/UnixConstants.java.template
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixConstants.java.template
@@ -153,7 +153,7 @@ class UnixConstants {
     static final int PREFIX_CLONE_NOFOLLOW = CLONE_NOFOLLOW;
     static final int PREFIX_CLONE_NOOWNERCOPY = CLONE_NOOWNERCOPY;
 
-    // flags used with setattrlist
+    // flags used with fsetattrlist
     static final int PREFIX_ATTR_CMN_CRTIME = ATTR_CMN_CRTIME;
     static final int PREFIX_ATTR_CMN_MODTIME = ATTR_CMN_MODTIME;
     static final int PREFIX_ATTR_CMN_ACCTIME = ATTR_CMN_ACCTIME;


### PR DESCRIPTION
If the path is on an HFS store, use the generic Unix implementation of `java.nio.file.attribute.BasicFileAttributeView::setTimes`to set the last access time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298187](https://bugs.openjdk.org/browse/JDK-8298187): (fs) BsdFileAttributeViews::setTimes does not support lastAccessTime on HFS+


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11600/head:pull/11600` \
`$ git checkout pull/11600`

Update a local copy of the PR: \
`$ git checkout pull/11600` \
`$ git pull https://git.openjdk.org/jdk pull/11600/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11600`

View PR using the GUI difftool: \
`$ git pr show -t 11600`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11600.diff">https://git.openjdk.org/jdk/pull/11600.diff</a>

</details>
