### PR TITLE
7175396: The text on label is not painted red for Nimbus LaF.

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
@@ -13389,8 +13389,32 @@
                   </layer>
                </canvas>
             </state>
+            <state stateKeys="Enabled">
+               <style>
+                  <textForeground>
+                     <matte red="0" green="0" blue="0" alpha="255" uiDefaultParentName="text" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0"/>
+                  </textForeground>
+                  <textBackground/>
+                  <background/>
+                  <uiproperties/>
+               </style>
+               <canvas>
+                  <size width="100" height="30"/>
+                  <nextLayerNameIndex>2</nextLayerNameIndex>
+                  <stretchingInsets top="5" bottom="5" left="5" right="5"/>
+                  <layer name="Layer 1">
+                     <opacity>1.0</opacity>
+                     <fillOpacity>1.0</fillOpacity>
+                     <blendingMode>NORMAL</blendingMode>
+                     <locked>false</locked>
+                     <visible>true</visible>
+                     <shapes/>
+                     <effects/>
+                  </layer>
+               </canvas>
+            </state>
          </backgroundStates>
-         <foregroundStates/>
+	 <foregroundStates/>
          <borderStates/>
          <regions/>
       </uiComponent>

--- a/test/jdk/javax/swing/plaf/nimbus/TestNimbusLabel.java
+++ b/test/jdk/javax/swing/plaf/nimbus/TestNimbusLabel.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 7175396
+ * @key headful
+ * @summary  Verifies the text on label is painted red for Nimbus LaF.
+ * @run main TestNimbusLabel
+ */
+
+import java.io.File;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class TestNimbusLabel
+{
+    private static JLabel label;
+    private static JFrame frame;
+    private static boolean passed = false;
+    private static int colorTolerance = 5;
+
+    private static boolean checkPixel(Color color) {
+        int red1 = color.getRed();
+        int blue1 = color.getBlue();
+        int green1 = color.getGreen();
+        int red2 = Color.red.getRed();
+        int blue2 = Color.red.getBlue();
+        int green2 = Color.red.getGreen();
+        if ((Math.abs(red1 - red2) < colorTolerance) &&
+                (Math.abs(green1 - green2) < colorTolerance) &&
+                (Math.abs(blue1 - blue2) < colorTolerance)) {
+            return true;
+        }
+        return false;
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        try {
+            UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
+            Robot robot = new Robot();
+
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame();
+                UIManager.getDefaults().put("Label[Enabled].textForeground",
+                                            java.awt.Color.red);
+                label =
+                    //new JLabel("This text should be in red");
+                    new JLabel("<html><body>This text should be in red</body></html>");
+
+                frame.getContentPane().add(label);
+                frame.setUndecorated(true);
+                frame.setLocationRelativeTo(null);
+                frame.pack();
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            Point p = frame.getLocationOnScreen();
+            Dimension d = frame.getSize();
+            System.out.println("width " + d.getWidth() +
+                                " height " + d.getHeight());
+            int y = p.y + d.height/2;
+
+            for (int x = p.x; x < p.x + d.width; x++) {
+                    System.out.println("color(" + x + "," + y + ")=" +
+                                        robot.getPixelColor(x, y));
+                    Color color = robot.getPixelColor(x, y);
+                    if (checkPixel(color)) {
+                        passed = true;
+                        break;
+                    }
+            }
+            if (!passed) {
+                BufferedImage img =
+                    robot.createScreenCapture(new Rectangle(p.x, p.y,
+                            d.width,
+                            d.height));
+                ImageIO.write(img, "png", new File("label.png"));
+                throw new RuntimeException("Label.foreground color not honoured");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}
+

--- a/test/jdk/javax/swing/plaf/nimbus/TestNimbusLabel.java
+++ b/test/jdk/javax/swing/plaf/nimbus/TestNimbusLabel.java
@@ -74,7 +74,6 @@ public class TestNimbusLabel
                 UIManager.getDefaults().put("Label[Enabled].textForeground",
                                             java.awt.Color.red);
                 label =
-                    //new JLabel("This text should be in red");
                     new JLabel("<html><body>This text should be in red</body></html>");
 
                 frame.getContentPane().add(label);

--- a/test/jdk/javax/swing/plaf/nimbus/TestNimbusLabel.java
+++ b/test/jdk/javax/swing/plaf/nimbus/TestNimbusLabel.java
@@ -25,7 +25,7 @@
  * @bug 7175396
  * @key headful
  * @summary  Verifies the text on label is painted red for Nimbus LaF.
- * @run main TestNimbusLabel
+ * @run main/othervm -Dsun.java2d.uiScale=1.0 TestNimbusLabel
  */
 
 import java.io.File;


### PR DESCRIPTION
Label.foreground UIProperty is not honored by Nimbus L&F. It needs to be Label[Enabled].textForeground which is the corresponding Synth property
Added support for setting JLabel foreground color for Nimbus L&F

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-7175396](https://bugs.openjdk.org/browse/JDK-7175396): The text on label is not painted red for Nimbus LaF.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11660/head:pull/11660` \
`$ git checkout pull/11660`

Update a local copy of the PR: \
`$ git checkout pull/11660` \
`$ git pull https://git.openjdk.org/jdk pull/11660/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11660`

View PR using the GUI difftool: \
`$ git pr show -t 11660`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11660.diff">https://git.openjdk.org/jdk/pull/11660.diff</a>

</details>
