### PR TITLE
8296412: Special case infinite loops with unmerged backedges in IdealLoopTree::check_safepts

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -3631,7 +3631,8 @@ void IdealLoopTree::check_safepts(VectorSet &visited, Node_List &stack) {
             }
             // Skip to head of inner loop
             assert(_phase->is_dominator(_head, nlpt->_head), "inner head dominated by outer head");
-            if (_head == nlpt->_head) {
+            n = nlpt->_head;
+            if (_head == n) {
               // this and nlpt (inner loop) have the same loop head. This should not happen because
               // during beautify_loops we call merge_many_backedges. However, infinite loops may not
               // have been attached to the loop-tree during build_loop_tree before beautify_loops,
@@ -3642,7 +3643,6 @@ void IdealLoopTree::check_safepts(VectorSet &visited, Node_List &stack) {
                      "only expect unmerged backedges in infinite loops");
               break;
             }
-            n = nlpt->_head;
           }
         }
       }

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -3631,6 +3631,17 @@ void IdealLoopTree::check_safepts(VectorSet &visited, Node_List &stack) {
             }
             // Skip to head of inner loop
             assert(_phase->is_dominator(_head, nlpt->_head), "inner head dominated by outer head");
+            if (_head == nlpt->_head) {
+              // this and nlpt (inner loop) have the same loop head. This should not happen because
+              // during beautify_loops we call merge_many_backedges. However, infinite loops may not
+              // have been attached to the loop-tree during build_loop_tree before beautify_loops,
+              // but then attached in the build_loop_tree afterwards, and so still have unmerged
+              // backedges. Check if we are indeed in an infinite subgraph, and terminate the scan,
+              // since we have reached the loop head of this.
+              assert(_head->as_Region()->is_in_infinite_subgraph(),
+                     "only expect unmerged backedges in infinite loops");
+              break;
+            }
             n = nlpt->_head;
           }
         }

