### PR TITLE
8299061: Using lambda to optimize GraphKit::compute_stack_effects()

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1024,14 +1024,9 @@ bool GraphKit::compute_stack_effects(int& inputs, int& depth) {
   }
 
   auto rsize = [&]() {
-    BasicType rtype = T_ILLEGAL;
-    int sz = 0;
-
-    rtype = Bytecodes::result_type(code); // checkcast=P, athrow=V
-    if (rtype < T_CONFLICT)
-      sz = type2size[rtype];
-
-    return sz;
+    assert(code != Bytecodes::_illegal, "code is illegal!");
+    BasicType rtype = Bytecodes::result_type(code); // checkcast=P, athrow=V
+    return (rtype < T_CONFLICT) ? type2size[rtype] : 0;
   };
 
   switch (code) {

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1019,15 +1019,20 @@ bool GraphKit::compute_stack_effects(int& inputs, int& depth) {
     code = method()->java_code_at_bci(bci() + 1);
   }
 
-  BasicType rtype = T_ILLEGAL;
-  int       rsize = 0;
-
   if (code != Bytecodes::_illegal) {
     depth = Bytecodes::depth(code); // checkcast=0, athrow=-1
+  }
+
+  auto rsize = [&]() {
+    BasicType rtype = T_ILLEGAL;
+    int sz = 0;
+
     rtype = Bytecodes::result_type(code); // checkcast=P, athrow=V
     if (rtype < T_CONFLICT)
-      rsize = type2size[rtype];
-  }
+      sz = type2size[rtype];
+
+    return sz;
+  };
 
   switch (code) {
   case Bytecodes::_illegal:
@@ -1089,8 +1094,8 @@ bool GraphKit::compute_stack_effects(int& inputs, int& depth) {
       iter.reset_to_bci(bci());
       iter.next();
       inputs = iter.get_dimensions();
-      assert(rsize == 1, "");
-      depth = rsize - inputs;
+      assert(rsize() == 1, "");
+      depth = 1 - inputs;
     }
     break;
 
@@ -1099,8 +1104,8 @@ bool GraphKit::compute_stack_effects(int& inputs, int& depth) {
   case Bytecodes::_freturn:
   case Bytecodes::_dreturn:
   case Bytecodes::_areturn:
-    assert(rsize == -depth, "");
-    inputs = rsize;
+    assert(rsize() == -depth, "");
+    inputs = -depth;
     break;
 
   case Bytecodes::_jsr:
@@ -1111,7 +1116,7 @@ bool GraphKit::compute_stack_effects(int& inputs, int& depth) {
 
   default:
     // bytecode produces a typed result
-    inputs = rsize - depth;
+    inputs = rsize() - depth;
     assert(inputs >= 0, "");
     break;
   }


### PR DESCRIPTION
Some bytecodes donot need rsize in GraphKit::compute_stack_effects(). 
This change defines rsize as a lambda and avoid computation if it's not in use. 

We utilize CTW($openjdk/test/hotspot/jtreg/testlibrary/ctw/dist) to test this patch.
We compile 2 builtin modules: java.base and jdk.compiler(javac).

```
JAVA_OPTIONS="-XX:+CITime -XX:-TieredCompilation" ./ctw.sh modules:java.base
JAVA_OPTIONS="-XX:+CITime -XX:-TieredCompilation" ./ctw.sh modules:jdk.compiler
```
For jdk.compiler module, the average compilation speed increases from 13236 bytes/s to 13303 bytes/s, or +0.51%.
For java.base module, the average compilation speed is almost same(+0.3%)


| java.base                 | before    | after     | diff  |
|---------------------------|-----------|-----------|-------|
| C2 Compile Time(s)        | 341.218   | 339.75    |       |
| Parse Time(s)             | 125.403   | 125.034   |       |
| ratio of parse            | 36.75%    | 36.80%    |       |
| throughput(bytes/s)       | 11841.628* | 11876.831 | 0.30% |
| Average compilation speed | 11779     | 11816     | 0.31% |
| Total compiled methods    | 58148     | 58158     |       |
|                           |           |           |       |


| jdk.compiler              | before    | after     |       |
|---------------------------|-----------|-----------|-------|
| C2 Compile Time(s)        | 66.486    | 66.087    |       |
| Parse Time(s)             | 21.877    | 21.731    |       |
| ratio of parse            | 32.90%    | 32.88%    |       |
| throughput(bytes/s)       | 14342.883 | 14436.494 | 0.65% |
| Average compilation speed | 13236     | 13303     | 0.51% |
| Total compiled methods    | 13734     | 13730     |       |
|                           |           |           |       |


*Throughtput is reported from Tier4 row. It's very close to 'Average compilation speed' but not exactly same. eg. here is from java.base module.

```
before:
  Tier4 {speed: 11841.628 bytes/s; standard: 339.754 s, 4014210 bytes, 58115 methods; osr:  0.345 s, 13109 bytes, 33 methods; nmethods_size: 52147560 bytes; nmethods_code_size: 32146360 bytes}
after:
  Tier4 {speed: 11876.831 bytes/s; standard: 338.350 s, 4009949 bytes, 58126 methods; osr:  0.368 s, 12951 bytes, 32 methods; nmethods_size: 52122744 bytes; nmethods_code_size: 32124952 bytes}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299061](https://bugs.openjdk.org/browse/JDK-8299061): Using lambda to optimize GraphKit::compute_stack_effects()


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11737/head:pull/11737` \
`$ git checkout pull/11737`

Update a local copy of the PR: \
`$ git checkout pull/11737` \
`$ git pull https://git.openjdk.org/jdk pull/11737/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11737`

View PR using the GUI difftool: \
`$ git pr show -t 11737`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11737.diff">https://git.openjdk.org/jdk/pull/11737.diff</a>

</details>
