### PR TITLE
8298794: Remove JVM_ACC_PROMOTED_FLAGS breaks minimal build

### DIFF
--- a/src/hotspot/share/oops/instanceKlassMiscStatus.cpp
+++ b/src/hotspot/share/oops/instanceKlassMiscStatus.cpp
@@ -58,6 +58,7 @@ void InstanceKlassMiscStatus::assign_class_loader_type(const ClassLoaderData* cl
     set_shared_class_loader_type(ClassLoader::APP_LOADER);
   }
 }
+#endif // INCLUDE_CDS
 
 #ifdef ASSERT
 void InstanceKlassMiscStatus::assert_is_safe(bool set) {
@@ -66,5 +67,3 @@ void InstanceKlassMiscStatus::assert_is_safe(bool set) {
   assert(!set || SafepointSynchronize::is_at_safepoint(), "set once or at safepoint");
 }
 #endif // ASSERT
-
-#endif // INCLUDE_CDS


### PR DESCRIPTION
Please review this trivial fix to fix the minimal build.  Testing is in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298794](https://bugs.openjdk.org/browse/JDK-8298794): Remove JVM_ACC_PROMOTED_FLAGS breaks minimal build


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11680/head:pull/11680` \
`$ git checkout pull/11680`

Update a local copy of the PR: \
`$ git checkout pull/11680` \
`$ git pull https://git.openjdk.org/jdk pull/11680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11680`

View PR using the GUI difftool: \
`$ git pr show -t 11680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11680.diff">https://git.openjdk.org/jdk/pull/11680.diff</a>

</details>
