### PR TITLE
8298639: Perform I/O operations in bulk for RandomAccessFile

### DIFF
--- a/src/java.base/share/classes/java/io/RandomAccessFile.java
+++ b/src/java.base/share/classes/java/io/RandomAccessFile.java
@@ -57,8 +57,6 @@ import sun.nio.ch.FileChannelImpl;
  * than {@code EOFException} is thrown. In particular, an
  * {@code IOException} may be thrown if the stream has been closed.
  *
- * @implNote This class is not thread safe.
- *
  * @since   1.0
  */
 
@@ -1061,7 +1059,6 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      */
     public final void writeBoolean(boolean v) throws IOException {
         write(v ? 1 : 0);
-        //written++;
     }
 
     /**
@@ -1073,7 +1070,6 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      */
     public final void writeByte(int v) throws IOException {
         write(v);
-        //written++;
     }
 
     /**
@@ -1087,7 +1083,6 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
         buffer[1] = (byte)(v       );
         buffer[0] = (byte)(v >>>  8);
         write(buffer, 0, Short.BYTES);
-        //written += 2;
     }
 
     /**
@@ -1125,7 +1120,6 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
     public final void writeLong(long v) throws IOException {
         Bits.putLong(buffer, 0, v);
         write(buffer, 0, Long.BYTES);
-        //written += 8;
     }
 
     /**

--- a/src/java.base/share/classes/java/io/RandomAccessFile.java
+++ b/src/java.base/share/classes/java/io/RandomAccessFile.java
@@ -26,7 +26,6 @@
 package java.io;
 
 import java.nio.channels.FileChannel;
-import java.util.Objects;
 
 import jdk.internal.access.JavaIORandomAccessFileAccess;
 import jdk.internal.access.SharedSecrets;

--- a/test/jdk/java/io/File/Basic.java
+++ b/test/jdk/java/io/File/Basic.java
@@ -29,10 +29,8 @@
  */
 
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.File;
 import java.io.PrintStream;
