### PR TITLE
8299199: Avoid redundant split calls in FontConfiguration.initReorderMap implementations

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
+++ b/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
@@ -852,11 +852,6 @@ public abstract class FontConfiguration {
         return parts;
     }
 
-    protected String[] split(String sequence) {
-        Vector<String> v = splitSequence(sequence);
-        return v.toArray(new String[0]);
-    }
-
     ////////////////////////////////////////////////////////////////////////
     // Methods for extracting information from the fontconfig data for AWT//
     ////////////////////////////////////////////////////////////////////////

--- a/src/java.desktop/unix/classes/sun/font/MFontConfiguration.java
+++ b/src/java.desktop/unix/classes/sun/font/MFontConfiguration.java
@@ -74,8 +74,7 @@ public class MFontConfiguration extends FontConfiguration {
         reorderMap.put("UTF-8.zh.TW", "chinese-tw-iso10646");
         reorderMap.put("UTF-8.zh.HK", "chinese-tw-iso10646");
         reorderMap.put("UTF-8.zh.CN", "chinese-cn-iso10646");
-        reorderMap.put("x-euc-jp-linux",
-                        split("japanese-x0201,japanese-x0208"));
+        reorderMap.put("x-euc-jp-linux", new String[] {"japanese-x0201", "japanese-x0208"});
         reorderMap.put("GB2312", "chinese-gb18030");
         reorderMap.put("Big5", "chinese-big5");
         reorderMap.put("EUC-KR", "korean");

--- a/src/java.desktop/windows/classes/sun/awt/windows/WFontConfiguration.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WFontConfiguration.java
@@ -79,8 +79,7 @@ public final class WFontConfiguration extends FontConfiguration {
         reorderMap.put("GBK", "chinese-ms936");
         reorderMap.put("GB18030", "chinese-gb18030");
         reorderMap.put("x-windows-950", "chinese-ms950");
-        reorderMap.put("x-MS950-HKSCS", split("chinese-ms950,chinese-hkscs"));
-//      reorderMap.put("windows-1252", "alphabetic");
+        reorderMap.put("x-MS950-HKSCS", new String[] {"chinese-ms950", "chinese-hkscs"});
     }
 
     @Override


### PR DESCRIPTION
`FontConfiguration.split` uses legacy synchronized `Vector` class. But actually there is no need to use it, because input arguments are known at compile time. Instead of split usages we can just create String[] array with filled values directly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299199](https://bugs.openjdk.org/browse/JDK-8299199): Avoid redundant split calls in FontConfiguration.initReorderMap implementations


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11754/head:pull/11754` \
`$ git checkout pull/11754`

Update a local copy of the PR: \
`$ git checkout pull/11754` \
`$ git pull https://git.openjdk.org/jdk pull/11754/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11754`

View PR using the GUI difftool: \
`$ git pr show -t 11754`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11754.diff">https://git.openjdk.org/jdk/pull/11754.diff</a>

</details>
