### PR TITLE
6513512: MetalLookAndFeel.initClassDefaults does not install an entry for MetalMenuBarUI

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
@@ -272,6 +272,7 @@ public class MetalLookAndFeel extends BasicLookAndFeel
               "FileChooserUI", metalPackageName + "MetalFileChooserUI",
             "InternalFrameUI", metalPackageName + "MetalInternalFrameUI",
                     "LabelUI", metalPackageName + "MetalLabelUI",
+                  "MenuBarUI", metalPackageName + "MetalMenuBarUI",
        "PopupMenuSeparatorUI", metalPackageName + "MetalPopupMenuSeparatorUI",
               "ProgressBarUI", metalPackageName + "MetalProgressBarUI",
               "RadioButtonUI", metalPackageName + "MetalRadioButtonUI",

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
@@ -246,18 +246,12 @@ public class MetalLookAndFeel extends BasicLookAndFeel
      * the fully qualified name of the ui class. {@code
      * MetalLookAndFeel} registers an entry for each of the classes in
      * the package {@code javax.swing.plaf.metal} that are named
-     * MetalXXXUI which are used by the current {@code MetalTheme}.
-     * The string {@code XXX} is one of Swing's uiClassIDs. For
+     * MetalXXXUI. The string {@code XXX} is one of Swing's uiClassIDs. For
      * the {@code uiClassIDs} that do not have a class in metal, the
      * corresponding class in {@code javax.swing.plaf.basic} is
