### PR TITLE
8297801: printnm crashes with invalid address due to null pointer dereference

### DIFF
--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -449,7 +449,7 @@ extern "C" JNIEXPORT void printnm(intptr_t p) {
   os::snprintf_checked(buffer, sizeof(buffer), "printnm: " INTPTR_FORMAT, p);
   Command c(buffer);
   CodeBlob* cb = CodeCache::find_blob((address) p);
-  if (cb->is_nmethod()) {
+  if (cb != NULL && cb->is_nmethod()) {
     nmethod* nm = (nmethod*)cb;
     nm->print_nmethod(true);
   }

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -452,6 +452,8 @@ extern "C" JNIEXPORT void printnm(intptr_t p) {
   if (cb != NULL && cb->is_nmethod()) {
     nmethod* nm = (nmethod*)cb;
     nm->print_nmethod(true);
+  } else {
+    tty->print_cr("Invalid address");
   }
 }
 


### PR DESCRIPTION
`printnm` crashes if you pass an invalid address. This is caused by a null pointer dereference.
Checking for NULL reference before checking if blob is a method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297801](https://bugs.openjdk.org/browse/JDK-8297801): printnm crashes with invalid address due to null pointer dereference


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11697/head:pull/11697` \
`$ git checkout pull/11697`

Update a local copy of the PR: \
`$ git checkout pull/11697` \
`$ git pull https://git.openjdk.org/jdk pull/11697/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11697`

View PR using the GUI difftool: \
`$ git pr show -t 11697`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11697.diff">https://git.openjdk.org/jdk/pull/11697.diff</a>

</details>
