### PR TITLE
8290899: java/lang/String/StringRepeat.java test requests too much heap on windows x86

### DIFF
--- a/test/jdk/java/lang/String/StringRepeat.java
+++ b/test/jdk/java/lang/String/StringRepeat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
  * @test
  * @summary This exercises String#repeat patterns with 16 * 1024 * 1024 repeats.
  * @requires os.maxMemory >= 2G
+ * @requires !(os.family == "windows" & sun.arch.data.model == "32")
  * @run main/othervm -Xmx2g StringRepeat 16777216
  */
 


### PR DESCRIPTION
The `java/lang/String/StringRepeat.java` test was updated twice after integration:

https://bugs.openjdk.org/browse/JDK-8221400 - the xmx4g was replaced by the xmx2g
https://bugs.openjdk.org/browse/JDK-8265421 - the "os.maxMemory >= 2G" was added

Unfortunately, this test still may fail on Windows x86 due to: `Could not reserve enough space for xxx object heap.`

This is a request to exclude it on win x86 since that JDK cannot allocate 2g.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290899](https://bugs.openjdk.org/browse/JDK-8290899): java/lang/String/StringRepeat.java test requests too much heap on windows x86


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11639/head:pull/11639` \
`$ git checkout pull/11639`

Update a local copy of the PR: \
`$ git checkout pull/11639` \
`$ git pull https://git.openjdk.org/jdk pull/11639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11639`

View PR using the GUI difftool: \
`$ git pr show -t 11639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11639.diff">https://git.openjdk.org/jdk/pull/11639.diff</a>

</details>
