### PR TITLE
8299079: Better interface nmethod oop accesses

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1462,7 +1462,6 @@ oop nmethod::oop_at(int index) const {
   if (index == 0) {
     return NULL;
   }
-
   return NMethodAccess<AS_NO_KEEPALIVE>::oop_load(oop_addr_at(index));
 }
 
@@ -1470,7 +1469,6 @@ oop nmethod::oop_at_phantom(int index) const {
   if (index == 0) {
     return NULL;
   }
-
   return NMethodAccess<ON_PHANTOM_OOP_REF>::oop_load(oop_addr_at(index));
 }
 

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1462,14 +1462,16 @@ oop nmethod::oop_at(int index) const {
   if (index == 0) {
     return NULL;
   }
-  return NativeAccess<AS_NO_KEEPALIVE>::oop_load(oop_addr_at(index));
+
+  return NMethodAccess<AS_NO_KEEPALIVE>::oop_load(oop_addr_at(index));
 }
 
 oop nmethod::oop_at_phantom(int index) const {
   if (index == 0) {
     return NULL;
   }
-  return NativeAccess<ON_PHANTOM_OOP_REF>::oop_load(oop_addr_at(index));
+
+  return NMethodAccess<ON_PHANTOM_OOP_REF>::oop_load(oop_addr_at(index));
 }
 
 //

--- a/src/hotspot/share/oops/access.hpp
+++ b/src/hotspot/share/oops/access.hpp
@@ -285,6 +285,11 @@ class HeapAccess: public Access<IN_HEAP | decorators> {};
 template <DecoratorSet decorators = DECORATORS_NONE>
 class NativeAccess: public Access<IN_NATIVE | decorators> {};
 
+// Helper for performing accesses in nmethods. These accesses
+// may resolve an accessor on a GC barrier set
+template <DecoratorSet decorators = DECORATORS_NONE>
+class NMethodAccess: public Access<IN_NMETHOD | decorators> {};
+
 // Helper for array access.
 template <DecoratorSet decorators = DECORATORS_NONE>
 class ArrayAccess: public HeapAccess<IS_ARRAY | decorators> {
@@ -362,6 +367,7 @@ void Access<decorators>::verify_decorators() {
   const DecoratorSet location_decorators = decorators & IN_DECORATOR_MASK;
   STATIC_ASSERT(location_decorators == 0 || ( // make sure location decorators are disjoint if set
     (location_decorators ^ IN_NATIVE) == 0 ||
+    (location_decorators ^ IN_NMETHOD) == 0 ||
     (location_decorators ^ IN_HEAP) == 0
   ));
 }

--- a/src/hotspot/share/oops/access.hpp
+++ b/src/hotspot/share/oops/access.hpp
@@ -271,22 +271,22 @@ public:
 };
 
 // Helper for performing raw accesses (knows only of memory ordering
-// atomicity decorators as well as compressed oops)
+// atomicity decorators as well as compressed oops).
 template <DecoratorSet decorators = DECORATORS_NONE>
 class RawAccess: public Access<AS_RAW | decorators> {};
 
 // Helper for performing normal accesses on the heap. These accesses
-// may resolve an accessor on a GC barrier set
+// may resolve an accessor on a GC barrier set.
 template <DecoratorSet decorators = DECORATORS_NONE>
 class HeapAccess: public Access<IN_HEAP | decorators> {};
 
 // Helper for performing normal accesses in roots. These accesses
-// may resolve an accessor on a GC barrier set
+// may resolve an accessor on a GC barrier set.
 template <DecoratorSet decorators = DECORATORS_NONE>
 class NativeAccess: public Access<IN_NATIVE | decorators> {};
 
 // Helper for performing accesses in nmethods. These accesses
-// may resolve an accessor on a GC barrier set
+// may resolve an accessor on a GC barrier set.
 template <DecoratorSet decorators = DECORATORS_NONE>
 class NMethodAccess: public Access<IN_NMETHOD | decorators> {};
 

--- a/src/hotspot/share/oops/accessDecorators.hpp
+++ b/src/hotspot/share/oops/accessDecorators.hpp
@@ -172,9 +172,11 @@ const DecoratorSet ON_DECORATOR_MASK  = ON_STRONG_OOP_REF | ON_WEAK_OOP_REF |
 // * IN_HEAP: The access is performed in the heap. Many barriers such as card marking will
 //   be omitted if this decorator is not set.
 // * IN_NATIVE: The access is performed in an off-heap data structure.
+// * IN_NMETHOD: The access is performed inside of an nmethod.
 const DecoratorSet IN_HEAP            = UCONST64(1) << 18;
 const DecoratorSet IN_NATIVE          = UCONST64(1) << 19;
-const DecoratorSet IN_DECORATOR_MASK  = IN_HEAP | IN_NATIVE;
+const DecoratorSet IN_NMETHOD         = UCONST64(1) << 20;
+const DecoratorSet IN_DECORATOR_MASK  = IN_HEAP | IN_NATIVE | IN_NMETHOD;
 
 // == Boolean Flag Decorators ==
 // * IS_ARRAY: The access is performed on a heap allocated array. This is sometimes a special case
