### PR TITLE
8298887: On the latest macOS+XCode the Robot API may report wrong colors

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
@@ -354,8 +354,8 @@ Java_sun_lwawt_macosx_CRobot_nativeGetScreenPixels
                                             picWidth, picHeight,
                                             8, picWidth * sizeof(jint),
                                             picColorSpace,
-                                            kCGBitmapByteOrder32Host |
-                                            kCGImageAlphaPremultipliedFirst);
+                                            kCGBitmapByteOrder32Little |
+                                            kCGImageAlphaNoneSkipFirst);
 
     CGColorSpaceRelease(picColorSpace);
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
@@ -47,10 +47,6 @@
 
 #define k_JAVA_ROBOT_WHEEL_COUNT 1
 
-#if !defined(kCGBitmapByteOrder32Host)
-#define kCGBitmapByteOrder32Host 0
-#endif
-
 // In OS X, left and right mouse button share the same click count.
 // That is, if one starts clicking the left button rapidly and then
 // switches to the right button, then the click count will continue
@@ -354,7 +350,7 @@ Java_sun_lwawt_macosx_CRobot_nativeGetScreenPixels
                                             picWidth, picHeight,
                                             8, picWidth * sizeof(jint),
                                             picColorSpace,
-                                            kCGBitmapByteOrder32Little |
+                                            kCGBitmapByteOrder32Host |
                                             kCGImageAlphaNoneSkipFirst);
 
     CGColorSpaceRelease(picColorSpace);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/QuartzSurfaceData.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/QuartzSurfaceData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,14 +28,6 @@
 #import "AWTFont.h"
 #import <Cocoa/Cocoa.h>
 #import "JNIUtilities.h"
-
-// these flags are not defined on Tiger on PPC, so we need to make them a no-op
-#if !defined(kCGBitmapByteOrder32Host)
-#define kCGBitmapByteOrder32Host 0
-#endif
-#if !defined(kCGBitmapByteOrder16Host)
-#define kCGBitmapByteOrder16Host 0
-#endif
 
 // NOTE : Modify the printSurfaceDataDiagnostics API if you change this enum
 enum SDRenderType

--- a/test/jdk/java/awt/AlphaComposite/WindowAlphaCompositeTest.java
+++ b/test/jdk/java/awt/AlphaComposite/WindowAlphaCompositeTest.java
@@ -25,7 +25,7 @@
 /**
  * @test
  * @key headful
- * @bug 8266079
+ * @bug 8266079 8298887
  * @summary [macosx] window rendering alpha composite test
  * @author Alexey Ushakov
  * @run main WindowAlphaCompositeTest

--- a/test/jdk/java/awt/Robot/CheckCommonColors/CheckCommonColors.java
+++ b/test/jdk/java/awt/Robot/CheckCommonColors/CheckCommonColors.java
@@ -40,7 +40,7 @@ import javax.imageio.ImageIO;
 /**
  * @test
  * @key headful
- * @bug 8215105 8211999
+ * @bug 8215105 8211999 8298887
  * @summary tests that Robot can capture the common colors without artifacts
  * @run main/othervm CheckCommonColors
  * @run main/othervm -Xcheck:jni CheckCommonColors

--- a/test/jdk/java/awt/font/GlyphVector/MultiSlotFontTest.java
+++ b/test/jdk/java/awt/font/GlyphVector/MultiSlotFontTest.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8240756
+ * @bug 8240756 8298887
  * @summary Non-English characters are printed with wrong glyphs on MacOS
  * @modules java.desktop/sun.java2d java.desktop/sun.java2d.loops java.desktop/sun.font
  * @requires os.family == "mac"


### PR DESCRIPTION
The new macOS SDK provided by XCode 14.2 changed this macro:
`# define kCGBitmapByteOrder32Host kCGBitmapByteOrder32Little`
to this constant
`static const CGBitmapInfo kCGBitmapByteOrder32Host = kCGBitmapByteOrder32Little;`

As a result, our native code started to redefine the macro value to "define kCGBitmapByteOrder32Host 0". I think that was added a long time ago for a PPC platform.

I have also changed the type of the color we pass to the java Robot, the java code expects the xrgb format(the alpha ignored), but we for some reason prepared pre-multiplied alpha.

Tested on macOS 12.6.1 and 13.0.1 using xcode 14.2 and xcode 12.5.1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298887](https://bugs.openjdk.org/browse/JDK-8298887): On the latest macOS+XCode the Robot API may report wrong colors


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11733/head:pull/11733` \
`$ git checkout pull/11733`

Update a local copy of the PR: \
`$ git checkout pull/11733` \
`$ git pull https://git.openjdk.org/jdk pull/11733/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11733`

View PR using the GUI difftool: \
`$ git pr show -t 11733`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11733.diff">https://git.openjdk.org/jdk/pull/11733.diff</a>

</details>
