### PR TITLE
8299044 : test/jdk/javax/swing/JComboBox/JComboBoxBorderTest.java fails on non mac

### DIFF
--- a/test/jdk/javax/swing/JComboBox/JComboBoxBorderTest.java
+++ b/test/jdk/javax/swing/JComboBox/JComboBoxBorderTest.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8054572
+ * @requires (os.family == "mac")
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @summary Tests if JComboBox displays correctly when editable/non-editable


### PR DESCRIPTION
This test needs to be executed on mac os only

@shurymury 
@honkar-jdk

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299044](https://bugs.openjdk.org/browse/JDK-8299044): test/jdk/javax/swing/JComboBox/JComboBoxBorderTest.java fails on non mac


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11730/head:pull/11730` \
`$ git checkout pull/11730`

Update a local copy of the PR: \
`$ git checkout pull/11730` \
`$ git pull https://git.openjdk.org/jdk pull/11730/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11730`

View PR using the GUI difftool: \
`$ git pr show -t 11730`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11730.diff">https://git.openjdk.org/jdk/pull/11730.diff</a>

</details>
