### PR TITLE
8299146: No copyright statement on ArtifactResolverException.java

### DIFF
--- a/test/lib/jdk/test/lib/artifacts/ArtifactResolverException.java
+++ b/test/lib/jdk/test/lib/artifacts/ArtifactResolverException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/lib/jdk/test/lib/artifacts/ArtifactResolverException.java
+++ b/test/lib/jdk/test/lib/artifacts/ArtifactResolverException.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package jdk.test.lib.artifacts;
 
 /**


### PR DESCRIPTION
The copyright statement was missed in the test file, test/lib/jdk/test/lib/artifacts/ArtifactResolverException.java.  The file was added in [JDK 11](http://hg.openjdk.java.net/jdk/jdk/rev/e59941f7247d) by @erikj79 at 2018.  This update is trying to add the copyright back.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299146](https://bugs.openjdk.org/browse/JDK-8299146): No copyright statement on ArtifactResolverException.java


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11743/head:pull/11743` \
`$ git checkout pull/11743`

Update a local copy of the PR: \
`$ git checkout pull/11743` \
`$ git pull https://git.openjdk.org/jdk pull/11743/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11743`

View PR using the GUI difftool: \
`$ git pr show -t 11743`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11743.diff">https://git.openjdk.org/jdk/pull/11743.diff</a>

</details>
