### PR TITLE
JDK-8298462 - InputStream.concat() provides anyonymous, optimized sequence of input streams

### DIFF
--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -793,4 +793,63 @@ public abstract class InputStream implements Closeable {
         }
         return transferred;
     }
+
+    /**
+     * Returns an input stream which is a sequence of the content of {@code this} stream
+     * followed by the content of the provided {@code in} stream.
+     *
+     * @apiNote No assumption must be made on the behavior of the returned implementation,
+     * In particular whether the implementation is synchronized in any way, is buffered,
+     * is {@link #markSupported()}, or is serializable.
+     *
+     * @implSpec The implementation SHOULD NOT explicitly synchronize nor buffer the content
+     * beyond delegating to the concatenated streams, which MAY keep their specific behavior.
+     * As a result, the wrapped streams MAY be synchronized, buffered and/or serializable.
+     *
+     * @implNote The implementation may change at any time without further note.
+     * It currently returns a {@link SequenceInputStream}, but MAY return a different
+     * class in future.
+     *
+     * @param in The input stream to concatenate to the end of {@code this} input stream.
+     * @return An input stream providing the content of {@code this} input stream until EOF,
+     * followed by the content of {@code in}.
+     * @throws IOException if an I/O error occurs while setting up the sequence
+     * @throws NullPointerException if {@code in} is {@code null}
+     *
+     * @since 21
+     */
+    public InputStream concat(InputStream in) throws IOException {
+        Object.requireNonNull(in, "in");
+        return new SequenceInputStream(this, in);
+    }
+
+    /**
+     * Returns an input stream which is a sequence of the content of {@code this} stream
+     * followed by the content of the provided {@code in} stream.
+     *
+     * @apiNote No assumption must be made on the behavior of the returned implementation,
+     * In particular whether the implementation is synchronized in any way, is buffered,
+     * is {@link #markSupported()}, or is serializable.
+     *
+     * @implSpec The implementation SHOULD NOT explicitly synchronize nor buffer the content
+     * beyond delegating to the concatenated streams, which MAY keep their specific behavior.
+     * As a result, the wrapped streams MAY be synchronized, buffered and/or serializable.
+     *
+     * @implNote The implementation may change at any time without further note.
+     * It currently returns {@code in1.concat(in2)}.
+     *
+     * @param in1 The first input stream of the returned sequence.
+     * @param in2 The second input stream of the returned sequence.
+     * @return An input stream providing the content of {@code in1} until EOF,
+     * followed by the content of {@code in2}.
+     * @throws IOException if an I/O error occurs while setting up the sequence
+     * @throws NullPointerException if {@code in} is {@code null}
+     *
+     * @since 21
+     */
+    public static InputStream concat(InputStream in1, InputStream in2) throws IOException {
+        Object.requireNonNull(in1, "in1");
+        Object.requireNonNull(in2, "in2");
+        return in1.concat(in2);
+    }
 }

--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -819,7 +819,7 @@ public abstract class InputStream implements Closeable {
      * @since 21
      */
     public InputStream concat(InputStream in) throws IOException {
-        Object.requireNonNull(in, "in");
+        Objects.requireNonNull(in, "in");
         return new SequenceInputStream(this, in);
     }
 
@@ -848,8 +848,8 @@ public abstract class InputStream implements Closeable {
      * @since 21
      */
     public static InputStream concat(InputStream in1, InputStream in2) throws IOException {
-        Object.requireNonNull(in1, "in1");
-        Object.requireNonNull(in2, "in2");
+        Objects.requireNonNull(in1, "in1");
+        Objects.requireNonNull(in2, "in2");
         return in1.concat(in2);
     }
 }


### PR DESCRIPTION
This PR provides proposals and discussion around [JDK-8298462](https://bugs.openjdk.org/browse/JDK-8298462).

In particular, it provides a `static` vs. a non-`static` variant of `InputStream.concat()`, including an at-most defensive API Specification and Implementation Notes aiming for at-most freedom to change the implementation later at any time in any direction. This should help to prevent "behavior-lock-in" as we noticed it with the original `SequenceInputStream` class.

Target: The target of this PR is to **discuss** what the final API and implementation shall look like, so in further future it can be heavily modified to become reviewed and merged *afterwards*.

Non-Target: This PR currently has NOT the target to get reviewed or merged *now*.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298462](https://bugs.openjdk.org/browse/JDK-8298462): InputStream.concat() provides anyonymous, optimized sequence of input streams


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11608/head:pull/11608` \
`$ git checkout pull/11608`

Update a local copy of the PR: \
`$ git checkout pull/11608` \
`$ git pull https://git.openjdk.org/jdk pull/11608/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11608`

View PR using the GUI difftool: \
`$ git pr show -t 11608`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11608.diff">https://git.openjdk.org/jdk/pull/11608.diff</a>

</details>
