### PR TITLE
8299261: Clean up AWT D3D exports

### DIFF
--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DBlitLoops.cpp
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DBlitLoops.cpp
@@ -55,77 +55,7 @@ extern "C" BlitFunc AnyIntIsomorphicCopy;
 extern "C" BlitFunc ByteIndexedToIntArgbConvert;
 extern "C" BlitFunc ByteIndexedToIntArgbPreConvert;
 
-#define GETMIN(v1, v2)    (((v1) > (t=(v2))) && ((v1) = t))
-#define GETMAX(v1, v2)    (((v1) < (t=(v2))) && ((v1) = t))
-
-#ifdef D3D_PPL_DLL
-
-JNIEXPORT void JNICALL
-SurfaceData_IntersectBounds(SurfaceDataBounds *dst, SurfaceDataBounds *src)
-{
-    int t;
-    GETMAX(dst->x1, src->x1);
-    GETMAX(dst->y1, src->y1);
-    GETMIN(dst->x2, src->x2);
-    GETMIN(dst->y2, src->y2);
-}
-
-JNIEXPORT void JNICALL
-SurfaceData_IntersectBoundsXYXY(SurfaceDataBounds *bounds,
-                                jint x1, jint y1, jint x2, jint y2)
-{
-    int t;
-    GETMAX(bounds->x1, x1);
-    GETMAX(bounds->y1, y1);
-    GETMIN(bounds->x2, x2);
-    GETMIN(bounds->y2, y2);
-}
-
-JNIEXPORT void JNICALL
-SurfaceData_IntersectBoundsXYWH(SurfaceDataBounds *bounds,
-                                jint x, jint y, jint w, jint h)
-{
-    w = (w <= 0) ? x : x+w;
-    if (w < x) {
-        w = 0x7fffffff;
-    }
-    if (bounds->x1 < x) {
-        bounds->x1 = x;
-    }
-    if (bounds->x2 > w) {
-        bounds->x2 = w;
-    }
-    h = (h <= 0) ? y : y+h;
-    if (h < y) {
-        h = 0x7fffffff;
-    }
-    if (bounds->y1 < y) {
-        bounds->y1 = y;
-    }
-    if (bounds->y2 > h) {
-        bounds->y2 = h;
-    }
-}
-
-JNIEXPORT void JNICALL
-SurfaceData_IntersectBlitBounds(SurfaceDataBounds *src,
-                                SurfaceDataBounds *dst,
-                                jint dx, jint dy)
-{
-    int t;
-    GETMAX(dst->x1, src->x1 + dx);
-    GETMAX(dst->y1, src->y1 + dy);
-    GETMIN(dst->x2, src->x2 + dx);
-    GETMIN(dst->y2, src->y2 + dy);
-    GETMAX(src->x1, dst->x1 - dx);
-    GETMAX(src->y1, dst->y1 - dy);
-    GETMIN(src->x2, dst->x2 - dx);
-    GETMIN(src->y2, dst->y2 - dy);
-}
-
-#endif /* D3D_PPL_DLL */
-
-D3DPIPELINE_API HRESULT
+HRESULT
 D3DBL_CopySurfaceToIntArgbImage(IDirect3DSurface9 *pSurface,
                                 SurfaceDataRasInfo *pDstInfo,
                                 jint srcx, jint srcy,
@@ -199,7 +129,7 @@ D3DBL_CopySurfaceToIntArgbImage(IDirect3DSurface9 *pSurface,
     return pSurface->UnlockRect();
 }
 
-D3DPIPELINE_API HRESULT
+HRESULT
 D3DBL_CopyImageToIntXrgbSurface(SurfaceDataRasInfo *pSrcInfo,
                                 int srctype,
                                 D3DResource *pDstSurfaceRes,
@@ -558,7 +488,7 @@ D3DBlitTextureToSurface(D3DContext *d3dc,
  * into the appropriate location in the destination surface.
  *
  */
-D3DPIPELINE_API HRESULT
+HRESULT
 D3DBlitToSurfaceViaTexture(D3DContext *d3dc, SurfaceDataRasInfo *srcInfo,
                            int srctype, D3DSDOps *srcOps,
                            jboolean swsurface, jint hint,
@@ -687,7 +617,7 @@ D3DBlitSwToTexture(D3DContext *d3dc,
  * Surface->Surface inner loops will be invoked, depending on the transform
  * state.
  */
-D3DPIPELINE_API HRESULT
+HRESULT
 D3DBlitLoops_IsoBlit(JNIEnv *env,
                      D3DContext *d3dc, jlong pSrcOps, jlong pDstOps,
                      jboolean xform, jint hint,

--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DBlitLoops.h
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DBlitLoops.h
@@ -37,7 +37,7 @@
 #define OFFSET_XFORM   sun_java2d_d3d_D3DBlitLoops_OFFSET_XFORM
 #define OFFSET_ISOBLIT sun_java2d_d3d_D3DBlitLoops_OFFSET_ISOBLIT
 
-D3DPIPELINE_API HRESULT
+HRESULT
 D3DBlitLoops_IsoBlit(JNIEnv *env,
                      D3DContext *d3dc, jlong pSrcOps, jlong pDstOps,
                      jboolean xform, jint hint,
@@ -47,14 +47,14 @@ D3DBlitLoops_IsoBlit(JNIEnv *env,
                      jdouble dx1, jdouble dy1,
                      jdouble dx2, jdouble dy2);
 
-D3DPIPELINE_API HRESULT
+HRESULT
 D3DBL_CopySurfaceToIntArgbImage(IDirect3DSurface9 *pSurface,
                                 SurfaceDataRasInfo *pDstInfo,
                                 jint srcx, jint srcy,
                                 jint srcWidth, jint srcHeight,
                                 jint dstx, jint dsty);
 
-D3DPIPELINE_API HRESULT
+HRESULT
 D3DBL_CopyImageToIntXrgbSurface(SurfaceDataRasInfo *pSrcInfo,
                                 int srctype,
                                 D3DResource *pDstSurfaceRes,

--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DContext.h
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DContext.h
@@ -106,7 +106,7 @@ class D3DGlyphCache;
  *  - holds a glyph cache texture for the associated device
  *  - implements primitives batching mechanism
  */
-class D3DPIPELINE_API D3DContext {
+class D3DContext {
 public:
     /**
      * Releases the old device (if there was one) and all associated

--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DPipeline.h
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DPipeline.h
@@ -28,43 +28,16 @@
 #define D3D_DEBUG_INFO
 #endif // DEBUG
 
-#ifdef D3D_PPL_DLL
+// this include ensures that with debug build we get
+// awt's overridden debug "new" and "delete" operators
+#include "awt.h"
 
+#include <windows.h>
+#include <d3d9.h>
+#include "Trace.h"
 
-    #ifndef WIN32_LEAN_AND_MEAN
-    #define WIN32_LEAN_AND_MEAN
-    #endif
-
-    #ifdef D3DPIPELINE_EXPORTS
-    #define D3DPIPELINE_API __declspec(dllexport)
-    #else
-    #define D3DPIPELINE_API __declspec(dllimport)
-    #endif
-
-    #include <windows.h>
-    #include <d3d9.h>
-    #include <DDErr.h>
-    #include "..\Import\Trace.h"
-
-    #define DebugPrintD3DError(res, msg) \
-        DXTRACE_ERR(msg, res)
-
-#else
-
-    #define D3DPIPELINE_API __declspec(dllexport)
-
-    // this include ensures that with debug build we get
-    // awt's overridden debug "new" and "delete" operators
-    #include "awt.h"
-
-    #include <windows.h>
-    #include <d3d9.h>
-    #include "Trace.h"
-
-    #define DebugPrintD3DError(res, msg) \
-        J2dTraceLn1(J2D_TRACE_ERROR, "D3D Error: " msg " res=%d", res)
-
-#endif /*D3D_PPL_DLL*/
+#define DebugPrintD3DError(res, msg) \
+    J2dTraceLn1(J2D_TRACE_ERROR, "D3D Error: " msg " res=%d", res)
 
 // some helper macros
 #define SAFE_RELEASE(RES) \

--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DPipelineManager.h
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DPipelineManager.h
@@ -37,7 +37,7 @@ typedef struct D3DAdapter
     HWND fsFocusWindow;
 } D3DAdapter;
 
-class D3DPIPELINE_API D3DPipelineManager
+class D3DPipelineManager
 {
     friend class D3DInitializer;
 private:

--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DRenderer.cpp
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DRenderer.cpp
@@ -31,7 +31,7 @@
 #include "D3DRenderer.h"
 #include "D3DRenderQueue.h"
 
-HRESULT D3DPIPELINE_API
+HRESULT
 D3DRenderer_DrawLine(D3DContext *d3dc,
                      jint x1, jint y1, jint x2, jint y2)
 {
@@ -42,7 +42,7 @@ D3DRenderer_DrawLine(D3DContext *d3dc,
     return d3dc->pVCacher->DrawLine(x1, y1, x2, y2);
 }
 
-HRESULT D3DPIPELINE_API
+HRESULT
 D3DRenderer_DrawRect(D3DContext *d3dc,
                      jint x, jint y, jint w, jint h)
 {
@@ -54,7 +54,7 @@ D3DRenderer_DrawRect(D3DContext *d3dc,
     return d3dc->pVCacher->DrawRect(x, y, x + w, y + h);
 }
 
-HRESULT D3DPIPELINE_API
+HRESULT
 D3DRenderer_FillRect(D3DContext *d3dc,
                      jint x, jint y, jint w, jint h)
 {
@@ -66,7 +66,7 @@ D3DRenderer_FillRect(D3DContext *d3dc,
     return d3dc->pVCacher->FillRect(x, y, x + w, y + h);
 }
 
-HRESULT D3DPIPELINE_API
+HRESULT
 D3DRenderer_DrawPoly(D3DContext *d3dc,
                      jint nPoints, jboolean isClosed,
                      jint transX, jint transY,
@@ -85,7 +85,7 @@ D3DRenderer_DrawPoly(D3DContext *d3dc,
                                     xPoints, yPoints);
 }
 
-HRESULT D3DPIPELINE_API
+HRESULT
 D3DRenderer_DrawScanlines(D3DContext *d3dc,
                           jint scanlineCount, jint *scanlines)
 {
@@ -102,7 +102,7 @@ D3DRenderer_DrawScanlines(D3DContext *d3dc,
     return d3dc->pVCacher->DrawScanlines(scanlineCount, scanlines);
 }
 
-HRESULT D3DPIPELINE_API
+HRESULT
 D3DRenderer_FillSpans(D3DContext *d3dc, jint spanCount, jint *spans)
 {
     J2dTraceLn(J2D_TRACE_INFO, "D3DRenderer_FillSpans");
@@ -114,7 +114,7 @@ D3DRenderer_FillSpans(D3DContext *d3dc, jint spanCount, jint *spans)
     return d3dc->pVCacher->FillSpans(spanCount, spans);
 }
 
-HRESULT D3DPIPELINE_API
+HRESULT
 D3DRenderer_FillParallelogram(D3DContext *d3dc,
                               jfloat fx11, jfloat fy11,
                               jfloat dx21, jfloat dy21,
@@ -135,7 +135,7 @@ D3DRenderer_FillParallelogram(D3DContext *d3dc,
                                              dx12, dy12);
 }
 
-HRESULT D3DPIPELINE_API
+HRESULT
 D3DRenderer_DrawParallelogram(D3DContext *d3dc,
                               jfloat fx11, jfloat fy11,
                               jfloat dx21, jfloat dy21,
@@ -242,7 +242,7 @@ D3DRenderer_DrawParallelogram(D3DContext *d3dc,
     return res;
 }
 
-HRESULT D3DPIPELINE_API
+HRESULT
 D3DRenderer_FillAAParallelogram(D3DContext *d3dc,
                                 jfloat fx11, jfloat fy11,
                                 jfloat dx21, jfloat dy21,
@@ -274,7 +274,7 @@ D3DRenderer_FillAAParallelogram(D3DContext *d3dc,
     return res;
 }
 
-HRESULT D3DPIPELINE_API
+HRESULT
 D3DRenderer_DrawAAParallelogram(D3DContext *d3dc,
                                 jfloat fx11, jfloat fy11,
                                 jfloat dx21, jfloat dy21,
@@ -349,8 +349,6 @@ D3DRenderer_DrawAAParallelogram(D3DContext *d3dc,
     return res;
 }
 
-#ifndef D3D_PPL_DLL
-
 extern "C"
 {
 
@@ -388,5 +386,3 @@ Java_sun_java2d_d3d_D3DRenderer_drawPoly
 }
 
 }
-
-#endif // D3D_PPL_DLL

--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DRenderer.h
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DRenderer.h
@@ -33,51 +33,51 @@
 #define BYTES_PER_SPAN \
     sun_java2d_pipe_BufferedRenderPipe_BYTES_PER_SPAN
 
-HRESULT D3DPIPELINE_API
+HRESULT
 D3DRenderer_DrawLine(D3DContext *d3dc,
                      jint x1, jint y1, jint x2, jint y2);
 
-HRESULT D3DPIPELINE_API
+HRESULT
 D3DRenderer_DrawRect(D3DContext *d3dc,
                      jint x, jint y, jint w, jint h);
 
-HRESULT D3DPIPELINE_API
+HRESULT
 D3DRenderer_FillRect(D3DContext *d3dc,
                      jint x, jint y, jint w, jint h);
 
-HRESULT D3DPIPELINE_API
+HRESULT
 D3DRenderer_DrawPoly(D3DContext *d3dc,
                      jint nPoints, jboolean isClosed,
                      jint transX, jint transY,
                      jint *xPoints, jint *yPoints);
 
-HRESULT D3DPIPELINE_API
+HRESULT
 D3DRenderer_DrawScanlines(D3DContext *d3dc,
                           jint scanlineCount, jint *scanlines);
 
-HRESULT D3DPIPELINE_API
+HRESULT
 D3DRenderer_FillSpans(D3DContext *d3dc, jint spanCount, jint *spans);
 
-HRESULT D3DPIPELINE_API
+HRESULT
 D3DRenderer_FillParallelogram(D3DContext *d3dc,
                               jfloat fx11, jfloat fy11,
                               jfloat dx21, jfloat dy21,
                               jfloat dx12, jfloat dy12);
 
-HRESULT D3DPIPELINE_API
+HRESULT
 D3DRenderer_DrawParallelogram(D3DContext *d3dc,
                               jfloat fx11, jfloat fy11,
                               jfloat dx21, jfloat dy21,
                               jfloat dx12, jfloat dy12,
                               jfloat lw21, jfloat lw12);
 
-HRESULT D3DPIPELINE_API
+HRESULT
 D3DRenderer_FillAAParallelogram(D3DContext *d3dc,
                                 jfloat fx11, jfloat fy11,
                                 jfloat dx21, jfloat dy21,
                                 jfloat dx12, jfloat dy12);
 
-HRESULT D3DPIPELINE_API
+HRESULT
 D3DRenderer_DrawAAParallelogram(D3DContext *d3dc,
                                 jfloat fx11, jfloat fy11,
                                 jfloat dx21, jfloat dy21,

--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DVertexCacher.h
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DVertexCacher.h
@@ -49,7 +49,7 @@ typedef struct {
 
 class D3DContext;
 
-class D3DPIPELINE_API D3DVertexCacher {
+class D3DVertexCacher {
 public:
     HRESULT Init(D3DContext *pCtx);
             ~D3DVertexCacher() { ReleaseDefPoolResources(); }


### PR DESCRIPTION
Please review this patch that removes unnecessary exports from awt.dll.

The exports were introduced in e4c9db984fe1a3a9d06fb60e333e92df3b165454, and as far as I could tell, they were never used; the exported functions are only used inside awt.dll.

Verified that:
- debug and release builds finish successfully
- mach5 client libs tests pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299261](https://bugs.openjdk.org/browse/JDK-8299261): Clean up AWT D3D exports


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11765/head:pull/11765` \
`$ git checkout pull/11765`

Update a local copy of the PR: \
`$ git checkout pull/11765` \
`$ git pull https://git.openjdk.org/jdk pull/11765/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11765`

View PR using the GUI difftool: \
`$ git pr show -t 11765`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11765.diff">https://git.openjdk.org/jdk/pull/11765.diff</a>

</details>