-     * used.
-     * For example, metal does not have a class named {@code
+     * used. For example, metal does not have a class named {@code
      * "MetalColorChooserUI"}, as such, {@code
      * javax.swing.plaf.basic.BasicColorChooserUI} is used.
-     * And {@code MetalMenuBarUI} is an example of a UI class
-     * that is registered and used only in one theme : {@code OceanTheme},
-     * and therefore will not be registered by {@code MetalLookAndFeel}
-     * and the other provided themes"
      *
      * @param table the {@code UIDefaults} instance the entries are
      *        added to
@@ -278,6 +272,7 @@ public class MetalLookAndFeel extends BasicLookAndFeel
               "FileChooserUI", metalPackageName + "MetalFileChooserUI",
             "InternalFrameUI", metalPackageName + "MetalInternalFrameUI",
                     "LabelUI", metalPackageName + "MetalLabelUI",
+                  "MenuBarUI", metalPackageName + "MetalMenuBarUI",
        "PopupMenuSeparatorUI", metalPackageName + "MetalPopupMenuSeparatorUI",
               "ProgressBarUI", metalPackageName + "MetalProgressBarUI",
               "RadioButtonUI", metalPackageName + "MetalRadioButtonUI",

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
@@ -252,6 +252,9 @@ public class MetalLookAndFeel extends BasicLookAndFeel
      * used. For example, metal does not have a class named {@code
      * "MetalColorChooserUI"}, as such, {@code
      * javax.swing.plaf.basic.BasicColorChooserUI} is used.
+     * Also, class {@code MetalMenubarUI} is used only for {@code OceanTheme}
+     * which is used by {@code MetalLookAndFeel} by default so
+     * it is registered in Ocean theme's entries.
      *
      * @param table the {@code UIDefaults} instance the entries are
      *        added to
@@ -272,7 +275,6 @@ public class MetalLookAndFeel extends BasicLookAndFeel
               "FileChooserUI", metalPackageName + "MetalFileChooserUI",
             "InternalFrameUI", metalPackageName + "MetalInternalFrameUI",
                     "LabelUI", metalPackageName + "MetalLabelUI",
-                  "MenuBarUI", metalPackageName + "MetalMenuBarUI",
        "PopupMenuSeparatorUI", metalPackageName + "MetalPopupMenuSeparatorUI",
               "ProgressBarUI", metalPackageName + "MetalProgressBarUI",
               "RadioButtonUI", metalPackageName + "MetalRadioButtonUI",

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
@@ -246,17 +246,18 @@ public class MetalLookAndFeel extends BasicLookAndFeel
      * the fully qualified name of the ui class. {@code
      * MetalLookAndFeel} registers an entry for each of the classes in
      * the package {@code javax.swing.plaf.metal} that are named
-     * MetalXXXUI. The string {@code XXX} is one of Swing's uiClassIDs. For
+     * MetalXXXUI which are used by the current {@code MetalTheme}.
+     * The string {@code XXX} is one of Swing's uiClassIDs. For
      * the {@code uiClassIDs} that do not have a class in metal, the
      * corresponding class in {@code javax.swing.plaf.basic} is
-     * used. For example, metal does not have a class named {@code
+     * used.
+     * For example, metal does not have a class named {@code
      * "MetalColorChooserUI"}, as such, {@code
      * javax.swing.plaf.basic.BasicColorChooserUI} is used.
-     * It is to be noted that some MetalXXXUI classes can be used only by
-     * a particular theme and registered only if that theme is selected
-     * for example, class {@code MetalMenuBarUI} is used only for
-     * {@code OceanTheme} which is used by {@code MetalLookAndFeel} by default
-     * so it is registered in Ocean theme's entries.
+     * And {@code MetalMenuBarUI} is an example of a UI class
+     * that is registered and used only in one theme : {@code OceanTheme},
+     * and therefore will not be registered by {@code MetalLookAndFeel}
+     * and the other provided themes"
      *
      * @param table the {@code UIDefaults} instance the entries are
      *        added to

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
@@ -252,7 +252,7 @@ public class MetalLookAndFeel extends BasicLookAndFeel
      * used. For example, metal does not have a class named {@code
      * "MetalColorChooserUI"}, as such, {@code
      * javax.swing.plaf.basic.BasicColorChooserUI} is used.
-     * Also, class {@code MetalMenubarUI} is used only for {@code OceanTheme}
+     * Also, class {@code MetalMenuBarUI} is used only for {@code OceanTheme}
      * which is used by {@code MetalLookAndFeel} by default so
      * it is registered in Ocean theme's entries.
      *

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
@@ -252,9 +252,11 @@ public class MetalLookAndFeel extends BasicLookAndFeel
      * used. For example, metal does not have a class named {@code
      * "MetalColorChooserUI"}, as such, {@code
      * javax.swing.plaf.basic.BasicColorChooserUI} is used.
-     * Also, class {@code MetalMenuBarUI} is used only for {@code OceanTheme}
-     * which is used by {@code MetalLookAndFeel} by default so
-     * it is registered in Ocean theme's entries.
+     * It is to be noted that some MetalXXXUI classes can be used only by
+     * a particular theme and registered only if that theme is selected
+     * for example, class {@code MetalMenuBarUI} is used only for
+     * {@code OceanTheme} which is used by {@code MetalLookAndFeel} by default
+     * so it is registered in Ocean theme's entries.
      *
      * @param table the {@code UIDefaults} instance the entries are
      *        added to

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/OceanTheme.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/OceanTheme.java
@@ -244,8 +244,6 @@ public class OceanTheme extends DefaultMetalTheme {
 
             "List.focusCellHighlightBorder", focusBorder,
 
-            "MenuBarUI", "javax.swing.plaf.metal.MetalMenuBarUI",
-
             "OptionPane.errorIcon",
                    getIconResource("icons/ocean/error.png"),
             "OptionPane.informationIcon",


### PR DESCRIPTION
Spec for [MetalLookAndFeel](https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java#L247)
says:
"...MetalLookAndFeel registers an entry for each of the classes
in the package javax.swing.plaf.metal that are named MetalXXXUI.
The string XXX is one of Swing's uiClassIDs. For the uiClassIDs
that do not have a class in metal, the corresponding class in
javax.swing.plaf.basic is used. For example, metal does not
have a class named "MetalColorChooserUI", as such,
javax.swing.plaf.basic.BasicColorChooserUI is used".

There is class MetalMenuBarUI, but the method populates given defaults table with the value
"javax.swing.plaf.basic.BasicMenuBarUI".

Added entry for MetalMenuBarUI..
CI tests including JCK tests are ok.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-6513512](https://bugs.openjdk.org/browse/JDK-6513512): MetalLookAndFeel.initClassDefaults does not install an entry for MetalMenuBarUI
 * [JDK-8298703](https://bugs.openjdk.org/browse/JDK-8298703): MetalLookAndFeel.initClassDefaults does not install an entry for MetalMenuBarUI (**CSR**) (Withdrawn)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to [71965da8](https://git.openjdk.org/jdk/pull/11646/files/71965da86a5f608373cce85888994e8e95033b3e)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11646/head:pull/11646` \
`$ git checkout pull/11646`

Update a local copy of the PR: \
`$ git checkout pull/11646` \
`$ git pull https://git.openjdk.org/jdk pull/11646/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11646`

View PR using the GUI difftool: \
`$ git pr show -t 11646`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11646.diff">https://git.openjdk.org/jdk/pull/11646.diff</a>

</details>
