### PR TITLE
8285416

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Launcher.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Launcher.java
@@ -167,6 +167,7 @@ public class Launcher extends DebugeeBinder {
             boolean vthreadMode = "Virtual".equals(System.getProperty("main.wrapper"));
             if (vthreadMode) {
                 args.add("-R--enable-preview");
+                args.add("-R-Djdk.virtualThreadScheduler.parallelism=15");
             }
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Binder.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Binder.java
@@ -755,6 +755,7 @@ public class Binder extends DebugeeBinder {
         boolean vthreadMode = "Virtual".equals(System.getProperty("main.wrapper"));
         if (vthreadMode) {
             vmArgs += " --enable-preview";
+            vmArgs += " -Djdk.virtualThreadScheduler.parallelism=15";
         }
 
 /*


### PR DESCRIPTION
There are a few nsk debugger tests that pin multiple virtual threads to carrier threads when synchronizing. Sometime the default number of carrier threads (which equals the number of CPUs) is not enough, and the test deadlocks because virtual threads start to wait forever for an available carrier thread. This PR fixes this problem by using the `jdk.virtualThreadScheduler.parallelism` property to change the default number of carrier threads. I believe the largest number of carrier threads any test needs is 11, so I chose 15 just to be safe.

I had initially tried to fix each individual test by using the test support in `VThreadRunner.setParallism()`. The advantage of this was limiting the scope of the change to just a few tests, and also being able to specify the exact number of needed carrier threads. The disadvantage was having to make quite a few changes to quite a few tests, plus I had one troublesome test that was still failing, I believe because I didn't fully understand how many carrier threads it needed. Just giving every test 15 carrier threads in the end was a lot easier.