### PR TITLE
8298343: "Could not confirm if TargetJDK is hardened." warning for SA tests on macosx-aarch64-debug

### DIFF
--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -295,6 +295,10 @@ public class Platform {
             } else if (line.indexOf("flags=0x20002(adhoc,linker-signed)") != -1 ) {
                 hardenedStatusConfirmed = true;
                 isHardened = false;
+                System.out.println("Target JDK is adhoc linker-signed, but not hardened.");
+            } else if (line.indexOf("flags=0x2(adhoc)") != -1 ) {
+                hardenedStatusConfirmed = true;
+                isHardened = false;
                 System.out.println("Target JDK is adhoc signed, but not hardened.");
             } else if (line.indexOf("code object is not signed at all") != -1) {
                 hardenedStatusConfirmed = true;


### PR DESCRIPTION
In the log for most SA tests on macos-aarch64-debug, you will see something like:

```
STDOUT: Executable=/System/Volumes/Data/mesos/work_dir/jib-master/install/2022-12-07-2219530.chris.plummer.jdk/macosx-aarch64-debug.jdk/jdk-20/fastdebug/bin/java
...
STDOUT: CodeDirectory v=20400 size=758 flags=0x2(adhoc) hashes=13+7 location=embedded
STDOUT: Signature=adhoc
...
Could not confirm if TargetJDK is hardened. Assuming not hardened.
```

The message at the end shouldn't be happening. The problem is in `Platform.isHardenedOSX()`, which is searching for "flags=0x20002(adhoc,linker-signed)", but instead we are seeing "flags=0x2(adhoc)". This is due to [JDK-8293550](https://bugs.openjdk.org/browse/JDK-8293550), which is now explicitly adding adhoc signing. Previously we just allowed the linker to just do the default adhoc signing, which is why you would also see the "linker-signed" flag. Since we explicitly do adhoc signing now, "linker-signed" is missing.

The fix is to just allow either form. Since it is possible to build without the explicit adhoc signing, we still need to support the old form that includes "linker-signed".

There seems to be no adverse affects from this bug, other than seeing the above message, since the conclusion that the JDK is not hardened is the correct one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298343](https://bugs.openjdk.org/browse/JDK-8298343): "Could not confirm if TargetJDK is hardened." warning for SA tests on macosx-aarch64-debug


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11619/head:pull/11619` \
`$ git checkout pull/11619`

Update a local copy of the PR: \
`$ git checkout pull/11619` \
`$ git pull https://git.openjdk.org/jdk pull/11619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11619`

View PR using the GUI difftool: \
`$ git pr show -t 11619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11619.diff">https://git.openjdk.org/jdk/pull/11619.diff</a>

</details>
