### PR TITLE
8298709: Fix typos in src/java.desktop/ and various test classes of client component

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/Document.java
+++ b/src/java.desktop/share/classes/javax/swing/text/Document.java
@@ -278,7 +278,7 @@ import javax.swing.event.UndoableEditListener;
  * <p>Removing text from a DefaultStyledDocument is similar to removing text from
  * a PlainDocument. The only difference is the extra level of Elements.
  * Consider what would happen if you deleted two characters at Offset 1
- * from Figure 10, above. Since the the second Element of Paragraph 1 is
+ * from Figure 10, above. Since the second Element of Paragraph 1 is
  * completely contained in the deleted region, it would be removed.
  * Assuming the attributes of Paragraph 1's first child matched those of
  * Paragraph2's first child, the results would be those shown in <u>Figure 11</u>.

--- a/test/jdk/java/awt/Multiscreen/DeviceIdentificationTest/DeviceIdentificationTest.java
+++ b/test/jdk/java/awt/Multiscreen/DeviceIdentificationTest/DeviceIdentificationTest.java
@@ -24,7 +24,7 @@
  * @test
  * @bug 6614214 8198613
  * @summary Verifies that we enter the fs mode on the correct screen.
- * Here is how to test: start the test on on a multi-screen system.
+ * Here is how to test: start the test on a multi-screen system.
  * Verify that the display is correctly tracked by dragging the frame back
  * and forth between screens. Then verify that the correct device enters
  * the full-screen mode - when "Enter FS mode" is pressed it should enter on

