### PR TITLE
6914801: IPv6 unavailable if stdin is a socket

### DIFF
--- a/src/java.base/unix/native/libnet/net_util_md.c
+++ b/src/java.base/unix/native/libnet/net_util_md.c
@@ -123,18 +123,7 @@ jint  IPv6_supported()
          */
         return JNI_FALSE;
     }
-
-    /*
-     * If fd 0 is a socket it means we may have been launched from inetd or
-     * xinetd. If it's a socket then check the family - if it's an
-     * IPv4 socket then we need to disable IPv6.
-     */
-    if (getsockname(0, &sa.sa, &sa_len) == 0) {
-        if (sa.sa.sa_family == AF_INET) {
-            close(fd);
-            return JNI_FALSE;
-        }
-    }
+    close(fd);
 
     /**
      * Linux - check if any interface has an IPv6 address.
@@ -147,13 +136,11 @@ jint  IPv6_supported()
         char *bufP;
 
         if (fP == NULL) {
-            close(fd);
             return JNI_FALSE;
         }
         bufP = fgets(buf, sizeof(buf), fP);
         fclose(fP);
         if (bufP == NULL) {
-            close(fd);
             return JNI_FALSE;
         }
     }
@@ -164,7 +151,6 @@ jint  IPv6_supported()
      *  we should also check if the APIs are available.
      */
     ipv6_fn = JVM_FindLibraryEntry(RTLD_DEFAULT, "inet_pton");