--- a/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopWithUnmergedBackedges.jasm
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopWithUnmergedBackedges.jasm
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+super public class TestInfiniteLoopWithUnmergedBackedges
+{
+    public Method "<init>":"()V"
+    stack 2 locals 1
+    {
+        aload_0;
+        invokespecial  Method java/lang/Object."<init>":"()V";
+        return;
+    }
+    static Method test_001:"(IIIII)V"
+    stack 5 locals 10
+    {
+        iload_0;
+        ifgt LOOP;
+        // below is dominated by the one above
+        iload_0;
+        ifle BACK;
+        goto HEAD;
+    HEAD:
+        iload_3;
+        ifeq BACK;
+    BACK:
+        goto HEAD;
+    LOOP:
+        iload_1;
+        iflt LOOP;
+        iload_2;
+        iflt LOOP;
+        return;
+    }
+    static Method test_002:"(IIIII)V"
+    stack 5 locals 30
+    {
+        iload_0;
+        ifgt LOOP;
+
+        iconst_0;
+        istore 9;
+
+        goto HEAD;
+    TAIL:
+        iload_3;
+        iload 9;
+        if_icmpeq HEAD;
+        iinc 9, 1;
+    HEAD:
+        goto TAIL;
+    LOOP:
+        iload_1;
+        iflt LOOP;
+        iload_2;
+        iflt LOOP;
+        return;
+    }
+    static Method test_003:"(IIIII)I"
+    stack 5 locals 30
+    {
+        iload_0;
+        ifgt SKIP;
+
+        iconst_0;
+        istore 9;
+
+        goto HEAD;
+    TAIL:
+        iload_3;
+        iload 9;
+        if_icmpeq HEAD;
+        iinc 9, 1;
+        // Two paths lead to HEAD, so we have an inner and outer loop
+        // But no SafePoint is placed here, because we go forward in bci
+    HEAD:
+        // SafePoint is placed here, because we go from here back in bci
+        goto TAIL;
+
+    SKIP:
+        iconst_0;
+        istore 8;
+        iconst_0;
+        istore 9;
+        // loop with two backedges, which calls
+        // merge_many_backedges and then recomputes
+        // build_loop_tree
+    LOOP:
+        iinc 9, 1;
+        iinc 8, -1;
+        iload 9;
+        ldc 7;
+        irem;
+        ifeq LOOP;
+        iload 9;
+        ldc 10001;
+        if_icmple LOOP;
+        iload 8;
+        ireturn;
+    }
+    static Method test_004:"(IIIII)I"
+    stack 5 locals 30
+    {
+        iload_0;
+        ifgt SKIP;
+
+        iconst_0;
+        istore 9;
+
+        goto HEAD;
+    TAIL:
+        iload_3;
+        iload 9;
+        if_icmpeq HEAD;
+        iinc 9, 1;
+        iload 9;
+        ldc 10001;
+        if_icmpeq HEAD; // a second one
+        iinc 9, 1;
+    HEAD:
+        goto TAIL;
+
+    SKIP:
+        iconst_0;
+        istore 8;
+        iconst_0;
+        istore 9;
+    LOOP:
+        iinc 9, 1;
+        iinc 8, -1;
+        iload 9;
+        ldc 7;
+        irem;
+        ifeq LOOP;
+        iload 9;
+        ldc 10001;
+        if_icmple LOOP;
+        iload 8;
+        ireturn;
+    }
+    static Method test_005:"(IIIII)I"
+    stack 5 locals 30
+    {
+        iload_0;
+        ifgt SKIP;
+
+        iconst_0;
+        istore 9;
+
+        goto HEAD;
+    TAIL:
+        iload_3;
+        iload 9;
+        if_icmpeq HEAD;
+        iinc 9, 1;
+        iload 9;
+        ldc 10001;
+        if_icmpeq HEAD; // a second one
+        iinc 9, 1;
+    HEAD:
+        goto TAIL;
+
+    SKIP:
+        iconst_0;
+        istore 8;
+        iconst_0;
+        istore 9;
+    LOOP:
+        iinc 9, 1;
+        iinc 8, -1;
+        iload 9;
+        ldc 7;
+        irem;
+        ifeq LOOP;
+        iload 9;
+        ldc 10001;
+        if_icmple LOOP;
+        iload 8;
+        ireturn;
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopWithUnmergedBackedgesMain.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopWithUnmergedBackedgesMain.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8296412
+ * @compile TestInfiniteLoopWithUnmergedBackedges.jasm
+ * @summary Infinite loops may not have the backedges merged, before we call IdealLoopTree::check_safepts
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:-LoopUnswitching
+ *      -XX:CompileCommand=compileonly,TestInfiniteLoopWithUnmergedBackedges::test*
+ *      TestInfiniteLoopWithUnmergedBackedgesMain
+ */
+
+public class TestInfiniteLoopWithUnmergedBackedgesMain {
+    public static void main (String[] args) {
+        TestInfiniteLoopWithUnmergedBackedges.test_001(1, 0, 0, 0, 0);
+        TestInfiniteLoopWithUnmergedBackedges.test_002(1, 0, 0, 0, 0);
+        TestInfiniteLoopWithUnmergedBackedges.test_003(1, 0, 0, 0, 0);
+        TestInfiniteLoopWithUnmergedBackedges.test_004(1, 0, 0, 0, 0);
+    }
+}
+
+

--- a/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopWithUnmergedBackedgesMain.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopWithUnmergedBackedgesMain.java
@@ -39,5 +39,3 @@ public class TestInfiniteLoopWithUnmergedBackedgesMain {
         TestInfiniteLoopWithUnmergedBackedges.test_004(1, 0, 0, 0, 0);
     }
 }
-
-


### PR DESCRIPTION
**Context**
During parsing, we insert SafePoints if we jump from higher to lower bci (`maybe_add_safepoint` is called for every if, goto etc).
https://github.com/openjdk/jdk/blob/8c472e481676ed0ef475c4989477d5714880c59e/src/hotspot/share/opto/parse.hpp#L490-L494
Generally, this alligns with backedges: the assumption is that the loop-head sits at the smallest bci of all blocks in the loop. So every jump back to the loop-head goes from higher to lower bci, hence we place a SafePoint just before the jump.

Also: the first `build_loop_tree` may not attach an infinite loop to the loop-tree. If during the same loop-opts-phase we go to `beautify_loops` and it requires us rebuilding the loop-tree (eg because some other loop did `merge_many_backedges`), we call `build_loop_tree` again, and this time around we do detect the infinite loop (it now has a NeverBranch exit, so it is attached because of that).
Afterwards, we call `IdealLoopTree::check_safepts`, which tries to find SafePoints on all backedges. Normally, we have SafePoints on all backedges, just before we go back to the head.

**Problem case**
My jasm fuzzer produced some infinite loops that have the following form:
The loop head is not at the smallest bci (bytecode index) of all blocks in the loop. So the SafePoints are placed somewhere in the body of the loop, just before an if branches into the two backedges. Because this is an infinite loop, it is only attached to the loop-tree in `build_loop_tree` after `beautify_loops`, so the two backedges were not merged.
When we call `IdealLoopTree::check_safepts`, we start with the inner loop, where we find the SafePoint above the if. Then we go to the outer loop. We don't find a SafePoint before we find the inner body. Now we decide to skip the inner body (which implies skipping the SafePoint in the body). The code assumes after skipping the inner loop, we are still in the outer loop. This is not true, because inner and outer loop have the same loop head (the backedges were not merged). We trigger an assert that checks that we are still in the outer loop (`nested loop`).

Why did we not find this earlier?
We have not extensively tested infinite loops before. Also, we have not tested loops with loop-heads that are not at the smallest bci of the loop. However, with my bytecode fuzzer I can find these issues. It is also more likely with irreducible loops: there at least one loop-entry cannot be at the smallest bci. Irreducible loops are not processed by `maybe_add_safepoint`, but once it only has a singe entry, it is not irreducible any more, and so it can happen that a loop-entry becomes loop head that does not have the smallest bci.

**Solution**
We could fix `maybe_add_safepoint` to not depend on bci, but rather the loop-tree from `ciTypeFlow`. That would be complex, and risky. That is not justified just for infinite loops, and even infinite loops where the loop head is not at the lowest bci.

I decided to simply special case infinite loops. I detect if we have an outer loop with the same head as an inner loop. This should not happen, as we must have merged those backedges. Except if it is an infinite loop: We can break the scan, as we have already reached the loop's head.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296412](https://bugs.openjdk.org/browse/JDK-8296412): Special case infinite loops with unmerged backedges in IdealLoopTree::check_safepts


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [2a02b338](https://git.openjdk.org/jdk/pull/11706/files/2a02b3380c208812397b2fdadb2efdde7a0e94d6)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [2a02b338](https://git.openjdk.org/jdk/pull/11706/files/2a02b3380c208812397b2fdadb2efdde7a0e94d6)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [2a02b338](https://git.openjdk.org/jdk/pull/11706/files/2a02b3380c208812397b2fdadb2efdde7a0e94d6)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11706/head:pull/11706` \
`$ git checkout pull/11706`

Update a local copy of the PR: \
`$ git checkout pull/11706` \
`$ git pull https://git.openjdk.org/jdk pull/11706/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11706`

View PR using the GUI difftool: \
`$ git pr show -t 11706`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11706.diff">https://git.openjdk.org/jdk/pull/11706.diff</a>

</details>
