### PR TITLE
8299072: java_lang_ref_Reference::clear_referent should be GC agnostic

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -952,6 +952,7 @@ class java_lang_ref_Reference: AllStatic {
   static inline oop phantom_referent_no_keepalive(oop ref);
   static inline oop unknown_referent_no_keepalive(oop ref);
   static inline void clear_referent(oop ref);
+  static inline void clear_referent_raw(oop ref);
   static inline HeapWord* referent_addr_raw(oop ref);
   static inline oop next(oop ref);
   static inline void set_next(oop ref, oop value);

--- a/src/hotspot/share/classfile/javaClasses.inline.hpp
+++ b/src/hotspot/share/classfile/javaClasses.inline.hpp
@@ -152,6 +152,10 @@ oop java_lang_ref_Reference::unknown_referent_no_keepalive(oop ref) {
 }
 
 void java_lang_ref_Reference::clear_referent(oop ref) {
+  HeapAccess<ON_UNKNOWN_OOP_REF | AS_NO_KEEPALIVE>::oop_store_at(ref, _referent_offset, nullptr);
+}
+
+void java_lang_ref_Reference::clear_referent_raw(oop ref) {
   ref->obj_field_put_raw(_referent_offset, nullptr);
 }
 

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -282,7 +282,7 @@ void DiscoveredListIterator::make_referent_alive() {
 }
 
 void DiscoveredListIterator::clear_referent() {
-  java_lang_ref_Reference::clear_referent(_current_discovered);
+  java_lang_ref_Reference::clear_referent_raw(_current_discovered);
 }
 
 void DiscoveredListIterator::enqueue() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -90,7 +90,7 @@ static oop reference_referent(oop reference) {
 }
 
 static void reference_clear_referent(oop reference) {
-  java_lang_ref_Reference::clear_referent(reference);
+  java_lang_ref_Reference::clear_referent_raw(reference);
 }
 
 template <typename T>

--- a/src/hotspot/share/gc/z/zReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/z/zReferenceProcessor.cpp
@@ -72,7 +72,7 @@ static oop reference_referent(oop reference) {
 }
 
 static void reference_clear_referent(oop reference) {
-  java_lang_ref_Reference::clear_referent(reference);
+  java_lang_ref_Reference::clear_referent_raw(reference);
 }
 
 static oop* reference_discovered_addr(oop reference) {


### PR DESCRIPTION
The current java_lang_ref_Reference::clear_referent implementation performs a raw reference clear. That doesn't work well with upcoming GC algorithms. It should be made GC agnostic by going through the normal access API.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299072](https://bugs.openjdk.org/browse/JDK-8299072): java_lang_ref_Reference::clear_referent should be GC agnostic


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) - **Reviewer** ⚠️ Added manually

### Contributors
 * Axel Boldt-Christmas `<aboldtch@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11736/head:pull/11736` \
`$ git checkout pull/11736`

Update a local copy of the PR: \
`$ git checkout pull/11736` \
`$ git pull https://git.openjdk.org/jdk pull/11736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11736`

View PR using the GUI difftool: \
`$ git pr show -t 11736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11736.diff">https://git.openjdk.org/jdk/pull/11736.diff</a>

</details>
