### PR TITLE
8298710: Fix typos in test/jdk/sun/security/tools/jarsigner/

### DIFF
--- a/test/jdk/javax/security/auth/x500/X500Principal/EscapedChars.java
+++ b/test/jdk/javax/security/auth/x500/X500Principal/EscapedChars.java
@@ -38,7 +38,7 @@ public class EscapedChars {
 
         System.out.println("RFC2253 DN is " +
             xp.getName(X500Principal.RFC2253));
-        System.out.println("CANONICAL DN is is " +
+        System.out.println("CANONICAL DN is " +
             xp.getName(X500Principal.CANONICAL));
 
         String dn1 = xp.getName(X500Principal.CANONICAL);

--- a/test/jdk/sun/security/tools/jarsigner/DigestDontIgnoreCase.java
+++ b/test/jdk/sun/security/tools/jarsigner/DigestDontIgnoreCase.java
@@ -47,7 +47,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 /*
  * <pre>mfDigest.equalsIgnoreCase(base64Digests[i])</pre>
- * previously in JarSigner.java on on line 985
+ * previously in JarSigner.java on line 985
  * @see jdk.security.jarsigner.JarSigner#updateDigests
  */
 public class DigestDontIgnoreCase {

--- a/test/jdk/sun/security/tools/jarsigner/FindHeaderEndVsManifestDigesterFindFirstSection.java
+++ b/test/jdk/sun/security/tools/jarsigner/FindHeaderEndVsManifestDigesterFindFirstSection.java
@@ -217,7 +217,7 @@ public class FindHeaderEndVsManifestDigesterFindFirstSection {
      * <li>which is then passed on as the third parameter to the constructor
      * of a new {@link ManifestDigester.Section#Section} by
      * <pre>new Section(0, pos.endOfSection + 1, pos.startOfNext, rawBytes)));</pre>
-     * in in ManifestDigester.java:128</li>
+     * in ManifestDigester.java:128</li>
      * <li>where it is assigned to
      * {@link ManifestDigester.Section#lengthWithBlankLine} by
      * <pre>this.lengthWithBlankLine = lengthWithBlankLine;</pre>


### PR DESCRIPTION
Can I please get a review of this change which fixes some typos in the files under test/jdk/sun/security/tools/jarsigner/?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298710](https://bugs.openjdk.org/browse/JDK-8298710): Fix typos in test/jdk/sun/security/tools/jarsigner/


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Contributors
 * Michael Ernst `<mernst@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11662/head:pull/11662` \
`$ git checkout pull/11662`

Update a local copy of the PR: \
`$ git checkout pull/11662` \
`$ git pull https://git.openjdk.org/jdk pull/11662/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11662`

View PR using the GUI difftool: \
`$ git pr show -t 11662`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11662.diff">https://git.openjdk.org/jdk/pull/11662.diff</a>

</details>
