### PR TITLE
8299125: UnifiedOopRef in JFR leakprofiler should treat thread local oops correctly

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/chains/rootSetClosure.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/rootSetClosure.cpp
@@ -48,7 +48,7 @@ template <typename Delegate>
 void RootSetClosure<Delegate>::do_oop(oop* ref) {
   assert(ref != NULL, "invariant");
   assert(is_aligned(ref, HeapWordSize), "invariant");
-  if (*ref != NULL) {
+  if (NativeAccess<>::oop_load(ref) != nullptr) {
     _delegate->do_root(UnifiedOopRef::encode_in_native(ref));
   }
 }
@@ -65,13 +65,41 @@ void RootSetClosure<Delegate>::do_oop(narrowOop* ref) {
 class RootSetClosureMarkScope : public MarkScope {};
 
 template <typename Delegate>
+class NonBarrieredRootClosure : public OopClosure {
+  Delegate* _delegate;
+
+public:
+  NonBarrieredRootClosure(Delegate* delegate) : _delegate(delegate) {}
+
+  void do_oop(oop* ref) {
+    assert(ref != NULL, "invariant");
+    assert(is_aligned(ref, HeapWordSize), "invariant");
+    if (*ref != nullptr) {
+      _delegate->do_root(UnifiedOopRef::encode_non_barriered(ref));
+    }
+  }
+
+  void do_oop(narrowOop* ref) {
+    assert(ref != NULL, "invariant");
+    assert(is_aligned(ref, HeapWordSize), "invariant");
+    if (!CompressedOops::is_null(*ref)) {
+      _delegate->do_root(UnifiedOopRef::encode_non_barriered(ref));
+    }
+  }
+};
+
+template <typename Delegate>
 void RootSetClosure<Delegate>::process() {
   RootSetClosureMarkScope mark_scope;
+
   CLDToOopClosure cldt_closure(this, ClassLoaderData::_claim_none);
   ClassLoaderDataGraph::always_strong_cld_do(&cldt_closure);
-  // We don't follow code blob oops, because they have misaligned oops.
-  Threads::oops_do(this, NULL);
+
   OopStorageSet::strong_oops_do(this);
+
+  // We don't follow code blob oops, because they have misaligned oops.
+  NonBarrieredRootClosure<Delegate> nbrc(_delegate);
+  Threads::oops_do(&nbrc, NULL);
 }
 
 template class RootSetClosure<BFSClosure>;

--- a/src/hotspot/share/jfr/leakprofiler/utilities/unifiedOopRef.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/utilities/unifiedOopRef.hpp
@@ -29,6 +29,15 @@
 #include "utilities/globalDefinitions.hpp"
 
 struct UnifiedOopRef {
+  static const uintptr_t tag_mask          = LP64_ONLY(0b111) NOT_LP64(0b011);
+  static const uintptr_t native_tag        = 0b001;
+  static const uintptr_t non_barriered_tag = 0b010;
+  static const uintptr_t narrow_tag        = LP64_ONLY(0b100) NOT_LP64(0);
+  STATIC_ASSERT((native_tag & non_barriered_tag) == 0);
+  STATIC_ASSERT((native_tag & narrow_tag) == 0);
+  STATIC_ASSERT((non_barriered_tag & narrow_tag) == 0);
+  STATIC_ASSERT((native_tag | non_barriered_tag | narrow_tag) == tag_mask);
+
   uintptr_t _value;
 
   template <typename T>
@@ -36,14 +45,17 @@ struct UnifiedOopRef {
 
   bool is_narrow() const;
   bool is_native() const;
+  bool is_non_barriered() const;
   bool is_null() const;
 
   oop dereference() const;
 
   static UnifiedOopRef encode_in_native(const narrowOop* ref);
   static UnifiedOopRef encode_in_native(const oop* ref);
-  static UnifiedOopRef encode_in_heap(const oop* ref);
+  static UnifiedOopRef encode_non_barriered(const narrowOop* ref);
+  static UnifiedOopRef encode_non_barriered(const oop* ref);
   static UnifiedOopRef encode_in_heap(const narrowOop* ref);
+  static UnifiedOopRef encode_in_heap(const oop* ref);
   static UnifiedOopRef encode_null();
 };
 

--- a/src/hotspot/share/jfr/leakprofiler/utilities/unifiedOopRef.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/utilities/unifiedOopRef.hpp
@@ -29,14 +29,14 @@
 #include "utilities/globalDefinitions.hpp"
 
 struct UnifiedOopRef {
-  static const uintptr_t tag_mask          = LP64_ONLY(0b111) NOT_LP64(0b011);
-  static const uintptr_t native_tag        = 0b001;
-  static const uintptr_t non_barriered_tag = 0b010;
-  static const uintptr_t narrow_tag        = LP64_ONLY(0b100) NOT_LP64(0);
-  STATIC_ASSERT((native_tag & non_barriered_tag) == 0);
+  static const uintptr_t tag_mask   = LP64_ONLY(0b111) NOT_LP64(0b011);
+  static const uintptr_t native_tag = 0b001;
+  static const uintptr_t raw_tag    = 0b010;
+  static const uintptr_t narrow_tag = LP64_ONLY(0b100) NOT_LP64(0);
+  STATIC_ASSERT((native_tag & raw_tag) == 0);
   STATIC_ASSERT((native_tag & narrow_tag) == 0);
-  STATIC_ASSERT((non_barriered_tag & narrow_tag) == 0);
-  STATIC_ASSERT((native_tag | non_barriered_tag | narrow_tag) == tag_mask);
+  STATIC_ASSERT((raw_tag & narrow_tag) == 0);
+  STATIC_ASSERT((native_tag | raw_tag | narrow_tag) == tag_mask);
 
   uintptr_t _value;
 
@@ -45,15 +45,15 @@ struct UnifiedOopRef {
 
   bool is_narrow() const;
   bool is_native() const;
-  bool is_non_barriered() const;
+  bool is_raw() const;
   bool is_null() const;
 
   oop dereference() const;
 
   static UnifiedOopRef encode_in_native(const narrowOop* ref);
   static UnifiedOopRef encode_in_native(const oop* ref);
-  static UnifiedOopRef encode_non_barriered(const narrowOop* ref);
-  static UnifiedOopRef encode_non_barriered(const oop* ref);
+  static UnifiedOopRef encode_as_raw(const narrowOop* ref);
+  static UnifiedOopRef encode_as_raw(const oop* ref);
   static UnifiedOopRef encode_in_heap(const narrowOop* ref);
   static UnifiedOopRef encode_in_heap(const oop* ref);
   static UnifiedOopRef encode_null();

--- a/src/hotspot/share/jfr/leakprofiler/utilities/unifiedOopRef.inline.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/utilities/unifiedOopRef.inline.hpp
@@ -32,7 +32,7 @@
 
 template <typename T>
 inline T UnifiedOopRef::addr() const {
-  return reinterpret_cast<T>(_value & ~uintptr_t(3));
+  return reinterpret_cast<T>(UnifiedOopRef::addr<uintptr_t>());
 }
 
 // Visual Studio 2019 and earlier have a problem with reinterpret_cast
@@ -42,47 +42,60 @@ inline T UnifiedOopRef::addr() const {
 // this specialization provides a workaround.
 template<>
 inline uintptr_t UnifiedOopRef::addr<uintptr_t>() const {
-  return _value & ~uintptr_t(3);
+  return (_value & ~tag_mask) LP64_ONLY(>> 1);
 }
 
 inline bool UnifiedOopRef::is_narrow() const {
-  return _value & 1;
+  return (_value & narrow_tag) != 0;
 }
 
 inline bool UnifiedOopRef::is_native() const {
-  return _value & 2;
+  return (_value & native_tag) != 0;
+}
+
+inline bool UnifiedOopRef::is_non_barriered() const {
+  return (_value & non_barriered_tag) != 0;
 }
 
 inline bool UnifiedOopRef::is_null() const {
   return _value == 0;
 }
 
-inline UnifiedOopRef UnifiedOopRef::encode_in_native(const narrowOop* ref) {
+template <typename T>
+inline UnifiedOopRef create_with_tag(T ref, uintptr_t tag) {
   assert(ref != NULL, "invariant");
-  UnifiedOopRef result = { reinterpret_cast<uintptr_t>(ref) | 3 };
-  assert(result.addr<narrowOop*>() == ref, "sanity");
+  assert(((reinterpret_cast<uintptr_t>(ref) LP64_ONLY(<< 1)) & UnifiedOopRef::tag_mask) == 0, "Unexpected low-order bits");
+  LP64_ONLY(assert(((reinterpret_cast<uintptr_t>(ref)) & (1ull << 63)) == 0, "Unexpected high-order bit"));
+  UnifiedOopRef result = { (reinterpret_cast<uintptr_t>(ref) LP64_ONLY(<< 1)) | tag };
+  assert(result.addr<T>() == ref, "sanity");
   return result;
+}
+
+inline UnifiedOopRef UnifiedOopRef::encode_in_native(const narrowOop* ref) {
+  NOT_LP64(ShouldNotReachHere());
+  return create_with_tag(ref, native_tag | narrow_tag);
 }
 
 inline UnifiedOopRef UnifiedOopRef::encode_in_native(const oop* ref) {
-  assert(ref != NULL, "invariant");
-  UnifiedOopRef result = { reinterpret_cast<uintptr_t>(ref) | 2 };
-  assert(result.addr<oop*>() == ref, "sanity");
-  return result;
+  return create_with_tag(ref, native_tag);
+}
+
+inline UnifiedOopRef UnifiedOopRef::encode_non_barriered(const narrowOop* ref) {
+  NOT_LP64(ShouldNotReachHere());
+  return create_with_tag(ref, non_barriered_tag | narrow_tag);
+}
+
+inline UnifiedOopRef UnifiedOopRef::encode_non_barriered(const oop* ref) {
+  return create_with_tag(ref, non_barriered_tag);
 }
 
 inline UnifiedOopRef UnifiedOopRef::encode_in_heap(const narrowOop* ref) {
-  assert(ref != NULL, "invariant");
-  UnifiedOopRef result = { reinterpret_cast<uintptr_t>(ref) | 1 };
-  assert(result.addr<narrowOop*>() == ref, "sanity");
-  return result;
+  NOT_LP64(ShouldNotReachHere());
+  return create_with_tag(ref, narrow_tag);
 }
 
 inline UnifiedOopRef UnifiedOopRef::encode_in_heap(const oop* ref) {
-  assert(ref != NULL, "invariant");
-  UnifiedOopRef result = { reinterpret_cast<uintptr_t>(ref) | 0 };
-  assert(result.addr<oop*>() == ref, "sanity");
-  return result;
+  return create_with_tag(ref, 0);
 }
 
 inline UnifiedOopRef UnifiedOopRef::encode_null() {
@@ -91,14 +104,23 @@ inline UnifiedOopRef UnifiedOopRef::encode_null() {
 }
 
 inline oop UnifiedOopRef::dereference() const {
-  if (is_native()) {
+  if (is_non_barriered()) {
     if (is_narrow()) {
+      NOT_LP64(ShouldNotReachHere());
+      return RawAccess<>::oop_load(addr<narrowOop*>());
+    } else {
+      return *addr<oop*>();
+    }
+  } else if (is_native()) {
+    if (is_narrow()) {
+      NOT_LP64(ShouldNotReachHere());
       return NativeAccess<AS_NO_KEEPALIVE>::oop_load(addr<narrowOop*>());
     } else {
       return NativeAccess<AS_NO_KEEPALIVE>::oop_load(addr<oop*>());
     }
   } else {
     if (is_narrow()) {
+      NOT_LP64(ShouldNotReachHere());
       return HeapAccess<AS_NO_KEEPALIVE>::oop_load(addr<narrowOop*>());
     } else {
       return HeapAccess<AS_NO_KEEPALIVE>::oop_load(addr<oop*>());

--- a/src/hotspot/share/jfr/leakprofiler/utilities/unifiedOopRef.inline.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/utilities/unifiedOopRef.inline.hpp
@@ -65,13 +65,18 @@ template <typename T>
 inline UnifiedOopRef create_with_tag(T ref, uintptr_t tag) {
   assert(ref != NULL, "invariant");
 
-  // We need to encode 3 bits worth of information on 64-bit and 2 bits worth on 32-bit.
-  // narrowOop* are 4 byte aligned on 64-bit so a shift is needed to fit the tag in the lower bits.
-  // The shift requires that the narrowOop/oop is in an address space with the highest bit not set.
-  uintptr_t raw_ref = reinterpret_cast<uintptr_t>(ref);
-  assert(((raw_ref LP64_ONLY(<< 1)) & UnifiedOopRef::tag_mask) == 0, "Unexpected low-order bits");
-  LP64_ONLY(assert((raw_ref & (1ull << 63)) == 0, "Unexpected high-order bit"));
-  UnifiedOopRef result = { (raw_ref LP64_ONLY(<< 1)) | tag };
+  uintptr_t value = reinterpret_cast<uintptr_t>(ref);
+
+#ifdef _LP64
+  // tag_mask is 3 bits. When ref is a narrowOop* we only have 2 alignment
+  // bits, because of the 4 byte alignment of compressed oops addresses.
+  // Shift up to make way for one more bit.
+  assert((value & (1ull << 63)) == 0, "Unexpected high-order bit");
+  value <<= 1;
+#endif
+  assert((value & UnifiedOopRef::tag_mask) == 0, "Unexpected low-order bits");
+
+  UnifiedOopRef result = { value | tag };
   assert(result.addr<T>() == ref, "sanity");
   return result;
 }

--- a/src/hotspot/share/jfr/leakprofiler/utilities/unifiedOopRef.inline.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/utilities/unifiedOopRef.inline.hpp
@@ -53,8 +53,8 @@ inline bool UnifiedOopRef::is_native() const {
   return (_value & native_tag) != 0;
 }
 
-inline bool UnifiedOopRef::is_non_barriered() const {
-  return (_value & non_barriered_tag) != 0;
+inline bool UnifiedOopRef::is_raw() const {
+  return (_value & raw_tag) != 0;
 }
 
 inline bool UnifiedOopRef::is_null() const {
@@ -80,13 +80,13 @@ inline UnifiedOopRef UnifiedOopRef::encode_in_native(const oop* ref) {
   return create_with_tag(ref, native_tag);
 }
 
-inline UnifiedOopRef UnifiedOopRef::encode_non_barriered(const narrowOop* ref) {
+inline UnifiedOopRef UnifiedOopRef::encode_as_raw(const narrowOop* ref) {
   NOT_LP64(ShouldNotReachHere());
-  return create_with_tag(ref, non_barriered_tag | narrow_tag);
+  return create_with_tag(ref, raw_tag | narrow_tag);
 }
 
-inline UnifiedOopRef UnifiedOopRef::encode_non_barriered(const oop* ref) {
-  return create_with_tag(ref, non_barriered_tag);
+inline UnifiedOopRef UnifiedOopRef::encode_as_raw(const oop* ref) {
+  return create_with_tag(ref, raw_tag);
 }
 
 inline UnifiedOopRef UnifiedOopRef::encode_in_heap(const narrowOop* ref) {
@@ -104,7 +104,7 @@ inline UnifiedOopRef UnifiedOopRef::encode_null() {
 }
 
 inline oop UnifiedOopRef::dereference() const {
-  if (is_non_barriered()) {
+  if (is_raw()) {
     if (is_narrow()) {
       NOT_LP64(ShouldNotReachHere());
       return RawAccess<>::oop_load(addr<narrowOop*>());

--- a/src/hotspot/share/oops/accessBackend.hpp
+++ b/src/hotspot/share/oops/accessBackend.hpp
@@ -1256,6 +1256,14 @@ namespace AccessInternal {
     inline bool operator !=(const T& other) const {
       return load<decorators | INTERNAL_VALUE_IS_OOP, P, T>(_addr) != other;
     }
+
+    inline bool operator ==(std::nullptr_t) const {
+      return load<decorators | INTERNAL_VALUE_IS_OOP, P, oop>(_addr) == nullptr;
+    }
+
+    inline bool operator !=(std::nullptr_t) const {
+      return load<decorators | INTERNAL_VALUE_IS_OOP, P, oop>(_addr) != nullptr;
+    }
   };
 
   // Infer the type that should be returned from an Access::load_at.


### PR DESCRIPTION
In a similar vain to [JDK-8299089](https://bugs.openjdk.org/browse/JDK-8299089) there are different semantics for OopStorage and thread local oops. UnifiedOopRef in the jfr leakprofiler must be able to distinguish these and treat them appropriately.

Testing: Running test at the moment. Has been running on the generational branch of ZGC for over three months. Not many tests exercise the leakprofiler. x86_32 has mostly been tested with GHA. 

Note: The accessBackend changes are only there to facilitate comparing OopLoadProxy objects directly with nullptr instead of creating and comparing with an `oop()` / `oop(NULL)`. Can be backed out of this PR and put in a different RFE instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299125](https://bugs.openjdk.org/browse/JDK-8299125): UnifiedOopRef in JFR leakprofiler should treat thread local oops correctly


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to [e0d2eea4](https://git.openjdk.org/jdk/pull/11741/files/e0d2eea43a4d70760a0885ef838ec3e7fbc6aa69)
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11741/head:pull/11741` \
`$ git checkout pull/11741`

Update a local copy of the PR: \
`$ git checkout pull/11741` \
`$ git pull https://git.openjdk.org/jdk pull/11741/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11741`

View PR using the GUI difftool: \
`$ git pr show -t 11741`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11741.diff">https://git.openjdk.org/jdk/pull/11741.diff</a>

</details>
