### PR TITLE
8298468: Clean up class_loader parameters

### DIFF
--- a/src/hotspot/share/cds/cdsProtectionDomain.cpp
+++ b/src/hotspot/share/cds/cdsProtectionDomain.cpp
@@ -25,6 +25,7 @@
 #include "precompiled.hpp"
 #include "cds/cdsProtectionDomain.hpp"
 #include "classfile/classLoader.hpp"
+#include "classfile/classLoaderData.inline.hpp"
 #include "classfile/classLoaderExt.hpp"
 #include "classfile/javaClasses.hpp"
 #include "classfile/moduleEntry.hpp"
@@ -125,7 +126,7 @@ PackageEntry* CDSProtectionDomain::get_package_entry_from_class(InstanceKlass* i
   }
   TempNewSymbol pkg_name = ClassLoader::package_from_class_name(ik->name());
   if (pkg_name != NULL) {
-    pkg_entry = SystemDictionaryShared::class_loader_data(class_loader)->packages()->lookup_only(pkg_name);
+    pkg_entry = ClassLoaderData::class_loader_data(class_loader())->packages()->lookup_only(pkg_name);
   } else {
     pkg_entry = NULL;
   }

--- a/src/hotspot/share/classfile/loaderConstraints.hpp
+++ b/src/hotspot/share/classfile/loaderConstraints.hpp
@@ -35,17 +35,18 @@ class Symbol;
 class LoaderConstraintTable : public AllStatic {
 
 private:
-  static LoaderConstraint* find_loader_constraint(Symbol* name, Handle loader);
+  static LoaderConstraint* find_loader_constraint(Symbol* name, ClassLoaderData* loader);
 
-  static void add_loader_constraint(Symbol* name, InstanceKlass* klass, oop class_loader1, oop class_loader2);
+  static void add_loader_constraint(Symbol* name, InstanceKlass* klass,
+                                    ClassLoaderData* loader1, ClassLoaderData* loader2);
 
   static void merge_loader_constraints(Symbol* class_name, LoaderConstraint* pp1,
                                        LoaderConstraint* pp2, InstanceKlass* klass);
 public:
 
   // Check class loader constraints
-  static bool add_entry(Symbol* name, InstanceKlass* klass1, Handle loader1,
-                        InstanceKlass* klass2, Handle loader2);
+  static bool add_entry(Symbol* name, InstanceKlass* klass1, ClassLoaderData* loader1,
+                        InstanceKlass* klass2, ClassLoaderData* loader2);
 
   // Note:  The main entry point for this module is via SystemDictionary.
   // SystemDictionary::check_signature_loaders(Symbol* signature,
@@ -53,10 +54,10 @@ public:
   //                                           Handle loader1, Handle loader2,
   //                                           bool is_method)
 
-  static InstanceKlass* find_constrained_klass(Symbol* name, Handle loader);
+  static InstanceKlass* find_constrained_klass(Symbol* name, ClassLoaderData* loader);
 
   // Class loader constraints
-  static bool check_or_update(InstanceKlass* k, Handle loader, Symbol* name);
+  static bool check_or_update(InstanceKlass* k, ClassLoaderData* loader, Symbol* name);
 
   static void purge_loader_constraints();
 

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -180,6 +180,11 @@ oop SystemDictionary::get_platform_class_loader_impl(TRAPS) {
   return result.get_oop();
 }
 
+// Helper function
+inline ClassLoaderData* class_loader_data(Handle class_loader) {
+  return ClassLoaderData::class_loader_data(class_loader());
+}
+
 ClassLoaderData* SystemDictionary::register_loader(Handle class_loader, bool create_mirror_cld) {
   if (create_mirror_cld) {
     // Add a new class loader data to the graph.
@@ -1064,7 +1069,7 @@ bool SystemDictionary::is_shared_class_visible_impl(Symbol* class_name,
     // Need to reload it now.
     TempNewSymbol pkg_name = ClassLoader::package_from_class_name(class_name);
     if (pkg_name != NULL) {
-      pkg_entry = ClassLoaderData::class_loader_data(class_loader())->packages()->lookup_only(pkg_name);
+      pkg_entry = class_loader_data(class_loader)->packages()->lookup_only(pkg_name);
     }
   }
 
@@ -1180,7 +1185,7 @@ InstanceKlass* SystemDictionary::load_shared_lambda_proxy_class(InstanceKlass* i
   // The lambda proxy class and its nest host have the same class loader and class loader data,
   // as verified in SystemDictionaryShared::add_lambda_proxy_class()
   assert(shared_nest_host->class_loader() == class_loader(), "mismatched class loader");
-  assert(shared_nest_host->class_loader_data() == ClassLoaderData::class_loader_data(class_loader()), "mismatched class loader data");
+  assert(shared_nest_host->class_loader_data() == class_loader_data(class_loader), "mismatched class loader data");
   ik->set_nest_host(shared_nest_host);
 
   return loaded_ik;
@@ -1228,7 +1233,7 @@ InstanceKlass* SystemDictionary::load_shared_class(InstanceKlass* ik,
   // loaders, including the bootstrap loader via the placeholder table,
   // this lock is currently a nop.
 
-  ClassLoaderData* loader_data = ClassLoaderData::class_loader_data(class_loader());
+  ClassLoaderData* loader_data = class_loader_data(class_loader);
   {
     HandleMark hm(THREAD);
     Handle lockObject = get_loader_lock_or_null(class_loader);
@@ -1264,12 +1269,11 @@ InstanceKlass* SystemDictionary::load_instance_class_impl(Symbol* class_name, Ha
     ResourceMark rm(THREAD);
     PackageEntry* pkg_entry = NULL;
     bool search_only_bootloader_append = false;
-    ClassLoaderData *loader_data = class_loader_data(class_loader);
 
     // Find the package in the boot loader's package entry table.
     TempNewSymbol pkg_name = ClassLoader::package_from_class_name(class_name);
     if (pkg_name != NULL) {
-      pkg_entry = loader_data->packages()->lookup_only(pkg_name);
+      pkg_entry = class_loader_data(class_loader)->packages()->lookup_only(pkg_name);
     }
 
     // Prior to attempting to load the class, enforce the boot loader's
@@ -1410,22 +1414,22 @@ InstanceKlass* SystemDictionary::load_instance_class(Symbol* name,
   // If everything was OK (no exceptions, no null return value), and
   // class_loader is NOT the defining loader, do a little more bookkeeping.
   if (loaded_class != NULL &&
-    loaded_class->class_loader() != class_loader()) {
+      loaded_class->class_loader() != class_loader()) {
 
-    check_constraints(loaded_class, class_loader, false, CHECK_NULL);
+    ClassLoaderData* loader_data = class_loader_data(class_loader);
+    check_constraints(loaded_class, loader_data, false, CHECK_NULL);
 
     // Record dependency for non-parent delegation.
     // This recording keeps the defining class loader of the klass (loaded_class) found
     // from being unloaded while the initiating class loader is loaded
     // even if the reference to the defining class loader is dropped
     // before references to the initiating class loader.
-    ClassLoaderData* loader_data = class_loader_data(class_loader);
     loader_data->record_dependency(loaded_class);
 
     { // Grabbing the Compile_lock prevents systemDictionary updates
       // during compilations.
       MutexLocker mu(THREAD, Compile_lock);
-      update_dictionary(THREAD, loaded_class, class_loader);
+      update_dictionary(THREAD, loaded_class, loader_data);
     }
 
     if (JvmtiExport::should_post_class_load()) {
@@ -1469,9 +1473,7 @@ void SystemDictionary::define_instance_class(InstanceKlass* k, Handle class_load
   // classloader lock held
   // Parallel classloaders will call find_or_define_instance_class
   // which will require a token to perform the define class
-  Symbol*  name_h = k->name();
-  Dictionary* dictionary = loader_data->dictionary();
-  check_constraints(k, class_loader, true, CHECK);
+  check_constraints(k, loader_data, true, CHECK);
 
   // Register class just loaded with class loader (placed in ArrayList)
   // Note we do this before updating the dictionary, as this can
@@ -1495,7 +1497,7 @@ void SystemDictionary::define_instance_class(InstanceKlass* k, Handle class_load
 
     // Add to systemDictionary - so other classes can see it.
     // Grabs and releases SystemDictionary_lock
-    update_dictionary(THREAD, k, class_loader);
+    update_dictionary(THREAD, k, loader_data);
   }
 
   // notify jvmti
@@ -1528,7 +1530,7 @@ void SystemDictionary::define_instance_class(InstanceKlass* k, Handle class_load
 InstanceKlass* SystemDictionary::find_or_define_helper(Symbol* class_name, Handle class_loader,
                                                        InstanceKlass* k, TRAPS) {
 
-  Symbol*  name_h = k->name(); // passed in class_name may be null
+  Symbol* name_h = k->name();
   ClassLoaderData* loader_data = class_loader_data(class_loader);
   Dictionary* dictionary = loader_data->dictionary();
 
@@ -1725,7 +1727,7 @@ void SystemDictionary::initialize(TRAPS) {
 // if initiating loader, then ok if InstanceKlass matches existing entry
 
 void SystemDictionary::check_constraints(InstanceKlass* k,
-                                         Handle class_loader,
+                                         ClassLoaderData* loader_data,
                                          bool defining,
                                          TRAPS) {
   ResourceMark rm(THREAD);
@@ -1733,8 +1735,7 @@ void SystemDictionary::check_constraints(InstanceKlass* k,
   bool throwException = false;
 
   {
-    Symbol *name = k->name();
-    ClassLoaderData *loader_data = class_loader_data(class_loader);
+    Symbol* name = k->name();
 
     MutexLocker mu(THREAD, SystemDictionary_lock);
 
@@ -1755,13 +1756,13 @@ void SystemDictionary::check_constraints(InstanceKlass* k,
     }
 
     if (throwException == false) {
-      if (LoaderConstraintTable::check_or_update(k, class_loader, name) == false) {
+      if (LoaderConstraintTable::check_or_update(k, loader_data, name) == false) {
         throwException = true;
         ss.print("loader constraint violation: loader %s", loader_data->loader_name_and_id());
         ss.print(" wants to load %s %s.",
                  k->external_kind(), k->external_name());
-        Klass *existing_klass = LoaderConstraintTable::find_constrained_klass(name, class_loader);
-        if (existing_klass != NULL && existing_klass->class_loader() != class_loader()) {
+        Klass *existing_klass = LoaderConstraintTable::find_constrained_klass(name, loader_data);
+        if (existing_klass != NULL && existing_klass->class_loader_data() != loader_data) {
           ss.print(" A different %s with the same name was previously loaded by %s. (%s)",
                    existing_klass->external_kind(),
                    existing_klass->class_loader_data()->loader_name_and_id(),
@@ -1784,23 +1785,20 @@ void SystemDictionary::check_constraints(InstanceKlass* k,
 // have been called.
 void SystemDictionary::update_dictionary(JavaThread* current,
                                          InstanceKlass* k,
-                                         Handle class_loader) {
+                                         ClassLoaderData* loader_data) {
   // Compile_lock prevents systemDictionary updates during compilations
   assert_locked_or_safepoint(Compile_lock);
-  Symbol*  name  = k->name();
-  ClassLoaderData *loader_data = class_loader_data(class_loader);
+  Symbol* name  = k->name();
 
-  {
-    MutexLocker mu1(SystemDictionary_lock);
+  MutexLocker mu1(SystemDictionary_lock);
 
-    // Make a new dictionary entry.
-    Dictionary* dictionary = loader_data->dictionary();
-    InstanceKlass* sd_check = dictionary->find_class(current, name);
-    if (sd_check == NULL) {
-      dictionary->add_klass(current, name, k);
-    }
-    SystemDictionary_lock->notify_all();
+  // Make a new dictionary entry.
+  Dictionary* dictionary = loader_data->dictionary();
+  InstanceKlass* sd_check = dictionary->find_class(current, name);
+  if (sd_check == NULL) {
+    dictionary->add_klass(current, name, k);
   }
+  SystemDictionary_lock->notify_all();
 }
 
 
@@ -1831,7 +1829,7 @@ Klass* SystemDictionary::find_constrained_instance_or_array_klass(
       klass = Universe::typeArrayKlassObj(t);
     } else {
       MutexLocker mu(current, SystemDictionary_lock);
-      klass = LoaderConstraintTable::find_constrained_klass(ss.as_symbol(), class_loader);
+      klass = LoaderConstraintTable::find_constrained_klass(ss.as_symbol(), class_loader_data(class_loader));
     }
     // If element class already loaded, allocate array klass
     if (klass != NULL) {
@@ -1840,7 +1838,7 @@ Klass* SystemDictionary::find_constrained_instance_or_array_klass(
   } else {
     MutexLocker mu(current, SystemDictionary_lock);
     // Non-array classes are easy: simply check the constraint table.
-    klass = LoaderConstraintTable::find_constrained_klass(class_name, class_loader);
+    klass = LoaderConstraintTable::find_constrained_klass(class_name, class_loader_data(class_loader));
   }
 
   return klass;
@@ -1880,8 +1878,8 @@ bool SystemDictionary::add_loader_constraint(Symbol* class_name,
     MutexLocker mu_s(SystemDictionary_lock);
     InstanceKlass* klass1 = dictionary1->find_class(current, constraint_name);
     InstanceKlass* klass2 = dictionary2->find_class(current, constraint_name);
-    bool result = LoaderConstraintTable::add_entry(constraint_name, klass1, class_loader1,
-                                                   klass2, class_loader2);
+    bool result = LoaderConstraintTable::add_entry(constraint_name, klass1, loader_data1,
+                                                   klass2, loader_data2);
 #if INCLUDE_CDS
     if (Arguments::is_dumping_archive() && klass_being_linked != NULL &&
         !klass_being_linked->is_shared()) {
@@ -2442,10 +2440,6 @@ void SystemDictionary::invoke_bootstrap_method(BootstrapInfo& bootstrap_specifie
           bootstrap_specifier.resolved_method().not_null()), "bootstrap method call failed");
 }
 
-
-ClassLoaderData* SystemDictionary::class_loader_data(Handle class_loader) {
-  return ClassLoaderData::class_loader_data(class_loader());
-}
 
 bool SystemDictionary::is_nonpublic_Object_method(Method* m) {
   assert(m != NULL, "Unexpected NULL Method*");

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -201,10 +201,6 @@ public:
   // Returns java system loader
   static oop java_system_loader();
 
-  // Returns the class loader data to be used when looking up/updating the
-  // system dictionary.
-  //static ClassLoaderData *class_loader_data(Handle class_loader);
-
   // Returns java platform loader
   static oop java_platform_loader();
 

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -203,7 +203,7 @@ public:
 
   // Returns the class loader data to be used when looking up/updating the
   // system dictionary.
-  static ClassLoaderData *class_loader_data(Handle class_loader);
+  //static ClassLoaderData *class_loader_data(Handle class_loader);
 
   // Returns java platform loader
   static oop java_platform_loader();
@@ -381,9 +381,9 @@ protected:
   static Symbol* find_placeholder(Symbol* name, ClassLoaderData* loader_data);
 
   // Class loader constraints
-  static void check_constraints(InstanceKlass* k, Handle loader,
+  static void check_constraints(InstanceKlass* k, ClassLoaderData* loader,
                                 bool defining, TRAPS);
-  static void update_dictionary(JavaThread* current, InstanceKlass* k, Handle loader);
+  static void update_dictionary(JavaThread* current, InstanceKlass* k, ClassLoaderData* loader_data);
 };
 
 #endif // SHARE_CLASSFILE_SYSTEMDICTIONARY_HPP


### PR DESCRIPTION
This patch passes ClassLoaderData* rather than Handle class_loader to the LoaderConstraintTable and to some functions in SystemDictionary that only need ClassLoaderData.  In general, class loading uses ClassLoaderData unless it has to call up to Java in loadClass().  There were a lot of unnecessary conversions back and forth.
Tested with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298468](https://bugs.openjdk.org/browse/JDK-8298468): Clean up class_loader parameters


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11672/head:pull/11672` \
`$ git checkout pull/11672`

Update a local copy of the PR: \
`$ git checkout pull/11672` \
`$ git pull https://git.openjdk.org/jdk pull/11672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11672`

View PR using the GUI difftool: \
`$ git pr show -t 11672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11672.diff">https://git.openjdk.org/jdk/pull/11672.diff</a>

</details>
