### PR TITLE
8298513: vmTestbase/nsk/jdi/EventSet/suspendPolicy/suspendpolicy009/TestDescription.java fails with usage tracker

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/suspendPolicy/suspendpolicy009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/suspendPolicy/suspendpolicy009.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -292,7 +292,7 @@ public class suspendpolicy009 extends JDIBase {
 
         for (int i = 0; ; i++) {
 
-            breakpointForCommunication();
+            breakpointForCommunication(debuggeeName);
 
             int instruction = ((IntegerValue)
                                (debuggeeClass.getValue(debuggeeClass.fieldByName("instruction")))).value();


### PR DESCRIPTION
The fix updates the test to ignore ThreadDeathEvent event from non-test  threads waiting for breakpoint

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298513](https://bugs.openjdk.org/browse/JDK-8298513): vmTestbase/nsk/jdi/EventSet/suspendPolicy/suspendpolicy009/TestDescription.java fails with usage tracker


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11620/head:pull/11620` \
`$ git checkout pull/11620`

Update a local copy of the PR: \
`$ git checkout pull/11620` \
`$ git pull https://git.openjdk.org/jdk pull/11620/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11620`

View PR using the GUI difftool: \
`$ git pr show -t 11620`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11620.diff">https://git.openjdk.org/jdk/pull/11620.diff</a>

</details>
