### PR TITLE
8298725: Add BitMap support for reverse iteration

### DIFF
--- a/src/hotspot/share/utilities/bitMap.hpp
+++ b/src/hotspot/share/utilities/bitMap.hpp
@@ -80,6 +80,14 @@ class BitMap {
     return bit >> LogBitsPerWord;
   }
 
+  // Converts word-aligned bit it to a word offset.
+  // precondition: bit <= size()
+  idx_t to_words_aligned(idx_t bit) const {
+    verify_limit(bit);
+    assert(is_aligned(bit, BitsPerWord), "Incorrect alignment");
+    return raw_to_words_align_down(bit);
+  }
+
   // Word-aligns bit and converts it to a word offset.
   // precondition: bit <= size()
   idx_t to_words_align_up(idx_t bit) const {
@@ -98,8 +106,17 @@ class BitMap {
   // - flip designates whether searching for 1s or 0s.  Must be one of
   //   find_{zeros,ones}_flip.
   // - aligned_right is true if end is a priori on a bm_word_t boundary.
+  // - returns end if bit not found
   template<bm_word_t flip, bool aligned_right>
   inline idx_t get_next_bit_impl(idx_t beg, idx_t end) const;
+
+  // Helper for get_prev_{zero,one}_bit variants.
+  // - flip designates whether searching for 1s or 0s.  Must be one of
+  //   find_{zeros,ones}_flip.
+  // - aligned_left is true if beg is a priori on a bm_word_t boundary.
+  // - returns idx_t(-1) if bit not found
+  template<bm_word_t flip, bool aligned_left>
+  inline idx_t get_prev_bit_impl(idx_t beg, idx_t end) const;
 
   // Values for get_next_bit_impl flip parameter.
   static const bm_word_t find_ones_flip = 0;
@@ -125,7 +142,8 @@ class BitMap {
   // Return the array of bitmap words, or a specific word from it.
   bm_word_t* map()                 { return _map; }
   const bm_word_t* map() const     { return _map; }
-  bm_word_t  map(idx_t word) const { return _map[word]; }
+
+  bm_word_t word(idx_t word_index, bm_word_t flip) const { return _map[word_index] ^ flip; }
 
   // Return a pointer to the word containing the specified bit.
   bm_word_t* word_addr(idx_t bit) {
@@ -248,19 +266,59 @@ class BitMap {
   // Verify [beg,end) is a valid range, e.g. beg <= end <= size().
   void verify_range(idx_t beg, idx_t end) const NOT_DEBUG_RETURN;
 
-  // Iteration support.  Applies the closure to the index for each set bit,
-  // starting from the least index in the range to the greatest, in order.
-  // The iteration terminates if the closure returns false.  Returns true if
-  // the iteration completed, false if terminated early because the closure
-  // returned false.  If the closure modifies the bitmap, modifications to
-  // bits at indices greater than the current index will affect which further
-  // indices the closure will be applied to.
+  // Applies the function to the index for each set bit, starting from the
+  // least index in the range to the greatest, in order. The iteration
+  // terminates if the closure returns false.
+  //
+  // If the function modifies the bitmap, modifications to bits at indices
+  // greater than the current index will affect which further indices the
+  // function will be applied to.
+  //
   // precondition: beg and end form a valid range.
-  template <class BitMapClosureType>
+  //  beg - inclusive
+  //  end - exclusive
+  //
+  // Function interface: bool function(idx_t index)
+  //  index - visited bit
+  //  return false if iterations should terminate early
+  //
+  // Returns true if the iteration completed, false if terminated early because
+  // the function returned false.
+  template <typename Function>
+  bool iterate(Function function, idx_t beg, idx_t end);
+
+  template <typename Function>
+  bool iterate(Function function) {
+    return iterate(function, 0, _size);
+  }
+
+  template <typename BitMapClosureType>
   bool iterate(BitMapClosureType* cl, idx_t beg, idx_t end);
 
-  template <class BitMapClosureType>
-  bool iterate(BitMapClosureType* cl);
+  template <typename BitMapClosureType>
+  bool iterate(BitMapClosureType* cl) {
+    return iterate(cl, 0, _size);
+  }
+
+  // Reverse version of "iterate".
+  //  beg - inclusive
+  //  end - exclusive
+  //  beg <= end
+  template <typename Function>
+  bool iterate_reverse(Function function, idx_t beg, idx_t end);
+
+  template <typename Function>
+  bool iterate_reverse(Function function) {
+    return iterate_reverse(function, 0, _size);
+  }
+
+  template <typename BitMapClosureType>
+  bool iterate_reverse(BitMapClosureType* cl, idx_t beg, idx_t end);
+
+  template <typename BitMapClosureType>
+  bool iterate_reverse(BitMapClosureType* cl) {
+    return iterate_reverse(cl, 0, _size);
+  }
 
   // Looking for 1's and 0's at indices equal to or greater than "beg",
   // stopping if none has been found before "end", and returning
@@ -278,6 +336,23 @@ class BitMap {
   // Like "get_next_one_offset", except requires that "end" is
   // aligned to bitsizeof(bm_word_t).
   idx_t get_next_one_offset_aligned_right(idx_t beg, idx_t end) const;
+
+  // Looking for 1's and 0's at indices lower than "end",
+  // stopping if none has been found before or at "beg", and returning
+  // idx_t(-1) in that case.
+  idx_t get_prev_one_offset (idx_t beg, idx_t end) const;
+  idx_t get_prev_zero_offset(idx_t beg, idx_t end) const;
+
+  idx_t get_prev_one_offset(idx_t offset) const {
+    return get_prev_one_offset(0, offset);
+  }
+  idx_t get_prev_zero_offset(idx_t offset) const {
+    return get_prev_zero_offset(0, offset);
+  }
+
+  // Like "get_prev_one_offset", except requires that "beg" is
+  // aligned to bitsizeof(bm_word_t).
+  idx_t get_prev_one_offset_aligned_left(idx_t beg, idx_t end) const;
 
   // Returns the number of bits set in the bitmap.
   idx_t count_one_bits() const;
@@ -453,6 +528,37 @@ class BitMapClosure {
   // Callback when bit in map is set.  Should normally return "true";
   // return of false indicates that the bitmap iteration should terminate.
   virtual bool do_bit(BitMap::idx_t index) = 0;
+};
+
+// Stand-alone iterators
+
+class BitMapIterator {
+private:
+  BitMap* const _bitmap;
+  BitMap::idx_t _pos;
+  BitMap::idx_t _end;
+
+public:
+  BitMapIterator(BitMap* bitmap);
+  BitMapIterator(BitMap* bitmap, BitMap::idx_t start, BitMap::idx_t end);
+
+  bool next(BitMap::idx_t* index);
+};
+
+class BitMapReverseIterator {
+private:
+  BitMap* const _bitmap;
+  BitMap::idx_t _start;
+  BitMap::idx_t _pos;
+
+public:
+  BitMapReverseIterator(BitMap* bitmap);
+  BitMapReverseIterator(BitMap* bitmap, BitMap::idx_t start, BitMap::idx_t end);
+
+  void reset(BitMap::idx_t start, BitMap::idx_t end);
+  void reset(BitMap::idx_t end);
+
+  bool next(BitMap::idx_t* index);
 };
 
 #endif // SHARE_UTILITIES_BITMAP_HPP

--- a/src/hotspot/share/utilities/bitMap.inline.hpp
+++ b/src/hotspot/share/utilities/bitMap.inline.hpp
@@ -188,44 +188,138 @@ inline BitMap::idx_t BitMap::get_next_bit_impl(idx_t l_index, idx_t r_index) con
   // range check because features of the calling algorithm guarantee
   // an interesting bit will be present.
 
-  if (l_index < r_index) {
-    // Get the word containing l_index, and shift out low bits.
-    idx_t index = to_words_align_down(l_index);
-    bm_word_t cword = (map(index) ^ flip) >> bit_in_word(l_index);
-    if ((cword & 1) != 0) {
-      // The first bit is similarly often interesting. When it matters
-      // (density or features of the calling algorithm make it likely
-      // the first bit is set), going straight to the next clause compares
-      // poorly with doing this check first; count_trailing_zeros can be
-      // relatively expensive, plus there is the additional range check.
-      // But when the first bit isn't set, the cost of having tested for
-      // it is relatively small compared to the rest of the search.
-      return l_index;
-    } else if (cword != 0) {
-      // Flipped and shifted first word is non-zero.
-      idx_t result = l_index + count_trailing_zeros(cword);
-      if (aligned_right || (result < r_index)) return result;
-      // Result is beyond range bound; return r_index.
-    } else {
-      // Flipped and shifted first word is zero.  Word search through
-      // aligned up r_index for a non-zero flipped word.
-      idx_t limit = aligned_right
-        ? to_words_align_down(r_index) // Minuscule savings when aligned.
-        : to_words_align_up(r_index);
-      while (++index < limit) {
-        cword = map(index) ^ flip;
-        if (cword != 0) {
-          idx_t result = bit_index(index) + count_trailing_zeros(cword);
-          if (aligned_right || (result < r_index)) return result;
-          // Result is beyond range bound; return r_index.
-          assert((index + 1) == limit, "invariant");
-          break;
-        }
+  if (l_index >= r_index) {
+    return r_index;
+  }
+
+  // Get the word containing l_index, and shift out low bits.
+  idx_t index = to_words_align_down(l_index);
+  bm_word_t cword = word(index, flip) >> bit_in_word(l_index);
+
+  // Check first bit
+  if ((cword & 1) != 0) {
+    // The first bit is similarly often interesting. When it matters
+    // (density or features of the calling algorithm make it likely
+    // the first bit is set), going straight to the next clause compares
+    // poorly with doing this check first; count_trailing_zeros can be
+    // relatively expensive, plus there is the additional range check.
+    // But when the first bit isn't set, the cost of having tested for
+    // it is relatively small compared to the rest of the search.
+    return l_index;
+  }
+
+  // Check fist word
+  if (cword != 0) {
+    // Flipped and shifted first word is non-zero.
+    idx_t result = l_index + count_trailing_zeros(cword);
+    if (aligned_right || (result < r_index)) {
+      return result;
+    }
+
+    // Result is beyond range bound
+    return r_index;
+  }
+
+  // Flipped and shifted first word is zero.  Word search through
+  // aligned up r_index for a non-zero flipped word.
+  idx_t word_limit = aligned_right
+      ? to_words_aligned(r_index) // Miniscule savings when aligned.
+      : to_words_align_up(r_index);
+
+  // Check the rest
+  while (++index < word_limit) {
+    cword = word(index, flip);
+    if (cword != 0) {
+      idx_t result = bit_index(index) + count_trailing_zeros(cword);
+      if (aligned_right || (result < r_index)) {
+        return result;
       }
-      // No bits in range; return r_index.
+      // Result is beyond range bound; return r_index.
+      assert((index + 1) == word_limit, "invariant");
+      return r_index;
     }
   }
+
+  // No bits in range
   return r_index;
+}
+
+static BitMap::idx_t high_order_bit_index(BitMap::bm_word_t cword) {
+  return ((BitsPerWord - 1) - count_leading_zeros(cword));
+}
+
+template<BitMap::bm_word_t flip, bool aligned_left>
+inline BitMap::idx_t BitMap::get_prev_bit_impl(idx_t l_index, idx_t r_index_exclusive) const {
+  STATIC_ASSERT(flip == find_ones_flip || flip == find_zeros_flip);
+  verify_range(l_index, r_index_exclusive);
+  assert(!aligned_left || is_aligned(l_index, BitsPerWord), "l_index not aligned");
+
+  if (l_index == r_index_exclusive) {
+    // Empty range
+    return idx_t(-1);
+  }
+
+  // The first word often contains an interesting bit, either due to
+  // density or because of features of the calling algorithm.  So it's
+  // important to examine that first word with a minimum of fuss,
+  // minimizing setup time for later words that will be wasted if the
+  // first word is indeed interesting.
+
+  // Get the word containing r_index, and shift out high bits.
+  idx_t r_index = r_index_exclusive - 1;
+  idx_t word_index = to_words_align_down(r_index);
+  idx_t r_index_in_word = bit_in_word(r_index);
+  idx_t r_index_bit = size_t(1) << r_index_in_word;
+
+  bm_word_t cword_unmasked = word(word_index, flip);
+
+  // Check first bit
+  if ((cword_unmasked & r_index_bit) != 0) {
+    // The first bit is similarly often interesting. When it matters
+    // (density or features of the calling algorithm make it likely
+    // the first bit is set), going straight to the next clause compares
+    // poorly with doing this check first; count_leading_zeros can be
+    // relatively expensive, plus there is the additional range check.
+    // But when the first bit isn't set, the cost of having tested for
+    // it is relatively small compared to the rest of the search.
+    return r_index;
+  }
+
+  // Mask out bits not part of the search
+  idx_t cword_mask = r_index_bit + (r_index_bit - 1);
+  idx_t cword = cword_unmasked & cword_mask;
+
+  // Check first word
+  if (cword != 0) {
+    // Flipped and shifted first word is non-zero.
+    idx_t result = bit_index(word_index) + high_order_bit_index(cword);
+    if (aligned_left || (result >= l_index)) {
+      return result;
+    }
+    // Result is beyond range bound
+    return idx_t(-1);
+  }
+
+  // Flipped and shifted first word is zero.  Word search through
+  // aligned down l_index for a non-zero flipped word.
+  idx_t word_limit = to_words_align_down(l_index);
+
+  // Check the rest
+  while (word_index-- > word_limit) {
+    cword = word(word_index, flip);
+    if (cword != 0) {
+      idx_t result = bit_index(word_index) + high_order_bit_index(cword);
+      if (aligned_left || (result >= l_index)) {
+        return result;
+      }
+      // Result is beyond range bound.
+      assert(word_index == word_limit, "invariant");
+      return idx_t(-1);
+    }
+  }
+
+  // No bits in range
+  return idx_t(-1);
 }
 
 inline BitMap::idx_t
@@ -243,21 +337,71 @@ BitMap::get_next_one_offset_aligned_right(idx_t l_offset, idx_t r_offset) const 
   return get_next_bit_impl<find_ones_flip, true>(l_offset, r_offset);
 }
 
-template <typename BitMapClosureType>
-inline bool BitMap::iterate(BitMapClosureType* cl, idx_t beg, idx_t end) {
+inline BitMap::idx_t
+BitMap::get_prev_one_offset(idx_t l_offset, idx_t r_offset) const {
+  return get_prev_bit_impl<find_ones_flip, false>(l_offset, r_offset);
+}
+
+inline BitMap::idx_t
+BitMap::get_prev_zero_offset(idx_t l_offset, idx_t r_offset) const {
+  return get_prev_bit_impl<find_zeros_flip, false>(l_offset, r_offset);
+}
+
+inline BitMap::idx_t
+BitMap::get_prev_one_offset_aligned_left(idx_t l_offset, idx_t r_offset) const {
+  return get_prev_bit_impl<find_ones_flip, true>(l_offset, r_offset);
+}
+
+template <typename Function>
+inline bool BitMap::iterate(Function function, idx_t beg, idx_t end) {
   for (idx_t index = beg; true; ++index) {
     index = get_next_one_offset(index, end);
     if (index >= end) {
+      // Nothing was found
       return true;
-    } else if (!cl->do_bit(index)) {
+    }
+
+    if (!function(index)) {
       return false;
     }
   }
 }
 
 template <typename BitMapClosureType>
-inline bool BitMap::iterate(BitMapClosureType* cl) {
-  return iterate(cl, 0, size());
+inline bool BitMap::iterate(BitMapClosureType* cl, idx_t beg, idx_t end) {
+  auto cl_to_lambda = [&](idx_t index) -> bool {
+    return cl->do_bit(index);
+  };
+
+  return iterate(cl_to_lambda, beg, end);
+}
+
+template <typename Function>
+inline bool BitMap::iterate_reverse(Function function, idx_t beg, idx_t end) {
+  for (idx_t index = end; true;) {
+    index = get_prev_one_offset(beg, index);
+    if (index == BitMap::idx_t(-1)) {
+      // Nothing was found
+      return true;
+    }
+
+    if (!function(index)) {
+      return false;
+    }
+
+    if (index == beg) {
+      return true;
+    }
+  }
+}
+
+template <typename BitMapClosureType>
+inline bool BitMap::iterate_reverse(BitMapClosureType* cl, idx_t beg, idx_t end) {
+  auto cl_to_lambda = [&](idx_t index) -> bool {
+    return cl->do_bit(index);
+  };
+
+  return iterate_reverse(cl_to_lambda, beg, end);
 }
 
 // Returns a bit mask for a range of bits [beg, end) within a single word.  Each
@@ -319,6 +463,55 @@ inline void BitMap2D::at_put_grow(idx_t slot_index, idx_t bit_within_slot_index,
     _map.resize(2 * MAX2(_map.size(), bit));
   }
   _map.at_put(bit, value);
+}
+
+inline BitMapIterator::BitMapIterator(BitMap* bitmap)
+  : BitMapIterator(bitmap, 0, bitmap->size()) {}
+
+inline BitMapIterator::BitMapIterator(BitMap* bitmap, BitMap::idx_t start, BitMap::idx_t end)
+  : _bitmap(bitmap),
+    _pos(start),
+    _end(end) {}
+
+inline bool BitMapIterator::next(BitMap::idx_t* index) {
+  BitMap::idx_t res = _bitmap->get_next_one_offset(_pos, _end);
+  if (res == _end) {
+    return false;
+  }
+
+  _pos = res + 1;
+
+  *index = res;
+  return true;
+}
+
+inline BitMapReverseIterator::BitMapReverseIterator(BitMap* bitmap)
+  : BitMapReverseIterator(bitmap, 0, bitmap->size()) {}
+
+inline BitMapReverseIterator::BitMapReverseIterator(BitMap* bitmap, BitMap::idx_t start, BitMap::idx_t end)
+  : _bitmap(bitmap),
+    _start(start),
+    _pos(end) {}
+
+inline void BitMapReverseIterator::reset(BitMap::idx_t start, BitMap::idx_t end) {
+  _start = start;
+  _pos = end;
+}
+
+inline void BitMapReverseIterator::reset(BitMap::idx_t end) {
+  _pos = end;
+}
+
+inline bool BitMapReverseIterator::next(size_t* index) {
+  BitMap::idx_t res = _bitmap->get_prev_one_offset(_start, _pos);
+  if (res == BitMap::idx_t(-1)) {
+    return false;
+  }
+
+  _pos = res;
+
+  *index = res;
+  return true;
 }
 
 #endif // SHARE_UTILITIES_BITMAP_INLINE_HPP


### PR DESCRIPTION
Generational ZGC uses reverse iteration through BitMaps to find the base pointer of objects. I propose that we upstream that patch, so that it can be reviewed and maintained separately from the Generational ZGC code.
