### PR TITLE
8298521: Rename members in G1MonitoringSupport

### DIFF
--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
@@ -88,13 +88,13 @@ public:
 
 G1MonitoringSupport::G1MonitoringSupport(G1CollectedHeap* g1h) :
   _g1h(g1h),
-  _incremental_memory_manager("G1 Young Generation", "end of minor GC"),
+  _young_gc_memory_manager("G1 Young Generation", "end of minor GC"),
   _full_gc_memory_manager("G1 Old Generation", "end of major GC"),
   _conc_gc_memory_manager("G1 Concurrent GC", "end of concurrent GC pause"),
   _eden_space_pool(NULL),
   _survivor_space_pool(NULL),
   _old_gen_pool(NULL),
-  _incremental_collection_counters(NULL),
+  _young_collection_counters(NULL),
   _full_collection_counters(NULL),
   _conc_collection_counters(NULL),
   _young_gen_counters(NULL),
@@ -121,7 +121,7 @@ G1MonitoringSupport::G1MonitoringSupport(G1CollectedHeap* g1h) :
   //
   //  name "collector.0".  In a generational collector this would be the
   // young generation collection.
-  _incremental_collection_counters =
+  _young_collection_counters =
     new CollectorCounters("G1 young collection pauses", 0);
   //   name "collector.1".  In a generational collector this would be the
   // old generation collection.
@@ -202,9 +202,9 @@ void G1MonitoringSupport::initialize_serviceability() {
 
   _conc_gc_memory_manager.add_pool(_old_gen_pool);
 
-  _incremental_memory_manager.add_pool(_eden_space_pool);
-  _incremental_memory_manager.add_pool(_survivor_space_pool);
-  _incremental_memory_manager.add_pool(_old_gen_pool, false /* always_affected_by_gc */);
+  _young_gc_memory_manager.add_pool(_eden_space_pool);
+  _young_gc_memory_manager.add_pool(_survivor_space_pool);
+  _young_gc_memory_manager.add_pool(_old_gen_pool, false /* always_affected_by_gc */);
 }
 
 MemoryUsage G1MonitoringSupport::memory_usage() {
@@ -214,7 +214,7 @@ MemoryUsage G1MonitoringSupport::memory_usage() {
 
 GrowableArray<GCMemoryManager*> G1MonitoringSupport::memory_managers() {
   GrowableArray<GCMemoryManager*> memory_managers(3);
-  memory_managers.append(&_incremental_memory_manager);
+  memory_managers.append(&_young_gc_memory_manager);
   memory_managers.append(&_full_gc_memory_manager);
   memory_managers.append(&_conc_gc_memory_manager);
   return memory_managers;
@@ -298,7 +298,7 @@ void G1MonitoringSupport::update_sizes() {
   if (UsePerfData) {
     _eden_space_counters->update_capacity(pad_capacity(_eden_space_committed));
     _eden_space_counters->update_used(_eden_space_used);
-   // only the "to" survivor space is active, so we don't need to
+    // only the "to" survivor space is active, so we don't need to
     // update the counters for the "from" survivor space
     _to_space_counters->update_capacity(pad_capacity(_survivor_space_committed));
     _to_space_counters->update_used(_survivor_space_used);
@@ -367,8 +367,8 @@ G1MonitoringScope::~G1MonitoringScope() {
 G1YoungGCMonitoringScope::G1YoungGCMonitoringScope(G1MonitoringSupport* monitoring_support,
                                                    bool all_memory_pools_affected) :
   G1MonitoringScope(monitoring_support,
-                    monitoring_support->_incremental_collection_counters,
-                    &monitoring_support->_incremental_memory_manager,
+                    monitoring_support->_young_collection_counters,
+                    &monitoring_support->_young_gc_memory_manager,
                     all_memory_pools_affected) {
 }
 

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
@@ -128,7 +128,7 @@ class G1MonitoringSupport : public CHeapObj<mtGC> {
   G1CollectedHeap* _g1h;
 
   // java.lang.management MemoryManager and MemoryPool support
-  GCMemoryManager _incremental_memory_manager;
+  GCMemoryManager _young_gc_memory_manager;
   GCMemoryManager _full_gc_memory_manager;
   GCMemoryManager _conc_gc_memory_manager;
 
@@ -137,11 +137,11 @@ class G1MonitoringSupport : public CHeapObj<mtGC> {
   MemoryPool* _old_gen_pool;
 
   // jstat performance counters
-  //  incremental collections both young and mixed
-  CollectorCounters*   _incremental_collection_counters;
+  //  young stop-the-world collections (including mixed)
+  CollectorCounters*   _young_collection_counters;
   //  full stop-the-world collections
   CollectorCounters*   _full_collection_counters;
-  //  stop-the-world phases in G1
+  //  stop-the-world phases in G1 concurrent collection
   CollectorCounters*   _conc_collection_counters;
   //  young collection set counters.  The _eden_counters,
   // _from_counters, and _to_counters are associated with


### PR DESCRIPTION
Hi,

Can I have review on this trivial change that renames a few members in G1MonitoringSupport for consistency?

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298521](https://bugs.openjdk.org/browse/JDK-8298521): Rename members in G1MonitoringSupport


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11623/head:pull/11623` \
`$ git checkout pull/11623`

Update a local copy of the PR: \
`$ git checkout pull/11623` \
`$ git pull https://git.openjdk.org/jdk pull/11623/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11623`

View PR using the GUI difftool: \
`$ git pr show -t 11623`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11623.diff">https://git.openjdk.org/jdk/pull/11623.diff</a>

</details>
