### PR TITLE
8298701: Cleanup SA entries in ProblemList-zgc.txt.

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -31,15 +31,9 @@ resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java 8276539   generic-
 serviceability/sa/CDSJMapClstats.java                         8276539   generic-all
 serviceability/sa/ClhsdbJhisto.java                           8276539   generic-all
 
-serviceability/sa/ClhsdbCDSCore.java                          8268722   macosx-x64
-serviceability/sa/ClhsdbFindPC.java#xcomp-core                8268722,8284045   macosx-x64,generic-all
-serviceability/sa/ClhsdbFindPC.java#no-xcomp-core             8268722   macosx-x64
-serviceability/sa/ClhsdbFindPC.java#xcomp-process             8276402   generic-all
-serviceability/sa/ClhsdbJstack.java#id0                       8276402   generic-all
-serviceability/sa/ClhsdbPmap.java#core                        8268722   macosx-x64
-serviceability/sa/ClhsdbPstack.java#core                      8268722   macosx-x64
-serviceability/sa/TestJmapCore.java                           8268722,8268283,8270202   macosx-x64,linux-aarch64,linux-x64
-serviceability/sa/TestJmapCoreMetaspace.java                  8268722,8268636   generic-all
+serviceability/sa/ClhsdbFindPC.java#xcomp-core                8284045   generic-all
+serviceability/sa/TestJmapCore.java                           8268283,8270202   linux-aarch64,linux-x64,macosx-aarch64
+serviceability/sa/TestJmapCoreMetaspace.java                  8268636   generic-all
 
 serviceability/sa/TestJhsdbJstackMixed.java                   8248912   generic-all
 serviceability/sa/ClhsdbPstack.java#process                   8248912   generic-all

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -287,15 +287,6 @@ tier1_gc_1 = \
   gc/g1/ \
   -gc/g1/ihop/TestIHOPErgo.java
 
-svc_core = \
-serviceability/sa/ClhsdbCDSCore.java \
-serviceability/sa/ClhsdbFindPC.java \
-serviceability/sa/ClhsdbJstack.java \
-serviceability/sa/ClhsdbPmap.java \
-serviceability/sa/ClhsdbPstack.java \
-serviceability/sa/TestJmapCore.java \
-serviceability/sa/TestJmapCoreMetaspace.java \
-
 tier1_gc_2 = \
   gc/ \
   -gc/g1/ \

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -287,6 +287,15 @@ tier1_gc_1 = \
   gc/g1/ \
   -gc/g1/ihop/TestIHOPErgo.java
 
+svc_core = \
+serviceability/sa/ClhsdbCDSCore.java \
+serviceability/sa/ClhsdbFindPC.java \
+serviceability/sa/ClhsdbJstack.java \
+serviceability/sa/ClhsdbPmap.java \
+serviceability/sa/ClhsdbPstack.java \
+serviceability/sa/TestJmapCore.java \
+serviceability/sa/TestJmapCoreMetaspace.java \
+
 tier1_gc_2 = \
   gc/ \
   -gc/g1/ \


### PR DESCRIPTION
The following ProblemList-zgc.txt entries need a lot of cleanup.

serviceability/sa/ClhsdbCDSCore.java                          8268722   macosx-x64
serviceability/sa/ClhsdbFindPC.java#xcomp-core                8268722,8284045   macosx-x64,generic-all
serviceability/sa/ClhsdbFindPC.java#no-xcomp-core             8268722   macosx-x64
serviceability/sa/ClhsdbFindPC.java#xcomp-process             8276402   generic-all
serviceability/sa/ClhsdbJstack.java#id0                       8276402   generic-all
serviceability/sa/ClhsdbPmap.java#core                        8268722   macosx-x64
serviceability/sa/ClhsdbPstack.java#core                      8268722   macosx-x64
serviceability/sa/TestJmapCore.java                           8268722,8268283,8270202   macosx-x64,linux-aarch64,linux-x64
serviceability/sa/TestJmapCoreMetaspace.java                  8268722,8268636   generic-all

[JDK-8268722](https://bugs.openjdk.org/browse/JDK-8268722) entries can be removed. It was closed as WNF. It doesn't really impact macosx-aarch64 (core files are reasonably small there), and on macosx-x64 all these core file tests are (probably indefinitely) problem listed for other reasons in the main problem list, so no need to problem list them here with a closed CR.

[JDK-8276402](https://bugs.openjdk.org/browse/JDK-8276402) has been closed as dup of a bug that is now fixed.

Lastly, TestJmapCore.java does fail on macosx-aarch64 due to [JDK-8268283](https://bugs.openjdk.org/browse/JDK-8268283), so its problem list entry needs to be updated to reflect that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298701](https://bugs.openjdk.org/browse/JDK-8298701): Cleanup SA entries in ProblemList-zgc.txt.


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11658/head:pull/11658` \
`$ git checkout pull/11658`

Update a local copy of the PR: \
`$ git checkout pull/11658` \
`$ git pull https://git.openjdk.org/jdk pull/11658/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11658`

View PR using the GUI difftool: \
`$ git pr show -t 11658`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11658.diff">https://git.openjdk.org/jdk/pull/11658.diff</a>

</details>
