### PR TITLE
JDK-8298852: Use of uninitialized memory in MetadataFactory::free_metadata

### DIFF
--- a/src/hotspot/share/memory/metadataFactory.hpp
+++ b/src/hotspot/share/memory/metadataFactory.hpp
@@ -70,6 +70,7 @@ class MetadataFactory : AllStatic {
       assert(!md->on_stack(), "can't deallocate things on stack");
       assert(!md->is_shared(), "cannot deallocate if in shared spaces");
       md->deallocate_contents(loader_data);
+      bool is_klass = md->is_klass();
       // Call the destructor. This is currently used for MethodData which has a member
       // that needs to be destructed to release resources. Most Metadata derived classes have noop
       // destructors and/or cleanup using deallocate_contents.
@@ -77,7 +78,7 @@ class MetadataFactory : AllStatic {
       // or volatile so we can call the destructor of the type T points to.
       using U = std::remove_cv_t<T>;
       md->~U();
-      loader_data->metaspace_non_null()->deallocate((MetaWord*)md, size, md->is_klass());
+      loader_data->metaspace_non_null()->deallocate((MetaWord*)md, size, is_klass);
     }
   }
 };


### PR DESCRIPTION
Fix undefined behavior by shifting call to member function to before destructor is called. Upon the destructor being called, the contents of the object are considered uninitialized and reading them is undefined.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298852](https://bugs.openjdk.org/browse/JDK-8298852): Use of uninitialized memory in MetadataFactory::free_metadata


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11688/head:pull/11688` \
`$ git checkout pull/11688`

Update a local copy of the PR: \
`$ git checkout pull/11688` \
`$ git pull https://git.openjdk.org/jdk pull/11688/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11688`

View PR using the GUI difftool: \
`$ git pr show -t 11688`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11688.diff">https://git.openjdk.org/jdk/pull/11688.diff</a>

</details>
