### PR TITLE
JDK-8298476: Unseal FinalReference<T>

### DIFF
--- a/src/java.base/share/classes/java/lang/ref/FinalReference.java
+++ b/src/java.base/share/classes/java/lang/ref/FinalReference.java
@@ -28,7 +28,7 @@ package java.lang.ref;
 /**
  * Final references, used to implement finalization
  */
-sealed class FinalReference<T> extends Reference<T> permits Finalizer {
+non-sealed class FinalReference<T> extends Reference<T> {
 
     public FinalReference(T referent, ReferenceQueue<? super T> q) {
         super(referent, q);


### PR DESCRIPTION
The change in [JDK-8283415](https://bugs.openjdk.org/browse/JDK-8283415) made use of the now available `sealed` keyword for `FinalReference<T>`.

Unfortunately this introduced a problem for the Espresso VM (Java on Truffle): Since Espresso is written in Java it uses the functionality of the "Host VM" to implement finalization. It does that however by [introducing a new subclass of `FinalReference<T>`](https://github.com/oracle/graal/blob/f195395329fba573afc6f81c5e70a18ac334dd10/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/ref/ClassAssembler.java#L85-L113) which does not work anymore with the changes made in JDK-8283415. We cannot use `Finalizer` itself because we want to inject an additional "Guest object".

Making `FinalReference<T>` `non-sealed` would simplify things for Espresso. Before pursuing other more involved solutions I thought I would ask how strongly the maintainers of core-libs feel about such a change. Would that be okay? Are there any implications for the GC for such a change?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298476](https://bugs.openjdk.org/browse/JDK-8298476): Unseal FinalReference<T>


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11610/head:pull/11610` \
`$ git checkout pull/11610`

Update a local copy of the PR: \
`$ git checkout pull/11610` \
`$ git pull https://git.openjdk.org/jdk pull/11610/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11610`

View PR using the GUI difftool: \
`$ git pr show -t 11610`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11610.diff">https://git.openjdk.org/jdk/pull/11610.diff</a>

</details>
