### PR TITLE
8298638: Cleanup of unix java_md.c for better re-exec handling

### DIFF
--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -46,11 +46,6 @@
 #define LD_LIBRARY_PATH "LD_LIBRARY_PATH"
 #endif
 
-/* help jettison the LD_LIBRARY_PATH settings in the future */
-#ifndef SETENV_REQUIRED
-#define SETENV_REQUIRED
-#endif
-
 /*
  * Flowchart of launcher execs and options processing on unix
  *
@@ -161,7 +156,6 @@ GetExecName() {
     return execname;
 }
 
-#ifdef SETENV_REQUIRED
 static jboolean
 JvmExists(const char *path) {
     char tmp[PATH_MAX + 1];
@@ -180,11 +174,14 @@ ContainsLibJVM(const char *env) {
     /* the usual suspects */
     char clientPattern[] = "lib/client";
     char serverPattern[] = "lib/server";
+    char minimalPattern[] = "lib/minimal";
+
     char *envpath;
     char *path;
     char* save_ptr = NULL;
     jboolean clientPatternFound;
     jboolean serverPatternFound;
+    jboolean minimalPatternFound;
 
     /* fastest path */
     if (env == NULL) {
@@ -194,7 +191,9 @@ ContainsLibJVM(const char *env) {
     /* to optimize for time, test if any of our usual suspects are present. */
     clientPatternFound = JLI_StrStr(env, clientPattern) != NULL;
     serverPatternFound = JLI_StrStr(env, serverPattern) != NULL;
-    if (clientPatternFound == JNI_FALSE && serverPatternFound == JNI_FALSE) {
+    minimalPatternFound = JLI_StrStr(env, minimalPattern) != NULL;
+
+    if (clientPatternFound == JNI_FALSE && serverPatternFound == JNI_FALSE && minimalPatternFound == JNI_FALSE) {
         return JNI_FALSE;
     }
 
@@ -210,6 +209,12 @@ ContainsLibJVM(const char *env) {
             }
         }
         if (serverPatternFound && JLI_StrStr(path, serverPattern)  != NULL) {
+            if (JvmExists(path)) {
+                JLI_MemFree(envpath);
+                return JNI_TRUE;
+            }
+        }
+        if (minimalPatternFound && JLI_StrStr(path, minimalPattern)  != NULL) {
             if (JvmExists(path)) {
                 JLI_MemFree(envpath);
                 return JNI_TRUE;
@@ -289,7 +294,6 @@ RequiresSetenv(const char *jvmpath) {
     }
     return JNI_FALSE;
 }
-#endif /* SETENV_REQUIRED */
 
 void
 CreateExecutionEnvironment(int *pargc, char ***pargv,
@@ -300,7 +304,6 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
     char * jvmtype = NULL;
     char **argv = *pargv;
 
-#ifdef SETENV_REQUIRED
     jboolean mustsetenv = JNI_FALSE;
     char *runpath = NULL; /* existing effective LD_LIBRARY_PATH setting */
     char* new_runpath = NULL; /* desired new LD_LIBRARY_PATH string */
@@ -308,7 +311,6 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
     char* lastslash = NULL;
     char** newenvp = NULL; /* current environment */
     size_t new_runpath_size;
-#endif  /* SETENV_REQUIRED */
 
     /* Compute/set the name of the executable */
     SetExecname(*pargv);
@@ -342,75 +344,73 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
      * we seem to have everything we need, so without further ado
      * we return back, otherwise proceed to set the environment.
      */
-#ifdef SETENV_REQUIRED
     mustsetenv = RequiresSetenv(jvmpath);
     JLI_TraceLauncher("mustsetenv: %s\n", mustsetenv ? "TRUE" : "FALSE");
 
     if (mustsetenv == JNI_FALSE) {
         return;
     }
-#else
-    return;
-#endif /* SETENV_REQUIRED */
 
-#ifdef SETENV_REQUIRED
-    if (mustsetenv) {
+    /**
+     * Update execution environment and re-exec the launcher
+     *
+     */
+
+    /*
+     * We will set the LD_LIBRARY_PATH as follows:
+     *
+     *     o          $JVMPATH (directory portion only)
+     *     o          $JRE/lib
+     *     o          $JRE/../lib
+     *
+     * followed by the user's previous effective LD_LIBRARY_PATH, if
+     * any.
+     */
+
+    runpath = getenv(LD_LIBRARY_PATH);
+
+    /* runpath contains current effective LD_LIBRARY_PATH setting */
+    { /* New scope to declare local variable */
+        char *new_jvmpath = JLI_StringDup(jvmpath);
+        new_runpath_size = ((runpath != NULL) ? JLI_StrLen(runpath) : 0) +
+                2 * JLI_StrLen(jrepath) +
+                JLI_StrLen(new_jvmpath) + 52;
+        new_runpath = JLI_MemAlloc(new_runpath_size);
+        newpath = new_runpath + JLI_StrLen(LD_LIBRARY_PATH "=");
+
+
         /*
-         * We will set the LD_LIBRARY_PATH as follows:
-         *
-         *     o          $JVMPATH (directory portion only)
-         *     o          $JRE/lib
-         *     o          $JRE/../lib
-         *
-         * followed by the user's previous effective LD_LIBRARY_PATH, if
-         * any.
+         * Create desired LD_LIBRARY_PATH value for target data model.
          */
+        {
+            /* remove the name of the .so from the JVM path */
+            lastslash = JLI_StrRChr(new_jvmpath, '/');
+            if (lastslash)
+                *lastslash = '\0';
 
-        runpath = getenv(LD_LIBRARY_PATH);
+            sprintf(new_runpath, LD_LIBRARY_PATH "="
+                    "%s:"
+                    "%s/lib:"
+                    "%s/../lib",
+                    new_jvmpath,
+                    jrepath,
+                    jrepath
+                    );
 
-        /* runpath contains current effective LD_LIBRARY_PATH setting */
-        { /* New scope to declare local variable */
-            char *new_jvmpath = JLI_StringDup(jvmpath);
-            new_runpath_size = ((runpath != NULL) ? JLI_StrLen(runpath) : 0) +
-                    2 * JLI_StrLen(jrepath) +
-                    JLI_StrLen(new_jvmpath) + 52;
-            new_runpath = JLI_MemAlloc(new_runpath_size);
-            newpath = new_runpath + JLI_StrLen(LD_LIBRARY_PATH "=");
-
+            JLI_MemFree(new_jvmpath);
 
             /*
-             * Create desired LD_LIBRARY_PATH value for target data model.
+             * Check to make sure that the prefix of the current path is the
+             * desired environment variable setting, though the RequiresSetenv
+             * checks if the desired runpath exists, this logic does a more
+             * comprehensive check.
              */
-            {
-                /* remove the name of the .so from the JVM path */
-                lastslash = JLI_StrRChr(new_jvmpath, '/');
-                if (lastslash)
-                    *lastslash = '\0';
-
-                sprintf(new_runpath, LD_LIBRARY_PATH "="
-                        "%s:"
-                        "%s/lib:"
-                        "%s/../lib",
-                        new_jvmpath,
-                        jrepath,
-                        jrepath
-                        );
-
-                JLI_MemFree(new_jvmpath);
-
-                /*
-                 * Check to make sure that the prefix of the current path is the
-                 * desired environment variable setting, though the RequiresSetenv
-                 * checks if the desired runpath exists, this logic does a more
-                 * comprehensive check.
-                 */
-                if (runpath != NULL &&
-                        JLI_StrNCmp(newpath, runpath, JLI_StrLen(newpath)) == 0 &&
-                        (runpath[JLI_StrLen(newpath)] == 0 ||
-                        runpath[JLI_StrLen(newpath)] == ':')) {
-                    JLI_MemFree(new_runpath);
-                    return;
-                }
+            if (runpath != NULL &&
+                    JLI_StrNCmp(newpath, runpath, JLI_StrLen(newpath)) == 0 &&
+                    (runpath[JLI_StrLen(newpath)] == 0 ||
+                    runpath[JLI_StrLen(newpath)] == ':')) {
+                JLI_MemFree(new_runpath);
+                return;
             }
         }
 
@@ -442,26 +442,17 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
 
         newenvp = environ;
     }
-#endif /* SETENV_REQUIRED */
     {
         char *newexec = execname;
         JLI_TraceLauncher("TRACER_MARKER:About to EXEC\n");
         (void) fflush(stdout);
         (void) fflush(stderr);
-#ifdef SETENV_REQUIRED
-        if (mustsetenv) {
-            execve(newexec, argv, newenvp);
-        } else {
-            execv(newexec, argv);
-        }
-#else /* !SETENV_REQUIRED */
-        execv(newexec, argv);
-#endif /* SETENV_REQUIRED */
+
+        execve(newexec, argv, newenvp);
         JLI_ReportErrorMessageSys(JRE_ERROR4, newexec);
     }
     exit(1);
 }
-
 
 static jboolean
 GetJVMPath(const char *jrepath, const char *jvmtype,


### PR DESCRIPTION
Move "unix" java_md.c cleanup, which is the prerequisites for the fix for JDK-8293806 (PR https://github.com/openjdk/jdk/pull/11538), to a separate PR.

@AlanBateman, @dholmes-ora please, take a look to the changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298638](https://bugs.openjdk.org/browse/JDK-8298638): Cleanup of unix java_md.c for better re-exec handling


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11645/head:pull/11645` \
`$ git checkout pull/11645`

Update a local copy of the PR: \
`$ git checkout pull/11645` \
`$ git pull https://git.openjdk.org/jdk pull/11645/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11645`

View PR using the GUI difftool: \
`$ git pr show -t 11645`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11645.diff">https://git.openjdk.org/jdk/pull/11645.diff</a>

</details>
