### PR TITLE
8298658: Platform-specific type leaks to platform independent code.

### DIFF
--- a/src/java.base/aix/classes/sun/nio/fs/DefaultFileSystemProvider.java
+++ b/src/java.base/aix/classes/sun/nio/fs/DefaultFileSystemProvider.java
@@ -26,6 +26,7 @@
 package sun.nio.fs;
 
 import java.nio.file.FileSystem;
+import java.nio.file.spi.FileSystemProvider;
 
 /**
  * Creates this platform's default FileSystemProvider.
@@ -40,7 +41,7 @@ public class DefaultFileSystemProvider {
     /**
      * Returns the platform's default file system provider.
      */
-    public static AixFileSystemProvider instance() {
+    public static FileSystemProvider instance() {
         return INSTANCE;
     }
 

--- a/src/java.base/linux/classes/sun/nio/fs/DefaultFileSystemProvider.java
+++ b/src/java.base/linux/classes/sun/nio/fs/DefaultFileSystemProvider.java
@@ -26,6 +26,7 @@
 package sun.nio.fs;
 
 import java.nio.file.FileSystem;
+import java.nio.file.spi.FileSystemProvider;
 
 /**
  * Creates this platform's default FileSystemProvider.
@@ -40,7 +41,7 @@ public class DefaultFileSystemProvider {
     /**
      * Returns the platform's default file system provider.
      */
-    public static LinuxFileSystemProvider instance() {
+    public static FileSystemProvider instance() {
         return INSTANCE;
     }
 

--- a/src/java.base/macosx/classes/sun/nio/fs/DefaultFileSystemProvider.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/DefaultFileSystemProvider.java
@@ -26,6 +26,7 @@
 package sun.nio.fs;
 
 import java.nio.file.FileSystem;
+import java.nio.file.spi.FileSystemProvider;
 
 /**
  * Creates this platform's default FileSystemProvider.
@@ -40,7 +41,7 @@ public class DefaultFileSystemProvider {
     /**
      * Returns the platform's default file system provider.
      */
-    public static MacOSXFileSystemProvider instance() {
+    public static FileSystemProvider instance() {
         return INSTANCE;
     }
 

--- a/src/java.base/windows/classes/sun/nio/fs/DefaultFileSystemProvider.java
+++ b/src/java.base/windows/classes/sun/nio/fs/DefaultFileSystemProvider.java
@@ -26,6 +26,7 @@
 package sun.nio.fs;
 
 import java.nio.file.FileSystem;
+import java.nio.file.spi.FileSystemProvider;
 
 /**
  * Creates this platform's default FileSystemProvider.
@@ -39,7 +40,7 @@ public class DefaultFileSystemProvider {
     /**
      * Returns the platform's default file system provider.
      */
-    public static WindowsFileSystemProvider instance() {
+    public static FileSystemProvider instance() {
         return INSTANCE;
     }
 


### PR DESCRIPTION
This is not a cosmetic change, it enforces the isolation of platform-specific code from the user-facing API.

`sun.nio.fs.DefaultFileSystemProvider#instance()` has a platform-specific return type. This makes the platform-independent `java.nio.file.FileSystems.DefaultFileSystemHolder#getDefaultProvider()` have a platform-dependent call e.g. INVOKESTATIC with different signatures.

The platform-specific return types were introduced in [JDK-8213406](https://bugs.openjdk.org/browse/JDK-8213406), the common SPI type was used before. There's no reason to leak types to platform-independent code, except for tests, which could just cast.

This change is motivated by [Espresso](https://github.com/oracle/graal/tree/master/espresso), a meta-circular, spec-compliant JVM written in Java. Espresso aims to provide a custom Java IO/NIO implementation on top of any vanilla JDK as a viable alternative to the imminent removal of `SecurityManager`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8298658](https://bugs.openjdk.org/browse/JDK-8298658)

### Issue
 * [JDK-8298658](https://bugs.openjdk.org/browse/JDK-8298658): (fs) Platform-specific type leaks to platform independent code ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/11674/head:pull/11674` \
`$ git checkout pull/11674`

Update a local copy of the PR: \
`$ git checkout pull/11674` \
`$ git pull https://git.openjdk.org/jdk.git pull/11674/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11674`

View PR using the GUI difftool: \
`$ git pr show -t 11674`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11674.diff">https://git.openjdk.org/jdk/pull/11674.diff</a>

</details>
