### PR TITLE
JDK-8298813: [C2] Converting double to float cause a loss of precision and resulting crypto.aes scores fluctuate

### DIFF
--- a/src/hotspot/share/opto/chaitin.hpp
+++ b/src/hotspot/share/opto/chaitin.hpp
@@ -478,7 +478,7 @@ class PhaseChaitin : public PhaseRegAlloc {
 
   Block **_blks;                // Array of blocks sorted by frequency for coalescing
 
-  double _high_frequency_lrg;    // Frequency at which LRG will be spilled for debug info
+  double _high_frequency_lrg;   // Frequency at which LRG will be spilled for debug info
 
 #ifndef PRODUCT
   bool _trace_spilling;

--- a/src/hotspot/share/opto/chaitin.hpp
+++ b/src/hotspot/share/opto/chaitin.hpp
@@ -478,7 +478,7 @@ class PhaseChaitin : public PhaseRegAlloc {
 
   Block **_blks;                // Array of blocks sorted by frequency for coalescing
 
-  float _high_frequency_lrg;    // Frequency at which LRG will be spilled for debug info
+  double _high_frequency_lrg;    // Frequency at which LRG will be spilled for debug info
 
 #ifndef PRODUCT
   bool _trace_spilling;
@@ -495,7 +495,7 @@ public:
   // Do all the real work of allocate
   void Register_Allocate();
 
-  float high_frequency_lrg() const { return _high_frequency_lrg; }
+  double high_frequency_lrg() const { return _high_frequency_lrg; }
 
   // Used when scheduling info generated, not in general register allocation
   bool _scheduling_info_generated;


### PR DESCRIPTION
Hi all,
For C2, convert double to float cause a loss of precision,

<pre><code class="cpp">
./chaitin.cpp:221
_high_frequency_lrg = MIN2(double(OPTO_LRG_HIGH_FREQ), _cfg.get_outer_loop_frequency());
</code></pre>

Here, _high_frequency_lrg type is float, so maybe has a loss of precision. when it be used:

<pre><code class="cpp">
./coalesce.cpp:379
if( lrg._maxfreq >= _phc.high_frequency_lrg() ) {
   ...
}
</code></pre>
Here, lrg._maxfreq type is double, so _high_frequency_lrg will be convert double again. But now, due to the loss of precision of _high_frequency_lrg, the conditions here may be true or false.

There are two cases that I tested for SPECjvm2008 crypto.aes.
case 1:
<pre><code class="shell">
//chaitin.cpp:221
// fcvt.s.d $f0,$f0 #double->float
d = 16.994714324523816
f = 16.9947147

//coalesce.cpp:379
// fcvt.d.s $f0,$f0 #float->double
// fcmp.sle.d $fcc2,$f0,$f1
(gdb) i r fa0
fa0 {f = 0x0, d = 0x10} {f = -1.08420217e-19, d = 16.994714736938477}
(gdb) i r fa1
fa1 {f = 0x0, d = 0x10} {f = -7.68722312e-24, d = 16.994714324523816}
</code></pre>

case2:
<pre><code class="shell">
//chaitin.cpp:221
// fcvt.s.d $f0,$f0
d = 16.996332681816536
f = 16.9963322

//coalesce.cpp
// fcvt.d.s $f0,$f0
// fcmp.sle.d $fcc2,$f0,$f1
(gdb) i r fa0
fa0 {f = 0x0, d = 0x10} {f = -1.08420217e-19, d = 16.996332168579102}
(gdb) i r fa1
fa1 {f = 0x0, d = 0x10} {f = -1.73570044e-14, d = 16.996332681816536}
</code></pre>

The above two cases result in different block generation（case2 can insert new SpillCopyNodes), and resulting score on cryto.aes is fluctuate.

This is a patch to fix this problem. Please help review it.

Thanks,
Sun Guoyun

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298813](https://bugs.openjdk.org/browse/JDK-8298813): [C2] Converting double to float  cause a loss of precision and resulting crypto.aes scores fluctuate


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [f017e49c](https://git.openjdk.org/jdk/pull/11685/files/f017e49c74f6f2018e51aadae59b88829d469850)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11685/head:pull/11685` \
`$ git checkout pull/11685`

Update a local copy of the PR: \
`$ git checkout pull/11685` \
`$ git pull https://git.openjdk.org/jdk pull/11685/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11685`

View PR using the GUI difftool: \
`$ git pr show -t 11685`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11685.diff">https://git.openjdk.org/jdk/pull/11685.diff</a>

</details>
