### PR TITLE
8298726: (fs) Change PollingWatchService to record last modified time as FileTime rather than milliseconds

### DIFF
--- a/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
+++ b/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
@@ -29,13 +29,13 @@ import java.nio.file.ClosedWatchServiceException;
 import java.nio.file.DirectoryIteratorException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
 import java.nio.file.NotDirectoryException;
 import java.nio.file.Path;
 import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedExceptionAction;
@@ -51,6 +51,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
 
 /**
  * Simple WatchService implementation that uses periodic tasks to poll
@@ -220,10 +221,10 @@ class PollingWatchService
      * Entry in directory cache to record file last-modified-time and tick-count
      */
     private static class CacheEntry {
-        private long lastModified;
+        private FileTime lastModified;
         private int lastTickCount;
 
-        CacheEntry(long lastModified, int lastTickCount) {
+        CacheEntry(FileTime lastModified, int lastTickCount) {
             this.lastModified = lastModified;
             this.lastTickCount = lastTickCount;
         }
@@ -232,11 +233,11 @@ class PollingWatchService
             return lastTickCount;
         }
 
-        long lastModified() {
+        FileTime lastModified() {
             return lastModified;
         }
 
-        void update(long lastModified, int tickCount) {
+        void update(FileTime lastModified, int tickCount) {
             this.lastModified = lastModified;
             this.lastTickCount = tickCount;
         }
@@ -278,8 +279,7 @@ class PollingWatchService
             try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
                 for (Path entry: stream) {
                     // don't follow links
-                    long lastModified =
-                        Files.getLastModifiedTime(entry, LinkOption.NOFOLLOW_LINKS).toMillis();
+                    FileTime lastModified = Files.getLastModifiedTime(entry, NOFOLLOW_LINKS);
                     entries.put(entry.getFileName(), new CacheEntry(lastModified, tickCount));
                 }
             } catch (DirectoryIteratorException e) {
@@ -356,10 +356,9 @@ class PollingWatchService
             // iterate over all entries in directory
             try {
                 for (Path entry: stream) {
-                    long lastModified = 0L;
+                    FileTime lastModified;
                     try {
-                        lastModified =
-                            Files.getLastModifiedTime(entry, LinkOption.NOFOLLOW_LINKS).toMillis();
+                        lastModified = Files.getLastModifiedTime(entry, NOFOLLOW_LINKS);
                     } catch (IOException x) {
                         // unable to get attributes of entry. If file has just
                         // been deleted then we'll report it as deleted on the
@@ -371,8 +370,7 @@ class PollingWatchService
                     CacheEntry e = entries.get(entry.getFileName());
                     if (e == null) {
                         // new file found
-                        entries.put(entry.getFileName(),
-                                     new CacheEntry(lastModified, tickCount));
+                        entries.put(entry.getFileName(), new CacheEntry(lastModified, tickCount));
 
                         // queue ENTRY_CREATE if event enabled
                         if (events.contains(StandardWatchEventKinds.ENTRY_CREATE)) {
@@ -391,7 +389,7 @@ class PollingWatchService
                     }
 
                     // check if file has changed
-                    if (e.lastModified != lastModified) {
+                    if (!e.lastModified().equals(lastModified)) {
                         if (events.contains(StandardWatchEventKinds.ENTRY_MODIFY)) {
                             signalEvent(StandardWatchEventKinds.ENTRY_MODIFY,
                                         entry.getFileName());


### PR DESCRIPTION
PollingWatchService currently records the last modified time of files in milliseconds. It would be better to just record the FileTime to avoid truncating high precision timestamps to millis.

It's possible this change may also help JDK-8297275.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298726](https://bugs.openjdk.org/browse/JDK-8298726): (fs) Change PollingWatchService to record last modified time as FileTime rather than milliseconds


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11665/head:pull/11665` \
`$ git checkout pull/11665`

Update a local copy of the PR: \
`$ git checkout pull/11665` \
`$ git pull https://git.openjdk.org/jdk pull/11665/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11665`

View PR using the GUI difftool: \
`$ git pr show -t 11665`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11665.diff">https://git.openjdk.org/jdk/pull/11665.diff</a>

</details>
