### PR TITLE
 8305947: SequenceInputStream implementation can use an Iterator rather than Enumeration

### DIFF
--- a/src/java.base/share/classes/java/io/SequenceInputStream.java
+++ b/src/java.base/share/classes/java/io/SequenceInputStream.java
@@ -26,8 +26,8 @@
 package java.io;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Enumeration;
+import java.util.Iterator;
 import java.util.Objects;
 
 /**
@@ -44,7 +44,7 @@ import java.util.Objects;
  * @since   1.0
  */
 public class SequenceInputStream extends InputStream {
-    private final Enumeration<? extends InputStream> e;
+    private final Iterator<? extends InputStream> e;
     private InputStream in;
 
     /**
@@ -64,8 +64,7 @@ public class SequenceInputStream extends InputStream {
      * @see     java.util.Enumeration
      */
     public SequenceInputStream(Enumeration<? extends InputStream> e) {
-        this.e = e;
-        peekNextStream();
+        this(e.asIterator());
     }
 
     /**
@@ -80,7 +79,18 @@ public class SequenceInputStream extends InputStream {
      * @param   s2   the second input stream to read.
      */
     public SequenceInputStream(InputStream s1, InputStream s2) {
-        this(Collections.enumeration(Arrays.asList(s1, s2)));
+        this(Arrays.asList(s1, s2).iterator());
+    }
+
+    /**
+     * Initializes this sequence state on the first available
+     * {@code InputStream} if any.
+     *
+     * @param iterator the iterator of the input streams.
+     */
+    private SequenceInputStream(final Iterator<? extends InputStream> iterator) {
+        this.e = iterator;
+        peekNextStream();
     }
 
     /**
@@ -94,8 +104,8 @@ public class SequenceInputStream extends InputStream {
     }
 
     private void peekNextStream() {
-        if (e.hasMoreElements()) {
-            in = e.nextElement();
+        if (e.hasNext()) {
+            in = e.next();
             if (in == null)
                 throw new NullPointerException();
         } else {


### PR DESCRIPTION
enumeration(list) will create an enumeration, a list and an iterator whereas the impl only requires an iterator
this PR drops the enumeration wrapper for binary constructor and just maps the enumeration to an iterator for the other case which should be a better compromise in practise.

Another side but nice effect is to have some lighter classloading (subgraph)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305947](https://bugs.openjdk.org/browse/JDK-8305947): SequenceInputStream implementation can use an Iterator rather than Enumeration (**Enhancement** - P5)


### Reviewers
 * @bmarwell (no known openjdk.org user name / role) ⚠️ Review applies to [bfbc1973](https://git.openjdk.org/jdk/pull/11718/files/bfbc1973152e3bb632a15ab2c51e427551ca5c76)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/11718/head:pull/11718` \
`$ git checkout pull/11718`

Update a local copy of the PR: \
`$ git checkout pull/11718` \
`$ git pull https://git.openjdk.org/jdk.git pull/11718/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11718`

View PR using the GUI difftool: \
`$ git pr show -t 11718`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11718.diff">https://git.openjdk.org/jdk/pull/11718.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/11718#issuecomment-1584103923)