### PR TITLE
8265688: Unused ciMethodType::ptype_at should be removed

### DIFF
--- a/src/hotspot/share/ci/ciMethodType.cpp
+++ b/src/hotspot/share/ci/ciMethodType.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,11 +51,4 @@ int ciMethodType::ptype_count() const {
 
 int ciMethodType::ptype_slot_count() const {
   GUARDED_VM_ENTRY(return java_lang_invoke_MethodType::ptype_slot_count(get_oop());)
-}
-
-ciType* ciMethodType::ptype_at(int index) const {
-  GUARDED_VM_ENTRY(
-    oop ptype = java_lang_invoke_MethodType::ptype(get_oop(), index);
-    return class_to_citype(ptype);
-  )
 }

--- a/src/hotspot/share/ci/ciMethodType.hpp
+++ b/src/hotspot/share/ci/ciMethodType.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,9 +43,7 @@ public:
   ciType* rtype() const;
 
   int ptype_count() const;
-  int ptype_slot_count() const ;
-
-  ciType* ptype_at(int index) const;
+  int ptype_slot_count() const;
 };
 
 #endif // SHARE_CI_CIMETHODTYPE_HPP


### PR DESCRIPTION
`ciMethodType::ptype_at` method is not used.

Removing it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8265688](https://bugs.openjdk.org/browse/JDK-8265688): Unused ciMethodType::ptype_at should be removed


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11708/head:pull/11708` \
`$ git checkout pull/11708`

Update a local copy of the PR: \
`$ git checkout pull/11708` \
`$ git pull https://git.openjdk.org/jdk pull/11708/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11708`

View PR using the GUI difftool: \
`$ git pr show -t 11708`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11708.diff">https://git.openjdk.org/jdk/pull/11708.diff</a>

</details>
