### PR TITLE
8299168: RISC-V: Fix MachNode size mismatch for MacroAssembler::_verify_oops*

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -409,9 +409,9 @@ void MacroAssembler::_verify_oop(Register reg, const char* s, const char* file, 
 
   mv(c_rarg0, reg); // c_rarg0 : x10
   {
-    // The length of the instruction sequence emitted should be independent
-    // of the value of the local char buffer address so that the size of mach
-    // nodes for scratch emit and normal emit matches.
+    // The length of the instruction sequence emitted should not depend
+    // on the address of the char buffer so that the size of mach nodes for
+    // scratch emit and normal emit matches.
     IncompressibleRegion ir(this);  // Fixed length
     movptr(t0, (address) b);
   }
@@ -454,9 +454,9 @@ void MacroAssembler::_verify_oop_addr(Address addr, const char* s, const char* f
   }
 
   {
-    // The length of the instruction sequence emitted should be independent
-    // of the value of the local char buffer address so that the size of mach
-    // nodes for scratch emit and normal emit matches.
+    // The length of the instruction sequence emitted should not depend
+    // on the address of the char buffer so that the size of mach nodes for
+    // scratch emit and normal emit matches.
     IncompressibleRegion ir(this);  // Fixed length
     movptr(t0, (address) b);
   }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -408,10 +408,13 @@ void MacroAssembler::_verify_oop(Register reg, const char* s, const char* file, 
   push_reg(RegSet::of(ra, t0, t1, c_rarg0), sp);
 
   mv(c_rarg0, reg); // c_rarg0 : x10
-  // The length of the instruction sequence emitted should be independent
-  // of the value of the local char buffer address so that the size of mach
-  // nodes for scratch emit and normal emit matches.
-  movptr(t0, (address)b);
+  {
+    // The length of the instruction sequence emitted should be independent
+    // of the value of the local char buffer address so that the size of mach
+    // nodes for scratch emit and normal emit matches.
+    IncompressibleRegion ir(this);  // Fixed length
+    movptr(t0, (address) b);
+  }
 
   // call indirectly to solve generation ordering problem
   ExternalAddress target(StubRoutines::verify_oop_subroutine_entry_address());
@@ -450,10 +453,13 @@ void MacroAssembler::_verify_oop_addr(Address addr, const char* s, const char* f
     ld(x10, addr);
   }
 
-  // The length of the instruction sequence emitted should be independent
-  // of the value of the local char buffer address so that the size of mach
-  // nodes for scratch emit and normal emit matches.
-  movptr(t0, (address)b);
+  {
+    // The length of the instruction sequence emitted should be independent
+    // of the value of the local char buffer address so that the size of mach
+    // nodes for scratch emit and normal emit matches.
+    IncompressibleRegion ir(this);  // Fixed length
+    movptr(t0, (address) b);
+  }
 
   // call indirectly to solve generation ordering problem
   ExternalAddress target(StubRoutines::verify_oop_subroutine_entry_address());


### PR DESCRIPTION
Nearly the same as [JDK-8285437](https://bugs.openjdk.org/browse/JDK-8285437). MachNode size should match in scratch emission and real emission phases. The address of the local char buffer is a random value, but when RVC is enabled, the `movptr`, containing `lui+addi+slli+addi+slli`, with another dangling `addi` at last to load the immediate address of the special local char buffer may get compressed depending on the char buffer's different addresses. So the size may at last mismatch. Due to this part containing implicit fixed-length semantics, it shall be a reasonable fix to add an `IncompressibleRegion` for these two special positions to disable automatic RVC transformations.

`test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestDFlags.java` in hotspot tier4 can reflect this issue. It contains a `vm.flagless` so it didn't run in my local environment until recently.

Tested Hotspot tier1\~4 with fastdebug build on physical hardware along with some other patches.

Thanks,
Xiaolin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299168](https://bugs.openjdk.org/browse/JDK-8299168): RISC-V: Fix MachNode size mismatch for MacroAssembler::_verify_oops*


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11750/head:pull/11750` \
`$ git checkout pull/11750`

Update a local copy of the PR: \
`$ git checkout pull/11750` \
`$ git pull https://git.openjdk.org/jdk pull/11750/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11750`

View PR using the GUI difftool: \
`$ git pr show -t 11750`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11750.diff">https://git.openjdk.org/jdk/pull/11750.diff</a>

</details>
