### PR TITLE
8298974: Add ftcolor.c to imported freetype sources

### DIFF
--- a/src/java.desktop/share/native/libfreetype/src/base/ftcolor.c
+++ b/src/java.desktop/share/native/libfreetype/src/base/ftcolor.c
@@ -1,0 +1,156 @@
+/****************************************************************************
+ *
+ * ftcolor.c
+ *
+ *   FreeType's glyph color management (body).
+ *
+ * Copyright (C) 2018-2022 by
+ * David Turner, Robert Wilhelm, and Werner Lemberg.
+ *
+ * This file is part of the FreeType project, and may only be used,
+ * modified, and distributed under the terms of the FreeType project
+ * license, LICENSE.TXT.  By continuing to use, modify, or distribute
+ * this file you indicate that you have read the license and
+ * understand and accept it fully.
+ *
+ */
+
+
+#include <freetype/internal/ftdebug.h>
+#include <freetype/internal/sfnt.h>
+#include <freetype/internal/tttypes.h>
+#include <freetype/ftcolor.h>
+
+
+#ifdef TT_CONFIG_OPTION_COLOR_LAYERS
+
+  static
+  const FT_Palette_Data  null_palette_data = { 0, NULL, NULL, 0, NULL };
+
+
+  /* documentation is in ftcolor.h */
+
+  FT_EXPORT_DEF( FT_Error )
+  FT_Palette_Data_Get( FT_Face           face,
+                       FT_Palette_Data  *apalette_data )
+  {
+    if ( !face )
+      return FT_THROW( Invalid_Face_Handle );
+    if ( !apalette_data)
+      return FT_THROW( Invalid_Argument );
+
+    if ( FT_IS_SFNT( face ) )
+      *apalette_data = ( (TT_Face)face )->palette_data;
+    else
+      *apalette_data = null_palette_data;
+
+    return FT_Err_Ok;
+  }
+
+
+  /* documentation is in ftcolor.h */
+
+  FT_EXPORT_DEF( FT_Error )
+  FT_Palette_Select( FT_Face     face,
+                     FT_UShort   palette_index,
+                     FT_Color*  *apalette )
+  {
+    FT_Error  error;
+
+    TT_Face       ttface;
+    SFNT_Service  sfnt;
+
+
+    if ( !face )
+      return FT_THROW( Invalid_Face_Handle );
+
+    if ( !FT_IS_SFNT( face ) )
+    {
+      if ( apalette )
+        *apalette = NULL;
+
+      return FT_Err_Ok;
+    }
+
+    ttface = (TT_Face)face;
+    sfnt   = (SFNT_Service)ttface->sfnt;
+
+    error = sfnt->set_palette( ttface, palette_index );
+    if ( error )
+      return error;
+
+    ttface->palette_index = palette_index;
+
+    if ( apalette )
+      *apalette = ttface->palette;
+
+    return FT_Err_Ok;
+  }
+
+
+  /* documentation is in ftcolor.h */
+
+  FT_EXPORT_DEF( FT_Error )
+  FT_Palette_Set_Foreground_Color( FT_Face   face,
+                                   FT_Color  foreground_color )
+  {
+    TT_Face  ttface;
+
+
+    if ( !face )
+      return FT_THROW( Invalid_Face_Handle );
+
+    if ( !FT_IS_SFNT( face ) )
+      return FT_Err_Ok;
+
+    ttface = (TT_Face)face;
+
+    ttface->foreground_color      = foreground_color;
+    ttface->have_foreground_color = 1;
+
+    return FT_Err_Ok;
+  }
+
+#else /* !TT_CONFIG_OPTION_COLOR_LAYERS */
+
+  FT_EXPORT_DEF( FT_Error )
+  FT_Palette_Data_Get( FT_Face           face,
+                       FT_Palette_Data  *apalette_data )
+  {
+    FT_UNUSED( face );
+    FT_UNUSED( apalette_data );
+
+
+    return FT_THROW( Unimplemented_Feature );
+  }
+
+
+  FT_EXPORT_DEF( FT_Error )
+  FT_Palette_Select( FT_Face     face,
+                     FT_UShort   palette_index,
+                     FT_Color*  *apalette )
+  {
+    FT_UNUSED( face );
+    FT_UNUSED( palette_index );
+    FT_UNUSED( apalette );
+
+
+    return FT_THROW( Unimplemented_Feature );
+  }
+
+
+  FT_EXPORT_DEF( FT_Error )
+  FT_Palette_Set_Foreground_Color( FT_Face   face,
+                                   FT_Color  foreground_color )
+  {
+    FT_UNUSED( face );
+    FT_UNUSED( foreground_color );
+
+
+    return FT_THROW( Unimplemented_Feature );
+  }
+
+#endif /* !TT_CONFIG_OPTION_COLOR_LAYERS */
+
+
+/* END */


### PR DESCRIPTION
Add ftcolor.c to the freetype sources we import as it is needed for Emoji rendering.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298974](https://bugs.openjdk.org/browse/JDK-8298974): Add ftcolor.c to imported freetype sources


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11728/head:pull/11728` \
`$ git checkout pull/11728`

Update a local copy of the PR: \
`$ git checkout pull/11728` \
`$ git pull https://git.openjdk.org/jdk pull/11728/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11728`

View PR using the GUI difftool: \
`$ git pr show -t 11728`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11728.diff">https://git.openjdk.org/jdk/pull/11728.diff</a>

</details>
