### PR TITLE
8296374: Check for young region in G1BarrierSet::invalidate instead of card-by-card check

### DIFF
--- a/src/hotspot/share/gc/g1/g1BarrierSet.cpp
+++ b/src/hotspot/share/gc/g1/g1BarrierSet.cpp
@@ -110,7 +110,11 @@ void G1BarrierSet::invalidate(MemRegion mr) {
 
   // skip young gen cards
   if (*byte == G1CardTable::g1_young_card_val()) {
-    assert(mr.word_size() <= HeapRegion::GrainWords, "Invalidated MemRegion is larger than HeapRegion in young gen");
+    // MemRegion should not span multiple regions for the young gen.
+    DEBUG_ONLY(HeapRegion* containing_hr = G1CollectedHeap::heap()->heap_region_containing(mr.start());)
+    assert(containing_hr->is_young(), "it should be young");
+    assert(containing_hr->is_in(mr.start()), "it should contain start");
+    assert(containing_hr->is_in(mr.last()), "it should also contain last");
     return;
   }
 


### PR DESCRIPTION
Hi,

Please review this change to young region card checks in G1BarrierSet::invalidate(). A single check should suffice because the MemRegion for invalidation in G1 is either completely in the young gen or not. 

Testing: Tier 1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296374](https://bugs.openjdk.org/browse/JDK-8296374): Check for young region in G1BarrierSet::invalidate instead of card-by-card check


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [58bf53a8](https://git.openjdk.org/jdk/pull/11677/files/58bf53a893d6f3a228e33d34100a0b98459a5b07)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11677/head:pull/11677` \
`$ git checkout pull/11677`

Update a local copy of the PR: \
`$ git checkout pull/11677` \
`$ git pull https://git.openjdk.org/jdk pull/11677/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11677`

View PR using the GUI difftool: \
`$ git pr show -t 11677`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11677.diff">https://git.openjdk.org/jdk/pull/11677.diff</a>

</details>