@@ -182,9 +184,9 @@ const DecoratorSet IN_DECORATOR_MASK  = IN_HEAP | IN_NATIVE;
 // * IS_DEST_UNINITIALIZED: This property can be important to e.g. SATB barriers by
 //   marking that the previous value is uninitialized nonsense rather than a real value.
 // * IS_NOT_NULL: This property can make certain barriers faster such as compressing oops.
-const DecoratorSet IS_ARRAY              = UCONST64(1) << 20;
-const DecoratorSet IS_DEST_UNINITIALIZED = UCONST64(1) << 21;
-const DecoratorSet IS_NOT_NULL           = UCONST64(1) << 22;
+const DecoratorSet IS_ARRAY              = UCONST64(1) << 21;
+const DecoratorSet IS_DEST_UNINITIALIZED = UCONST64(1) << 22;
+const DecoratorSet IS_NOT_NULL           = UCONST64(1) << 23;
 
 // == Arraycopy Decorators ==
 // * ARRAYCOPY_CHECKCAST: This property means that the class of the objects in source
@@ -196,11 +198,11 @@ const DecoratorSet IS_NOT_NULL           = UCONST64(1) << 22;
 // * ARRAYCOPY_ARRAYOF: The copy is in the arrayof form.
 // * ARRAYCOPY_ATOMIC: The accesses have to be atomic over the size of its elements.
 // * ARRAYCOPY_ALIGNED: The accesses have to be aligned on a HeapWord.
-const DecoratorSet ARRAYCOPY_CHECKCAST            = UCONST64(1) << 23;
-const DecoratorSet ARRAYCOPY_DISJOINT             = UCONST64(1) << 24;
-const DecoratorSet ARRAYCOPY_ARRAYOF              = UCONST64(1) << 25;
-const DecoratorSet ARRAYCOPY_ATOMIC               = UCONST64(1) << 26;
-const DecoratorSet ARRAYCOPY_ALIGNED              = UCONST64(1) << 27;
+const DecoratorSet ARRAYCOPY_CHECKCAST            = UCONST64(1) << 24;
+const DecoratorSet ARRAYCOPY_DISJOINT             = UCONST64(1) << 25;
+const DecoratorSet ARRAYCOPY_ARRAYOF              = UCONST64(1) << 26;
+const DecoratorSet ARRAYCOPY_ATOMIC               = UCONST64(1) << 27;
+const DecoratorSet ARRAYCOPY_ALIGNED              = UCONST64(1) << 28;
 const DecoratorSet ARRAYCOPY_DECORATOR_MASK       = ARRAYCOPY_CHECKCAST | ARRAYCOPY_DISJOINT |
                                                     ARRAYCOPY_DISJOINT | ARRAYCOPY_ARRAYOF |
                                                     ARRAYCOPY_ATOMIC | ARRAYCOPY_ALIGNED;
@@ -209,11 +211,11 @@ const DecoratorSet ARRAYCOPY_DECORATOR_MASK       = ARRAYCOPY_CHECKCAST | ARRAYC
 // * ACCESS_READ: Indicate that the resolved object is accessed read-only. This allows the GC
 //   backend to use weaker and more efficient barriers.
 // * ACCESS_WRITE: Indicate that the resolved object is used for write access.
-const DecoratorSet ACCESS_READ                    = UCONST64(1) << 28;
-const DecoratorSet ACCESS_WRITE                   = UCONST64(1) << 29;
+const DecoratorSet ACCESS_READ                    = UCONST64(1) << 29;
+const DecoratorSet ACCESS_WRITE                   = UCONST64(1) << 30;
 
 // Keep track of the last decorator.
-const DecoratorSet DECORATOR_LAST = UCONST64(1) << 29;
+const DecoratorSet DECORATOR_LAST = UCONST64(1) << 30;
 
 namespace AccessInternal {
   // This class adds implied decorators that follow according to decorator rules.


### PR DESCRIPTION
Today when oops are read from nmethods, we use the same interfacing that we would use to read any other IN_NATIVE oops. That isn't enough for generational ZGC. The nmethod oops are rather different from other IN_NATIVE oops in that they are encoded in the machine code as direct pointers. Normally, IN_NATIVE oops with generational ZGC are not direct pointers, but are colored pointered that can be converted to direct pointers by going through a load barrier. For nmethod oops, that conversion requires external knowledge from the surrounding nmethod. I propose a new NMethodAccess to interface better with the GC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299079](https://bugs.openjdk.org/browse/JDK-8299079): Better interface nmethod oop accesses


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [f9577ba8](https://git.openjdk.org/jdk/pull/11738/files/f9577ba89b8a7bc37ea8d7e5193a3b6d2f035ade)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [f9577ba8](https://git.openjdk.org/jdk/pull/11738/files/f9577ba89b8a7bc37ea8d7e5193a3b6d2f035ade)


### Contributors
 * Axel Boldt-Christmas `<aboldtch@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11738/head:pull/11738` \
`$ git checkout pull/11738`

Update a local copy of the PR: \
`$ git checkout pull/11738` \
`$ git pull https://git.openjdk.org/jdk pull/11738/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11738`

View PR using the GUI difftool: \
`$ git pr show -t 11738`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11738.diff">https://git.openjdk.org/jdk/pull/11738.diff</a>

</details>
