### PR TITLE
JDK-8299025: BMPImageReader.java readColorPalette could use staggeredReadByteStream

### DIFF
--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/bmp/BMPImageReader.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/bmp/BMPImageReader.java
@@ -226,30 +226,7 @@ public class BMPImageReader extends ImageReader implements BMPConstants {
     }
 
     private void readColorPalette(int sizeOfPalette) throws IOException {
-        final int UNIT_SIZE = 1024000;
-        if (sizeOfPalette < UNIT_SIZE) {
-            palette = new byte[sizeOfPalette];
-            iis.readFully(palette, 0, sizeOfPalette);
-        } else {
-            int bytesToRead = sizeOfPalette;
-            int bytesRead = 0;
-            List<byte[]> bufs = new ArrayList<>();
-            while (bytesToRead != 0) {
-                int sz = Math.min(bytesToRead, UNIT_SIZE);
-                byte[] unit = new byte[sz];
-                iis.readFully(unit, 0, sz);
-                bufs.add(unit);
-                bytesRead += sz;
-                bytesToRead -= sz;
-            }
-            byte[] paletteData = new byte[bytesRead];
-            int copiedBytes = 0;
-            for (byte[] ba : bufs) {
-                System.arraycopy(ba, 0, paletteData, copiedBytes, ba.length);
-                copiedBytes += ba.length;
-            }
-            palette = paletteData;
-        }
+        palette = ReaderUtil.staggeredReadByteStream(iis, sizeOfPalette);
     }
 
     /**


### PR DESCRIPTION
Looks like the coding in jdk/src/java.desktop/share/classes/com/sun/imageio/plugins/bmp/BMPImageReader.java readColorPalette is rather close to what staggeredReadByteStream does, so we could instead use staggeredReadByteStream and do not duplicate the coding.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299025](https://bugs.openjdk.org/browse/JDK-8299025): BMPImageReader.java readColorPalette could use staggeredReadByteStream


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * @SWinxy (no known github.com user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11720/head:pull/11720` \
`$ git checkout pull/11720`

Update a local copy of the PR: \
`$ git checkout pull/11720` \
`$ git pull https://git.openjdk.org/jdk pull/11720/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11720`

View PR using the GUI difftool: \
`$ git pr show -t 11720`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11720.diff">https://git.openjdk.org/jdk/pull/11720.diff</a>

</details>
