### PR TITLE
8298692: Fix typos in test/jdk/com/sun/jdi files

### DIFF
--- a/test/jdk/com/sun/jdi/ArgumentValuesTest.java
+++ b/test/jdk/com/sun/jdi/ArgumentValuesTest.java
@@ -227,7 +227,7 @@ public class ArgumentValuesTest extends TestScaffold {
             }
         }
 
-        // a method with with one generic param
+        // a method with one generic param
         {
             System.out.println("----- Testing generic args");
             bpe = resumeTo("ArgumentValuesTarg", GENERIC_ARGS_LINE_1);

--- a/test/jdk/com/sun/jdi/connect/spi/GeneratedConnectors.java
+++ b/test/jdk/com/sun/jdi/connect/spi/GeneratedConnectors.java
@@ -25,7 +25,7 @@
  * @bug 4287596
  * @summary Unit test for "Pluggable Connectors and Transports" feature.
  *
- * When a transport service is deployed the virtual machine machine
+ * When a transport service is deployed the virtual machine
  * is required to create an AttachingConnector and ListeningConnector
  * to encapsulate the transport. This tests that the connectors are
  * created and that they have an "address" argument.

--- a/test/jdk/com/sun/jdi/lib/jdb/Jdb.java
+++ b/test/jdk/com/sun/jdi/lib/jdb/Jdb.java
@@ -152,7 +152,7 @@ public class Jdb implements AutoCloseable {
         #
         # 5) ^main[89] > @
         #
-        # i.e., the > prompt comes out AFTER the prompt we we need to wait for.
+        # i.e., the > prompt comes out AFTER the prompt we need to wait for.
     */
     // compile regexp once
     private final static String promptPattern = "<?[a-zA-Z0-9_-]*>?\\[[1-9][0-9]*\\] [ >]*$";


### PR DESCRIPTION
These are the typos from #10029 that relate to test/jdk/com/sun/jdi.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298692](https://bugs.openjdk.org/browse/JDK-8298692): Fix typos in test/jdk/com/sun/jdi files


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11656/head:pull/11656` \
`$ git checkout pull/11656`

Update a local copy of the PR: \
`$ git checkout pull/11656` \
`$ git pull https://git.openjdk.org/jdk pull/11656/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11656`

View PR using the GUI difftool: \
`$ git pr show -t 11656`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11656.diff">https://git.openjdk.org/jdk/pull/11656.diff</a>

</details>
