### PR TITLE
7093322: (fs spec) Files.newBufferedWriter should be clear when coding errors are detected

### DIFF
--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -2938,7 +2938,12 @@ public final class Files {
      * a size of {@code 0} if it exists.
      *
      * <p> The {@code Writer} methods to write text throw {@code IOException}
-     * if the text cannot be encoded using the specified charset.
+     * if the text cannot be encoded using the specified charset. Such coding
+     * exceptions will not occur until characters are flushed to the underlying
+     * stream either because the internal buffer was filled during writing, or
+     * {@linkplain BufferedWriter#close close()} or
+     * {@linkplain BufferedWriter#flush flush()}
+     * was invoked explicitly on the returned {@code BufferedWriter}.
      *
      * @param   path
      *          the path to the file

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -2938,12 +2938,10 @@ public final class Files {
      * a size of {@code 0} if it exists.
      *
      * <p> The {@code Writer} methods to write text throw {@code IOException}
-     * if the text cannot be encoded using the specified charset. Such coding
-     * exceptions will not occur until characters are flushed to the underlying
-     * stream either because the internal buffer was filled during writing, or
-     * {@linkplain BufferedWriter#close close()} or
-     * {@linkplain BufferedWriter#flush flush()}
-     * was invoked explicitly on the returned {@code BufferedWriter}.
+     * if the text cannot be encoded using the specified charset. Due to
+     * buffering, an {@code IOException} caused by an encoding error
+     * (unmappable-character or malformed-input) may be thrown when writing,
+     * flushing, or closing the buffered writer.
      *
      * @param   path
      *          the path to the file

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -2940,8 +2940,10 @@ public final class Files {
      * <p> The {@code Writer} methods to write text throw {@code IOException}
      * if the text cannot be encoded using the specified charset. Due to
      * buffering, an {@code IOException} caused by an encoding error
-     * (unmappable-character or malformed-input) may be thrown when writing,
-     * flushing, or closing the buffered writer.
+     * (unmappable-character or malformed-input) may be thrown when {@linkplain
+     * BufferedWriter#write(char[],int,int) writing}, {@linkplain
+     * BufferedWriter#flush flushing}, or {@linkplain BufferedWriter#close
+     * closing} the buffered writer.
      *
      * @param   path
      *          the path to the file


### PR DESCRIPTION
Add a sentence to clarify that coding exceptions are not thrown until the characters are actually written to the underlying stream.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-7093322](https://bugs.openjdk.org/browse/JDK-7093322): (fs spec) Files.newBufferedWriter should be clear when coding errors are detected
 * [JDK-8298609](https://bugs.openjdk.org/browse/JDK-8298609): (fs spec) Files.newBufferedWriter should be clear when coding errors are detected (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11616/head:pull/11616` \
`$ git checkout pull/11616`

Update a local copy of the PR: \
`$ git checkout pull/11616` \
`$ git pull https://git.openjdk.org/jdk pull/11616/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11616`

View PR using the GUI difftool: \
`$ git pr show -t 11616`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11616.diff">https://git.openjdk.org/jdk/pull/11616.diff</a>

</details>
