### PR TITLE
8299187: (bf) ByteOrder.name should be declared final

### DIFF
--- a/src/java.base/share/classes/java/nio/ByteOrder.java
+++ b/src/java.base/share/classes/java/nio/ByteOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/nio/ByteOrder.java
+++ b/src/java.base/share/classes/java/nio/ByteOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/nio/ByteOrder.java
+++ b/src/java.base/share/classes/java/nio/ByteOrder.java
@@ -37,7 +37,7 @@ import jdk.internal.misc.Unsafe;
 
 public final class ByteOrder {
 
-    private String name;
+    private final String name;
 
     private ByteOrder(String name) {
         this.name = name;


### PR DESCRIPTION
This PR proposes to declare the field  `ByteOrder.name` `final`. 

This will ensure the class is thread safe and is using safe publication.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299187](https://bugs.openjdk.org/browse/JDK-8299187): (bf) ByteOrder.name should be declared final


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11752/head:pull/11752` \
`$ git checkout pull/11752`

Update a local copy of the PR: \
`$ git checkout pull/11752` \
`$ git pull https://git.openjdk.org/jdk pull/11752/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11752`

View PR using the GUI difftool: \
`$ git pr show -t 11752`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11752.diff">https://git.openjdk.org/jdk/pull/11752.diff</a>

</details>
