### PR TITLE
JDK-8299045: tools/doclint/BadPackageCommentTest.java fails after JDK-8298943

### DIFF
--- a/test/langtools/tools/doclint/BadPackageCommentTest.out
+++ b/test/langtools/tools/doclint/BadPackageCommentTest.out
@@ -1,13 +1,13 @@
 BadPackageCommentTest.java:14: warning: documentation comment not expected here
 package p;
 ^
-BadPackageCommentTest.java:12: error: no tag name after @
+BadPackageCommentTest.java:12: error: no tag name after '@'
  * @@@
    ^
-BadPackageCommentTest.java:12: error: no tag name after @
+BadPackageCommentTest.java:12: error: no tag name after '@'
  * @@@
     ^
-BadPackageCommentTest.java:12: error: no tag name after @
+BadPackageCommentTest.java:12: error: no tag name after '@'
  * @@@
      ^
 3 errors


### PR DESCRIPTION
Please review a fix for the golden-file for a test, required after quotes in resources were fixed in JDK-8298943.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299045](https://bugs.openjdk.org/browse/JDK-8299045): tools/doclint/BadPackageCommentTest.java fails after JDK-8298943


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11732/head:pull/11732` \
`$ git checkout pull/11732`

Update a local copy of the PR: \
`$ git checkout pull/11732` \
`$ git pull https://git.openjdk.org/jdk pull/11732/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11732`

View PR using the GUI difftool: \
`$ git pr show -t 11732`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11732.diff">https://git.openjdk.org/jdk/pull/11732.diff</a>

</details>
