### PR TITLE
8298875: A module requiring "java.base" with flags ACC_SYNTHETIC should be rejected

### DIFF
--- a/src/java.base/share/classes/jdk/internal/module/ModuleInfo.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleInfo.java
@@ -401,6 +401,10 @@ public final class ModuleInfo {
             }
 
             if (dn.equals("java.base")) {
+                if (mods.contains(Requires.Modifier.SYNTHETIC)) {
+                    throw invalidModuleDescriptor("The requires entry for java.base"
+                                                  + " has ACC_SYNTHETIC set");
+                }
                 if (major >= 54
                     && (mods.contains(Requires.Modifier.TRANSITIVE)
                         || mods.contains(Requires.Modifier.STATIC))) {

--- a/test/jdk/java/lang/module/ModuleDescriptorTest.java
+++ b/test/jdk/java/lang/module/ModuleDescriptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @bug 8142968 8158456 8298875
  * @modules java.base/jdk.internal.access
  *          java.base/jdk.internal.module
  * @run testng ModuleDescriptorTest
@@ -63,6 +64,7 @@ import static org.testng.Assert.*;
 
 @Test
 public class ModuleDescriptorTest {
+    private static final JavaLangModuleAccess JLMA = SharedSecrets.getJavaLangModuleAccess();
 
     @DataProvider(name = "invalidNames")
     public Object[][] invalidNames() {
@@ -1084,7 +1086,6 @@ public class ModuleDescriptorTest {
     }
 
     private ModuleDescriptor newModule(String name, String vs) {
-        JavaLangModuleAccess JLMA = SharedSecrets.getJavaLangModuleAccess();
         Builder builder = JLMA.newModuleBuilder(name, false, Set.of());
         if (vs != null)
             builder.version(vs);
@@ -1094,7 +1095,6 @@ public class ModuleDescriptorTest {
     }
 
     private Requires newRequires(String name, String vs) {
-        JavaLangModuleAccess JLMA = SharedSecrets.getJavaLangModuleAccess();
         Builder builder = JLMA.newModuleBuilder("foo", false, Set.of());
         if (vs == null) {
             builder.requires(name);
@@ -1361,7 +1361,6 @@ public class ModuleDescriptorTest {
      * Test ModuleDescriptor with a packager finder that doesn't return the
      * complete set of packages.
      */
-    @Test(expectedExceptions = InvalidModuleDescriptorException.class)
     public void testReadsWithBadPackageFinder() throws Exception {
         ModuleDescriptor descriptor = ModuleDescriptor.newModule("foo")
                 .requires("java.base")
@@ -1373,7 +1372,8 @@ public class ModuleDescriptorTest {
         ByteBuffer bb = ByteBuffer.wrap(baos.toByteArray());
 
         // package finder returns a set that doesn't include p
-        ModuleDescriptor.read(bb, () -> Set.of("q"));
+        assertThrows(InvalidModuleDescriptorException.class,
+                     () -> ModuleDescriptor.read(bb, () -> Set.of("q")));
     }
 
     @Test(expectedExceptions = InvalidModuleDescriptorException.class)
@@ -1392,63 +1392,76 @@ public class ModuleDescriptorTest {
         ModuleDescriptor.read(bb);
     }
 
-    // The requires table for java.base must be 0 length
-    @Test(expectedExceptions = InvalidModuleDescriptorException.class)
+    /**
+     * Test ModuleDescriptor.read reading a module-info for java.base that has a non-0
+     * length requires table.
+     */
     public void testReadOfJavaBaseWithRequires() {
-        ModuleDescriptor descriptor
-            = ModuleDescriptor.newModule("java.base")
+        ModuleDescriptor descriptor = ModuleDescriptor.newModule("java.base")
                 .requires("other")
                 .build();
         ByteBuffer bb = ModuleInfoWriter.toByteBuffer(descriptor);
-        ModuleDescriptor.read(bb);
+        assertThrows(InvalidModuleDescriptorException.class,
+                     () -> ModuleDescriptor.read(bb));
     }
 
-    // The requires table must have an entry for java.base
-    @Test(expectedExceptions = InvalidModuleDescriptorException.class)
+    /**
+     * Test ModuleDescriptor.read reading a module-info with a zero length requires table
+     * (no entry for java.base).
+     */
     public void testReadWithEmptyRequires() {
-        ModuleDescriptor descriptor = SharedSecrets.getJavaLangModuleAccess()
-                .newModuleBuilder("m1", false, Set.of()).build();
+        // use non-strict builder to create module that does not require java.base
+        ModuleDescriptor descriptor = JLMA.newModuleBuilder("m", false, Set.of()).build();
         ByteBuffer bb = ModuleInfoWriter.toByteBuffer(descriptor);
-        ModuleDescriptor.read(bb);
+        assertThrows(InvalidModuleDescriptorException.class,
+                     () -> ModuleDescriptor.read(bb));
     }
 
-    // The requires table must have an entry for java.base
-    @Test(expectedExceptions = InvalidModuleDescriptorException.class)
+    /**
+     * Test ModuleDescriptor.read reading a module-info with a non-zero length requires
+     * table that does not have entry for java.base.
+     */
     public void testReadWithNoRequiresBase() {
-        ModuleDescriptor descriptor = SharedSecrets.getJavaLangModuleAccess()
-                .newModuleBuilder("m1", false, Set.of()).requires("m2").build();
+        // use non-strict builder to create module that does not require java.base
+        ModuleDescriptor descriptor = JLMA.newModuleBuilder("m1", false, Set.of())
+                .requires("m2")
+                .build();
         ByteBuffer bb = ModuleInfoWriter.toByteBuffer(descriptor);
-        ModuleDescriptor.read(bb);
+        assertThrows(InvalidModuleDescriptorException.class,
+                     () -> ModuleDescriptor.read(bb));
     }
 
+    /**
+     * Test ModuleDescriptor.read reading a module-info with a requires entry for
+     * java.base with the ACC_SYNTHETIC flag set.
+     */
+    public void testReadWithSynethticRequiresBase() {
+        ModuleDescriptor descriptor = ModuleDescriptor.newModule("m")
+                .requires(Set.of(SYNTHETIC), "java.base")
+                .build();
+        ByteBuffer bb = ModuleInfoWriter.toByteBuffer(descriptor);
+        assertThrows(InvalidModuleDescriptorException.class,
+                     () -> ModuleDescriptor.read(bb));
+    }
+
+    /**
+     * Test ModuleDescriptor.read with a null parameter.
+     */
     public void testReadWithNull() throws Exception {
         Module base = Object.class.getModule();
 
-        try {
-            ModuleDescriptor.read((InputStream)null);
-            assertTrue(false);
-        } catch (NullPointerException expected) { }
-
-
-        try (InputStream in = base.getResourceAsStream("module-info.class")) {
-            try {
-                ModuleDescriptor.read(in, null);
-                assertTrue(false);
-            } catch (NullPointerException expected) { }
-        }
-
-        try {
-            ModuleDescriptor.read((ByteBuffer)null);
-            assertTrue(false);
-        } catch (NullPointerException expected) { }
-
+        assertThrows(NullPointerException.class,
+                     () -> ModuleDescriptor.read((InputStream) null));
+        assertThrows(NullPointerException.class,
+                     () -> ModuleDescriptor.read((ByteBuffer) null));
 
         try (InputStream in = base.getResourceAsStream("module-info.class")) {
+            assertThrows(NullPointerException.class,
+                        () -> ModuleDescriptor.read(in, null));
+
             ByteBuffer bb = ByteBuffer.wrap(in.readAllBytes());
-            try {
-                ModuleDescriptor.read(bb, null);
-                assertTrue(false);
-            } catch (NullPointerException expected) { }
+            assertThrows(NullPointerException.class,
+                         () -> ModuleDescriptor.read(bb, null));
         }
     }
 


### PR DESCRIPTION
A small oversight with ModuleDescriptor.read when checking the requires table of a Module attribute. The requires entry for java.base should not have ACC_SYNTHETIC set.

A new test is added. Some of the existing tests used `@Test(expectedExceptions=...)`. I've changed some of these to use assertThrows to narrow it down to method that is expected to throw.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298875](https://bugs.openjdk.org/browse/JDK-8298875): A module requiring "java.base" with flags ACC_SYNTHETIC should be rejected


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11714/head:pull/11714` \
`$ git checkout pull/11714`

Update a local copy of the PR: \
`$ git checkout pull/11714` \
`$ git pull https://git.openjdk.org/jdk pull/11714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11714`

View PR using the GUI difftool: \
`$ git pr show -t 11714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11714.diff">https://git.openjdk.org/jdk/pull/11714.diff</a>

</details>
