### PR TITLE
8298824: C2 crash: assert(is_Bool()) failed: invalid node class: ConI

### DIFF
--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -1467,7 +1467,8 @@ Node *BoolNode::Ideal(PhaseGVN *phase, bool can_reshape) {
       (_test._test == BoolTest::eq || _test._test == BoolTest::ne) &&
       cmp1_op == Op_CMoveI && cmp2->find_int_con(1) == 0) {
     // 0 should be on the true branch
-    if (cmp1->in(CMoveNode::IfTrue)->find_int_con(1) == 0 &&
+    if (cmp1->in(CMoveNode::Condition)->is_Bool() &&
+        cmp1->in(CMoveNode::IfTrue)->find_int_con(1) == 0 &&
         cmp1->in(CMoveNode::IfFalse)->find_int_con(0) != 0) {
       BoolNode* target = cmp1->in(CMoveNode::Condition)->as_Bool();
       return new BoolNode(target->in(1),

--- a/test/hotspot/jtreg/compiler/c2/TestCMoveIConAsBool.java
+++ b/test/hotspot/jtreg/compiler/c2/TestCMoveIConAsBool.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8298824
+ * @summary Test BoolNode::Ideal() transformation with CMoveINode that has a Con node as condition.
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.c2.TestCMoveIConAsBool::test
+ *                   compiler.c2.TestCMoveIConAsBool
+ */
+
+package compiler.c2;
+
+public class TestCMoveIConAsBool {
+    static int x;
+
+    public static void main(String[] strArr) {
+        test();
+    }
+
+    static void test() {
+        int i = 7;
+        boolean b = false;
+        float f = 7.135f;
+
+        do {
+            b = i > f | b || x != 7;
+        }
+        while (++i < 0);
+    }
+}


### PR DESCRIPTION
[JDK-8292889](https://bugs.openjdk.org/browse/JDK-8292289) added the following optimization to `BoolNode::Ideal()` for patterns that include `CMoveI` nodes:

https://github.com/openjdk/jdk/blob/fa322e40b68abf0a253040d14414d41f4e01e028/src/hotspot/share/opto/subnode.cpp#L1465-L1472

However, we could have a `CMoveI` during IGVN that will later be folded because the `Bool` condition node was replaced by a constant but IGVN has not processed this node, yet:

 
![Screenshot from 2022-12-16 09-40-28](https://user-images.githubusercontent.com/17833009/208068197-4819b322-604c-412e-8898-3d3546a8a663.png)

We fail when trying to call `as_Bool()` on `28 ConI`. The fix is straight forward to additionally check if we actually have a `BoolNode`.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298824](https://bugs.openjdk.org/browse/JDK-8298824): C2 crash: assert(is_Bool()) failed: invalid node class: ConI


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11705/head:pull/11705` \
`$ git checkout pull/11705`

Update a local copy of the PR: \
`$ git checkout pull/11705` \
`$ git pull https://git.openjdk.org/jdk pull/11705/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11705`

View PR using the GUI difftool: \
`$ git pr show -t 11705`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11705.diff">https://git.openjdk.org/jdk/pull/11705.diff</a>

</details>
