### PR TITLE
8298568: Fastdebug build fails after JDK-8296389

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
@@ -2002,7 +2002,7 @@ Node* ShenandoahIUBarrierNode::Identity(PhaseGVN* phase) {
 static bool has_never_branch(Node* root) {
   for (uint i = 1; i < root->req(); i++) {
     Node* in = root->in(i);
-    if (in != NULL && in->Opcode() == Op_Halt && in->in(0)->is_Proj() && in->in(0)->in(0)->isNeverBranch()) {
+    if (in != NULL && in->Opcode() == Op_Halt && in->in(0)->is_Proj() && in->in(0)->in(0)->is_NeverBranch()) {
       return true;
     }
   }


### PR DESCRIPTION
This is a trivial change fixing a typo introduced by JDK-8296389.

The correct version is "is_NeverBranch()" instead of "isNeverBranch()".

Testing: Fastdebug builds fine with this fix on linux-aarch64 platform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298568](https://bugs.openjdk.org/browse/JDK-8298568): Fastdebug build fails after JDK-8296389


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Hao Sun](https://openjdk.org/census#haosun) (@shqking - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11631/head:pull/11631` \
`$ git checkout pull/11631`

Update a local copy of the PR: \
`$ git checkout pull/11631` \
`$ git pull https://git.openjdk.org/jdk pull/11631/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11631`

View PR using the GUI difftool: \
`$ git pr show -t 11631`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11631.diff">https://git.openjdk.org/jdk/pull/11631.diff</a>

</details>
