### PR TITLE
8298576: Serial: Move some MarkSweep method definitions to cpp

### DIFF
--- a/src/hotspot/share/gc/serial/markSweep.cpp
+++ b/src/hotspot/share/gc/serial/markSweep.cpp
@@ -65,7 +65,7 @@ MarkAndPushClosure MarkSweep::mark_and_push_closure(ClassLoaderData::_claim_stw_
 CLDToOopClosure    MarkSweep::follow_cld_closure(&mark_and_push_closure, ClassLoaderData::_claim_stw_fullgc_mark);
 CLDToOopClosure    MarkSweep::adjust_cld_closure(&adjust_pointer_closure, ClassLoaderData::_claim_stw_fullgc_adjust);
 
-template <class T> inline void MarkSweep::KeepAliveClosure::do_oop_work(T* p) {
+template <class T> void MarkSweep::KeepAliveClosure::do_oop_work(T* p) {
   mark_and_push(p);
 }
 
@@ -75,7 +75,7 @@ void MarkSweep::push_objarray(oop obj, size_t index) {
   _objarray_stack.push(task);
 }
 
-inline void MarkSweep::follow_array(objArrayOop array) {
+void MarkSweep::follow_array(objArrayOop array) {
   MarkSweep::follow_klass(array->klass());
   // Don't push empty arrays to avoid unnecessary work.
   if (array->length() > 0) {
@@ -83,7 +83,7 @@ inline void MarkSweep::follow_array(objArrayOop array) {
   }
 }
 
-inline void MarkSweep::follow_object(oop obj) {
+void MarkSweep::follow_object(oop obj) {
   assert(obj->is_gc_marked(), "should be marked");
   if (obj->is_objArray()) {
     // Handle object arrays explicitly to allow them to
@@ -128,7 +128,7 @@ MarkSweep::FollowStackClosure MarkSweep::follow_stack_closure;
 
 void MarkSweep::FollowStackClosure::do_void() { follow_stack(); }
 
-template <class T> inline void MarkSweep::follow_root(T* p) {
+template <class T> void MarkSweep::follow_root(T* p) {
   assert(!Universe::heap()->is_in(p),
          "roots shouldn't be things within the heap");
   T heap_oop = RawAccess<>::oop_load(p);
@@ -172,6 +172,46 @@ void MarkSweep::set_ref_processor(ReferenceProcessor* rp) {
   _ref_processor = rp;
   mark_and_push_closure.set_ref_discoverer(_ref_processor);
 }
+
+void MarkSweep::mark_object(oop obj) {
+  if (StringDedup::is_enabled() &&
+      java_lang_String::is_instance(obj) &&
+      SerialStringDedup::is_candidate_from_mark(obj)) {
+    _string_dedup_requests->add(obj);
+  }
+
+  // some marks may contain information we need to preserve so we store them away
+  // and overwrite the mark.  We'll restore it at the end of markSweep.
+  markWord mark = obj->mark();
+  obj->set_mark(markWord::prototype().set_marked());
+
+  ContinuationGCSupport::transform_stack_chunk(obj);
+
+  if (obj->mark_must_be_preserved(mark)) {
+    preserve_mark(obj, mark);
+  }
+}
+
+template <class T> void MarkSweep::mark_and_push(T* p) {
+  T heap_oop = RawAccess<>::oop_load(p);
+  if (!CompressedOops::is_null(heap_oop)) {
+    oop obj = CompressedOops::decode_not_null(heap_oop);
+    if (!obj->mark().is_marked()) {
+      mark_object(obj);
+      _marking_stack.push(obj);
+    }
+  }
+}
+
+void MarkSweep::follow_klass(Klass* klass) {
+  oop op = klass->class_loader_data()->holder_no_keepalive();
+  MarkSweep::mark_and_push(&op);
+}
+
+template <typename T>
+void MarkAndPushClosure::do_oop_work(T* p)            { MarkSweep::mark_and_push(p); }
+void MarkAndPushClosure::do_oop(      oop* p)         { do_oop_work(p); }
+void MarkAndPushClosure::do_oop(narrowOop* p)         { do_oop_work(p); }
 
 AdjustPointerClosure MarkSweep::adjust_pointer_closure;
 


### PR DESCRIPTION
Simple change of moving some code from `inline.hpp` to `cpp`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298576](https://bugs.openjdk.org/browse/JDK-8298576): Serial: Move some MarkSweep method definitions to cpp


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11633/head:pull/11633` \
`$ git checkout pull/11633`

Update a local copy of the PR: \
`$ git checkout pull/11633` \
`$ git pull https://git.openjdk.org/jdk pull/11633/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11633`

View PR using the GUI difftool: \
`$ git pr show -t 11633`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11633.diff">https://git.openjdk.org/jdk/pull/11633.diff</a>

</details>
