### PR TITLE
8299193: (bf) Buffer.capacity should be declared final 

### DIFF
--- a/src/java.base/share/classes/java/nio/Buffer.java
+++ b/src/java.base/share/classes/java/nio/Buffer.java
@@ -213,7 +213,7 @@ public abstract sealed class Buffer
     private int mark = -1;
     private int position = 0;
     private int limit;
-    private int capacity;
+    private final int capacity;
 
     // Used by heap byte buffers or direct buffers with Unsafe access
     // For heap byte buffers this field will be the address relative to the


### PR DESCRIPTION
It is possible to declare the field `capacity` in `java.nio.Buffer` `final` as the value never changes outside the constructors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299193](https://bugs.openjdk.org/browse/JDK-8299193): (bf) Buffer.capacity should be declared final


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11755/head:pull/11755` \
`$ git checkout pull/11755`

Update a local copy of the PR: \
`$ git checkout pull/11755` \
`$ git pull https://git.openjdk.org/jdk pull/11755/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11755`

View PR using the GUI difftool: \
`$ git pr show -t 11755`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11755.diff">https://git.openjdk.org/jdk/pull/11755.diff</a>

</details>
