### PR TITLE
8298081: DiagnoseSyncOnValueBasedClasses doesn't report useful information for virtual threads

### DIFF
--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1758,6 +1758,14 @@ void JavaThread::print_vthread_stack_on(outputStream* st) {
   }
 }
 
+void JavaThread::print_active_stack_on(outputStream* st) {
+  if (is_vthread_mounted()) {
+    print_vthread_stack_on(st);
+  } else {
+    print_stack_on(st);
+  }
+}
+
 #if INCLUDE_JVMTI
 // Rebind JVMTI thread state from carrier to virtual or from virtual to carrier.
 JvmtiThreadState* JavaThread::rebind_to_jvmti_thread_state_of(oop thread_oop) {

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -938,10 +938,13 @@ private:
   Klass* security_get_caller_class(int depth);
 
   // Print stack trace in external format
+  // These variants print carrier/platform thread information only.
   void print_stack_on(outputStream* st);
   void print_stack() { print_stack_on(tty); }
+  // This prints the currently mounted virtual thread.
   void print_vthread_stack_on(outputStream* st);
-
+  // This prints the active stack: either carrier/platform or virtual.
+  void print_active_stack_on(outputStream* st);
   // Print stack trace for checked JNI warnings and JNI fatal errors.
   // This is the external format from above, but selecting the platform
   // or vthread as applicable.

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -429,7 +429,11 @@ void ObjectSynchronizer::handle_sync_on_value_based_class(Handle obj, JavaThread
   if (DiagnoseSyncOnValueBasedClasses == FATAL_EXIT) {
     ResourceMark rm(current);
     stringStream ss;
-    current->print_stack_on(&ss);
+    if (current->is_vthread_mounted()) {
+      current->print_vthread_stack_on(&ss);
+    } else {
+      current->print_stack_on(&ss);
+    }
     char* base = (char*)strstr(ss.base(), "at");
     char* newline = (char*)strchr(ss.base(), '\n');
     if (newline != NULL) {
@@ -444,7 +448,11 @@ void ObjectSynchronizer::handle_sync_on_value_based_class(Handle obj, JavaThread
     vblog.info("Synchronizing on object " INTPTR_FORMAT " of klass %s", p2i(obj()), obj->klass()->external_name());
     if (current->has_last_Java_frame()) {
       LogStream info_stream(vblog.info());
-      current->print_stack_on(&info_stream);
+      if (current->is_vthread_mounted()) {
+        current->print_vthread_stack_on(&info_stream);
+      } else {
+        current->print_stack_on(&info_stream);
+      }
     } else {
       vblog.info("Cannot find the last Java frame");
     }

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -429,11 +429,7 @@ void ObjectSynchronizer::handle_sync_on_value_based_class(Handle obj, JavaThread
   if (DiagnoseSyncOnValueBasedClasses == FATAL_EXIT) {
     ResourceMark rm(current);
     stringStream ss;
-    if (current->is_vthread_mounted()) {
-      current->print_vthread_stack_on(&ss);
-    } else {
-      current->print_stack_on(&ss);
-    }
+    current->print_active_stack_on(&ss);
     char* base = (char*)strstr(ss.base(), "at");
     char* newline = (char*)strchr(ss.base(), '\n');
     if (newline != NULL) {
@@ -448,11 +444,7 @@ void ObjectSynchronizer::handle_sync_on_value_based_class(Handle obj, JavaThread
     vblog.info("Synchronizing on object " INTPTR_FORMAT " of klass %s", p2i(obj()), obj->klass()->external_name());
     if (current->has_last_Java_frame()) {
       LogStream info_stream(vblog.info());
-      if (current->is_vthread_mounted()) {
-        current->print_vthread_stack_on(&info_stream);
-      } else {
-        current->print_stack_on(&info_stream);
-      }
+      current->print_active_stack_on(&info_stream);
     } else {
       vblog.info("Cannot find the last Java frame");
     }


### PR DESCRIPTION
The mechanism used by DiagnoseSyncOnValueBasedClasses to show where the sync occurs only reports platform/carrier thread stack details. That is no use if the code is being executed by a virtual thread. We can use the code being introduced by [JDK-8292674](https://bugs.openjdk.org/browse/JDK-8292674) for JNI error/warning reporting to show the virtual thread stack instead.

Before the fix the logging shows:
```
[0.173s][info][valuebasedclasses] Synchronizing on object 0x00000007ff880e68 of klass java.lang.Character
[0.173s][info][valuebasedclasses] at jdk.internal.vm.Continuation.run([java.base@21-internal](mailto:java.base@21-internal)/Continuation.java:257)
[0.173s][info][valuebasedclasses] at java.lang.VirtualThread.runContinuation([java.base@21-internal](mailto:java.base@21-internal)/VirtualThread.java:216)
[0.173s][info][valuebasedclasses] at java.lang.VirtualThread$$Lambda$8/0x0000000801046f70.run([java.base@21-internal](mailto:java.base@21-internal)/Unknown Source)
[0.173s][info][valuebasedclasses] at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec([java.base@21-internal](mailto:java.base@21-internal)/ForkJoinTask.java:1423)
[0.173s][info][valuebasedclasses] at java.util.concurrent.ForkJoinTask.doExec([java.base@21-internal](mailto:java.base@21-internal)/ForkJoinTask.java:387)
[0.173s][info][valuebasedclasses] at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec([java.base@21-internal](mailto:java.base@21-internal)/ForkJoinPool.java:1312)
[0.173s][info][valuebasedclasses] at java.util.concurrent.ForkJoinPool.scan([java.base@21-internal](mailto:java.base@21-internal)/ForkJoinPool.java:1843)
[0.173s][info][valuebasedclasses] at java.util.concurrent.ForkJoinPool.runWorker([java.base@21-internal](mailto:java.base@21-internal)/ForkJoinPool.java:1808)
[0.173s][info][valuebasedclasses] at java.util.concurrent.ForkJoinWorkerThread.run([java.base@21-internal](mailto:java.base@21-internal)/ForkJoinWorkerThread.java:188)
```
after the fix:
```
[0.177s][info][valuebasedclasses] Synchronizing on object 0x00000007ff880e68 of klass java.lang.Character
[0.177s][info][valuebasedclasses] at SyncOnValueBasedClassTest$VTTest.lambda$main$0(SyncOnValueBasedClassTest.java:195)
[0.177s][info][valuebasedclasses] - locked <0x00000007ff880e68> (a java.lang.Character)
[0.177s][info][valuebasedclasses] at SyncOnValueBasedClassTest$VTTest$$Lambda$1/0x0000000801000c10.run(Unknown Source)
[0.177s][info][valuebasedclasses] at java.lang.VirtualThread.runWith([java.base@21-internal](mailto:java.base@21-internal)/VirtualThread.java:335)
[0.177s][info][valuebasedclasses] at java.lang.VirtualThread.run([java.base@21-internal](mailto:java.base@21-internal)/VirtualThread.java:305)
[0.177s][info][valuebasedclasses] at java.lang.VirtualThread$VThreadContinuation.lambda$new$0([java.base@21-internal](mailto:java.base@21-internal)/VirtualThread.java:177)
[0.177s][info][valuebasedclasses] at java.lang.VirtualThread$VThreadContinuation$$Lambda$7/0x0000000801046d48.run([java.base@21-internal](mailto:java.base@21-internal)/Unknown Source)
[0.177s][info][valuebasedclasses] at jdk.internal.vm.Continuation.enter0([java.base@21-internal](mailto:java.base@21-internal)/Continuation.java:327)
[0.177s][info][valuebasedclasses] at jdk.internal.vm.Continuation.enter([java.base@21-internal](mailto:java.base@21-internal)/Continuation.java:320)
```

The existing test for `DiagnoseSyncOnValueBasedClasses` is adapted to provide a basic sanity test using virtual threads, which suffices to test the stack information. Unfortunately the `--enable-preview` has a viral impact.

Other testing: tiers 1-3 sanity check

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298081](https://bugs.openjdk.org/browse/JDK-8298081): DiagnoseSyncOnValueBasedClasses doesn't report useful information for virtual threads


### Reviewers
 * [Gerard Ziemski](https://openjdk.org/census#gziemski) (@gerard-ziemski - Committer)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11641/head:pull/11641` \
`$ git checkout pull/11641`

Update a local copy of the PR: \
`$ git checkout pull/11641` \
`$ git pull https://git.openjdk.org/jdk pull/11641/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11641`

View PR using the GUI difftool: \
`$ git pr show -t 11641`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11641.diff">https://git.openjdk.org/jdk/pull/11641.diff</a>

</details>
