### PR TITLE
8298859: ProblemList java/awt/Mouse/EnterExitEvents/DragWindowTest.java on macosx-all

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -668,7 +668,7 @@ java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64
 java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 macosx-aarch64
 javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8274106 macosx-aarch64
 
-java/awt/Mouse/EnterExitEvents/DragWindowTest.java 8297296 macosx-all
+java/awt/Mouse/EnterExitEvents/DragWindowTest.java 8298823 macosx-all
 javax/swing/JFileChooser/8046391/bug8046391.java 8293862 windows-x64
 javax/swing/JFileChooser/4847375/bug4847375.java 8293862 windows-x64
 java/awt/Focus/NonFocusableWindowTest/NonfocusableOwnerTest.java 8280392 windows-x64

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -668,6 +668,7 @@ java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64
 java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 macosx-aarch64
 javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8274106 macosx-aarch64
 
+java/awt/Mouse/EnterExitEvents/DragWindowTest.java 8297296 macosx-all
 javax/swing/JFileChooser/8046391/bug8046391.java 8293862 windows-x64
 javax/swing/JFileChooser/4847375/bug4847375.java 8293862 windows-x64
 java/awt/Focus/NonFocusableWindowTest/NonfocusableOwnerTest.java 8280392 windows-x64


### PR DESCRIPTION
java/awt/Mouse/EnterExitEvents/DragWindowTest.java fails again in the CI

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298859](https://bugs.openjdk.org/browse/JDK-8298859): ProblemList java/awt/Mouse/EnterExitEvents/DragWindowTest.java on macosx-all


### Reviewers
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**) ⚠️ Review applies to [9e9828b3](https://git.openjdk.org/jdk/pull/11691/files/9e9828b31b3c2ca7e12af7bc1c8aea95eaaf8a84)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11691/head:pull/11691` \
`$ git checkout pull/11691`

Update a local copy of the PR: \
`$ git checkout pull/11691` \
`$ git pull https://git.openjdk.org/jdk pull/11691/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11691`

View PR using the GUI difftool: \
`$ git pr show -t 11691`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11691.diff">https://git.openjdk.org/jdk/pull/11691.diff</a>

</details>
