### PR TITLE
8298971: Move Console implementation into jdk internal package

### DIFF
--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -31,6 +31,7 @@ import java.util.*;
 import java.nio.charset.Charset;
 import jdk.internal.access.JavaIOAccess;
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.io.JdkConsoleImpl;
 import jdk.internal.io.JdkConsoleProvider;
 import jdk.internal.util.StaticProperty;
 import sun.security.action.GetPropertyAction;
@@ -93,7 +94,7 @@ import sun.security.action.GetPropertyAction;
  * @author  Xueming Shen
  * @since   1.6
  */
-public sealed class Console implements Flushable permits ConsoleImpl, ProxyingConsole {
+public sealed class Console implements Flushable permits ProxyingConsole {
     /**
      * Package private no-arg constructor.
      */
@@ -392,12 +393,12 @@ public sealed class Console implements Flushable permits ConsoleImpl, ProxyingCo
                         .filter(Objects::nonNull)
                         .findAny()
                         .map(jc -> (Console) new ProxyingConsole(jc))
-                        .orElse(istty ? new ConsoleImpl() : null);
+                        .orElse(istty ? new ProxyingConsole(JdkConsoleImpl.getJdkConsole(CHARSET)) : null);
             };
             return AccessController.doPrivileged(pa);
         } catch (ServiceConfigurationError ignore) {
             // default to built-in Console
-            return istty ? new ConsoleImpl() : null;
+            return istty ? new ProxyingConsole(JdkConsoleImpl.getJdkConsole(CHARSET)) : null;
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java
+++ b/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java
@@ -57,7 +57,7 @@ public final class JdkConsoleImpl implements JdkConsole {
     }
 
     @Override
-    public JdkConsole format(String fmt, Object ...args) {
+    public JdkConsole format(String fmt, Object ... args) {
         formatter.format(fmt, args).flush();
         return this;
     }

--- a/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java
+++ b/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java
@@ -36,6 +36,8 @@ import java.io.Writer;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Formatter;
+import java.util.Objects;
+
 import jdk.internal.access.SharedSecrets;
 import sun.nio.cs.StreamDecoder;
 import sun.nio.cs.StreamEncoder;
@@ -163,7 +165,6 @@ public final class JdkConsoleImpl implements JdkConsole {
 
     @Override
     public Charset charset() {
-        assert charset != null : "charset() should not return null";
         return charset;
     }
 
@@ -328,6 +329,7 @@ public final class JdkConsoleImpl implements JdkConsole {
     }
 
     public JdkConsoleImpl(Charset charset) {
+        Objects.requireNonNull(charset);
         this.charset = charset;
         readLock = new Object();
         writeLock = new Object();

--- a/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java
+++ b/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java
@@ -23,55 +23,48 @@
  * questions.
  */
 
-package java.io;
+package jdk.internal.io;
 
-import java.util.*;
+import java.io.IOError;
+import java.io.IOException;
+import java.io.FileDescriptor;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Writer;
 import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Formatter;
 import jdk.internal.access.SharedSecrets;
 import sun.nio.cs.StreamDecoder;
 import sun.nio.cs.StreamEncoder;
 
 /**
- * Console implementation based on the platform's TTY.
+ * JdkConsole implementation based on the platform's TTY.
  */
-
-final class ConsoleImpl extends Console {
-    /**
-     * {@inheritDoc}
-     */
+public final class JdkConsoleImpl implements JdkConsole, JdkConsoleProvider {
     @Override
     public PrintWriter writer() {
         return pw;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Reader reader() {
         return reader;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public Console format(String fmt, Object ...args) {
+    public JdkConsole format(String fmt, Object ...args) {
         formatter.format(fmt, args).flush();
         return this;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public Console printf(String format, Object ... args) {
+    public JdkConsole printf(String format, Object ... args) {
         return format(format, args);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String readLine(String fmt, Object ... args) {
         String line = null;
@@ -91,17 +84,11 @@ final class ConsoleImpl extends Console {
         return line;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String readLine() {
         return readLine("");
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public char[] readPassword(String fmt, Object ... args) {
         char[] passwd = null;
@@ -164,37 +151,32 @@ final class ConsoleImpl extends Console {
         shutdownHookInstalled = true;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public char[] readPassword() {
         return readPassword("");
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void flush() {
         pw.flush();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Charset charset() {
-        assert CHARSET != null : "charset() should not return null";
-        return CHARSET;
+        assert charset != null : "charset() should not return null";
+        return charset;
     }
 
-    private final Object readLock;
-    private final Object writeLock;
-    private final Reader reader;
-    private final Writer out;
-    private final PrintWriter pw;
-    private final Formatter formatter;
+    // The singleton
+    private volatile static JdkConsole INSTANCE;
+
+    private Charset charset;
+    private Object readLock;
+    private Object writeLock;
+    private Reader reader;
+    private Writer out;
+    private PrintWriter pw;
+    private Formatter formatter;
     private char[] rcb;
     private boolean restoreEcho;
     private boolean shutdownHookInstalled;
@@ -348,19 +330,38 @@ final class ConsoleImpl extends Console {
         }
     }
 
-    ConsoleImpl() {
-        readLock = new Object();
-        writeLock = new Object();
-        out = StreamEncoder.forOutputStreamWriter(
-                new FileOutputStream(FileDescriptor.out),
-                writeLock,
-                CHARSET);
-        pw = new PrintWriter(out, true) { public void close() {} };
-        formatter = new Formatter(out);
-        reader = new LineReader(StreamDecoder.forInputStreamReader(
-                new FileInputStream(FileDescriptor.in),
-                readLock,
-                CHARSET));
-        rcb = new char[1024];
+    @Override
+    public JdkConsole console(boolean isTTY, Charset charset) {
+        if (isTTY) {
+            if (INSTANCE == null) {
+                this.charset = charset;
+                readLock = new Object();
+                writeLock = new Object();
+                out = StreamEncoder.forOutputStreamWriter(
+                        new FileOutputStream(FileDescriptor.out),
+                        writeLock,
+                        charset);
+                pw = new PrintWriter(out, true) {
+                    public void close() {
+                    }
+                };
+                formatter = new Formatter(out);
+                reader = new LineReader(StreamDecoder.forInputStreamReader(
+                        new FileInputStream(FileDescriptor.in),
+                        readLock,
+                        charset));
+                rcb = new char[1024];
+                INSTANCE = this;
+            }
+            return INSTANCE;
+        } else {
+            // not instantiable
+            return null;
+        }
+    }
+
+    // For convenience
+    public static JdkConsole getJdkConsole(Charset cs) {
+        return INSTANCE != null ? INSTANCE : new JdkConsoleImpl().console(true, cs);
     }
 }

--- a/src/java.base/unix/native/libjava/Console_md.c
+++ b/src/java.base/unix/native/libjava/Console_md.c
@@ -27,7 +27,7 @@
 #include "jni_util.h"
 #include "jvm.h"
 #include "java_io_Console.h"
-#include "java_io_ConsoleImpl.h"
+#include "jdk_internal_io_JdkConsoleImpl.h"
 
 #include <stdlib.h>
 #include <unistd.h>
@@ -46,7 +46,7 @@ Java_java_io_Console_encoding(JNIEnv *env, jclass cls)
 }
 
 JNIEXPORT jboolean JNICALL
-Java_java_io_ConsoleImpl_echo(JNIEnv *env,
+Java_jdk_internal_io_JdkConsoleImpl_echo(JNIEnv *env,
                           jclass cls,
                           jboolean on)
 {

--- a/src/java.base/unix/native/libjava/JdkConsoleImpl_md.c
+++ b/src/java.base/unix/native/libjava/JdkConsoleImpl_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,19 +26,32 @@
 #include "jni.h"
 #include "jni_util.h"
 #include "jvm.h"
-#include "java_io_Console.h"
+#include "jdk_internal_io_JdkConsoleImpl.h"
 
 #include <stdlib.h>
 #include <unistd.h>
+#include <termios.h>
 
 JNIEXPORT jboolean JNICALL
-Java_java_io_Console_istty(JNIEnv *env, jclass cls)
+Java_jdk_internal_io_JdkConsoleImpl_echo(JNIEnv *env,
+                          jclass cls,
+                          jboolean on)
 {
-    return isatty(fileno(stdin)) && isatty(fileno(stdout));
-}
-
-JNIEXPORT jstring JNICALL
-Java_java_io_Console_encoding(JNIEnv *env, jclass cls)
-{
-    return NULL;
+    struct termios tio;
+    jboolean old;
+    int tty = fileno(stdin);
+    if (tcgetattr(tty, &tio) == -1) {
+        JNU_ThrowIOExceptionWithLastError(env, "tcgetattr failed");
+        return !on;
+    }
+    old = (tio.c_lflag & ECHO) != 0;
+    if (on) {
+        tio.c_lflag |= ECHO;
+    } else {
+        tio.c_lflag &= ~ECHO;
+    }
+    if (tcsetattr(tty, TCSANOW, &tio) == -1) {
+        JNU_ThrowIOExceptionWithLastError(env, "tcsetattr failed");
+    }
+    return old;
 }


### PR DESCRIPTION
Moving the built-in implementation of `Console` from `java.io` package into `jdk.internal.io` package. It now implements `JdkConsole` interface and is accessed through `ProxyingConsole`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298971](https://bugs.openjdk.org/browse/JDK-8298971): Move Console implementation into jdk internal package


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [1f6b4f4f](https://git.openjdk.org/jdk/pull/11729/files/1f6b4f4ff8ed05c009ffe2d395646e1af3bdd54e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11729/head:pull/11729` \
`$ git checkout pull/11729`

Update a local copy of the PR: \
`$ git checkout pull/11729` \
`$ git pull https://git.openjdk.org/jdk pull/11729/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11729`

View PR using the GUI difftool: \
`$ git pr show -t 11729`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11729.diff">https://git.openjdk.org/jdk/pull/11729.diff</a>

</details>
