### PR TITLE
8299234: JMX Repository.query performance

### DIFF
--- a/src/java.management/share/classes/com/sun/jmx/mbeanserver/Repository.java
+++ b/src/java.management/share/classes/com/sun/jmx/mbeanserver/Repository.java
@@ -117,7 +117,7 @@ public class Repository {
             for (NamedObject no : moiTb.values()) {
                 final ObjectName on = no.getName();
                 // if all couples (property, value) are contained
-                if (pattern.apply(on)) result.add(no);
+                if (pattern.apply(ObjectName.getInstance(on))) result.add(no);
             }
         }
     }
@@ -406,7 +406,7 @@ public class Repository {
             pattern.getCanonicalName().length() == 0 ||
             pattern.equals(ObjectName.WILDCARD))
            name = ObjectName.WILDCARD;
-        else name = pattern;
+        else name = ObjectName.getInstance(pattern);
 
         lock.readLock().lock();
         try {

--- a/src/java.management/share/classes/com/sun/jmx/mbeanserver/Repository.java
+++ b/src/java.management/share/classes/com/sun/jmx/mbeanserver/Repository.java
@@ -106,131 +106,18 @@ public class Repository {
     // Private fields <=============================================
 
     // Private methods --------------------------------------------->
-
-    /* This class is used to match an ObjectName against a pattern. */
-    private static final class ObjectNamePattern {
-        private final String[] keys;
-        private final String[] values;
-        private final String   properties;
-        private final boolean  isPropertyListPattern;
-        private final boolean  isPropertyValuePattern;
-
-        /**
-         * The ObjectName pattern against which ObjectNames are matched.
-         **/
-        public final ObjectName pattern;
-
-        /**
-         * Builds a new ObjectNamePattern object from an ObjectName pattern.
-         * @param pattern The ObjectName pattern under examination.
-         **/
-        public ObjectNamePattern(ObjectName pattern) {
-            this(pattern.isPropertyListPattern(),
-                 pattern.isPropertyValuePattern(),
-                 pattern.getCanonicalKeyPropertyListString(),
-                 pattern.getKeyPropertyList(),
-                 pattern);
-        }
-
-        /**
-         * Builds a new ObjectNamePattern object from an ObjectName pattern
-         * constituents.
-         * @param propertyListPattern pattern.isPropertyListPattern().
-         * @param propertyValuePattern pattern.isPropertyValuePattern().
-         * @param canonicalProps pattern.getCanonicalKeyPropertyListString().
-         * @param keyPropertyList pattern.getKeyPropertyList().
-         * @param pattern The ObjectName pattern under examination.
-         **/
-        ObjectNamePattern(boolean propertyListPattern,
-                          boolean propertyValuePattern,
-                          String canonicalProps,
-                          Map<String,String> keyPropertyList,
-                          ObjectName pattern) {
-            this.isPropertyListPattern = propertyListPattern;
-            this.isPropertyValuePattern = propertyValuePattern;
-            this.properties = canonicalProps;
-            final int len = keyPropertyList.size();
-            this.keys   = new String[len];
-            this.values = new String[len];
-            int i = 0;
-            for (Map.Entry<String,String> entry : keyPropertyList.entrySet()) {
-                keys[i]   = entry.getKey();
-                values[i] = entry.getValue();
-                i++;
-            }
-            this.pattern = pattern;
-        }
-
-        /**
-         * Return true if the given ObjectName matches the ObjectName pattern
-         * for which this object has been built.
-         * WARNING: domain name is not considered here because it is supposed
-         *          not to be wildcard when called. PropertyList is also
-         *          supposed not to be zero-length.
-         * @param name The ObjectName we want to match against the pattern.
-         * @return true if <code>name</code> matches the pattern.
-         **/
-        public boolean matchKeys(ObjectName name) {
-            // If key property value pattern but not key property list
-            // pattern, then the number of key properties must be equal
-            //
-            if (isPropertyValuePattern &&
-                !isPropertyListPattern &&
-                (name.getKeyPropertyList().size() != keys.length))
-                return false;
-
-            // If key property value pattern or key property list pattern,
-            // then every property inside pattern should exist in name
-            //
-            if (isPropertyValuePattern || isPropertyListPattern) {
-                for (int i = keys.length - 1; i >= 0 ; i--) {
-                    // Find value in given object name for key at current
-                    // index in receiver
-                    //
-                    String v = name.getKeyProperty(keys[i]);
-                    // Did we find a value for this key ?
-                    //
-                    if (v == null) return false;
-                    // If this property is ok (same key, same value), go to next
-                    //
-                    if (isPropertyValuePattern &&
-                        pattern.isPropertyValuePattern(keys[i])) {
-                        // wildmatch key property values
-                        // values[i] is the pattern;
-                        // v is the string
-                        if (Util.wildmatch(v,values[i]))
-                            continue;
-                        else
-                            return false;
-                    }
-                    if (v.equals(values[i])) continue;
-                    return false;
-                }
-                return true;
-            }
-
-            // If no pattern, then canonical names must be equal
-            //
-            final String p1 = name.getCanonicalKeyPropertyListString();
-            final String p2 = properties;
-            return (p1.equals(p2));
-        }
-    }
-
     /**
      * Add all the matching objects from the given hashtable in the
-     * result set for the given ObjectNamePattern
-     * Do not check whether the domains match (only check for matching
-     * key property lists - see <i>matchKeys()</i>)
+     * result set for the given pattern
      **/
     private void addAllMatching(final Map<String,NamedObject> moiTb,
                                 final Set<NamedObject> result,
-                                final ObjectNamePattern pattern) {
+                                final ObjectName pattern) {
         synchronized (moiTb) {
             for (NamedObject no : moiTb.values()) {
                 final ObjectName on = no.getName();
                 // if all couples (property, value) are contained
-                if (pattern.matchKeys(on)) result.add(no);
+                if (pattern.apply(on)) result.add(no);
             }
         }
     }
@@ -543,38 +430,36 @@ public class Repository {
                     name.getCanonicalKeyPropertyListString();
             final boolean allNames =
                     (canonical_key_property_list_string.length()==0);
-            final ObjectNamePattern namePattern =
-                (allNames?null:new ObjectNamePattern(name));
+            final String dom2Match = name.getDomain();
 
             // All names in default domain
-            if (name.getDomain().length() == 0) {
+            if (dom2Match.length() == 0) {
                 final Map<String,NamedObject> moiTb = domainTb.get(domain);
                 if (allNames)
                     result.addAll(moiTb.values());
                 else
-                    addAllMatching(moiTb, result, namePattern);
+                    addAllMatching(moiTb, result, Util.newObjectName(domain + name.getCanonicalName()));
                 return result;
             }
 
             if (!name.isDomainPattern()) {
-                final Map<String,NamedObject> moiTb = domainTb.get(name.getDomain());
+                final Map<String,NamedObject> moiTb = domainTb.get(dom2Match);
                 if (moiTb == null) return Collections.emptySet();
                 if (allNames)
                     result.addAll(moiTb.values());
                 else
-                    addAllMatching(moiTb, result, namePattern);
+                    addAllMatching(moiTb, result, name);
                 return result;
             }
 
             // Pattern matching in the domain name (*, ?)
-            final String dom2Match = name.getDomain();
             for (String dom : domainTb.keySet()) {
                 if (Util.wildmatch(dom, dom2Match)) {
                     final Map<String,NamedObject> moiTb = domainTb.get(dom);
                     if (allNames)
                         result.addAll(moiTb.values());
                     else
-                        addAllMatching(moiTb, result, namePattern);
+                        addAllMatching(moiTb, result, name);
                 }
             }
             return result;

--- a/src/java.management/share/classes/com/sun/jmx/mbeanserver/Util.java
+++ b/src/java.management/share/classes/com/sun/jmx/mbeanserver/Util.java
@@ -175,7 +175,7 @@ public class Util {
        of the string, which will match if that remainder looks like
        YC, so the whole string looks like AXBYC.
     */
-    private static boolean wildmatch(final String str, final String pat,
+    public static boolean wildmatch(final String str, final String pat,
             int stri, final int strend, int pati, final int patend) {
 
         // System.out.println("matching "+pat.substring(pati,patend)+

--- a/src/java.management/share/classes/com/sun/jmx/mbeanserver/Util.java
+++ b/src/java.management/share/classes/com/sun/jmx/mbeanserver/Util.java
@@ -175,7 +175,7 @@ public class Util {
        of the string, which will match if that remainder looks like
        YC, so the whole string looks like AXBYC.
     */
-    public static boolean wildmatch(final String str, final String pat,
+    private static boolean wildmatch(final String str, final String pat,
             int stri, final int strend, int pati, final int patend) {
 
         // System.out.println("matching "+pat.substring(pati,patend)+

--- a/src/java.management/share/classes/javax/management/ObjectName.java
+++ b/src/java.management/share/classes/javax/management/ObjectName.java
@@ -2016,12 +2016,21 @@ public class ObjectName implements Comparable<ObjectName>, QueryExp {
     }
 
     private final boolean matchDomains(ObjectName name) {
+        boolean useOptimized = (this.getClass() == ObjectName.class) &&
+                               (name.getClass() == ObjectName.class);
+
         if (isDomainPattern()) {
             // wildmatch domains
             // This ObjectName is the pattern
             // The other ObjectName is the string.
+            if (useOptimized)
+                return Util.wildmatch(name._canonicalName, _canonicalName,
+                           0, name.getDomainLength(), 0, getDomainLength());
             return Util.wildmatch(name.getDomain(),getDomain());
         }
+        if (useOptimized)
+            return getDomainLength() == name.getDomainLength() &&
+                   _canonicalName.regionMatches(0, name._canonicalName, 0, getDomainLength());
         return getDomain().equals(name.getDomain());
     }
 

--- a/src/java.management/share/classes/javax/management/ObjectName.java
+++ b/src/java.management/share/classes/javax/management/ObjectName.java
@@ -2023,14 +2023,16 @@ public class ObjectName implements Comparable<ObjectName>, QueryExp {
             // wildmatch domains
             // This ObjectName is the pattern
             // The other ObjectName is the string.
-            if (useOptimized)
+            if (useOptimized) {
                 return Util.wildmatch(name._canonicalName, _canonicalName,
                            0, name.getDomainLength(), 0, getDomainLength());
+            }
             return Util.wildmatch(name.getDomain(),getDomain());
         }
-        if (useOptimized)
+        if (useOptimized) {
             return getDomainLength() == name.getDomainLength() &&
                    _canonicalName.regionMatches(0, name._canonicalName, 0, getDomainLength());
+        }
         return getDomain().equals(name.getDomain());
     }
 

--- a/src/java.management/share/classes/javax/management/ObjectName.java
+++ b/src/java.management/share/classes/javax/management/ObjectName.java
@@ -2020,9 +2020,11 @@ public class ObjectName implements Comparable<ObjectName>, QueryExp {
             // wildmatch domains
             // This ObjectName is the pattern
             // The other ObjectName is the string.
-            return Util.wildmatch(name.getDomain(),getDomain());
+            return Util.wildmatch(name._canonicalName, _canonicalName,
+                   0, 0, name.getDomainLength(), getDomainLength());
         }
-        return getDomain().equals(name.getDomain());
+        return (getDomainLength() == name.getDomainLength() &&
+               _canonicalName.regionMatches(0, name._canonicalName, 0, getDomainLength()));
     }
 
     private final boolean matchKeys(ObjectName name) {

--- a/src/java.management/share/classes/javax/management/ObjectName.java
+++ b/src/java.management/share/classes/javax/management/ObjectName.java
@@ -2021,7 +2021,7 @@ public class ObjectName implements Comparable<ObjectName>, QueryExp {
             // This ObjectName is the pattern
             // The other ObjectName is the string.
             return Util.wildmatch(name._canonicalName, _canonicalName,
-                   0, 0, name.getDomainLength(), getDomainLength());
+                   0, name.getDomainLength(), 0, getDomainLength());
         }
         return (getDomainLength() == name.getDomainLength() &&
                _canonicalName.regionMatches(0, name._canonicalName, 0, getDomainLength()));

--- a/src/java.management/share/classes/javax/management/ObjectName.java
+++ b/src/java.management/share/classes/javax/management/ObjectName.java
@@ -2020,11 +2020,9 @@ public class ObjectName implements Comparable<ObjectName>, QueryExp {
             // wildmatch domains
             // This ObjectName is the pattern
             // The other ObjectName is the string.
-            return Util.wildmatch(name._canonicalName, _canonicalName,
-                   0, name.getDomainLength(), 0, getDomainLength());
+            return Util.wildmatch(name.getDomain(),getDomain());
         }
-        return (getDomainLength() == name.getDomainLength() &&
-               _canonicalName.regionMatches(0, name._canonicalName, 0, getDomainLength()));
+        return getDomain().equals(name.getDomain());
     }
 
     private final boolean matchKeys(ObjectName name) {

--- a/test/jdk/javax/management/ObjectName/ApplyWildcardTest.java
+++ b/test/jdk/javax/management/ObjectName/ApplyWildcardTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4716807
+ * @bug 4716807 8299234
  * @summary Test the ObjectName.apply(ObjectName) method
  *          with wildcards in the key properties value part.
  * @author Luis-Miguel Alventosa
@@ -75,6 +75,10 @@ public class ApplyWildcardTest {
         { "d:k1=\"a?b\",k2=\"c*d\"", "d:k1=\"axb\",k2=\"cyzd\"" },
         { "d:k1=\"a?b\",k2=\"c*d\",*", "d:k1=\"axb\",k2=\"cyzd\",k3=\"v3\"" },
         { "d:*,k1=\"a?b\",k2=\"c*d\"", "d:k1=\"axb\",k2=\"cyzd\",k3=\"v3\"" },
+
+        { "*:k=a", "d:k=a" },
+        { "*b*:k=a", "abc:k=a" },
+        { "?b?:k=a", "abc:k=a" },
     };
 
     private static final String negativeTests[][] = {
@@ -115,6 +119,10 @@ public class ApplyWildcardTest {
         { "d:k1=\"a?b\",k2=\"c*d\"", "d:k1=\"ab\",k2=\"cd\"" },
         { "d:k1=\"a?b\",k2=\"c*d\",*", "d:k1=\"ab\",k2=\"cd\",k3=\"v3\"" },
         { "d:*,k1=\"a?b\",k2=\"c*d\"", "d:k1=\"ab\",k2=\"cd\",k3=\"v3\"" },
+
+        { "?:k=a", "dd:k=a" },
+        { "*b*:k=a", "adc:k=a" },
+        { "?b?:k=a", "adc:k=a" },
     };
 
     private static int runPositiveTests() {


### PR DESCRIPTION
Please find a patch to improve JMX Repository.query performance

Using ObjectName.apply() allows significantly decrease memory usage and the number of GC cycles:
Before:
```
$ java test 1000000 1000000
Test PASSED in 8943169791 ns.
GC: G1 Young Generation getCollectionCount()=177 getCollectionTime()=118
```

After:
```
$ java test 1000000 1000000
Test PASSED in 4808213917 ns.
GC: G1 Young Generation getCollectionCount()=88 getCollectionTime()=53
```
Private ObjectName.matchDomains() method is also updated to minimize unnecessary memory allocation.

All javax/management jtreg tests passed successfully.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299234](https://bugs.openjdk.org/browse/JDK-8299234): JMX Repository.query performance


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11758/head:pull/11758` \
`$ git checkout pull/11758`

Update a local copy of the PR: \
`$ git checkout pull/11758` \
`$ git pull https://git.openjdk.org/jdk pull/11758/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11758`

View PR using the GUI difftool: \
`$ git pr show -t 11758`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11758.diff">https://git.openjdk.org/jdk/pull/11758.diff</a>

</details>
