### PR TITLE
8297572: Remove unused PrecisionStyle::Precise

### DIFF
--- a/src/hotspot/share/gc/shared/cardTable.hpp
+++ b/src/hotspot/share/gc/shared/cardTable.hpp
@@ -113,17 +113,6 @@ public:
   virtual ~CardTable();
   virtual void initialize();
 
-  // The kinds of precision a CardTable may offer.
-  enum PrecisionStyle {
-    Precise,
-    ObjHeadPreciseArray
-  };
-
-  // Tells what style of precision this card table offers.
-  PrecisionStyle precision() {
-    return ObjHeadPreciseArray; // Only one supported for now.
-  }
-
   // *** Barrier set functions.
 
   // Initialization utilities; covered_words is the size of the covered region

--- a/src/hotspot/share/gc/shared/cardTableRS.cpp
+++ b/src/hotspot/share/gc/shared/cardTableRS.cpp
@@ -451,7 +451,7 @@ void CardTableRS::non_clean_card_iterate(ContiguousSpace* sp,
   }
   // clear_cl finds contiguous dirty ranges of cards to process and clear.
 
-  DirtyCardToOopClosure* dcto_cl = sp->new_dcto_cl(cl, precision(), gen_boundary);
+  DirtyCardToOopClosure* dcto_cl = sp->new_dcto_cl(cl, gen_boundary);
   ClearNoncleanCardWrapper clear_cl(dcto_cl, ct);
 
   clear_cl.do_MemRegion(mr);

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -51,20 +51,18 @@ HeapWord* DirtyCardToOopClosure::get_actual_top(HeapWord* top,
                                                 HeapWord* top_obj) {
   if (top_obj != NULL) {
     if (_sp->block_is_obj(top_obj)) {
-      if (_precision == CardTable::ObjHeadPreciseArray) {
-        if (cast_to_oop(top_obj)->is_objArray() || cast_to_oop(top_obj)->is_typeArray()) {
-          // An arrayOop is starting on the dirty card - since we do exact
-          // store checks for objArrays we are done.
-        } else {
-          // Otherwise, it is possible that the object starting on the dirty
-          // card spans the entire card, and that the store happened on a
-          // later card.  Figure out where the object ends.
-          // Use the block_size() method of the space over which
-          // the iteration is being done.  That space (e.g. CMS) may have
-          // specific requirements on object sizes which will
-          // be reflected in the block_size() method.
-          top = top_obj + cast_to_oop(top_obj)->size();
-        }
+      if (cast_to_oop(top_obj)->is_objArray() || cast_to_oop(top_obj)->is_typeArray()) {
+        // An arrayOop is starting on the dirty card - since we do exact
+        // store checks for objArrays we are done.
+      } else {
+        // Otherwise, it is possible that the object starting on the dirty
+        // card spans the entire card, and that the store happened on a
+        // later card.  Figure out where the object ends.
+        // Use the block_size() method of the space over which
+        // the iteration is being done.  That space (e.g. CMS) may have
+        // specific requirements on object sizes which will
+        // be reflected in the block_size() method.
+        top = top_obj + cast_to_oop(top_obj)->size();
       }
     } else {
       top = top_obj;
@@ -115,12 +113,7 @@ void DirtyCardToOopClosure::do_MemRegion(MemRegion mr) {
   HeapWord* bottom_obj;
   HeapWord* top_obj;
 
-  assert(_precision == CardTable::ObjHeadPreciseArray ||
-         _precision == CardTable::Precise,
-         "Only ones we deal with for now.");
-
-  assert(_precision != CardTable::ObjHeadPreciseArray ||
-         _last_bottom == NULL || top <= _last_bottom,
+  assert(_last_bottom == NULL || top <= _last_bottom,
          "Not decreasing");
   NOT_PRODUCT(_last_bottom = mr.start());
 
@@ -136,9 +129,7 @@ void DirtyCardToOopClosure::do_MemRegion(MemRegion mr) {
   top = get_actual_top(top, top_obj);
 
   // If the previous call did some part of this region, don't redo.
-  if (_precision == CardTable::ObjHeadPreciseArray &&
-      _min_done != NULL &&
-      _min_done < top) {
+  if (_min_done != NULL && _min_done < top) {
     top = _min_done;
   }
 
@@ -148,9 +139,7 @@ void DirtyCardToOopClosure::do_MemRegion(MemRegion mr) {
   bottom = MIN2(bottom, top);
   MemRegion extended_mr = MemRegion(bottom, top);
   assert(bottom <= top &&
-         (_precision != CardTable::ObjHeadPreciseArray ||
-          _min_done == NULL ||
-          top <= _min_done),
+         (_min_done == NULL || top <= _min_done),
          "overlap!");
 
   // Walk the region if it is not empty; otherwise there is nothing to do.
@@ -164,18 +153,16 @@ void DirtyCardToOopClosure::do_MemRegion(MemRegion mr) {
 HeapWord* ContiguousSpaceDCTOC::get_actual_top(HeapWord* top,
                                                HeapWord* top_obj) {
   if (top_obj != NULL && top_obj < (_sp->toContiguousSpace())->top()) {
-    if (_precision == CardTable::ObjHeadPreciseArray) {
-      if (cast_to_oop(top_obj)->is_objArray() || cast_to_oop(top_obj)->is_typeArray()) {
-        // An arrayOop is starting on the dirty card - since we do exact
-        // store checks for objArrays we are done.
-      } else {
-        // Otherwise, it is possible that the object starting on the dirty
-        // card spans the entire card, and that the store happened on a
-        // later card.  Figure out where the object ends.
-        assert(_sp->block_size(top_obj) == cast_to_oop(top_obj)->size(),
-          "Block size and object size mismatch");
-        top = top_obj + cast_to_oop(top_obj)->size();
-      }
+    if (cast_to_oop(top_obj)->is_objArray() || cast_to_oop(top_obj)->is_typeArray()) {
+      // An arrayOop is starting on the dirty card - since we do exact
+      // store checks for objArrays we are done.
+    } else {
+      // Otherwise, it is possible that the object starting on the dirty
+      // card spans the entire card, and that the store happened on a
+      // later card.  Figure out where the object ends.
+      assert(_sp->block_size(top_obj) == cast_to_oop(top_obj)->size(),
+        "Block size and object size mismatch");
+      top = top_obj + cast_to_oop(top_obj)->size();
     }
   } else {
     top = (_sp->toContiguousSpace())->top();
@@ -235,9 +222,8 @@ ContiguousSpaceDCTOC__walk_mem_region_with_cl_DEFN(FilteringClosure)
 
 DirtyCardToOopClosure*
 ContiguousSpace::new_dcto_cl(OopIterateClosure* cl,
-                             CardTable::PrecisionStyle precision,
                              HeapWord* boundary) {
-  return new ContiguousSpaceDCTOC(this, cl, precision, boundary);
+  return new ContiguousSpaceDCTOC(this, cl, boundary);
 }
 
 void Space::initialize(MemRegion mr,

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -240,11 +240,10 @@ class DirtyCardToOopClosure: public MemRegionClosureRO {
 protected:
   OopIterateClosure* _cl;
   Space* _sp;
-  CardTable::PrecisionStyle _precision;
   HeapWord* _boundary;          // If non-NULL, process only non-NULL oops
                                 // pointing below boundary.
-  HeapWord* _min_done;          // ObjHeadPreciseArray precision requires
-                                // a downwards traversal; this is the
+  HeapWord* _min_done;          // Need a downwards traversal to compensate
+                                // imprecise write barrier; this is the
                                 // lowest location already done (or,
                                 // alternatively, the lowest address that
                                 // shouldn't be done again.  NULL means infinity.)
@@ -268,9 +267,8 @@ protected:
 
 public:
   DirtyCardToOopClosure(Space* sp, OopIterateClosure* cl,
-                        CardTable::PrecisionStyle precision,
                         HeapWord* boundary) :
-    _cl(cl), _sp(sp), _precision(precision), _boundary(boundary),
+    _cl(cl), _sp(sp), _boundary(boundary),
     _min_done(NULL) {
     NOT_PRODUCT(_last_bottom = NULL);
   }
@@ -467,7 +465,6 @@ class ContiguousSpace: public CompactibleSpace {
   }
 
   DirtyCardToOopClosure* new_dcto_cl(OopIterateClosure* cl,
-                                     CardTable::PrecisionStyle precision,
                                      HeapWord* boundary);
 
   // Apply "blk->do_oop" to the addresses of all reference fields in objects
@@ -544,9 +541,8 @@ class ContiguousSpaceDCTOC : public DirtyCardToOopClosure {
 
 public:
   ContiguousSpaceDCTOC(ContiguousSpace* sp, OopIterateClosure* cl,
-                       CardTable::PrecisionStyle precision,
                        HeapWord* boundary) :
-    DirtyCardToOopClosure(sp, cl, precision, boundary)
+    DirtyCardToOopClosure(sp, cl, boundary)
   {}
 };
 

--- a/src/hotspot/share/gc/shared/vmStructs_gc.hpp
+++ b/src/hotspot/share/gc/shared/vmStructs_gc.hpp
@@ -235,8 +235,6 @@
                                                                             \
   declare_constant(CardTable::clean_card)                                   \
   declare_constant(CardTable::dirty_card)                                   \
-  declare_constant(CardTable::Precise)                                      \
-  declare_constant(CardTable::ObjHeadPreciseArray)                          \
                                                                             \
   declare_constant(CollectedHeap::Serial)                                   \
   declare_constant(CollectedHeap::Parallel)                                 \


### PR DESCRIPTION
Simple change of removing some effectively dead code.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297572](https://bugs.openjdk.org/browse/JDK-8297572): Remove unused PrecisionStyle::Precise


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11676/head:pull/11676` \
`$ git checkout pull/11676`

Update a local copy of the PR: \
`$ git checkout pull/11676` \
`$ git pull https://git.openjdk.org/jdk pull/11676/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11676`

View PR using the GUI difftool: \
`$ git pr show -t 11676`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11676.diff">https://git.openjdk.org/jdk/pull/11676.diff</a>

</details>
