### PR TITLE
8298931: java/net/httpclient/CancelStreamedBodyTest.java fails with AssertionError due to Pending TCP connections: 1

### DIFF
--- a/test/jdk/java/net/httpclient/CancelStreamedBodyTest.java
+++ b/test/jdk/java/net/httpclient/CancelStreamedBodyTest.java
@@ -104,6 +104,7 @@ public class CancelStreamedBodyTest implements HttpServerAdapters {
 
     static final long SERVER_LATENCY = 75;
     static final int ITERATION_COUNT = 3;
+    static final long CLIENT_SHUTDOWN_GRACE_DELAY = 1500; // milliseconds
     // a shared executor helps reduce the amount of threads created by the test
     static final Executor executor = new TestExecutor(Executors.newCachedThreadPool());
     static final ConcurrentMap<String, Throwable> FAILURES = new ConcurrentHashMap<>();
@@ -287,7 +288,7 @@ public class CancelStreamedBodyTest implements HttpServerAdapters {
             if (sameClient) continue;
             client = null;
             System.gc();
-            var error = TRACKER.check(tracker, 500);
+            var error = TRACKER.check(tracker, CLIENT_SHUTDOWN_GRACE_DELAY);
             if (error != null) throw error;
         }
     }
@@ -329,7 +330,7 @@ public class CancelStreamedBodyTest implements HttpServerAdapters {
             if (sameClient) continue;
             client = null;
             System.gc();
-            var error = TRACKER.check(tracker, 1);
+            var error = TRACKER.check(tracker, CLIENT_SHUTDOWN_GRACE_DELAY);
             if (error != null) throw error;
         }
     }

--- a/test/jdk/java/net/httpclient/ISO_8859_1_Test.java
+++ b/test/jdk/java/net/httpclient/ISO_8859_1_Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -447,7 +447,7 @@ public class ISO_8859_1_Test implements HttpServerAdapters {
                 sharedClient == null ? null : sharedClient.toString();
         sharedClient = null;
         Thread.sleep(100);
-        AssertionError fail = TRACKER.check(500);
+        AssertionError fail = TRACKER.check(1500);
         try {
             http1TestServer.stop();
             https1TestServer.stop();


### PR DESCRIPTION
The CancelStreamedBodyTest.java and ISO_8859_1_Test.java were observed failing in AssertioError due to resources not being released in the imparted time. I am suspecting this to occur on particularly slow/overloaded machines.

This change propose to increase the time these two tests wait for resources to be released. It also improves traces in the ReferenceTracker to give better visibility on the tracker waiting loop and help better diagnose any future issue that might be cause by the tracker not waiting long enough.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298931](https://bugs.openjdk.org/browse/JDK-8298931): java/net/httpclient/CancelStreamedBodyTest.java fails with AssertionError due to Pending TCP connections: 1


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11725/head:pull/11725` \
`$ git checkout pull/11725`

Update a local copy of the PR: \
`$ git checkout pull/11725` \
`$ git pull https://git.openjdk.org/jdk pull/11725/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11725`

View PR using the GUI difftool: \
`$ git pr show -t 11725`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11725.diff">https://git.openjdk.org/jdk/pull/11725.diff</a>

</details>
