### PR TITLE
8298532: Declare private constructors for FFM internal Architecture implementations

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Architecture.java
@@ -30,8 +30,10 @@ import jdk.internal.foreign.abi.Architecture;
 import jdk.internal.foreign.abi.StubLocations;
 import jdk.internal.foreign.abi.VMStorage;
 
-public class AArch64Architecture implements Architecture {
+public final class AArch64Architecture implements Architecture {
     public static final Architecture INSTANCE = new AArch64Architecture();
+
+    private AArch64Architecture() {}
 
     private static final short REG64_MASK = 0b0000_0000_0000_0001;
     private static final short V128_MASK = 0b0000_0000_0000_0001;

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/X86_64Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/X86_64Architecture.java
@@ -31,8 +31,10 @@ import jdk.internal.foreign.abi.VMStorage;
 
 import java.util.stream.IntStream;
 
-public class X86_64Architecture implements Architecture {
+public final class X86_64Architecture implements Architecture {
     public static final Architecture INSTANCE = new X86_64Architecture();
+
+    private X86_64Architecture() {}
 
     private static final short REG8_H_MASK = 0b0000_0000_0000_0010;
     private static final short REG8_L_MASK = 0b0000_0000_0000_0001;


### PR DESCRIPTION
This PR proposes declaring `AArch64Architecture` and `X86_64Architecture` `final` and creating a `private` constructor so that this redundant byte code can be eliminated:

```
 public jdk.internal.foreign.abi.x64.X86_64Architecture(); 
    Code: 
       0: aload_0 
       1: invokespecial #1 // Method java/lang/Object."<init>":()V 
       4: return 

 public jdk.internal.foreign.abi.aarch64.AArch64Architectur(); 
    Code: 
       0: aload_0 
       1: invokespecial #1 // Method java/lang/Object."<init>":()V 
       4: return 

```
and other potential optimizations can be unlocked.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298532](https://bugs.openjdk.org/browse/JDK-8298532): Declare private constructors for FFM internal Architecture implementations


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11629/head:pull/11629` \
`$ git checkout pull/11629`

Update a local copy of the PR: \
`$ git checkout pull/11629` \
`$ git pull https://git.openjdk.org/jdk pull/11629/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11629`

View PR using the GUI difftool: \
`$ git pr show -t 11629`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11629.diff">https://git.openjdk.org/jdk/pull/11629.diff</a>

</details>
