### PR TITLE
8299018: java/net/httpclient/HttpsTunnelAuthTest.java fails with java.io.IOException: HTTP/1.1 header parser received no bytes

### DIFF
--- a/test/jdk/java/net/httpclient/ProxyServer.java
+++ b/test/jdk/java/net/httpclient/ProxyServer.java
@@ -331,8 +331,10 @@ public class ProxyServer extends Thread implements Closeable {
                     // check authorization credentials, if required by the server
                     if (credentials != null) {
                         if (!authorized(credentials, headers)) {
+                            boolean shouldClose = shouldCloseAfter407(headers);
+                            var closestr = shouldClose ? "Connection: close\r\n" : "";
                             String resp = "HTTP/1.1 407 Proxy Authentication Required\r\n" +
-                                    "Content-Length: 0\r\n" +
+                                    "Content-Length: 0\r\n" + closestr +
                                     "Proxy-Authenticate: Basic realm=\"proxy realm\"\r\n\r\n";
                             clientSocket.setOption(StandardSocketOptions.TCP_NODELAY, true);
                             clientSocket.setOption(StandardSocketOptions.SO_LINGER, 2);
@@ -344,7 +346,7 @@ public class ProxyServer extends Thread implements Closeable {
                                 System.out.printf("Proxy: unauthorized; 407 sent (%s/%s), linger: %s, nodelay: %s%n",
                                         buffer.position(), buffer.position() + buffer.remaining(), linger, nodelay);
                             }
-                            if (shouldCloseAfter407(headers)) {
+                            if (shouldClose) {
                                 closeConnection();
                                 return;
                             }
@@ -445,6 +447,11 @@ public class ProxyServer extends Thread implements Closeable {
         // If the client sends a request body we will need to close the connection
         // otherwise, we can keep it open.
         private boolean shouldCloseAfter407(List<String> headers) throws IOException {
+            var cmdline = headers.get(0);
+            int m = cmdline.indexOf(' ');
+            var method = (m > 0) ? cmdline.substring(0, m) : null;
+            var nobody = List.of("GET", "HEAD");
+
             var te = findFirst(headers, "transfer-encoding");
             if (te != null) {
                 // processing transfer encoding not implemented
@@ -455,19 +462,29 @@ public class ProxyServer extends Thread implements Closeable {
             }
             var cl = findFirst(headers, "content-length");
             int n = -1;
-            try {
-                n = Integer.parseInt(cl);
-                if (debug) {
-                    System.out.printf("Proxy: content-length: %d%n", n);
+            if (cl == null) {
+                if (nobody.contains(method)) {
+                    n = 0;
+                    System.out.printf("Proxy: no content length for %s, assuming 0%n", method);
+                } else {
+                    System.out.printf("Proxy: no content-length for %s, closing connection%n", method);
+                    return true;
                 }
-            } catch (NumberFormatException x) {
-                if (debug) {
-                    System.out.println("Proxy: bad content-length, closing connection");
-                    System.out.println("Proxy: \tcontent-length: " + cl);
-                    System.out.println("Proxy: \theaders: " + headers);
-                    System.out.println("Proxy: \t" + x);
+            } else {
+                try {
+                    n = Integer.parseInt(cl);
+                    if (debug) {
+                        System.out.printf("Proxy: content-length: %d%n", n);
+                    }
+                } catch (NumberFormatException x) {
+                    if (debug) {
+                        System.out.println("Proxy: bad content-length, closing connection");
+                        System.out.println("Proxy: \tcontent-length: " + cl);
+                        System.out.println("Proxy: \theaders: " + headers);
+                        System.out.println("Proxy: \t" + x);
+                    }
+                    return true;  // should close
                 }
-                return true;  // should close
             }
             if (n > 0 || n < -1) {
                 if (debug) {
@@ -475,11 +492,7 @@ public class ProxyServer extends Thread implements Closeable {
                 }
                 return true;  // should close
             }
-            var cmdline = headers.get(0);
-            int m = cmdline.indexOf(' ');
-            var method = (m > 0) ? cmdline.substring(0, m) : null;
-            var nobody = List.of("GET", "HEAD");
-            if (n == 0 || nobody.contains(m)) {
+            if (n == 0) {
                 var available = clientIn.available();
                 var drained = drain(clientSocket);
                 if (drained > 0 || available > 0) {

--- a/test/jdk/java/net/httpclient/ProxyServer.java
+++ b/test/jdk/java/net/httpclient/ProxyServer.java
@@ -486,7 +486,7 @@ public class ProxyServer extends Thread implements Closeable {
                     return true;  // should close
                 }
             }
-            if (n > 0 || n < -1) {
+            if (n > 0) {
                 if (debug) {
                     System.out.println("Proxy: request body with 407, closing connection");
                 }

--- a/test/jdk/java/net/httpclient/ProxyServer.java
+++ b/test/jdk/java/net/httpclient/ProxyServer.java
@@ -460,7 +460,7 @@ public class ProxyServer extends Thread implements Closeable {
                 if (debug) {
                     System.out.printf("Proxy: content-length: %d%n", n);
                 }
-            } catch (IllegalFormatException x) {
+            } catch (NumberFormatException x) {
                 if (debug) {
                     System.out.println("Proxy: bad content-length, closing connection");
                     System.out.println("Proxy: \tcontent-length: " + cl);

--- a/test/jdk/java/net/httpclient/ProxyServer.java
+++ b/test/jdk/java/net/httpclient/ProxyServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -458,11 +458,14 @@ public class ProxyServer extends Thread implements Closeable {
             try {
                 n = Integer.parseInt(cl);
                 if (debug) {
-                    System.out.printf("Proxy: content-length: %d%n", cl);
+                    System.out.printf("Proxy: content-length: %d%n", n);
                 }
             } catch (IllegalFormatException x) {
                 if (debug) {
                     System.out.println("Proxy: bad content-length, closing connection");
+                    System.out.println("Proxy: \tcontent-length: " + cl);
+                    System.out.println("Proxy: \theaders: " + headers);
+                    System.out.println("Proxy: \t" + x);
                 }
                 return true;  // should close
             }


### PR DESCRIPTION
Please find here a trivial fix for a test issue in the HttpClient test's ProxyServer.

The ProxyServer has a bad printf that throws an IllegalFormatConversionException, which causes the proxy to close the connection after sending a 407 request. Depending on timing, the client might attempt to reuse the closed (or soon to be closed) connection for sending authentication, which then gets the next POST request to fail.

This failure is rare and intermittent (the client usually gets the close notification before it reuses the connection), but sometimes it doesn't.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299018](https://bugs.openjdk.org/browse/JDK-8299018): java/net/httpclient/HttpsTunnelAuthTest.java fails with java.io.IOException: HTTP/1.1 header parser received no bytes


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - Committer) ⚠️ Review applies to [3d4db2b6](https://git.openjdk.org/jdk/pull/11717/files/3d4db2b6d7ff49c9f6233d9f772f92cb12dd8bca)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11717/head:pull/11717` \
`$ git checkout pull/11717`

Update a local copy of the PR: \
`$ git checkout pull/11717` \
`$ git pull https://git.openjdk.org/jdk pull/11717/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11717`

View PR using the GUI difftool: \
`$ git pr show -t 11717`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11717.diff">https://git.openjdk.org/jdk/pull/11717.diff</a>

</details>