-import java.io.RandomAccessFile;
 
 
 public class Basic {

--- a/test/micro/org/openjdk/bench/java/io/RandomAccessFileBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/io/RandomAccessFileBenchmark.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 
 @Fork(2)
 @State(Scope.Thread)
-@Warmup(iterations=5, time = 1)
+@Warmup(iterations = 5, time = 1)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @Measurement(iterations = 5, time = 2)
@@ -44,6 +44,8 @@ public class RandomAccessFileBenchmark {
     private int kiloBytes;
     private int size;
     private File file;
+
+    private RandomAccessFile raf;
 
     private short[] shorts;
     private int[] ints;
@@ -63,64 +65,64 @@ public class RandomAccessFileBenchmark {
         }
         ints = rnd.ints(size / Integer.BYTES).toArray();
         longs = rnd.longs(size / Long.BYTES).toArray();
+        raf = new RandomAccessFile(file, "rw");
+        // Make it more likely file content is directly available
+        for (int i = 0; i < size / Integer.BYTES; i++) {
+            raf.readInt();
+        }
     }
 
     @TearDown(Level.Iteration)
-    public void afterRun() {
+    public void afterRun() throws IOException {
+        raf.close();
         file.delete();
     }
 
     @Benchmark
     public void readShort(Blackhole bh) throws IOException {
-        try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
-            for (int i = 0; i < size / Short.BYTES; i++) {
-                bh.consume(raf.readShort());
-            }
+        raf.seek(0);
+        for (int i = 0; i < size / Short.BYTES; i++) {
+            bh.consume(raf.readShort());
         }
     }
 
     @Benchmark
     public void readInt(Blackhole bh) throws IOException {
-        try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
-            for (int i = 0; i < size / Integer.BYTES; i++) {
-                bh.consume(raf.readInt());
-            }
+        raf.seek(0);
+        for (int i = 0; i < size / Integer.BYTES; i++) {
+            bh.consume(raf.readInt());
         }
     }
 
     @Benchmark
     public void readLong(Blackhole bh) throws IOException {
-        try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
-            for (int i = 0; i < size / Long.BYTES; i++) {
-                bh.consume(raf.readLong());
-            }
+        raf.seek(0);
+        for (int i = 0; i < size / Long.BYTES; i++) {
+            bh.consume(raf.readLong());
         }
     }
 
     @Benchmark
     public void writeShort() throws IOException {
-        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
-            for (int i = 0; i < size / Short.BYTES; i++) {
-                raf.writeShort(shorts[i]);
-            }
+        raf.seek(0);
+        for (int i = 0; i < size / Short.BYTES; i++) {
+            raf.writeShort(shorts[i]);
         }
     }
 
     @Benchmark
     public void writeInt() throws IOException {
-        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
-            for (int i = 0; i < size / Integer.BYTES; i++) {
-                raf.writeInt(ints[i]);
-            }
+        raf.seek(0);
+        for (int i = 0; i < size / Integer.BYTES; i++) {
+            raf.writeInt(ints[i]);
         }
     }
 
     @Benchmark
     public void writeLong() throws IOException {
-        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
-            for (int i = 0; i < size / Long.BYTES; i++) {
-                raf.writeLong(longs[i]);
-            }
+        raf.seek(0);
+        for (int i = 0; i < size / Long.BYTES; i++) {
+            raf.writeLong(longs[i]);
         }
     }
 

--- a/test/micro/org/openjdk/bench/java/io/RandomAccessFileBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/io/RandomAccessFileBenchmark.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package micro.org.openjdk.bench.java.io;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+@Fork(2)
+@State(Scope.Thread)
+@Warmup(iterations=5, time = 1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Measurement(iterations = 5, time = 2)
+
+public class RandomAccessFileBenchmark {
+
+    @Param({"1", "5"})
+    private int kiloBytes;
+    private int size;
+    private File file;
+
+    private short[] shorts;
+    private int[] ints;
+    private long[] longs;
+
+    @Setup(Level.Iteration)
+    public void beforeRun() throws IOException {
+        Random rnd = ThreadLocalRandom.current();
+        size = kiloBytes << 10;
+        var bytes = new byte[size];
+        rnd.nextBytes(bytes);
+        file = File.createTempFile(getClass().getName(), ".txt");
+        Files.write(file.toPath(), bytes);
+        shorts = new short[size];
+        for (int i = 0; i < size / Short.BYTES; i++) {
+            shorts[i] = (short) rnd.nextInt();
+        }
+        ints = rnd.ints(size / Integer.BYTES).toArray();
+        longs = rnd.longs(size / Long.BYTES).toArray();
+    }
+
+    @TearDown(Level.Iteration)
+    public void afterRun() {
+        file.delete();
+    }
+
+    @Benchmark
+    public void readShort(Blackhole bh) throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
+            for (int i = 0; i < size / Short.BYTES; i++) {
+                bh.consume(raf.readShort());
+            }
+        }
+    }
+
+    @Benchmark
+    public void readInt(Blackhole bh) throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
+            for (int i = 0; i < size / Integer.BYTES; i++) {
+                bh.consume(raf.readInt());
+            }
+        }
+    }
+
+    @Benchmark
+    public void readLong(Blackhole bh) throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
+            for (int i = 0; i < size / Long.BYTES; i++) {
+                bh.consume(raf.readLong());
+            }
+        }
+    }
+
+    @Benchmark
+    public void writeShort() throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+            for (int i = 0; i < size / Short.BYTES; i++) {
+                raf.writeShort(shorts[i]);
+            }
+        }
+    }
+
+    @Benchmark
+    public void writeInt() throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+            for (int i = 0; i < size / Integer.BYTES; i++) {
+                raf.writeInt(ints[i]);
+            }
+        }
+    }
+
+    @Benchmark
+    public void writeLong() throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+            for (int i = 0; i < size / Long.BYTES; i++) {
+                raf.writeLong(longs[i]);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
This PR suggests improving performance for read and write operations for the longer primitives in `RandomAccessFile`.

These improvements would also propagate to other JDK classes relying on these improved `RandomAccessFile` operations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298639](https://bugs.openjdk.org/browse/JDK-8298639): Perform I/O operations in bulk for RandomAccessFile


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Contributors
 * Sergey Tsypanov `<stsypanov@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11644/head:pull/11644` \
`$ git checkout pull/11644`

Update a local copy of the PR: \
`$ git checkout pull/11644` \
`$ git pull https://git.openjdk.org/jdk pull/11644/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11644`

View PR using the GUI difftool: \
`$ git pr show -t 11644`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11644.diff">https://git.openjdk.org/jdk/pull/11644.diff</a>

</details>
