### PR TITLE
8299043 : test/jdk/javax/swing/AbstractButton/5049549/bug5049549.java fails with java.lang.NullPointerException

### DIFF
--- a/test/jdk/javax/swing/AbstractButton/5049549/bug5049549.java
+++ b/test/jdk/javax/swing/AbstractButton/5049549/bug5049549.java
@@ -41,13 +41,13 @@ import javax.swing.UIManager;
 
 public class bug5049549 {
 
-    private static ImageIcon DE = new ImageIcon(bug5049549.class.getResource("DE1.GIF"));
-    private static ImageIcon DI = new ImageIcon(bug5049549.class.getResource("DI1.GIF"));
-    private static ImageIcon DS = new ImageIcon(bug5049549.class.getResource("DS1.GIF"));
-    private static ImageIcon RO = new ImageIcon(bug5049549.class.getResource("RO1.GIF"));
-    private static ImageIcon RS = new ImageIcon(bug5049549.class.getResource("RS1.GIF"));
-    private static ImageIcon SE = new ImageIcon(bug5049549.class.getResource("SE1.GIF"));
-    private static ImageIcon PR = new ImageIcon(bug5049549.class.getResource("PR1.GIF"));
+    private static ImageIcon DE = new ImageIcon(bug5049549.class.getResource("DE1.gif"));
+    private static ImageIcon DI = new ImageIcon(bug5049549.class.getResource("DI1.gif"));
+    private static ImageIcon DS = new ImageIcon(bug5049549.class.getResource("DS1.gif"));
+    private static ImageIcon RO = new ImageIcon(bug5049549.class.getResource("RO1.gif"));
+    private static ImageIcon RS = new ImageIcon(bug5049549.class.getResource("RS1.gif"));
+    private static ImageIcon SE = new ImageIcon(bug5049549.class.getResource("SE1.gif"));
+    private static ImageIcon PR = new ImageIcon(bug5049549.class.getResource("PR1.gif"));
 
     private static Blocker blocker = new Blocker();
 


### PR DESCRIPTION
Test was failing with java.lang.NullPointerException due to image file extension was specified in upper case ( GIF ) https://github.com/openjdk/jdk/blob/master/test/jdk/javax/swing/AbstractButton/5049549/bug5049549.java#L44-L50  but actually it is in smaller case ( gif )  https://github.com/openjdk/jdk/tree/master/test/jdk/javax/swing/AbstractButton/5049549 . 
The was working as expected in mac but failed in ubuntu. After fixing the image file extension( gif ) and run the test it worked and exception was not reproduced. 

@shurymury 
@honkar-jdk

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299043](https://bugs.openjdk.org/browse/JDK-8299043): test/jdk/javax/swing/AbstractButton/5049549/bug5049549.java fails with java.lang.NullPointerException


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11731/head:pull/11731` \
`$ git checkout pull/11731`

Update a local copy of the PR: \
`$ git checkout pull/11731` \
`$ git pull https://git.openjdk.org/jdk pull/11731/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11731`

View PR using the GUI difftool: \
`$ git pr show -t 11731`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11731.diff">https://git.openjdk.org/jdk/pull/11731.diff</a>

</details>
