### PR TITLE
JDK-8299052: ViewportOverlapping test fails intermittently on Win10 & Win11

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -645,7 +645,6 @@ javax/swing/plaf/basic/BasicTextUI/8001470/bug8001470.java 8233177 linux-all,win
 javax/swing/JWindow/ShapedAndTranslucentWindows/ShapedTranslucentPerPixelTranslucentGradient.java 8233582 linux-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/ShapedPerPixelTranslucentGradient.java 8233582 linux-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/PerPixelTranslucentSwing.java 8194128 macosx-all
-javax/swing/JWindow/ShapedAndTranslucentWindows/SetShapeAndClickSwing.java 8013450 macosx-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/TranslucentJComboBox.java 8024627 macosx-all
 # The next test below is an intermittent failure
 javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all
@@ -674,7 +673,6 @@ javax/swing/JFileChooser/8046391/bug8046391.java 8293862 windows-x64
 javax/swing/JFileChooser/4847375/bug4847375.java 8293862 windows-x64
 java/awt/Focus/NonFocusableWindowTest/NonfocusableOwnerTest.java 8280392 windows-x64
 java/awt/Mixing/AWT_Mixing/OpaqueOverlapping.java 8294264 windows-x64
-java/awt/Mixing/AWT_Mixing/ViewportOverlapping.java 8253184,8295813 windows-x64
 
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8293001 linux-all
 sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java 8265770 macosx-all

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -645,6 +645,7 @@ javax/swing/plaf/basic/BasicTextUI/8001470/bug8001470.java 8233177 linux-all,win
 javax/swing/JWindow/ShapedAndTranslucentWindows/ShapedTranslucentPerPixelTranslucentGradient.java 8233582 linux-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/ShapedPerPixelTranslucentGradient.java 8233582 linux-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/PerPixelTranslucentSwing.java 8194128 macosx-all
+javax/swing/JWindow/ShapedAndTranslucentWindows/SetShapeAndClickSwing.java 8013450 macosx-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/TranslucentJComboBox.java 8024627 macosx-all
 # The next test below is an intermittent failure
 javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all

--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -31,7 +31,9 @@ exclusiveAccess.dirs=java/math/BigInteger/largeMemory \
 java/rmi/Naming java/util/prefs sun/management/jmxremote \
 sun/tools/jstatd sun/security/mscapi java/util/Arrays/largeMemory \
 java/util/BitSet/stream javax/rmi java/net/httpclient/websocket \
-com/sun/net/httpserver/simpleserver
+com/sun/net/httpserver/simpleserver \
+java/awt \
+javax/swing
 
 # Group definitions
 groups=TEST.groups

--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -31,9 +31,7 @@ exclusiveAccess.dirs=java/math/BigInteger/largeMemory \
 java/rmi/Naming java/util/prefs sun/management/jmxremote \
 sun/tools/jstatd sun/security/mscapi java/util/Arrays/largeMemory \
 java/util/BitSet/stream javax/rmi java/net/httpclient/websocket \
