### PR TITLE
8298589: java/net/SctpSanity.java fail with NoClassDefFoundError: sun/nio/ch/sctp/UnsupportedUtil

### DIFF
--- a/make/modules/jdk.sctp/Java.gmk
+++ b/make/modules/jdk.sctp/Java.gmk
@@ -46,7 +46,7 @@ ifeq ($(call isTargetOs, aix), true)
 endif
 
 ifeq ($(call isTargetOsType, unix), true)
-  ifeq ($(call isTargetOs, macos aix), false)
+  ifeq ($(call isTargetOs, macosx aix), false)
     # This class is not needed on "unix" because SCTP in Java is supported for that platform
     EXCLUDE_FILES += $(TOPDIR)/src/jdk.sctp/share/classes/sun/nio/ch/sctp/UnsupportedUtil.java
   endif


### PR DESCRIPTION
This PR fixes a typo

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298589](https://bugs.openjdk.org/browse/JDK-8298589): java/net/SctpSanity.java fail with NoClassDefFoundError: sun/nio/ch/sctp/UnsupportedUtil


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11636/head:pull/11636` \
`$ git checkout pull/11636`

Update a local copy of the PR: \
`$ git checkout pull/11636` \
`$ git pull https://git.openjdk.org/jdk pull/11636/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11636`

View PR using the GUI difftool: \
`$ git pr show -t 11636`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11636.diff">https://git.openjdk.org/jdk/pull/11636.diff</a>

</details>