--- a/test/jdk/java/awt/datatransfer/HTMLDataFlavors/ManualHTMLDataFlavorTest.java
+++ b/test/jdk/java/awt/datatransfer/HTMLDataFlavors/ManualHTMLDataFlavorTest.java
@@ -121,7 +121,7 @@ public class ManualHTMLDataFlavorTest extends Applet {
                 "6) The output should contain data in three different formats",
                 "   provided by the system clipboard",
                 "    - Data after the \"ALL:\" marker should include the data",
-                "      from the the \"SELECTION:\" marker",
+                "      from the \"SELECTION:\" marker",
                 "    - Data after the \"FRAGMENT\" marker should include the data",
                 "      from the \"SELECTION:\" marker and may be some closing",
                 "      tags could be added to the mark-up",

--- a/test/jdk/java/awt/print/PrinterJob/PageFormatChange.java
+++ b/test/jdk/java/awt/print/PrinterJob/PageFormatChange.java
@@ -34,7 +34,7 @@ import javax.print.*;
 public class PageFormatChange {
 
     static String[] text = {
-    "This is is a manual test intended to be run on Windows, and you",
+    "This is a manual test intended to be run on Windows, and you",
     "must have at least two printers installed, and ideally the second",
     "printer should support large paper sizes. When the pageDialog appears",
     "first change printers, then choose a large paper size, then OK",

--- a/test/jdk/javax/imageio/stream/DeleteOnExitTest.sh
+++ b/test/jdk/javax/imageio/stream/DeleteOnExitTest.sh
@@ -22,7 +22,7 @@
 # @test
 # @bug 6291034
 # @run shell DeleteOnExitTest.sh
-# @summary Verify that temporary imageio files files are deleted on VM exit.
+# @summary Verify that temporary imageio files are deleted on VM exit.
 
 if [ -z "${TESTSRC}" ]; then
   echo "TESTSRC undefined: defaulting to ."

--- a/test/jdk/javax/print/attribute/ServiceDlgPageRangeTest.java
+++ b/test/jdk/javax/print/attribute/ServiceDlgPageRangeTest.java
@@ -99,7 +99,7 @@ public class ServiceDlgPageRangeTest {
         } catch (InterruptedException e) {
             if (!testPassed && testGeneratedInterrupt) {
                 throw new RuntimeException("PageRanges option is not disabled "
-                        + "for for Non serv-formatted flvrs");
+                        + "for Non serv-formatted flvrs");
             }
         }
         if (!testGeneratedInterrupt) {

--- a/test/jdk/javax/sound/midi/Sequencer/SequencerState.java
+++ b/test/jdk/javax/sound/midi/Sequencer/SequencerState.java
@@ -55,7 +55,7 @@ public class SequencerState {
 
 
     public static void main(String[] args) throws Exception {
-        out("4913027: several Sequencer methods should should specify behaviour on closed Sequencer");
+        out("4913027: several Sequencer methods should specify behaviour on closed Sequencer");
         if (hasSequencer()) {
             boolean passed = testAll();
             if (passed) {

--- a/test/jdk/javax/swing/JColorChooser/Test4193384.java
+++ b/test/jdk/javax/swing/JColorChooser/Test4193384.java
@@ -51,7 +51,7 @@ public class Test4193384 {
         float[] hsb = new float[3];
         for (int i = 0; i < colors.length; i++) {
             Color color = colors[i];
-            // Make sure sure that there wasn't a regression
+            // Make sure that there wasn't a regression
             // in java.awt.Color and the conversion methods
             Color.RGBtoHSB(color.getRed(), color.getGreen(), color.getBlue(), hsb);
             if (!color.equals(Color.getHSBColor(hsb[0], hsb[1], hsb[2]))) {

--- a/test/jdk/sanity/client/SwingSet/src/EditorPaneDemoTest.java
+++ b/test/jdk/sanity/client/SwingSet/src/EditorPaneDemoTest.java
@@ -52,7 +52,7 @@ import com.sun.swingset3.demos.editorpane.EditorPaneDemo;
 /*
  * @test
  * @key headful screenshots
- * @summary Verifies SwingSet3 EditorPaneDemo by navigating and and validating
+ * @summary Verifies SwingSet3 EditorPaneDemo by navigating and validating
  *  the page contents in all pages
  *
  * @library /sanity/client/lib/jemmy/src

--- a/test/jdk/sanity/client/SwingSet/src/TabbedPaneDemoTest.java
+++ b/test/jdk/sanity/client/SwingSet/src/TabbedPaneDemoTest.java
@@ -39,7 +39,7 @@ import org.testng.annotations.Listeners;
  * @test
  * @key headful
  * @summary Verifies SwingSet3 TabbedPaneDemo by iterating through tab placement
- *          positions, opening each tab and verifying the the tab gets selected.
+ *          positions, opening each tab and verifying the tab gets selected.
  *
  * @library /sanity/client/lib/jemmy/src
  * @library /sanity/client/lib/Extensions/src

--- a/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/tree/resources/TreeDemo.properties
+++ b/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/tree/resources/TreeDemo.properties
@@ -1,6 +1,6 @@
 ### Tree Demo ###
 
-TreeDemo.accessible_description=This demo shows shows a sample usage of a JTree component.
+TreeDemo.accessible_description=This demo shows a sample usage of a JTree component.
 TreeDemo.tooltip=JTree demo
 TreeDemo.name=Tree Demo
 TreeDemo.music=Music

--- a/test/jdk/sanity/client/lib/jemmy/src/org/netbeans/jemmy/WindowWaiter.java
+++ b/test/jdk/sanity/client/lib/jemmy/src/org/netbeans/jemmy/WindowWaiter.java
@@ -286,7 +286,7 @@ public class WindowWaiter extends Waiter<Window, Void> implements Timeoutable {
     }
 
     /**
-     * Wait till the count of windows which meet the the search criteria becomes
+     * Wait till the count of windows which meet the search criteria becomes
      * equal to count.
      *
      * @param ch a component chooser used to define and apply the search
@@ -300,7 +300,7 @@ public class WindowWaiter extends Waiter<Window, Void> implements Timeoutable {
     }
 
     /**
-     * Wait till the count of windows which meet the the search criteria becomes
+     * Wait till the count of windows which meet the search criteria becomes
      * equal to count.
      *
      * @param owner The owner window of all the windows to be checked

--- a/test/jdk/sanity/client/lib/jemmy/src/org/netbeans/jemmy/operators/ComponentOperator.java
+++ b/test/jdk/sanity/client/lib/jemmy/src/org/netbeans/jemmy/operators/ComponentOperator.java
@@ -252,7 +252,7 @@ public class ComponentOperator extends Operator
 
     /**
      * Constructor. Waits for a component in a container to show. The component
-     * is is the first {@code java.awt.Component} that shows and that lies
+     * is the first {@code java.awt.Component} that shows and that lies
      * below the container in the display containment hierarchy. Uses cont's
      * timeout and output for waiting and to init operator.
      *

--- a/test/jdk/sanity/client/lib/jemmy/src/org/netbeans/jemmy/operators/JTreeOperator.java
+++ b/test/jdk/sanity/client/lib/jemmy/src/org/netbeans/jemmy/operators/JTreeOperator.java
@@ -66,7 +66,7 @@ import org.netbeans.jemmy.util.EmptyVisualizer;
  * <BR><BR>Timeouts used: <BR>
  * JTreeOperator.WaitNodeExpandedTimeout - time to wait node expanded <BR>
  * JTreeOperator.WaitNodeCollapsedTimeout - time to wait node collapsed <BR>
- * JTreeOperator.WaitAfterNodeExpandedTimeout - time to to sleep after node
+ * JTreeOperator.WaitAfterNodeExpandedTimeout - time to sleep after node
  * expanded <BR>
  * JTreeOperator.WaitNextNodeTimeout - time to wait next node displayed <BR>
  * JTreeOperator.WaitNodeVisibleTimeout - time to wait node visible <BR>

--- a/test/jdk/sanity/client/lib/jemmy/src/org/netbeans/jemmy/operators/Operator.java
+++ b/test/jdk/sanity/client/lib/jemmy/src/org/netbeans/jemmy/operators/Operator.java
@@ -366,7 +366,7 @@ public abstract class Operator
     }
 
     /**
-     * Returns component visualizer. Visualizer is used from from
+     * Returns component visualizer. Visualizer is used from
      * makeComponentVisible() method.
      *
      * @return a visualizer assigned to this operator.
@@ -378,7 +378,7 @@ public abstract class Operator
     }
 
     /**
-     * Changes component visualizer. Visualizer is used from from
+     * Changes component visualizer. Visualizer is used from
      * makeComponentVisible() method.
      *
      * @param vo a visualizer to assign to this operator.
@@ -1080,7 +1080,7 @@ public abstract class Operator
     }
 
     /**
-     * Interface used to make component visible & ready to to make operations
+     * Interface used to make component visible & ready to make operations
      * with.
      */
     public interface ComponentVisualizer {

--- a/test/jdk/sun/java2d/pipe/hw/RSLAPITest/RSLAPITest.java
+++ b/test/jdk/sun/java2d/pipe/hw/RSLAPITest/RSLAPITest.java
@@ -75,7 +75,7 @@ public class RSLAPITest {
         if (ret != 0l) {
             System.err.printf(
                     "FAILED: surface.getNativeResource(%d) returned" +
-                    " 0x%s. It should have have returned 0L\n",
+                    " 0x%s. It should have returned 0L\n",
                     type, ret);
             failed = true;
         }


### PR DESCRIPTION
Can I please get a review for this change which only fixes typos? The original PR for this change is https://github.com/openjdk/jdk/pull/10029. However, that PR included changes to multiple different files in different areas of the JDK and as a result didn't see progress.

This current PR splits off those changes and includes only client area related typo fixes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298709](https://bugs.openjdk.org/browse/JDK-8298709): Fix typos in src/java.desktop/ and various test classes of client component


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Contributors
 * Michael Ernst `<mernst@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11661/head:pull/11661` \
`$ git checkout pull/11661`

Update a local copy of the PR: \
`$ git checkout pull/11661` \
`$ git pull https://git.openjdk.org/jdk pull/11661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11661`

View PR using the GUI difftool: \
`$ git pr show -t 11661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11661.diff">https://git.openjdk.org/jdk/pull/11661.diff</a>

</details>