-com/sun/net/httpserver/simpleserver \
-java/awt \
-javax/swing
+com/sun/net/httpserver/simpleserver
 
 # Group definitions
 groups=TEST.groups

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/OverlappingTestBase.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/OverlappingTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/OverlappingTestBase.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/OverlappingTestBase.java
@@ -68,7 +68,7 @@ public abstract class OverlappingTestBase {
      */
     protected static final Color AWT_BACKGROUND_COLOR = new Color(21, 244, 54);
     protected static Color AWT_VERIFY_COLOR = AWT_BACKGROUND_COLOR;
-    protected static final int ROBOT_DELAY = 500;
+    protected static final int ROBOT_DELAY = 400;
     private static final String[] simpleAwtControls = {"Button", "Checkbox", "Label", "TextArea"};
     /**
      * Generic strings array. To be used for population of List based controls.
@@ -156,6 +156,7 @@ public abstract class OverlappingTestBase {
                 }
             });
             Robot robot = new Robot();
+            robot.setAutoWaitForIdle(true);
             robot.waitForIdle();
             Thread.sleep(ROBOT_DELAY);
             AWT_VERIFY_COLOR = robot.getPixelColor(p[0].x+size/2, p[0].y+size/2);
@@ -458,6 +459,7 @@ public abstract class OverlappingTestBase {
         Robot robot = null;
         try {
             robot = new Robot();
+            robot.setAutoWaitForIdle(true);
         }catch(Exception ignorex) {
         }
         currentAwtControl = component;
@@ -490,6 +492,7 @@ public abstract class OverlappingTestBase {
         Robot robot = null;
         try {
             robot = new Robot();
+            robot.setAutoWaitForIdle(true);
         }catch(Exception ignorex) {
         }
         System.out.println("Testing EmbeddedFrame");

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/ViewportOverlapping.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/ViewportOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ import java.awt.Dimension;
 import java.awt.GridLayout;
 import java.awt.Point;
 import java.awt.Robot;
-import java.awt.event.InputEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import javax.swing.BorderFactory;
@@ -39,18 +38,20 @@ import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
 import test.java.awt.regtesthelpers.Util;
 
+import static java.awt.event.InputEvent.BUTTON1_DOWN_MASK;
+
 /**
  * AWT/Swing overlapping test for viewport
  * <p>This test verify if AWT components are drawn correctly being partially shown through viewport
  * <p>See <a href="http://monaco.sfbay.sun.com/detail.jsf?cr=6778882">CR6778882</a> for details
  * <p>See base class for test info.
  */
+
 /*
  * @test
  * @key headful
  * @bug 6778882
  * @summary Viewport overlapping test for each AWT component
- * @author sergey.grinev@oracle.com: area=awt.mixing
  * @library /java/awt/patchlib ../../regtesthelpers
  * @modules java.desktop/sun.awt
  *          java.desktop/java.awt.peer
@@ -127,23 +128,24 @@ public class ViewportOverlapping extends OverlappingTestBase {
         }
         // run robot
         Robot robot = Util.createRobot();
+        robot.setAutoWaitForIdle(true);
         robot.setAutoDelay(ROBOT_DELAY);
 
         robot.mouseMove(hLoc.x, hLoc.y);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mousePress(BUTTON1_DOWN_MASK);
+        robot.mouseRelease(BUTTON1_DOWN_MASK);
         Util.waitForIdle(robot);
 
         robot.mouseMove(vLoc.x, vLoc.y);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mousePress(BUTTON1_DOWN_MASK);
+        robot.mouseRelease(BUTTON1_DOWN_MASK);
         Util.waitForIdle(robot);
 
         clickAndBlink(robot, testLoc, false);
         robot.mouseMove(resizeLoc.x, resizeLoc.y);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
+        robot.mousePress(BUTTON1_DOWN_MASK);
         robot.mouseMove(resizeLoc.x + 5, resizeLoc.y + 5);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mouseRelease(BUTTON1_DOWN_MASK);
         Util.waitForIdle(robot);
 
         clickAndBlink(robot, testLoc, false);


### PR DESCRIPTION
ViewportOverlapping was failing intermittently on Windows (Win10 & 11). Added robot.setAutoWaitForIdle() to ViewportOverlapping and its base class (OverlappingTestBase) to stabilize the test.

Additionally added awt & swings tests to exclusiveAccess.dir in TEST.ROOT.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299052](https://bugs.openjdk.org/browse/JDK-8299052): ViewportOverlapping test fails intermittently on Win10 &amp; Win11


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/11747/head:pull/11747` \
`$ git checkout pull/11747`

Update a local copy of the PR: \
`$ git checkout pull/11747` \
`$ git pull https://git.openjdk.org/jdk.git pull/11747/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11747`

View PR using the GUI difftool: \
`$ git pr show -t 11747`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11747.diff">https://git.openjdk.org/jdk/pull/11747.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/11747#issuecomment-1360472851)