-    close(fd);
     if (ipv6_fn == NULL ) {
         return JNI_FALSE;
     } else {

--- a/src/java.base/unix/native/libnio/ch/InheritedChannel.c
+++ b/src/java.base/unix/native/libnio/ch/InheritedChannel.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/unix/native/libnio/ch/InheritedChannel.c
+++ b/src/java.base/unix/native/libnio/ch/InheritedChannel.c
@@ -38,10 +38,6 @@
 
 #include "sun_nio_ch_InheritedChannel.h"
 
-static int toInetFamily(SOCKETADDRESS *sa) {
-    return (sa->sa.sa_family == (ipv6_available() ? AF_INET6 : AF_INET));
-}
-
 JNIEXPORT void JNICALL
 Java_sun_nio_ch_InheritedChannel_initIDs(JNIEnv *env, jclass cla)
 {
@@ -58,9 +54,7 @@ Java_sun_nio_ch_InheritedChannel_inetPeerAddress0(JNIEnv *env, jclass cla, jint 
     jint remote_port;
 
     if (getpeername(fd, &sa.sa, &len) == 0) {
-        if (toInetFamily(&sa)) {
-            remote_ia = NET_SockaddrToInetAddress(env, &sa, (int *)&remote_port);
-        }
+        remote_ia = NET_SockaddrToInetAddress(env, &sa, (int *)&remote_port);
     }
 
     return remote_ia;
@@ -89,9 +83,7 @@ Java_sun_nio_ch_InheritedChannel_peerPort0(JNIEnv *env, jclass cla, jint fd)
     jint remote_port = -1;
 
     if (getpeername(fd, (struct sockaddr *)&sa.sa, &len) == 0) {
-        if (toInetFamily(&sa)) {
-            NET_SockaddrToInetAddress(env, &sa, (int *)&remote_port);
-        }
+        NET_SockaddrToInetAddress(env, &sa, (int *)&remote_port);
     }
 
     return remote_port;

--- a/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/CheckIPv6Service.java
+++ b/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/CheckIPv6Service.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,53 +21,11 @@
  * questions.
  */
 
-/*
- *
- *
- * An "echo" service designed to be used with inetd. It can be configured in
- * inetd.conf to be used by any of the following types of services :-
- *
- *      stream  tcp   nowait
- *      stream  tcp6  nowait
- *      stream  tcp   wait
- *      stream  tcp6  wait
- *      dgram   udp   wait
- *      dgram   udp6  wait
- *
- * If configured as a "tcp nowait" service then inetd will launch a
- * VM to run the EchoService each time that a client connects to
- * the TCP port. The EchoService simply echos any messages it
- * receives from the client and shuts if the client closes the
- * connection.
- *
- * If configured as a "tcp wait" service then inetd will launch a VM
- * to run the EchoService when a client connects to the port. When
- * launched the EchoService takes over the listener socket. It
- * terminates when all clients have disconnected and the service
- * is idle for a few seconds.
- *
- * If configured as a "udp wait" service then a VM will be launched for
- * each UDP packet to the configured port. System.inheritedChannel()
- * will return a DatagramChannel. The echo service here will terminate after
- * echoing the UDP packet back to the client.
- *
- * The service closes the inherited network channel when complete. To
- * facilate testing that the channel is closed the "tcp nowait" service
- * can close the connection after a given number of bytes.
- */
-
-import jdk.test.lib.Utils;
-
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
-import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channel;
-import java.nio.channels.DatagramChannel;
-import java.nio.channels.SelectionKey;
-import java.nio.channels.Selector;
-import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 
 public class CheckIPv6Service {
@@ -121,7 +79,6 @@ public class CheckIPv6Service {
             return;
         }
 
-        // tcp nowait
         if (c instanceof SocketChannel) {
             int closeAfter = 0;
             int delay = 0;
@@ -133,15 +90,6 @@ public class CheckIPv6Service {
             }
             doIt((SocketChannel)c, closeAfter, delay);
         }
-
-        // linger?
-        if (args.length > 0) {
-            int delay = Integer.parseInt(args[0]);
-            try {
-                Thread.currentThread().sleep(delay);
-            } catch (InterruptedException x) { }
-        }
-
     }
 
 }

--- a/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/CheckIPv6Service.java
+++ b/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/CheckIPv6Service.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ *
+ *
+ * An "echo" service designed to be used with inetd. It can be configured in
+ * inetd.conf to be used by any of the following types of services :-
+ *
+ *      stream  tcp   nowait
+ *      stream  tcp6  nowait
+ *      stream  tcp   wait
+ *      stream  tcp6  wait
+ *      dgram   udp   wait
+ *      dgram   udp6  wait
+ *
+ * If configured as a "tcp nowait" service then inetd will launch a
+ * VM to run the EchoService each time that a client connects to
+ * the TCP port. The EchoService simply echos any messages it
+ * receives from the client and shuts if the client closes the
+ * connection.
+ *
+ * If configured as a "tcp wait" service then inetd will launch a VM
+ * to run the EchoService when a client connects to the port. When
+ * launched the EchoService takes over the listener socket. It
+ * terminates when all clients have disconnected and the service
+ * is idle for a few seconds.
+ *
+ * If configured as a "udp wait" service then a VM will be launched for
+ * each UDP packet to the configured port. System.inheritedChannel()
+ * will return a DatagramChannel. The echo service here will terminate after
+ * echoing the UDP packet back to the client.
+ *
+ * The service closes the inherited network channel when complete. To
+ * facilate testing that the channel is closed the "tcp nowait" service
+ * can close the connection after a given number of bytes.
+ */
+
+import jdk.test.lib.Utils;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channel;
+import java.nio.channels.DatagramChannel;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+
+public class CheckIPv6Service {
+
+    static boolean isIPv6Available() {
+        try {
+            new ServerSocket(0,0, InetAddress.getByAddress(new byte[16])).close();
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static void doIt(SocketChannel sc, int closeAfter, int delay) throws IOException {
+        ByteBuffer bb = ByteBuffer.allocate(1024);
+        int total = 0;
+        for (;;) {
+            bb.clear();
+            int n = sc.read(bb);
+            if (n < 0) {
+                break;
+            }
+            total += n;
+
+            // echo
+            bb.flip();
+            sc.write(bb);
+
+            // close after X bytes?
+            if (closeAfter > 0 && total >= closeAfter) {
+                break;
+            }
+        }
+
+        sc.close();
+        if (delay > 0) {
+            try {
+                Thread.currentThread().sleep(delay);
+            } catch (InterruptedException x) { }
+        }
+    }
+
+    public static void main(String args[]) throws IOException {
+        // check if IPv6 is available; if it is, behave like EchoService.
+        if (!isIPv6Available()) {
+            return;
+        }
+
+        Channel c = System.inheritedChannel();
+        if (c == null) {
+            return;
+        }
+
+        // tcp nowait
+        if (c instanceof SocketChannel) {
+            int closeAfter = 0;
+            int delay = 0;
+            if (args.length > 0) {
+                closeAfter = Integer.parseInt(args[0]);
+            }
+            if (args.length > 1) {
+                delay = Integer.parseInt(args[1]);
+            }
+            doIt((SocketChannel)c, closeAfter, delay);
+        }
+
+        // linger?
+        if (args.length > 0) {
+            int delay = Integer.parseInt(args[0]);
+            try {
+                Thread.currentThread().sleep(delay);
+            } catch (InterruptedException x) { }
+        }
+
+    }
+
+}

--- a/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/CheckIPv6Test.java
+++ b/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/CheckIPv6Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,37 +21,17 @@
  * questions.
  */
 
-/*
- *
- *
- * Used in conjunction to EchoService to test System.inheritedChannel().
- *
- * The first test is the TCP echo test. A service is launched with a TCP
- * socket and a TCP message is sent to the service. The test checks that
- * the message is correctly echoed.
- *
- * The second test is a UDP echo test. A service is launched with a UDP
- * socket and a UDP packet is sent to the service. The test checks that
- * the packet is correctly echoed.
- *
- */
-
-import jdk.test.lib.Utils;
-
 import java.io.IOException;
-import java.net.DatagramPacket;
-import java.nio.ByteBuffer;
-import java.nio.channels.DatagramChannel;
-import java.nio.channels.SelectionKey;
-import java.nio.channels.Selector;
-import java.nio.channels.SocketChannel;
-import java.util.Random;
 
+/**
+ * This test verifies that a service launched with IPv4 inherited channel
+ * can use IPv6 networking; this used to be impossible, see JDK-6914801
+ */
 public class CheckIPv6Test {
 
     private static int failures = 0;
 
-    private static String SERVICE = "CheckIPv6Service";
+    private static final String SERVICE = "CheckIPv6Service";
 
     public static void main(String args[]) throws IOException {
 

--- a/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/CheckIPv6Test.java
+++ b/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/CheckIPv6Test.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ *
+ *
+ * Used in conjunction to EchoService to test System.inheritedChannel().
+ *
+ * The first test is the TCP echo test. A service is launched with a TCP
+ * socket and a TCP message is sent to the service. The test checks that
+ * the message is correctly echoed.
+ *
+ * The second test is a UDP echo test. A service is launched with a UDP
+ * socket and a UDP packet is sent to the service. The test checks that
+ * the packet is correctly echoed.
+ *
+ */
+
+import jdk.test.lib.Utils;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.SocketChannel;
+import java.util.Random;
+
+public class CheckIPv6Test {
+
+    private static int failures = 0;
+
+    private static String SERVICE = "CheckIPv6Service";
+
+    public static void main(String args[]) throws IOException {
+
+        if (!CheckIPv6Service.isIPv6Available()) {
+            System.out.println("IPv6 not available. Test skipped.");
+            return;
+        }
+
+        try {
+            EchoTest.TCPEchoTest(SERVICE);
+            System.out.println("IPv6 test passed.");
+        } catch (Exception x) {
+            System.err.println(x);
+            failures++;
+        }
+
+        if (failures > 0) {
+            throw new RuntimeException("Test failed - see log for details");
+        }
+    }
+
+}

--- a/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/EchoTest.java
+++ b/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/EchoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/EchoTest.java
+++ b/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/EchoTest.java
@@ -57,8 +57,8 @@ public class EchoTest {
      * a reply (with timeout). Once the reply is received it is checked to ensure
      * that it matches the original message.
      */
-    private static void TCPEchoTest() throws IOException {
-        SocketChannel sc = Launcher.launchWithInetSocketChannel(ECHO_SERVICE, null);
+    static void TCPEchoTest(String echoService) throws IOException {
+        SocketChannel sc = Launcher.launchWithInetSocketChannel(echoService, null);
 
         String msg = "Where's that damn torpedo?";
         int repeat = 100;
@@ -160,7 +160,7 @@ public class EchoTest {
 
         // TCP echo
         try {
-            TCPEchoTest();
+            TCPEchoTest(ECHO_SERVICE);
             System.out.println("TCP echo test passed.");
         } catch (Exception x) {
             System.err.println(x);

--- a/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java
+++ b/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java
+++ b/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4673940 4930794 8211842
+ * @bug 4673940 4930794 8211842 6914801
  * @summary Unit tests for inetd feature
  * @requires (os.family == "linux" | os.family == "mac")
  * @library /test/lib

--- a/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java
+++ b/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java
@@ -35,6 +35,7 @@
  *        jdk.test.lib.process.*
  *        UnixSocketTest StateTest StateTestService EchoTest EchoService
  *        UnixDomainChannelTest CloseTest Launcher Util
+ *        CheckIPv6Test CheckIPv6Service
  * @run testng/othervm/native InheritedChannelTest
  * @key intermittent
  */
@@ -79,6 +80,7 @@ public class InheritedChannelTest {
             { "UnixSocketTest", List.of(UnixSocketTest.class.getName())},
             { "StateTest", List.of(StateTest.class.getName(), "-Dtest.classes="+TEST_CLASSES)},
             { "EchoTest",  List.of(EchoTest.class.getName())  },
+            { "CheckIPv6Test",  List.of(CheckIPv6Test.class.getName())  },
             { "CloseTest", List.of(CloseTest.class.getName()) },
 
             // run StateTest with a SecurityManager set

--- a/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/Launcher.java
+++ b/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/Launcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/Launcher.java
+++ b/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/Launcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,11 +104,14 @@ public class Launcher {
         ServerSocketChannel ch;
         try {
             ch = ServerSocketChannel.open(INET);
+            System.out.println("Using INET (IPv4) channel");
         } catch (Exception e) {
             ch = ServerSocketChannel.open();
+            System.out.println("Using default channel (probably IPv6)");
         }
         try (ServerSocketChannel ssc = ch) {
             ssc.socket().bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+            System.out.println("Socket bound to " + ssc.getLocalAddress());
             SocketChannel sc1 = SocketChannel.open(ssc.getLocalAddress());
             try (SocketChannel sc2 = ssc.accept()) {
                 launch(className, options, args, Util.getFD(sc2));

--- a/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/Launcher.java
+++ b/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/Launcher.java
@@ -108,10 +108,8 @@ public class Launcher {
             ch = ServerSocketChannel.open();
         }
         try (ServerSocketChannel ssc = ch) {
-            ssc.socket().bind(new InetSocketAddress(InetAddress.getLocalHost(), 0));
-            InetSocketAddress isa = new InetSocketAddress(InetAddress.getLocalHost(),
-                                                      ssc.socket().getLocalPort());
-            SocketChannel sc1 = SocketChannel.open(isa);
+            ssc.socket().bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+            SocketChannel sc1 = SocketChannel.open(ssc.getLocalAddress());
             try (SocketChannel sc2 = ssc.accept()) {
                 launch(className, options, args, Util.getFD(sc2));
             }

--- a/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/Launcher.java
+++ b/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/Launcher.java
@@ -36,6 +36,7 @@ import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.file.Files;
 
+import static java.net.StandardProtocolFamily.INET;
 import static java.net.StandardProtocolFamily.UNIX;
 
 public class Launcher {
@@ -100,7 +101,13 @@ public class Launcher {
                                                         String... args)
             throws IOException
     {
-        try (ServerSocketChannel ssc = ServerSocketChannel.open()) {
+        ServerSocketChannel ch;
+        try {
+            ch = ServerSocketChannel.open(INET);
+        } catch (Exception e) {
+            ch = ServerSocketChannel.open();
+        }
+        try (ServerSocketChannel ssc = ch) {
             ssc.socket().bind(new InetSocketAddress(InetAddress.getLocalHost(), 0));
             InetSocketAddress isa = new InetSocketAddress(InetAddress.getLocalHost(),
                                                       ssc.socket().getLocalPort());


### PR DESCRIPTION
This patch reenables IPv6 stack when stdin is an IPv4 socket.

The code that blocked IPv6 was introduced in JDK-4673940 back when JDK could only operate with either IPv4 or IPv6 sockets, and was using `IPv6_available` to determine which socket type was in use. Now that JDK is able to operate with both IPv4 and IPv6 sockets at the same time, the check for IPv4 stdin is no longer relevant.

Included test passes with the changes applied, fails without them. Other tier1-3 tests also pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6914801](https://bugs.openjdk.org/browse/JDK-6914801): IPv6 unavailable if stdin is a socket


### Reviewers
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11638/head:pull/11638` \
`$ git checkout pull/11638`

Update a local copy of the PR: \
`$ git checkout pull/11638` \
`$ git pull https://git.openjdk.org/jdk pull/11638/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11638`

View PR using the GUI difftool: \
`$ git pr show -t 11638`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11638.diff">https://git.openjdk.org/jdk/pull/11638.diff</a>

</details>
