### PR TITLE
8299260: libawt and libfreetype should export only explicitly requested symbols

### DIFF
--- a/make/common/modules/LibCommon.gmk
+++ b/make/common/modules/LibCommon.gmk
@@ -41,15 +41,12 @@ ifeq ($(TOOLCHAIN_TYPE), gcc)
   CFLAGS_JDKLIB += -fvisibility=hidden
   CXXFLAGS_JDKLIB += -fvisibility=hidden
   LDFLAGS_JDKLIB += -Wl,--exclude-libs,ALL
-  EXPORT_ALL_SYMBOLS := -fvisibility=default
 else ifeq ($(TOOLCHAIN_TYPE), clang)
   CFLAGS_JDKLIB += -fvisibility=hidden
   CXXFLAGS_JDKLIB += -fvisibility=hidden
-  EXPORT_ALL_SYMBOLS := -fvisibility=default
 else ifeq ($(TOOLCHAIN_TYPE), xlc)
   CFLAGS_JDKLIB += -qvisibility=hidden
   CXXFLAGS_JDKLIB += -qvisibility=hidden
-  EXPORT_ALL_SYMBOLS := -qvisibility=default
 endif
 
 # Put the libraries here.

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -120,11 +120,6 @@ ifeq ($(call isTargetOs, windows), true)
   LIBAWT_VERSIONINFO_RESOURCE := $(TOPDIR)/src/$(MODULE)/windows/native/libawt/windows/awt.rc
 endif
 
-ifeq ($(call isTargetOs, linux), true)
-  # FIXME: This is probably not what we want to do, but keep it now for compatibility.
-  LIBAWT_CFLAGS += $(EXPORT_ALL_SYMBOLS)
-endif
-
 # Turn off all warnings for debug_mem.c This is needed because the specific warning
 # about initializing a declared 'extern' cannot be turned off individually. Only
 # applies to debug builds. This limitation in gcc is tracked in
@@ -414,7 +409,7 @@ ifeq ($(FREETYPE_TO_USE), system)
   LIBFREETYPE_LIBS := $(FREETYPE_LIBS)
 else
   BUILD_LIBFREETYPE_HEADER_DIRS := $(TOPDIR)/src/$(MODULE)/share/native/libfreetype/include
-  BUILD_LIBFREETYPE_CFLAGS := -DFT2_BUILD_LIBRARY $(EXPORT_ALL_SYMBOLS)
+  BUILD_LIBFREETYPE_CFLAGS := -DFT2_BUILD_LIBRARY
 
   # For use by libfontmanager:
   LIBFREETYPE_CFLAGS := -I$(BUILD_LIBFREETYPE_HEADER_DIRS)


### PR DESCRIPTION
Please review this patch that removes unnecessary exports from libawt and libfreetype.

Verified that:
- mach5 client libs tests pass
- both release and debug builds finish successfully

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299260](https://bugs.openjdk.org/browse/JDK-8299260): libawt and libfreetype should export only explicitly requested symbols


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11742/head:pull/11742` \
`$ git checkout pull/11742`

Update a local copy of the PR: \
`$ git checkout pull/11742` \
`$ git pull https://git.openjdk.org/jdk pull/11742/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11742`

View PR using the GUI difftool: \
`$ git pr show -t 11742`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11742.diff">https://git.openjdk.org/jdk/pull/11742.diff</a>

</details>
