### PR TITLE
8298651: Serial: Remove MarkSweep::follow_klass

### DIFF
--- a/src/hotspot/share/gc/serial/markSweep.cpp
+++ b/src/hotspot/share/gc/serial/markSweep.cpp
@@ -76,7 +76,7 @@ void MarkSweep::push_objarray(oop obj, size_t index) {
 }
 
 void MarkSweep::follow_array(objArrayOop array) {
-  MarkSweep::follow_klass(array->klass());
+  mark_and_push_closure.do_klass(array->klass());
   // Don't push empty arrays to avoid unnecessary work.
   if (array->length() > 0) {
     MarkSweep::push_objarray(array, 0);
@@ -201,11 +201,6 @@ template <class T> void MarkSweep::mark_and_push(T* p) {
       _marking_stack.push(obj);
     }
   }
-}
-
-void MarkSweep::follow_klass(Klass* klass) {
-  oop op = klass->class_loader_data()->holder_no_keepalive();
-  MarkSweep::mark_and_push(&op);
 }
 
 template <typename T>

--- a/src/hotspot/share/gc/serial/markSweep.hpp
+++ b/src/hotspot/share/gc/serial/markSweep.hpp
@@ -148,8 +148,6 @@ class MarkSweep : AllStatic {
 
   static void follow_stack();   // Empty marking stack.
 
-  static void follow_klass(Klass* klass);
-
   template <class T> static inline void adjust_pointer(T* p);
 
   // Check mark and maybe push on marking stack


### PR DESCRIPTION
Simple change to make CLD better encapsulated during marking.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298651](https://bugs.openjdk.org/browse/JDK-8298651): Serial: Remove MarkSweep::follow_klass


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11650/head:pull/11650` \
`$ git checkout pull/11650`

Update a local copy of the PR: \
`$ git checkout pull/11650` \
`$ git pull https://git.openjdk.org/jdk pull/11650/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11650`

View PR using the GUI difftool: \
`$ git pr show -t 11650`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11650.diff">https://git.openjdk.org/jdk/pull/11650.diff</a>

</details>
