### PR TITLE
JDK-8299022: Linux ppc64le and s390x build issues after JDK-8160404

### DIFF
--- a/src/hotspot/cpu/ppc/assembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.hpp
@@ -95,7 +95,7 @@ class AddressLiteral {
 
  protected:
   // creation
-  AddressLiteral() : _address(NULL), _rspec(NULL) {}
+  AddressLiteral() : _address(NULL), _rspec() {}
 
  public:
   AddressLiteral(address addr, RelocationHolder const& rspec)

--- a/src/hotspot/cpu/s390/assembler_s390.hpp
+++ b/src/hotspot/cpu/s390/assembler_s390.hpp
@@ -295,7 +295,7 @@ class AddressLiteral {
 
  protected:
   // creation
-  AddressLiteral() : _address(NULL), _rspec(NULL) {}
+  AddressLiteral() : _address(NULL), _rspec() {}
 
  public:
   AddressLiteral(address addr, RelocationHolder const& rspec)


### PR DESCRIPTION
Looks like [JDK-8160404](https://bugs.openjdk.org/browse/JDK-8160404) caused issues in the Linux ppc64le build.
We now run into

/openjdk/nb/linuxppc64le/jdk/src/hotspot/cpu/ppc/assembler_ppc.hpp:98:49: error: no matching function for call to 'RelocationHolder::RelocationHolder(NULL)'
   AddressLiteral() : _address(NULL), _rspec(NULL) {}

This change changes the usage of a constructor that is no longer present after JDK-8160404 .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299022](https://bugs.openjdk.org/browse/JDK-8299022): Linux ppc64le and s390x build issues after JDK-8160404


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11719/head:pull/11719` \
`$ git checkout pull/11719`

Update a local copy of the PR: \
`$ git checkout pull/11719` \
`$ git pull https://git.openjdk.org/jdk pull/11719/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11719`

View PR using the GUI difftool: \
`$ git pr show -t 11719`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11719.diff">https://git.openjdk.org/jdk/pull/11719.diff</a>

</details>
