### PR TITLE
8298241: Replace C-style casts with JavaThread::cast

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -734,12 +734,12 @@ extern "C" void pf(uintptr_t sp, uintptr_t fp, uintptr_t pc,
                    uintptr_t bcx, uintptr_t thread) {
   if (!reg_map) {
     reg_map = NEW_C_HEAP_OBJ(RegisterMap, mtInternal);
-    ::new (reg_map) RegisterMap((JavaThread*)thread,
+    ::new (reg_map) RegisterMap(reinterpret_cast<JavaThread*>(thread),
                                 RegisterMap::UpdateMap::skip,
                                 RegisterMap::ProcessFrames::include,
                                 RegisterMap::WalkContinuation::skip);
   } else {
-    *reg_map = RegisterMap((JavaThread*)thread,
+    *reg_map = RegisterMap(reinterpret_cast<JavaThread*>(thread),
                            RegisterMap::UpdateMap::skip,
                            RegisterMap::ProcessFrames::include,
                            RegisterMap::WalkContinuation::skip);

--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -639,7 +639,7 @@ int JVM_HANDLE_XXX_SIGNAL(int sig, siginfo_t* info,
 
   // Call platform dependent signal handler.
   if (!signal_was_handled) {
-    JavaThread* const jt = (t != NULL && t->is_Java_thread()) ? (JavaThread*) t : NULL;
+    JavaThread* const jt = (t != NULL && t->is_Java_thread()) ? JavaThread::cast(t) : NULL;
     signal_was_handled = PosixSignals::pd_hotspot_signal_handler(sig, info, uc, jt);
   }
 

--- a/src/hotspot/os_cpu/bsd_aarch64/javaThread_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/javaThread_bsd_aarch64.cpp
@@ -50,13 +50,10 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
 }
 
 bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava) {
-  assert(this->is_Java_thread(), "must be JavaThread");
-  JavaThread* jt = (JavaThread *)this;
-
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
-  if (jt->has_last_Java_frame() && jt->frame_anchor()->walkable()) {
-    *fr_addr = jt->pd_last_frame();
+  if (has_last_Java_frame() && frame_anchor()->walkable()) {
+    *fr_addr = pd_last_frame();
     return true;
   }
 
@@ -75,11 +72,11 @@ bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava)
     }
 
     frame ret_frame(ret_sp, ret_fp, addr);
-    if (!ret_frame.safe_for_sender(jt)) {
+    if (!ret_frame.safe_for_sender(this)) {
 #if COMPILER2_OR_JVMCI
       // C2 and JVMCI use ebp as a general register see if NULL fp helps
       frame ret_frame2(ret_sp, NULL, addr);
-      if (!ret_frame2.safe_for_sender(jt)) {
+      if (!ret_frame2.safe_for_sender(this)) {
         // nothing else to try if the frame isn't good
         return false;
       }
@@ -98,4 +95,3 @@ bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava)
 }
 
 void JavaThread::cache_global_variables() { }
-

--- a/src/hotspot/os_cpu/windows_aarch64/javaThread_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/javaThread_windows_aarch64.cpp
@@ -49,15 +49,10 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
 }
 
 bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava) {
-
-  assert(this->is_Java_thread(), "must be JavaThread");
-
-  JavaThread* jt = (JavaThread *)this;
-
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than CONTEXT info.
-  if (jt->has_last_Java_frame() && jt->frame_anchor()->walkable()) {
-    *fr_addr = jt->pd_last_frame();
+  if (has_last_Java_frame() && frame_anchor()->walkable()) {
+    *fr_addr = pd_last_frame();
     return true;
   }
 
@@ -71,11 +66,11 @@ bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava)
       return false;
     }
 
-    if (!ret_frame.safe_for_sender(jt)) {
+    if (!ret_frame.safe_for_sender(this)) {
 #if COMPILER2_OR_JVMCI
       // C2 and JVMCI use ebp as a general register see if NULL fp helps
       frame ret_frame2(ret_frame.sp(), NULL, ret_frame.pc());
-      if (!ret_frame2.safe_for_sender(jt)) {
+      if (!ret_frame2.safe_for_sender(this)) {
         // nothing else to try if the frame isn't good
         return false;
       }
@@ -88,7 +83,6 @@ bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava)
     *fr_addr = ret_frame;
     return true;
   }
-
   // nothing else to try
   return false;
 }

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -1714,7 +1714,7 @@ void java_lang_Thread::serialize_offsets(SerializeClosure* f) {
 #endif
 
 JavaThread* java_lang_Thread::thread(oop java_thread) {
-  return (JavaThread*)java_thread->address_field(_eetop_offset);
+  return reinterpret_cast<JavaThread*>(java_thread->address_field(_eetop_offset));
 }
 
 void java_lang_Thread::set_thread(oop java_thread, JavaThread* thread) {

--- a/src/hotspot/share/jvmci/jvmci.cpp
+++ b/src/hotspot/share/jvmci/jvmci.cpp
@@ -108,7 +108,7 @@ void JVMCI::initialize_compiler(TRAPS) {
   }
   JVMCIRuntime* runtime;
   if (UseJVMCINativeLibrary) {
-      runtime = JVMCI::compiler_runtime((JavaThread*) THREAD);
+      runtime = JVMCI::compiler_runtime(THREAD);
   } else {
       runtime = JVMCI::java_runtime();
   }

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -986,7 +986,7 @@ static void _flush_log() {
 static void _fatal() {
   Thread* thread = Thread::current_or_null_safe();
   if (thread != nullptr && thread->is_Java_thread()) {
-    JavaThread* jthread = (JavaThread*) thread;
+    JavaThread* jthread = JavaThread::cast(thread);
     JVMCIRuntime* runtime = jthread->libjvmci_runtime();
     if (runtime != nullptr) {
       int javaVM_id = runtime->get_shared_library_javavm_id();

--- a/src/hotspot/share/oops/instanceStackChunkKlass.cpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.cpp
@@ -168,7 +168,7 @@ class DescribeStackChunkClosure {
 public:
   DescribeStackChunkClosure(stackChunkOop chunk)
     : _chunk(chunk),
-      _map((JavaThread*)nullptr,
+      _map(nullptr,
            RegisterMap::UpdateMap::include,
            RegisterMap::ProcessFrames::skip,
            RegisterMap::WalkContinuation::include),

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -192,7 +192,7 @@ inline void stackChunkOopDesc::iterate_stack(StackChunkFrameClosureType* closure
   bool should_continue = true;
 
   if (f.is_stub()) {
-    RegisterMap full_map((JavaThread*)nullptr,
+    RegisterMap full_map(nullptr,
                          RegisterMap::UpdateMap::include,
                          RegisterMap::ProcessFrames::skip,
                          RegisterMap::WalkContinuation::include);

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -583,7 +583,7 @@ JvmtiEnv::SetEventNotificationMode(jvmtiEventMode mode, jvmtiEvent event_type, j
     // ThreadsListHandle that is common to both thread-specific and
     // global code paths.
 
-    JvmtiEventController::set_user_enabled(this, (JavaThread*) NULL, (oop) NULL, event_type, enabled);
+    JvmtiEventController::set_user_enabled(this, NULL, (oop) NULL, event_type, enabled);
   } else {
     // We have a specified event_thread.
     ThreadsListHandle tlh;

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -2333,7 +2333,7 @@ VirtualThreadGetOwnedMonitorInfoClosure::do_thread(Thread *target) {
   javaVFrame *jvf = JvmtiEnvBase::get_vthread_jvf(_vthread_h());
 
   if (!java_thread->is_exiting() && java_thread->threadObj() != NULL) {
-    _result = ((JvmtiEnvBase *)_env)->get_owned_monitors((JavaThread*)target,
+    _result = ((JvmtiEnvBase *)_env)->get_owned_monitors(java_thread,
                                                          java_thread,
                                                          jvf,
                                                          _owned_monitors_list);

--- a/src/hotspot/share/prims/jvmtiImpl.cpp
+++ b/src/hotspot/share/prims/jvmtiImpl.cpp
@@ -745,7 +745,7 @@ bool VM_BaseGetOrSetLocal::allow_nested_vm_operations() const {
 
 // Constructor for non-object getter
 VM_GetOrSetLocal::VM_GetOrSetLocal(JavaThread* thread, jint depth, jint index, BasicType type, bool self)
-  : VM_BaseGetOrSetLocal((JavaThread*)NULL, depth, index, type, _DEFAULT_VALUE, false, self),
+  : VM_BaseGetOrSetLocal(NULL, depth, index, type, _DEFAULT_VALUE, false, self),
     _thread(thread),
     _eb(false, NULL, NULL)
 {
@@ -753,7 +753,7 @@ VM_GetOrSetLocal::VM_GetOrSetLocal(JavaThread* thread, jint depth, jint index, B
 
 // Constructor for object or non-object setter
 VM_GetOrSetLocal::VM_GetOrSetLocal(JavaThread* thread, jint depth, jint index, BasicType type, jvalue value, bool self)
-  : VM_BaseGetOrSetLocal((JavaThread*)NULL, depth, index, type, value, true, self),
+  : VM_BaseGetOrSetLocal(NULL, depth, index, type, value, true, self),
     _thread(thread),
     _eb(type == T_OBJECT, JavaThread::current(), thread)
 {
@@ -816,7 +816,7 @@ VM_GetReceiver::VM_GetReceiver(
 // Constructor for non-object getter
 VM_VirtualThreadGetOrSetLocal::VM_VirtualThreadGetOrSetLocal(JvmtiEnv* env, Handle vthread_h, jint depth,
                                                              jint index, BasicType type, bool self)
-  : VM_BaseGetOrSetLocal((JavaThread*)NULL, depth, index, type, _DEFAULT_VALUE, false, self)
+  : VM_BaseGetOrSetLocal(NULL, depth, index, type, _DEFAULT_VALUE, false, self)
 {
   _env = env;
   _vthread_h = vthread_h;
@@ -825,7 +825,7 @@ VM_VirtualThreadGetOrSetLocal::VM_VirtualThreadGetOrSetLocal(JvmtiEnv* env, Hand
 // Constructor for object or non-object setter
 VM_VirtualThreadGetOrSetLocal::VM_VirtualThreadGetOrSetLocal(JvmtiEnv* env, Handle vthread_h, jint depth,
                                                              jint index, BasicType type, jvalue value, bool self)
-  : VM_BaseGetOrSetLocal((JavaThread*)NULL, depth, index, type, value, true, self)
+  : VM_BaseGetOrSetLocal(NULL, depth, index, type, value, true, self)
 {
   _env = env;
   _vthread_h = vthread_h;

--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -80,7 +80,7 @@ public:
 
   void do_thread(Thread* thread) {
 
-    JavaThread* jt = (JavaThread*)thread;
+    JavaThread* jt = JavaThread::cast(thread);
 
     if (!jt->has_last_Java_frame()) {
       return;

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -426,9 +426,8 @@ static JNINativeMethod CONT_methods[] = {
 };
 
 void CONT_RegisterNativeMethods(JNIEnv *env, jclass cls) {
-    Thread* thread = Thread::current();
-    assert(thread->is_Java_thread(), "");
-    ThreadToNativeFromVM trans((JavaThread*)thread);
+    JavaThread* thread = JavaThread::current();
+    ThreadToNativeFromVM trans(thread);
     int status = env->RegisterNatives(cls, CONT_methods, sizeof(CONT_methods)/sizeof(JNINativeMethod));
     guarantee(status == JNI_OK, "register jdk.internal.vm.Continuation natives");
     guarantee(!env->ExceptionOccurred(), "register jdk.internal.vm.Continuation natives");

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -2563,7 +2563,7 @@ static void print_frame_layout(const frame& f, bool callee_complete, outputStrea
   FrameValues values;
   assert(f.get_cb() != nullptr, "");
   RegisterMap map(f.is_heap_frame() ?
-                    (JavaThread*)nullptr :
+                    nullptr :
                     JavaThread::current(),
                   RegisterMap::UpdateMap::include,
                   RegisterMap::ProcessFrames::skip,
@@ -2574,7 +2574,7 @@ static void print_frame_layout(const frame& f, bool callee_complete, outputStrea
     frame::update_map_with_saved_link(&map, ContinuationHelper::Frame::callee_link_address(f));
   }
   const_cast<frame&>(f).describe(values, 0, &map);
-  values.print_on((JavaThread*)nullptr, st);
+  values.print_on(static_cast<JavaThread*>(nullptr), st);
 }
 #endif
 

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -1565,7 +1565,7 @@ void FrameValues::validate() {
       prev = fv;
     }
   }
-  // if (error) { tty->cr(); print_on((JavaThread*)nullptr, tty); }
+  // if (error) { tty->cr(); print_on(nullptr, tty); }
   assert(!error, "invalid layout");
 }
 #endif // ASSERT

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -1565,7 +1565,7 @@ void FrameValues::validate() {
       prev = fv;
     }
   }
-  // if (error) { tty->cr(); print_on(nullptr, tty); }
+  // if (error) { tty->cr(); print_on(static_cast<JavaThread*>(nullptr), tty); }
   assert(!error, "invalid layout");
 }
 #endif // ASSERT

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -822,7 +822,7 @@ private:
   // We don't assert it is Thread::current here as that is done at the
   // external JNI entry points where the JNIEnv is passed into the VM.
   static JavaThread* thread_from_jni_environment(JNIEnv* env) {
-    JavaThread* current = (JavaThread*)((intptr_t)env - in_bytes(jni_environment_offset()));
+    JavaThread* current = reinterpret_cast<JavaThread*>(((intptr_t)env - in_bytes(jni_environment_offset())));
     // We can't normally get here in a thread that has completed its
     // execution and so "is_terminated", except when the call is from
     // AsyncGetCallTrace, which can be triggered by a signal at any point in

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -1879,7 +1879,7 @@ int ObjectMonitor::TrySpin(JavaThread* current) {
   ctr = _SpinDuration;
   if (ctr <= 0) return 0;
 
-  if (NotRunnable(current, (JavaThread*) owner_raw())) {
+  if (NotRunnable(current, static_cast<JavaThread*>(owner_raw()))) {
     return 0;
   }
 
@@ -1928,9 +1928,9 @@ int ObjectMonitor::TrySpin(JavaThread* current) {
     // the spin without prejudice or apply a "penalty" to the
     // spin count-down variable "ctr", reducing it by 100, say.
 
-    JavaThread* ox = (JavaThread*) owner_raw();
+    JavaThread* ox = static_cast<JavaThread*>(owner_raw());
     if (ox == NULL) {
-      ox = (JavaThread*)try_set_owner_from(NULL, current);
+      ox = static_cast<JavaThread*>(try_set_owner_from(NULL, current));
       if (ox == NULL) {
         // The CAS succeeded -- this thread acquired ownership
         // Take care of some bookkeeping to exit spin state.

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -372,7 +372,7 @@ bool ObjectSynchronizer::quick_enter(oop obj, JavaThread* current,
     if (m->object_peek() == NULL) {
       return false;
     }
-    JavaThread* const owner = (JavaThread*) m->owner_raw();
+    JavaThread* const owner = static_cast<JavaThread*>(m->owner_raw());
 
     // Lock contention and Transactional Lock Elision (TLE) diagnostics
     // and observability


### PR DESCRIPTION
This is a simple cleanup RFE to get rid of old-style C casts in relation to JavaThread.

In many cases involving NULL/nullptr the cast could just be dropped. Sometimes a static cast is needed to disambiguate overloads.

A couple of reinterpret_cast are needed when doing int/ptr conversion.

static_cast is used for void* conversion.

The other changes should be self explanatory.

The changes in

src/hotspot/os_cpu/bsd_aarch64/javaThread_bsd_aarch64.cpp
src/hotspot/os_cpu/windows_aarch64/javaThread_windows_aarch64.cpp

are a bit more extensive. That code was using an alias for `this` which is completely unnecessary (and the alias creation was using the cast). This could be factored out if thought necessary.

I grep'd as best I could for the old C-style casts but can't be certain I got them all.

Testing: 
 - all builds in our tiers1-5
 - local linux x64 product, slowdebug and fastdebug
 - GHA
 - Sanity testing tiers 1-3
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298241](https://bugs.openjdk.org/browse/JDK-8298241): Replace C-style casts with JavaThread::cast


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [5641507a](https://git.openjdk.org/jdk/pull/11682/files/5641507aca51dcf10496b3c5fcb9e01daac09609)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to [5641507a](https://git.openjdk.org/jdk/pull/11682/files/5641507aca51dcf10496b3c5fcb9e01daac09609)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [5641507a](https://git.openjdk.org/jdk/pull/11682/files/5641507aca51dcf10496b3c5fcb9e01daac09609)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11682/head:pull/11682` \
`$ git checkout pull/11682`

Update a local copy of the PR: \
`$ git checkout pull/11682` \
`$ git pull https://git.openjdk.org/jdk pull/11682/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11682`

View PR using the GUI difftool: \
`$ git pr show -t 11682`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11682.diff">https://git.openjdk.org/jdk/pull/11682.diff</a>

</details>
