### PR TITLE
8299089: Instrument global jni handles with tag to make them distinguishable

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
@@ -122,8 +122,8 @@ void BarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet decorators
 void BarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler* masm, Register jni_env,
                                                         Register obj, Register tmp, Label& slowpath) {
   // If mask changes we need to ensure that the inverse is still encodable as an immediate
-  STATIC_ASSERT(JNIHandles::weak_tag_mask == 1);
-  __ andr(obj, obj, ~JNIHandles::weak_tag_mask);
+  STATIC_ASSERT(JNIHandles::tag_mask == 0b11);
+  __ andr(obj, obj, ~JNIHandles::tag_mask);
   __ ldr(obj, Address(obj, 0));             // *obj
 }
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -2457,22 +2457,56 @@ void MacroAssembler::verify_heapbase(const char* msg) {
 #endif
 
 void MacroAssembler::resolve_jobject(Register value, Register tmp1, Register tmp2) {
-  Label done, not_weak;
+  assert_different_registers(value, tmp1, tmp2);
+  Label done, tagged, weak_tagged;
+
   cbz(value, done);           // Use NULL as-is.
+  tst(value, JNIHandles::tag_mask); // Test for tag.
+  br(Assembler::NE, tagged);
 
-  STATIC_ASSERT(JNIHandles::weak_tag_mask == 1u);
-  tbz(value, 0, not_weak);    // Test for jweak tag.
-
-  // Resolve jweak.
-  access_load_at(T_OBJECT, IN_NATIVE | ON_PHANTOM_OOP_REF, value,
-                 Address(value, -JNIHandles::weak_tag_value), tmp1, tmp2);
+  // Resolve local handle
+  access_load_at(T_OBJECT, IN_NATIVE | AS_RAW, value, Address(value, 0), tmp1, tmp2);
   verify_oop(value);
   b(done);
 
-  bind(not_weak);
-  // Resolve (untagged) jobject.
-  access_load_at(T_OBJECT, IN_NATIVE, value, Address(value, 0), tmp1, tmp2);
+  bind(tagged);
+  STATIC_ASSERT(JNIHandles::weak_tag_mask == 0b1);
+  tbnz(value, 0, weak_tagged);    // Test for weak tag.
+
+  // Resolve global handle
+  access_load_at(T_OBJECT, IN_NATIVE, value, Address(value, -JNIHandles::global_tag_value), tmp1, tmp2);
   verify_oop(value);
+  b(done);
+
+  bind(weak_tagged);
+  // Resolve jweak.
+  access_load_at(T_OBJECT, IN_NATIVE | ON_PHANTOM_OOP_REF,
+                 value, Address(value, -JNIHandles::weak_tag_value), tmp1, tmp2);
+  verify_oop(value);
+
+  bind(done);
+}
+
+void MacroAssembler::resolve_global_jobject(Register value, Register tmp1, Register tmp2) {
+  assert_different_registers(value, tmp1, tmp2);
+  Label done;
+
+  cbz(value, done);           // Use NULL as-is.
+
+#ifdef ASSERT
+  {
+    STATIC_ASSERT(JNIHandles::global_tag_value == 0b10);
+    Label valid_global_tag;
+    tbnz(value, 1, valid_global_tag); // Test for global tag
+    stop("non global jobject using resolve_global_jobject");
+    bind(valid_global_tag);
+  }
+#endif
+
+  // Resolve global handle
+  access_load_at(T_OBJECT, IN_NATIVE, value, Address(value, -JNIHandles::global_tag_value), tmp1, tmp2);
+  verify_oop(value);
+
   bind(done);
 }
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -2470,18 +2470,18 @@ void MacroAssembler::resolve_jobject(Register value, Register tmp1, Register tmp
   b(done);
 
   bind(tagged);
-  STATIC_ASSERT(JNIHandles::weak_tag_mask == 0b1);
+  STATIC_ASSERT(JNIHandles::TypeTag::weak == 0b1);
   tbnz(value, 0, weak_tagged);    // Test for weak tag.
 
   // Resolve global handle
-  access_load_at(T_OBJECT, IN_NATIVE, value, Address(value, -JNIHandles::global_tag_value), tmp1, tmp2);
+  access_load_at(T_OBJECT, IN_NATIVE, value, Address(value, -JNIHandles::TypeTag::global), tmp1, tmp2);
   verify_oop(value);
   b(done);
 
   bind(weak_tagged);
   // Resolve jweak.
   access_load_at(T_OBJECT, IN_NATIVE | ON_PHANTOM_OOP_REF,
-                 value, Address(value, -JNIHandles::weak_tag_value), tmp1, tmp2);
+                 value, Address(value, -JNIHandles::TypeTag::weak), tmp1, tmp2);
   verify_oop(value);
 
   bind(done);
@@ -2495,7 +2495,7 @@ void MacroAssembler::resolve_global_jobject(Register value, Register tmp1, Regis
 
 #ifdef ASSERT
   {
-    STATIC_ASSERT(JNIHandles::global_tag_value == 0b10);
+    STATIC_ASSERT(JNIHandles::TypeTag::global == 0b10);
     Label valid_global_tag;
     tbnz(value, 1, valid_global_tag); // Test for global tag
     stop("non global jobject using resolve_global_jobject");
@@ -2504,7 +2504,7 @@ void MacroAssembler::resolve_global_jobject(Register value, Register tmp1, Regis
 #endif
 
   // Resolve global handle
-  access_load_at(T_OBJECT, IN_NATIVE, value, Address(value, -JNIHandles::global_tag_value), tmp1, tmp2);
+  access_load_at(T_OBJECT, IN_NATIVE, value, Address(value, -JNIHandles::TypeTag::global), tmp1, tmp2);
   verify_oop(value);
 
   bind(done);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2021, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -2470,7 +2470,7 @@ void MacroAssembler::resolve_jobject(Register value, Register tmp1, Register tmp
   b(done);
 
   bind(tagged);
-  STATIC_ASSERT(JNIHandles::TypeTag::weak == 0b1);
+  STATIC_ASSERT(JNIHandles::TypeTag::weak_global == 0b1);
   tbnz(value, 0, weak_tagged);    // Test for weak tag.
 
   // Resolve global handle
@@ -2481,7 +2481,7 @@ void MacroAssembler::resolve_jobject(Register value, Register tmp1, Register tmp
   bind(weak_tagged);
   // Resolve jweak.
   access_load_at(T_OBJECT, IN_NATIVE | ON_PHANTOM_OOP_REF,
-                 value, Address(value, -JNIHandles::TypeTag::weak), tmp1, tmp2);
+                 value, Address(value, -JNIHandles::TypeTag::weak_global), tmp1, tmp2);
   verify_oop(value);
 
   bind(done);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -823,6 +823,7 @@ public:
   void store_check(Register obj, Address dst);   // same as above, dst is exact store location (reg. is destroyed)
 
   void resolve_jobject(Register value, Register tmp1, Register tmp2);
+  void resolve_global_jobject(Register value, Register tmp1, Register tmp2);
 
   // C 'boolean' to Java boolean: x == 0 ? 0 : 1
   void c2bool(Register x);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2021, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2022, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -6920,12 +6920,7 @@ class StubGenerator: public StubCodeGenerator {
   // The handle is dereferenced through a load barrier.
   static void jfr_epilogue(MacroAssembler* _masm) {
     __ reset_last_Java_frame(true);
-    Label null_jobject;
-    __ cbz(r0, null_jobject);
-    DecoratorSet decorators = ACCESS_READ | IN_NATIVE;
-    BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-    bs->load_at(_masm, decorators, T_OBJECT, r0, Address(r0, 0), rscratch1, rscratch2);
-    __ bind(null_jobject);
+    __ resolve_global_jobject(r0, rscratch1, rscratch2);
   }
 
   // For c2: c_rarg0 is junk, call to runtime to write a checkpoint.
@@ -6940,7 +6935,7 @@ class StubGenerator: public StubCodeGenerator {
       framesize // inclusive of return address
     };
 
-    int insts_size = 512;
+    int insts_size = 1024;
     int locs_size = 64;
     CodeBuffer code("jfr_write_checkpoint", insts_size, locs_size);
     OopMapSet* oop_maps = new OopMapSet();

--- a/src/hotspot/cpu/arm/jniFastGetField_arm.cpp
+++ b/src/hotspot/cpu/arm/jniFastGetField_arm.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/arm/jniFastGetField_arm.cpp
+++ b/src/hotspot/cpu/arm/jniFastGetField_arm.cpp
@@ -113,7 +113,7 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
   __ ldr_s32(Rsafept_cnt, Address(Rsafepoint_counter_addr));
   __ tbnz(Rsafept_cnt, 0, slow_case);
 
-  __ bic(R1, R1, JNIHandles::weak_tag_mask);
+  __ bic(R1, R1, JNIHandles::tag_mask);
 
   if (JvmtiExport::can_post_field_access()) {
     // Using barrier to order wrt. JVMTI check and load of result.

--- a/src/hotspot/cpu/arm/macroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/macroAssembler_arm.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/arm/macroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/macroAssembler_arm.cpp
@@ -1284,20 +1284,57 @@ void MacroAssembler::resolve_jobject(Register value,
                                      Register tmp1,
                                      Register tmp2) {
   assert_different_registers(value, tmp1, tmp2);
-  Label done, not_weak;
-  cbz(value, done);             // Use NULL as-is.
-  STATIC_ASSERT(JNIHandles::weak_tag_mask == 1u);
-  tbz(value, 0, not_weak);      // Test for jweak tag.
+  Label done, tagged, weak_tagged;
 
+  cbz(value, done);           // Use NULL as-is.
+  tst(value, JNIHandles::tag_mask); // Test for tag.
+  b(tagged, ne);
+
+  // Resolve local handle
+  access_load_at(T_OBJECT, IN_NATIVE | AS_RAW, Address(value, 0), value, tmp1, tmp2, noreg);
+  verify_oop(value);
+  b(done);
+
+  bind(tagged);
+  tst(value, JNIHandles::weak_tag_mask); // Test for weak tag.
+  b(weak_tagged, ne);
+
+  // Resolve global handle
+  access_load_at(T_OBJECT, IN_NATIVE, Address(value, -JNIHandles::global_tag_value), value, tmp1, tmp2, noreg);
+  verify_oop(value);
+  b(done);
+
+  bind(weak_tagged);
   // Resolve jweak.
   access_load_at(T_OBJECT, IN_NATIVE | ON_PHANTOM_OOP_REF,
                  Address(value, -JNIHandles::weak_tag_value), value, tmp1, tmp2, noreg);
-  b(done);
-  bind(not_weak);
-  // Resolve (untagged) jobject.
-  access_load_at(T_OBJECT, IN_NATIVE,
-                 Address(value, 0), value, tmp1, tmp2, noreg);
   verify_oop(value);
+
+  bind(done);
+}
+
+void MacroAssembler::resolve_global_jobject(Register value,
+                                     Register tmp1,
+                                     Register tmp2) {
+  assert_different_registers(value, tmp1, tmp2);
+  Label done;
+
+  cbz(value, done);           // Use NULL as-is.
+
+#ifdef ASSERT
+  {
+    Label valid_global_tag;
+    tst(value, JNIHandles::global_tag_value); // Test for global tag.
+    b(valid_global_tag, ne);
+    stop("non global jobject using resolve_global_jobject");
+    bind(valid_global_tag);
+  }
+#endif
+
+  // Resolve global handle
+  access_load_at(T_OBJECT, IN_NATIVE, Address(value, -JNIHandles::global_tag_value), value, tmp1, tmp2, noreg);
+  verify_oop(value);
+
   bind(done);
 }
 

--- a/src/hotspot/cpu/arm/macroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/macroAssembler_arm.cpp
@@ -1296,18 +1296,18 @@ void MacroAssembler::resolve_jobject(Register value,
   b(done);
 
   bind(tagged);
-  tst(value, JNIHandles::weak_tag_mask); // Test for weak tag.
+  tst(value, JNIHandles::TypeTag::weak); // Test for weak tag.
   b(weak_tagged, ne);
 
   // Resolve global handle
-  access_load_at(T_OBJECT, IN_NATIVE, Address(value, -JNIHandles::global_tag_value), value, tmp1, tmp2, noreg);
+  access_load_at(T_OBJECT, IN_NATIVE, Address(value, -JNIHandles::TypeTag::global), value, tmp1, tmp2, noreg);
   verify_oop(value);
   b(done);
 
   bind(weak_tagged);
   // Resolve jweak.
   access_load_at(T_OBJECT, IN_NATIVE | ON_PHANTOM_OOP_REF,
-                 Address(value, -JNIHandles::weak_tag_value), value, tmp1, tmp2, noreg);
+                 Address(value, -JNIHandles::TypeTag::weak), value, tmp1, tmp2, noreg);
   verify_oop(value);
 
   bind(done);
@@ -1324,7 +1324,7 @@ void MacroAssembler::resolve_global_jobject(Register value,
 #ifdef ASSERT
   {
     Label valid_global_tag;
-    tst(value, JNIHandles::global_tag_value); // Test for global tag.
+    tst(value, JNIHandles::TypeTag::global); // Test for global tag.
     b(valid_global_tag, ne);
     stop("non global jobject using resolve_global_jobject");
     bind(valid_global_tag);
@@ -1332,7 +1332,7 @@ void MacroAssembler::resolve_global_jobject(Register value,
 #endif
 
   // Resolve global handle
-  access_load_at(T_OBJECT, IN_NATIVE, Address(value, -JNIHandles::global_tag_value), value, tmp1, tmp2, noreg);
+  access_load_at(T_OBJECT, IN_NATIVE, Address(value, -JNIHandles::TypeTag::global), value, tmp1, tmp2, noreg);
   verify_oop(value);
 
   bind(done);

--- a/src/hotspot/cpu/arm/macroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/macroAssembler_arm.cpp
@@ -1296,7 +1296,7 @@ void MacroAssembler::resolve_jobject(Register value,
   b(done);
 
   bind(tagged);
-  tst(value, JNIHandles::TypeTag::weak); // Test for weak tag.
+  tst(value, JNIHandles::TypeTag::weak_global); // Test for weak tag.
   b(weak_tagged, ne);
 
   // Resolve global handle
@@ -1307,7 +1307,7 @@ void MacroAssembler::resolve_jobject(Register value,
   bind(weak_tagged);
   // Resolve jweak.
   access_load_at(T_OBJECT, IN_NATIVE | ON_PHANTOM_OOP_REF,
-                 Address(value, -JNIHandles::TypeTag::weak), value, tmp1, tmp2, noreg);
+                 Address(value, -JNIHandles::TypeTag::weak_global), value, tmp1, tmp2, noreg);
   verify_oop(value);
 
   bind(done);

--- a/src/hotspot/cpu/arm/macroAssembler_arm.hpp
+++ b/src/hotspot/cpu/arm/macroAssembler_arm.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/arm/macroAssembler_arm.hpp
+++ b/src/hotspot/cpu/arm/macroAssembler_arm.hpp
@@ -356,6 +356,7 @@ public:
   }
 
   void resolve_jobject(Register value, Register tmp1, Register tmp2);
+  void resolve_global_jobject(Register value, Register tmp1, Register tmp2);
 
   void nop() {
     mov(R0, R0);

--- a/src/hotspot/cpu/arm/stubGenerator_arm.cpp
+++ b/src/hotspot/cpu/arm/stubGenerator_arm.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/arm/stubGenerator_arm.cpp
+++ b/src/hotspot/cpu/arm/stubGenerator_arm.cpp
@@ -3005,13 +3005,7 @@ class StubGenerator: public StubCodeGenerator {
     __ reset_last_Java_frame(Rtemp);
 
     // R0 is jobject handle result, unpack and process it through a barrier.
-    Label L_null_jobject;
-    __ cbz(R0, L_null_jobject);
-
-    BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-    bs->load_at(masm, ACCESS_READ | IN_NATIVE, T_OBJECT, R0, Address(R0, 0), Rtemp, R1, R2);
-
-    __ bind(L_null_jobject);
+    __ resolve_global_jobject(R0, Rtemp, R1);
 
     __ raw_pop(R1, R2, LR);
     __ ret();

--- a/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.cpp
@@ -377,7 +377,7 @@ void G1BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value
   __ cmpdi(CCR0, value, 0);
   __ beq(CCR0, done);         // Use NULL as-is.
 
-  __ clrrdi(tmp1, value, JNIHandles::weak_tag_size);
+  __ clrrdi(tmp1, value, JNIHandles::tag_size);
   __ andi_(tmp2, value, JNIHandles::weak_tag_mask);
   __ ld(value, 0, tmp1);      // Resolve (untagged) jobject.
 

--- a/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.cpp
@@ -378,7 +378,7 @@ void G1BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value
   __ beq(CCR0, done);         // Use NULL as-is.
 
   __ clrrdi(tmp1, value, JNIHandles::tag_size);
-  __ andi_(tmp2, value, JNIHandles::TypeTag::weak);
+  __ andi_(tmp2, value, JNIHandles::TypeTag::weak_global);
   __ ld(value, 0, tmp1);      // Resolve (untagged) jobject.
 
   __ beq(CCR0, not_weak);     // Test for jweak tag.

--- a/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.cpp
@@ -378,7 +378,7 @@ void G1BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value
   __ beq(CCR0, done);         // Use NULL as-is.
 
   __ clrrdi(tmp1, value, JNIHandles::tag_size);
-  __ andi_(tmp2, value, JNIHandles::weak_tag_mask);
+  __ andi_(tmp2, value, JNIHandles::TypeTag::weak);
   __ ld(value, 0, tmp1);      // Resolve (untagged) jobject.
 
   __ beq(CCR0, not_weak);     // Test for jweak tag.

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
@@ -115,31 +115,65 @@ void BarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet decorators,
 void BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value,
                                           Register tmp1, Register tmp2,
                                           MacroAssembler::PreservationLevel preservation_level) {
-  Label done, not_weak, verify;
+  Label done, tagged, weak_tagged, verify;
   __ cmpdi(CCR0, value, 0);
   __ beq(CCR0, done);         // Use NULL as-is.
 
-  __ andi_(tmp1, value, JNIHandles::weak_tag_mask);
-  __ beq(CCR0, not_weak);     // Test for jweak tag.
+  __ andi_(tmp1, value, JNIHandles::tag_mask);
+  __ bne(CCR0, tagged);       // Test for tag.
 
-  // Resolve (untagged) jobject.
-  __ clrrdi(value, value, JNIHandles::weak_tag_size);
-  load_at(masm, IN_NATIVE | ON_PHANTOM_OOP_REF, T_OBJECT,
-          value, (intptr_t)0, value, tmp1, tmp2, preservation_level);
+  __ access_load_at(T_OBJECT, IN_NATIVE | AS_RAW, // no uncoloring
+                    value, (intptr_t)0, value, tmp1, tmp2, preservation_level);
   __ b(verify);
 
-  __ bind(not_weak);
-  load_at(masm, IN_NATIVE, T_OBJECT,
-          value, (intptr_t)0, value, tmp1, tmp2, preservation_level);
+  __ bind(tagged);
+  __ andi_(tmp1, value, JNIHandles::weak_tag_mask);
+  __ clrrdi(value, value, JNIHandles::tag_size); // Untag.
+  __ bne(CCR0, weak_tagged);   // Test for jweak tag.
+
+  __ access_load_at(T_OBJECT, IN_NATIVE,
+                    value, (intptr_t)0, value, tmp1, tmp2, preservation_level);
+  __ b(verify);
+
+  __ bind(weak_tagged);
+  __ access_load_at(T_OBJECT, IN_NATIVE | ON_PHANTOM_OOP_REF,
+                    value, (intptr_t)0, value, tmp1, tmp2, preservation_level);
 
   __ bind(verify);
   __ verify_oop(value, FILE_AND_LINE);
   __ bind(done);
 }
 
+// Generic implementation. GCs can provide an optimized one.
+void BarrierSetAssembler::resolve_global_jobject(MacroAssembler* masm, Register value,
+                                          Register tmp1, Register tmp2,
+                                          MacroAssembler::PreservationLevel preservation_level) {
+  Label done;
+
+  __ cmpdi(CCR0, value, 0);
+  __ beq(CCR0, done);         // Use NULL as-is.
+
+#ifdef ASSERT
+  {
+    Label valid_global_tag;
+    __ andi_(tmp1, value, JNIHandles::global_tag_value);
+    __ bne(CCR0, valid_global_tag);       // Test for global tag.
+    __ stop("non global jobject using resolve_global_jobject");
+    __ bind(valid_global_tag);
+  }
+#endif
+
+  __ clrrdi(value, value, JNIHandles::tag_size); // Untag.
+  __ access_load_at(T_OBJECT, IN_NATIVE,
+                    value, (intptr_t)0, value, tmp1, tmp2, preservation_level);
+  __ verify_oop(value, FILE_AND_LINE);
+
+  __ bind(done);
+}
+
 void BarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler* masm, Register dst, Register jni_env,
                                                         Register obj, Register tmp, Label& slowpath) {
-  __ clrrdi(dst, obj, JNIHandles::weak_tag_size);
+  __ clrrdi(dst, obj, JNIHandles::tag_size);
   __ ld(dst, 0, dst);         // Resolve (untagged) jobject.
 }
 

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
@@ -127,7 +127,7 @@ void BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value,
   __ b(verify);
 
   __ bind(tagged);
-  __ andi_(tmp1, value, JNIHandles::weak_tag_mask);
+  __ andi_(tmp1, value, JNIHandles::TypeTag::weak);
   __ clrrdi(value, value, JNIHandles::tag_size); // Untag.
   __ bne(CCR0, weak_tagged);   // Test for jweak tag.
 
@@ -156,7 +156,7 @@ void BarrierSetAssembler::resolve_global_jobject(MacroAssembler* masm, Register 
 #ifdef ASSERT
   {
     Label valid_global_tag;
-    __ andi_(tmp1, value, JNIHandles::global_tag_value);
+    __ andi_(tmp1, value, JNIHandles::TypeTag::global);
     __ bne(CCR0, valid_global_tag);       // Test for global tag.
     __ stop("non global jobject using resolve_global_jobject");
     __ bind(valid_global_tag);

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
@@ -127,7 +127,7 @@ void BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value,
   __ b(verify);
 
   __ bind(tagged);
-  __ andi_(tmp1, value, JNIHandles::TypeTag::weak);
+  __ andi_(tmp1, value, JNIHandles::TypeTag::weak_global);
   __ clrrdi(value, value, JNIHandles::tag_size); // Untag.
   __ bne(CCR0, weak_tagged);   // Test for jweak tag.
 

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.hpp
@@ -56,6 +56,9 @@ public:
   virtual void resolve_jobject(MacroAssembler* masm, Register value,
                                Register tmp1, Register tmp2,
                                MacroAssembler::PreservationLevel preservation_level);
+  virtual void resolve_global_jobject(MacroAssembler* masm, Register value,
+                                      Register tmp1, Register tmp2,
+                                      MacroAssembler::PreservationLevel preservation_level);
 
   virtual void try_resolve_jobject_in_native(MacroAssembler* masm, Register dst, Register jni_env,
                                              Register obj, Register tmp, Label& slowpath);

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/ppc/gc/shared/modRefBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/modRefBarrierSetAssembler_ppc.cpp
@@ -84,7 +84,7 @@ void ModRefBarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register v
   __ cmpdi(CCR0, value, 0);
   __ beq(CCR0, done);         // Use NULL as-is.
 
-  __ clrrdi(tmp1, value, JNIHandles::weak_tag_size);
+  __ clrrdi(tmp1, value, JNIHandles::tag_size);
   __ ld(value, 0, tmp1);      // Resolve (untagged) jobject.
 
   __ verify_oop(value, FILE_AND_LINE);

--- a/src/hotspot/cpu/ppc/gc/shared/modRefBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/modRefBarrierSetAssembler_ppc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -2891,6 +2891,12 @@ void MacroAssembler::resolve_jobject(Register value, Register tmp1, Register tmp
   bs->resolve_jobject(this, value, tmp1, tmp2, preservation_level);
 }
 
+void MacroAssembler::resolve_global_jobject(Register value, Register tmp1, Register tmp2,
+                                     MacroAssembler::PreservationLevel preservation_level) {
+  BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
+  bs->resolve_global_jobject(this, value, tmp1, tmp2, preservation_level);
+}
+
 // Values for last_Java_pc, and last_Java_sp must comply to the rules
 // in frame_ppc.hpp.
 void MacroAssembler::set_last_Java_frame(Register last_Java_sp, Register last_Java_pc) {

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -661,6 +661,8 @@ class MacroAssembler: public Assembler {
 
   void resolve_jobject(Register value, Register tmp1, Register tmp2,
                        MacroAssembler::PreservationLevel preservation_level);
+  void resolve_global_jobject(Register value, Register tmp1, Register tmp2,
+                              MacroAssembler::PreservationLevel preservation_level);
 
   // Support for managing the JavaThread pointer (i.e.; the reference to
   // thread-local information).
@@ -698,7 +700,6 @@ class MacroAssembler: public Assembler {
 
   // Access heap oop, handle encoding and GC barriers.
   // Some GC barriers call C so use needs_frame = true if an extra frame is needed at the current call site.
- private:
   inline void access_store_at(BasicType type, DecoratorSet decorators,
                               Register base, RegisterOrConstant ind_or_offs, Register val,
                               Register tmp1, Register tmp2, Register tmp3,

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -4628,13 +4628,7 @@ class StubGenerator: public StubCodeGenerator {
     address calls_return_pc = __ last_calls_return_pc();
     __ reset_last_Java_frame();
     // The handle is dereferenced through a load barrier.
-    Label null_jobject;
-    __ cmpdi(CCR0, R3_RET, 0);
-    __ beq(CCR0, null_jobject);
-    DecoratorSet decorators = ACCESS_READ | IN_NATIVE;
-    BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-    bs->load_at(_masm, decorators, T_OBJECT, R3_RET /*base*/, (intptr_t)0, R3_RET /*dst*/, tmp1, tmp2, MacroAssembler::PRESERVATION_NONE);
-    __ bind(null_jobject);
+    __ resolve_global_jobject(R3_RET, tmp1, tmp2, MacroAssembler::PRESERVATION_NONE);
     __ pop_frame();
     __ ld(tmp1, _abi0(lr), R1_SP);
     __ mtlr(tmp1);

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
@@ -122,8 +122,8 @@ void BarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet decorators
 void BarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler* masm, Register jni_env,
                                                         Register obj, Register tmp, Label& slowpath) {
   // If mask changes we need to ensure that the inverse is still encodable as an immediate
-  STATIC_ASSERT(JNIHandles::weak_tag_mask == 1);
-  __ andi(obj, obj, ~JNIHandles::weak_tag_mask);
+  STATIC_ASSERT(JNIHandles::tag_mask == 3);
+  __ andi(obj, obj, ~JNIHandles::tag_mask);
   __ ld(obj, Address(obj, 0));             // *obj
 }
 

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -565,7 +565,7 @@ void MacroAssembler::resolve_jobject(Register value, Register tmp1, Register tmp
 
   bind(tagged);
   // Test for jweak tag.
-  andi(t0, value, JNIHandles::TypeTag::weak);
+  andi(t0, value, JNIHandles::TypeTag::weak_global);
   bnez(t0, weak_tagged);
 
   // Resolve global handle
@@ -576,7 +576,7 @@ void MacroAssembler::resolve_jobject(Register value, Register tmp1, Register tmp
   bind(weak_tagged);
   // Resolve jweak.
   access_load_at(T_OBJECT, IN_NATIVE | ON_PHANTOM_OOP_REF, value,
-                 Address(value, -JNIHandles::TypeTag::weak), tmp1, tmp2);
+                 Address(value, -JNIHandles::TypeTag::weak_global), tmp1, tmp2);
   verify_oop(value);
 
   bind(done);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -550,23 +550,59 @@ void MacroAssembler::debug64(char* msg, int64_t pc, int64_t regs[])
 }
 
 void MacroAssembler::resolve_jobject(Register value, Register tmp1, Register tmp2) {
-  Label done, not_weak;
-  beqz(value, done);           // Use NULL as-is.
+  assert_different_registers(value, tmp1, tmp2);
+  Label done, tagged, weak_tagged;
 
+  beqz(value, done);           // Use NULL as-is.
+  // Test for tag.
+  andi(t0, value, JNIHandles::tag_mask);
+  bnez(t0, tagged);
+
+  // Resolve local handle
+  access_load_at(T_OBJECT, IN_NATIVE | AS_RAW, value, Address(value, 0), tmp1, tmp2);
+  verify_oop(value);
+  j(done);
+
+  bind(tagged);
   // Test for jweak tag.
   andi(t0, value, JNIHandles::weak_tag_mask);
-  beqz(t0, not_weak);
+  bnez(t0, weak_tagged);
 
+  // Resolve global handle
+  access_load_at(T_OBJECT, IN_NATIVE, value,
+                 Address(value, -JNIHandles::global_tag_value), tmp1, tmp2);
+  j(done);
+
+  bind(weak_tagged);
   // Resolve jweak.
   access_load_at(T_OBJECT, IN_NATIVE | ON_PHANTOM_OOP_REF, value,
                  Address(value, -JNIHandles::weak_tag_value), tmp1, tmp2);
   verify_oop(value);
-  j(done);
 
-  bind(not_weak);
-  // Resolve (untagged) jobject.
-  access_load_at(T_OBJECT, IN_NATIVE, value, Address(value, 0), tmp1, tmp2);
+  bind(done);
+}
+
+void MacroAssembler::resolve_global_jobject(Register value, Register tmp1, Register tmp2) {
+  assert_different_registers(value, tmp1, tmp2);
+  Label done;
+
+  beqz(value, done);           // Use NULL as-is.
+
+#ifdef ASSERT
+  {
+    Label valid_global_tag;
+    andi(t0, value, JNIHandles::global_tag_value); // Test for global tag.
+    bnez(t0, valid_global_tag);
+    stop("non global jobject using resolve_global_jobject");
+    bind(valid_global_tag);
+  }
+#endif
+
+  // Resolve global handle
+  access_load_at(T_OBJECT, IN_NATIVE, value,
+                 Address(value, -JNIHandles::global_tag_value), tmp1, tmp2);
   verify_oop(value);
+
   bind(done);
 }
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -565,18 +565,18 @@ void MacroAssembler::resolve_jobject(Register value, Register tmp1, Register tmp
 
   bind(tagged);
   // Test for jweak tag.
-  andi(t0, value, JNIHandles::weak_tag_mask);
+  andi(t0, value, JNIHandles::TypeTag::weak);
   bnez(t0, weak_tagged);
 
   // Resolve global handle
   access_load_at(T_OBJECT, IN_NATIVE, value,
-                 Address(value, -JNIHandles::global_tag_value), tmp1, tmp2);
+                 Address(value, -JNIHandles::TypeTag::global), tmp1, tmp2);
   j(done);
 
   bind(weak_tagged);
   // Resolve jweak.
   access_load_at(T_OBJECT, IN_NATIVE | ON_PHANTOM_OOP_REF, value,
-                 Address(value, -JNIHandles::weak_tag_value), tmp1, tmp2);
+                 Address(value, -JNIHandles::TypeTag::weak), tmp1, tmp2);
   verify_oop(value);
 
   bind(done);
@@ -591,7 +591,7 @@ void MacroAssembler::resolve_global_jobject(Register value, Register tmp1, Regis
 #ifdef ASSERT
   {
     Label valid_global_tag;
-    andi(t0, value, JNIHandles::global_tag_value); // Test for global tag.
+    andi(t0, value, JNIHandles::TypeTag::global); // Test for global tag.
     bnez(t0, valid_global_tag);
     stop("non global jobject using resolve_global_jobject");
     bind(valid_global_tag);
@@ -600,7 +600,7 @@ void MacroAssembler::resolve_global_jobject(Register value, Register tmp1, Regis
 
   // Resolve global handle
   access_load_at(T_OBJECT, IN_NATIVE, value,
-                 Address(value, -JNIHandles::global_tag_value), tmp1, tmp2);
+                 Address(value, -JNIHandles::TypeTag::global), tmp1, tmp2);
   verify_oop(value);
 
   bind(done);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -181,6 +181,7 @@ class MacroAssembler: public Assembler {
   void resolve_weak_handle(Register result, Register tmp1, Register tmp2);
   void resolve_oop_handle(Register result, Register tmp1, Register tmp2);
   void resolve_jobject(Register value, Register tmp1, Register tmp2);
+  void resolve_global_jobject(Register value, Register tmp1, Register tmp2);
 
   void movoop(Register dst, jobject obj);
   void mov_metadata(Register dst, Metadata* obj);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -3979,14 +3979,8 @@ class StubGenerator: public StubCodeGenerator {
 
   static void jfr_epilogue(MacroAssembler* _masm) {
     __ reset_last_Java_frame(true);
-    Label null_jobject;
-    __ beqz(x10, null_jobject);
-    DecoratorSet decorators = ACCESS_READ | IN_NATIVE;
-    BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-    bs->load_at(_masm, decorators, T_OBJECT, x10, Address(x10, 0), t0, t1);
-    __ bind(null_jobject);
+    __ resolve_global_jobject(x10, t0, t1);
   }
-
   // For c2: c_rarg0 is junk, call to runtime to write a checkpoint.
   // It returns a jobject handle to the event writer.
   // The handle is dereferenced and the return value is the event writer oop.
@@ -4012,6 +4006,7 @@ class StubGenerator: public StubCodeGenerator {
     address the_pc = __ pc();
     jfr_prologue(the_pc, _masm, xthread);
     __ call_VM_leaf(CAST_FROM_FN_PTR(address, JfrIntrinsicSupport::write_checkpoint), 1);
+
     jfr_epilogue(_masm);
     __ leave();
     __ ret();

--- a/src/hotspot/cpu/s390/gc/g1/g1BarrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/g1/g1BarrierSetAssembler_s390.cpp
@@ -397,7 +397,7 @@ void G1BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value
   __ z_ltgr(tmp1, value);
   __ z_bre(Ldone);          // Use NULL result as-is.
 
-  __ z_nill(value, ~JNIHandles::weak_tag_mask);
+  __ z_nill(value, ~JNIHandles::tag_mask);
   __ z_lg(value, 0, value); // Resolve (untagged) jobject.
 
   __ z_tmll(tmp1, JNIHandles::weak_tag_mask); // Test for jweak tag.

--- a/src/hotspot/cpu/s390/gc/g1/g1BarrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/g1/g1BarrierSetAssembler_s390.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2019 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/s390/gc/g1/g1BarrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/g1/g1BarrierSetAssembler_s390.cpp
@@ -400,7 +400,7 @@ void G1BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value
   __ z_nill(value, ~JNIHandles::tag_mask);
   __ z_lg(value, 0, value); // Resolve (untagged) jobject.
 
-  __ z_tmll(tmp1, JNIHandles::TypeTag::weak); // Test for jweak tag.
+  __ z_tmll(tmp1, JNIHandles::TypeTag::weak_global); // Test for jweak tag.
   __ z_braz(Lnot_weak);
   __ verify_oop(value, FILE_AND_LINE);
   DecoratorSet decorators = IN_NATIVE | ON_PHANTOM_OOP_REF;

--- a/src/hotspot/cpu/s390/gc/g1/g1BarrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/g1/g1BarrierSetAssembler_s390.cpp
@@ -400,7 +400,7 @@ void G1BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value
   __ z_nill(value, ~JNIHandles::tag_mask);
   __ z_lg(value, 0, value); // Resolve (untagged) jobject.
 
-  __ z_tmll(tmp1, JNIHandles::weak_tag_mask); // Test for jweak tag.
+  __ z_tmll(tmp1, JNIHandles::TypeTag::weak); // Test for jweak tag.
   __ z_braz(Lnot_weak);
   __ verify_oop(value, FILE_AND_LINE);
   DecoratorSet decorators = IN_NATIVE | ON_PHANTOM_OOP_REF;

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -110,7 +110,7 @@ void BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value, 
   __ z_ltgr(tmp1, value);
   __ z_bre(Ldone);          // Use NULL result as-is.
 
-  __ z_nill(value, ~JNIHandles::weak_tag_mask);
+  __ z_nill(value, ~JNIHandles::tag_mask);
   __ z_lg(value, 0, value); // Resolve (untagged) jobject.
 
   __ verify_oop(value, FILE_AND_LINE);
@@ -119,7 +119,7 @@ void BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value, 
 
 void BarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler* masm, Register jni_env,
                                                         Register obj, Register tmp, Label& slowpath) {
-  __ z_nill(obj, ~JNIHandles::weak_tag_mask);
+  __ z_nill(obj, ~JNIHandles::tag_mask);
   __ z_lg(obj, 0, obj); // Resolve (untagged) jobject.
 }
 

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
@@ -197,7 +197,7 @@ void BarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet decorators
 
 void BarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler* masm, Register jni_env,
                                                         Register obj, Register tmp, Label& slowpath) {
-  __ clear_jweak_tag(obj);
+  __ clear_jobject_tag(obj);
   __ movptr(obj, Address(obj, 0));
 }
 

--- a/src/hotspot/cpu/x86/jniFastGetField_x86_32.cpp
+++ b/src/hotspot/cpu/x86/jniFastGetField_x86_32.cpp
@@ -93,7 +93,7 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
                                             // rdx is data dependent on rcx.
   __ movptr(rax, Address(rsp, 3*wordSize));  // jfieldID
 
-  __ clear_jweak_tag(rdx);
+  __ clear_jobject_tag(rdx);
 
   __ movptr(rdx, Address(rdx, 0));           // *obj
   __ shrptr (rax, 2);                         // offset
@@ -214,7 +214,7 @@ address JNI_FastGetField::generate_fast_get_long_field() {
                                             // rdx is data dependent on rcx.
   __ movptr(rsi, Address(rsp, 4*wordSize));  // jfieldID
 
-  __ clear_jweak_tag(rdx);
+  __ clear_jobject_tag(rdx);
 
   __ movptr(rdx, Address(rdx, 0));           // *obj
   __ shrptr(rsi, 2);                         // offset
@@ -304,7 +304,7 @@ address JNI_FastGetField::generate_fast_get_float_field0(BasicType type) {
                                             // rdx is data dependent on rcx.
   __ movptr(rax, Address(rsp, 3*wordSize));  // jfieldID
 
-  __ clear_jweak_tag(rdx);
+  __ clear_jobject_tag(rdx);
 
   __ movptr(rdx, Address(rdx, 0));           // *obj
   __ shrptr(rax, 2);                         // offset

--- a/src/hotspot/cpu/x86/jniFastGetField_x86_32.cpp
+++ b/src/hotspot/cpu/x86/jniFastGetField_x86_32.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/jniFastGetField_x86_64.cpp
+++ b/src/hotspot/cpu/x86/jniFastGetField_x86_64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/jniFastGetField_x86_64.cpp
+++ b/src/hotspot/cpu/x86/jniFastGetField_x86_64.cpp
@@ -35,7 +35,7 @@
 
 #define __ masm->
 
-#define BUFFER_SIZE 30*wordSize
+#define BUFFER_SIZE 40*wordSize
 
 // Common register usage:
 // rax/xmm0: result

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -3896,7 +3896,7 @@ void MacroAssembler::resolve_jobject(Register value,
   jmp(done);
 
   bind(tagged);
-  testptr(value, JNIHandles::TypeTag::weak); // Test for weak tag.
+  testptr(value, JNIHandles::TypeTag::weak_global); // Test for weak tag.
   jcc(Assembler::notZero, weak_tagged);
 
   // Resolve global handle
@@ -3907,7 +3907,7 @@ void MacroAssembler::resolve_jobject(Register value,
   bind(weak_tagged);
   // Resolve jweak.
   access_load_at(T_OBJECT, IN_NATIVE | ON_PHANTOM_OOP_REF,
-                 value, Address(value, -JNIHandles::TypeTag::weak), tmp, thread);
+                 value, Address(value, -JNIHandles::TypeTag::weak_global), tmp, thread);
   verify_oop(value);
 
   bind(done);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -3896,18 +3896,18 @@ void MacroAssembler::resolve_jobject(Register value,
   jmp(done);
 
   bind(tagged);
-  testptr(value, JNIHandles::weak_tag_mask); // Test for weak tag.
+  testptr(value, JNIHandles::TypeTag::weak); // Test for weak tag.
   jcc(Assembler::notZero, weak_tagged);
 
   // Resolve global handle
-  access_load_at(T_OBJECT, IN_NATIVE, value, Address(value, -JNIHandles::global_tag_value), tmp, thread);
+  access_load_at(T_OBJECT, IN_NATIVE, value, Address(value, -JNIHandles::TypeTag::global), tmp, thread);
   verify_oop(value);
   jmp(done);
 
   bind(weak_tagged);
   // Resolve jweak.
   access_load_at(T_OBJECT, IN_NATIVE | ON_PHANTOM_OOP_REF,
-                 value, Address(value, -JNIHandles::weak_tag_value), tmp, thread);
+                 value, Address(value, -JNIHandles::TypeTag::weak), tmp, thread);
   verify_oop(value);
 
   bind(done);
@@ -3925,7 +3925,7 @@ void MacroAssembler::resolve_global_jobject(Register value,
 #ifdef ASSERT
   {
     Label valid_global_tag;
-    testptr(value, JNIHandles::global_tag_value); // Test for global tag.
+    testptr(value, JNIHandles::TypeTag::global); // Test for global tag.
     jcc(Assembler::notZero, valid_global_tag);
     stop("non global jobject using resolve_global_jobject");
     bind(valid_global_tag);
@@ -3933,7 +3933,7 @@ void MacroAssembler::resolve_global_jobject(Register value,
 #endif
 
   // Resolve global handle
-  access_load_at(T_OBJECT, IN_NATIVE, value, Address(value, -JNIHandles::global_tag_value), tmp, thread);
+  access_load_at(T_OBJECT, IN_NATIVE, value, Address(value, -JNIHandles::TypeTag::global), tmp, thread);
   verify_oop(value);
 
   bind(done);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -3873,31 +3873,69 @@ void MacroAssembler::vpermd(XMMRegister dst,  XMMRegister nds, AddressLiteral sr
   }
 }
 
-void MacroAssembler::clear_jweak_tag(Register possibly_jweak) {
-  const int32_t inverted_jweak_mask = ~static_cast<int32_t>(JNIHandles::weak_tag_mask);
-  STATIC_ASSERT(inverted_jweak_mask == -2); // otherwise check this code
+void MacroAssembler::clear_jobject_tag(Register possibly_non_local) {
+  const int32_t inverted_mask = ~static_cast<int32_t>(JNIHandles::tag_mask);
+  STATIC_ASSERT(inverted_mask == -4); // otherwise check this code
   // The inverted mask is sign-extended
-  andptr(possibly_jweak, inverted_jweak_mask);
+  andptr(possibly_non_local, inverted_mask);
 }
 
 void MacroAssembler::resolve_jobject(Register value,
                                      Register thread,
                                      Register tmp) {
   assert_different_registers(value, thread, tmp);
-  Label done, not_weak;
+  Label done, tagged, weak_tagged;
   testptr(value, value);
-  jcc(Assembler::zero, done);                // Use NULL as-is.
-  testptr(value, JNIHandles::weak_tag_mask); // Test for jweak tag.
-  jcc(Assembler::zero, not_weak);
+  jcc(Assembler::zero, done);           // Use NULL as-is.
+  testptr(value, JNIHandles::tag_mask); // Test for tag.
+  jcc(Assembler::notZero, tagged);
+
+  // Resolve local handle
+  access_load_at(T_OBJECT, IN_NATIVE | AS_RAW, value, Address(value, 0), tmp, thread);
+  verify_oop(value);
+  jmp(done);
+
+  bind(tagged);
+  testptr(value, JNIHandles::weak_tag_mask); // Test for weak tag.
+  jcc(Assembler::notZero, weak_tagged);
+
+  // Resolve global handle
+  access_load_at(T_OBJECT, IN_NATIVE, value, Address(value, -JNIHandles::global_tag_value), tmp, thread);
+  verify_oop(value);
+  jmp(done);
+
+  bind(weak_tagged);
   // Resolve jweak.
   access_load_at(T_OBJECT, IN_NATIVE | ON_PHANTOM_OOP_REF,
                  value, Address(value, -JNIHandles::weak_tag_value), tmp, thread);
   verify_oop(value);
-  jmp(done);
-  bind(not_weak);
-  // Resolve (untagged) jobject.
-  access_load_at(T_OBJECT, IN_NATIVE, value, Address(value, 0), tmp, thread);
+
+  bind(done);
+}
+
+void MacroAssembler::resolve_global_jobject(Register value,
+                                            Register thread,
+                                            Register tmp) {
+  assert_different_registers(value, thread, tmp);
+  Label done;
+
+  testptr(value, value);
+  jcc(Assembler::zero, done);           // Use NULL as-is.
+
+#ifdef ASSERT
+  {
+    Label valid_global_tag;
+    testptr(value, JNIHandles::global_tag_value); // Test for global tag.
+    jcc(Assembler::notZero, valid_global_tag);
+    stop("non global jobject using resolve_global_jobject");
+    bind(valid_global_tag);
+  }
+#endif
+
+  // Resolve global handle
+  access_load_at(T_OBJECT, IN_NATIVE, value, Address(value, -JNIHandles::global_tag_value), tmp, thread);
   verify_oop(value);
+
   bind(done);
 }
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -326,8 +326,9 @@ class MacroAssembler: public Assembler {
   void reset_last_Java_frame(bool clear_fp);
 
   // jobjects
-  void clear_jweak_tag(Register possibly_jweak);
+  void clear_jobject_tag(Register possibly_non_local);
   void resolve_jobject(Register value, Register thread, Register tmp);
+  void resolve_global_jobject(Register value, Register thread, Register tmp);
 
   // C 'boolean' to Java boolean: x == 0 ? 0 : 1
   void c2bool(Register x);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
@@ -4011,13 +4011,7 @@ class StubGenerator: public StubCodeGenerator {
     Register java_thread = rdi;
     __ get_thread(java_thread);
     __ reset_last_Java_frame(java_thread, true);
-    Label null_jobject;
-    __ testptr(rax, rax);
-    __ jcc(Assembler::zero, null_jobject);
-    DecoratorSet decorators = ACCESS_READ | IN_NATIVE;
-    BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-    bs->load_at(masm, decorators, T_OBJECT, rax, Address(rax, 0), noreg, java_thread);
-    __ bind(null_jobject);
+    __ resolve_global_jobject(rax, java_thread, rdx);
   }
 
   // For c2: c_rarg0 is junk, call to runtime to write a checkpoint.
@@ -4036,7 +4030,7 @@ class StubGenerator: public StubCodeGenerator {
       framesize
     };
 
-    int insts_size = 512;
+    int insts_size = 1024;
     int locs_size = 64;
     CodeBuffer code("jfr_write_checkpoint", insts_size, locs_size);
     OopMapSet* oop_maps = new OopMapSet();

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -3504,7 +3504,7 @@ RuntimeStub* StubGenerator::generate_jfr_write_checkpoint() {
     framesize // inclusive of return address
   };
 
-  CodeBuffer code("jfr_write_checkpoint", 512, 64);
+  CodeBuffer code("jfr_write_checkpoint", 1024, 64);
   MacroAssembler* _masm = new MacroAssembler(&code);
   address start = __ pc();
 
@@ -3519,14 +3519,7 @@ RuntimeStub* StubGenerator::generate_jfr_write_checkpoint() {
   __ reset_last_Java_frame(true);
 
   // rax is jobject handle result, unpack and process it through a barrier.
-  Label L_null_jobject;
-  __ testptr(rax, rax);
-  __ jcc(Assembler::zero, L_null_jobject);
-
-  BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-  bs->load_at(_masm, ACCESS_READ | IN_NATIVE, T_OBJECT, rax, Address(rax, 0), c_rarg0, r15_thread);
-
-  __ bind(L_null_jobject);
+  __ resolve_global_jobject(rax, r15_thread, c_rarg0);
 
   __ leave();
   __ ret(0);

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1113,7 +1113,8 @@ void nmethod::fix_oop_relocations(address begin, address end, bool initialize_im
       oop_Relocation* reloc = iter.oop_reloc();
       if (initialize_immediates && reloc->oop_is_immediate()) {
         oop* dest = reloc->oop_addr();
-        initialize_immediate_oop(dest, cast_from_oop<jobject>(*dest));
+        jobject obj = *reinterpret_cast<jobject*>(dest);
+        initialize_immediate_oop(dest, obj);
       }
       // Refresh the oop-related bits of this instruction.
       reloc->fix_oop_relocation();

--- a/src/hotspot/share/compiler/compileTask.cpp
+++ b/src/hotspot/share/compiler/compileTask.cpp
@@ -176,7 +176,7 @@ void CompileTask::mark_on_stack() {
 }
 
 bool CompileTask::is_unloaded() const {
-  return _method_holder != NULL && JNIHandles::is_weak_global_handle(_method_holder) && JNIHandles::is_global_weak_cleared(_method_holder);
+  return _method_holder != NULL && JNIHandles::is_weak_global_handle(_method_holder) && JNIHandles::is_weak_global_cleared(_method_holder);
 }
 
 // RedefineClasses support

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -3122,7 +3122,7 @@ bool LibraryCallKit::inline_native_getEventWriter() {
   ciInstanceKlass* const instklass_EventWriter = klass_EventWriter->as_instance_klass();
   const TypeKlassPtr* const aklass = TypeKlassPtr::make(instklass_EventWriter);
   const TypeOopPtr* const xtype = aklass->as_instance_type();
-  Node* jobj_untagged = _gvn.transform(new AddPNode(top(), jobj, _gvn.MakeConX(-JNIHandles::global_tag_value)));
+  Node* jobj_untagged = _gvn.transform(new AddPNode(top(), jobj, _gvn.MakeConX(-JNIHandles::TypeTag::global)));
   Node* event_writer = access_load(jobj_untagged, xtype, T_OBJECT, IN_NATIVE | C2_CONTROL_DEPENDENT_LOAD);
 
   // Load the current thread id from the event writer object.

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -51,6 +51,7 @@
 #include "opto/rootnode.hpp"
 #include "opto/subnode.hpp"
 #include "prims/unsafe.hpp"
+#include "runtime/jniHandles.inline.hpp"
 #include "runtime/objectMonitor.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"
@@ -3121,7 +3122,8 @@ bool LibraryCallKit::inline_native_getEventWriter() {
   ciInstanceKlass* const instklass_EventWriter = klass_EventWriter->as_instance_klass();
   const TypeKlassPtr* const aklass = TypeKlassPtr::make(instklass_EventWriter);
   const TypeOopPtr* const xtype = aklass->as_instance_type();
-  Node* event_writer = access_load(jobj, xtype, T_OBJECT, IN_NATIVE | C2_CONTROL_DEPENDENT_LOAD);
+  Node* jobj_untagged = _gvn.transform(new AddPNode(top(), jobj, _gvn.MakeConX(-JNIHandles::global_tag_value)));
+  Node* event_writer = access_load(jobj_untagged, xtype, T_OBJECT, IN_NATIVE | C2_CONTROL_DEPENDENT_LOAD);
 
   // Load the current thread id from the event writer object.
   Node* const event_writer_tid = load_field_from_object(event_writer, "threadID", "J");

--- a/src/hotspot/share/runtime/jniHandles.cpp
+++ b/src/hotspot/share/runtime/jniHandles.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/jniHandles.cpp
+++ b/src/hotspot/share/runtime/jniHandles.cpp
@@ -91,9 +91,10 @@ jobject JNIHandles::make_global(Handle obj, AllocFailType alloc_failmode) {
     oop* ptr = global_handles()->allocate();
     // Return NULL on allocation failure.
     if (ptr != NULL) {
-      assert(*ptr == NULL, "invariant");
+      assert(NativeAccess<AS_NO_KEEPALIVE>::oop_load(ptr) == oop(NULL), "invariant");
       NativeAccess<>::oop_store(ptr, obj());
-      res = reinterpret_cast<jobject>(ptr);
+      char* tptr = reinterpret_cast<char*>(ptr) + global_tag_value;
+      res = reinterpret_cast<jobject>(tptr);
     } else {
       report_handle_allocation_failure(alloc_failmode, "global");
     }
@@ -112,7 +113,7 @@ jobject JNIHandles::make_weak_global(Handle obj, AllocFailType alloc_failmode) {
     oop* ptr = weak_global_handles()->allocate();
     // Return NULL on allocation failure.
     if (ptr != NULL) {
-      assert(*ptr == NULL, "invariant");
+      assert(NativeAccess<AS_NO_KEEPALIVE>::oop_load(ptr) == oop(NULL), "invariant");
       NativeAccess<ON_PHANTOM_OOP_REF>::oop_store(ptr, obj());
       char* tptr = reinterpret_cast<char*>(ptr) + weak_tag_value;
       res = reinterpret_cast<jobject>(tptr);
@@ -137,7 +138,8 @@ oop JNIHandles::resolve_external_guard(jobject handle) {
 
 bool JNIHandles::is_global_weak_cleared(jweak handle) {
   assert(handle != NULL, "precondition");
-  assert(is_jweak(handle), "not a weak handle");
+  assert(is_jweak_tagged(handle), "not a weak handle");
+  assert(!is_global_tagged(handle), "not a weak handle");
   oop* oop_ptr = jweak_ptr(handle);
   oop value = NativeAccess<ON_PHANTOM_OOP_REF | AS_NO_KEEPALIVE>::oop_load(oop_ptr);
   return value == NULL;
@@ -145,8 +147,9 @@ bool JNIHandles::is_global_weak_cleared(jweak handle) {
 
 void JNIHandles::destroy_global(jobject handle) {
   if (handle != NULL) {
-    assert(!is_jweak(handle), "wrong method for destroying jweak");
-    oop* oop_ptr = jobject_ptr(handle);
+    assert(is_global_tagged(handle), "must be global handle");
+    assert(!is_jweak_tagged(handle), "wrong method for destroying jweak");
+    oop* oop_ptr = global_ptr(handle);
     NativeAccess<>::oop_store(oop_ptr, (oop)NULL);
     global_handles()->release(oop_ptr);
   }
@@ -155,7 +158,8 @@ void JNIHandles::destroy_global(jobject handle) {
 
 void JNIHandles::destroy_weak_global(jobject handle) {
   if (handle != NULL) {
-    assert(is_jweak(handle), "JNI handle not jweak");
+    assert(is_jweak_tagged(handle), "JNI handle not jweak");
+    assert(!is_global_tagged(handle), "wrong method for destroying global");
     oop* oop_ptr = jweak_ptr(handle);
     NativeAccess<ON_PHANTOM_OOP_REF>::oop_store(oop_ptr, (oop)NULL);
     weak_global_handles()->release(oop_ptr);
@@ -184,12 +188,12 @@ inline bool is_storage_handle(const OopStorage* storage, const oop* ptr) {
 jobjectRefType JNIHandles::handle_type(JavaThread* thread, jobject handle) {
   assert(handle != NULL, "precondition");
   jobjectRefType result = JNIInvalidRefType;
-  if (is_jweak(handle)) {
+  if (is_jweak_tagged(handle)) {
     if (is_storage_handle(weak_global_handles(), jweak_ptr(handle))) {
       result = JNIWeakGlobalRefType;
     }
-  } else {
-    switch (global_handles()->allocation_status(jobject_ptr(handle))) {
+  } else if (is_global_tagged(handle)) {
+    switch (global_handles()->allocation_status(global_ptr(handle))) {
     case OopStorage::ALLOCATED_ENTRY:
       result = JNIGlobalRefType;
       break;
@@ -197,14 +201,14 @@ jobjectRefType JNIHandles::handle_type(JavaThread* thread, jobject handle) {
     case OopStorage::UNALLOCATED_ENTRY:
       break;                    // Invalid global handle
 
-    case OopStorage::INVALID_ENTRY:
-      // Not in global storage.  Might be a local handle.
-      if (is_local_handle(thread, handle) || is_frame_handle(thread, handle)) {
-        result = JNILocalRefType;
-      }
-      break;
-
     default:
+      ShouldNotReachHere();
+    }
+  } else {
+    // Not in global storage.  Might be a local handle.
+    if (is_local_handle(thread, handle) || is_frame_handle(thread, handle)) {
+      result = JNILocalRefType;
+    } else {
       ShouldNotReachHere();
     }
   }
@@ -243,13 +247,13 @@ bool JNIHandles::is_frame_handle(JavaThread* thr, jobject handle) {
 
 bool JNIHandles::is_global_handle(jobject handle) {
   assert(handle != NULL, "precondition");
-  return !is_jweak(handle) && is_storage_handle(global_handles(), jobject_ptr(handle));
+  return is_global_tagged(handle) && !is_jweak_tagged(handle) && is_storage_handle(global_handles(), global_ptr(handle));
 }
 
 
 bool JNIHandles::is_weak_global_handle(jobject handle) {
   assert(handle != NULL, "precondition");
-  return is_jweak(handle) && is_storage_handle(weak_global_handles(), jweak_ptr(handle));
+  return is_jweak_tagged(handle) && !is_global_tagged(handle) && is_storage_handle(weak_global_handles(), jweak_ptr(handle));
 }
 
 // We assume this is called at a safepoint: no lock is needed.
@@ -455,7 +459,7 @@ jobject JNIHandleBlock::allocate_handle(JavaThread* caller, oop obj, AllocFailTy
   // Try last block
   if (_last->_top < block_size_in_oops) {
     oop* handle = (oop*)&(_last->_handles)[_last->_top++];
-    NativeAccess<IS_DEST_UNINITIALIZED>::oop_store(handle, obj);
+    *handle = obj;
     return (jobject) handle;
   }
 
@@ -463,7 +467,7 @@ jobject JNIHandleBlock::allocate_handle(JavaThread* caller, oop obj, AllocFailTy
   if (_free_list != NULL) {
     oop* handle = (oop*)_free_list;
     _free_list = (uintptr_t*) untag_free_list(*_free_list);
-    NativeAccess<IS_DEST_UNINITIALIZED>::oop_store(handle, obj);
+    *handle = obj;
     return (jobject) handle;
   }
   // Check if unused block follow last

--- a/src/hotspot/share/runtime/jniHandles.cpp
+++ b/src/hotspot/share/runtime/jniHandles.cpp
@@ -66,6 +66,7 @@ jobject JNIHandles::make_local(JavaThread* thread, oop obj, AllocFailType alloc_
   } else {
     assert(oopDesc::is_oop(obj), "not an oop");
     assert(!current_thread_in_native(), "must not be in native");
+    STATIC_ASSERT(TypeTag::local == 0);
     return thread->active_handles()->allocate_handle(thread, obj, alloc_failmode);
   }
 }
@@ -138,8 +139,6 @@ oop JNIHandles::resolve_external_guard(jobject handle) {
 
 bool JNIHandles::is_global_weak_cleared(jweak handle) {
   assert(handle != NULL, "precondition");
-  assert(is_jweak_tagged(handle), "not a weak handle");
-  assert(!is_global_tagged(handle), "not a weak handle");
   oop* oop_ptr = jweak_ptr(handle);
   oop value = NativeAccess<ON_PHANTOM_OOP_REF | AS_NO_KEEPALIVE>::oop_load(oop_ptr);
   return value == NULL;
@@ -147,8 +146,6 @@ bool JNIHandles::is_global_weak_cleared(jweak handle) {
 
 void JNIHandles::destroy_global(jobject handle) {
   if (handle != NULL) {
-    assert(is_global_tagged(handle), "must be global handle");
-    assert(!is_jweak_tagged(handle), "wrong method for destroying jweak");
     oop* oop_ptr = global_ptr(handle);
     NativeAccess<>::oop_store(oop_ptr, (oop)NULL);
     global_handles()->release(oop_ptr);
@@ -158,8 +155,6 @@ void JNIHandles::destroy_global(jobject handle) {
 
 void JNIHandles::destroy_weak_global(jobject handle) {
   if (handle != NULL) {
-    assert(is_jweak_tagged(handle), "JNI handle not jweak");
-    assert(!is_global_tagged(handle), "wrong method for destroying global");
     oop* oop_ptr = jweak_ptr(handle);
     NativeAccess<ON_PHANTOM_OOP_REF>::oop_store(oop_ptr, (oop)NULL);
     weak_global_handles()->release(oop_ptr);

--- a/src/hotspot/share/runtime/jniHandles.cpp
+++ b/src/hotspot/share/runtime/jniHandles.cpp
@@ -93,7 +93,7 @@ jobject JNIHandles::make_global(Handle obj, AllocFailType alloc_failmode) {
     if (ptr != NULL) {
       assert(NativeAccess<AS_NO_KEEPALIVE>::oop_load(ptr) == oop(NULL), "invariant");
       NativeAccess<>::oop_store(ptr, obj());
-      char* tptr = reinterpret_cast<char*>(ptr) + global_tag_value;
+      char* tptr = reinterpret_cast<char*>(ptr) + TypeTag::global;
       res = reinterpret_cast<jobject>(tptr);
     } else {
       report_handle_allocation_failure(alloc_failmode, "global");
@@ -115,7 +115,7 @@ jobject JNIHandles::make_weak_global(Handle obj, AllocFailType alloc_failmode) {
     if (ptr != NULL) {
       assert(NativeAccess<AS_NO_KEEPALIVE>::oop_load(ptr) == oop(NULL), "invariant");
       NativeAccess<ON_PHANTOM_OOP_REF>::oop_store(ptr, obj());
-      char* tptr = reinterpret_cast<char*>(ptr) + weak_tag_value;
+      char* tptr = reinterpret_cast<char*>(ptr) + TypeTag::weak;
       res = reinterpret_cast<jobject>(tptr);
     } else {
       report_handle_allocation_failure(alloc_failmode, "weak global");
@@ -247,13 +247,15 @@ bool JNIHandles::is_frame_handle(JavaThread* thr, jobject handle) {
 
 bool JNIHandles::is_global_handle(jobject handle) {
   assert(handle != NULL, "precondition");
-  return is_global_tagged(handle) && !is_jweak_tagged(handle) && is_storage_handle(global_handles(), global_ptr(handle));
+  assert(!is_global_tagged(handle) || is_storage_handle(global_handles(), global_ptr(handle)), "invalid storage");
+  return is_global_tagged(handle);
 }
 
 
 bool JNIHandles::is_weak_global_handle(jobject handle) {
   assert(handle != NULL, "precondition");
-  return is_jweak_tagged(handle) && !is_global_tagged(handle) && is_storage_handle(weak_global_handles(), jweak_ptr(handle));
+  assert(!is_jweak_tagged(handle) || is_storage_handle(weak_global_handles(), jweak_ptr(handle)), "invalid storage");
+  return is_jweak_tagged(handle);
 }
 
 // We assume this is called at a safepoint: no lock is needed.

--- a/src/hotspot/share/runtime/jniHandles.hpp
+++ b/src/hotspot/share/runtime/jniHandles.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/jniHandles.hpp
+++ b/src/hotspot/share/runtime/jniHandles.hpp
@@ -45,8 +45,10 @@ class JNIHandles : AllStatic {
   static OopStorage* global_handles();
   static OopStorage* weak_global_handles();
 
-  inline static bool is_jweak(jobject handle);
-  inline static oop* jobject_ptr(jobject handle); // NOT jweak!
+  inline static bool is_jweak_tagged(jobject handle);
+  inline static bool is_global_tagged(jobject handle);
+  inline static oop* jobject_ptr(jobject handle); // NOT jweak or global!
+  inline static oop* global_ptr(jobject handle);
   inline static oop* jweak_ptr(jobject handle);
 
   template <DecoratorSet decorators, bool external_guard> inline static oop resolve_impl(jobject handle);
@@ -70,7 +72,15 @@ class JNIHandles : AllStatic {
   static const uintptr_t weak_tag_size = 1;
   static const uintptr_t weak_tag_alignment = (1u << weak_tag_size);
   static const uintptr_t weak_tag_mask = weak_tag_alignment - 1;
+  static const uintptr_t tag_size = 2;
+  static const uintptr_t tag_alignment = (1u << tag_size);
+  static const uintptr_t tag_mask = tag_alignment - 1;
   static const int weak_tag_value = 1;
+  // Low tag bit in jobject used to distinguish a global jobject.
+  // There are places where we need to be able to distinguish global
+  // values from other jobjects, and is_global_handle is unsuitable
+  // for performance reasons.
+  static const int global_tag_value = 2;
 
   // Resolve handle into oop
   inline static oop resolve(jobject handle);

--- a/src/hotspot/share/runtime/jniHandles.hpp
+++ b/src/hotspot/share/runtime/jniHandles.hpp
@@ -46,11 +46,11 @@ class JNIHandles : AllStatic {
   static OopStorage* weak_global_handles();
 
   inline static bool is_local_tagged(jobject handle);
-  inline static bool is_jweak_tagged(jobject handle);
+  inline static bool is_weak_global_tagged(jobject handle);
   inline static bool is_global_tagged(jobject handle);
-  inline static oop* jobject_ptr(jobject handle); // NOT jweak or global!
+  inline static oop* local_ptr(jobject handle);
   inline static oop* global_ptr(jobject handle);
-  inline static oop* jweak_ptr(jobject handle);
+  inline static oop* weak_global_ptr(jweak handle);
 
   template <DecoratorSet decorators, bool external_guard> inline static oop resolve_impl(jobject handle);
 
@@ -66,7 +66,7 @@ class JNIHandles : AllStatic {
   // the underlying storage type is unsuitable for performance reasons.
   enum TypeTag {
     local = 0b00,
-    weak = 0b01,
+    weak_global = 0b01,
     global = 0b10,
   };
 
@@ -78,7 +78,7 @@ public:
   static const uintptr_t tag_mask = ((1u << tag_size) - 1u);
 
   STATIC_ASSERT((TypeTag::local & tag_mask) == TypeTag::local);
-  STATIC_ASSERT((TypeTag::weak & tag_mask) == TypeTag::weak);
+  STATIC_ASSERT((TypeTag::weak_global & tag_mask) == TypeTag::weak_global);
   STATIC_ASSERT((TypeTag::global & tag_mask) == TypeTag::global);
 
   // Resolve handle into oop
@@ -103,10 +103,10 @@ public:
   static void destroy_global(jobject handle);
 
   // Weak global handles
-  static jobject make_weak_global(Handle obj,
-                                  AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
-  static void destroy_weak_global(jobject handle);
-  static bool is_global_weak_cleared(jweak handle); // Test jweak without resolution
+  static jweak make_weak_global(Handle obj,
+                                AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
+  static void destroy_weak_global(jweak handle);
+  static bool is_weak_global_cleared(jweak handle); // Test jweak without resolution
 
   // Debugging
   static void print_on(outputStream* st);

--- a/src/hotspot/share/runtime/jniHandles.inline.hpp
+++ b/src/hotspot/share/runtime/jniHandles.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/jniHandles.inline.hpp
+++ b/src/hotspot/share/runtime/jniHandles.inline.hpp
@@ -50,6 +50,7 @@ inline bool JNIHandles::is_global_tagged(jobject handle) {
 
 inline oop* JNIHandles::jobject_ptr(jobject handle) {
   assert(is_local_tagged(handle), "precondition");
+  STATIC_ASSERT(TypeTag::local == 0);
   return reinterpret_cast<oop*>(handle);
 }
 
@@ -118,8 +119,6 @@ inline oop JNIHandles::resolve_non_null(jobject handle) {
 
 inline void JNIHandles::destroy_local(jobject handle) {
   if (handle != NULL) {
-    assert(!is_jweak_tagged(handle), "Invalid JNI local handle");
-    assert(!is_global_tagged(handle), "Invalid JNI local handle");
     *jobject_ptr(handle) = NULL;
   }
 }

--- a/src/hotspot/share/runtime/jniHandles.inline.hpp
+++ b/src/hotspot/share/runtime/jniHandles.inline.hpp
@@ -32,19 +32,32 @@
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-inline bool JNIHandles::is_jweak(jobject handle) {
+inline bool JNIHandles::is_jweak_tagged(jobject handle) {
   STATIC_ASSERT(weak_tag_size == 1);
   STATIC_ASSERT(weak_tag_value == 1);
   return (reinterpret_cast<uintptr_t>(handle) & weak_tag_mask) != 0;
 }
 
+inline bool JNIHandles::is_global_tagged(jobject handle) {
+  return (reinterpret_cast<uintptr_t>(handle) & global_tag_value) == global_tag_value;
+}
+
 inline oop* JNIHandles::jobject_ptr(jobject handle) {
-  assert(!is_jweak(handle), "precondition");
+  assert(!is_jweak_tagged(handle), "precondition");
+  assert(!is_global_tagged(handle), "precondition");
   return reinterpret_cast<oop*>(handle);
 }
 
+inline oop* JNIHandles::global_ptr(jobject handle) {
+  assert(is_global_tagged(handle), "precondition");
+  assert(!is_jweak_tagged(handle), "precondition");
+  char* ptr = reinterpret_cast<char*>(handle) - global_tag_value;
+  return reinterpret_cast<oop*>(ptr);
+}
+
 inline oop* JNIHandles::jweak_ptr(jobject handle) {
-  assert(is_jweak(handle), "precondition");
+  assert(is_jweak_tagged(handle), "precondition");
+  assert(!is_global_tagged(handle), "precondition");
   char* ptr = reinterpret_cast<char*>(handle) - weak_tag_value;
   return reinterpret_cast<oop*>(ptr);
 }
@@ -55,10 +68,15 @@ inline oop JNIHandles::resolve_impl(jobject handle) {
   assert(handle != NULL, "precondition");
   assert(!current_thread_in_native(), "must not be in native");
   oop result;
-  if (is_jweak(handle)) {       // Unlikely
+  if (is_jweak_tagged(handle)) {       // Unlikely
     result = NativeAccess<ON_PHANTOM_OOP_REF|decorators>::oop_load(jweak_ptr(handle));
+  } else if (is_global_tagged(handle)) {
+    result = NativeAccess<decorators>::oop_load(global_ptr(handle));
+    // Construction of jobjects canonicalize a null value into a null
+    // jobject, so for non-jweak the pointee should never be null.
+    assert(external_guard || result != NULL, "Invalid JNI handle");
   } else {
-    result = NativeAccess<decorators>::oop_load(jobject_ptr(handle));
+    result = *jobject_ptr(handle);
     // Construction of jobjects canonicalize a null value into a null
     // jobject, so for non-jweak the pointee should never be null.
     assert(external_guard || result != NULL, "Invalid JNI handle");
@@ -97,8 +115,9 @@ inline oop JNIHandles::resolve_non_null(jobject handle) {
 
 inline void JNIHandles::destroy_local(jobject handle) {
   if (handle != NULL) {
-    assert(!is_jweak(handle), "Invalid JNI local handle");
-    NativeAccess<>::oop_store(jobject_ptr(handle), (oop)NULL);
+    assert(!is_jweak_tagged(handle), "Invalid JNI local handle");
+    assert(!is_global_tagged(handle), "Invalid JNI local handle");
+    *jobject_ptr(handle) = NULL;
   }
 }
 

--- a/test/hotspot/jtreg/runtime/jni/FastGetField/FastGetField.java
+++ b/test/hotspot/jtreg/runtime/jni/FastGetField/FastGetField.java
@@ -28,12 +28,15 @@
             with primitive type are generated.
  * @requires vm.jvmti
  * @compile FastGetField.java
- * @run main/othervm/native -agentlib:FastGetField -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyJNIFields FastGetField
- * @run main/othervm/native -agentlib:FastGetField -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyJNIFields -XX:+UnlockDiagnosticVMOptions -XX:+ForceUnreachable -XX:+SafepointALot -XX:GuaranteedSafepointInterval=1 FastGetField
+ * @run main/othervm/native -agentlib:FastGetField -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyJNIFields FastGetField 0
+ * @run main/othervm/native -agentlib:FastGetField -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyJNIFields FastGetField 1
+ * @run main/othervm/native -agentlib:FastGetField -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyJNIFields FastGetField 2
+ * @run main/othervm/native -agentlib:FastGetField -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyJNIFields -XX:+UnlockDiagnosticVMOptions -XX:+ForceUnreachable -XX:+SafepointALot -XX:GuaranteedSafepointInterval=1 FastGetField 0
+ * @run main/othervm/native -agentlib:FastGetField -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyJNIFields -XX:+UnlockDiagnosticVMOptions -XX:+ForceUnreachable -XX:+SafepointALot -XX:GuaranteedSafepointInterval=1 FastGetField 1
+ * @run main/othervm/native -agentlib:FastGetField -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyJNIFields -XX:+UnlockDiagnosticVMOptions -XX:+ForceUnreachable -XX:+SafepointALot -XX:GuaranteedSafepointInterval=1 FastGetField 2
  */
 
 import java.lang.reflect.Field;
-
 
 public class FastGetField {
 
@@ -41,7 +44,10 @@ public class FastGetField {
 
     private native boolean initFieldIDs(Class c);
     private native boolean initWatchers(Class c);
+    public native void registerGlobal(MyItem i);
+    public native void registerWeak(MyItem i);
     public native long accessFields(MyItem i);
+    public native long accessFieldsViaHandle();
     public static native long getFieldAccessCount();
 
     static final int loop_cnt = 10000;
@@ -92,16 +98,43 @@ public class FastGetField {
         }
     }
 
+    private int mode;
+    private MyItem obj;
+
+    private FastGetField(int mode) {
+        this.mode = mode;
+        this.obj = new MyItem();
+
+        if (mode == 0) {
+            // Direct
+        } else if (mode == 1) {
+            registerGlobal(this.obj);
+        } else if ( mode == 2) {
+            registerWeak(this.obj);
+        } else {
+          throw new IllegalArgumentException("Unexpected mode");
+        }
+    }
+
+    private long accessFields() {
+        if (mode == 0) {
+            return accessFields(obj);
+        }
+
+        // Otherwise through a handle
+        return accessFieldsViaHandle();
+    }
+
     public void TestFieldAccess() throws Exception {
-        MyItem i = new MyItem();
+
         if (!initFieldIDs(MyItem.class)) throw new RuntimeException("FieldID initialization failed!");
 
         long duration = System.nanoTime();
         for (int c = 0; c < loop_cnt; ++c) {
-            if (accessFields(i) != 0l) throw new RuntimeException("Wrong initial result!");
-            i.change_values();
-            if (accessFields(i) != 8l) throw new RuntimeException("Wrong result after changing!");
-            i.reset_values();
+            if (accessFields() != 0l) throw new RuntimeException("Wrong initial result!");
+            obj.change_values();
+            if (accessFields() != 8l) throw new RuntimeException("Wrong result after changing!");
+            obj.reset_values();
         }
         duration = System.nanoTime() - duration;
         System.out.println(loop_cnt + " iterations took " + duration + "ns.");
@@ -112,14 +145,20 @@ public class FastGetField {
         if (!initWatchers(MyItem.class)) throw new RuntimeException("JVMTI missing!");
 
         // Try again with watchers.
-        if (accessFields(i) != 0l) throw new RuntimeException("Wrong initial result!");
-        i.change_values();
-        if (accessFields(i) != 8l) throw new RuntimeException("Wrong result after changing!");
+        if (accessFields() != 0l) throw new RuntimeException("Wrong initial result!");
+        obj.change_values();
+        if (accessFields() != 8l) throw new RuntimeException("Wrong result after changing!");
         if (getFieldAccessCount() != 16) throw new RuntimeException("Unexpected event count!");
     }
 
     public static void main(String[] args) throws Exception {
-        FastGetField inst = new FastGetField();
+        if (args.length != 1) {
+           throw new IllegalArgumentException("Expected one argument");
+        }
+
+        int mode = Integer.parseInt(args[0]);
+
+        FastGetField inst = new FastGetField(mode);
         inst.TestFieldAccess();
     }
 }

--- a/test/hotspot/jtreg/runtime/jni/FastGetField/FastGetField.java
+++ b/test/hotspot/jtreg/runtime/jni/FastGetField/FastGetField.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019 SAP SE and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/hotspot/jtreg/runtime/jni/FastGetField/libFastGetField.c
+++ b/test/hotspot/jtreg/runtime/jni/FastGetField/libFastGetField.c
@@ -32,7 +32,7 @@ static const char* fields[] = { "Z", "B", "C", "S", "I", "J", "F", "D" };
 #define NUM_FIELDS (sizeof fields / sizeof fields[0])
 static jfieldID fieldIDs[NUM_FIELDS];
 static jlong fieldAccessCount = 0;
-
+static jobject objHandle;
 
 JNIEXPORT jboolean JNICALL Java_FastGetField_initFieldIDs(JNIEnv *env, jobject this, jclass c) {
   for (int i = 0; i < (int)NUM_FIELDS; ++i) {
@@ -63,6 +63,13 @@ JNIEXPORT jboolean JNICALL Java_FastGetField_initWatchers(JNIEnv *env, jobject t
   return JNI_TRUE;
 }
 
+JNIEXPORT void JNICALL Java_FastGetField_registerGlobal(JNIEnv *env, jobject this, jobject obj) {
+  objHandle = (*env)->NewGlobalRef(env, obj);
+}
+
+JNIEXPORT void JNICALL Java_FastGetField_registerWeak(JNIEnv *env, jobject this, jobject obj) {
+  objHandle = (*env)->NewWeakGlobalRef(env, obj);
+}
 
 JNIEXPORT jlong JNICALL Java_FastGetField_accessFields(JNIEnv *env, jobject this, jobject obj) {
   return
@@ -76,6 +83,9 @@ JNIEXPORT jlong JNICALL Java_FastGetField_accessFields(JNIEnv *env, jobject this
       (jlong)((*env)->GetDoubleField(env, obj, fieldIDs[7]));
 }
 
+JNIEXPORT jlong JNICALL Java_FastGetField_accessFieldsViaHandle(JNIEnv *env, jobject this) {
+  return Java_FastGetField_accessFields(env, this, objHandle);
+}
 
 JNIEXPORT jlong JNICALL Java_FastGetField_getFieldAccessCount(JNIEnv *env, jclass c) {
   return fieldAccessCount;

--- a/test/hotspot/jtreg/runtime/jni/FastGetField/libFastGetField.c
+++ b/test/hotspot/jtreg/runtime/jni/FastGetField/libFastGetField.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2022 SAP SE and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *


### PR DESCRIPTION
Weak global jni handles are tagged so the GC can distinguish them when resolving the object. Today there is no cheap way of distinguishing global jni handles from local jni handles. For generational ZGC the OopStorage handles and the thread local handles semantical difference requires the handles to be distinguishable. 

This enhancements instruments the jni handles with a global tag similarly to the jweak tag. 

Note: 
 * the s390 implementation has minimal changes and requires improvement.
 * There is room for enchantment here to create the same abstraction that ppc uses for all platforms, i.e. move the resolve_jobject from the MacroAssembler to the BarrierSetAssembler which allows for more optimised code for GCs that can treat local and global handles the same. 

Testing: GHA. Oracle supported platforms tier1-3. Will run higher tiers. Has also been tested on the generational branch of ZGC for over three months. Requires testing on non Oracle platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299089](https://bugs.openjdk.org/browse/JDK-8299089): Instrument global jni handles with tag to make them distinguishable


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to [3629e2e4](https://git.openjdk.org/jdk/pull/11740/files/3629e2e495aa4d8e6ee0da57cf1a7e597b63b45f)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to [3629e2e4](https://git.openjdk.org/jdk/pull/11740/files/3629e2e495aa4d8e6ee0da57cf1a7e597b63b45f)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [f4b8fde1](https://git.openjdk.org/jdk/pull/11740/files/f4b8fde1a427eaccb6494652fc8986cd23ce346f)


### Contributors
 * Stefan Karlsson `<stefank@openjdk.org>`
 * Martin Doerr `<mdoerr@openjdk.org>`
 * Leslie Zhai `<lzhai@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11740/head:pull/11740` \
`$ git checkout pull/11740`

Update a local copy of the PR: \
`$ git checkout pull/11740` \
`$ git pull https://git.openjdk.org/jdk pull/11740/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11740`

View PR using the GUI difftool: \
`$ git pr show -t 11740`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11740.diff">https://git.openjdk.org/jdk/pull/11740.diff</a>

</details>
