### PR TITLE
8298636: Fix return value in WB_CountAliveClasses and WB_GetSymbolRefcount

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -207,7 +207,9 @@ public:
 
 WB_ENTRY(jint, WB_CountAliveClasses(JNIEnv* env, jobject target, jstring name))
   oop h_name = JNIHandles::resolve(name);
-  if (h_name == NULL) return false;
+  if (h_name == NULL) {
+    return 0;
+  }
   Symbol* sym = java_lang_String::as_symbol(h_name);
   TempNewSymbol tsym(sym); // Make sure to decrement reference count on sym on return
 
@@ -220,7 +222,9 @@ WB_END
 
 WB_ENTRY(jint, WB_GetSymbolRefcount(JNIEnv* env, jobject unused, jstring name))
   oop h_name = JNIHandles::resolve(name);
-  if (h_name == NULL) return false;
+  if (h_name == NULL) {
+    return 0;
+  }
   Symbol* sym = java_lang_String::as_symbol(h_name);
   TempNewSymbol tsym(sym); // Make sure to decrement reference count on sym on return
   return (jint)sym->refcount();


### PR DESCRIPTION
Simple change of conforming to the return type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298636](https://bugs.openjdk.org/browse/JDK-8298636): Fix return value in WB_CountAliveClasses and WB_GetSymbolRefcount


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11643/head:pull/11643` \
`$ git checkout pull/11643`

Update a local copy of the PR: \
`$ git checkout pull/11643` \
`$ git pull https://git.openjdk.org/jdk pull/11643/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11643`

View PR using the GUI difftool: \
`$ git pr show -t 11643`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11643.diff">https://git.openjdk.org/jdk/pull/11643.diff</a>

</details>
