### PR TITLE
8287699: jdk/jfr/api/consumer/TestRecordingFileWrite.java fails with exception: java.lang.Exception: Found event that should not be there. 

### DIFF
--- a/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
@@ -208,6 +208,9 @@ void JfrThreadLocal::on_exit(Thread* t) {
   assert(t != NULL, "invariant");
   JfrThreadLocal * const tl = t->jfr_thread_local();
   assert(!tl->is_dead(), "invariant");
+  if (JfrRecorder::is_recording()) {
+    JfrCheckpointManager::write_checkpoint(t);
+  }
   if (t->is_Java_thread()) {
     JavaThread* const jt = JavaThread::cast(t);
     send_java_thread_end_event(jt, JfrThreadLocal::jvm_thread_id(jt));

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -755,7 +755,6 @@ jdk/jfr/startupargs/TestStartName.java                          8214685 windows-
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all
 jdk/jfr/api/consumer/recordingstream/TestOnEvent.java           8255404 linux-x64
-jdk/jfr/api/consumer/TestRecordingFileWrite.java                8287699 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Greetings,

the problem here addressed will close a gap in the constant pool data for threads, which up to now has been written on thread start only, but not on thread end. This leads to a race where a thread can write an event in a new chunk and terminate before the JFR recorder thread has had a chance to iterate it. By also writing constant pool data for threads on thread end, we close this gap.

Testing: jdk_jfr, stress testing

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287699](https://bugs.openjdk.org/browse/JDK-8287699): jdk/jfr/api/consumer/TestRecordingFileWrite.java fails with exception: java.lang.Exception: Found event that should not be there.


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11692/head:pull/11692` \
`$ git checkout pull/11692`

Update a local copy of the PR: \
`$ git checkout pull/11692` \
`$ git pull https://git.openjdk.org/jdk pull/11692/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11692`

View PR using the GUI difftool: \
`$ git pr show -t 11692`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11692.diff">https://git.openjdk.org/jdk/pull/11692.diff</a>

</details>
