### PR TITLE
8298271: java/security/SignedJar/spi-calendar-provider/TestSPISigned.java failing on Windows

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -618,8 +618,6 @@ sun/security/pkcs11/rsa/TestKeyPairGenerator.java               8295343 linux-al
 sun/security/pkcs11/rsa/TestKeyFactory.java                     8295343 linux-all
 sun/security/pkcs11/KeyStore/Basic.java                         8295343 linux-all
 
-java/security/SignedJar/spi-calendar-provider/TestSPISigned.java 8298271 windows-all
-
 ############################################################################
 
 # jdk_sound

--- a/test/jdk/java/security/SignedJar/spi-calendar-provider/TestSPISigned.java
+++ b/test/jdk/java/security/SignedJar/spi-calendar-provider/TestSPISigned.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.nio.file.Paths;
 import java.nio.file.Path;
 import java.nio.file.Files;
+import java.io.File;
 import static java.util.Calendar.WEDNESDAY;
 
 /*
@@ -95,7 +96,7 @@ public class TestSPISigned {
             testRun.add("-Djava.locale.providers=SPI");
             testRun.add("-cp");
             String classPath = System.getProperty("java.class.path");
-            classPath = classPath + ":" + SIGNED_JAR.toAbsolutePath().toString();
+            classPath = classPath + File.pathSeparator + SIGNED_JAR.toAbsolutePath().toString();
             testRun.add(classPath);
             testRun.add(TestSPISigned.class.getSimpleName());
             testRun.add("run-test");


### PR DESCRIPTION
The test introduced with [JDK-8298108](https://bugs.openjdk.org/browse/JDK-8298108) failed on Windows apparently due to a non-portable use of `path.separator` in the test.

@seanjmullan was kind enough to test this change, which fixes the issue on Windows.

Thus, remove the test from the `ProblemList.txt` as the test now works on that platform as well. Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298271](https://bugs.openjdk.org/browse/JDK-8298271): java/security/SignedJar/spi-calendar-provider/TestSPISigned.java failing on Windows


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11606/head:pull/11606` \
`$ git checkout pull/11606`

Update a local copy of the PR: \
`$ git checkout pull/11606` \
`$ git pull https://git.openjdk.org/jdk pull/11606/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11606`

View PR using the GUI difftool: \
`$ git pr show -t 11606`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11606.diff">https://git.openjdk.org/jdk/pull/11606.diff</a>

</details>
