### PR TITLE
8298645 JNI works with accessibleSelection on a wrong thread

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
@@ -817,7 +817,7 @@ class CAccessibility implements PropertyChangeListener {
         }, c);
     }
 
-
+    // This method is called from the native in ComboBoxAccessibility.m
     private static Accessible getAccessibleComboboxValue(Accessible a, Component c) {
         if (a == null) return null;
 

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
@@ -817,6 +817,26 @@ class CAccessibility implements PropertyChangeListener {
         }, c);
     }
 
+
+    private static Accessible getAccessibleComboboxValue(Accessible a, Component c) {
+        if (a == null) return null;
+
+        return invokeAndWait(new Callable<Accessible>() {
+            @Override
+            public Accessible call() throws Exception {
+                AccessibleContext ac = a.getAccessibleContext();
+                if (ac != null) {
+                    AccessibleSelection as = ac.getAccessibleSelection();
+                    if (as != null) {
+                        return as.getAccessibleSelection(0);
+                    }
+                }
+
+                return null;
+            }
+        }, c);
+    }
+
     @Native private static final int JAVA_AX_ROWS = 1;
     @Native private static final int JAVA_AX_COLS = 2;
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ComboBoxAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ComboBoxAccessibility.m
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, JetBrains s.r.o.. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, JetBrains s.r.o.. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ComboBoxAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ComboBoxAccessibility.m
@@ -37,46 +37,26 @@ static jmethodID sjm_getAccessibleName = NULL;
     GET_STATIC_METHOD_RETURN(sjm_getAccessibleName, sjc_CAccessibility, "getAccessibleName", \
                      "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;", ret);
 
-static jmethodID sjm_getAccessibleSelection = NULL;
-#define GET_ACCESSIBLESELECTION_METHOD_RETURN(ret) \
-    GET_CACCESSIBILITY_CLASS_RETURN(ret); \
-    GET_STATIC_METHOD_RETURN(sjm_getAccessibleSelection, sjc_CAccessibility, "getAccessibleSelection", \
-    "(Ljavax/accessibility/AccessibleContext;Ljava/awt/Component;)Ljavax/accessibility/AccessibleSelection;", ret);
-
 @implementation ComboBoxAccessibility
 
-// NSAccessibilityElement protocol methods
-
-- (id)accessibilityValue {
+- (CommonComponentAccessibility *)accessibleSelection
+{
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-    jobject axContext = [self axContextWithEnv:env];
-    if (axContext == NULL) return nil;
-    GET_ACCESSIBLESELECTION_METHOD_RETURN(nil);
-    jobject axSelection = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, sjm_getAccessibleSelection, axContext, self->fComponent);
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(sjm_getAccessibleComboboxValue, sjc_CAccessibility, "getAccessibleComboboxValue", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/Accessible;", nil);
+    jobject axSelectedChild = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, sjm_getAccessibleComboboxValue, fAccessible, fComponent);
     CHECK_EXCEPTION();
-    if (axSelection == NULL) {
-        return nil;
-    }
-    jclass axSelectionClass = (*env)->GetObjectClass(env, axSelection);
-    DECLARE_METHOD_RETURN(jm_getAccessibleSelection, axSelectionClass, "getAccessibleSelection", "(I)Ljavax/accessibility/Accessible;", nil);
-    jobject axSelectedChild = (*env)->CallObjectMethod(env, axSelection, jm_getAccessibleSelection, 0);
-    CHECK_EXCEPTION();
-    (*env)->DeleteLocalRef(env, axSelection);
-    (*env)->DeleteLocalRef(env, axContext);
     if (axSelectedChild == NULL) {
         return nil;
     }
-    GET_ACCESSIBLENAME_METHOD_RETURN(nil);
-    jobject childName = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, sjm_getAccessibleName, axSelectedChild, fComponent);
-    CHECK_EXCEPTION();
-    if (childName == NULL) {
-        (*env)->DeleteLocalRef(env, axSelectedChild);
-        return nil;
-    }
-    NSString *selectedText = JavaStringToNSString(env, childName);
-    (*env)->DeleteLocalRef(env, axSelectedChild);
-    (*env)->DeleteLocalRef(env, childName);
-    return selectedText;
+    return [CommonComponentAccessibility createWithAccessible:axSelectedChild withEnv:env withView:fView];
+}
+
+// NSAccessibilityElement protocol methods
+
+- (id)accessibilityValue
+{
+    return [[self accessibleSelection] accessibilityLabel];
 }
 
 @end


### PR DESCRIPTION
[ComboBoxAccessibility accessibilityValue] works with the accessibleSelection object directly, however the work should go through CAccessibility so that it is executed on the Event Dispatch thread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298645](https://bugs.openjdk.org/browse/JDK-8298645): JNI works with accessibleSelection on a wrong thread


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to [38319bf7](https://git.openjdk.org/jdk/pull/11653/files/38319bf724d9b43d0ab93bfff86a450f6e001297)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**) ⚠️ Review applies to [38319bf7](https://git.openjdk.org/jdk/pull/11653/files/38319bf724d9b43d0ab93bfff86a450f6e001297)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11653/head:pull/11653` \
`$ git checkout pull/11653`

Update a local copy of the PR: \
`$ git checkout pull/11653` \
`$ git pull https://git.openjdk.org/jdk pull/11653/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11653`

View PR using the GUI difftool: \
`$ git pr show -t 11653`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11653.diff">https://git.openjdk.org/jdk/pull/11653.diff</a>

</details>
