### PR TITLE
8298643 JNI call of getAccessibleRowWithIndex and getAccessibleColumnWithIndex on a wrong thread

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TableAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TableAccessibility.m
@@ -88,28 +88,20 @@ static jmethodID sjm_getAccessibleName = NULL;
 
 - (int)accessibleRowAtIndex:(int)index
 {
-    JNIEnv *env = [ThreadUtilities getJNIEnv];
-    jobject axContext = [self axContextWithEnv:env];
-    if (axContext == NULL) return 0;
-    jclass clsInfo = (*env)->GetObjectClass(env, axContext);
-    DECLARE_METHOD_RETURN(jm_getAccessibleRowAtIndex, clsInfo, "getAccessibleRowAtIndex", "(I)I", -1);
-    jint rowAtIndex = (*env)->CallIntMethod(env, axContext, jm_getAccessibleRowAtIndex, (jint)index);
-    CHECK_EXCEPTION();
-    (*env)->DeleteLocalRef(env, axContext);
-    return (int)rowAtIndex;
+    int columnCount = [self accessibilityColumnCount];
+    if (columnCount != 0) {
+        return index / columnCount;
+    }
+    return -1;
 }
 
 - (int)accessibleColumnAtIndex:(int)index
 {
-    JNIEnv *env = [ThreadUtilities getJNIEnv];
-    jobject axContext = [self axContextWithEnv:env];
-    if (axContext == NULL) return 0;
-    jclass clsInfo = (*env)->GetObjectClass(env, axContext);
-    DECLARE_METHOD_RETURN(jm_getAccessibleColumnAtIndex, clsInfo, "getAccessibleColumnAtIndex", "(I)I", -1);
-    jint columnAtIndex = (*env)->CallIntMethod(env, axContext, jm_getAccessibleColumnAtIndex, (jint)index);
-    CHECK_EXCEPTION();
-    (*env)->DeleteLocalRef(env, axContext);
-    return (int)columnAtIndex;
+    int columnCount = [self accessibilityColumnCount];
+    if (columnCount != 0) {
+        return index % columnCount;
+    }
+    return -1;
 }
 
 - (BOOL) isAccessibleChildSelectedFromIndex:(int)index


### PR DESCRIPTION
[TableAccessibility accessibleRowWithIndex] and [TableAccessibility accessibleColumnWithIndex] defines the getAccessibleRowWithIndex and getAccessibleColumnWithIndex methods on the AccessibleContext instance of AccessibleJTable class, however the call should go through CAccessibility so that it is executed on the Event Dispatch thread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298643](https://bugs.openjdk.org/browse/JDK-8298643): JNI call of getAccessibleRowWithIndex and getAccessibleColumnWithIndex on a wrong thread


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11649/head:pull/11649` \
`$ git checkout pull/11649`

Update a local copy of the PR: \
`$ git checkout pull/11649` \
`$ git pull https://git.openjdk.org/jdk pull/11649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11649`

View PR using the GUI difftool: \
`$ git pr show -t 11649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11649.diff">https://git.openjdk.org/jdk/pull/11649.diff</a>

</details>
