### PR TITLE
8298524: Debug function to trace reachability of CDS archived heap objects

### DIFF
--- a/src/hotspot/share/cds/cdsHeapVerifier.cpp
+++ b/src/hotspot/share/cds/cdsHeapVerifier.cpp
@@ -236,7 +236,7 @@ inline bool CDSHeapVerifier::do_entry(oop& orig_obj, HeapShared::CachedOopInfo& 
     ls.print("Value: ");
     orig_obj->print_on(&ls);
     ls.print_cr("--- trace begin ---");
-    trace_to_root(orig_obj, NULL, &value);
+    trace_to_root(&ls, orig_obj, NULL, &value);
     ls.print_cr("--- trace end ---");
     ls.cr();
     _problems ++;
@@ -248,54 +248,63 @@ inline bool CDSHeapVerifier::do_entry(oop& orig_obj, HeapShared::CachedOopInfo& 
 class CDSHeapVerifier::TraceFields : public FieldClosure {
   oop _orig_obj;
   oop _orig_field;
-  LogStream* _ls;
+  outputStream* _st;
 
 public:
-  TraceFields(oop orig_obj, oop orig_field, LogStream* ls)
-    : _orig_obj(orig_obj), _orig_field(orig_field), _ls(ls) {}
+  TraceFields(oop orig_obj, oop orig_field, outputStream* st)
+    : _orig_obj(orig_obj), _orig_field(orig_field), _st(st) {}
 
   void do_field(fieldDescriptor* fd) {
     if (fd->field_type() == T_OBJECT || fd->field_type() == T_ARRAY) {
       oop obj_field = _orig_obj->obj_field(fd->offset());
       if (obj_field == _orig_field) {
-        _ls->print("::%s (offset = %d)", fd->name()->as_C_string(), fd->offset());
+        _st->print("::%s (offset = %d)", fd->name()->as_C_string(), fd->offset());
       }
     }
   }
 };
 
+// Call this function (from gdb, etc) if you want to know why an object is archived.
+void CDSHeapVerifier::trace_to_root(outputStream* st, oop orig_obj) {
+  HeapShared::CachedOopInfo* info = HeapShared::archived_object_cache()->get(orig_obj);
+  if (info != NULL) {
+    trace_to_root(st, orig_obj, NULL, info);
+  } else {
+    st->print_cr("Not an archived object??");
+  }
+}
+
 // Hint: to exercise this function, uncomment out one of the ADD_EXCL lines above.
-int CDSHeapVerifier::trace_to_root(oop orig_obj, oop orig_field, HeapShared::CachedOopInfo* p) {
+int CDSHeapVerifier::trace_to_root(outputStream* st, oop orig_obj, oop orig_field, HeapShared::CachedOopInfo* info) {
   int level = 0;
-  LogStream ls(Log(cds, heap)::warning());
-  if (p->_referrer != NULL) {
-    HeapShared::CachedOopInfo* ref = HeapShared::archived_object_cache()->get(p->_referrer);
+  if (info->_referrer != NULL) {
+    HeapShared::CachedOopInfo* ref = HeapShared::archived_object_cache()->get(info->_referrer);
     assert(ref != NULL, "sanity");
-    level = trace_to_root(p->_referrer, orig_obj, ref) + 1;
+    level = trace_to_root(st, info->_referrer, orig_obj, ref) + 1;
   } else if (java_lang_String::is_instance(orig_obj)) {
-    ls.print_cr("[%2d] (shared string table)", level++);
+    st->print_cr("[%2d] (shared string table)", level++);
   }
   Klass* k = orig_obj->klass();
   ResourceMark rm;
-  ls.print("[%2d] ", level);
-  orig_obj->print_address_on(&ls);
-  ls.print(" %s", k->internal_name());
+  st->print("[%2d] ", level);
+  orig_obj->print_address_on(st);
+  st->print(" %s", k->internal_name());
   if (orig_field != NULL) {
     if (k->is_instance_klass()) {
-      TraceFields clo(orig_obj, orig_field, &ls);;
+      TraceFields clo(orig_obj, orig_field, st);
       InstanceKlass::cast(k)->do_nonstatic_fields(&clo);
     } else {
       assert(orig_obj->is_objArray(), "must be");
       objArrayOop array = (objArrayOop)orig_obj;
       for (int i = 0; i < array->length(); i++) {
         if (array->obj_at(i) == orig_field) {
-          ls.print(" @[%d]", i);
+          st->print(" @[%d]", i);
           break;
         }
       }
     }
   }
-  ls.cr();
+  st->cr();
 
   return level;
 }

--- a/src/hotspot/share/cds/cdsHeapVerifier.cpp
+++ b/src/hotspot/share/cds/cdsHeapVerifier.cpp
@@ -274,7 +274,6 @@ void CDSHeapVerifier::trace_to_root(outputStream* st, oop orig_obj) {
   }
 }
 
-// Hint: to exercise this function, uncomment out one of the ADD_EXCL lines above.
 int CDSHeapVerifier::trace_to_root(outputStream* st, oop orig_obj, oop orig_field, HeapShared::CachedOopInfo* info) {
   int level = 0;
   if (info->_referrer != NULL) {

--- a/src/hotspot/share/cds/cdsHeapVerifier.hpp
+++ b/src/hotspot/share/cds/cdsHeapVerifier.hpp
@@ -69,7 +69,7 @@ class CDSHeapVerifier : public KlassClosure {
     }
     return NULL;
   }
-  int trace_to_root(oop orig_obj, oop orig_field, HeapShared::CachedOopInfo* p);
+  static int trace_to_root(outputStream* st, oop orig_obj, oop orig_field, HeapShared::CachedOopInfo* p);
 
   CDSHeapVerifier();
   ~CDSHeapVerifier();
@@ -83,6 +83,8 @@ public:
   inline bool do_entry(oop& orig_obj, HeapShared::CachedOopInfo& value);
 
   static void verify() NOT_DEBUG_RETURN;
+
+  static void trace_to_root(outputStream* st, oop orig_obj);
 };
 
 #endif // INCLUDE_CDS_JAVA_HEAP


### PR DESCRIPTION
Please review this small change to help debugging the CDS heap archiving code. 

Here's an example in gdb that shows how the `java.lang.Module` object at `0x00000005ce8d9ba0` is reached from the root (`ArchivedClassLoaders::servicesCatalogs `)

```
Thread 8 "VM Thread" hit Breakpoint 2, HeapShared::check_module_oop (orig_module_obj=0x5ce8bf588)
    at heapShared.cpp:1193
1193	  assert(DumpSharedSpaces, "must be");
(gdb) call CDSHeapVerifier::trace_to_root(tty, orig_module_obj)
[ 0] {0x00000005ce8bb900} jdk.internal.loader.ArchivedClassLoaders::servicesCatalogs (offset = 24)
[ 1] {0x00000005ce8bba08} [Ljdk.internal.module.ServicesCatalog; @[0]
[ 2] {0x00000005ce8bbb60} jdk.internal.module.ServicesCatalog::map (offset = 12)
[ 3] {0x00000005ce8bbb70} java.util.concurrent.ConcurrentHashMap::table (offset = 40)
[ 4] {0x00000005ce8d9638} [Ljava.util.concurrent.ConcurrentHashMap$Node; @[0]
[ 5] {0x00000005ce8d9bc0} java.util.concurrent.ConcurrentHashMap$Node::val (offset = 20)
[ 6] {0x00000005ce8d9b78} java.util.concurrent.CopyOnWriteArrayList::array (offset = 16)
[ 7] {0x00000005ce8d9ba0} [Ljava.lang.Object; @[0]
[ 8] {0x00000005ce8d9b30} jdk.internal.module.ServicesCatalog$ServiceProvider::module (offset = 12)
[ 9] {0x00000005ce8bf588} java.lang.Module
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298524](https://bugs.openjdk.org/browse/JDK-8298524): Debug function to trace reachability of CDS archived heap objects


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**) ⚠️ Review applies to [d6f1a2fa](https://git.openjdk.org/jdk/pull/11628/files/d6f1a2fa29d5d5368c8cbcf400e513c1f92765e3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11628/head:pull/11628` \
`$ git checkout pull/11628`

Update a local copy of the PR: \
`$ git checkout pull/11628` \
`$ git pull https://git.openjdk.org/jdk pull/11628/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11628`

View PR using the GUI difftool: \
`$ git pr show -t 11628`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11628.diff">https://git.openjdk.org/jdk/pull/11628.diff</a>

</details>
