### PR TITLE
8299172: RISC-V: [TESTBUG] Fix stack alignment logic in jvmci RISCV64TestAssembler.java

### DIFF
--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/riscv64/RISCV64TestAssembler.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/riscv64/RISCV64TestAssembler.java
@@ -226,8 +226,7 @@ public class RISCV64TestAssembler extends TestAssembler {
 
     @Override
     public void emitCallPrologue(CallingConvention cc, Object... prim) {
-        emitGrowStack(cc.getStackSize());
-        frameSize += cc.getStackSize();
+        growFrame(cc.getStackSize());
         AllocatableValue[] args = cc.getArguments();
         for (int i = 0; i < args.length; i++) {
             emitLoad(args[i], prim[i]);
@@ -236,8 +235,7 @@ public class RISCV64TestAssembler extends TestAssembler {
 
     @Override
     public void emitCallEpilogue(CallingConvention cc) {
-        emitGrowStack(-cc.getStackSize());
-        frameSize -= cc.getStackSize();
+        growFrame(-cc.getStackSize());
     }
 
     @Override


### PR DESCRIPTION
We observed a failure in JVMCI tests after `-ea -esa` turned on when running `./test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java`.

Failure at the line [1].

```
java.lang.AssertionError
at jdk.vm.ci.code.test.riscv64.RISCV64TestAssembler.emitGrowStack(RISCV64TestAssembler.java:203)
at jdk.vm.ci.code.test.riscv64.RISCV64TestAssembler.emitCallPrologue(RISCV64TestAssembler.java:239)
...
...
````

The failure output has been attached to the JBS issue link.

To be short, the stack alignment should align with `16`, and we can align with the logic in AArch64 [2] and x86_64 [3]. The x86_64 one is inside a recent change.

Tested along with other patches, and the failed test passed.

Thanks,
Xiaolin

[1] https://github.com/openjdk/jdk/blob/f56285c3613bb127e22f544bd4b461a0584e9d2a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/riscv64/RISCV64TestAssembler.java#L193
[2] https://github.com/openjdk/jdk/blob/f56285c3613bb127e22f544bd4b461a0584e9d2a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/aarch64/AArch64TestAssembler.java#L273-L285
[3] https://github.com/openjdk/jdk/commit/277f0c24a2e186166bfe70fc93ba79aec10585aa

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299172](https://bugs.openjdk.org/browse/JDK-8299172): RISC-V: [TESTBUG] Fix stack alignment logic in jvmci RISCV64TestAssembler.java


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11751/head:pull/11751` \
`$ git checkout pull/11751`

Update a local copy of the PR: \
`$ git checkout pull/11751` \
`$ git pull https://git.openjdk.org/jdk pull/11751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11751`

View PR using the GUI difftool: \
`$ git pr show -t 11751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11751.diff">https://git.openjdk.org/jdk/pull/11751.diff</a>

</details>
