### PR TITLE
8298808: Check `script` code on detecting the base locales

### DIFF
--- a/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
@@ -633,7 +633,7 @@ public class CLDRConverter {
     /**
      * Examine if the id includes the country (territory) code. If it does, it returns
      * the country code.
-     * Otherwise, it returns null. eg. when the id is "zh_Hans_SG", it return "SG".
+     * Otherwise, it returns null. eg. when the id is "zh_Hans_SG", it returns "SG".
      * It does NOT return UN M.49 code, e.g., '001', as those three digit numbers cannot
      * be translated into package names.
      */
@@ -645,11 +645,19 @@ public class CLDRConverter {
     /**
      * Examine if the id includes the region code. If it does, it returns
      * the region code.
-     * Otherwise, it returns null. eg. when the id is "zh_Hans_SG", it return "SG".
+     * Otherwise, it returns null. eg. when the id is "zh_Hans_SG", it returns "SG".
      * It DOES return UN M.49 code, e.g., '001', as well as ISO 3166 two letter country codes.
      */
     static String getRegionCode(String id) {
         return Locale.forLanguageTag(id.replaceAll("_", "-")).getCountry();
+    }
+
+    /**
+     * Examine if the id includes the script code. If it does, it returns
+     * the script code.
+     */
+    static String getScriptCode(String id) {
+        return Locale.forLanguageTag(id.replaceAll("_", "-")).getScript();
     }
 
     private static class KeyComparator implements Comparator<String> {

--- a/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
@@ -1028,6 +1028,7 @@ public class CLDRConverter {
     private static void setupBaseLocales(String localeList) {
         Arrays.stream(localeList.split(","))
             .map(Locale::forLanguageTag)
+            .map(l -> new Locale.Builder().setLocale(l).setScript("Latn").build())
             .map(l -> Control.getControl(Control.FORMAT_DEFAULT)
                              .getCandidateLocales("", l))
             .forEach(BASE_LOCALES::addAll);

--- a/make/jdk/src/classes/build/tools/cldrconverter/ResourceBundleGenerator.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/ResourceBundleGenerator.java
@@ -417,11 +417,11 @@ class ResourceBundleGenerator implements BundleGenerator {
     private static final Locale.Builder LOCALE_BUILDER = new Locale.Builder();
     private static boolean isBaseLocale(String localeID) {
         localeID = localeID.replaceAll("-", "_");
-        // ignore script here
         Locale locale = LOCALE_BUILDER
                             .clear()
                             .setLanguage(CLDRConverter.getLanguageCode(localeID))
                             .setRegion(CLDRConverter.getRegionCode(localeID))
+                            .setScript(CLDRConverter.getScriptCode(localeID))
                             .build();
         return CLDRConverter.BASE_LOCALES.contains(locale);
     }


### PR DESCRIPTION
Fixing `CLDRConverter` build tool to not regard [new locales](https://github.com/unicode-org/cldr/pull/2508/files#diff-94cbefde02914335da884f768063a06a84ad651ee4e56cdb1cb90625d7776731) introduced in CLDR 43 as one of the base locales. Otherwise they would incorrectly go into `java.base` module, then a test case fails.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298808](https://bugs.openjdk.org/browse/JDK-8298808): Check `script` code on detecting the base locales


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11684/head:pull/11684` \
`$ git checkout pull/11684`

Update a local copy of the PR: \
`$ git checkout pull/11684` \
`$ git pull https://git.openjdk.org/jdk pull/11684/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11684`

View PR using the GUI difftool: \
`$ git pr show -t 11684`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11684.diff">https://git.openjdk.org/jdk/pull/11684.diff</a>

</details>
