### PR TITLE
8297791: update _max_classes in node type system

### DIFF
--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -763,7 +763,7 @@ public:
     DEFINE_CLASS_ID(Move,     Node, 17)
     DEFINE_CLASS_ID(LShift,   Node, 18)
 
-    _max_classes  = ClassMask_Move
+    _max_classes  = ClassMask_LShift
   };
   #undef DEFINE_CLASS_ID
 


### PR DESCRIPTION
Updates _max_classes to reflect the newly introduced LShift node from JDK-8259609

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297791](https://bugs.openjdk.org/browse/JDK-8297791): update _max_classes in node type system


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11669/head:pull/11669` \
`$ git checkout pull/11669`

Update a local copy of the PR: \
`$ git checkout pull/11669` \
`$ git pull https://git.openjdk.org/jdk pull/11669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11669`

View PR using the GUI difftool: \
`$ git pr show -t 11669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11669.diff">https://git.openjdk.org/jdk/pull/11669.diff</a>

</details>
