### PR TITLE
8299194: CustomTzIDCheckDST.java may fail at future date

### DIFF
--- a/test/jdk/java/util/TimeZone/CustomTzIDCheckDST.java
+++ b/test/jdk/java/util/TimeZone/CustomTzIDCheckDST.java
@@ -58,7 +58,7 @@ public class CustomTzIDCheckDST {
         }
     }
 
-    /* TZ code will always be set to "MEZ-1MESZ,M3.5.0,M10.5.0/3".
+    /* TZ is set to "MEZ-1MESZ,M3.5.0,M10.5.0/3", it will be the northern hemisphere.
      * This ensures the transition periods for Daylights Savings should be at March's last
      * Sunday and October's last Sunday.
      */
@@ -67,7 +67,7 @@ public class CustomTzIDCheckDST {
         String tzStr = System.getenv("TZ");
         if (tzStr == null)
             throw new RuntimeException("Got unexpected timezone information: TZ is null");
-        boolean nor = tzStr.matches(".*,M3\\..*,M10\\..*");
+        boolean nor = CUSTOM_TZ.equals(tzStr);
         TimeZone tz = new SimpleTimeZone(3600000, tzStr,
             nor ? Calendar.MARCH : Calendar.OCTOBER, -1,
             Calendar.SUNDAY, 3600000, SimpleTimeZone.UTC_TIME,

--- a/test/jdk/java/util/TimeZone/CustomTzIDCheckDST.java
+++ b/test/jdk/java/util/TimeZone/CustomTzIDCheckDST.java
@@ -33,32 +33,48 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.SimpleTimeZone;
+import java.util.TimeZone;
 import java.time.DayOfWeek;
 import java.time.ZonedDateTime;
 import java.time.temporal.TemporalAdjusters;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 public class CustomTzIDCheckDST {
-    private static String CUSTOM_TZ = "MEZ-1MESZ,M3.5.0,M10.5.0";
+    // Northern Hemisphere
+    private static String CUSTOM_TZ = "MEZ-1MESZ,M3.5.0,M10.5.0/3";
+    // Simulate Southern Hemisphere
+    private static String CUSTOM_TZ2 = "MEZ-1MESZ,M10.5.0,M3.5.0/3";
     public static void main(String args[]) throws Throwable {
         if (args.length == 0) {
             ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(List.of("CustomTzIDCheckDST", "runTZTest"));
             pb.environment().put("TZ", CUSTOM_TZ);
             OutputAnalyzer output = ProcessTools.executeProcess(pb);
             output.shouldHaveExitValue(0);
+            pb.environment().put("TZ", CUSTOM_TZ2);
+            output = ProcessTools.executeProcess(pb);
+            output.shouldHaveExitValue(0);
         } else {
             runTZTest();
         }
     }
 
-    /* TZ code will always be set to "MEZ-1MESZ,M3.5.0,M10.5.0".
+    /* TZ code will always be set to "MEZ-1MESZ,M3.5.0,M10.5.0/3".
      * This ensures the transition periods for Daylights Savings should be at March's last
      * Sunday and October's last Sunday.
      */
     private static void runTZTest() {
         Date time = new Date();
-        if (new SimpleTimeZone(3600000, "MEZ-1MESZ", Calendar.MARCH, -1, Calendar.SUNDAY, 0,
-                Calendar.OCTOBER, -1, Calendar.SUNDAY, 0).inDaylightTime(time)) {
+        String tzStr = System.getenv("TZ");
+        if (tzStr == null)
+            throw new RuntimeException("Got unexpected timezone information: TZ is null");
+        boolean nor = tzStr.matches(".*,M3\\..*,M10\\..*");
+        TimeZone tz = new SimpleTimeZone(3600000, tzStr,
+            nor ? Calendar.MARCH : Calendar.OCTOBER, -1,
+            Calendar.SUNDAY, 3600000, SimpleTimeZone.UTC_TIME,
+            nor ? Calendar.OCTOBER : Calendar.MARCH, -1,
+            Calendar.SUNDAY, 3600000, SimpleTimeZone.UTC_TIME,
+            3600000);
+        if (tz.inDaylightTime(time)) {
             // We are in Daylight savings period.
             if (time.toString().endsWith("GMT+02:00 " + Integer.toString(time.getYear() + 1900)))
                 return;
@@ -68,7 +84,7 @@ public class CustomTzIDCheckDST {
         }
 
         // Reaching here means time zone did not match up as expected.
-        throw new RuntimeException("Got unexpected timezone information: " + time);
+        throw new RuntimeException("Got unexpected timezone information: " + tzStr + " " + time);
     }
 
     private static ZonedDateTime getLastSundayOfMonth(ZonedDateTime date) {


### PR DESCRIPTION
test/jdk/java/util/TimeZone/CustomTzIDCheckDST.java may fail at future date.
I used following standalone testcase
```
import java.util.Calendar;
import java.util.Date;
import java.util.SimpleTimeZone;

public class CheckDST {
    private static String CUSTOM_TZ = "MEZ-1MESZ,M3.5.0,M10.5.0";
    public static void main(String args[]) throws Throwable {
        runTZTest();
    }

    /* TZ code will always be set to "MEZ-1MESZ,M3.5.0,M10.5.0".
     * This ensures the transition periods for Daylights Savings should be at March's last
     * Sunday and October's last Sunday.
     */
    private static void runTZTest() {
        Date time = new Date();
        if (new SimpleTimeZone(3600000, "MEZ-1MESZ", Calendar.MARCH, -1, Calendar.SUNDAY, 0,
                Calendar.OCTOBER, -1, Calendar.SUNDAY, 0).inDaylightTime(time)) {
            // We are in Daylight savings period.
            if (time.toString().endsWith("GMT+02:00 " + Integer.toString(time.getYear() + 1900)))
                return;
        } else {
            if (time.toString().endsWith("GMT+01:00 " + Integer.toString(time.getYear() + 1900)))
                return;
        }

        // Reaching here means time zone did not match up as expected.
        throw new RuntimeException("Got unexpected timezone information: " + time);
    }
}
```

I tested CheckDST with faketime, then I got following results
```
$ TZ=GMT faketime -m "2023-03-25 22:59:59" env TZ="MEZ-1MESZ,M3.5.0,M10.5.0" $HOME/jdk-21-b02/bin/java CheckDST
$ TZ=GMT faketime -m "2023-03-25 23:00:00" env TZ="MEZ-1MESZ,M3.5.0,M10.5.0" $HOME/jdk-21-b02/bin/java CheckDST
Exception in thread "main" java.lang.RuntimeException: Got unexpected timezone information: Sun Mar 26 00:00:00 GMT+01:00 2023
        at CheckDST.runTZTest(CheckDST.java:28)
        at CheckDST.main(CheckDST.java:8)
```

I assume `TZ=MEZ-1MESZ`refers Europe/Berlin timezone.
In this case, `TZ` environment variable should be `MEZ-1MESZ,M3.5.0,M10.5.0/3` (`/3` is missing in testcase)

CustomTzIDCheckDST should run with daylight saving time.
Add Simulate Southern Hemisphere by `MEZ-1MESZ,M10.5.0,M3.5.0/3`

Tested by standalone testcase
```
$ cat CheckDST1.java
import java.util.Calendar;
import java.util.Date;
import java.util.List;
import java.util.SimpleTimeZone;
import java.util.TimeZone;
import java.time.DayOfWeek;
import java.time.ZonedDateTime;
import java.time.temporal.TemporalAdjusters;
public class CheckDST1 {
    // Northern Hemisphere
    private static String CUSTOM_TZ = "MEZ-1MESZ,M3.5.0,M10.5.0/3";
    // Simulate Southern Hemisphere
    private static String CUSTOM_TZ2 = "MEZ-1MESZ,M10.5.0,M3.5.0/3";
    public static void main(String args[]) throws Throwable {
        runTZTest();
    }

    /* TZ code will always be set to "MEZ-1MESZ,M3.5.0,M10.5.0/3".
     * This ensures the transition periods for Daylights Savings should be at March's last
     * Sunday and October's last Sunday.
     */
    private static void runTZTest() {
        Date time = new Date();
        String tzStr = System.getenv("TZ");
        if (tzStr == null)
            throw new RuntimeException("Got unexpected timezone information: TZ is null");
        boolean nor = tzStr.matches(".*,M3\\..*,M10\\..*");
        TimeZone tz = new SimpleTimeZone(3600000, tzStr,
            nor ? Calendar.MARCH : Calendar.OCTOBER, -1,
            Calendar.SUNDAY, 3600000, SimpleTimeZone.UTC_TIME,
            nor ? Calendar.OCTOBER : Calendar.MARCH, -1,
            Calendar.SUNDAY, 3600000, SimpleTimeZone.UTC_TIME,
            3600000);
        System.out.println(time);
        if (tz.inDaylightTime(time)) {
            // We are in Daylight savings period.
            if (time.toString().endsWith("GMT+02:00 " + Integer.toString(time.getYear() + 1900)))
                return;
        } else {
            if (time.toString().endsWith("GMT+01:00 " + Integer.toString(time.getYear() + 1900)))
                return;
        }

        // Reaching here means time zone did not match up as expected.
        throw new RuntimeException("Got unexpected timezone information: " + tzStr + " " + time);
    }

    private static ZonedDateTime getLastSundayOfMonth(ZonedDateTime date) {
        return date.with(TemporalAdjusters.lastInMonth(DayOfWeek.SUNDAY));
    }
}
```

Check Europe/Berlin timezone settings
```
$ zdump -v Europe/Berlin | grep 2023
Europe/Berlin  Sun Mar 26 00:59:59 2023 UTC = Sun Mar 26 01:59:59 2023 CET isdst=0 gmtoff=3600
Europe/Berlin  Sun Mar 26 01:00:00 2023 UTC = Sun Mar 26 03:00:00 2023 CEST isdst=1 gmtoff=7200
Europe/Berlin  Sun Oct 29 00:59:59 2023 UTC = Sun Oct 29 02:59:59 2023 CEST isdst=1 gmtoff=7200
Europe/Berlin  Sun Oct 29 01:00:00 2023 UTC = Sun Oct 29 02:00:00 2023 CET isdst=0 gmtoff=3600
```

Test results are as follows:

Northern Hemisphere side
```
$ TZ=GMT faketime -m '2023-03-26 00:59:59' env TZ=MEZ-1MESZ,M3.5.0,M10.5.0/3 date
Sun Mar 26 01:59:59 MEZ 2023
$ TZ=GMT faketime -m '2023-03-26 00:59:59' env TZ=MEZ-1MESZ,M3.5.0,M10.5.0/3 java CheckDST1
Sun Mar 26 01:59:59 GMT+01:00 2023

$ TZ=GMT faketime -m '2023-03-26 01:00:00' env TZ=MEZ-1MESZ,M3.5.0,M10.5.0/3 date
Sun Mar 26 03:00:00 MESZ 2023
$ TZ=GMT faketime -m '2023-03-26 01:00:00' env TZ=MEZ-1MESZ,M3.5.0,M10.5.0/3 java CheckDST1
Sun Mar 26 03:00:00 GMT+02:00 2023

$ TZ=GMT faketime -m '2023-10-29 00:59:59' env TZ=MEZ-1MESZ,M3.5.0,M10.5.0/3 date
Sun Oct 29 02:59:59 MESZ 2023
$ TZ=GMT faketime -m '2023-10-29 00:59:59' env TZ=MEZ-1MESZ,M3.5.0,M10.5.0/3 java CheckDST1
Sun Oct 29 02:59:59 GMT+02:00 2023

$ TZ=GMT faketime -m '2023-10-29 01:00:00' env TZ=MEZ-1MESZ,M3.5.0,M10.5.0/3 date
Sun Oct 29 02:00:00 MEZ 2023
$ TZ=GMT faketime -m '2023-10-29 01:00:00' env TZ=MEZ-1MESZ,M3.5.0,M10.5.0/3 java CheckDST1
Sun Oct 29 02:00:00 GMT+01:00 2023
```

Southern Hemisphere side
```
$ TZ=GMT faketime -m '2023-03-26 00:59:59' env TZ=MEZ-1MESZ,M10.5.0,M3.5.0/3 date
Sun Mar 26 02:59:59 MESZ 2023
$bTZ=GMT faketime -m '2023-03-26 00:59:59' env TZ=MEZ-1MESZ,M10.5.0,M3.5.0/3 java CheckDST1
Sun Mar 26 02:59:59 GMT+02:00 2023

$ TZ=GMT faketime -m '2023-03-26 01:00:00' env TZ=MEZ-1MESZ,M10.5.0,M3.5.0/3 date
Sun Mar 26 02:00:00 MEZ 2023
$ TZ=GMT faketime -m '2023-03-26 01:00:00' env TZ=MEZ-1MESZ,M10.5.0,M3.5.0/3 java CheckDST1
Sun Mar 26 02:00:00 GMT+01:00 2023

$ TZ=GMT faketime -m '2023-10-29 00:59:59' env TZ=MEZ-1MESZ,M10.5.0,M3.5.0/3 date
Sun Oct 29 01:59:59 MEZ 2023
$ TZ=GMT faketime -m '2023-10-29 00:59:59' env TZ=MEZ-1MESZ,M10.5.0,M3.5.0/3 java CheckDST1
Sun Oct 29 01:59:59 GMT+01:00 2023

$ TZ=GMT faketime -m '2023-10-29 01:00:00' env TZ=MEZ-1MESZ,M10.5.0,M3.5.0/3 date
Sun Oct 29 03:00:00 MESZ 2023
$ TZ=GMT faketime -m '2023-10-29 01:00:00' env TZ=MEZ-1MESZ,M10.5.0,M3.5.0/3 java CheckDST1
Sun Oct 29 03:00:00 GMT+02:00 2023
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299194](https://bugs.openjdk.org/browse/JDK-8299194): CustomTzIDCheckDST.java may fail at future date


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11756/head:pull/11756` \
`$ git checkout pull/11756`

Update a local copy of the PR: \
`$ git checkout pull/11756` \
`$ git pull https://git.openjdk.org/jdk pull/11756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11756`

View PR using the GUI difftool: \
`$ git pr show -t 11756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11756.diff">https://git.openjdk.org/jdk/pull/11756.diff</a>

</details>
