### PR TITLE
8298038: [s390] Configure script detects num_cores +1

### DIFF
--- a/make/autoconf/build-performance.m4
+++ b/make/autoconf/build-performance.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/autoconf/build-performance.m4
+++ b/make/autoconf/build-performance.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ AC_DEFUN([BPERF_CHECK_CORES],
 
   if test -f /proc/cpuinfo; then
     # Looks like a Linux (or cygwin) system
-    NUM_CORES=`cat /proc/cpuinfo  | grep -c processor`
+    NUM_CORES=`cat /proc/cpuinfo  | grep -cw processor`
     if test "$NUM_CORES" -eq "0"; then
       NUM_CORES=`cat /proc/cpuinfo  | grep -c ^CPU`
     fi


### PR DESCRIPTION
cpuinfo on s390x architecture contains additional header information on Linux/Z which is not seen on GNU Linux:

```
vendor_id       : IBM/S390
# processors    : 8
```
due to this one extra build job is created. 

Reported Issue can be found here : [JDK-8298038](https://bugs.openjdk.org/browse/JDK-8298038)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298038](https://bugs.openjdk.org/browse/JDK-8298038): [s390] Configure script detects num_cores +1


### Reviewers
 * [Tyler Steele](https://openjdk.org/census#tsteele) (@backwaterred - Committer)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11659/head:pull/11659` \
`$ git checkout pull/11659`

Update a local copy of the PR: \
`$ git checkout pull/11659` \
`$ git pull https://git.openjdk.org/jdk pull/11659/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11659`

View PR using the GUI difftool: \
`$ git pr show -t 11659`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11659.diff">https://git.openjdk.org/jdk/pull/11659.diff</a>

</details>
