### PR TITLE
JDK-8299158: Improve MD5 intrinsic on AArch64

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -3246,7 +3246,7 @@ class StubGenerator: public StubCodeGenerator {
     __ addw(rscratch4, r1, rscratch2);
     __ ldrw(rscratch1, Address(buf, k*4));
     __ eorw(rscratch3, rscratch3, r4);
-    __ addw(rscratch3, rscratch3, rscratch1);
+    __ addw(rscratch4, rscratch4, rscratch1);
     __ addw(rscratch3, rscratch3, rscratch4);
     __ rorw(rscratch2, rscratch3, 32 - s);
     __ addw(r1, rscratch2, r2);
@@ -3263,7 +3263,7 @@ class StubGenerator: public StubCodeGenerator {
     __ movw(rscratch2, t);
     __ eorw(rscratch3, rscratch3, r3);
     __ addw(rscratch4, r1, rscratch2);
-    __ addw(rscratch3, rscratch3, rscratch1);
+    __ addw(rscratch4, rscratch4, rscratch1);
     __ addw(rscratch3, rscratch3, rscratch4);
     __ rorw(rscratch2, rscratch3, 32 - s);
     __ addw(r1, rscratch2, r2);
@@ -3279,7 +3279,7 @@ class StubGenerator: public StubCodeGenerator {
     __ addw(rscratch4, r1, rscratch2);
     __ ldrw(rscratch1, Address(buf, k*4));
     __ eorw(rscratch3, rscratch3, r2);
-    __ addw(rscratch3, rscratch3, rscratch1);
+    __ addw(rscratch4, rscratch4, rscratch1);
     __ addw(rscratch3, rscratch3, rscratch4);
     __ rorw(rscratch2, rscratch3, 32 - s);
     __ addw(r1, rscratch2, r2);
@@ -3295,7 +3295,7 @@ class StubGenerator: public StubCodeGenerator {
     __ addw(rscratch4, r1, rscratch3);
     __ ldrw(rscratch1, Address(buf, k*4));
     __ eorw(rscratch3, rscratch2, r3);
-    __ addw(rscratch3, rscratch3, rscratch1);
+    __ addw(rscratch4, rscratch4, rscratch1);
     __ addw(rscratch3, rscratch3, rscratch4);
     __ rorw(rscratch2, rscratch3, 32 - s);
     __ addw(r1, rscratch2, r2);

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -3257,11 +3257,11 @@ class StubGenerator: public StubCodeGenerator {
     Register rscratch3 = r10;
     Register rscratch4 = r11;
 
-    __ eorw(rscratch2, r2, r3);
+    __ andw(rscratch3, r2, r4);
+    __ bicw(rscratch4, r3, r4);
     __ ldrw(rscratch1, Address(buf, k*4));
-    __ andw(rscratch3, rscratch2, r4);
     __ movw(rscratch2, t);
-    __ eorw(rscratch3, rscratch3, r3);
+    __ orrw(rscratch3, rscratch3, rscratch4);
     __ addw(rscratch4, r1, rscratch2);
     __ addw(rscratch4, rscratch4, rscratch1);
     __ addw(rscratch3, rscratch3, rscratch4);


### PR DESCRIPTION
There are two optimizations to reduce the length of the data path.
1) Replace
```
    __ eorw(rscratch3, rscratch3, r4);
    __ addw(rscratch3, rscratch3, rscratch1);
    __ addw(rscratch3, rscratch3, rscratch4);
```
with
```
    __ eorw(rscratch3, rscratch3, r4);
    __ addw(rscratch4, rscratch4, rscratch1);
    __ addw(rscratch3, rscratch3, rscratch4);
```
The eorw and the first addw can be computed in parallel.

2) Replace
```
    __ eorw(rscratch2, r2, r3);
    __ andw(rscratch3, rscratch2, r4);
    __ eorw(rscratch3, rscratch3, r3);
```
to
```
    __ andw(rscratch3, r2, r4);
    __ bicw(rscratch4, r3, r4);
    __ orrw(rscratch3, rscratch3, rscratch4);
```

This is based on the equation `((r2 ^ r3) & r4) ^ r3 == (r2 & r4) | (r3 & -r4)`.
The two subexpressions on RHS can be computed in parallel.

Correctness proof
```
r2 r3 r4 (r2 ^ r3) ((r2 ^ r3) & r4) LHS (r2 & r4) (r3 & -r4) RHS
 0  0  0     0                0      0      0         0       0
 0  0  1     0                0      0      0         0       0
 0  1  0     1                0      1      0         1       1
 0  1  1     1                1      0      0         0       0
 1  0  0     1                0      0      0         0       0
 1  0  1     1                1      1      1         0       1
 1  1  0     0                0      1      0         1       1
 1  1  1     0                0      1      1         0       1
```

The change has been tested by TestMD5Intrinsics and TestMD5MultiBlockIntrinsics.

The performance is measured on EC2 m6g instance (Graviton2) and shows 18-25% improvement.
Baseline
```
Benchmark                    (digesterName)  (length)  (provider)   Mode  Cnt     Score    Error   Units
MessageDigests.digest                   md5        64     DEFAULT  thrpt   15  2989.149 ? 54.895  ops/ms
MessageDigests.digest                   md5     16384     DEFAULT  thrpt   15    24.927 ?  0.002  ops/ms
MessageDigests.getAndDigest             md5        64     DEFAULT  thrpt   15  2433.184 ? 74.616  ops/ms
MessageDigests.getAndDigest             md5     16384     DEFAULT  thrpt   15    24.736 ?  0.002  ops/ms
```
Optimized
```
Benchmark                    (digesterName)  (length)  (provider)   Mode  Cnt     Score    Error   Units
MessageDigests.digest                   md5        64     DEFAULT  thrpt   15  3719.214 ? 23.087  ops/ms
MessageDigests.digest                   md5     16384     DEFAULT  thrpt   15    31.280 ?  0.003  ops/ms
MessageDigests.getAndDigest             md5        64     DEFAULT  thrpt   15  2874.308 ? 88.455  ops/ms
MessageDigests.getAndDigest             md5     16384     DEFAULT  thrpt   15    31.014 ?  0.060  ops/ms
```
