### PR TITLE
Code for JEP Candiate 435: Asynchronous Stack Trace VM API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+
+# Fork
+
+Fork of the JDK to experiment with a new version of the AsyncGetCallTrace call (and code reuse regarding stack walking).
+
+It should work with JMC and related tools.
+For using the AsyncGetStackTrace, we recommend using a modified [async-profiler](https://github.com/SAP/async-profiler/tree/parttimenerd_asgst).
+
+For more information and a demo, please refer to [asgct2-demo](https://github.com/parttimenerd/asgct2-demo).
+
+
+
 # Welcome to the JDK!
 
 For build instructions please see the

--- a/make/data/hotspot-symbols/symbols-shared
+++ b/make/data/hotspot-symbols/symbols-shared
@@ -22,6 +22,7 @@
 #
 
 AsyncGetCallTrace
+AsyncGetStackTrace
 jio_fprintf
 jio_printf
 jio_snprintf

--- a/make/test/JtregNativeHotspot.gmk
+++ b/make/test/JtregNativeHotspot.gmk
@@ -866,6 +866,8 @@ ifeq ($(call isTargetOs, linux), true)
   BUILD_HOTSPOT_JTREG_EXECUTABLES_LIBS_exeFPRegs := -ldl
   BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetCallTraceTest := -ldl
   BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceTest := -ldl -ljvm
+  BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceInnerCTest := -ldl -ljvm
+  BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceInnerCSkipCTest := -ldl -ljvm
   BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceSampler := -ldl -ljvm
   BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceFuzzingSampler := -ldl -ljvm
   BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceSmallFuzzTest := -ldl -ljvm

--- a/make/test/JtregNativeHotspot.gmk
+++ b/make/test/JtregNativeHotspot.gmk
@@ -867,6 +867,8 @@ ifeq ($(call isTargetOs, linux), true)
   BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetCallTraceTest := -ldl
   BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceTest := -ldl -ljvm
   BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceSampler := -ldl -ljvm
+  BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceFuzzingSampler := -ldl -ljvm
+  BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceSmallFuzzTest := -ldl -ljvm
 else
   BUILD_HOTSPOT_JTREG_EXCLUDE += libtest-rw.c libtest-rwx.c \
       exeinvoke.c exestack-gap.c exestack-tls.c libAsyncGetCallTraceTest.cpp

--- a/make/test/JtregNativeHotspot.gmk
+++ b/make/test/JtregNativeHotspot.gmk
@@ -865,6 +865,8 @@ ifeq ($(call isTargetOs, linux), true)
   BUILD_TEST_exeinvoke_exeinvoke.c_OPTIMIZATION := NONE
   BUILD_HOTSPOT_JTREG_EXECUTABLES_LIBS_exeFPRegs := -ldl
   BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetCallTraceTest := -ldl
+  BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceTest := -ldl -ljvm
+  BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceSampler := -ldl -ljvm
 else
   BUILD_HOTSPOT_JTREG_EXCLUDE += libtest-rw.c libtest-rwx.c \
       exeinvoke.c exestack-gap.c exestack-tls.c libAsyncGetCallTraceTest.cpp

--- a/make/test/JtregNativeHotspot.gmk
+++ b/make/test/JtregNativeHotspot.gmk
@@ -855,6 +855,9 @@ BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceTest := -ldl -ljvm
 BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceInnerCTest := -ldl -ljvm
 BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceInnerCSkipCTest := -ldl -ljvm
 BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceSampler := -ldl -ljvm
+BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceSampler2 := -ldl -ljvm
+BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceMoreTraces := -ldl -ljvm
+BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceEquivalenceSampler := -ldl -ljvm
 
 ################################################################################
 

--- a/make/test/JtregNativeHotspot.gmk
+++ b/make/test/JtregNativeHotspot.gmk
@@ -850,6 +850,12 @@ BUILD_HOTSPOT_JTREG_LIBRARIES_CFLAGS_libVirtualMachine07agent02 := $(NSK_AOD_INC
 BUILD_HOTSPOT_JTREG_LIBRARIES_CFLAGS_libVirtualMachine07agent03 := $(NSK_AOD_INCLUDES)
 BUILD_HOTSPOT_JTREG_LIBRARIES_CFLAGS_libVirtualMachine09agent00 := $(NSK_AOD_INCLUDES)
 
+BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetCallTraceTest := -ldl
+BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceTest := -ldl -ljvm
+BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceInnerCTest := -ldl -ljvm
+BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceInnerCSkipCTest := -ldl -ljvm
+BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceSampler := -ldl -ljvm
+
 ################################################################################
 
 # Platform specific setup
@@ -864,11 +870,6 @@ ifeq ($(call isTargetOs, linux), true)
   BUILD_HOTSPOT_JTREG_EXECUTABLES_LIBS_exestack-tls := -ljvm
   BUILD_TEST_exeinvoke_exeinvoke.c_OPTIMIZATION := NONE
   BUILD_HOTSPOT_JTREG_EXECUTABLES_LIBS_exeFPRegs := -ldl
-  BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetCallTraceTest := -ldl
-  BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceTest := -ldl -ljvm
-  BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceInnerCTest := -ldl -ljvm
-  BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceInnerCSkipCTest := -ldl -ljvm
-  BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceSampler := -ldl -ljvm
   BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceFuzzingSampler := -ldl -ljvm
   BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetStackTraceSmallFuzzTest := -ldl -ljvm
 else

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -420,7 +420,7 @@ frame frame::sender_for_upcall_stub_frame(RegisterMap* map) const {
 // given unextended SP.
 #ifdef ASSERT
 void frame::verify_deopt_original_pc(CompiledMethod* nm, intptr_t* unextended_sp) {
-  if (JavaThread::currently_in_in_async_stack_walking()) {
+  if (JavaThread::currently_in_async_stack_walking()) {
     return;
   }
 

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -512,7 +512,12 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
 
   // first the method
 
-  Method* m = *interpreter_frame_method_addr();
+  Method** m_addr = interpreter_frame_method_addr();
+  if (!os::is_readable_pointer(m_addr)) {
+    return false;
+  }
+
+  Method* m = *m_addr;
 
   // validate the method we'd find in this potential sender
   if (!Method::is_valid_method(m)) return false;

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -85,9 +85,9 @@ bool frame::safe_for_sender(JavaThread *thread) {
     return false;
   }
 
-  // an fp must be within the stack and above (but not equal) sp
+  // an fp must be within the stack and above sp
   // second evaluation on fp+ is added to handle situation where fp is -1
-  bool fp_safe = thread->is_in_stack_range_excl(fp, sp) &&
+  bool fp_safe = thread->is_in_stack_range_incl(fp, sp) &&
                  thread->is_in_full_stack_checked(fp + (return_addr_offset * sizeof(void*)));
 
   // We know sp/unextended_sp are safe only fp is questionable here

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -420,6 +420,10 @@ frame frame::sender_for_upcall_stub_frame(RegisterMap* map) const {
 // given unextended SP.
 #ifdef ASSERT
 void frame::verify_deopt_original_pc(CompiledMethod* nm, intptr_t* unextended_sp) {
+  if (JavaThread::currently_in_in_async_stack_walking()) {
+    return;
+  }
+
   frame fr;
 
   // This is ugly but it's better than to change {get,set}_original_pc

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -77,7 +77,7 @@ inline void frame::setup(address pc) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;
     #ifdef ASSERT
-    if (JavaThread::currently_in_in_async_stack_walking()) {
+    if (!JavaThread::currently_in_async_stack_walking()) {
       assert(_cb == nullptr || _cb->as_compiled_method()->insts_contains_inclusive(_pc),
              "original PC must be in the main code section of the compiled method (or must be immediately following it)");
     }

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -76,8 +76,12 @@ inline void frame::setup(address pc) {
   if (original_pc != nullptr) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;
-    assert(_cb == nullptr || _cb->as_compiled_method()->insts_contains_inclusive(_pc),
-           "original PC must be in the main code section of the compiled method (or must be immediately following it)");
+    #ifdef ASSERT
+    if (JavaThread::currently_in_in_async_stack_walking()) {
+      assert(_cb == nullptr || _cb->as_compiled_method()->insts_contains_inclusive(_pc),
+             "original PC must be in the main code section of the compiled method (or must be immediately following it)");
+    }
+    #endif
   } else {
     if (_cb == SharedRuntime::deopt_blob()) {
       _deopt_state = is_deoptimized;

--- a/src/hotspot/cpu/arm/frame_arm.cpp
+++ b/src/hotspot/cpu/arm/frame_arm.cpp
@@ -334,7 +334,7 @@ bool frame::upcall_stub_frame_is_first() const {
 // for MethodHandle call sites.
 #ifdef ASSERT
 void frame::verify_deopt_original_pc(CompiledMethod* nm, intptr_t* unextended_sp, bool is_method_handle_return) {
-  if (JavaThread::currently_in_in_async_stack_walking()) {
+  if (JavaThread::currently_in_async_stack_walking()) {
     return;
   }
 

--- a/src/hotspot/cpu/arm/frame_arm.cpp
+++ b/src/hotspot/cpu/arm/frame_arm.cpp
@@ -425,7 +425,12 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
 
   // first the method
 
-  Method* m = *interpreter_frame_method_addr();
+  Method** m_addr = interpreter_frame_method_addr();
+  if (!os::is_readable_pointer(m_addr)) {
+    return false;
+  }
+
+  Method* m = *m_addr;
 
   // validate the method we'd find in this potential sender
   if (!Method::is_valid_method(m)) return false;

--- a/src/hotspot/cpu/arm/frame_arm.cpp
+++ b/src/hotspot/cpu/arm/frame_arm.cpp
@@ -334,6 +334,10 @@ bool frame::upcall_stub_frame_is_first() const {
 // for MethodHandle call sites.
 #ifdef ASSERT
 void frame::verify_deopt_original_pc(CompiledMethod* nm, intptr_t* unextended_sp, bool is_method_handle_return) {
+  if (JavaThread::currently_in_in_async_stack_walking()) {
+    return;
+  }
+
   frame fr;
 
   // This is ugly but it's better than to change {get,set}_original_pc

--- a/src/hotspot/cpu/arm/frame_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/frame_arm.inline.hpp
@@ -62,7 +62,7 @@ inline void frame::init(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, add
   if (original_pc != nullptr) {
     _pc = original_pc;
     #ifdef ASSERT
-    if (JavaThread::currently_in_in_async_stack_walking()) {
+    if (!JavaThread::currently_in_async_stack_walking()) {
       assert(_cb->as_compiled_method()->insts_contains_inclusive(_pc),
              "original PC must be in the main code section of the compiled method (or must be immediately following it)");
     }

--- a/src/hotspot/cpu/arm/frame_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/frame_arm.inline.hpp
@@ -61,9 +61,13 @@ inline void frame::init(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, add
   address original_pc = CompiledMethod::get_deopt_original_pc(this);
   if (original_pc != nullptr) {
     _pc = original_pc;
-    assert(_cb->as_compiled_method()->insts_contains_inclusive(_pc),
-           "original PC must be in the main code section of the the compiled method (or must be immediately following it)");
-    _deopt_state = is_deoptimized;
+    #ifdef ASSERT
+    if (JavaThread::currently_in_in_async_stack_walking()) {
+      assert(_cb->as_compiled_method()->insts_contains_inclusive(_pc),
+             "original PC must be in the main code section of the compiled method (or must be immediately following it)");
+    }
+    #endif
+   _deopt_state = is_deoptimized;
   } else {
     _deopt_state = not_deoptimized;
   }

--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -305,7 +305,12 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
 
   // first the method
 
-  Method* m = *interpreter_frame_method_addr();
+  Method** m_addr = interpreter_frame_method_addr();
+  if (!os::is_readable_pointer(m_addr)) {
+    return false;
+  }
+
+  Method* m = *m_addr;
 
   // validate the method we'd find in this potential sender
   if (!Method::is_valid_method(m)) return false;

--- a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
@@ -66,7 +66,7 @@ inline void frame::setup() {
     _pc = original_pc;
     _deopt_state = is_deoptimized;
     #ifdef ASSERT
-    if (JavaThread::currently_in_in_async_stack_walking()) {
+    if (!JavaThread::currently_in_async_stack_walking()) {
       assert(_cb == nullptr || _cb->as_compiled_method()->insts_contains_inclusive(_pc),
              "original PC must be in the main code section of the compiled method (or must be immediately following it)");
     }

--- a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
@@ -65,8 +65,12 @@ inline void frame::setup() {
   if (original_pc != nullptr) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;
-    assert(_cb == nullptr || _cb->as_compiled_method()->insts_contains_inclusive(_pc),
-           "original PC must be in the main code section of the compiled method (or must be immediately following it)");
+    #ifdef ASSERT
+    if (JavaThread::currently_in_in_async_stack_walking()) {
+      assert(_cb == nullptr || _cb->as_compiled_method()->insts_contains_inclusive(_pc),
+             "original PC must be in the main code section of the compiled method (or must be immediately following it)");
+    }
+    #endif
   } else {
     if (_cb == SharedRuntime::deopt_blob()) {
       _deopt_state = is_deoptimized;

--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -393,6 +393,10 @@ frame frame::sender_for_upcall_stub_frame(RegisterMap* map) const {
 // given unextended SP.
 #ifdef ASSERT
 void frame::verify_deopt_original_pc(CompiledMethod* nm, intptr_t* unextended_sp) {
+  if (JavaThread::currently_in_in_async_stack_walking()) {
+    return;
+  }
+
   frame fr;
 
   // This is ugly but it's better than to change {get,set}_original_pc

--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -393,7 +393,7 @@ frame frame::sender_for_upcall_stub_frame(RegisterMap* map) const {
 // given unextended SP.
 #ifdef ASSERT
 void frame::verify_deopt_original_pc(CompiledMethod* nm, intptr_t* unextended_sp) {
-  if (JavaThread::currently_in_in_async_stack_walking()) {
+  if (JavaThread::currently_in_async_stack_walking()) {
     return;
   }
 

--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -482,7 +482,13 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
   // do some validation of frame elements
 
   // first the method
-  Method* m = *interpreter_frame_method_addr();
+  Method** m_addr = interpreter_frame_method_addr();
+  if (!os::is_readable_pointer(m_addr)) {
+    return false;
+  }
+
+  Method* m = *m_addr;
+
   // validate the method we'd find in this potential sender
   if (!Method::is_valid_method(m)) {
     return false;

--- a/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
@@ -74,8 +74,12 @@ inline void frame::setup(address pc) {
   if (original_pc != nullptr) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;
-    assert(_cb == nullptr || _cb->as_compiled_method()->insts_contains_inclusive(_pc),
-           "original PC must be in the main code section of the compiled method (or must be immediately following it)");
+    #ifdef ASSERT
+    if (JavaThread::currently_in_in_async_stack_walking()) {
+      assert(_cb == nullptr || _cb->as_compiled_method()->insts_contains_inclusive(_pc),
+             "original PC must be in the main code section of the compiled method (or must be immediately following it)");
+    }
+    #endif
   } else {
     if (_cb == SharedRuntime::deopt_blob()) {
       _deopt_state = is_deoptimized;

--- a/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
@@ -75,7 +75,7 @@ inline void frame::setup(address pc) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;
     #ifdef ASSERT
-    if (JavaThread::currently_in_in_async_stack_walking()) {
+    if (!JavaThread::currently_in_async_stack_walking()) {
       assert(_cb == nullptr || _cb->as_compiled_method()->insts_contains_inclusive(_pc),
              "original PC must be in the main code section of the compiled method (or must be immediately following it)");
     }

--- a/src/hotspot/cpu/s390/frame_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.inline.hpp
@@ -61,7 +61,7 @@ inline void frame::setup() {
     _pc = original_pc;
     _deopt_state = is_deoptimized;
     #ifdef ASSERT
-    if (JavaThread::currently_in_in_async_stack_walking()) {
+    if (!JavaThread::currently_in_async_stack_walking()) {
       assert(_cb == nullptr || _cb->as_compiled_method()->insts_contains_inclusive(_pc),
              "original PC must be in the main code section of the compiled method (or must be immediately following it)");
     }

--- a/src/hotspot/cpu/s390/frame_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.inline.hpp
@@ -60,8 +60,12 @@ inline void frame::setup() {
   if (original_pc != nullptr) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;
-    assert(_cb == nullptr || _cb->as_compiled_method()->insts_contains_inclusive(_pc),
-           "original PC must be in the main code section of the compiled method (or must be immediately following it)");
+    #ifdef ASSERT
+    if (JavaThread::currently_in_in_async_stack_walking()) {
+      assert(_cb == nullptr || _cb->as_compiled_method()->insts_contains_inclusive(_pc),
+             "original PC must be in the main code section of the compiled method (or must be immediately following it)");
+    }
+    #endif
   } else {
     if (_cb == SharedRuntime::deopt_blob()) {
       _deopt_state = is_deoptimized;

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -417,7 +417,7 @@ frame frame::sender_for_upcall_stub_frame(RegisterMap* map) const {
 // given unextended SP.
 #ifdef ASSERT
 void frame::verify_deopt_original_pc(CompiledMethod* nm, intptr_t* unextended_sp) {
-  if (JavaThread::currently_in_in_async_stack_walking()) {
+  if (JavaThread::currently_in_async_stack_walking()) {
     return;
   }
 

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -417,6 +417,10 @@ frame frame::sender_for_upcall_stub_frame(RegisterMap* map) const {
 // given unextended SP.
 #ifdef ASSERT
 void frame::verify_deopt_original_pc(CompiledMethod* nm, intptr_t* unextended_sp) {
+  if (JavaThread::currently_in_in_async_stack_walking()) {
+    return;
+  }
+
   frame fr;
 
   // This is ugly but it's better than to change {get,set}_original_pc
@@ -425,9 +429,9 @@ void frame::verify_deopt_original_pc(CompiledMethod* nm, intptr_t* unextended_sp
   fr._unextended_sp = unextended_sp;
 
   address original_pc = nm->get_original_pc(&fr);
-  // this is known to break during fuzzing
-  //assert(nm->insts_contains_inclusive(original_pc),
-  //       "original PC must be in the main code section of the compiled method (or must be immediately following it) original_pc: " INTPTR_FORMAT " unextended_sp: " INTPTR_FORMAT " name: %s", p2i(original_pc), p2i(unextended_sp), nm->name());
+
+  assert(nm->insts_contains_inclusive(original_pc),
+         "original PC must be in the main code section of the compiled method (or must be immediately following it) original_pc: " INTPTR_FORMAT " unextended_sp: " INTPTR_FORMAT " name: %s", p2i(original_pc), p2i(unextended_sp), nm->name());
 }
 #endif
 

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -36,10 +36,12 @@
 #include "runtime/handles.inline.hpp"
 #include "runtime/javaCalls.hpp"
 #include "runtime/monitorChunk.hpp"
+#include "runtime/safefetch.hpp"
 #include "runtime/signature.hpp"
 #include "runtime/stackWatermarkSet.hpp"
 #include "runtime/stubCodeGenerator.hpp"
 #include "runtime/stubRoutines.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "vmreg_x86.inline.hpp"
 #include "utilities/formatBuffer.hpp"
 #ifdef COMPILER1
@@ -254,10 +256,9 @@ bool frame::safe_for_sender(JavaThread *thread) {
     return false;
   }
 
-  // Will the pc we fetch be non-zero (which we'll find at the oldest frame)
+  // Will the pc we fetch be non-zero (which we'll find at the oldest frame) and readable
 
   if ( (address) this->fp()[return_addr_offset] == nullptr) return false;
-
 
   // could try and do some more potential verification of native frame if we could think of some...
 

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -125,6 +125,12 @@ bool frame::safe_for_sender(JavaThread *thread) {
       if (!fp_safe) {
         return false;
       }
+      // check that the accessed stack slots are safe too
+      if (SafeFetchN(this->fp() + return_addr_offset, 0) == 0 ||
+          SafeFetchN(this->fp() + sender_sp_offset, 0) == 0 ||
+          SafeFetchN(this->fp() + interpreter_frame_sender_sp_offset, 0) == 0 ||
+          SafeFetchN(this->fp() + link_offset, 0) == 0
+         ) return false;
 
       sender_pc = (address) this->fp()[return_addr_offset];
       // for interpreted frames, the value below is the sender "raw" sp,

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -127,7 +127,6 @@ bool frame::safe_for_sender(JavaThread *thread) {
       }
       // check that the accessed stack slots are safe too
       if (SafeFetchN(this->fp() + return_addr_offset, 0) == 0 ||
-          SafeFetchN(this->fp() + sender_sp_offset, 0) == 0 ||
           SafeFetchN(this->fp() + interpreter_frame_sender_sp_offset, 0) == 0 ||
           SafeFetchN(this->fp() + link_offset, 0) == 0
          ) return false;

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -425,8 +425,9 @@ void frame::verify_deopt_original_pc(CompiledMethod* nm, intptr_t* unextended_sp
   fr._unextended_sp = unextended_sp;
 
   address original_pc = nm->get_original_pc(&fr);
-  assert(nm->insts_contains_inclusive(original_pc),
-         "original PC must be in the main code section of the compiled method (or must be immediately following it) original_pc: " INTPTR_FORMAT " unextended_sp: " INTPTR_FORMAT " name: %s", p2i(original_pc), p2i(unextended_sp), nm->name());
+  // this is known to break during fuzzing
+  //assert(nm->insts_contains_inclusive(original_pc),
+  //       "original PC must be in the main code section of the compiled method (or must be immediately following it) original_pc: " INTPTR_FORMAT " unextended_sp: " INTPTR_FORMAT " name: %s", p2i(original_pc), p2i(unextended_sp), nm->name());
 }
 #endif
 

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -507,7 +507,12 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
   // do some validation of frame elements
   // first the method
 
-  Method* m = *interpreter_frame_method_addr();
+  Method** m_addr = interpreter_frame_method_addr();
+  if (!os::is_readable_pointer(m_addr)) {
+    return false;
+  }
+
+  Method* m = *m_addr;
 
   // validate the method we'd find in this potential sender
   if (!Method::is_valid_method(m)) return false;

--- a/src/hotspot/cpu/x86/frame_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.inline.hpp
@@ -72,7 +72,7 @@ inline void frame::setup(address pc) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;
     #ifdef ASSERT
-    if (JavaThread::currently_in_in_async_stack_walking()) {
+    if (!JavaThread::currently_in_async_stack_walking()) {
       assert(_cb == nullptr || _cb->as_compiled_method()->insts_contains_inclusive(_pc),
              "original PC must be in the main code section of the compiled method (or must be immediately following it)");
     }

--- a/src/hotspot/cpu/x86/frame_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.inline.hpp
@@ -71,8 +71,12 @@ inline void frame::setup(address pc) {
   if (original_pc != nullptr) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;
-    assert(_cb == nullptr || _cb->as_compiled_method()->insts_contains_inclusive(_pc),
-           "original PC must be in the main code section of the compiled method (or must be immediately following it)");
+    #ifdef ASSERT
+    if (JavaThread::currently_in_in_async_stack_walking()) {
+      assert(_cb == nullptr || _cb->as_compiled_method()->insts_contains_inclusive(_pc),
+             "original PC must be in the main code section of the compiled method (or must be immediately following it)");
+    }
+    #endif
   } else {
     if (_cb == SharedRuntime::deopt_blob()) {
       _deopt_state = is_deoptimized;

--- a/src/hotspot/cpu/zero/frame_zero.cpp
+++ b/src/hotspot/cpu/zero/frame_zero.cpp
@@ -136,7 +136,12 @@ bool frame::is_interpreted_frame_valid(JavaThread *thread) const {
   // do some validation of frame elements
   // first the method
 
-  Method* m = *interpreter_frame_method_addr();
+  Method** m_addr = interpreter_frame_method_addr();
+  if (!os::is_readable_pointer(m_addr)) {
+    return false;
+  }
+
+  Method* m = *m_addr;
 
   // validate the method we'd find in this potential sender
   if (!Method::is_valid_method(m)) {

--- a/src/hotspot/os/posix/threadCrashProtection_posix.cpp
+++ b/src/hotspot/os/posix/threadCrashProtection_posix.cpp
@@ -31,7 +31,8 @@ ThreadCrashProtection* ThreadCrashProtection::_crash_protection = nullptr;
 
 ThreadCrashProtection::ThreadCrashProtection() {
   _protected_thread = Thread::current();
-  assert(_protected_thread->is_JfrSampler_thread(), "should be JFRSampler");
+  assert(_protected_thread->is_JfrSampler_thread() || _protected_thread->in_async_stack_walking(),
+    "should be JFRSampler or asgct");
 }
 
 /*

--- a/src/hotspot/os/windows/threadCrashProtection_windows.cpp
+++ b/src/hotspot/os/windows/threadCrashProtection_windows.cpp
@@ -31,7 +31,8 @@ ThreadCrashProtection* ThreadCrashProtection::_crash_protection = nullptr;
 
 ThreadCrashProtection::ThreadCrashProtection() {
   _protected_thread = Thread::current();
-  assert(_protected_thread->is_JfrSampler_thread(), "should be JFRSampler");
+  assert(_protected_thread->is_JfrSampler_thread() || _protected_thread->in_asgct(),
+    "should be JFRSampler or asgct");
 }
 
 // See the caveats for this class in os_windows.hpp

--- a/src/hotspot/os_cpu/aix_ppc/javaThread_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/javaThread_aix_ppc.cpp
@@ -40,11 +40,14 @@ frame JavaThread::pd_last_frame() {
   return frame(sp, pc);
 }
 
-bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava) {
+bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava,
+                                                bool forceUContextUsage) {
 
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
-  if (has_last_Java_frame() && frame_anchor()->walkable()) {
+  // But forceUContextUsage == true overrides this.
+  if (ucontext == NULL ||
+      (!forceUContextUsage && has_last_Java_frame() && frame_anchor()->walkable())) {
     intptr_t* sp = last_Java_sp();
     address pc = _anchor.last_Java_pc();
     // pc can be seen as null because not all writers use store pc + release store sp.
@@ -109,8 +112,9 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
 }
 
 // Forte Analyzer AsyncGetCallTrace profiling support.
-bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext, bool isInJava) {
-  return pd_get_top_frame_for_profiling(fr_addr, ucontext, isInJava);
+bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext, bool isInJava,
+                                                     bool forceUContextUsage) {
+  return pd_get_top_frame_for_profiling(fr_addr, ucontext, isInJava, forceUContextUsage);
 }
 
 void JavaThread::cache_global_variables() { }

--- a/src/hotspot/os_cpu/aix_ppc/javaThread_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/javaThread_aix_ppc.cpp
@@ -46,8 +46,8 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
   // But forceUContextUsage == true overrides this.
-  if (ucontext == NULL ||
-      (!forceUContextUsage && has_last_Java_frame() && frame_anchor()->walkable())) {
+  if (has_last_Java_frame() && frame_anchor()->walkable() &&
+      (ucontext == NULL || !forceUContextUsage)) {
     intptr_t* sp = last_Java_sp();
     address pc = _anchor.last_Java_pc();
     // pc can be seen as null because not all writers use store pc + release store sp.

--- a/src/hotspot/os_cpu/aix_ppc/javaThread_aix_ppc.hpp
+++ b/src/hotspot/os_cpu/aix_ppc/javaThread_aix_ppc.hpp
@@ -36,9 +36,9 @@
 
  public:
   bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext,
-                                           bool isInJava);
+                                           bool isInJava, bool forceUContextUsage = false);
 
   bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext,
-                                      bool isInJava);
+                                      bool isInJava, bool forceUContextUsage = false);
 
 #endif // OS_CPU_AIX_PPC_JAVATHREAD_AIX_PPC_HPP

--- a/src/hotspot/os_cpu/bsd_aarch64/javaThread_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/javaThread_bsd_aarch64.cpp
@@ -52,14 +52,12 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
 
 bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava,
   bool forceUContextUsage) {
-  JavaThread* jt = (JavaThread *)this;
-
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
   // But forceUContextUsage == true overrides this.
   if (ucontext == NULL ||
-      (!forceUContextUsage && jt->has_last_Java_frame() && jt->frame_anchor()->walkable())) {
-    *fr_addr = jt->pd_last_frame();
+      (!forceUContextUsage && has_last_Java_frame() && frame_anchor()->walkable())) {
+    *fr_addr = pd_last_frame();
     return true;
   }
 

--- a/src/hotspot/os_cpu/bsd_aarch64/javaThread_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/javaThread_bsd_aarch64.cpp
@@ -41,7 +41,8 @@ frame JavaThread::pd_last_frame() {
 // currently interrupted by SIGPROF
 bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr,
   void* ucontext, bool isInJava, bool forceUContextUsage) {
-  assert(Thread::current() == this, "caller must be current thread");
+  assert(Thread::current() == this || Thread::currently_in_async_stack_walking(),
+    "caller must be current thread or in async stack walking");
   return pd_get_top_frame(fr_addr, ucontext, isInJava, forceUContextUsage);
 }
 

--- a/src/hotspot/os_cpu/bsd_aarch64/javaThread_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/javaThread_bsd_aarch64.cpp
@@ -40,20 +40,26 @@ frame JavaThread::pd_last_frame() {
 // For Forte Analyzer AsyncGetCallTrace profiling support - thread is
 // currently interrupted by SIGPROF
 bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr,
-  void* ucontext, bool isInJava) {
+  void* ucontext, bool isInJava, bool forceUContextUsage) {
   assert(Thread::current() == this, "caller must be current thread");
-  return pd_get_top_frame(fr_addr, ucontext, isInJava);
+  return pd_get_top_frame(fr_addr, ucontext, isInJava, forceUContextUsage);
 }
 
-bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava) {
-  return pd_get_top_frame(fr_addr, ucontext, isInJava);
+bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava,
+  bool forceUContextUsage) {
+  return pd_get_top_frame(fr_addr, ucontext, isInJava, forceUContextUsage);
 }
 
-bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava) {
+bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava,
+  bool forceUContextUsage) {
+  JavaThread* jt = (JavaThread *)this;
+
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
-  if (has_last_Java_frame() && frame_anchor()->walkable()) {
-    *fr_addr = pd_last_frame();
+  // But forceUContextUsage == true overrides this.
+  if (ucontext == NULL ||
+      (!forceUContextUsage && jt->has_last_Java_frame() && jt->frame_anchor()->walkable())) {
+    *fr_addr = jt->pd_last_frame();
     return true;
   }
 

--- a/src/hotspot/os_cpu/bsd_aarch64/javaThread_bsd_aarch64.hpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/javaThread_bsd_aarch64.hpp
@@ -40,12 +40,14 @@
   }
 
   bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext,
-    bool isInJava);
+    bool isInJava, bool forceUContextUsage = false);
 
-  bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava);
+  bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava,
+    bool forceUContextUsage = false);
 
 private:
-  bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava);
+  bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava,
+    bool forceUContextUsage);
 public:
 
   static Thread *aarch64_get_thread_helper() {

--- a/src/hotspot/os_cpu/bsd_x86/javaThread_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/javaThread_bsd_x86.cpp
@@ -35,19 +35,23 @@ frame JavaThread::pd_last_frame() {
 // For Forte Analyzer AsyncGetCallTrace profiling support - thread is
 // currently interrupted by SIGPROF
 bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr,
-  void* ucontext, bool isInJava) {
+  void* ucontext, bool isInJava, bool forceUContextUsage) {
   assert(Thread::current() == this, "caller must be current thread");
-  return pd_get_top_frame(fr_addr, ucontext, isInJava);
+  return pd_get_top_frame(fr_addr, ucontext, isInJava, forceUContextUsage);
 }
 
-bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava) {
-  return pd_get_top_frame(fr_addr, ucontext, isInJava);
+bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava,
+  bool forceUContextUsage) {
+  return pd_get_top_frame(fr_addr, ucontext, isInJava, forceUContextUsage);
 }
 
-bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava) {
+bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava,
+  bool forceUContextUsage) {
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
-  if (has_last_Java_frame() && frame_anchor()->walkable()) {
+  // But forceUContextUsage == true overrides this.
+  if (ucontext == NULL ||
+      (!forceUContextUsage && has_last_Java_frame() && frame_anchor()->walkable())) {
     *fr_addr = pd_last_frame();
     return true;
   }

--- a/src/hotspot/os_cpu/bsd_x86/javaThread_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/javaThread_bsd_x86.cpp
@@ -50,8 +50,8 @@ bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava,
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
   // But forceUContextUsage == true overrides this.
-  if (ucontext == NULL ||
-      (!forceUContextUsage && has_last_Java_frame() && frame_anchor()->walkable())) {
+  if (has_last_Java_frame() && frame_anchor()->walkable() &&
+      (ucontext == NULL || !forceUContextUsage)) {
     *fr_addr = pd_last_frame();
     return true;
   }

--- a/src/hotspot/os_cpu/bsd_x86/javaThread_bsd_x86.hpp
+++ b/src/hotspot/os_cpu/bsd_x86/javaThread_bsd_x86.hpp
@@ -38,12 +38,12 @@
   }
 
   bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext,
-    bool isInJava);
+    bool isInJava, bool forceUContextUsage = false);
 
   bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext,
-    bool isInJava);
+    bool isInJava, bool forceUContextUsage = false);
 
 private:
-  bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava);
+  bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava, bool forceUContextUsage);
 
 #endif // OS_CPU_BSD_X86_JAVATHREAD_BSD_X86_HPP

--- a/src/hotspot/os_cpu/bsd_zero/javaThread_bsd_zero.hpp
+++ b/src/hotspot/os_cpu/bsd_zero/javaThread_bsd_zero.hpp
@@ -96,7 +96,8 @@
  public:
   bool pd_get_top_frame_for_signal_handler(frame* fr_addr,
                                            void* ucontext,
-                                           bool isInJava) {
+                                           bool isInJava,
+                                           bool forceUContextUsage = false) {
     ShouldNotCallThis();
     return false;
   }

--- a/src/hotspot/os_cpu/linux_aarch64/javaThread_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/javaThread_linux_aarch64.cpp
@@ -37,20 +37,24 @@ frame JavaThread::pd_last_frame() {
 // For Forte Analyzer AsyncGetCallTrace profiling support - thread is
 // currently interrupted by SIGPROF
 bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr,
-  void* ucontext, bool isInJava) {
+  void* ucontext, bool isInJava, bool forceUContextUsage) {
 
   assert(Thread::current() == this, "caller must be current thread");
-  return pd_get_top_frame(fr_addr, ucontext, isInJava);
+  return pd_get_top_frame(fr_addr, ucontext, isInJava, forceUContextUsage);
 }
 
-bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava) {
-  return pd_get_top_frame(fr_addr, ucontext, isInJava);
+bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava,
+  bool forceUContextUsage) {
+  return pd_get_top_frame(fr_addr, ucontext, isInJava, forceUContextUsage);
 }
 
-bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava) {
+bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava,
+  bool forceUContextUsage) {
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
-  if (has_last_Java_frame() && frame_anchor()->walkable()) {
+  // But forceUContextUsage == true overrides this.
+  if (ucontext == NULL ||
+      (!forceUContextUsage && has_last_Java_frame() && frame_anchor()->walkable())) {
     *fr_addr = pd_last_frame();
     return true;
   }

--- a/src/hotspot/os_cpu/linux_aarch64/javaThread_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/javaThread_linux_aarch64.cpp
@@ -53,8 +53,8 @@ bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava,
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
   // But forceUContextUsage == true overrides this.
-  if (ucontext == NULL ||
-      (!forceUContextUsage && has_last_Java_frame() && frame_anchor()->walkable())) {
+  if (has_last_Java_frame() && frame_anchor()->walkable() &&
+      (ucontext == NULL || !forceUContextUsage)) {
     *fr_addr = pd_last_frame();
     return true;
   }

--- a/src/hotspot/os_cpu/linux_aarch64/javaThread_linux_aarch64.hpp
+++ b/src/hotspot/os_cpu/linux_aarch64/javaThread_linux_aarch64.hpp
@@ -40,11 +40,13 @@
   }
 
   bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext,
-    bool isInJava);
+    bool isInJava, bool forceUContextUsage = false);
 
-  bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava);
+  bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava,
+    bool forceUContextUsage = false);
 private:
-  bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava);
+  bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava,
+    bool forceUContextUsage);
 public:
 
   static Thread *aarch64_get_thread_helper();

--- a/src/hotspot/os_cpu/linux_arm/javaThread_linux_arm.cpp
+++ b/src/hotspot/os_cpu/linux_arm/javaThread_linux_arm.cpp
@@ -54,19 +54,23 @@ void JavaThread::cache_global_variables() {
 // For Forte Analyzer AsyncGetCallTrace profiling support - thread is
 // currently interrupted by SIGPROF
 bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr,
-  void* ucontext, bool isInJava) {
+  void* ucontext, bool isInJava, bool forceUContextUsage) {
   assert(Thread::current() == this, "caller must be current thread");
-  return pd_get_top_frame(fr_addr, ucontext, isInJava);
+  return pd_get_top_frame(fr_addr, ucontext, isInJava, forceUContextUsage);
 }
 
-bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava) {
-  return pd_get_top_frame(fr_addr, ucontext, isInJava);
+bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava,
+  bool forceUContextUsage) {
+  return pd_get_top_frame(fr_addr, ucontext, isInJava, forceUContextUsage);
 }
 
-bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava) {
+bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava,
+  bool forceUContextUsage) {
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
-  if (has_last_Java_frame()) {
+  // But forceUContextUsage == true overrides this.
+  if (ucontext == NULL ||
+      (!forceUContextUsage && has_last_Java_frame())) {
     *fr_addr = pd_last_frame();
     return true;
   }

--- a/src/hotspot/os_cpu/linux_arm/javaThread_linux_arm.cpp
+++ b/src/hotspot/os_cpu/linux_arm/javaThread_linux_arm.cpp
@@ -69,8 +69,7 @@ bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava,
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
   // But forceUContextUsage == true overrides this.
-  if (ucontext == NULL ||
-      (!forceUContextUsage && has_last_Java_frame())) {
+  if (has_last_Java_frame() && (ucontext == NULL || !forceUContextUsage)) {
     *fr_addr = pd_last_frame();
     return true;
   }

--- a/src/hotspot/os_cpu/linux_arm/javaThread_linux_arm.hpp
+++ b/src/hotspot/os_cpu/linux_arm/javaThread_linux_arm.hpp
@@ -53,11 +53,13 @@ public:
   static ByteSize in_top_frame_unsafe_section_offset() { return byte_offset_of(JavaThread, _in_top_frame_unsafe_section); }
   bool in_top_frame_unsafe_section() { return _in_top_frame_unsafe_section == this; }
 
-  bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext, bool isInJava);
+  bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext, bool isInJava,
+    bool forceUContextUsage = false);
 
-  bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava);
+  bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava,
+    bool forceUContextUsage = false);
 private:
-  bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava);
+  bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava, bool forceUContextUsage);
 public:
 
 #endif // OS_CPU_LINUX_ARM_JAVATHREAD_LINUX_ARM_HPP

--- a/src/hotspot/os_cpu/linux_ppc/javaThread_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/javaThread_linux_ppc.cpp
@@ -39,11 +39,14 @@ frame JavaThread::pd_last_frame() {
   return frame(sp, pc);
 }
 
-bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava) {
+bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava,
+  bool forceUContextUsage) {
 
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
-  if (has_last_Java_frame() && frame_anchor()->walkable()) {
+  // But forceUContextUsage == true overrides this.
+  if (ucontext == NULL ||
+      (!forceUContextUsage && has_last_Java_frame() && frame_anchor()->walkable())) {
     intptr_t* sp = last_Java_sp();
     address pc = _anchor.last_Java_pc();
     // pc can be seen as null because not all writers use store pc + release store sp.
@@ -108,8 +111,9 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
 }
 
 // Forte Analyzer AsyncGetCallTrace profiling support.
-bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext, bool isInJava) {
-  return pd_get_top_frame_for_profiling(fr_addr, ucontext, isInJava);
+bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext, bool isInJava,
+  bool forceUContextUsage) {
+  return pd_get_top_frame_for_profiling(fr_addr, ucontext, isInJava, forceUContextUsage);
 }
 
 void JavaThread::cache_global_variables() { }

--- a/src/hotspot/os_cpu/linux_ppc/javaThread_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/javaThread_linux_ppc.cpp
@@ -45,8 +45,8 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
   // But forceUContextUsage == true overrides this.
-  if (ucontext == NULL ||
-      (!forceUContextUsage && has_last_Java_frame() && frame_anchor()->walkable())) {
+  if (has_last_Java_frame() && frame_anchor()->walkable() &&
+      (ucontext == NULL || !forceUContextUsage)) {
     intptr_t* sp = last_Java_sp();
     address pc = _anchor.last_Java_pc();
     // pc can be seen as null because not all writers use store pc + release store sp.

--- a/src/hotspot/os_cpu/linux_ppc/javaThread_linux_ppc.hpp
+++ b/src/hotspot/os_cpu/linux_ppc/javaThread_linux_ppc.hpp
@@ -37,8 +37,10 @@
 
  public:
 
-  bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext, bool isInJava);
+  bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext, bool isInJava,
+    bool forceUContextUsage = false);
 
-  bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava);
+  bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava,
+    bool forceUContextUsage = false);
 
 #endif // OS_CPU_LINUX_PPC_JAVATHREAD_LINUX_PPC_HPP

--- a/src/hotspot/os_cpu/linux_riscv/javaThread_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/javaThread_linux_riscv.cpp
@@ -35,20 +35,24 @@ frame JavaThread::pd_last_frame() {
 // For Forte Analyzer AsyncGetCallTrace profiling support - thread is
 // currently interrupted by SIGPROF
 bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr,
-  void* ucontext, bool isInJava) {
+  void* ucontext, bool isInJava, bool forceUContextUsage) {
 
   assert(Thread::current() == this, "caller must be current thread");
-  return pd_get_top_frame(fr_addr, ucontext, isInJava);
+  return pd_get_top_frame(fr_addr, ucontext, isInJava, forceUContextUsage);
 }
 
-bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava) {
-  return pd_get_top_frame(fr_addr, ucontext, isInJava);
+bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava,
+  bool forceUContextUsage) {
+  return pd_get_top_frame(fr_addr, ucontext, isInJava, forceUContextUsage);
 }
 
-bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava) {
-  // If we have a last_Java_frame, then we should use it even if
+bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava,
+  bool forceUContextUsage) {
+    // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
-  if (has_last_Java_frame() && frame_anchor()->walkable()) {
+  // But forceUContextUsage == true overrides this.
+  if (ucontext == NULL ||
+      (!forceUContextUsage && has_last_Java_frame() && frame_anchor()->walkable())) {
     *fr_addr = pd_last_frame();
     return true;
   }

--- a/src/hotspot/os_cpu/linux_riscv/javaThread_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/javaThread_linux_riscv.cpp
@@ -51,8 +51,8 @@ bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava,
     // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
   // But forceUContextUsage == true overrides this.
-  if (ucontext == NULL ||
-      (!forceUContextUsage && has_last_Java_frame() && frame_anchor()->walkable())) {
+  if (has_last_Java_frame() && frame_anchor()->walkable() &&
+      (ucontext == NULL || !forceUContextUsage)) {
     *fr_addr = pd_last_frame();
     return true;
   }

--- a/src/hotspot/os_cpu/linux_riscv/javaThread_linux_riscv.hpp
+++ b/src/hotspot/os_cpu/linux_riscv/javaThread_linux_riscv.hpp
@@ -39,10 +39,11 @@
   }
 
   bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext,
-    bool isInJava);
+    bool isInJava, bool forceUContextUsage = false);
 
-  bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava);
+  bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava,
+    bool forceUContextUsage = false);
 private:
-  bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava);
+  bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava, bool forceUContextUsage);
 
 #endif // OS_CPU_LINUX_RISCV_JAVATHREAD_LINUX_RISCV_HPP

--- a/src/hotspot/os_cpu/linux_s390/javaThread_linux_s390.cpp
+++ b/src/hotspot/os_cpu/linux_s390/javaThread_linux_s390.cpp
@@ -44,11 +44,14 @@ frame JavaThread::pd_last_frame() {
   return frame(sp, pc);
 }
 
-bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava) {
+bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava,
+  bool forceUContextUsage) {
 
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
-  if (has_last_Java_frame() && frame_anchor()->walkable()) {
+  // But forceUContextUsage == true overrides this.
+  if (ucontext == NULL ||
+      (!forceUContextUsage && has_last_Java_frame() && frame_anchor()->walkable())) {
     *fr_addr = pd_last_frame();
     return true;
   }
@@ -132,8 +135,9 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
 }
 
 // Forte Analyzer AsyncGetCallTrace profiling support.
-bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext, bool isInJava) {
-  return pd_get_top_frame_for_profiling(fr_addr, ucontext, isInJava);
+bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext, bool isInJava,
+  bool forceUContextUsage) {
+  return pd_get_top_frame_for_profiling(fr_addr, ucontext, isInJava, forceUContextUsage);
 }
 
 void JavaThread::cache_global_variables() { }

--- a/src/hotspot/os_cpu/linux_s390/javaThread_linux_s390.cpp
+++ b/src/hotspot/os_cpu/linux_s390/javaThread_linux_s390.cpp
@@ -50,8 +50,8 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
   // But forceUContextUsage == true overrides this.
-  if (ucontext == NULL ||
-      (!forceUContextUsage && has_last_Java_frame() && frame_anchor()->walkable())) {
+  if (has_last_Java_frame() && frame_anchor()->walkable() &&
+      (ucontext == NULL || !forceUContextUsage)) {
     *fr_addr = pd_last_frame();
     return true;
   }

--- a/src/hotspot/os_cpu/linux_s390/javaThread_linux_s390.hpp
+++ b/src/hotspot/os_cpu/linux_s390/javaThread_linux_s390.hpp
@@ -36,8 +36,10 @@
   frame pd_last_frame();
 
  public:
-  bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext, bool isInJava);
+  bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext, bool isInJava,
+    bool forceUContextUsage = false);
 
-  bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava);
+  bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava,
+    bool forceUContextUsage = false);
 
 #endif // OS_CPU_LINUX_S390_JAVATHREAD_LINUX_S390_HPP

--- a/src/hotspot/os_cpu/linux_x86/javaThread_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/javaThread_linux_x86.cpp
@@ -48,7 +48,8 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
 bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava) {
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
-  if (has_last_Java_frame() && frame_anchor()->walkable()) {
+  if (ucontext == NULL && (has_last_Java_frame() && frame_anchor()->walkable())) {
+    fprintf(stderr, "Has last java frame\n");
     *fr_addr = pd_last_frame();
     return true;
   }
@@ -57,6 +58,7 @@ bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava)
   // we try to glean some information out of the ucontext
   // if we were running Java code when SIGPROF came in.
   if (isInJava) {
+
     ucontext_t* uc = (ucontext_t*) ucontext;
 
     intptr_t* ret_fp;

--- a/src/hotspot/os_cpu/linux_x86/javaThread_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/javaThread_linux_x86.cpp
@@ -35,20 +35,24 @@ frame JavaThread::pd_last_frame() {
 // For Forte Analyzer AsyncGetCallTrace profiling support - thread is
 // currently interrupted by SIGPROF
 bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr,
-  void* ucontext, bool isInJava) {
+  void* ucontext, bool isInJava, bool forceUContextUsage) {
 
   assert(Thread::current() == this, "caller must be current thread");
-  return pd_get_top_frame(fr_addr, ucontext, isInJava);
+  return pd_get_top_frame(fr_addr, ucontext, isInJava, forceUContextUsage);
 }
 
-bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava) {
-  return pd_get_top_frame(fr_addr, ucontext, isInJava);
+bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava,
+  bool forceUContextUsage) {
+  return pd_get_top_frame(fr_addr, ucontext, isInJava, forceUContextUsage);
 }
 
-bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava) {
+bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava,
+  bool forceUContextUsage) {
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
-  if (ucontext == NULL && (has_last_Java_frame() && frame_anchor()->walkable())) {
+  // But forceUContextUsage == true overrides this.
+  if (ucontext == NULL ||
+      (!forceUContextUsage && has_last_Java_frame() && frame_anchor()->walkable())) {
     fprintf(stderr, "Has last java frame\n");
     *fr_addr = pd_last_frame();
     return true;

--- a/src/hotspot/os_cpu/linux_x86/javaThread_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/javaThread_linux_x86.cpp
@@ -52,13 +52,11 @@ bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava,
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
   // But forceUContextUsage == true overrides this.
-  fprintf(stderr, "JavaThread::pd_get_top_frame: ucontext=%p, isInJava=%d, forceUContextUsage=%d\n", ucontext, isInJava, forceUContextUsage);
   if (ucontext == NULL ||
       (!forceUContextUsage && has_last_Java_frame() && frame_anchor()->walkable())) {
     *fr_addr = pd_last_frame();
     return true;
   }
-
 
   // At this point, we don't have a last_Java_frame, so
   // we try to glean some information out of the ucontext

--- a/src/hotspot/os_cpu/linux_x86/javaThread_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/javaThread_linux_x86.cpp
@@ -25,6 +25,7 @@
 #include "precompiled.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/javaThread.hpp"
+#include <cstdio>
 
 frame JavaThread::pd_last_frame() {
   assert(has_last_Java_frame(), "must have last_Java_sp() when suspended");
@@ -51,12 +52,13 @@ bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava,
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
   // But forceUContextUsage == true overrides this.
+  fprintf(stderr, "JavaThread::pd_get_top_frame: ucontext=%p, isInJava=%d, forceUContextUsage=%d\n", ucontext, isInJava, forceUContextUsage);
   if (ucontext == NULL ||
       (!forceUContextUsage && has_last_Java_frame() && frame_anchor()->walkable())) {
-    fprintf(stderr, "Has last java frame\n");
     *fr_addr = pd_last_frame();
     return true;
   }
+
 
   // At this point, we don't have a last_Java_frame, so
   // we try to glean some information out of the ucontext

--- a/src/hotspot/os_cpu/linux_x86/javaThread_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/javaThread_linux_x86.cpp
@@ -38,7 +38,8 @@ frame JavaThread::pd_last_frame() {
 bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr,
   void* ucontext, bool isInJava, bool forceUContextUsage) {
 
-  assert(Thread::current() == this, "caller must be current thread");
+  assert(Thread::current() == this || Thread::currently_in_async_stack_walking(),
+    "caller must be current thread or in async stack walking");
   return pd_get_top_frame(fr_addr, ucontext, isInJava, forceUContextUsage);
 }
 

--- a/src/hotspot/os_cpu/linux_x86/javaThread_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/javaThread_linux_x86.cpp
@@ -52,8 +52,8 @@ bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava,
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
   // But forceUContextUsage == true overrides this.
-  if (ucontext == NULL ||
-      (!forceUContextUsage && has_last_Java_frame() && frame_anchor()->walkable())) {
+  if (has_last_Java_frame() && frame_anchor()->walkable() &&
+      (ucontext == NULL || !forceUContextUsage)) {
     *fr_addr = pd_last_frame();
     return true;
   }

--- a/src/hotspot/os_cpu/linux_x86/javaThread_linux_x86.hpp
+++ b/src/hotspot/os_cpu/linux_x86/javaThread_linux_x86.hpp
@@ -38,11 +38,12 @@
   }
 
   bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext,
-    bool isInJava);
+    bool isInJava, bool forceUContextUsage = false);
 
-  bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava);
+  bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava,
+    bool forceUContextUsage = false);
 private:
-  bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava);
+  bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava, bool forceUContextUsage);
 public:
 
 #endif // OS_CPU_LINUX_X86_JAVATHREAD_LINUX_X86_HPP

--- a/src/hotspot/os_cpu/linux_zero/javaThread_linux_zero.cpp
+++ b/src/hotspot/os_cpu/linux_zero/javaThread_linux_zero.cpp
@@ -38,8 +38,10 @@ void JavaThread::cache_global_variables() {
 
 bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr,
                                          void* ucontext,
-                                         bool isInJava) {
-  if (has_last_Java_frame()) {
+                                         bool isInJava,
+                                         bool forceUContextUsage) {
+  if (ucontext == NULL ||
+      (!forceUContextUsage && has_last_Java_frame())) {
     *fr_addr = pd_last_frame();
     return true;
   }
@@ -69,6 +71,7 @@ bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr,
 
 bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr,
                                     void* ucontext,
-                                    bool isInJava) {
-  return pd_get_top_frame_for_signal_handler(fr_addr, ucontext, isInJava);
+                                    bool isInJava,
+                                    bool forceUContextUsage) {
+  return pd_get_top_frame_for_signal_handler(fr_addr, ucontext, isInJava, forceUContextUsage);
 }

--- a/src/hotspot/os_cpu/linux_zero/javaThread_linux_zero.cpp
+++ b/src/hotspot/os_cpu/linux_zero/javaThread_linux_zero.cpp
@@ -40,8 +40,7 @@ bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr,
                                          void* ucontext,
                                          bool isInJava,
                                          bool forceUContextUsage) {
-  if (ucontext == NULL ||
-      (!forceUContextUsage && has_last_Java_frame())) {
+  if (has_last_Java_frame() && (ucontext == NULL || !forceUContextUsage)) {
     *fr_addr = pd_last_frame();
     return true;
   }

--- a/src/hotspot/os_cpu/linux_zero/javaThread_linux_zero.hpp
+++ b/src/hotspot/os_cpu/linux_zero/javaThread_linux_zero.hpp
@@ -96,10 +96,12 @@
  public:
   bool pd_get_top_frame_for_signal_handler(frame* fr_addr,
                                            void* ucontext,
-                                           bool isInJava);
+                                           bool isInJava,
+                                           bool forceUContextUsage = false);
 
   bool pd_get_top_frame_for_profiling(frame* fr_addr,
                                       void* ucontext,
-                                      bool isInJava);
+                                      bool isInJava,
+                                      bool forceUContextUsage = false);
 
 #endif // OS_CPU_LINUX_ZERO_JAVATHREAD_LINUX_ZERO_HPP

--- a/src/hotspot/os_cpu/windows_aarch64/javaThread_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/javaThread_windows_aarch64.cpp
@@ -38,20 +38,23 @@ frame JavaThread::pd_last_frame() {
 // For Forte Analyzer AsyncGetCallTrace profiling support - thread is
 // currently interrupted by SIGPROF
 bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr,
-  void* ucontext, bool isInJava) {
+  void* ucontext, bool isInJava, bool forceUContextUsage) {
 
   assert(Thread::current() == this, "caller must be current thread");
-  return pd_get_top_frame(fr_addr, ucontext, isInJava);
+  return pd_get_top_frame(fr_addr, ucontext, isInJava, forceUContextUsage);
 }
 
-bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava) {
-  return pd_get_top_frame(fr_addr, ucontext, isInJava);
+bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava,
+  bool forceUContextUsage) {
+  return pd_get_top_frame(fr_addr, ucontext, isInJava, forceUContextUsage);
 }
 
 bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava) {
   // If we have a last_Java_frame, then we should use it even if
-  // isInJava == true.  It should be more reliable than CONTEXT info.
-  if (has_last_Java_frame() && frame_anchor()->walkable()) {
+  // isInJava == true.  It should be more reliable than ucontext info.
+  // But forceUContextUsage == true overrides this.
+  if (ucontext == NULL ||
+      (!forceUContextUsage && has_last_Java_frame() && frame_anchor()->walkable())) {
     *fr_addr = pd_last_frame();
     return true;
   }

--- a/src/hotspot/os_cpu/windows_aarch64/javaThread_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/javaThread_windows_aarch64.cpp
@@ -40,7 +40,8 @@ frame JavaThread::pd_last_frame() {
 bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr,
   void* ucontext, bool isInJava, bool forceUContextUsage) {
 
-  assert(Thread::current() == this, "caller must be current thread");
+  assert(Thread::current() == this || Thread::currently_in_async_stack_walking(),
+    "caller must be current thread or in async stack walking");
   return pd_get_top_frame(fr_addr, ucontext, isInJava, forceUContextUsage);
 }
 

--- a/src/hotspot/os_cpu/windows_aarch64/javaThread_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/javaThread_windows_aarch64.cpp
@@ -53,8 +53,8 @@ bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava)
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
   // But forceUContextUsage == true overrides this.
-  if (ucontext == NULL ||
-      (!forceUContextUsage && has_last_Java_frame() && frame_anchor()->walkable())) {
+  if (has_last_Java_frame() && frame_anchor()->walkable() &&
+      (ucontext == NULL || !forceUContextUsage)) {
     *fr_addr = pd_last_frame();
     return true;
   }

--- a/src/hotspot/os_cpu/windows_aarch64/javaThread_windows_aarch64.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/javaThread_windows_aarch64.hpp
@@ -39,11 +39,12 @@
   }
 
   bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext,
-    bool isInJava);
+    bool isInJava, bool forceUContextUsage = false);
 
-  bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava);
+  bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava,
+    bool forceUContextUsage = false);
 private:
-  bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava);
+  bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava, bool forceUContextUsage);
 public:
 
   static Thread *aarch64_get_thread_helper() {

--- a/src/hotspot/os_cpu/windows_x86/javaThread_windows_x86.cpp
+++ b/src/hotspot/os_cpu/windows_x86/javaThread_windows_x86.cpp
@@ -35,20 +35,24 @@ frame JavaThread::pd_last_frame() {
 // For Forte Analyzer AsyncGetCallTrace profiling support - thread is
 // currently interrupted by SIGPROF
 bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr,
-  void* ucontext, bool isInJava) {
+  void* ucontext, bool isInJava, bool forceUContextUsage) {
 
   assert(Thread::current() == this, "caller must be current thread");
-  return pd_get_top_frame(fr_addr, ucontext, isInJava);
+  return pd_get_top_frame(fr_addr, ucontext, isInJava, forceUContextUsage);
 }
 
-bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava) {
-  return pd_get_top_frame(fr_addr, ucontext, isInJava);
+bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava,
+  bool forceUContextUsage) {
+  return pd_get_top_frame(fr_addr, ucontext, isInJava, forceUContextUsage);
 }
 
-bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava) {
+bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava,
+  bool forceUContextUsage) {
   // If we have a last_Java_frame, then we should use it even if
-  // isInJava == true.  It should be more reliable than CONTEXT info.
-  if (has_last_Java_frame() && frame_anchor()->walkable()) {
+  // isInJava == true.  It should be more reliable than ucontext info.
+  // But forceUContextUsage == true overrides this.
+  if (ucontext == NULL ||
+      (!forceUContextUsage && has_last_Java_frame() && frame_anchor()->walkable())) {
     *fr_addr = pd_last_frame();
     return true;
   }

--- a/src/hotspot/os_cpu/windows_x86/javaThread_windows_x86.cpp
+++ b/src/hotspot/os_cpu/windows_x86/javaThread_windows_x86.cpp
@@ -51,8 +51,8 @@ bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava,
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
   // But forceUContextUsage == true overrides this.
-  if (ucontext == NULL ||
-      (!forceUContextUsage && has_last_Java_frame() && frame_anchor()->walkable())) {
+  if (has_last_Java_frame() && frame_anchor()->walkable() &&
+      (ucontext == NULL || !forceUContextUsage)) {
     *fr_addr = pd_last_frame();
     return true;
   }

--- a/src/hotspot/os_cpu/windows_x86/javaThread_windows_x86.hpp
+++ b/src/hotspot/os_cpu/windows_x86/javaThread_windows_x86.hpp
@@ -45,13 +45,14 @@
   }
 
   bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext,
-    bool isInJava);
+    bool isInJava, bool forceUContextUsage = false);
 
-   bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava);
+   bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava,
+     bool forceUContextUsage = false);
 
   static ByteSize windows_saved_rsi_offset() { return byte_offset_of(JavaThread, _windows_saved_rsi); }
   static ByteSize windows_saved_rdi_offset() { return byte_offset_of(JavaThread, _windows_saved_rdi); }
 private:
-  bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava);
+  bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava, bool forceUContextUsage);
 
 #endif // OS_CPU_WINDOWS_X86_JAVATHREAD_WINDOWS_X86_HPP

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -1725,8 +1725,9 @@ void java_lang_Thread::set_thread_status(oop java_thread, JavaThreadStatus statu
 // Read thread status value from threadStatus field in java.lang.Thread java class.
 JavaThreadStatus java_lang_Thread::get_thread_status(oop java_thread) {
   // Make sure the caller is operating on behalf of the VM or is
-  // running VM code (state == _thread_in_vm).
-  assert(Threads_lock->owned_by_self() || Thread::current()->is_VM_thread() ||
+  // running VM code (state == _thread_in_vm), or is walking the stack
+  // asynchronously
+  assert(Threads_lock->owned_by_self() || Thread::currently_in_async_stack_walking() || Thread::current()->is_VM_thread() ||
          JavaThread::current()->thread_state() == _thread_in_vm,
          "Java Thread is not running in vm");
   GET_FIELDHOLDER_FIELD(java_thread, get_thread_status, JavaThreadStatus::NEW /* not initialized */);

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -1624,6 +1624,7 @@ oop java_lang_Thread::holder(oop java_thread) {
 bool java_lang_Thread::interrupted(oop java_thread) {
   // Make sure the caller can safely access oops.
   assert(Thread::current()->is_VM_thread() ||
+         Thread::currently_in_async_stack_walking() ||
          (JavaThread::current()->thread_state() != _thread_blocked &&
           JavaThread::current()->thread_state() != _thread_in_native),
          "Unsafe access to oop");

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -2088,6 +2088,11 @@ PcDesc* PcDescContainer::find_pc_desc_internal(address pc, bool approximate, con
   upper -= 1; // exclude final sentinel
   if (lower >= upper)  return nullptr;  // native method; no PcDescs at all
 
+  if (lower->pc_offset() >= pc_offset || upper->pc_offset() < pc_offset) {
+    // this might happen during AsyncGetStackTrace stack walking
+    return NULL;
+  }
+
 #define assert_LU_OK \
   /* invariant on lower..upper during the following search: */ \
   assert(lower->pc_offset() <  pc_offset, "sanity"); \

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -2141,7 +2141,7 @@ PcDesc* PcDescContainer::find_pc_desc_internal(address pc, bool approximate, con
 
   if (match_desc(upper, pc_offset, approximate)) {
     assert(upper == linear_search(search, pc_offset, approximate), "search ok");
-    if (!Thread::current_in_asgct()) {
+    if (!Thread::currently_in_async_stack_walking()) {
       // we don't want to modify the cache if we're in ASGCT
       // which is typically called in a signal handler
       _pc_desc_cache.add_pc_desc(upper);

--- a/src/hotspot/share/include/profile.h
+++ b/src/hotspot/share/include/profile.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifndef JVM_PROFILE_H
+#define JVM_PROFILE_H
+
+#include <cstdint>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "jni.h"
+
+
+namespace asgst {
+// error codes, equivalent to the forte error codes for AsyncGetCallTrace
+enum Error {
+  NO_JAVA_FRAME         =   0,
+  NO_CLASS_LOAD         =  -1,
+  GC_ACTIVE             =  -2,
+  UNKNOWN_NOT_JAVA      =  -3,
+  NOT_WALKABLE_NOT_JAVA =  -4,
+  UNKNOWN_JAVA          =  -5,
+  UNKNOWN_STATE         =  -7,
+  THREAD_EXIT           =  -8,
+  DEOPT                 =  -9,
+  THREAD_NOT_JAVA       = -10
+};
+
+enum FrameTypeId : uint8_t {
+  FRAME_JAVA         = 1, // JIT compiled and interpreted
+  FRAME_JAVA_INLINED = 2, // inlined JIT compiled
+  FRAME_NATIVE       = 3, // native wrapper to call C methods from Java
+  FRAME_STUB         = 4, // VM generated stubs
+  FRAME_CPP          = 5  // C/C++/... frames
+};
+
+typedef struct {
+  FrameTypeId type;            // frame type
+  uint8_t comp_level;      // compilation level, 0 is interpreted, -1 is undefined, > 1 is JIT compiled
+  uint16_t bci;            // 0 < bci < 65536
+  jmethodID method_id;
+} JavaFrame;               // used for FRAME_JAVA and FRAME_JAVA_INLINED
+
+typedef struct {
+  FrameTypeId type;  // frame type
+  void *pc;          // current program counter inside this frame
+} NonJavaFrame;
+
+typedef union {
+  FrameTypeId type;     // to distinguish between JavaFrame and NonJavaFrame
+  JavaFrame java_frame;
+  NonJavaFrame non_java_frame;
+} CallFrame;
+
+// Enumeration to distinguish tiers of compilation, only >= 0 are used
+/*enum CompLevel {
+  CompLevel_any               = -1,        // Used for querying the state
+  CompLevel_all               = -1,        // Used for changing the state  // unused
+  CompLevel_none              = 0,         // Interpreter
+  CompLevel_simple            = 1,         // C1
+  CompLevel_limited_profile   = 2,         // C1, invocation & backedge counters
+  CompLevel_full_profile      = 3,         // C1, invocation & backedge counters + mdo
+  CompLevel_full_optimization = 4          // C2 or JVMCI
+};*/
+
+typedef struct {
+  jint num_frames;                // number of frames in this trace,
+                                  // (< 0 indicates the frame is not walkable).
+  CallFrame *frames;              // frames that make up this trace. Callee followed by callers.
+  void* frame_info;               // more information on frames
+} CallTrace;
+
+
+enum Options {
+  INCLUDE_C_FRAMES = 1
+};
+
+}
+
+
+// Asynchronous profiling entry point which is usually called from signal
+// handler. It is a replacement of AsyncGetCallTrace.
+//
+// This function must only be called when JVM/TI
+// CLASS_LOAD events have been enabled since agent startup. The enabled
+// event will cause the jmethodIDs to be allocated at class load time.
+// The jmethodIDs cannot be allocated in a signal handler because locks
+// cannot be grabbed in a signal handler safely.
+//
+// void AsyncGetStackTrace(asgst::CallTrace *trace, jint depth, void* ucontext, int32_t options)
+//
+// Called by the profiler to obtain the current method call stack trace for
+// a given thread. The thread is identified by the env_id field in the
+// asgst::CallTrace structure. The profiler agent should allocate a asgst::CallTrace
+// structure with enough memory for the requested stack depth. The VM fills in
+// the frames buffer and the num_frames field.
+//
+// Arguments:
+//
+//   trace    - trace data structure to be filled by the VM.
+//   depth    - depth of the call stack trace.
+//   ucontext - ucontext_t of the LWP
+//   options  - bit flags for additional configuration,
+//              currently only the lowest bit is used: setting it to 1 enables capturing C frames
+extern "C" {
+JNIEXPORT
+void AsyncGetStackTrace(asgst::CallTrace *trace, jint depth, void* ucontext, int32_t options);
+}
+
+#endif // JVM_PROFILE_H

--- a/src/hotspot/share/oops/accessBackend.cpp
+++ b/src/hotspot/share/oops/accessBackend.cpp
@@ -220,7 +220,8 @@ namespace AccessInternal {
 
     JavaThread* java_thread = JavaThread::cast(thread);
     JavaThreadState state = java_thread->thread_state();
-    assert(state == _thread_in_vm || state == _thread_in_Java || state == _thread_new,
+    assert(state == _thread_in_vm || state == _thread_in_Java || state == _thread_new
+        || Thread::currently_in_async_stack_walking(),
            "Wrong thread state for accesses: %d", (int)state);
   }
 #endif

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -666,6 +666,7 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     trace->num_frames = ticks_unknown_state; // -7
     break;
   }
+  DEBUG_ONLY(thread->set_in_async_stack_walking(false);)
 }
 
 

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -607,7 +607,7 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
   }
 
   // signify to other code in the VM that we're in ASGCT
-  ThreadInAsgct tia(thread);
+  ThreadInAsyncStackWalking tia(thread);
 
   switch (thread->thread_state()) {
   case _thread_new:
@@ -666,7 +666,6 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     trace->num_frames = ticks_unknown_state; // -7
     break;
   }
-  DEBUG_ONLY(thread->set_in_async_stack_walking(false);)
 }
 
 

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -731,6 +731,7 @@ JvmtiEnvBase::get_cthread_last_java_vframe(JavaThread* jt, RegisterMap* reg_map_
 
 jint
 JvmtiEnvBase::get_thread_state(oop thread_oop, JavaThread* jt) {
+  // any changes here should be propagated to profile.cpp
   jint state = 0;
 
   if (thread_oop != nullptr) {

--- a/src/hotspot/share/prims/profile.cpp
+++ b/src/hotspot/share/prims/profile.cpp
@@ -82,6 +82,7 @@ static void fill_call_trace_given_top(JavaThread* thd,
 
 extern "C" JNIEXPORT void AsyncGetStackTrace(ASGST_CallTrace *trace, jint depth, void* ucontext, int32_t options) {
   assert(trace->frames != NULL, "");
+  fprintf(stdout, "######################## asc\n");
 
   // Can't use thread_from_jni_environment as it may also perform a VM exit check that is unsafe to
   // do from this context.
@@ -94,7 +95,7 @@ extern "C" JNIEXPORT void AsyncGetStackTrace(ASGST_CallTrace *trace, jint depth,
     return;
   }
 
-  if (!raw_thread->is_Java_thread()) {
+  if (!raw_thread->is_Java_thread()) { // TODO: disable this check
     trace->num_frames = (jint)ASGST_THREAD_NOT_JAVA; // -8
     return;
   }
@@ -119,6 +120,8 @@ extern "C" JNIEXPORT void AsyncGetStackTrace(ASGST_CallTrace *trace, jint depth,
     trace->num_frames = (jint)ASGST_GC_ACTIVE; // -2
     return;
   }
+
+
 
   // !important! make sure all to call thread->set_in_asgct(false) before every return
   thread->set_in_asgct(true);

--- a/src/hotspot/share/prims/profile.cpp
+++ b/src/hotspot/share/prims/profile.cpp
@@ -71,7 +71,7 @@ static void fill_call_trace_given_top(JavaThread* thd,
       };
     } else {
       trace->frames[count] = {.non_java_frame = {
-          st.base_frame()->is_stub_frame() ? ASGST_FRAME_STUB : ASGST_FRAME_CPP,
+          (uint8_t)(st.base_frame()->is_stub_frame() ? ASGST_FRAME_STUB : ASGST_FRAME_CPP),
           st.base_frame()->pc()
         }
       };

--- a/src/hotspot/share/prims/profile.cpp
+++ b/src/hotspot/share/prims/profile.cpp
@@ -182,10 +182,6 @@ extern "C" JNIEXPORT void AsyncGetStackTrace(ASGST_CallTrace *trace, jint depth,
     return;
   }
 
-
-  // !important! make sure all to call thread->set_in_asgct(false) before every return
-  thread->set_in_asgct(true);
-
   switch (thread->thread_state()) {
   case _thread_new:
   case _thread_uninitialized:
@@ -220,5 +216,4 @@ extern "C" JNIEXPORT void AsyncGetStackTrace(ASGST_CallTrace *trace, jint depth,
     trace->num_frames = (jint)ASGST_UNKNOWN_STATE; // -7
     break;
   }
-  thread->set_in_asgct(false);
 }

--- a/src/hotspot/share/prims/profile.cpp
+++ b/src/hotspot/share/prims/profile.cpp
@@ -50,7 +50,6 @@ static void fill_call_trace_given_top(JavaThread* thd,
   for (; count < depth && !st.at_end(); st.next(), count++) {
     if (st.at_error()) {
       trace->num_frames = st.state();
-      printf("error: %d at count %d\n", st.state(), count);
       return;
     }
     if (st.is_java_frame()) {

--- a/src/hotspot/share/prims/profile.cpp
+++ b/src/hotspot/share/prims/profile.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "profile.h"
+
+#include "gc/shared/collectedHeap.inline.hpp"
+#include "runtime/frame.inline.hpp"
+#include "runtime/thread.hpp"
+#include "runtime/thread.inline.hpp"
+#include "runtime/vframe.inline.hpp"
+#include "runtime/vframeArray.hpp"
+#include "runtime/vframe_hp.hpp"
+#include "prims/stackWalker.hpp"
+#include "prims/jvmtiExport.hpp"
+
+namespace asgst {
+
+static void fill_call_trace_given_top(JavaThread* thd,
+                                      CallTrace* trace,
+                                      int depth,
+                                      frame top_frame,
+                                      bool skip_c_frames) {
+  NoHandleMark nhm;
+  assert(trace->frames != NULL, "trace->frames must be non-NULL");
+  trace->frame_info = NULL;
+
+  StackWalker st(thd, top_frame, skip_c_frames,
+    MaxJavaStackTraceDepth * 2);
+
+  int count = 0;
+  for (; count < depth && !st.at_end(); st.next(), count++) {
+    if (st.at_error()) {
+      trace->num_frames = st.state();
+      return;
+    }
+    if (st.is_java_frame()) {
+      FrameTypeId type = FRAME_JAVA;
+      if (st.is_native_frame()) {
+        type = FRAME_NATIVE;
+      } else if (st.is_inlined()) {
+        type = FRAME_JAVA_INLINED;
+      }
+      int comp_level = 0;
+      if (st.state() == STACKWALKER_COMPILED_FRAME) {
+        comp_level = st.method()->highest_comp_level();
+      }
+      trace->frames[count] = {.java_frame = {
+          type, (uint8_t)comp_level,
+          st.is_native_frame() ? (uint16_t)0 : (uint16_t)st.bci(),
+          st.method()->find_jmethod_id_or_null()
+        }
+      };
+    } else {
+      trace->frames[count] = {.non_java_frame = {
+          st.base_frame()->is_stub_frame() ? FRAME_STUB : FRAME_CPP,
+          st.base_frame()->pc()
+        }
+      };
+    }
+  }
+  trace->num_frames = count;
+}
+}
+
+extern "C" {
+JNIEXPORT
+void AsyncGetStackTrace(asgst::CallTrace *trace, jint depth, void* ucontext, int32_t options) {
+  assert(trace->frames != NULL, "");
+  JavaThread* thread = JavaThread::current();
+  if (thread->is_terminated()) {
+    thread->block_if_vm_exited();
+    // thread has exited or thread is exiting
+    trace->num_frames = (jint)asgst::Error::THREAD_EXIT; // -8;
+    return;
+  }
+  if (!thread->is_Java_thread()) {
+    trace->num_frames = (jint)asgst::Error::THREAD_NOT_JAVA; // -10
+    return;
+  }
+
+  if (thread->in_deopt_handler()) {
+    // thread is in the deoptimization handler so return no frames
+    trace->num_frames = (jint)asgst::Error::DEOPT; // -9
+    return;
+  }
+
+  if (!JvmtiExport::should_post_class_load()) {
+    trace->num_frames = (jint)asgst::Error::NO_CLASS_LOAD; // -1
+    return;
+  }
+
+  if (Universe::heap()->is_gc_active()) {
+    trace->num_frames = (jint)asgst::Error::GC_ACTIVE; // -2
+    return;
+  }
+
+  switch (thread->thread_state()) {
+  case _thread_new:
+  case _thread_uninitialized:
+  case _thread_new_trans:
+    // We found the thread on the threads list above, but it is too
+    // young to be useful so return that there are no Java frames.
+    trace->num_frames = 0;
+    break;
+  case _thread_in_native:
+  case _thread_in_native_trans:
+  case _thread_blocked:
+  case _thread_blocked_trans:
+  case _thread_in_vm:
+  case _thread_in_vm_trans:
+  case _thread_in_Java:
+  case _thread_in_Java_trans:
+    {
+      frame ret_frame;
+      if (!thread->pd_get_top_frame_for_signal_handler(&ret_frame, ucontext, true)) {
+        trace->num_frames = (jint)asgst::Error::UNKNOWN_NOT_JAVA;  // -3 unknown frame
+        return;
+      }
+      fill_call_trace_given_top(thread, trace, depth, ret_frame,
+        (options & asgst::INCLUDE_C_FRAMES) == 0);
+    }
+    break;
+  default:
+    // Unknown thread state
+    trace->num_frames = (jint)asgst::Error::UNKNOWN_STATE; // -7
+    break;
+  }
+}
+}

--- a/src/hotspot/share/prims/profile.cpp
+++ b/src/hotspot/share/prims/profile.cpp
@@ -82,8 +82,6 @@ static void fill_call_trace_given_top(JavaThread* thd,
 
 extern "C" JNIEXPORT void AsyncGetStackTrace(ASGST_CallTrace *trace, jint depth, void* ucontext, int32_t options) {
   assert(trace->frames != NULL, "");
-  fprintf(stdout, "######################## asc\n");
-
   // Can't use thread_from_jni_environment as it may also perform a VM exit check that is unsafe to
   // do from this context.
   Thread* raw_thread = Thread::current_or_null_safe();

--- a/src/hotspot/share/prims/profile.cpp
+++ b/src/hotspot/share/prims/profile.cpp
@@ -34,10 +34,8 @@
 #include "prims/stackWalker.hpp"
 #include "prims/jvmtiExport.hpp"
 
-namespace asgst {
-
 static void fill_call_trace_given_top(JavaThread* thd,
-                                      CallTrace* trace,
+                                      ASGST_CallTrace* trace,
                                       int depth,
                                       frame top_frame,
                                       bool skip_c_frames) {
@@ -52,28 +50,29 @@ static void fill_call_trace_given_top(JavaThread* thd,
   for (; count < depth && !st.at_end(); st.next(), count++) {
     if (st.at_error()) {
       trace->num_frames = st.state();
+      printf("error: %d at count %d\n", st.state(), count);
       return;
     }
     if (st.is_java_frame()) {
-      FrameTypeId type = FRAME_JAVA;
+      uint8_t type = ASGST_FRAME_JAVA;
       if (st.is_native_frame()) {
-        type = FRAME_NATIVE;
+        type = ASGST_FRAME_NATIVE;
       } else if (st.is_inlined()) {
-        type = FRAME_JAVA_INLINED;
+        type = ASGST_FRAME_JAVA_INLINED;
       }
       int comp_level = 0;
       if (st.state() == STACKWALKER_COMPILED_FRAME) {
         comp_level = st.method()->highest_comp_level();
       }
       trace->frames[count] = {.java_frame = {
-          type, (uint8_t)comp_level,
+          type, (int8_t)comp_level,
           st.is_native_frame() ? (uint16_t)0 : (uint16_t)st.bci(),
           st.method()->find_jmethod_id_or_null()
         }
       };
     } else {
       trace->frames[count] = {.non_java_frame = {
-          st.base_frame()->is_stub_frame() ? FRAME_STUB : FRAME_CPP,
+          st.base_frame()->is_stub_frame() ? ASGST_FRAME_STUB : ASGST_FRAME_CPP,
           st.base_frame()->pc()
         }
       };
@@ -81,37 +80,34 @@ static void fill_call_trace_given_top(JavaThread* thd,
   }
   trace->num_frames = count;
 }
-}
 
-extern "C" {
-JNIEXPORT
-void AsyncGetStackTrace(asgst::CallTrace *trace, jint depth, void* ucontext, int32_t options) {
+extern "C" JNIEXPORT void AsyncGetStackTrace(ASGST_CallTrace *trace, jint depth, void* ucontext, int32_t options) {
   assert(trace->frames != NULL, "");
   JavaThread* thread = JavaThread::current();
   if (thread->is_terminated()) {
     thread->block_if_vm_exited();
     // thread has exited or thread is exiting
-    trace->num_frames = (jint)asgst::Error::THREAD_EXIT; // -8;
+    trace->num_frames = (jint)ASGST_THREAD_EXIT; // -8;
     return;
   }
   if (!thread->is_Java_thread()) {
-    trace->num_frames = (jint)asgst::Error::THREAD_NOT_JAVA; // -10
+    trace->num_frames = (jint)ASGST_THREAD_NOT_JAVA; // -10
     return;
   }
 
   if (thread->in_deopt_handler()) {
     // thread is in the deoptimization handler so return no frames
-    trace->num_frames = (jint)asgst::Error::DEOPT; // -9
+    trace->num_frames = (jint)ASGST_DEOPT; // -9
     return;
   }
 
   if (!JvmtiExport::should_post_class_load()) {
-    trace->num_frames = (jint)asgst::Error::NO_CLASS_LOAD; // -1
+    trace->num_frames = (jint)ASGST_NO_CLASS_LOAD; // -1
     return;
   }
 
   if (Universe::heap()->is_gc_active()) {
-    trace->num_frames = (jint)asgst::Error::GC_ACTIVE; // -2
+    trace->num_frames = (jint)ASGST_GC_ACTIVE; // -2
     return;
   }
 
@@ -134,17 +130,16 @@ void AsyncGetStackTrace(asgst::CallTrace *trace, jint depth, void* ucontext, int
     {
       frame ret_frame;
       if (!thread->pd_get_top_frame_for_signal_handler(&ret_frame, ucontext, true)) {
-        trace->num_frames = (jint)asgst::Error::UNKNOWN_NOT_JAVA;  // -3 unknown frame
+        trace->num_frames = (jint)ASGST_UNKNOWN_NOT_JAVA;  // -3 unknown frame
         return;
       }
       fill_call_trace_given_top(thread, trace, depth, ret_frame,
-        (options & asgst::INCLUDE_C_FRAMES) == 0);
+        (options & ASGST_INCLUDE_C_FRAMES) == 0);
     }
     break;
   default:
     // Unknown thread state
-    trace->num_frames = (jint)asgst::Error::UNKNOWN_STATE; // -7
+    trace->num_frames = (jint)ASGST_UNKNOWN_STATE; // -7
     break;
   }
-}
 }

--- a/src/hotspot/share/prims/profile.cpp
+++ b/src/hotspot/share/prims/profile.cpp
@@ -65,12 +65,8 @@ void fill_call_trace_given_top(JavaThread* thd,
       } else if (st.is_inlined()) {
         type = ASGST_FRAME_JAVA_INLINED;
       }
-      int comp_level = 0;
-      if (st.state() == STACKWALKER_COMPILED_FRAME) {
-        comp_level = st.method()->highest_comp_level();
-      }
       trace->frames[count] = {.java_frame = {
-          type, (int8_t)comp_level,
+          type, (int8_t) st.compilation_level(),
           st.is_native_frame() ? (uint16_t)0 : (uint16_t)st.bci(),
           st.method()->find_jmethod_id_or_null()
         }

--- a/src/hotspot/share/prims/profile.cpp
+++ b/src/hotspot/share/prims/profile.cpp
@@ -35,6 +35,8 @@
 #include "prims/stackWalker.hpp"
 #include "prims/jvmtiExport.hpp"
 
+#define PRINT_C_FRAME_INFO 0
+
 // thd can be null for non java threads (only c frames then)
 void fill_call_trace_given_top(JavaThread* thd,
                                ASGST_CallTrace* trace,
@@ -75,6 +77,12 @@ void fill_call_trace_given_top(JavaThread* thd,
           st.base_frame()->pc()
         }
       };
+      #if PRINT_C_FRAME_INFO
+      char buf[1000];
+      int offset;
+      os::dll_address_to_function_name(st.base_frame()->pc(), buf, 1000, &offset);
+      printf("C frame: %s\n", buf);
+      #endif
     }
   }
   trace->num_frames = count;

--- a/src/hotspot/share/prims/profile.cpp
+++ b/src/hotspot/share/prims/profile.cpp
@@ -81,7 +81,7 @@ void fill_call_trace_given_top(JavaThread* thd,
       char buf[1000];
       int offset;
       os::dll_address_to_function_name(st.base_frame()->pc(), buf, 1000, &offset);
-      printf("C frame: %s\n", buf);
+      printf("C frame: %s   fp: %p, sp: %p, pc: %p\n", buf, st.base_frame()->fp(), st.base_frame()->sp(), st.base_frame()->pc());
       #endif
     }
   }
@@ -148,7 +148,6 @@ void asyncGetStackTraceImpl(ASGST_CallTrace *trace, jint depth, void* ucontext, 
   bool include_non_java_threads = (options & ASGST_INCLUDE_NON_JAVA_THREADS) != 0;
   bool walk_during_unsafe_states = (options & ASGST_WALK_DURING_UNSAFE_STATES) != 0;
   bool walk_same_thread = (options & ASGST_WALK_SAME_THREAD) != 0;
-
   Thread* raw_thread;
 
   if (walk_same_thread) {

--- a/src/hotspot/share/prims/profile.cpp
+++ b/src/hotspot/share/prims/profile.cpp
@@ -22,9 +22,10 @@
  *
  */
 
+#include "precompiled.hpp"
+
 #include "profile.h"
 
-#include "precompiled.hpp"
 #include "gc/shared/collectedHeap.inline.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/safefetch.hpp"

--- a/src/hotspot/share/prims/profile.cpp
+++ b/src/hotspot/share/prims/profile.cpp
@@ -59,11 +59,7 @@ void fill_call_trace_given_top(JavaThread* thd,
   int count = 0;
   for (; count < depth && !st.at_end(); st.next(), count++) {
     if (st.at_error()) {
-      if (st.at_end()) {
-        trace->num_frames = count;
-        break;
-      }
-      trace->num_frames = ASGST_NOT_WALKABLE_JAVA;
+      trace->num_frames = st.at_error();
       return;
     }
     if (st.is_java_frame()) {
@@ -188,7 +184,7 @@ void asyncGetStackTraceImpl(ASGST_CallTrace *trace, jint depth, void* ucontext, 
   trace->state = -1;
 
   if (raw_thread == NULL || !raw_thread->is_Java_thread()) {
-    trace->kind = ASGST_CPP_TRACE;
+    trace->kind = raw_thread == NULL ? ASGST_UNKNOWN_TRACE : ASGST_CPP_TRACE;
     if ((trace->kind & kind_mask) == 0) {
       trace->num_frames = ASGST_WRONG_KIND;
       return;

--- a/src/hotspot/share/prims/profile.cpp
+++ b/src/hotspot/share/prims/profile.cpp
@@ -316,7 +316,7 @@ void asyncGetStackTraceImpl(ASGST_CallTrace *trace, jint depth, void* ucontext, 
       if (!thread->pd_get_top_frame_for_profiling(&ret_frame, ucontext, true, include_c_frames)) {
         // check without forced ucontext again
         if (!include_c_frames || !thread->pd_get_top_frame_for_profiling(&ret_frame, ucontext, true, false)) {
-          trace->num_frames = (jint)ASGST_UNKNOWN_NOT_JAVA;  // -3 unknown frame
+          trace->num_frames = (jint)ASGST_UNKNOWN_JAVA;
           return;
         }
       }

--- a/src/hotspot/share/prims/profile.cpp
+++ b/src/hotspot/share/prims/profile.cpp
@@ -41,7 +41,6 @@ void fill_call_trace_given_top(JavaThread* thd,
                                int depth,
                                frame top_frame,
                                bool skip_c_frames) {
-  NoHandleMark nhm;
   assert(trace->frames != NULL, "trace->frames must be non-NULL");
   trace->frame_info = NULL;
   StackWalker st(thd, top_frame, skip_c_frames,
@@ -79,6 +78,17 @@ void fill_call_trace_given_top(JavaThread* thd,
     }
   }
   trace->num_frames = count;
+}
+
+// thd cannot be null, as we use assertions that require it
+void fill_call_trace_given_top_with_thread(JavaThread* thd,
+                               ASGST_CallTrace* trace,
+                               int depth,
+                               frame top_frame,
+                               bool skip_c_frames) {
+  assert(thd != NULL, "thd cannot be null");
+  NoHandleMark nhm;
+  fill_call_trace_given_top(thd, trace, depth, top_frame, skip_c_frames);
 }
 
 // check if the frame has at least valid pointers
@@ -207,7 +217,7 @@ extern "C" JNIEXPORT void AsyncGetStackTrace(ASGST_CallTrace *trace, jint depth,
           return;
         }
       }
-      fill_call_trace_given_top(thread, trace, depth, ret_frame,
+      fill_call_trace_given_top_with_thread(thread, trace, depth, ret_frame,
         !include_c_frames);
     }
     break;

--- a/src/hotspot/share/prims/profile.cpp
+++ b/src/hotspot/share/prims/profile.cpp
@@ -67,7 +67,7 @@ void fill_call_trace_given_top(JavaThread* thd,
       }
       trace->frames[count] = {.java_frame = {
           type, (int8_t) st.compilation_level(),
-          st.is_native_frame() ? (uint16_t)0 : (uint16_t)st.bci(),
+          st.is_native_frame() ? (uint16_t)-1 : (uint16_t)st.bci(),
           st.method()->find_jmethod_id_or_null()
         }
       };

--- a/src/hotspot/share/prims/profile.cpp
+++ b/src/hotspot/share/prims/profile.cpp
@@ -305,7 +305,7 @@ void asyncGetStackTraceImpl(ASGST_CallTrace *trace, jint depth, void* ucontext, 
     // We found the thread on the threads list above, but it is too
     // young to be useful so return that there are no Java frames.
     if (walk_during_unsafe_states && include_c_frames) {
-      trace->kind == ASGST_NEW_THREAD_TRACE;
+      trace->kind = ASGST_NEW_THREAD_TRACE;
       if ((trace->kind & kind_mask) == 0) {
         trace->num_frames = ASGST_WRONG_KIND;
         return;

--- a/src/hotspot/share/prims/profile.cpp
+++ b/src/hotspot/share/prims/profile.cpp
@@ -24,6 +24,7 @@
 
 #include "profile.h"
 
+#include "precompiled.hpp"
 #include "gc/shared/collectedHeap.inline.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/safefetch.hpp"

--- a/src/hotspot/share/prims/profile.cpp
+++ b/src/hotspot/share/prims/profile.cpp
@@ -200,6 +200,8 @@ extern "C" JNIEXPORT void AsyncGetStackTrace(ASGST_CallTrace *trace, jint depth,
     return;
   }
 
+  DEBUG_ONLY(thread->set_in_async_stack_walking(true));
+
   switch (thread->thread_state()) {
   case _thread_new:
   case _thread_uninitialized:
@@ -222,6 +224,7 @@ extern "C" JNIEXPORT void AsyncGetStackTrace(ASGST_CallTrace *trace, jint depth,
         // check without forced ucontext again
         if (!include_c_frames || !thread->pd_get_top_frame_for_profiling(&ret_frame, ucontext, true, false)) {
           trace->num_frames = (jint)ASGST_UNKNOWN_NOT_JAVA;  // -3 unknown frame
+          DEBUG_ONLY(thread->set_in_async_stack_walking(false));
           return;
         }
       }
@@ -234,4 +237,5 @@ extern "C" JNIEXPORT void AsyncGetStackTrace(ASGST_CallTrace *trace, jint depth,
     trace->num_frames = (jint)ASGST_UNKNOWN_STATE; // -7
     break;
   }
+  DEBUG_ONLY(thread->set_in_async_stack_walking(false));
 }

--- a/src/hotspot/share/prims/stackWalker.cpp
+++ b/src/hotspot/share/prims/stackWalker.cpp
@@ -404,6 +404,13 @@ void StackWalker::process_normal() {
         set_state(STACKWALKER_GC_ACTIVE); // -2
         return;
       }
+      if (_method->is_native()) {
+        // because is_interpreted_frame return true for native method frames too
+        _bci = -1;
+        _inlined = false;
+        set_state(STACKWALKER_NATIVE_FRAME);
+        return;
+      }
       set_state(STACKWALKER_INTERPRETED_FRAME);
       assert(!_inlined || in_c_on_top || !_st.invalid(), "have to advance somehow 2");
       return;

--- a/src/hotspot/share/prims/stackWalker.cpp
+++ b/src/hotspot/share/prims/stackWalker.cpp
@@ -1,0 +1,483 @@
+/*
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "stackWalker.hpp"
+#include "code/debugInfoRec.hpp"
+#include "code/pcDesc.hpp"
+#include "gc/shared/collectedHeap.inline.hpp"
+#include "memory/universe.hpp"
+#include "oops/oop.inline.hpp"
+#include "prims/forte.hpp"
+#include "prims/jvmtiExport.hpp"
+#include "runtime/frame.inline.hpp"
+#include "runtime/javaCalls.hpp"
+#include "runtime/registerMap.hpp"
+#include "runtime/thread.inline.hpp"
+#include "runtime/vframe.inline.hpp"
+#include "runtime/vframeArray.hpp"
+#include "runtime/vframe_hp.hpp"
+#include "compiler/compilerDefinitions.hpp"
+
+
+// the following code was originally present in the forte.cpp file
+// it is moved in to this file to allow reuse in JFR
+
+#define LOG 0
+#define ST_LOG(...) LOG ? printf(__VA_ARGS__) : 1
+
+compiledFrameStream::compiledFrameStream(JavaThread *jt, frame fr, bool stop_at_java_call_stub) :
+  vframeStreamCommon(RegisterMap(jt, RegisterMap::UpdateMap::skip,
+    RegisterMap::ProcessFrames::skip, RegisterMap::WalkContinuation::skip)),
+  cf_next_into_inlined(false), _invalid(false) {
+
+  _stop_at_java_call_stub = stop_at_java_call_stub;
+  _frame = fr;
+
+  // We must always have a valid frame to start filling
+
+  bool filled_in = fill_from_frame();
+
+  assert(filled_in, "invariant");
+
+}
+
+
+// Solaris SPARC Compiler1 needs an additional check on the grandparent
+// of the top_frame when the parent of the top_frame is interpreted and
+// the grandparent is compiled. However, in this method we do not know
+// the relationship of the current _frame relative to the top_frame so
+// we implement a more broad sanity check. When the previous callee is
+// interpreted and the current sender is compiled, we verify that the
+// current sender is also walkable. If it is not walkable, then we mark
+// the current vframeStream as at the end.
+//
+// returns true if inlined
+void compiledFrameStream::cf_next() {
+  assert(!_invalid, "invalid stream used");
+  // handle frames with inlining
+  cf_next_into_inlined = false;
+  if (_mode == compiled_mode &&
+      vframeStreamCommon::fill_in_compiled_inlined_sender()) {
+    cf_next_into_inlined = true;
+    return;
+  }
+
+  // handle general case
+
+  int loop_count = 0;
+  int loop_max = MaxJavaStackTraceDepth * 2;
+
+
+  do {
+
+    loop_count++;
+
+    // By the time we get here we should never see unsafe but better
+    // safe then segv'd
+
+    if ((loop_max != 0 && loop_count > loop_max) || !_frame.safe_for_sender(_thread)) {
+      _mode = at_end_mode;
+      return;
+    }
+
+    _frame = _frame.sender(&_reg_map);
+
+  } while (!fill_from_frame());
+}
+
+// Determine if 'fr' is a decipherable compiled frame. We are already
+// assured that fr is for a java compiled method.
+
+static bool is_decipherable_compiled_frame(JavaThread* thread, frame* fr, CompiledMethod* nm) {
+  assert(nm->is_java_method(), "invariant");
+
+  if (thread->has_last_Java_frame() && thread->last_Java_pc() == fr->pc()) {
+    // We're stopped at a call into the JVM so look for a PcDesc with
+    // the actual pc reported by the frame.
+    PcDesc* pc_desc = nm->pc_desc_at(fr->pc());
+
+    // Did we find a useful PcDesc?
+    if (pc_desc != NULL &&
+        pc_desc->scope_decode_offset() != DebugInformationRecorder::serialized_null) {
+      return true;
+    }
+  }
+
+  // We're at some random pc in the compiled method so search for the PcDesc
+  // whose pc is greater than the current PC.  It's done this way
+  // because the extra PcDescs that are recorded for improved debug
+  // info record the end of the region covered by the ScopeDesc
+  // instead of the beginning.
+  PcDesc* pc_desc = nm->pc_desc_near(fr->pc() + 1);
+
+  // Now do we have a useful PcDesc?
+  if (pc_desc == NULL ||
+      pc_desc->scope_decode_offset() == DebugInformationRecorder::serialized_null) {
+    // No debug information is available for this PC.
+    //
+    // vframeStreamCommon::fill_from_frame() will decode the frame depending
+    // on the state of the thread.
+    //
+    // Case #1: If the thread is in Java (state == _thread_in_Java), then
+    // the vframeStreamCommon object will be filled as if the frame were a native
+    // compiled frame. Therefore, no debug information is needed.
+    //
+    // Case #2: If the thread is in any other state, then two steps will be performed:
+    // - if asserts are enabled, found_bad_method_frame() will be called and
+    //   the assert in found_bad_method_frame() will be triggered;
+    // - if asserts are disabled, the vframeStreamCommon object will be filled
+    //   as if it were a native compiled frame.
+    //
+    // Case (2) is similar to the way interpreter frames are processed in
+    // vframeStreamCommon::fill_from_interpreter_frame in case no valid BCI
+    // was found for an interpreted frame. If asserts are enabled, the assert
+    // in found_bad_method_frame() will be triggered. If asserts are disabled,
+    // the vframeStreamCommon object will be filled afterwards as if the
+    // interpreter were at the point of entering into the method.
+    return false;
+  }
+
+  // This PcDesc is useful however we must adjust the frame's pc
+  // so that the vframeStream lookups will use this same pc
+  fr->set_pc(pc_desc->real_pc(nm));
+  return true;
+}
+
+
+// Determine if 'fr' is a walkable interpreted frame. Returns false
+// if it is not. *method_p, and *bci_p are not set when false is
+// returned. *method_p is non-NULL if frame was executing a Java
+// method. *bci_p is != -1 if a valid BCI in the Java method could
+// be found.
+// Note: this method returns true when a valid Java method is found
+// even if a valid BCI cannot be found.
+
+static bool is_decipherable_interpreted_frame(JavaThread* thread,
+                                              frame* fr,
+                                              Method** method_p,
+                                              int* bci_p) {
+  assert(fr->is_interpreted_frame(), "just checking");
+
+  // top frame is an interpreted frame
+  // check if it is walkable (i.e. valid Method* and valid bci)
+
+  // Because we may be racing a gc thread the method and/or bci
+  // of a valid interpreter frame may look bad causing us to
+  // fail the is_interpreted_frame_valid test. If the thread
+  // is in any of the following states we are assured that the
+  // frame is in fact valid and we must have hit the race.
+
+  JavaThreadState state = thread->thread_state();
+  bool known_valid = (state == _thread_in_native ||
+                      state == _thread_in_vm ||
+                      state == _thread_blocked );
+
+  if (known_valid || fr->is_interpreted_frame_valid(thread)) {
+
+    // The frame code should completely validate the frame so that
+    // references to Method* and bci are completely safe to access
+    // If they aren't the frame code should be fixed not this
+    // code. However since gc isn't locked out the values could be
+    // stale. This is a race we can never completely win since we can't
+    // lock out gc so do one last check after retrieving their values
+    // from the frame for additional safety
+
+    Method* method = fr->interpreter_frame_method();
+
+    // We've at least found a method.
+    // NOTE: there is something to be said for the approach that
+    // if we don't find a valid bci then the method is not likely
+    // a valid method. Then again we may have caught an interpreter
+    // frame in the middle of construction and the bci field is
+    // not yet valid.
+    if (!Method::is_valid_method(method)) return false;
+    *method_p = method; // If the Method* found is invalid, it is
+                        // ignored by forte_fill_call_trace_given_top().
+                        // So set method_p only if the Method is valid.
+
+    address bcp = fr->interpreter_frame_bcp();
+    int bci = method->validate_bci_from_bcp(bcp);
+
+    // note: bci is set to -1 if not a valid bci
+    *bci_p = bci;
+    return true;
+  }
+
+  return false;
+}
+
+static bool is_decipherable_native_frame(frame* fr, CompiledMethod* nm) {
+  assert(nm->is_native_method(), "invariant");
+  return fr->cb()->frame_size() >= 0;
+}
+
+StackWalker::StackWalker(JavaThread* thread, frame top_frame, bool skip_c_frames, int max_c_frames_skip):
+  _thread(thread),
+  _skip_c_frames(skip_c_frames), _max_c_frames_skip(max_c_frames_skip), _frame(top_frame),
+  supports_os_get_frame(!skip_c_frames && os::current_frame().pc() != NULL),
+  _state(STACKWALKER_START), _map(thread, RegisterMap::UpdateMap::skip,
+     RegisterMap::ProcessFrames::skip, RegisterMap::WalkContinuation::skip),
+    in_c_on_top(false) {
+  init();
+}
+
+StackWalker::StackWalker(JavaThread* thread, bool skip_c_frames, int max_c_frames_skip):
+  _thread(thread), _skip_c_frames(skip_c_frames), _max_c_frames_skip(max_c_frames_skip),
+  supports_os_get_frame(!skip_c_frames && os::current_frame().pc() != NULL),
+  _state(STACKWALKER_START), _map(thread, RegisterMap::UpdateMap::skip,
+     RegisterMap::ProcessFrames::skip, RegisterMap::WalkContinuation::skip),
+  in_c_on_top(false) {
+  if (!thread->has_last_Java_frame()) {
+    set_state(STACKWALKER_END);
+    return;
+  }
+
+  _frame = _thread->last_frame();
+  init();
+}
+
+void StackWalker::init() {
+  if (checkFrame()) {
+    process();
+    if (_skip_c_frames) {
+      skip_c_frames();
+    }
+  }
+}
+
+/**
+ *
+ * Gets the caller frame of `fr`.
+ *
+ * based on the next_frame method from vmError.cpp aka pns gdb command
+ *
+ * only usable when we are sure to not have any compiled frames afterwards,
+ * as this method might trip up
+ *
+ * Problem: leads to "invalid bci or invalid scope error" in vframestream
+ */
+ frame StackWalker::next_c_frame(frame fr) {
+  // Compiled code may use EBP register on x86 so it looks like
+  // non-walkable C frame. Use frame.sender() for java frames.
+  frame invalid;
+  // Catch very first native / c frame by using stack address.
+  // For JavaThread stack_base and stack_size should be set.
+  if (!_thread->is_in_full_stack((address)(fr.real_fp() + 1))) {
+    return invalid;
+  }
+  if (fr.is_java_frame() || fr.is_native_frame() || fr.is_runtime_frame() || !supports_os_get_frame) {
+    if (!fr.safe_for_sender(_thread)) {
+      return invalid;
+    }
+    RegisterMap map(_thread, RegisterMap::UpdateMap::skip, RegisterMap::ProcessFrames::skip,
+        RegisterMap::WalkContinuation::skip); // No update
+    return fr.sender(&map);
+  } else {
+    // is_first_C_frame() does only simple checks for frame pointer,
+    // it will pass if java compiled code has a pointer in EBP.
+    if (os::is_first_C_frame(&fr)) {
+      return invalid;
+    }
+    return os::get_sender_for_C_frame(&fr);
+  }
+}
+
+void StackWalker::reset() {
+  _inlined = false;
+  _method = NULL;
+  _bci = -1;
+}
+
+void StackWalker::set_state(int state) {
+  _state = state;
+  if (_state != STACKWALKER_INTERPRETED_FRAME &&
+      _state != STACKWALKER_COMPILED_FRAME &&
+      _state != STACKWALKER_NATIVE_FRAME) {
+    reset();
+  }
+}
+
+void StackWalker::advance() {
+  if (!has_frame()) {
+    return;
+  }
+  if (in_c_on_top) {
+    advance_fully_c();
+  } else {
+    advance_normal();
+    process();
+  }
+}
+
+bool StackWalker::checkFrame() {
+  ST_LOG("_frame.is_first_frame() %d !_frame.safe_for_sender(_thread) %d\n", _frame.is_first_frame(), !_frame.safe_for_sender(_thread));
+  if (_frame.is_first_frame() || !_frame.safe_for_sender(_thread)) {
+    if (_skip_c_frames) {
+      set_state(STACKWALKER_END);
+      return false;
+    } else {
+      in_c_on_top = true;
+      ST_LOG("set in_c_on_top to true\n");
+      set_state(STACKWALKER_C_FRAME);
+    }
+  }
+  return true;
+}
+
+void StackWalker::advance_normal() {
+  assert(!_inlined || in_c_on_top || !_st.invalid(), "have to advance somehow");
+  if (checkFrame()) {
+    if (in_c_on_top) {
+      advance_fully_c();
+    } else if (!_inlined) {
+      _frame = _frame.sender(&_map);
+    }
+  }
+}
+
+void StackWalker::process() {
+  ST_LOG("state %d c_on_top %d\n", _state, in_c_on_top);
+  if (in_c_on_top){ // nothing to do
+    return;
+  }
+    ST_LOG("%d\n", __LINE__);
+  if (_st.invalid()) {
+      ST_LOG("%d\n", __LINE__);
+    process_normal();
+
+  ST_LOG("state %d line %d\n", _state, __LINE__);
+  } else {
+      ST_LOG("%d\n", __LINE__);
+    process_in_compiled();
+    ST_LOG("state %d line %d\n", _state, __LINE__);
+  }
+}
+
+// assumes that _frame has been advanced and not already in compiled stream
+// leaves the _frame unchanged
+void StackWalker::process_normal() {
+  if (_frame.is_native_frame()) {
+    CompiledMethod* nm = _frame.cb()->as_compiled_method();
+    if (!is_decipherable_native_frame(&_frame, nm)) {
+      set_state(STACKWALKER_INDECIPHERABLE_FRAME);
+      return;
+    }
+    _method = nm->method();
+    _bci = -1;
+    _inlined = false;
+    set_state(STACKWALKER_NATIVE_FRAME);
+    return;
+  } else if (_frame.is_java_frame()) { // another validity check
+    if (_frame.is_interpreted_frame()) {
+      _inlined = false;
+      if (!_frame.is_interpreted_frame_valid(_thread) || !is_decipherable_interpreted_frame(_thread, &_frame, &_method, &_bci)) {
+        set_state(STACKWALKER_INDECIPHERABLE_FRAME);
+        return;
+      }
+      if (!Method::is_valid_method(_method)) {
+        // we throw away everything we've gathered in this sample since
+        // none of it is safe
+        ST_LOG("interpreted method not valid\n");
+        set_state(STACKWALKER_GC_ACTIVE); // -2
+        return;
+      }
+      set_state(STACKWALKER_INTERPRETED_FRAME);
+      assert(!_inlined || in_c_on_top || !_st.invalid(), "have to advance somehow 2");
+      return;
+    } else if (_frame.is_compiled_frame()) {
+      CompiledMethod* nm = _frame.cb()->as_compiled_method();
+      if (!is_decipherable_compiled_frame(_thread, &_frame, nm)){
+        set_state(STACKWALKER_INDECIPHERABLE_FRAME);
+        return;
+      }
+      _st = compiledFrameStream(_thread, _frame, false);
+      set_state(STACKWALKER_COMPILED_FRAME);
+      process_in_compiled();
+      return;
+    }
+  }
+  set_state(STACKWALKER_C_FRAME);
+}
+
+// assumes that work has to be done with compiledFrameStream
+// leaves the _frame unchanged
+// only changes the compiledFrameStream (advances it after copying the data)
+void StackWalker::process_in_compiled() {
+  assert(!_st.invalid(), "st is invalid");
+  if (_st.at_end()) {
+    advance_normal();
+    _st = {};
+    return;
+  }
+  _method = _st.method();
+  _bci = _st.bci();
+
+  if (!Method::is_valid_method(_method)) {
+    // we throw away everything we've gathered in this sample since
+    // none of it is safe
+    ST_LOG("compiled method not valid\n");
+    set_state(STACKWALKER_GC_ACTIVE);
+    return;
+  }
+  _inlined = _st.inlined();
+  if (!_inlined) {
+    _st = {};
+    advance_normal();
+    return;
+  }
+  _st.cf_next();
+}
+
+void StackWalker::advance_fully_c() {
+  if ((_frame = next_c_frame(_frame)).pc() != NULL) {
+    set_state(STACKWALKER_C_FRAME);
+  } else {
+    set_state(STACKWALKER_END);
+  }
+}
+
+bool StackWalker::skip_c_frames() {
+  for (int i = 0; (i < _max_c_frames_skip || _max_c_frames_skip == -1) && is_c_frame(); i++) {
+    advance();
+  }
+  if (is_c_frame()) {
+    set_state(STACKWALKER_NO_JAVA_FRAME);
+    return false;
+  }
+  return is_java_frame();
+}
+
+void StackWalker::skip_frames(int skip) {
+  for (int i = 0; i < skip && !at_end(); i++) {
+    advance();
+  }
+}
+
+int StackWalker::next(){
+  advance();
+  if (_skip_c_frames) {
+    skip_c_frames();
+  }
+  return _state;
+}

--- a/src/hotspot/share/prims/stackWalker.cpp
+++ b/src/hotspot/share/prims/stackWalker.cpp
@@ -352,7 +352,11 @@ void StackWalker::advance_normal() {
     if (in_c_on_top) {
       advance_fully_c();
     } else if (!_inlined) {
-      _frame = _frame.sender(&_map);
+      if (_frame.safe_for_sender(_thread)) {
+        _frame = _frame.sender(&_map);
+      } else {
+        in_c_on_top = true;
+      }
     }
   }
 }

--- a/src/hotspot/share/prims/stackWalker.cpp
+++ b/src/hotspot/share/prims/stackWalker.cpp
@@ -332,7 +332,7 @@ void StackWalker::advance() {
 
 bool StackWalker::checkFrame() {
   ST_LOG("_frame.is_first_frame() %d !_frame.safe_for_sender(_thread) %d\n", _frame.is_first_frame(), !_frame.safe_for_sender(_thread));
-  if (_frame.is_first_frame() || !_frame.safe_for_sender(_thread)) {
+  if (!_frame.safe_for_sender(_thread) || _frame.is_first_frame()) {
     if (_skip_c_frames) {
       set_state(STACKWALKER_END);
       return false;

--- a/src/hotspot/share/prims/stackWalker.cpp
+++ b/src/hotspot/share/prims/stackWalker.cpp
@@ -470,8 +470,16 @@ void StackWalker::process_normal(bool potentially_first_java_frame) {
       return;
     } else if (_frame.is_compiled_frame()) {
       CompiledMethod* nm = _frame.cb()->as_compiled_method();
-      if (!nm->is_native_method() && potentially_first_java_frame && !is_decipherable_first_compiled_frame(_thread, &_frame, nm, debug)){
+      if (!nm->is_native_method() && potentially_first_java_frame && !is_decipherable_first_compiled_frame(_thread, &_frame, nm)){
         set_state(STACKWALKER_INDECIPHERABLE_FRAME);
+        return;
+      }
+      if (nm->is_native_method()) {
+        _method = nm->method();
+        _bci = 0;
+        _inlined = false;
+        set_state(STACKWALKER_NATIVE_FRAME);
+        had_first_java_frame = true;
         return;
       }
       _st = compiledFrameStream(_thread, _frame, false);

--- a/src/hotspot/share/prims/stackWalker.cpp
+++ b/src/hotspot/share/prims/stackWalker.cpp
@@ -362,11 +362,6 @@ void StackWalker::advance_normal() {
       advance_fully_c();
     } else if (!_inlined) {
       if (_frame.safe_for_sender(_thread)) {
-        if (is_stub_frame() && !_skip_c_frames) {
-          // we walk the stub frame as a C frame
-          _frame = os::get_sender_for_C_frame(&_frame);
-          return;
-        }
         _frame = _frame.sender(&_map);
       } else {
         in_c_on_top = true;

--- a/src/hotspot/share/prims/stackWalker.cpp
+++ b/src/hotspot/share/prims/stackWalker.cpp
@@ -26,6 +26,7 @@
 #include "code/debugInfoRec.hpp"
 #include "code/pcDesc.hpp"
 #include "gc/shared/collectedHeap.inline.hpp"
+#include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
 #include "oops/oop.inline.hpp"
 #include "prims/forte.hpp"

--- a/src/hotspot/share/prims/stackWalker.cpp
+++ b/src/hotspot/share/prims/stackWalker.cpp
@@ -108,7 +108,6 @@ void compiledFrameStream::cf_next() {
 // assured that fr is for a java compiled method.
 // Might change the compiled frame
 static void make_first_compiled_frame_more_precise(JavaThread* thread, frame* fr, CompiledMethod* nm) {
-       if (std::getenv("ASGST_SIG") != nullptr && *std::getenv("ASGST_SIG") == '1') {
   assert(nm->is_java_method(), "invariant");
 
   if (thread->has_last_Java_frame() && thread->last_Java_pc() == fr->pc()) {

--- a/src/hotspot/share/prims/stackWalker.hpp
+++ b/src/hotspot/share/prims/stackWalker.hpp
@@ -158,6 +158,8 @@ public:
 
   bool is_native_frame() const { return _state == STACKWALKER_NATIVE_FRAME; }
 
+  bool is_stub_frame() const { return _state == STACKWALKER_C_FRAME && _frame.is_stub_frame(); }
+
   bool is_c_frame() const { return _state == STACKWALKER_C_FRAME; }
 
   bool is_java_frame() const { return is_interpreted_frame() || is_compiled_frame() || is_native_frame(); }

--- a/src/hotspot/share/prims/stackWalker.hpp
+++ b/src/hotspot/share/prims/stackWalker.hpp
@@ -1,0 +1,176 @@
+
+/*
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_JFR_RECORDER_STACKTRACE_STACKWALKER_HPP
+#define SHARE_JFR_RECORDER_STACKTRACE_STACKWALKER_HPP
+
+#include "runtime/frame.hpp"
+#include "runtime/registerMap.hpp"
+#include "runtime/thread.hpp"
+#include "runtime/vframe.inline.hpp"
+
+// a helper stream
+class compiledFrameStream : public vframeStreamCommon {
+  bool cf_next_into_inlined;
+  bool _invalid;
+ public:
+  compiledFrameStream(): vframeStreamCommon(RegisterMap(NULL,
+    RegisterMap::UpdateMap::skip,
+    RegisterMap::ProcessFrames::skip, RegisterMap::WalkContinuation::skip)),
+    cf_next_into_inlined(false), _invalid(true) {};
+  // constructor that starts with sender of frame fr (top_frame)
+  compiledFrameStream(JavaThread *jt, frame fr, bool stop_at_java_call_stub);
+  void cf_next();
+  bool cf_next_did_go_into_inlined() const { return cf_next_into_inlined; }
+  bool inlined() const { return _sender_decode_offset != 0; }
+  bool invalid() const { return _invalid; }
+};
+
+// errors, subset of forte errors
+enum StackWalkerError {
+  STACKWALKER_NO_JAVA_FRAME        =  0,  // too many c frames to skip and no java frame found
+  STACKWALKER_INDECIPHERABLE_FRAME = -1,
+  STACKWALKER_GC_ACTIVE            = -2,
+  STACKWALKER_NOT_WALKABLE         = -6
+};
+
+enum StackWalkerReturn {
+  STACKWALKER_END = 1,
+  STACKWALKER_INTERPRETED_FRAME = 2,
+  STACKWALKER_COMPILED_FRAME = 3,
+  STACKWALKER_NATIVE_FRAME = 4,
+  STACKWALKER_C_FRAME = 5, // might be runtime, stub or real C frame
+  STACKWALKER_START = 6
+};
+
+// walk the stack of a thread from any given frame
+// includes all c frames and lot's of checks
+// borrowed from forte.hpp
+class StackWalker {
+
+  // Java thread to walk
+  JavaThread* _thread;
+
+  bool _skip_c_frames;
+
+  int _max_c_frames_skip;
+
+  // current frame (surrounding frame if inlined)
+  frame _frame;
+
+  // is os::get_sender_for_C_frame currently supported?
+  const bool supports_os_get_frame;
+
+  // StackWalkerError + StackWalkerReturn
+  int _state;
+
+  bool _inlined;
+
+  Method *_method;
+
+  int _bci;
+
+  RegisterMap _map;
+
+  compiledFrameStream _st;
+
+  bool in_c_on_top;
+
+  frame next_c_frame(frame fr);
+
+  void init();
+
+  void process();
+
+  void advance();
+
+  // reset _method, _bci and inlined
+  void reset();
+
+  // set the state and reset everything besides interpreted and compiled frame
+  void set_state(int state);
+
+  // check that current frame is processable
+  bool checkFrame();
+
+  void advance_normal();
+
+  void advance_fully_c();
+
+  void process_normal();
+
+  void process_in_compiled();
+
+public:
+
+  StackWalker(JavaThread* thread, frame top_frame, bool skip_c_frames = true, int max_c_frames_skip = -1);
+
+  StackWalker(JavaThread* thread, bool skip_c_frames = true, int max_c_frames_skip = -1);
+
+  // returns an error code < 0 on error and StackWalkerReturn code otherwise.
+  // 0 == ended,
+  int next();
+
+  // skip all c frames, return true if Java frame found
+  bool skip_c_frames();
+
+  // call advance at most skip times in a row
+  void skip_frames(int skip);
+
+  // StackWalkerError + StackWalkerReturn
+  int state() const { return _state; }
+
+  bool at_end() const { return _state == STACKWALKER_END; }
+
+  bool at_error() const { return _state <= 0; }
+
+  // not at and and not at error
+  bool has_frame() const { return !at_end() && !at_error(); }
+
+  bool is_interpreted_frame() const { return _state == STACKWALKER_INTERPRETED_FRAME; }
+
+  bool is_compiled_frame() const { return _state == STACKWALKER_COMPILED_FRAME; }
+
+  bool is_native_frame() const { return _state == STACKWALKER_NATIVE_FRAME; }
+
+  bool is_c_frame() const { return _state == STACKWALKER_C_FRAME; }
+
+  bool is_java_frame() const { return is_interpreted_frame() || is_compiled_frame() || is_native_frame(); }
+
+  // inlined, returns true only for inlined compiled frames, otherwise false
+  bool is_inlined() const { return _inlined; }
+
+  // current frame (surrounding frame if inlined) or NULL if at error or at end
+  const frame* base_frame() const { return has_frame() ? &_frame : NULL; }
+
+  // current method or NULL if at error or at end
+  Method* method() const { return _method; }
+
+  // bci or -1 if not at a Java frame
+  int bci() const { return _bci; }
+
+};
+
+#endif // SHARE_JFR_RECORDER_STACKTRACE_STACKWALKER_HPP

--- a/src/hotspot/share/prims/stackWalker.hpp
+++ b/src/hotspot/share/prims/stackWalker.hpp
@@ -71,6 +71,7 @@ enum StackWalkerReturn {
 class StackWalker {
 
   // Java thread to walk
+  // can be null for non java threads (only c frames then)
   JavaThread* _thread;
 
   bool _skip_c_frames;
@@ -81,6 +82,7 @@ class StackWalker {
   frame _frame;
 
   // is os::get_sender_for_C_frame currently supported?
+  // invariant: true if _thread is null
   const bool supports_os_get_frame;
 
   // StackWalkerError + StackWalkerReturn
@@ -127,6 +129,7 @@ public:
 
   StackWalker(JavaThread* thread, frame top_frame, bool skip_c_frames = true, int max_c_frames_skip = -1);
 
+  // requires a non null thread
   StackWalker(JavaThread* thread, bool skip_c_frames = true, int max_c_frames_skip = -1);
 
   // returns an error code < 0 on error and StackWalkerReturn code otherwise.

--- a/src/hotspot/share/prims/stackWalker.hpp
+++ b/src/hotspot/share/prims/stackWalker.hpp
@@ -156,6 +156,8 @@ public:
 
   bool at_error() const { return _state <= 0; }
 
+  int error() const { return at_error() ? _state : 1;}
+
   // not at and and not at error
   bool has_frame() const { return !at_end() && !at_error(); }
 

--- a/src/hotspot/share/prims/stackWalker.hpp
+++ b/src/hotspot/share/prims/stackWalker.hpp
@@ -123,6 +123,9 @@ class StackWalker {
 
   void process_normal();
 
+  // additional check used in process_normal
+  bool is_frame_indecipherable();
+
   void process_in_compiled();
 
 public:

--- a/src/hotspot/share/prims/stackWalker.hpp
+++ b/src/hotspot/share/prims/stackWalker.hpp
@@ -36,7 +36,7 @@ class compiledFrameStream : public vframeStreamCommon {
   bool cf_next_into_inlined;
   bool _invalid;
  public:
-  compiledFrameStream(): vframeStreamCommon(RegisterMap(NULL,
+  compiledFrameStream(): vframeStreamCommon(RegisterMap(nullptr,
     RegisterMap::UpdateMap::skip,
     RegisterMap::ProcessFrames::skip, RegisterMap::WalkContinuation::skip)),
     cf_next_into_inlined(false), _invalid(true) {};
@@ -100,11 +100,13 @@ class StackWalker {
 
   bool in_c_on_top;
 
+  bool had_first_java_frame;
+
   frame next_c_frame(frame fr);
 
   void init();
 
-  void process();
+  void process(bool potentially_first_java_frame = false);
 
   void advance();
 
@@ -121,7 +123,7 @@ class StackWalker {
 
   void advance_fully_c();
 
-  void process_normal();
+  void process_normal(bool potentially_first_java_frame = false);
 
   // additional check used in process_normal
   bool is_frame_indecipherable();
@@ -171,7 +173,7 @@ public:
   bool is_inlined() const { return _inlined; }
 
   // current frame (surrounding frame if inlined) or NULL if at error or at end
-  const frame* base_frame() const { return has_frame() ? &_frame : NULL; }
+  const frame* base_frame() const { return has_frame() ? &_frame : nullptr; }
 
   // current method or NULL if at error or at end
   Method* method() const { return _method; }

--- a/src/hotspot/share/prims/stackWalker.hpp
+++ b/src/hotspot/share/prims/stackWalker.hpp
@@ -94,6 +94,8 @@ class StackWalker {
 
   int _bci;
 
+  int _compilation_level;
+
   RegisterMap _map;
 
   compiledFrameStream _st;
@@ -180,6 +182,9 @@ public:
 
   // bci or -1 if not at a Java frame
   int bci() const { return _bci; }
+
+  // -1 if not at a Java frame
+  int compilation_level() const;
 
 };
 

--- a/src/hotspot/share/runtime/frame.inline.hpp
+++ b/src/hotspot/share/runtime/frame.inline.hpp
@@ -53,6 +53,7 @@ inline bool frame::is_stub_frame() const {
 }
 
 inline bool frame::is_first_frame() const {
+  // not safe for potentially broken frames, check safe_for_sender first
   return (is_entry_frame() && entry_frame_is_first())
       // Upcall stub frames entry frames are only present on certain platforms
       || (is_upcall_stub_frame() && upcall_stub_frame_is_first());

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -402,9 +402,6 @@ JavaThread::JavaThread() :
   // Initialize fields
 
   _on_thread_list(false),
-#ifdef ASSERT
-  _in_async_stack_walking(false),
-#endif
   DEBUG_ONLY(_java_call_counter(0) COMMA)
   _entry_point(nullptr),
   _deopt_mark(nullptr),

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -402,6 +402,9 @@ JavaThread::JavaThread() :
   // Initialize fields
 
   _on_thread_list(false),
+#ifdef ASSERT
+  _in_async_stack_walking(false),
+#endif
   DEBUG_ONLY(_java_call_counter(0) COMMA)
   _entry_point(nullptr),
   _deopt_mark(nullptr),

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -1192,7 +1192,7 @@ public:
   inline bool in_async_stack_walking() { return _in_async_stack_walking; }
   inline void set_in_async_stack_walking(bool b) { _in_async_stack_walking = b; }
 
-  static bool currently_in_in_async_stack_walking() {
+  static bool currently_in_async_stack_walking() {
     JavaThread* thread = JavaThread::checked_current_or_null();
     return thread != NULL && thread->in_async_stack_walking();
   }

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -87,11 +87,6 @@ class JavaThread: public Thread {
  private:
   bool           _on_thread_list;                // Is set when this JavaThread is added to the Threads list
 
-#ifdef ASSERT
-  // to adapt assertions during asynchronous stack walking
-  bool _in_async_stack_walking;
-#endif
-
   // All references to Java objects managed via OopHandles. These
   // have to be released by the ServiceThread after the JavaThread has
   // terminated - see add_oop_handles_for_release().
@@ -1186,17 +1181,6 @@ public:
   // Helper function to do vm_exit_on_initialization for osthread
   // resource allocation failure.
   static void vm_exit_on_osthread_failure(JavaThread* thread);
-
- #ifdef ASSERT
-  // to adapt assertions during asynchronous stack walking
-  inline bool in_async_stack_walking() { return _in_async_stack_walking; }
-  inline void set_in_async_stack_walking(bool b) { _in_async_stack_walking = b; }
-
-  static bool currently_in_async_stack_walking() {
-    JavaThread* thread = JavaThread::checked_current_or_null();
-    return thread != NULL && thread->in_async_stack_walking();
-  }
- #endif
 
   // Deferred OopHandle release support
  private:

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1264,6 +1264,8 @@ bool os::is_first_C_frame(frame* fr) {
   if (old_fp < ufp) return true;
   if (old_fp - ufp > 64 * K) return true;
 
+  if (fr->sender_pc() == NULL) return true;
+
   return false;
 }
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -629,31 +629,33 @@ protected:
 #endif // __APPLE__ && AARCH64
 
  private:
-  bool _in_asgct = false;
+  bool _in_async_stack_walking = false;
  public:
-  bool in_asgct() const { return _in_asgct; }
-  void set_in_asgct(bool value) { _in_asgct = value; }
-  static bool current_in_asgct() {
-    Thread *cur = Thread::current_or_null_safe();
-    return cur != nullptr && cur->in_asgct();
+   // to adapt assertions during asynchronous stack walking
+  inline bool in_async_stack_walking() { return _in_async_stack_walking; }
+  inline void set_in_async_stack_walking(bool b) { _in_async_stack_walking = b; }
+
+  static bool currently_in_async_stack_walking() {
+    Thread* thread = Thread::current_or_null_safe();
+    return thread != NULL && thread->in_async_stack_walking();
   }
 
  private:
   VMErrorCallback* _vm_error_callbacks;
 };
 
-class ThreadInAsgct {
+class ThreadInAsyncStackWalking {
  private:
   Thread* _thread;
  public:
-  ThreadInAsgct(Thread* thread) : _thread(thread) {
-    assert(thread != nullptr, "invariant");
-    assert(!thread->in_asgct(), "invariant");
-    thread->set_in_asgct(true);
+  ThreadInAsyncStackWalking(Thread* thread) : _thread(thread) {
+    assert(_thread != nullptr, "invariant");
+    assert(!_thread->in_async_stack_walking(), "invariant");
+    _thread->set_in_async_stack_walking(true);
   }
-  ~ThreadInAsgct() {
-    assert(_thread->in_asgct(), "invariant");
-    _thread->set_in_asgct(false);
+  ~ThreadInAsyncStackWalking() {
+    assert(_thread->in_async_stack_walking(), "invariant");
+    _thread->set_in_async_stack_walking(false);
   }
 };
 

--- a/src/hotspot/share/runtime/threadSMR.cpp
+++ b/src/hotspot/share/runtime/threadSMR.cpp
@@ -731,6 +731,21 @@ JavaThread* ThreadsList::find_JavaThread_from_java_tid(jlong java_tid) const {
   return nullptr;
 }
 
+JavaThread* ThreadsList::find_JavaThread_from_ucontext(const void* ucontext) const {
+  address sp = (address)os::fetch_frame_from_context(ucontext).sp();
+
+  for (uint i = 0; i < length(); i++) {
+    JavaThread* thread = thread_at(i);
+    if (thread == nullptr) {
+      continue;
+    }
+    if (thread->is_in_usable_stack(sp)) {
+      return thread;
+    }
+  }
+  return nullptr;
+}
+
 void ThreadsList::inc_nested_handle_cnt() {
   Atomic::inc(&_nested_handle_cnt);
 }

--- a/src/hotspot/share/runtime/threadSMR.hpp
+++ b/src/hotspot/share/runtime/threadSMR.hpp
@@ -206,6 +206,8 @@ public:
   // Returns -1 if target is not found.
   int find_index_of_JavaThread(JavaThread* target);
   JavaThread* find_JavaThread_from_java_tid(jlong java_tid) const;
+  // find the JavaThread from the ucontext (using its stack pointer)
+  JavaThread* find_JavaThread_from_ucontext(const void* ucontext) const;
   bool includes(const JavaThread * const p) const;
 
 #ifdef ASSERT

--- a/src/hotspot/share/runtime/vframe.cpp
+++ b/src/hotspot/share/runtime/vframe.cpp
@@ -93,6 +93,49 @@ vframe* vframe::new_vframe(const frame* f, const RegisterMap* reg_map, JavaThrea
   return new externalVFrame(f, reg_map, thread);
 }
 
+void vframe::new_vframe(const frame* f, const RegisterMap* reg_map, JavaThread* thread, vframe* vframe_) {
+  // Interpreter frame
+  if (f->is_interpreted_frame()) {
+    interpretedVFrame iframe(f, reg_map, thread);
+    memcpy((char*)vframe_, (char*)&iframe, sizeof(interpretedVFrame));
+    return;
+  }
+
+  // Compiled frame
+  CodeBlob* cb = f->cb();
+  if (cb != NULL) {
+    if (cb->is_compiled()) {
+      CompiledMethod* nm = (CompiledMethod*)cb;
+      compiledVFrame cframe(f, reg_map, thread, nm);
+      memcpy((char*)vframe_, (char*)&cframe, sizeof(compiledVFrame));
+      return;
+    }
+
+    if (f->is_runtime_frame()) {
+      // Skip this frame and try again.
+      RegisterMap temp_map = *reg_map;
+      frame s = f->sender(&temp_map);
+      new_vframe(&s, &temp_map, thread, vframe_);
+      return;
+    }
+  }
+
+  // Entry frame
+  if (f->is_entry_frame()) {
+    entryVFrame eframe(f, reg_map, thread);
+    memcpy((char*)vframe_, (char*)&eframe, sizeof(eframe));
+    return;
+  }
+
+  // External frame
+  externalVFrame eframe(f, reg_map, thread);
+  memcpy((char*)vframe_, (char*)&eframe, sizeof(entryVFrame));
+}
+
+size_t vframe::max_allocated_size() {
+  return MAX(sizeof(vframe), MAX(sizeof(javaVFrame), sizeof(externalVFrame)));
+}
+
 vframe* vframe::sender() const {
   RegisterMap temp_map = *register_map();
   assert(is_top(), "just checking");
@@ -101,6 +144,16 @@ vframe* vframe::sender() const {
   frame s = _fr.real_sender(&temp_map);
   if (s.is_first_frame()) return nullptr;
   return vframe::new_vframe(&s, &temp_map, thread());
+}
+
+bool vframe::sender(vframe* sender) const {
+  RegisterMap temp_map = *register_map();
+  assert(is_top(), "just checking");
+  if (_fr.is_entry_frame() && _fr.is_first_frame()) return false;
+  frame s = _fr.real_sender(&temp_map);
+  if (s.is_first_frame()) return false;
+  vframe::new_vframe(&s, &temp_map, thread(), sender);
+  return true;
 }
 
 bool vframe::is_vthread_entry() const {

--- a/src/hotspot/share/runtime/vframe.hpp
+++ b/src/hotspot/share/runtime/vframe.hpp
@@ -67,6 +67,10 @@ class vframe: public ResourceObj {
  public:
   // Factory methods for creating vframes
   static vframe* new_vframe(const frame* f, const RegisterMap *reg_map, JavaThread* thread);
+  static vframe* new_vframe(StackFrameStream& fst, JavaThread* thread);
+  // with preallocation
+  static void new_vframe(const frame* f, const RegisterMap *reg_map, JavaThread* thread, vframe* vframe_);
+  static size_t max_allocated_size();
 
   // Accessors
   frame             fr() const { return _fr;       }
@@ -80,6 +84,8 @@ class vframe: public ResourceObj {
 
   // Returns the sender vframe
   virtual vframe* sender() const;
+  // stores the sender in the passed vframe if return is true, omitting allocations
+  virtual bool sender(vframe* sender) const;
 
   // Returns the next javaVFrame on the stack (skipping all other kinds of frame)
   javaVFrame *java_sender() const;

--- a/src/hotspot/share/runtime/vframe.inline.hpp
+++ b/src/hotspot/share/runtime/vframe.inline.hpp
@@ -158,17 +158,19 @@ inline void vframeStreamCommon::fill_from_compiled_frame(int decode_offset) {
     // Therefore, do not use the decode offset if invalid, but fill the frame
     // as it were a native compiled frame (no Java-level assumptions).
 #ifdef ASSERT
-    if (WizardMode) {
-      ttyLocker ttyl;
-      tty->print_cr("Error in fill_from_frame: pc_desc for "
-                    INTPTR_FORMAT " not found or invalid at %d",
-                    p2i(_frame.pc()), decode_offset);
-      nm()->print();
-      nm()->method()->print_codes();
-      nm()->print_code();
-      nm()->print_pcs();
+    if (!JavaThread::currently_in_async_stack_walking()) {
+      if (WizardMode) {
+        ttyLocker ttyl;
+        tty->print_cr("Error in fill_from_frame: pc_desc for "
+                      INTPTR_FORMAT " not found or invalid at %d",
+                      p2i(_frame.pc()), decode_offset);
+        nm()->print();
+        nm()->method()->print_codes();
+        nm()->print_code();
+        nm()->print_pcs();
+      }
+      found_bad_method_frame();
     }
-    found_bad_method_frame();
 #endif
     // Provide a cheap fallback in product mode.  (See comment above.)
     fill_from_compiled_native_frame();

--- a/src/hotspot/share/runtime/vframe_hp.cpp
+++ b/src/hotspot/share/runtime/vframe_hp.cpp
@@ -407,6 +407,24 @@ vframe* compiledVFrame::sender() const {
   }
 }
 
+
+bool compiledVFrame::sender(vframe *sender) const {
+  const frame f = fr();
+  if (scope() == NULL) {
+    // native nmethods have no scope the method/bci is implied
+    nmethod* nm = code()->as_nmethod();
+    assert(nm->is_native_method(), "must be native");
+    return vframe::sender(sender);
+  } else {
+    if (scope()->is_top()) {
+      return vframe::sender(sender);
+    }
+    compiledVFrame frame(&f, register_map(), thread(), scope()->sender(), vframe_id() + 1);
+    memcpy((char*)sender, (char*)&frame, sizeof(compiledVFrame));
+    return true;
+  }
+}
+
 jvmtiDeferredLocalVariableSet::jvmtiDeferredLocalVariableSet(Method* method, int bci, intptr_t* id, int vframe_id) {
   _method = method;
   _bci = bci;

--- a/src/hotspot/share/runtime/vframe_hp.hpp
+++ b/src/hotspot/share/runtime/vframe_hp.hpp
@@ -48,6 +48,7 @@ class compiledVFrame: public javaVFrame {
   // Virtuals defined in vframe
   bool is_compiled_frame() const { return true; }
   vframe* sender() const;
+  bool sender(vframe *sender) const;
   bool is_top() const;
 
   // Casting

--- a/src/java.base/share/native/include/profile.h
+++ b/src/java.base/share/native/include/profile.h
@@ -119,19 +119,16 @@ enum ASGST_Options {
 // void AsyncGetStackTrace(ASGST_CallTrace *trace, jint depth, void* ucontext, int32_t options)
 //
 // Called by the profiler to obtain the current method call stack trace for
-// a given thread. The thread is identified by the env_id field in the
-// ASGST_CallTrace structure. The profiler agent should allocate a ASGST_CallTrace
+// a given thread. The profiler agent should allocate a ASGST_CallTrace
 // structure with enough memory for the requested stack depth. The VM fills in
-// the frames buffer and the num_frames field.
+// the frames buffer, the num_frames and the kind field.
 //
 // Arguments:
 //
 //   trace    - trace data structure to be filled by the VM.
 //   depth    - depth of the call stack trace.
 //   ucontext - ucontext_t of the LWP
-//   options  - bit flags for additional configuration,
-//              currently only the lowest bit is used: setting it to 1 enables capturing C frames
-
+//   options  - bit flags for additional configuration
 extern "C" JNIEXPORT
 void AsyncGetStackTrace(ASGST_CallTrace *trace, jint depth, void* ucontext, int32_t options);
 

--- a/src/java.base/share/native/include/profile.h
+++ b/src/java.base/share/native/include/profile.h
@@ -65,7 +65,7 @@ typedef struct {
 typedef struct {
   uint8_t type;      // frame type
   void *pc;          // current program counter inside this frame
-} ASGST_NonJavaFrame;
+} ASGST_NonJavaFrame; // used for FRAME_STUB, FRAME_CPP
 
 typedef union {
   uint8_t type;     // to distinguish between JavaFrame and NonJavaFrame
@@ -84,16 +84,26 @@ typedef union {
   CompLevel_full_optimization = 4          // C2 or JVMCI
 };*/
 
+enum ASGST_TRACE_KIND {
+  ASGST_JAVA_TRACE     = 0,
+  ASGST_CPP_TRACE      = 1,
+  ASGST_GC_TRACE       = 2,
+  ASGST_DEOPT_TRACE    = 3,
+  ASGST_UNKNOWN_TRACE  = 4,
+};
+
 typedef struct {
   jint num_frames;                // number of frames in this trace,
                                   // (< 0 indicates the frame is not walkable).
+  uint8_t kind;                   // kind of the trace
   ASGST_CallFrame *frames;        // frames that make up this trace. Callee followed by callers.
   void* frame_info;               // more information on frames
 } ASGST_CallTrace;
 
 
 enum ASGST_Options {
-  ASGST_INCLUDE_C_FRAMES = 1
+  ASGST_INCLUDE_C_FRAMES         = 1, // include C and stub frames too
+  ASGST_INCLUDE_NON_JAVA_THREADS = 2, // walk the stacks of C/Cpp, GC and deopt threads too
 };
 
 

--- a/src/java.base/share/native/include/profile.h
+++ b/src/java.base/share/native/include/profile.h
@@ -26,7 +26,6 @@
 #ifndef JVM_PROFILE_H
 #define JVM_PROFILE_H
 
-#include <_types/_uint8_t.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <stdint.h>

--- a/src/java.base/share/native/include/profile.h
+++ b/src/java.base/share/native/include/profile.h
@@ -26,6 +26,7 @@
 #ifndef JVM_PROFILE_H
 #define JVM_PROFILE_H
 
+#include <_types/_uint8_t.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <stdint.h>
@@ -47,6 +48,8 @@ enum ASGST_Error {
   ASGST_THREAD_NOT_JAVA       = -10,
   ASGST_NO_THREAD             = -11,
   ASGST_UNSAFE_STATE          = -12,
+  ASGST_WRONG_STATE           = -13,
+  ASGST_WRONG_KIND            = -14,
 };
 
 enum ASGST_FrameTypeId {
@@ -86,17 +89,18 @@ typedef union {
 };*/
 
 enum ASGST_TRACE_KIND {
-  ASGST_JAVA_TRACE     = 0,
-  ASGST_CPP_TRACE      = 1,
-  ASGST_GC_TRACE       = 2,
-  ASGST_DEOPT_TRACE    = 3,
-  ASGST_UNKNOWN_TRACE  = 4,
+  ASGST_JAVA_TRACE     =  1,
+  ASGST_CPP_TRACE      =  2,
+  ASGST_GC_TRACE       =  4,
+  ASGST_DEOPT_TRACE    =  8,
+  ASGST_UNKNOWN_TRACE  = 16,
 };
 
 typedef struct {
   jint num_frames;                // number of frames in this trace,
                                   // (< 0 indicates the frame is not walkable).
-  uint8_t kind;                   // kind of the trace
+  uint8_t kind;                   // kind of the trace, if non zero intialized, it is a bit mask for accepted kinds
+  uint8_t state;
   ASGST_CallFrame *frames;        // frames that make up this trace. Callee followed by callers.
   void* frame_info;               // more information on frames
 } ASGST_CallTrace;

--- a/src/java.base/share/native/include/profile.h
+++ b/src/java.base/share/native/include/profile.h
@@ -90,11 +90,12 @@ typedef union {
 };*/
 
 enum ASGST_TRACE_KIND {
-  ASGST_JAVA_TRACE     =  1,
-  ASGST_CPP_TRACE      =  2,
-  ASGST_GC_TRACE       =  4,
-  ASGST_DEOPT_TRACE    =  8,
-  ASGST_UNKNOWN_TRACE  = 16,
+  ASGST_JAVA_TRACE       =  1,
+  ASGST_CPP_TRACE        =  2,
+  ASGST_GC_TRACE         =  4,
+  ASGST_DEOPT_TRACE      =  8,
+  ASGST_NEW_THREAD_TRACE = 16,
+  ASGST_UNKNOWN_TRACE    = 32,
 };
 
 typedef struct {

--- a/src/java.base/share/native/include/profile.h
+++ b/src/java.base/share/native/include/profile.h
@@ -42,6 +42,7 @@ enum ASGST_Error {
   ASGST_UNKNOWN_NOT_JAVA      =  -3,
   ASGST_NOT_WALKABLE_NOT_JAVA =  -4,
   ASGST_UNKNOWN_JAVA          =  -5,
+  ASGST_NOT_WALKABLE_JAVA     =  -6,
   ASGST_UNKNOWN_STATE         =  -7,
   ASGST_THREAD_EXIT           =  -8,
   ASGST_DEOPT                 =  -9,
@@ -62,7 +63,7 @@ enum ASGST_FrameTypeId {
 typedef struct {
   uint8_t type;            // frame type
   int8_t comp_level;      // compilation level, 0 is interpreted, -1 is undefined, > 1 is JIT compiled
-  uint16_t bci;            // 0 < bci < 65536
+  uint16_t bci;            // 0 <= bci < 65536, 65535 (= -1) if the bci is >= 65535 or not available (like in native frames)
   jmethodID method_id;
 } ASGST_JavaFrame;         // used for FRAME_JAVA, FRAME_JAVA_INLINED and FRAME_NATIVE
 

--- a/src/java.base/share/native/include/profile.h
+++ b/src/java.base/share/native/include/profile.h
@@ -100,14 +100,16 @@ typedef struct {
   jint num_frames;                // number of frames in this trace,
                                   // (< 0 indicates the frame is not walkable).
   uint8_t kind;                   // kind of the trace, if non zero intialized, it is a bit mask for accepted kinds
-  uint8_t state;
+  jint state;                     // thread state (jvmti->GetThreadState), if non zero initialized,
+                                  // it is a bit mask for accepted states, non Java kind traces are always accepted
+                                  // and get state -1
   ASGST_CallFrame *frames;        // frames that make up this trace. Callee followed by callers.
   void* frame_info;               // more information on frames
 } ASGST_CallTrace;
 
 
 enum ASGST_Options {
- ASGST_INCLUDE_C_FRAMES         = 1, // include C/C++ (this includes Stub frames)
+  ASGST_INCLUDE_C_FRAMES         = 1, // include C/C++ (this includes Stub frames)
   ASGST_INCLUDE_NON_JAVA_THREADS = 2, // walk the stacks of C/C++, GC and deopt threads too
   ASGST_WALK_DURING_UNSAFE_STATES = 4, // walk the stack during potentially unsafe thread states (like safepoints)
   // walk the stack for the same thread (e.g. in a signal handler),

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -546,7 +546,8 @@ tier1_serviceability = \
   -serviceability/sa/ClhsdbScanOops.java \
   -serviceability/sa/ClhsdbJstackXcompStress.java \
   -serviceability/sa/TestJmapCore.java \
-  -serviceability/sa/TestJmapCoreMetaspace.java
+  -serviceability/sa/TestJmapCoreMetaspace.java \
+  -serviceability/profiling/stress
 
 tier1 = \
   :tier1_common \
@@ -589,7 +590,8 @@ hotspot_tier2_runtime = \
 
 hotspot_tier2_serviceability = \
   serviceability/ \
- -:tier1_serviceability
+ -:tier1_serviceability \
+  -serviceability/profiling/stress
 
 hotspot_tier2_runtime_platform_agnostic = \
   runtime/SelectionResolution \

--- a/test/hotspot/jtreg/serviceability/profiling/fuzzing/ASGSTFuzzingTest.java
+++ b/test/hotspot/jtreg/serviceability/profiling/fuzzing/ASGSTFuzzingTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Google and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package profiling.stress;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.ClassLoader;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Random;
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+import jdk.test.lib.process.*;
+import jdk.test.whitebox.WhiteBox;
+
+/**
+ * @test
+ * @summary Verifies that the stack walking of AsyncGetStackTrace is save in a high-frequency signal sampler with randomly modifed stack and frame pointers
+ * It is an adaptation of ASGSTStabilityTest.java to additionally fuzz the stack and frame pointers.
+ * @library /test/jdk/lib/testlibrary /test/lib
+ * @compile ASGSTFuzzingTest.java
+ * @key stress
+ * @requires os.family == "linux"
+ * @requires os.arch=="amd64" | os.arch=="x86_64"
+ * @build jdk.test.whitebox.WhiteBox
+ * @run main/othervm/native/timeout=216000 profiling.stress.ASGSTFuzzingTest akka-uct 1
+ */
+
+public class ASGSTFuzzingTest {
+  private static final String RENAISSANCE_URL = "https://github.com/renaissance-benchmarks/renaissance/releases/download/v0.14.1/renaissance-gpl-0.14.1.jar";
+
+  public static final class Runner {
+    private static final String MAIN_CLASS = "org.renaissance.core.Launcher";
+    public static void main(String[] args) throws Exception {
+      WhiteBox wb = WhiteBox.getWhiteBox();
+
+      // start a thread which will randomly deoptimize frames in order
+      // to increase the chance of hitting problems when walking the stack
+      // in the middle of opt/deopt - this used to be a source of various
+      // crashes in the original ASGCT so it sounds useful to have a regtest
+      // covering it
+      Thread t = new Thread(() -> {
+        Random rnd = new Random(845123525117L);
+        while (!Thread.currentThread().isInterrupted()) {
+          try {
+            Thread.sleep(100 + rnd.nextInt(300));
+            wb.deoptimizeFrames(true);
+          } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+            break;
+          }
+        }
+      });
+      t.setDaemon(true);
+      t.start();
+
+      Class<?> clz = Runner.class.getClassLoader().loadClass(MAIN_CLASS);
+      clz.getMethod("main", String[].class).invoke(null, (Object)args);
+
+    }
+  }
+
+  private static void downloadRenaissance(Path target) throws IOException {
+    System.out.println("Downloading " + RENAISSANCE_URL + " to " + target);
+    URL url = new URL(RENAISSANCE_URL);
+    ReadableByteChannel readableByteChannel = Channels.newChannel(url.openStream());
+
+    try (FileOutputStream os = new FileOutputStream(target.toFile())) {
+      os.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+    }
+    System.out.println("Downloaded renaissance.jar to " + target);
+  }
+
+  public static void main(String[] args) throws Exception {
+    String tmpPath = System.getProperty("java.io.tmpdir");
+    Path jarPath = Paths.get(tmpPath, "renaissance.jar");
+    if (!Files.exists(jarPath)) {
+      downloadRenaissance(jarPath);
+    }
+
+    if (!Files.exists(jarPath)) {
+      throw new Error("Renaissance library not found.");
+    }
+
+    Path out = Paths.get("renaissance.out").toAbsolutePath();
+    String[] benchmarks = new String[] {
+      "akka-uct", "finagle-chirper", "finagle-http", "akka-uct"
+    };
+    String benchmark = args[0];
+    int duration = Integer.parseInt(args[1]);
+    System.out.println("=== Going to run '" + benchmark + "' benchmark for " + duration + " seconds ...");
+    String testCp = System.getProperty("test.class.path") +
+                      File.pathSeparator + jarPath.toString();
+    System.out.println("===> Classpath: " + testCp);
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+      List.of(
+        "-Xbootclasspath/a:./WhiteBox.jar",
+        "-XX:+UnlockDiagnosticVMOptions",
+        "-XX:+WhiteBoxAPI",
+        "-agentlib:AsyncGetStackTraceFuzzingSampler",
+        "-Djava.library.path=" + System.getProperty("test.nativepath"),
+        "-cp", testCp,
+        ASGSTFuzzingTest.Runner.class.getName(),
+        benchmark, "-t", Integer.toString(duration)))
+      .redirectErrorStream(true);
+    ProcessTools.executeProcess(pb)
+      .shouldHaveExitValue(0)
+      .shouldContain("=== asgst sampler initialized ===");
+
+    System.out.println("=== ... done");
+  }
+}

--- a/test/hotspot/jtreg/serviceability/profiling/fuzzing/ASGSTFuzzingTest.java
+++ b/test/hotspot/jtreg/serviceability/profiling/fuzzing/ASGSTFuzzingTest.java
@@ -51,6 +51,9 @@ import jdk.test.whitebox.WhiteBox;
  *
  * It is known to fail at frame::verify_deopt_original_pc in debug builds, but this should be ignored.
  *
+ * This tests simulates a tool like async-profiler which uses AsyncGetStackTrace to walk the stack and
+ * moves the stack and frame pointers around a bit to get better results.
+ *
  * @library /test/jdk/lib/testlibrary /test/lib
  * @compile ASGSTFuzzingTest.java
  * @key stress
@@ -58,7 +61,9 @@ import jdk.test.whitebox.WhiteBox;
  * @requires os.arch=="amd64" | os.arch=="x86_64"
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar WhiteBox.jar jdk.test.whitebox.WhiteBox
- * @run main/othervm/native/timeout=216000 profiling.fuzzing.ASGSTFuzzingTest akka-uct 1
+ * @run main/othervm/native/timeout=216000 profiling.fuzzing.ASGSTFuzzingTest akka-uct 10
+ * @run main/othervm/native/timeout=216000 profiling.fuzzing.ASGSTFuzzingTest finagle-chirper 120
+ * @run main/othervm/native/timeout=216000 profiling.fuzzing.ASGSTFuzzingTest finagle-http 120
  */
 
 public class ASGSTFuzzingTest {
@@ -133,12 +138,12 @@ public class ASGSTFuzzingTest {
         "-Xbootclasspath/a:./WhiteBox.jar",
         "-XX:+UnlockDiagnosticVMOptions",
         "-XX:+WhiteBoxAPI",
-        "-agentlib:AsyncGetStackTraceFuzzingSampler",
+        "-agentlib:AsyncGetStackTraceFuzzingSampler=random",
         "-Djava.library.path=" + System.getProperty("test.nativepath"),
         "-cp", testCp,
         ASGSTFuzzingTest.Runner.class.getName(),
         benchmark, "-t", Integer.toString(duration)))
-      .redirectErrorStream(true);
+        .redirectErrorStream(true);
     ProcessTools.executeProcess(pb)
       .shouldHaveExitValue(0)
       .shouldContain("=== asgst sampler initialized ===");

--- a/test/hotspot/jtreg/serviceability/profiling/fuzzing/ASGSTFuzzingTest.java
+++ b/test/hotspot/jtreg/serviceability/profiling/fuzzing/ASGSTFuzzingTest.java
@@ -58,7 +58,9 @@ import jdk.test.whitebox.WhiteBox;
  * @requires os.arch=="amd64" | os.arch=="x86_64"
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar WhiteBox.jar jdk.test.whitebox.WhiteBox
- * @run main/othervm/native/timeout=216000 profiling.stress.ASGSTFuzzingTest akka-uct 1
+ * @run main/othervm/native/timeout=216000 profiling.stress.ASGSTFuzzingTest akka-uct 5
+ * @run main/othervm/native/timeout=216000 profiling.stress.ASGSTFuzzingTest finagle-chirper 60
+ * @run main/othervm/native/timeout=216000 profiling.stress.ASGSTFuzzingTest finagle-http 60
  */
 
 public class ASGSTFuzzingTest {

--- a/test/hotspot/jtreg/serviceability/profiling/fuzzing/ASGSTFuzzingTest.java
+++ b/test/hotspot/jtreg/serviceability/profiling/fuzzing/ASGSTFuzzingTest.java
@@ -48,12 +48,16 @@ import jdk.test.whitebox.WhiteBox;
  * @test
  * @summary Verifies that the stack walking of AsyncGetStackTrace is save in a high-frequency signal sampler with randomly modifed stack and frame pointers
  * It is an adaptation of ASGSTStabilityTest.java to additionally fuzz the stack and frame pointers.
+ *
+ * It is known to fail at frame::verify_deopt_original_pc in debug builds, but this should be ignored.
+ *
  * @library /test/jdk/lib/testlibrary /test/lib
  * @compile ASGSTFuzzingTest.java
  * @key stress
  * @requires os.family == "linux"
  * @requires os.arch=="amd64" | os.arch=="x86_64"
  * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar WhiteBox.jar jdk.test.whitebox.WhiteBox
  * @run main/othervm/native/timeout=216000 profiling.stress.ASGSTFuzzingTest akka-uct 1
  */
 

--- a/test/hotspot/jtreg/serviceability/profiling/fuzzing/ASGSTFuzzingTest.java
+++ b/test/hotspot/jtreg/serviceability/profiling/fuzzing/ASGSTFuzzingTest.java
@@ -58,9 +58,9 @@ import jdk.test.whitebox.WhiteBox;
  * @requires os.arch=="amd64" | os.arch=="x86_64"
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar WhiteBox.jar jdk.test.whitebox.WhiteBox
- * @run main/othervm/native/timeout=216000 profiling.stress.ASGSTFuzzingTest akka-uct 5
- * @run main/othervm/native/timeout=216000 profiling.stress.ASGSTFuzzingTest finagle-chirper 60
- * @run main/othervm/native/timeout=216000 profiling.stress.ASGSTFuzzingTest finagle-http 60
+ * @run main/othervm/native/timeout=216000 profiling.stress.ASGSTFuzzingTest akka-uct 10
+ * @run main/othervm/native/timeout=216000 profiling.stress.ASGSTFuzzingTest finagle-chirper 120
+ * @run main/othervm/native/timeout=216000 profiling.stress.ASGSTFuzzingTest finagle-http 120
  */
 
 public class ASGSTFuzzingTest {

--- a/test/hotspot/jtreg/serviceability/profiling/fuzzing/ASGSTFuzzingTest.java
+++ b/test/hotspot/jtreg/serviceability/profiling/fuzzing/ASGSTFuzzingTest.java
@@ -22,7 +22,7 @@
  * questions.
  */
 
-package profiling.stress;
+package profiling.fuzzing;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -58,9 +58,7 @@ import jdk.test.whitebox.WhiteBox;
  * @requires os.arch=="amd64" | os.arch=="x86_64"
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar WhiteBox.jar jdk.test.whitebox.WhiteBox
- * @run main/othervm/native/timeout=216000 profiling.stress.ASGSTFuzzingTest akka-uct 10
- * @run main/othervm/native/timeout=216000 profiling.stress.ASGSTFuzzingTest finagle-chirper 120
- * @run main/othervm/native/timeout=216000 profiling.stress.ASGSTFuzzingTest finagle-http 120
+ * @run main/othervm/native/timeout=216000 profiling.fuzzing.ASGSTFuzzingTest akka-uct 1
  */
 
 public class ASGSTFuzzingTest {
@@ -109,6 +107,7 @@ public class ASGSTFuzzingTest {
   }
 
   public static void main(String[] args) throws Exception {
+
     String tmpPath = System.getProperty("java.io.tmpdir");
     Path jarPath = Paths.get(tmpPath, "renaissance.jar");
     if (!Files.exists(jarPath)) {

--- a/test/hotspot/jtreg/serviceability/profiling/fuzzing/ASGSTFuzzingTest.java
+++ b/test/hotspot/jtreg/serviceability/profiling/fuzzing/ASGSTFuzzingTest.java
@@ -49,10 +49,12 @@ import jdk.test.whitebox.WhiteBox;
  * @summary Verifies that the stack walking of AsyncGetStackTrace is save in a high-frequency signal sampler with randomly modifed stack and frame pointers
  * It is an adaptation of ASGSTStabilityTest.java to additionally fuzz the stack and frame pointers.
  *
- * It is known to fail at frame::verify_deopt_original_pc in debug builds, but this should be ignored.
- *
  * This tests simulates a tool like async-profiler which uses AsyncGetStackTrace to walk the stack and
  * moves the stack and frame pointers around a bit to get better results.
+ *
+ * The default length of this test is 300 seconds, but you can increase it by passing a new duration
+ * using the ASGST_FUZZING_TEST_DURATION environment variable (in seconds).
+ * Keep in mind that it cannot fuzz longer than the benchmark itself runs.
  *
  * @library /test/jdk/lib/testlibrary /test/lib
  * @compile ASGSTFuzzingTest.java

--- a/test/hotspot/jtreg/serviceability/profiling/innerc/ASGSTInnerCTest.java
+++ b/test/hotspot/jtreg/serviceability/profiling/innerc/ASGSTInnerCTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Google and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package profiling.innerc;
+
+/**
+ * @test
+ * @summary Verifies that AsyncGetStackTrace works correctly with Java and native frames intermingled.
+ * @compile ASGSTInnerCTest.java
+ * @requires os.family == "linux"
+ * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="arm" | os.arch=="aarch64" | os.arch=="ppc64" | os.arch=="s390" | os.arch=="riscv64"
+ * @requires vm.jvmti
+ * @run main/othervm/native -agentlib:AsyncGetStackTraceInnerCTest profiling.innerc.ASGSTInnerCTest
+ */
+
+public class ASGSTInnerCTest {
+  static {
+    try {
+      System.loadLibrary("AsyncGetStackTraceInnerCTest");
+    } catch (UnsatisfiedLinkError ule) {
+      System.err.println("Could not load AsyncGetStackTrace library");
+      System.err.println("java.library.path: " + System.getProperty("java.library.path"));
+      throw ule;
+    }
+  }
+
+  /** more complex test: checkNativeChain() -> checkCMethod() -> checkJavaInner() -> checkNativeLeaf() -> ASGST() */
+  private static native boolean checkNativeChain();
+  private static boolean checkJavaInner() { return checkNativeLeaf(); }
+  private static native boolean checkNativeLeaf();
+
+  public static void main(String[] args) throws Exception {
+    if (!checkNativeChain()) {
+      throw new RuntimeException("AsyncGetCallTrace with Java and native frames intermingled ");
+    }
+  }
+}

--- a/test/hotspot/jtreg/serviceability/profiling/innerc/ASGSTInnerCTest.java
+++ b/test/hotspot/jtreg/serviceability/profiling/innerc/ASGSTInnerCTest.java
@@ -28,7 +28,7 @@ package profiling.innerc;
  * @test
  * @summary Verifies that AsyncGetStackTrace works correctly with Java and native frames intermingled.
  * @compile ASGSTInnerCTest.java
- * @requires os.family == "linux"
+ * @requires os.family == "linux" | os.family == "mac"
  * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="arm" | os.arch=="aarch64" | os.arch=="ppc64" | os.arch=="s390" | os.arch=="riscv64"
  * @requires vm.jvmti
  * @run main/othervm/native -agentlib:AsyncGetStackTraceInnerCTest profiling.innerc.ASGSTInnerCTest

--- a/test/hotspot/jtreg/serviceability/profiling/innerc/ASGSTInnerCTest.java
+++ b/test/hotspot/jtreg/serviceability/profiling/innerc/ASGSTInnerCTest.java
@@ -52,7 +52,7 @@ public class ASGSTInnerCTest {
 
   public static void main(String[] args) throws Exception {
     if (!checkNativeChain()) {
-      throw new RuntimeException("AsyncGetCallTrace with Java and native frames intermingled ");
+      throw new RuntimeException("AsyncGetStackTrace with Java and native frames intermingled ");
     }
   }
 }

--- a/test/hotspot/jtreg/serviceability/profiling/innercSkipC/ASGSTInnerCSkipCTest.java
+++ b/test/hotspot/jtreg/serviceability/profiling/innercSkipC/ASGSTInnerCSkipCTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Google and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package profiling.innerc;
+
+/**
+ * @test
+ * @summary Verifies that AsyncGetStackTrace works correctly with Java and native frames intermingled, when skipping all C frames.
+ * @compile ASGSTInnerCSkipCTest.java
+ * @requires os.family == "linux"
+ * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="arm" | os.arch=="aarch64" | os.arch=="ppc64" | os.arch=="s390" | os.arch=="riscv64"
+ * @requires vm.jvmti
+ * @run main/othervm/native -agentlib:AsyncGetStackTraceInnerCSkipCTest profiling.innerc.ASGSTInnerCSkipCTest
+ */
+
+public class ASGSTInnerCSkipCTest {
+  static {
+    try {
+      System.loadLibrary("AsyncGetStackTraceInnerCSkipCTest");
+    } catch (UnsatisfiedLinkError ule) {
+      System.err.println("Could not load AsyncGetStackTrace library");
+      System.err.println("java.library.path: " + System.getProperty("java.library.path"));
+      throw ule;
+    }
+  }
+
+  /** more complex test: checkNativeChain() -> checkCMethod() -> checkJavaInner() -> checkNativeLeaf() -> ASGST() */
+  private static native boolean checkNativeChain();
+  private static boolean checkJavaInner() { return checkNativeLeaf(); }
+  private static native boolean checkNativeLeaf();
+
+  public static void main(String[] args) throws Exception {
+    if (!checkNativeChain()) {
+      throw new RuntimeException("AsyncGetCallTrace with Java and native frames intermingled ");
+    }
+  }
+}

--- a/test/hotspot/jtreg/serviceability/profiling/innercSkipC/ASGSTInnerCSkipCTest.java
+++ b/test/hotspot/jtreg/serviceability/profiling/innercSkipC/ASGSTInnerCSkipCTest.java
@@ -28,7 +28,7 @@ package profiling.innerc;
  * @test
  * @summary Verifies that AsyncGetStackTrace works correctly with Java and native frames intermingled, when skipping all C frames.
  * @compile ASGSTInnerCSkipCTest.java
- * @requires os.family == "linux"
+ * @requires os.family == "linux" | os.family == "mac"
  * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="arm" | os.arch=="aarch64" | os.arch=="ppc64" | os.arch=="s390" | os.arch=="riscv64"
  * @requires vm.jvmti
  * @run main/othervm/native -agentlib:AsyncGetStackTraceInnerCSkipCTest profiling.innerc.ASGSTInnerCSkipCTest

--- a/test/hotspot/jtreg/serviceability/profiling/innercSkipC/ASGSTInnerCSkipCTest.java
+++ b/test/hotspot/jtreg/serviceability/profiling/innercSkipC/ASGSTInnerCSkipCTest.java
@@ -52,7 +52,7 @@ public class ASGSTInnerCSkipCTest {
 
   public static void main(String[] args) throws Exception {
     if (!checkNativeChain()) {
-      throw new RuntimeException("AsyncGetCallTrace with Java and native frames intermingled ");
+      throw new RuntimeException("AsyncGetStackTrace with Java and native frames intermingled ");
     }
   }
 }

--- a/test/hotspot/jtreg/serviceability/profiling/iterativeFuzzing/ASGSTIterativeFuzzingTest.java
+++ b/test/hotspot/jtreg/serviceability/profiling/iterativeFuzzing/ASGSTIterativeFuzzingTest.java
@@ -49,10 +49,12 @@ import jdk.test.whitebox.WhiteBox;
  * @summary Verifies that the stack walking of AsyncGetStackTrace is save in a high-frequency signal sampler with randomly modifed stack and frame pointers
  * It is an adaptation of ASGSTStabilityTest.java to additionally fuzz the stack and frame pointers.
  *
- * It is known to fail at frame::verify_deopt_original_pc in debug builds, but this should be ignored.
- *
  * This tests simulates a tool like async-profiler which uses AsyncGetStackTrace to walk the stack and
  * moves the stack and frame pointers around a bit to get better results.
+ *
+ * The default length of this test is 300 seconds, but you can increase it by passing a new duration
+ * using the ASGST_FUZZING_TEST_DURATION environment variable (in seconds).
+ * Keep in mind that it cannot fuzz longer than the benchmark itself runs.
  *
  * @library /test/jdk/lib/testlibrary /test/lib
  * @compile ASGSTIterativeFuzzingTest.java

--- a/test/hotspot/jtreg/serviceability/profiling/iterativeFuzzing/ASGSTIterativeFuzzingTest.java
+++ b/test/hotspot/jtreg/serviceability/profiling/iterativeFuzzing/ASGSTIterativeFuzzingTest.java
@@ -131,7 +131,7 @@ public class ASGSTIterativeFuzzingTest {
     String testCp = System.getProperty("test.class.path") +
                       File.pathSeparator + jarPath.toString();
     System.out.println("===> Classpath: " + testCp);
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
       List.of(
         "-Xbootclasspath/a:./WhiteBox.jar",
         "-XX:+UnlockDiagnosticVMOptions",

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceFuzzingSampler.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceFuzzingSampler.cpp
@@ -117,6 +117,7 @@ void fuzzingAsyncGetStackTraceLike(ASGST_CallTrace *trace, int max_depth, int op
   uc.uc_mcontext.gregs[REG_RSP] += sp_fuzz;
   uc.uc_mcontext.gregs[REG_RBP] += fp_fuzz;
 
+
   AsyncGetStackTrace(trace, max_depth, &uc, options);
 }
 
@@ -127,6 +128,7 @@ static void signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
   trace.frames = frames;
   trace.frame_info = NULL;
   trace.num_frames = 0;
+    fprintf(stdout, "######################## asc2\n");
   fuzzingAsyncGetStackTraceLike(&trace, MAX_DEPTH, ASGST_INCLUDE_C_FRAMES, rand() % sp_max_fuzz, rand() % fp_max_fuzz, ucontext);
 }
 
@@ -146,7 +148,6 @@ static bool startITimerSampler(long interval_ns) {
 
 static void JNICALL OnVMInit(jvmtiEnv *jvmti, JNIEnv *jni_env, jthread thread) {
   jint class_count = 0;
-
   // Get any previously loaded classes that won't have gone through the
   // OnClassPrepare callback to prime the jmethods for AsyncGetStackTrace.
   JvmtiDeallocator<jclass*> classes;
@@ -170,7 +171,6 @@ extern "C" {
 
 static
 jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
-
   jint res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION);
   if (res != JNI_OK || jvmti == NULL) {
     fprintf(stderr, "Error: wrong result of a valid call to GetEnv!\n");

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceFuzzingSampler.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceFuzzingSampler.cpp
@@ -106,9 +106,9 @@ static SigAction installSignalHandler(int signo, SigAction action, SigHandler ha
 }
 
 // max increase of sp
-int sp_max_fuzz = 1000;
+int sp_max_fuzz = 250;
 // max increase of fp
-int fp_max_fuzz = 1000;
+int fp_max_fuzz = 250;
 
 int sp_max_random_fuzz = 1000000;
 int fp_max_random_fuzz = 1000000;

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceFuzzingSampler.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceFuzzingSampler.cpp
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Google and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <assert.h>
+#include <ctime>
+#include <dlfcn.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/time.h>
+#include <sys/ucontext.h>
+#include <ucontext.h>
+#include "jvmti.h"
+#include "profile.h"
+
+static jvmtiEnv* jvmti;
+
+typedef void (*SigAction)(int, siginfo_t*, void*);
+typedef void (*SigHandler)(int);
+typedef void (*TimerCallback)(void*);
+
+template <class T>
+class JvmtiDeallocator {
+ public:
+  JvmtiDeallocator() {
+    elem_ = NULL;
+  }
+
+  ~JvmtiDeallocator() {
+    jvmti->Deallocate(reinterpret_cast<unsigned char*>(elem_));
+  }
+
+  T* get_addr() {
+    return &elem_;
+  }
+
+  T get() {
+    return elem_;
+  }
+
+ private:
+  T elem_;
+};
+
+static void GetJMethodIDs(jclass klass) {
+  jint method_count = 0;
+  JvmtiDeallocator<jmethodID*> methods;
+  jvmtiError err = jvmti->GetClassMethods(klass, &method_count, methods.get_addr());
+
+  // If ever the GetClassMethods fails, just ignore it, it was worth a try.
+  if (err != JVMTI_ERROR_NONE && err != JVMTI_ERROR_CLASS_NOT_PREPARED) {
+    fprintf(stderr, "GetJMethodIDs: Error in GetClassMethods: %d\n", err);
+  }
+}
+
+// AsyncGetStackTrace needs class loading events to be turned on!
+static void JNICALL OnClassLoad(jvmtiEnv *jvmti, JNIEnv *jni_env,
+                                jthread thread, jclass klass) {
+}
+
+static void JNICALL OnClassPrepare(jvmtiEnv *jvmti, JNIEnv *jni_env,
+                                   jthread thread, jclass klass) {
+  // We need to do this to "prime the pump" and get jmethodIDs primed.
+  GetJMethodIDs(klass);
+}
+
+static SigAction installSignalHandler(int signo, SigAction action, SigHandler handler = NULL) {
+    struct sigaction sa;
+    struct sigaction oldsa;
+    sigemptyset(&sa.sa_mask);
+
+    if (handler != NULL) {
+        sa.sa_handler = handler;
+        sa.sa_flags = 0;
+    } else {
+        sa.sa_sigaction = action;
+        sa.sa_flags = SA_SIGINFO | SA_RESTART;
+    }
+
+    sigaction(signo, &sa, &oldsa);
+    return oldsa.sa_sigaction;
+}
+
+// max increase of sp
+int sp_max_fuzz = 100000;
+// max increase of fp
+int fp_max_fuzz = 100000;
+
+
+void fuzzingAsyncGetStackTraceLike(ASGST_CallTrace *trace, int max_depth, int options, int sp_fuzz, int fp_fuzz, void* ucontext) {
+  ucontext_t uc = *((ucontext_t *)ucontext);
+  AsyncGetStackTrace(trace, max_depth, &uc, options);
+  uc.uc_mcontext.gregs[REG_RSP] += sp_fuzz;
+  uc.uc_mcontext.gregs[REG_RBP] += fp_fuzz;
+
+  AsyncGetStackTrace(trace, max_depth, &uc, options);
+}
+
+static void signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
+  const int MAX_DEPTH = 512;
+  static ASGST_CallFrame frames[MAX_DEPTH];
+  ASGST_CallTrace trace;
+  trace.frames = frames;
+  trace.frame_info = NULL;
+  trace.num_frames = 0;
+  fuzzingAsyncGetStackTraceLike(&trace, MAX_DEPTH, ASGST_INCLUDE_C_FRAMES, rand() % sp_max_fuzz, rand() % fp_max_fuzz, ucontext);
+}
+
+static bool startITimerSampler(long interval_ns) {
+  time_t sec = interval_ns / 1000000000;
+  suseconds_t usec = (interval_ns % 1000000000) / 1000;
+  struct itimerval tv = {{sec, usec}, {sec, usec}};
+
+  installSignalHandler(SIGPROF, signalHandler);
+
+  if (setitimer(ITIMER_PROF, &tv, NULL) != 0) {
+    return false;
+  }
+  fprintf(stderr, "=== asgst sampler initialized ===\n");
+  return true;
+}
+
+static void JNICALL OnVMInit(jvmtiEnv *jvmti, JNIEnv *jni_env, jthread thread) {
+  jint class_count = 0;
+
+  // Get any previously loaded classes that won't have gone through the
+  // OnClassPrepare callback to prime the jmethods for AsyncGetStackTrace.
+  JvmtiDeallocator<jclass*> classes;
+  jvmtiError err = jvmti->GetLoadedClasses(&class_count, classes.get_addr());
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "OnVMInit: Error in GetLoadedClasses: %d\n", err);
+    return;
+  }
+
+  // Prime any class already loaded and try to get the jmethodIDs set up.
+  jclass *classList = classes.get();
+  for (int i = 0; i < class_count; ++i) {
+    GetJMethodIDs(classList[i]);
+  }
+
+  startITimerSampler(1000); // 1us
+}
+
+
+extern "C" {
+
+static
+jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
+
+  jint res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION);
+  if (res != JNI_OK || jvmti == NULL) {
+    fprintf(stderr, "Error: wrong result of a valid call to GetEnv!\n");
+    return JNI_ERR;
+  }
+
+  jvmtiError err;
+  jvmtiCapabilities caps;
+  memset(&caps, 0, sizeof(caps));
+  caps.can_get_line_numbers = 1;
+  caps.can_get_source_file_name = 1;
+
+  err = jvmti->AddCapabilities(&caps);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "AgentInitialize: Error in AddCapabilities: %d\n", err);
+    return JNI_ERR;
+  }
+
+  jvmtiEventCallbacks callbacks;
+  memset(&callbacks, 0, sizeof(callbacks));
+  callbacks.ClassLoad = &OnClassLoad;
+  callbacks.VMInit = &OnVMInit;
+  callbacks.ClassPrepare = &OnClassPrepare;
+
+  err = jvmti->SetEventCallbacks(&callbacks, sizeof(jvmtiEventCallbacks));
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "AgentInitialize: Error in SetEventCallbacks: %d\n", err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_LOAD, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "AgentInitialize: Error in SetEventNotificationMode for CLASS_LOAD: %d\n", err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_PREPARE, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr,
+            "AgentInitialize: Error in SetEventNotificationMode for CLASS_PREPARE: %d\n",
+            err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(
+        stderr, "AgentInitialize: Error in SetEventNotificationMode for VM_INIT: %d\n",
+        err);
+    return JNI_ERR;
+  }
+
+  return JNI_OK;
+}
+
+JNIEXPORT
+jint JNICALL Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+  return Agent_Initialize(jvm, options, reserved);
+}
+
+JNIEXPORT
+jint JNICALL Agent_OnAttach(JavaVM *jvm, char *options, void *reserved) {
+  return Agent_Initialize(jvm, options, reserved);
+}
+
+JNIEXPORT
+jint JNICALL JNI_OnLoad(JavaVM *jvm, void *reserved) {
+  return JNI_VERSION_1_8;
+}
+
+}

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceFuzzingSampler.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceFuzzingSampler.cpp
@@ -25,7 +25,6 @@
 #if defined(LINUX) && defined(__x86_64__)
 
 #include <assert.h>
-#include <ctime>
 #include <dlfcn.h>
 #include <signal.h>
 #include <stdio.h>
@@ -85,9 +84,9 @@ const int fp_max_random_fuzz = 1000000;
 
 const long random_interval_ns = 1000; // 1us
 
-const long iterative_interval_ns = random_interval_ns * sp_max_fuzz * fp_max_fuzz;
+const long iterative_interval_ns = random_interval_ns * sp_max_fuzz * fp_max_fuzz / 100;
 
-const long duration_s = 100;
+long duration_s = 300;
 
 bool iterative = false;
 
@@ -191,6 +190,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     fprintf(stderr, "Unknown option: %s", options);
     return JNI_ERR;
   }
+
+  char* dur_env = getenv("ASGST_FUZZING_TEST_DURATION");
+  if (dur_env != NULL) {
+    duration_s = atoi(dur_env);
+  }
+
+
   jint res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION);
   if (res != JNI_OK || jvmti == NULL) {
     fprintf(stderr, "Error: wrong result of a valid call to GetEnv!\n");

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceFuzzingSampler.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceFuzzingSampler.cpp
@@ -147,7 +147,6 @@ static void signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
   trace.frames = frames;
   trace.frame_info = NULL;
   trace.num_frames = 0;
-  printf("iterative: %d\n", iterative);
   if (iterative) {
     iterativeFuzzingAsyncGetStackTraceLike(&trace, MAX_DEPTH, ASGST_INCLUDE_C_FRAMES, ucontext);
   } else {

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceFuzzingSampler.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceFuzzingSampler.cpp
@@ -22,6 +22,8 @@
  * questions.
  */
 
+#if defined(LINUX) && defined(__x86_64__)
+
 #include <assert.h>
 #include <ctime>
 #include <dlfcn.h>
@@ -271,3 +273,5 @@ jint JNICALL JNI_OnLoad(JavaVM *jvm, void *reserved) {
 }
 
 }
+
+#endif // defined(LINUX) && defined(__x86_64__)

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceInnerCSkipCTest.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceInnerCSkipCTest.cpp
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Google and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/time.h>
+#include <sys/ucontext.h>
+#include <ucontext.h>
+#include "jni.h"
+#include "jvmti.h"
+#include "profile.h"
+#include "util.hpp"
+
+// AsyncGetStackTrace needs class loading events to be turned on!
+static void JNICALL OnClassLoad(jvmtiEnv *jvmti, JNIEnv *jni_env,
+                                jthread thread, jclass klass) {
+}
+
+static void JNICALL OnClassPrepare(jvmtiEnv *jvmti, JNIEnv *jni_env,
+                                   jthread thread, jclass klass) {
+  // We need to do this to "prime the pump" and get jmethodIDs primed.
+  GetJMethodIDs(klass);
+}
+
+static void JNICALL OnVMInit(jvmtiEnv *jvmti, JNIEnv *jni_env, jthread thread) {
+  jint class_count = 0;
+
+  // Get any previously loaded classes that won't have gone through the
+  // OnClassPrepare callback to prime the jmethods for AsyncGetStackTrace.
+  JvmtiDeallocator<jclass*> classes;
+  jvmtiError err = jvmti->GetLoadedClasses(&class_count, classes.get_addr());
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "OnVMInit: Error in GetLoadedClasses: %d\n", err);
+    return;
+  }
+
+  // Prime any class already loaded and try to get the jmethodIDs set up.
+  jclass *classList = classes.get();
+  for (int i = 0; i < class_count; ++i) {
+    GetJMethodIDs(classList[i]);
+  }
+}
+
+extern "C" {
+
+static
+jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
+  jint res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION);
+  if (res != JNI_OK || jvmti == NULL) {
+    fprintf(stderr, "Error: wrong result of a valid call to GetEnv!\n");
+    return JNI_ERR;
+  }
+
+  jvmtiError err;
+  jvmtiCapabilities caps;
+  memset(&caps, 0, sizeof(caps));
+  caps.can_get_line_numbers = 1;
+  caps.can_get_source_file_name = 1;
+
+  err = jvmti->AddCapabilities(&caps);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "AgentInitialize: Error in AddCapabilities: %d\n", err);
+    return JNI_ERR;
+  }
+
+  jvmtiEventCallbacks callbacks;
+  memset(&callbacks, 0, sizeof(callbacks));
+  callbacks.ClassLoad = &OnClassLoad;
+  callbacks.VMInit = &OnVMInit;
+  callbacks.ClassPrepare = &OnClassPrepare;
+
+  err = jvmti->SetEventCallbacks(&callbacks, sizeof(jvmtiEventCallbacks));
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "AgentInitialize: Error in SetEventCallbacks: %d\n", err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_LOAD, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "AgentInitialize: Error in SetEventNotificationMode for CLASS_LOAD: %d\n", err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_PREPARE, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr,
+            "AgentInitialize: Error in SetEventNotificationMode for CLASS_PREPARE: %d\n",
+            err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(
+        stderr, "AgentInitialize: Error in SetEventNotificationMode for VM_INIT: %d\n",
+        err);
+    return JNI_ERR;
+  }
+
+  return JNI_OK;
+}
+
+JNIEXPORT
+jint JNICALL Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+  return Agent_Initialize(jvm, options, reserved);
+}
+
+JNIEXPORT
+jint JNICALL Agent_OnAttach(JavaVM *jvm, char *options, void *reserved) {
+  return Agent_Initialize(jvm, options, reserved);
+}
+
+JNIEXPORT
+jint JNICALL JNI_OnLoad(JavaVM *jvm, void *reserved) {
+  return JNI_VERSION_1_8;
+}
+
+
+// checkNativeChain() -> checkCMethod() -> checkJavaInner() -> checkNativeLeaf() -> ASGST() chain
+
+// a non JNI method, so we see a C frame
+[[gnu::noinline]] __attribute__((noinline)) static bool checkCMethod(JNIEnv* env, jclass cls) {
+  jmethodID method = env->GetStaticMethodID(cls, "checkJavaInner", "()Z");
+  if (method == NULL) {
+    fprintf(stderr, "Failed to get method ID for checkJavaInner\n");
+    return false;
+  }
+  return env->CallStaticBooleanMethod(cls, method);
+}
+
+[[gnu::noinline]] __attribute__((noinline)) JNIEXPORT jboolean JNICALL
+Java_profiling_innerc_ASGSTInnerCSkipCTest_checkNativeChain(JNIEnv* env, jclass cls) {
+  return checkCMethod(env, cls);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_profiling_innerc_ASGSTInnerCSkipCTest_checkNativeLeaf(JNIEnv* env, jclass cls) {
+  const int MAX_DEPTH = 16;
+  ASGST_CallTrace trace;
+  ASGST_CallFrame frames[MAX_DEPTH];
+  trace.frames = frames;
+  trace.frame_info = NULL;
+  trace.num_frames = 0;
+
+  // with ASGST_INCLUDE_C_FRAMES
+
+  AsyncGetStackTrace(&trace, MAX_DEPTH, NULL, 0);
+
+  if (trace.num_frames <= 0) {
+    fprintf(stderr, "skip chain: The num_frames must be positive: %d\n", trace.num_frames);
+    return false;
+  }
+
+  if (trace.frames[0].type != ASGST_FRAME_NATIVE) {
+    fprintf(stderr, "skip chain: The first frame must be a Java frame: %d\n", trace.frames[0].type);
+    return false;
+  }
+
+  printTrace<1>(stdout, trace);
+
+  ASGST_JavaFrame first_frame = trace.frames[0].java_frame;
+  if (first_frame.bci != 0) {
+    fprintf(stderr, "skip chain: The first frame must have a bci of 0 as it is a native frame: %d\n", first_frame.bci);
+    return false;
+  }
+  if (first_frame.method_id == NULL) {
+    fprintf(stderr, "skip chain: The first frame must have a method_id: %p\n", first_frame.method_id);
+    return false;
+  }
+
+  if (trace.num_frames != 5) {
+    fprintf(stderr, "skip chain: The number of frames must be 12: %d\n", trace.num_frames);
+    return false;
+  }
+
+  if (!doesFrameBelongToJavaMethod(trace.frames[0], ASGST_FRAME_NATIVE,
+        "checkNativeLeaf", "skip chain frame 0") ||
+      !doesFrameBelongToJavaMethod(trace.frames[1], ASGST_FRAME_JAVA,
+        "checkJavaInner", "skip chain frame 1") ||
+      !doesFrameBelongToJavaMethod(trace.frames[2], ASGST_FRAME_NATIVE,
+        "checkNativeChain", "skip chain frame 2"),
+      !doesFrameBelongToJavaMethod(trace.frames[3], ASGST_FRAME_JAVA,
+        "main", "skip chain frame 3") ||
+      !doesFrameBelongToJavaMethod(trace.frames[4], ASGST_FRAME_JAVA,
+        "invokeStatic", "skip chain frame 4")) {
+    return false;
+  }
+
+  return true;
+}
+
+}

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceInnerCSkipCTest.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceInnerCSkipCTest.cpp
@@ -32,8 +32,6 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/time.h>
-#include <sys/ucontext.h>
-#include <ucontext.h>
 #include "jni.h"
 #include "jvmti.h"
 #include "profile.h"

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceInnerCTest.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceInnerCTest.cpp
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Google and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/time.h>
+#include <ucontext.h>
+#include "jni.h"
+#include "jvmti.h"
+#include "profile.h"
+#include "util.hpp"
+
+// AsyncGetStackTrace needs class loading events to be turned on!
+static void JNICALL OnClassLoad(jvmtiEnv *jvmti, JNIEnv *jni_env,
+                                jthread thread, jclass klass) {
+}
+
+static void JNICALL OnClassPrepare(jvmtiEnv *jvmti, JNIEnv *jni_env,
+                                   jthread thread, jclass klass) {
+  // We need to do this to "prime the pump" and get jmethodIDs primed.
+  GetJMethodIDs(klass);
+}
+
+static void JNICALL OnVMInit(jvmtiEnv *jvmti, JNIEnv *jni_env, jthread thread) {
+  jint class_count = 0;
+
+  // Get any previously loaded classes that won't have gone through the
+  // OnClassPrepare callback to prime the jmethods for AsyncGetStackTrace.
+  JvmtiDeallocator<jclass*> classes;
+  jvmtiError err = jvmti->GetLoadedClasses(&class_count, classes.get_addr());
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "OnVMInit: Error in GetLoadedClasses: %d\n", err);
+    return;
+  }
+
+  // Prime any class already loaded and try to get the jmethodIDs set up.
+  jclass *classList = classes.get();
+  for (int i = 0; i < class_count; ++i) {
+    GetJMethodIDs(classList[i]);
+  }
+}
+
+extern "C" {
+
+static
+jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
+  jint res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION);
+  if (res != JNI_OK || jvmti == NULL) {
+    fprintf(stderr, "Error: wrong result of a valid call to GetEnv!\n");
+    return JNI_ERR;
+  }
+
+  jvmtiError err;
+  jvmtiCapabilities caps;
+  memset(&caps, 0, sizeof(caps));
+  caps.can_get_line_numbers = 1;
+  caps.can_get_source_file_name = 1;
+
+  err = jvmti->AddCapabilities(&caps);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "AgentInitialize: Error in AddCapabilities: %d\n", err);
+    return JNI_ERR;
+  }
+
+  jvmtiEventCallbacks callbacks;
+  memset(&callbacks, 0, sizeof(callbacks));
+  callbacks.ClassLoad = &OnClassLoad;
+  callbacks.VMInit = &OnVMInit;
+  callbacks.ClassPrepare = &OnClassPrepare;
+
+  err = jvmti->SetEventCallbacks(&callbacks, sizeof(jvmtiEventCallbacks));
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "AgentInitialize: Error in SetEventCallbacks: %d\n", err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_LOAD, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "AgentInitialize: Error in SetEventNotificationMode for CLASS_LOAD: %d\n", err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_PREPARE, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr,
+            "AgentInitialize: Error in SetEventNotificationMode for CLASS_PREPARE: %d\n",
+            err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(
+        stderr, "AgentInitialize: Error in SetEventNotificationMode for VM_INIT: %d\n",
+        err);
+    return JNI_ERR;
+  }
+
+  return JNI_OK;
+}
+
+JNIEXPORT
+jint JNICALL Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+  return Agent_Initialize(jvm, options, reserved);
+}
+
+JNIEXPORT
+jint JNICALL Agent_OnAttach(JavaVM *jvm, char *options, void *reserved) {
+  return Agent_Initialize(jvm, options, reserved);
+}
+
+JNIEXPORT
+jint JNICALL JNI_OnLoad(JavaVM *jvm, void *reserved) {
+  return JNI_VERSION_1_8;
+}
+
+
+// checkNativeChain() -> checkCMethod() -> checkJavaInner() -> checkNativeLeaf() -> ASGST() chain
+
+// a non JNI method, so we see a C frame
+[[gnu::noinline]] __attribute__((noinline)) static bool checkCMethod(JNIEnv* env, jclass cls) {
+  jmethodID method = env->GetStaticMethodID(cls, "checkJavaInner", "()Z");
+  if (method == NULL) {
+    fprintf(stderr, "Failed to get method ID for checkJavaInner\n");
+    return false;
+  }
+  return env->CallStaticBooleanMethod(cls, method);
+}
+
+[[gnu::noinline]] __attribute__((noinline)) JNIEXPORT jboolean JNICALL
+Java_profiling_innerc_ASGSTInnerCTest_checkNativeChain(JNIEnv* env, jclass cls) {
+  return checkCMethod(env, cls);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_profiling_innerc_ASGSTInnerCTest_checkNativeLeaf(JNIEnv* env, jclass cls) {
+  const int MAX_DEPTH = 16;
+  ASGST_CallTrace trace;
+  ASGST_CallFrame frames[MAX_DEPTH];
+  trace.frames = frames;
+  trace.frame_info = NULL;
+  trace.num_frames = 0;
+
+  // with ASGST_INCLUDE_C_FRAMES
+
+  AsyncGetStackTrace(&trace, MAX_DEPTH, NULL, ASGST_INCLUDE_C_FRAMES);
+
+  if (trace.num_frames <= 0) {
+    fprintf(stderr, "chain: The num_frames must be positive: %d\n", trace.num_frames);
+    return false;
+  }
+
+  if (trace.frames[0].type != ASGST_FRAME_NATIVE) {
+    fprintf(stderr, "chain: The first frame must be a Java frame: %d\n", trace.frames[0].type);
+    return false;
+  }
+
+  printTrace<1>(stdout, trace, {std::make_pair("checkCMethod", (void*)&checkCMethod)});
+
+  ASGST_JavaFrame first_frame = trace.frames[0].java_frame;
+  if (first_frame.bci != 0) {
+    fprintf(stderr, "chain: The first frame must have a bci of 0 as it is a native frame: %d\n", first_frame.bci);
+    return false;
+  }
+  if (first_frame.method_id == NULL) {
+    fprintf(stderr, "chain: The first frame must have a method_id: %p\n", first_frame.method_id);
+    return false;
+  }
+
+  if (trace.num_frames != 11) {
+    fprintf(stderr, "chain: The number of frames must be 12: %d\n", trace.num_frames);
+    return false;
+  }
+
+  if (!doesFrameBelongToJavaMethod(trace.frames[0], ASGST_FRAME_NATIVE,
+        "checkNativeLeaf", "chain frame 0") ||
+      !doesFrameBelongToJavaMethod(trace.frames[1], ASGST_FRAME_JAVA,
+        "checkJavaInner", "chain frame 1") ||
+      !isStubFrame(trace.frames[2], "chain frame 2") ||
+      !areFramesCPPFrames(trace.frames, 3, 7, "chain frames 3-5") ||
+      !doesFrameBelongToMethod(trace.frames[7], &checkCMethod, "chain frame 7") ||
+      !doesFrameBelongToJavaMethod(trace.frames[8], ASGST_FRAME_NATIVE,
+        "checkNativeChain", "chain frame 8"),
+      !doesFrameBelongToJavaMethod(trace.frames[9], ASGST_FRAME_JAVA,
+        "main", "chain frame 9") ||
+      !doesFrameBelongToJavaMethod(trace.frames[10], ASGST_FRAME_JAVA,
+        "invokeStatic", "chain frame 10")) {
+    return false;
+  }
+
+  return true;
+}
+
+}

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceInnerCTest.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceInnerCTest.cpp
@@ -31,8 +31,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
-#include <sys/time.h>
-#include <ucontext.h>
 #include "jni.h"
 #include "jvmti.h"
 #include "profile.h"

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceInnerCTest.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceInnerCTest.cpp
@@ -212,7 +212,6 @@ Java_profiling_innerc_ASGSTInnerCTest_checkNativeLeaf(JNIEnv* env, jclass cls) {
         "checkNativeLeaf", "chain frame 0") ||
       !doesFrameBelongToJavaMethod(trace.frames[1], ASGST_FRAME_JAVA,
         "checkJavaInner", "chain frame 1") ||
-      !isStubFrame(trace.frames[2], "chain frame 2") ||
       !areFramesCPPFrames(trace.frames, 3, 7, "chain frames 3-5")) {
     return false;
   }

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceSampler.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceSampler.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Google and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/time.h>
+#include "jvmti.h"
+#include "profile.h"
+
+static jvmtiEnv* jvmti;
+
+typedef void (*SigAction)(int, siginfo_t*, void*);
+typedef void (*SigHandler)(int);
+typedef void (*TimerCallback)(void*);
+
+template <class T>
+class JvmtiDeallocator {
+ public:
+  JvmtiDeallocator() {
+    elem_ = NULL;
+  }
+
+  ~JvmtiDeallocator() {
+    jvmti->Deallocate(reinterpret_cast<unsigned char*>(elem_));
+  }
+
+  T* get_addr() {
+    return &elem_;
+  }
+
+  T get() {
+    return elem_;
+  }
+
+ private:
+  T elem_;
+};
+
+static void GetJMethodIDs(jclass klass) {
+  jint method_count = 0;
+  JvmtiDeallocator<jmethodID*> methods;
+  jvmtiError err = jvmti->GetClassMethods(klass, &method_count, methods.get_addr());
+
+  // If ever the GetClassMethods fails, just ignore it, it was worth a try.
+  if (err != JVMTI_ERROR_NONE && err != JVMTI_ERROR_CLASS_NOT_PREPARED) {
+    fprintf(stderr, "GetJMethodIDs: Error in GetClassMethods: %d\n", err);
+  }
+}
+
+// AsyncGetStackTrace needs class loading events to be turned on!
+static void JNICALL OnClassLoad(jvmtiEnv *jvmti, JNIEnv *jni_env,
+                                jthread thread, jclass klass) {
+}
+
+static void JNICALL OnClassPrepare(jvmtiEnv *jvmti, JNIEnv *jni_env,
+                                   jthread thread, jclass klass) {
+  // We need to do this to "prime the pump" and get jmethodIDs primed.
+  GetJMethodIDs(klass);
+}
+
+static SigAction installSignalHandler(int signo, SigAction action, SigHandler handler = NULL) {
+    struct sigaction sa;
+    struct sigaction oldsa;
+    sigemptyset(&sa.sa_mask);
+
+    if (handler != NULL) {
+        sa.sa_handler = handler;
+        sa.sa_flags = 0;
+    } else {
+        sa.sa_sigaction = action;
+        sa.sa_flags = SA_SIGINFO | SA_RESTART;
+    }
+
+    sigaction(signo, &sa, &oldsa);
+    return oldsa.sa_sigaction;
+}
+
+static void signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
+  const int MAX_DEPTH = 512;
+  static ASGST_CallFrame frames[MAX_DEPTH];
+  ASGST_CallTrace trace;
+  trace.frames = frames;
+  trace.frame_info = NULL;
+  trace.num_frames = 0;
+
+  AsyncGetStackTrace(&trace, MAX_DEPTH, NULL, ASGST_INCLUDE_C_FRAMES);
+}
+
+static bool startITimerSampler(long interval_ns) {
+  time_t sec = interval_ns / 1000000000;
+  suseconds_t usec = (interval_ns % 1000000000) / 1000;
+  struct itimerval tv = {{sec, usec}, {sec, usec}};
+  
+  installSignalHandler(SIGPROF, signalHandler);
+
+  if (setitimer(ITIMER_PROF, &tv, NULL) != 0) {
+    return false;
+  }
+  fprintf(stderr, "=== asgst sampler initialized ===\n");
+  return true;
+}
+
+static void JNICALL OnVMInit(jvmtiEnv *jvmti, JNIEnv *jni_env, jthread thread) {
+  jint class_count = 0;
+
+  // Get any previously loaded classes that won't have gone through the
+  // OnClassPrepare callback to prime the jmethods for AsyncGetStackTrace.
+  JvmtiDeallocator<jclass*> classes;
+  jvmtiError err = jvmti->GetLoadedClasses(&class_count, classes.get_addr());
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "OnVMInit: Error in GetLoadedClasses: %d\n", err);
+    return;
+  }
+
+  // Prime any class already loaded and try to get the jmethodIDs set up.
+  jclass *classList = classes.get();
+  for (int i = 0; i < class_count; ++i) {
+    GetJMethodIDs(classList[i]);
+  }
+  
+  startITimerSampler(1000); // 1us
+}
+
+extern "C" {
+
+static
+jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
+  jint res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION);
+  if (res != JNI_OK || jvmti == NULL) {
+    fprintf(stderr, "Error: wrong result of a valid call to GetEnv!\n");
+    return JNI_ERR;
+  }
+
+  jvmtiError err;
+  jvmtiCapabilities caps;
+  memset(&caps, 0, sizeof(caps));
+  caps.can_get_line_numbers = 1;
+  caps.can_get_source_file_name = 1;
+
+  err = jvmti->AddCapabilities(&caps);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "AgentInitialize: Error in AddCapabilities: %d\n", err);
+    return JNI_ERR;
+  }
+
+  jvmtiEventCallbacks callbacks;
+  memset(&callbacks, 0, sizeof(callbacks));
+  callbacks.ClassLoad = &OnClassLoad;
+  callbacks.VMInit = &OnVMInit;
+  callbacks.ClassPrepare = &OnClassPrepare;
+
+  err = jvmti->SetEventCallbacks(&callbacks, sizeof(jvmtiEventCallbacks));
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "AgentInitialize: Error in SetEventCallbacks: %d\n", err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_LOAD, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "AgentInitialize: Error in SetEventNotificationMode for CLASS_LOAD: %d\n", err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_PREPARE, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr,
+            "AgentInitialize: Error in SetEventNotificationMode for CLASS_PREPARE: %d\n",
+            err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(
+        stderr, "AgentInitialize: Error in SetEventNotificationMode for VM_INIT: %d\n",
+        err);
+    return JNI_ERR;
+  }
+
+  return JNI_OK;
+}
+
+JNIEXPORT
+jint JNICALL Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+  return Agent_Initialize(jvm, options, reserved);
+}
+
+JNIEXPORT
+jint JNICALL Agent_OnAttach(JavaVM *jvm, char *options, void *reserved) {
+  return Agent_Initialize(jvm, options, reserved);
+}
+
+JNIEXPORT
+jint JNICALL JNI_OnLoad(JavaVM *jvm, void *reserved) {
+  return JNI_VERSION_1_8;
+}
+
+}

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceSampler.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceSampler.cpp
@@ -34,6 +34,9 @@
 #include "jvmti.h"
 #include "profile.h"
 
+const int INTERVAL_NS = 1000; // 1us, 1 0000 000 times per second
+                              // 20000 times more than in a normal profiling run
+
 static jvmtiEnv* jvmti;
 
 typedef void (*SigAction)(int, siginfo_t*, void*);
@@ -145,7 +148,7 @@ static void JNICALL OnVMInit(jvmtiEnv *jvmti, JNIEnv *jni_env, jthread thread) {
     GetJMethodIDs(classList[i]);
   }
 
-  startITimerSampler(1000); // 1us
+  startITimerSampler(INTERVAL_NS);
 }
 
 extern "C" {

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceSampler.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceSampler.cpp
@@ -34,8 +34,13 @@
 #include "jvmti.h"
 #include "profile.h"
 
+#ifdef DEBUG
+const int INTERVAL_NS = 20000; // 20us, 50 000 times per second
+                               // 1000 times more than in a normal profiling run
+#else
 const int INTERVAL_NS = 1000; // 1us, 1 0000 000 times per second
                               // 20000 times more than in a normal profiling run
+#endif
 
 static jvmtiEnv* jvmti;
 

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceSampler.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceSampler.cpp
@@ -117,7 +117,7 @@ static bool startITimerSampler(long interval_ns) {
   time_t sec = interval_ns / 1000000000;
   suseconds_t usec = (interval_ns % 1000000000) / 1000;
   struct itimerval tv = {{sec, usec}, {sec, usec}};
-  
+
   installSignalHandler(SIGPROF, signalHandler);
 
   if (setitimer(ITIMER_PROF, &tv, NULL) != 0) {
@@ -144,7 +144,7 @@ static void JNICALL OnVMInit(jvmtiEnv *jvmti, JNIEnv *jni_env, jthread thread) {
   for (int i = 0; i < class_count; ++i) {
     GetJMethodIDs(classList[i]);
   }
-  
+
   startITimerSampler(1000); // 1us
 }
 

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceSmallFuzzTest.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceSmallFuzzTest.cpp
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Google and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/time.h>
+#include <ucontext.h>
+#include "jvmti.h"
+#include "profile.h"
+
+static jvmtiEnv* jvmti;
+
+typedef void (*SigAction)(int, siginfo_t*, void*);
+typedef void (*SigHandler)(int);
+typedef void (*TimerCallback)(void*);
+
+template <class T>
+class JvmtiDeallocator {
+ public:
+  JvmtiDeallocator() {
+    elem_ = NULL;
+  }
+
+  ~JvmtiDeallocator() {
+    jvmti->Deallocate(reinterpret_cast<unsigned char*>(elem_));
+  }
+
+  T* get_addr() {
+    return &elem_;
+  }
+
+  T get() {
+    return elem_;
+  }
+
+ private:
+  T elem_;
+};
+
+static void GetJMethodIDs(jclass klass) {
+  jint method_count = 0;
+  JvmtiDeallocator<jmethodID*> methods;
+  jvmtiError err = jvmti->GetClassMethods(klass, &method_count, methods.get_addr());
+
+  // If ever the GetClassMethods fails, just ignore it, it was worth a try.
+  if (err != JVMTI_ERROR_NONE && err != JVMTI_ERROR_CLASS_NOT_PREPARED) {
+    fprintf(stderr, "GetJMethodIDs: Error in GetClassMethods: %d\n", err);
+  }
+}
+
+// AsyncGetStackTrace needs class loading events to be turned on!
+static void JNICALL OnClassLoad(jvmtiEnv *jvmti, JNIEnv *jni_env,
+                                jthread thread, jclass klass) {
+}
+
+static void JNICALL OnClassPrepare(jvmtiEnv *jvmti, JNIEnv *jni_env,
+                                   jthread thread, jclass klass) {
+  // We need to do this to "prime the pump" and get jmethodIDs primed.
+  GetJMethodIDs(klass);
+}
+
+static void JNICALL OnVMInit(jvmtiEnv *jvmti, JNIEnv *jni_env, jthread thread) {
+  jint class_count = 0;
+
+  // Get any previously loaded classes that won't have gone through the
+  // OnClassPrepare callback to prime the jmethods for AsyncGetStackTrace.
+  JvmtiDeallocator<jclass*> classes;
+  jvmtiError err = jvmti->GetLoadedClasses(&class_count, classes.get_addr());
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "OnVMInit: Error in GetLoadedClasses: %d\n", err);
+    return;
+  }
+
+  // Prime any class already loaded and try to get the jmethodIDs set up.
+  jclass *classList = classes.get();
+  for (int i = 0; i < class_count; ++i) {
+    GetJMethodIDs(classList[i]);
+  }
+}
+
+extern "C" {
+
+static
+jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
+  jint res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION);
+  if (res != JNI_OK || jvmti == NULL) {
+    fprintf(stderr, "Error: wrong result of a valid call to GetEnv!\n");
+    return JNI_ERR;
+  }
+
+  jvmtiError err;
+  jvmtiCapabilities caps;
+  memset(&caps, 0, sizeof(caps));
+  caps.can_get_line_numbers = 1;
+  caps.can_get_source_file_name = 1;
+
+  err = jvmti->AddCapabilities(&caps);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "AgentInitialize: Error in AddCapabilities: %d\n", err);
+    return JNI_ERR;
+  }
+
+  jvmtiEventCallbacks callbacks;
+  memset(&callbacks, 0, sizeof(callbacks));
+  callbacks.ClassLoad = &OnClassLoad;
+  callbacks.VMInit = &OnVMInit;
+  callbacks.ClassPrepare = &OnClassPrepare;
+
+  err = jvmti->SetEventCallbacks(&callbacks, sizeof(jvmtiEventCallbacks));
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "AgentInitialize: Error in SetEventCallbacks: %d\n", err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_LOAD, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "AgentInitialize: Error in SetEventNotificationMode for CLASS_LOAD: %d\n", err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_PREPARE, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr,
+            "AgentInitialize: Error in SetEventNotificationMode for CLASS_PREPARE: %d\n",
+            err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(
+        stderr, "AgentInitialize: Error in SetEventNotificationMode for VM_INIT: %d\n",
+        err);
+    return JNI_ERR;
+  }
+
+  return JNI_OK;
+}
+
+JNIEXPORT
+jint JNICALL Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+  return Agent_Initialize(jvm, options, reserved);
+}
+
+JNIEXPORT
+jint JNICALL Agent_OnAttach(JavaVM *jvm, char *options, void *reserved) {
+  return Agent_Initialize(jvm, options, reserved);
+}
+
+JNIEXPORT
+jint JNICALL JNI_OnLoad(JavaVM *jvm, void *reserved) {
+  return JNI_VERSION_1_8;
+}
+
+// max increase of sp
+int sp_max_fuzz = 10000;
+int sp_max_random_fuzz = 1000000;
+// max increase of fp
+int fp_max_fuzz = 10000;
+int fp_max_random_fuzz = 1000000;
+// granularity of sp and fp increases
+int granularity = 1;
+int random_fuzzes = 1000000;
+
+void fuzzingAsyncGetStackTraceLike(ASGST_CallTrace *trace, int max_depth, int options, int sp_fuzz, int fp_fuzz) {
+  ucontext_t uc;
+  getcontext(&uc);
+  uc.uc_mcontext.gregs[REG_RSP] += sp_fuzz;
+  uc.uc_mcontext.gregs[REG_RBP] += fp_fuzz;
+  AsyncGetStackTrace(trace, max_depth, &uc, options);
+}
+
+
+JNIEXPORT jboolean JNICALL
+Java_profiling_sanity_ASGSTSmallFuzzTest_checkAsyncGetStackTraceCall(JNIEnv* env, jclass cls) {
+  const int MAX_DEPTH = 16;
+  ASGST_CallTrace trace;
+  ASGST_CallFrame frames[MAX_DEPTH];
+  trace.frames = frames;
+  trace.frame_info = NULL;
+  trace.num_frames = 0;
+
+  for (int i = 0; i < sp_max_fuzz; i += granularity) {
+    for (int j = 0; j < fp_max_fuzz; j += granularity) {
+      fuzzingAsyncGetStackTraceLike(&trace, MAX_DEPTH, ASGST_INCLUDE_C_FRAMES, i, j);
+      if (trace.num_frames == 0) {
+        return JNI_FALSE;
+      }
+    }
+  }
+  for (int i = 0; i < random_fuzzes; i++) {
+    int sp_fuzz = rand() % sp_max_random_fuzz;
+    int fp_fuzz = rand() % fp_max_random_fuzz;
+    fuzzingAsyncGetStackTraceLike(&trace, MAX_DEPTH, ASGST_INCLUDE_C_FRAMES, sp_fuzz, fp_fuzz);
+  }
+
+  return true;
+}
+
+}

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceSmallFuzzTest.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceSmallFuzzTest.cpp
@@ -181,6 +181,17 @@ jint JNICALL JNI_OnLoad(JavaVM *jvm, void *reserved) {
   return JNI_VERSION_1_8;
 }
 
+#ifdef DEBUG
+// max increase of sp
+int sp_max_fuzz = 5000;
+int sp_max_random_fuzz = 1000000;
+// max increase of fp
+int fp_max_fuzz = 5000;
+int fp_max_random_fuzz = 1000000;
+// granularity of sp and fp increases
+int granularity = 1;
+int random_fuzzes = 500000;
+#else
 // max increase of sp
 int sp_max_fuzz = 10000;
 int sp_max_random_fuzz = 1000000;
@@ -190,6 +201,7 @@ int fp_max_random_fuzz = 1000000;
 // granularity of sp and fp increases
 int granularity = 1;
 int random_fuzzes = 1000000;
+#endif
 
 void fuzzingAsyncGetStackTraceLike(ASGST_CallTrace *trace, int max_depth, int options, int sp_fuzz, int fp_fuzz) {
   ucontext_t uc;

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceSmallFuzzTest.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceSmallFuzzTest.cpp
@@ -22,6 +22,8 @@
  * questions.
  */
 
+#if defined(LINUX) && defined(__x86_64__)
+
 #include <assert.h>
 #include <dlfcn.h>
 #include <signal.h>
@@ -225,3 +227,4 @@ Java_profiling_sanity_ASGSTSmallFuzzTest_checkAsyncGetStackTraceCall(JNIEnv* env
 }
 
 }
+#endif // defined(LINUX) && defined(__x86_64__)

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceTest.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceTest.cpp
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Google and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/time.h>
+#include "jvmti.h"
+#include "profile.h"
+
+static jvmtiEnv* jvmti;
+
+typedef void (*SigAction)(int, siginfo_t*, void*);
+typedef void (*SigHandler)(int);
+typedef void (*TimerCallback)(void*);
+
+template <class T>
+class JvmtiDeallocator {
+ public:
+  JvmtiDeallocator() {
+    elem_ = NULL;
+  }
+
+  ~JvmtiDeallocator() {
+    jvmti->Deallocate(reinterpret_cast<unsigned char*>(elem_));
+  }
+
+  T* get_addr() {
+    return &elem_;
+  }
+
+  T get() {
+    return elem_;
+  }
+
+ private:
+  T elem_;
+};
+
+static void GetJMethodIDs(jclass klass) {
+  jint method_count = 0;
+  JvmtiDeallocator<jmethodID*> methods;
+  jvmtiError err = jvmti->GetClassMethods(klass, &method_count, methods.get_addr());
+
+  // If ever the GetClassMethods fails, just ignore it, it was worth a try.
+  if (err != JVMTI_ERROR_NONE && err != JVMTI_ERROR_CLASS_NOT_PREPARED) {
+    fprintf(stderr, "GetJMethodIDs: Error in GetClassMethods: %d\n", err);
+  }
+}
+
+// AsyncGetStackTrace needs class loading events to be turned on!
+static void JNICALL OnClassLoad(jvmtiEnv *jvmti, JNIEnv *jni_env,
+                                jthread thread, jclass klass) {
+}
+
+static void JNICALL OnClassPrepare(jvmtiEnv *jvmti, JNIEnv *jni_env,
+                                   jthread thread, jclass klass) {
+  // We need to do this to "prime the pump" and get jmethodIDs primed.
+  GetJMethodIDs(klass);
+}
+
+static void JNICALL OnVMInit(jvmtiEnv *jvmti, JNIEnv *jni_env, jthread thread) {
+  jint class_count = 0;
+
+  // Get any previously loaded classes that won't have gone through the
+  // OnClassPrepare callback to prime the jmethods for AsyncGetStackTrace.
+  JvmtiDeallocator<jclass*> classes;
+  jvmtiError err = jvmti->GetLoadedClasses(&class_count, classes.get_addr());
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "OnVMInit: Error in GetLoadedClasses: %d\n", err);
+    return;
+  }
+
+  // Prime any class already loaded and try to get the jmethodIDs set up.
+  jclass *classList = classes.get();
+  for (int i = 0; i < class_count; ++i) {
+    GetJMethodIDs(classList[i]);
+  }
+}
+
+extern "C" {
+
+static
+jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
+  jint res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION);
+  if (res != JNI_OK || jvmti == NULL) {
+    fprintf(stderr, "Error: wrong result of a valid call to GetEnv!\n");
+    return JNI_ERR;
+  }
+
+  jvmtiError err;
+  jvmtiCapabilities caps;
+  memset(&caps, 0, sizeof(caps));
+  caps.can_get_line_numbers = 1;
+  caps.can_get_source_file_name = 1;
+
+  err = jvmti->AddCapabilities(&caps);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "AgentInitialize: Error in AddCapabilities: %d\n", err);
+    return JNI_ERR;
+  }
+
+  jvmtiEventCallbacks callbacks;
+  memset(&callbacks, 0, sizeof(callbacks));
+  callbacks.ClassLoad = &OnClassLoad;
+  callbacks.VMInit = &OnVMInit;
+  callbacks.ClassPrepare = &OnClassPrepare;
+
+  err = jvmti->SetEventCallbacks(&callbacks, sizeof(jvmtiEventCallbacks));
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "AgentInitialize: Error in SetEventCallbacks: %d\n", err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_LOAD, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "AgentInitialize: Error in SetEventNotificationMode for CLASS_LOAD: %d\n", err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_PREPARE, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr,
+            "AgentInitialize: Error in SetEventNotificationMode for CLASS_PREPARE: %d\n",
+            err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(
+        stderr, "AgentInitialize: Error in SetEventNotificationMode for VM_INIT: %d\n",
+        err);
+    return JNI_ERR;
+  }
+
+  return JNI_OK;
+}
+
+JNIEXPORT
+jint JNICALL Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+  return Agent_Initialize(jvm, options, reserved);
+}
+
+JNIEXPORT
+jint JNICALL Agent_OnAttach(JavaVM *jvm, char *options, void *reserved) {
+  return Agent_Initialize(jvm, options, reserved);
+}
+
+JNIEXPORT
+jint JNICALL JNI_OnLoad(JavaVM *jvm, void *reserved) {
+  return JNI_VERSION_1_8;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_profiling_sanity_ASGSTBaseTest_checkAsyncGetStackTraceCall(JNIEnv* env, jclass cls) {
+  const int MAX_DEPTH = 16;
+  ASGST_CallTrace trace;
+  ASGST_CallFrame frames[MAX_DEPTH];
+  trace.frames = frames;
+  trace.frame_info = NULL;
+  trace.num_frames = 0;
+
+  AsyncGetStackTrace(&trace, MAX_DEPTH, NULL, ASGST_INCLUDE_C_FRAMES);  
+
+  // For now, just check that the first frame is (-3, checkAsyncGetStackTraceCall).
+  if (trace.num_frames <= 0) {
+    fprintf(stderr, "The num_frames must be positive: %d\n", trace.num_frames);
+    return false;
+  } 
+  // for (int i = 0; i < trace.num_frames; i++) {
+  //   fprintf(stderr, "frame %d: type=%u, bci=%d\n", i, trace.frames[i].type, trace.frames[i].java_frame.bci);
+  //   if (trace.frames[i].type == ASGST_FRAME_JAVA) {
+  //     fprintf(stderr, "java type: %u\n", trace.frames[i].java_frame.type);
+  //     JvmtiDeallocator<char*> name;
+  //     jvmtiError err = jvmti->GetMethodName(trace.frames[i].java_frame.method_id, name.get_addr(), NULL, NULL);
+  //     if (err != JVMTI_ERROR_NONE) {
+  //       fprintf(stderr, "checkAsyncGetStackTrace: Error in GetMethodName: %d\n", err);
+  //       return false;
+  //     }
+
+  //     if (name.get() == NULL) {
+  //       fprintf(stderr, "Name is NULL\n");
+  //       return false;
+  //     }
+  //     fprintf(stderr, "name: %s\n", name.get());
+  //   }
+  // }
+
+  ASGST_CallFrame frame = trace.frames[0];
+  if (frame.type != ASGST_FRAME_NATIVE) {
+    fprintf(stderr, "Native frame is expected to have type %u but instead it is %u\n", ASGST_FRAME_NATIVE, frame.type);
+    return false;
+  }
+  // if (frame.pc == NULL) {
+  //   fprintf(stderr, "Non-java frame PC is expected to exist\n");
+  //   return false;
+  // }
+  // if (trace.frames[0].type != -3) {
+  //   fprintf(stderr, "lineno is not -3 as expected: %d\n", trace.frames[0].lineno);
+  //   return false;
+  // }
+
+  // JvmtiDeallocator<char*> name;
+  // if (trace.frames[0].method_id == NULL) {
+  //   fprintf(stderr, "First frame method_id is NULL\n");
+  //   return false;
+  // }
+
+  // jvmtiError err = jvmti->GetMethodName(trace.frames[0].method_id, name.get_addr(), NULL, NULL);
+  // if (err != JVMTI_ERROR_NONE) {
+  //   fprintf(stderr, "checkAsyncGetStackTrace: Error in GetMethodName: %d\n", err);
+  //   return false;
+  // }
+
+  // if (name.get() == NULL) {
+  //   fprintf(stderr, "Name is NULL\n");
+  //   return false;
+  // }
+
+  // return strcmp(name.get(), "checkAsyncGetStackTraceCall") == 0;
+  return true;
+}
+
+}

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceTest.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceTest.cpp
@@ -348,7 +348,6 @@ Java_profiling_sanity_ASGSTBaseTest_checkAsyncGetStackTraceCall(JNIEnv* env, jcl
 
   AsyncGetStackTrace(&trace, MAX_DEPTH, NULL, ASGST_INCLUDE_C_FRAMES);
 
-  // For now, just check that the first frame is (-3, checkAsyncGetStackTraceCall).
   if (trace.num_frames <= 0) {
     fprintf(stderr, "JNICALL: The num_frames must be positive: %d\n", trace.num_frames);
     return false;
@@ -370,7 +369,7 @@ Java_profiling_sanity_ASGSTBaseTest_checkAsyncGetStackTraceCall(JNIEnv* env, jcl
   }
 
   if (trace.num_frames != 3) {
-    fprintf(stderr, "JNICALL: The number of frames must be 4: %d\n", trace.num_frames);
+    fprintf(stderr, "JNICALL: The number of frames must be 3: %d\n", trace.num_frames);
     return false;
   }
 

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceTest.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceTest.cpp
@@ -22,6 +22,12 @@
  * questions.
  */
 
+#if defined(BSD) || defined(LINUX)
+
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 600
+#endif
+
 #include <assert.h>
 #include <dlfcn.h>
 #include <pthread.h>
@@ -32,12 +38,12 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/time.h>
+#include <sys/ucontext.h>
 #include <ucontext.h>
 #include "jni.h"
 #include "jvmti.h"
 #include "profile.h"
 #include "util.hpp"
-
 
 // AsyncGetStackTrace needs class loading events to be turned on!
 static void JNICALL OnClassLoad(jvmtiEnv *jvmti, JNIEnv *jni_env,
@@ -391,3 +397,4 @@ Java_profiling_sanity_ASGSTBaseTest_checkAsyncGetStackTraceCall(JNIEnv* env, jcl
   return checkForNonJavaFromThread() && checkWithSkippedCFrames();
 }
 }
+#endif // defined(BSD) || defined(LINUX)

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceTest.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceTest.cpp
@@ -253,7 +253,7 @@ static void* checkForNonJava(void *arg) {
   AsyncGetStackTrace(&trace, MAX_DEPTH, &context,
     ASGST_INCLUDE_C_FRAMES | ASGST_INCLUDE_NON_JAVA_THREADS);
   if (trace.num_frames < 0) {
-    fprintf(stderr, "checkForNonJava: No frames found for non-java thread\n");
+    fprintf(stderr, "checkForNonJava: No frames found for non-java thread, error code %d\n", trace.num_frames);
     return NULL;
   }
   if (trace.kind != ASGST_CPP_TRACE) {

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceTest.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceTest.cpp
@@ -320,7 +320,7 @@ Java_profiling_sanity_ASGSTBaseTest_checkAsyncGetStackTraceCall(JNIEnv* env, jcl
     return false;
   }
 
-  return check<MAX_DEPTH>("basic", env) && checkForNonJavaFromThread();
+  return check<MAX_DEPTH>("basic", env) && checkThatWithCAndWithoutAreSimilar("basic with C") && checkForNonJavaFromThread();
 }
 }
 #endif // defined(__APPLE__) || defined(LINUX)

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceTest.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceTest.cpp
@@ -39,7 +39,6 @@
 #include "util.hpp"
 
 
-
 // AsyncGetStackTrace needs class loading events to be turned on!
 static void JNICALL OnClassLoad(jvmtiEnv *jvmti, JNIEnv *jni_env,
                                 jthread thread, jclass klass) {

--- a/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceTest.cpp
+++ b/test/hotspot/jtreg/serviceability/profiling/libAsyncGetStackTraceTest.cpp
@@ -166,7 +166,7 @@ static bool checkForNonJava2() {
   trace.frames = frames;
 
   AsyncGetStackTrace(&trace, MAX_DEPTH, &context,
-    ASGST_INCLUDE_C_FRAMES | ASGST_INCLUDE_NON_JAVA_THREADS);
+    ASGST_INCLUDE_C_FRAMES | ASGST_INCLUDE_NON_JAVA_THREADS | ASGST_WALK_SAME_THREAD);
   if (trace.num_frames < 0) {
     fprintf(stderr, "checkForNonJava2: No frames found for non-java thread\n");
     return false;
@@ -200,7 +200,7 @@ static bool checkForNonJavaNoCFrames() {
   ASGST_CallFrame frames[MAX_DEPTH];
   trace.frames = frames;
 
-  AsyncGetStackTrace(&trace, MAX_DEPTH, &context, ASGST_INCLUDE_NON_JAVA_THREADS);
+  AsyncGetStackTrace(&trace, MAX_DEPTH, &context, ASGST_INCLUDE_NON_JAVA_THREADS | ASGST_WALK_SAME_THREAD);
   if (trace.num_frames != 0) {
     fprintf(stderr, "checkForNonJavaNoCFrames: Frames found for non-java thread\n");
     return false;
@@ -224,7 +224,7 @@ static bool checkForNonJavaNoJavaFramesIncluded() {
   ASGST_CallFrame frames[MAX_DEPTH];
   trace.frames = frames;
 
-  AsyncGetStackTrace(&trace, MAX_DEPTH, &context, 0);
+  AsyncGetStackTrace(&trace, MAX_DEPTH, &context, ASGST_WALK_SAME_THREAD);
   if (trace.num_frames != ASGST_THREAD_NOT_JAVA) {
     fprintf(stderr, "NoJavaFramesIncluded: Found incorrect error code %d\n", trace.num_frames);
     return false;
@@ -252,7 +252,7 @@ static void* checkForNonJava(void *arg) {
 
 
   AsyncGetStackTrace(&trace, MAX_DEPTH, &context,
-    ASGST_INCLUDE_C_FRAMES | ASGST_INCLUDE_NON_JAVA_THREADS);
+    ASGST_INCLUDE_C_FRAMES | ASGST_INCLUDE_NON_JAVA_THREADS | ASGST_WALK_SAME_THREAD);
   if (trace.num_frames < 0) {
     fprintf(stderr, "checkForNonJava: No frames found for non-java thread, error code %d\n", trace.num_frames);
     return NULL;
@@ -296,7 +296,9 @@ Java_profiling_sanity_ASGSTBaseTest_checkAsyncGetStackTraceCall(JNIEnv* env, jcl
   trace.frame_info = NULL;
   trace.num_frames = 0;
 
-  AsyncGetStackTrace(&trace, MAX_DEPTH, NULL, 0);
+  ucontext_t context;
+  getcontext(&context);
+  AsyncGetStackTrace(&trace, MAX_DEPTH, &context, ASGST_WALK_SAME_THREAD);
 
   if (trace.num_frames <= 0) {
     fprintf(stderr, "basic: The num_frames must be positive: %d\n", trace.num_frames);

--- a/test/hotspot/jtreg/serviceability/profiling/sanity/ASGSTBaseTest.java
+++ b/test/hotspot/jtreg/serviceability/profiling/sanity/ASGSTBaseTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Google and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package profiling.sanity;
+
+/**
+ * @test
+ * @summary Verifies that AsyncGetStackTrace is call-able and provides sane information.
+ * @compile ASGSTBaseTest.java
+ * @requires os.family == "linux"
+ * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="arm" | os.arch=="aarch64" | os.arch=="ppc64" | os.arch=="s390" | os.arch=="riscv64"
+ * @requires vm.jvmti
+ * @run main/othervm/native -agentlib:AsyncGetStackTraceTest profiling.sanity.ASGSTBaseTest
+ */
+
+public class ASGSTBaseTest {
+  static {
+    try {
+      System.loadLibrary("AsyncGetStackTraceTest");
+    } catch (UnsatisfiedLinkError ule) {
+      System.err.println("Could not load AsyncGetStackTrace library");
+      System.err.println("java.library.path: " + System.getProperty("java.library.path"));
+      throw ule;
+    }
+  }
+
+  private static native boolean checkAsyncGetStackTraceCall();
+
+  public static void main(String[] args) throws Exception {
+    if (!checkAsyncGetStackTraceCall()) {
+      throw new RuntimeException("AsyncGetStackTrace call failed.");
+    }
+  }
+}

--- a/test/hotspot/jtreg/serviceability/profiling/sanity/ASGSTBaseTest.java
+++ b/test/hotspot/jtreg/serviceability/profiling/sanity/ASGSTBaseTest.java
@@ -45,11 +45,12 @@ public class ASGSTBaseTest {
     }
   }
 
+  /** check a simple native call which calls ASGST */
   private static native boolean checkAsyncGetStackTraceCall();
 
   public static void main(String[] args) throws Exception {
     if (!checkAsyncGetStackTraceCall()) {
-      throw new RuntimeException("AsyncGetStackTrace call failed.");
+      throw new RuntimeException("Basic AsyncGetStackTrace calls failed.");
     }
   }
 }

--- a/test/hotspot/jtreg/serviceability/profiling/sanity/ASGSTBaseTest.java
+++ b/test/hotspot/jtreg/serviceability/profiling/sanity/ASGSTBaseTest.java
@@ -28,7 +28,7 @@ package profiling.sanity;
  * @test
  * @summary Verifies that AsyncGetStackTrace is call-able and provides sane information.
  * @compile ASGSTBaseTest.java
- * @requires os.family == "linux"
+ * @requires os.family == "linux" | os.family == "mac"
  * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="arm" | os.arch=="aarch64" | os.arch=="ppc64" | os.arch=="s390" | os.arch=="riscv64"
  * @requires vm.jvmti
  * @run main/othervm/native -agentlib:AsyncGetStackTraceTest profiling.sanity.ASGSTBaseTest

--- a/test/hotspot/jtreg/serviceability/profiling/smallerFuzz/ASGSTSmallFuzzTest.java
+++ b/test/hotspot/jtreg/serviceability/profiling/smallerFuzz/ASGSTSmallFuzzTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Google and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package profiling.sanity;
+
+/**
+ * @test
+ * @summary Verifies that AsyncGetStackTrace is call-able with slightly randomized sp and fp
+ * @compile ASGSTSmallFuzzTest.java
+ * @requires os.family == "linux"
+ * @requires os.arch=="amd64" | os.arch=="x86_64"
+ * @requires vm.jvmti
+ * @run main/othervm/native -agentlib:AsyncGetStackTraceSmallFuzzTest profiling.sanity.ASGSTSmallFuzzTest
+ */
+
+public class ASGSTSmallFuzzTest {
+  static {
+    try {
+      System.loadLibrary("AsyncGetStackTraceSmallFuzzTest");
+    } catch (UnsatisfiedLinkError ule) {
+      System.err.println("Could not load AsyncGetStackTraceSmallFuzzTest library");
+      System.err.println("java.library.path: " + System.getProperty("java.library.path"));
+      throw ule;
+    }
+  }
+
+  private static native boolean checkAsyncGetStackTraceCall();
+
+  public static void main(String[] args) throws Exception {
+    if (!checkAsyncGetStackTraceCall()) {
+      throw new RuntimeException("AsyncGetStackTrace call failed.");
+    }
+  }
+}

--- a/test/hotspot/jtreg/serviceability/profiling/stress/ASGSTStabilityTest.java
+++ b/test/hotspot/jtreg/serviceability/profiling/stress/ASGSTStabilityTest.java
@@ -80,7 +80,7 @@ public class ASGSTStabilityTest {
           } catch (InterruptedException ignored) {
             Thread.currentThread().interrupt();
             break;
-          } 
+          }
         }
       });
       t.setDaemon(true);

--- a/test/hotspot/jtreg/serviceability/profiling/stress/ASGSTStabilityTest.java
+++ b/test/hotspot/jtreg/serviceability/profiling/stress/ASGSTStabilityTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Google and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package profiling.stress;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.ClassLoader;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Random;
+import java.lang.reflect.Method;
+
+import jdk.test.lib.process.*;
+import jdk.test.whitebox.WhiteBox;
+
+/**
+ * @test
+ * @summary Verifies that AsyncGetStackTrace usage is stable in a high-frequency signal sampler
+ * @library /test/jdk/lib/testlibrary /test/lib
+ * @compile ASGSTStabilityTest.java
+ * @key stress
+ * @requires os.family == "linux"
+ * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="arm" | os.arch=="aarch64" | os.arch=="ppc64" | os.arch=="s390" | os.arch=="riscv64"
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar WhiteBox.jar jdk.test.whitebox.WhiteBox
+ * @run main/othervm/native/timeout=216000 profiling.stress.ASGSTStabilityTest akka-uct 10
+ * @run main/othervm/native/timeout=216000 profiling.stress.ASGSTStabilityTest finagle-chirper 120
+ * @run main/othervm/native/timeout=216000 profiling.stress.ASGSTStabilityTest finagle-http 120
+ */
+
+public class ASGSTStabilityTest {
+  private static final String RENAISSANCE_URL = "https://github.com/renaissance-benchmarks/renaissance/releases/download/v0.14.1/renaissance-gpl-0.14.1.jar";
+
+  public static final class Runner {
+    private static final String MAIN_CLASS = "org.renaissance.core.Launcher";
+    public static void main(String[] args) throws Exception {
+      WhiteBox wb = WhiteBox.getWhiteBox();
+
+      // start a thread which will randomly deoptimize frames in order
+      // to increase the chance of hitting problems when walking the stack
+      // in the middle of opt/deopt - this used to be a source of various
+      // crashes in the original ASGCT so it sounds useful to have a regtest
+      // covering it
+      Thread t = new Thread(() -> {
+        Random rnd = new Random(845123525117L);
+        while (!Thread.currentThread().isInterrupted()) {
+          try {
+            Thread.sleep(100 + rnd.nextInt(300));
+            wb.deoptimizeFrames(true);
+          } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+            break;
+          } 
+        }
+      });
+      t.setDaemon(true);
+      t.start();
+
+      Class<?> clz = Runner.class.getClassLoader().loadClass(MAIN_CLASS);
+      clz.getMethod("main", String[].class).invoke(null, (Object)args);
+
+    }
+  }
+
+  private static void downloadRenaissance(Path target) throws IOException {
+    System.out.println("Downloading " + RENAISSANCE_URL + " to " + target);
+    URL url = new URL(RENAISSANCE_URL);
+    ReadableByteChannel readableByteChannel = Channels.newChannel(url.openStream());
+    
+    try (FileOutputStream os = new FileOutputStream(target.toFile())) {
+      os.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+    }
+    System.out.println("Downloaded renaissance.jar to " + target);
+  }
+
+  public static void main(String[] args) throws Exception {
+    String tmpPath = System.getProperty("java.io.tmpdir");
+    Path jarPath = Paths.get(tmpPath, "renaissance.jar");
+    if (!Files.exists(jarPath)) {
+      downloadRenaissance(jarPath);
+    }
+
+    if (!Files.exists(jarPath)) {
+      throw new Error("Renaissance library not found.");
+    }
+    
+    Path out = Paths.get("renaissance.out").toAbsolutePath();
+    String[] benchmarks = new String[] {
+      "akka-uct", "finagle-chirper", "finagle-http", "akka-uct"
+    };
+    String benchmark = args[0];
+    int duration = Integer.parseInt(args[1]);
+    System.out.println("=== Going to run '" + benchmark + "' benchmark for " + duration + " seconds ...");
+    String testCp = System.getProperty("test.class.path") + 
+                      File.pathSeparator + jarPath.toString();
+    System.out.println("===> Classpath: " + testCp);
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+      List.of(
+        "-Xbootclasspath/a:./WhiteBox.jar",
+        "-XX:+UnlockDiagnosticVMOptions",
+        "-XX:+WhiteBoxAPI", 
+        "-agentlib:AsyncGetStackTraceSampler",
+        "-Djava.library.path=" + System.getProperty("test.nativepath"),
+        "-cp", testCp, 
+        ASGSTStabilityTest.Runner.class.getName(),
+        benchmark, "-t", Integer.toString(duration)))
+      .redirectErrorStream(true);
+    ProcessTools.executeProcess(pb)
+      .shouldHaveExitValue(0)
+      .shouldContain("=== asgst sampler initialized ===");
+
+    System.out.println("=== ... done");
+  }
+}

--- a/test/hotspot/jtreg/serviceability/profiling/stress/ASGSTStabilityTest.java
+++ b/test/hotspot/jtreg/serviceability/profiling/stress/ASGSTStabilityTest.java
@@ -49,7 +49,7 @@ import jdk.test.whitebox.WhiteBox;
  * @library /test/jdk/lib/testlibrary /test/lib
  * @compile ASGSTStabilityTest.java
  * @key stress
- * @requires os.family == "linux"
+ * @requires os.family == "linux" | os.family == "mac"
  * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="arm" | os.arch=="aarch64" | os.arch=="ppc64" | os.arch=="s390" | os.arch=="riscv64"
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar WhiteBox.jar jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/serviceability/profiling/util.hpp
+++ b/test/hotspot/jtreg/serviceability/profiling/util.hpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, SAP SE. All rights reserved.
  * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, Google and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.

--- a/test/hotspot/jtreg/serviceability/profiling/util.hpp
+++ b/test/hotspot/jtreg/serviceability/profiling/util.hpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Google and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <array>
+#include <assert.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/time.h>
+#include <ucontext.h>
+#include <utility>
+#include "jni.h"
+#include "jvmti.h"
+#include "profile.h"
+
+static jvmtiEnv* jvmti;
+
+typedef void (*SigAction)(int, siginfo_t*, void*);
+typedef void (*SigHandler)(int);
+typedef void (*TimerCallback)(void*);
+
+
+template <class T>
+class JvmtiDeallocator {
+ public:
+  JvmtiDeallocator() {
+    elem_ = NULL;
+  }
+
+  ~JvmtiDeallocator() {
+    jvmti->Deallocate(reinterpret_cast<unsigned char*>(elem_));
+  }
+
+  T* get_addr() {
+    return &elem_;
+  }
+
+  T get() {
+    return elem_;
+  }
+
+ private:
+  T elem_;
+};
+
+static void GetJMethodIDs(jclass klass) {
+  jint method_count = 0;
+  JvmtiDeallocator<jmethodID*> methods;
+  jvmtiError err = jvmti->GetClassMethods(klass, &method_count, methods.get_addr());
+
+  // If ever the GetClassMethods fails, just ignore it, it was worth a try.
+  if (err != JVMTI_ERROR_NONE && err != JVMTI_ERROR_CLASS_NOT_PREPARED) {
+    fprintf(stderr, "GetJMethodIDs: Error in GetClassMethods: %d\n", err);
+  }
+}
+
+// assumes that getcontext is called in the beginning of the function
+template <typename T> bool doesFrameBelongToMethod(ASGST_CallFrame frame, T* method, const char* msg_prefix) {
+  if (frame.type != ASGST_FRAME_CPP) {
+    fprintf(stderr, "%s: Expected CPP frame, got %d\n", msg_prefix, frame.type);
+    return false;
+  }
+  ASGST_NonJavaFrame non_java_frame = frame.non_java_frame;
+  size_t pc = (size_t)non_java_frame.pc;
+  size_t expected_pc_start = (size_t)method;
+  size_t expected_pc_end = (size_t)method + 0x100;
+  if (pc < expected_pc_start || pc > expected_pc_end) {
+    fprintf(stderr, "%s: Expected PC in range [%p, %p], got %p\n", msg_prefix,
+      (void*)expected_pc_start, (void*)expected_pc_end, (void*)pc);
+    return false;
+  }
+  return true;
+}
+
+bool doesFrameBelongToJavaMethod(ASGST_CallFrame frame, uint8_t type, const char* expected_name, const char* msg_prefix) {
+  if (frame.type != type) {
+    fprintf(stderr, "%s: Expected type %d but got %d\n", msg_prefix, type, frame.type);
+    return false;
+  }
+  ASGST_JavaFrame java_frame = frame.java_frame;
+  JvmtiDeallocator<char*> name;
+  jvmtiError err = jvmti->GetMethodName(java_frame.method_id, name.get_addr(), NULL, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "%s: Error in GetMethodName: %d\n", msg_prefix, err);
+    return false;
+  }
+  if (strcmp(expected_name, name.get()) != 0) {
+    fprintf(stderr, "%s: Expected method name %s but got %s\n", msg_prefix, expected_name, name.get());
+    return false;
+  }
+  return true;
+}
+
+bool isStubFrame(ASGST_CallFrame frame, const char* msg_prefix) {
+  if (frame.type != ASGST_FRAME_STUB) {
+    fprintf(stderr, "%s: Expected STUB frame, got %d", msg_prefix, frame.type);
+    return false;
+  }
+  return true;
+}
+
+void printJavaFrame(FILE *stream, ASGST_JavaFrame frame) {
+  JvmtiDeallocator<char*> name;
+  jvmtiError err = jvmti->GetMethodName(frame.method_id, name.get_addr(), NULL, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    fprintf(stream, "Error in GetMethodName: %d", err);
+    return;
+  }
+  switch (frame.type) {
+    case ASGST_FRAME_JAVA:
+    fprintf(stream, "Java");
+    break;
+    case ASGST_FRAME_JAVA_INLINED:
+    fprintf(stream, "Java inlined");
+    break;
+    case ASGST_FRAME_NATIVE:
+    fprintf(stream, "Native");
+    break;
+  }
+  fprintf(stream, " frame, method = %s, bci = %d", name.get(), frame.bci);
+}
+
+template <size_t N = 0> const char* lookForMethod(void* pc, std::array<std::pair<const char*, void*>, N> methods = {}) {
+  std::array<std::pair<const char*, size_t>, N> distances;
+  int i = 0;
+  for (auto method : methods) {
+    if (pc >= method.second && pc < (void*)((size_t)method.second + 0x100)) {
+      distances[i] = std::make_pair(method.first, (size_t)pc - (size_t)method.second);
+    }
+    i++;
+  }
+  if (distances.empty()) {
+    return NULL;
+  }
+  auto min_pair = distances[0];
+  for (auto pair : distances) {
+    if (pair.second < min_pair.second) {
+      min_pair = pair;
+    }
+  }
+  return min_pair.first;
+}
+
+template <size_t N = 0> void printNonJavaFrame(FILE* stream, ASGST_NonJavaFrame frame, std::array<std::pair<const char*, void*>, N> methods = {}) {
+  if (frame.type == ASGST_FRAME_CPP) {
+    fprintf(stream, "CPP frame, pc = %p", frame.pc);
+  } else if (frame.type == ASGST_FRAME_STUB) {
+    fprintf(stream, "Stub frame, pc = %p", frame.pc);
+  } else {
+    fprintf(stream, "Unknown frame type: %d", frame.type);
+  }
+
+  const char* method_name = lookForMethod(frame.pc, methods);
+  if (method_name != NULL) {
+    fprintf(stream, " (%s)", method_name);
+  } else {
+    fprintf(stream, " (%p)", frame.pc);
+  }
+}
+
+template <size_t N = 0> void printFrame(FILE* stream, ASGST_CallFrame frame, std::array<std::pair<const char*, void*>, N> methods = {}) {
+  switch (frame.type) {
+    case ASGST_FRAME_JAVA:
+    case ASGST_FRAME_JAVA_INLINED:
+    case ASGST_FRAME_NATIVE:
+      printJavaFrame(stream, frame.java_frame);
+      break;
+    case ASGST_FRAME_CPP:
+    case ASGST_FRAME_STUB:
+      printNonJavaFrame(stream, frame.non_java_frame, methods);
+      break;
+    default:
+        fprintf(stream, "Unknown frame type: %d", frame.type);
+  }
+}
+
+template <size_t N = 0> void printFrames(FILE* stream, ASGST_CallFrame *frames, int length, std::array<std::pair<const char*, void*>, N> methods = {}) {
+  for (int i = 0; i < length; i++) {
+    fprintf(stream, "Frame %d: ", i);
+    printFrame(stream, frames[i], methods);
+    fprintf(stream, "\n");
+  }
+}
+
+template <size_t N = 0> void printTrace(FILE* stream, ASGST_CallTrace trace, std::array<std::pair<const char*, void*>, N> methods = {}) {
+  fprintf(stream, "Trace length: %d\n", trace.num_frames);
+  fprintf(stream, "Kind: %d\n", trace.kind);
+  if (trace.num_frames > 0) {
+    printFrames(stream, trace.frames, trace.num_frames, methods);
+  }
+}
+
+bool areFramesCPPFrames(ASGST_CallFrame *frames, int start, int inclEnd, const char* msg_prefix) {
+  for (int i = start; i <= inclEnd; i++) {
+    if (frames[i].type != ASGST_FRAME_CPP) {
+      fprintf(stderr, "%s: Expected CPP frame at index %d, got %d", msg_prefix, i, frames[i].type);
+      return false;
+    }
+  }
+  return true;
+}

--- a/test/hotspot/jtreg/serviceability/profiling/util.hpp
+++ b/test/hotspot/jtreg/serviceability/profiling/util.hpp
@@ -23,6 +23,10 @@
  * questions.
  */
 
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 600
+#endif
+
 #include <array>
 #include <assert.h>
 #include <signal.h>
@@ -32,6 +36,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/time.h>
+#include <sys/ucontext.h>
 #include <ucontext.h>
 #include <utility>
 #include "jni.h"

--- a/test/hotspot/jtreg/serviceability/profiling/util.hpp
+++ b/test/hotspot/jtreg/serviceability/profiling/util.hpp
@@ -326,10 +326,11 @@ void printASGCTFrames(FILE* stream, ASGCT_CallFrame *frames, int length) {
 }
 
 void printASGCTTrace(FILE* stream, ASGCT_CallTrace trace) {
-  fprintf(stream, "Trace length: %d\n", trace.num_frames);
+  fprintf(stream, "ASGCT Trace length: %d\n", trace.num_frames);
   if (trace.num_frames > 0) {
     printASGCTFrames(stream, trace.frames, trace.num_frames);
   }
+  fprintf(stream, "ASGCT Trace end\n");
 }
 
 void printTraces(ASGST_CallTrace* trace, ASGCT_CallTrace* asgct_trace) {
@@ -350,11 +351,11 @@ void initASGCT() {
 
 JNIEnv* env;
 
-template<int max_depth> void printASGCT(void* ucontext) {
+template<int max_depth> void printASGCT(void* ucontext, JNIEnv* oenv = nullptr) {
   ASGCT_CallTrace asgct_trace;
   static ASGCT_CallFrame asgct_frames[max_depth];
   asgct_trace.frames = asgct_frames;
-  asgct_trace.env_id = env;
+  asgct_trace.env_id = oenv == nullptr ? env : oenv;
   asgct_trace.num_frames = 0;
 
   asgct(&asgct_trace, max_depth, ucontext, false);

--- a/test/hotspot/jtreg/serviceability/profiling/util.hpp
+++ b/test/hotspot/jtreg/serviceability/profiling/util.hpp
@@ -51,8 +51,10 @@
 #ifdef DEBUG
 // more space for debug info
 const int METHOD_HEADER_SIZE = 0x200;
+const int METHOD_PRE_HEADER_SIZE = 0x20;
 #else
 const int METHOD_HEADER_SIZE = 0x100;
+const int METHOD_PRE_HEADER_SIZE = 0x10;
 #endif
 
 static jvmtiEnv* jvmti;
@@ -104,7 +106,7 @@ template <typename T> bool doesFrameBelongToMethod(ASGST_CallFrame frame, T* met
   }
   ASGST_NonJavaFrame non_java_frame = frame.non_java_frame;
   size_t pc = (size_t)non_java_frame.pc;
-  size_t expected_pc_start = (size_t)method;
+  size_t expected_pc_start = (size_t)method - METHOD_PRE_HEADER_SIZE;
   size_t expected_pc_end = (size_t)method + METHOD_HEADER_SIZE;
   if (pc < expected_pc_start || pc > expected_pc_end) {
     fprintf(stderr, "%s: Expected PC in range [%p, %p], got %p\n", msg_prefix,

--- a/test/hotspot/jtreg/serviceability/profiling/util.hpp
+++ b/test/hotspot/jtreg/serviceability/profiling/util.hpp
@@ -141,6 +141,14 @@ bool isStubFrame(ASGST_CallFrame frame, const char* msg_prefix) {
   return true;
 }
 
+bool isCppFrame(ASGST_CallFrame frame, const char* msg_prefix) {
+  if (frame.type != ASGST_FRAME_CPP) {
+    fprintf(stderr, "%s: Expected CPP frame, got %d", msg_prefix, frame.type);
+    return false;
+  }
+  return true;
+}
+
 void printJavaFrame(FILE *stream, ASGST_JavaFrame frame) {
   JvmtiDeallocator<char*> name;
   jvmtiError err = jvmti->GetMethodName(frame.method_id, name.get_addr(), NULL, NULL);

--- a/test/hotspot/jtreg/serviceability/profiling/util.hpp
+++ b/test/hotspot/jtreg/serviceability/profiling/util.hpp
@@ -43,6 +43,13 @@
 #include "jvmti.h"
 #include "profile.h"
 
+#ifdef DEBUG
+// more space for debug info
+const int METHOD_HEADER_SIZE = 0x200;
+#else
+const int METHOD_HEADER_SIZE = 0x100;
+#endif
+
 static jvmtiEnv* jvmti;
 
 typedef void (*SigAction)(int, siginfo_t*, void*);
@@ -93,7 +100,7 @@ template <typename T> bool doesFrameBelongToMethod(ASGST_CallFrame frame, T* met
   ASGST_NonJavaFrame non_java_frame = frame.non_java_frame;
   size_t pc = (size_t)non_java_frame.pc;
   size_t expected_pc_start = (size_t)method;
-  size_t expected_pc_end = (size_t)method + 0x100;
+  size_t expected_pc_end = (size_t)method + METHOD_HEADER_SIZE;
   if (pc < expected_pc_start || pc > expected_pc_end) {
     fprintf(stderr, "%s: Expected PC in range [%p, %p], got %p\n", msg_prefix,
       (void*)expected_pc_start, (void*)expected_pc_end, (void*)pc);
@@ -154,7 +161,7 @@ template <size_t N = 0> const char* lookForMethod(void* pc, std::array<std::pair
   std::array<std::pair<const char*, size_t>, N> distances;
   int i = 0;
   for (auto method : methods) {
-    if (pc >= method.second && pc < (void*)((size_t)method.second + 0x100)) {
+    if (pc >= method.second && pc < (void*)((size_t)method.second + METHOD_HEADER_SIZE)) {
       distances[i] = std::make_pair(method.first, (size_t)pc - (size_t)method.second);
     }
     i++;

--- a/test/hotspot/jtreg/serviceability/profiling/util.hpp
+++ b/test/hotspot/jtreg/serviceability/profiling/util.hpp
@@ -43,6 +43,10 @@
 #include "jvmti.h"
 #include "profile.h"
 
+#ifdef _GNU_SOURCE
+#include <dlfcn.h>
+#endif
+
 #ifdef DEBUG
 // more space for debug info
 const int METHOD_HEADER_SIZE = 0x200;
@@ -192,6 +196,12 @@ template <size_t N = 0> void printNonJavaFrame(FILE* stream, ASGST_NonJavaFrame 
     fprintf(stream, " (%s)", method_name);
   } else {
     fprintf(stream, " (%p)", frame.pc);
+    #ifdef _GNU_SOURCE
+    Dl_info info;
+    if (dladdr(frame.pc, &info) != 0 && info.dli_sname != NULL) {
+      fprintf(stream, " (%s)", info.dli_sname);
+    }
+    #endif
   }
 }
 

--- a/test/hotspot/jtreg/serviceability/profiling/util.hpp
+++ b/test/hotspot/jtreg/serviceability/profiling/util.hpp
@@ -29,6 +29,7 @@
 
 #include <array>
 #include <assert.h>
+#include <chrono>
 #include <signal.h>
 #include <stdio.h>
 #include <stddef.h>
@@ -245,4 +246,8 @@ bool areFramesCPPFrames(ASGST_CallFrame *frames, int start, int inclEnd, const c
     }
   }
   return true;
+}
+
+long getSecondsSinceEpoch(){
+    return std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 }


### PR DESCRIPTION
This is an implementation of the [Asynchronous Stack Trace VM API](https://openjdk.org/jeps/435). It also contains several JTREG tests with which the implementation has been thoroughly tested.

To see this API in action, go to the [demo](https://github.com/parttimenerd/asgct2-demo) repository.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Integration blockers
&nbsp;⚠️ The commit message does not reference any issue. To add an issue reference to this PR, edit the title to be of the format `issue number`: `message`. (failed with the updated jcheck configuration)
&nbsp;⚠️ Too few reviewers with at least role reviewer found (have 0, need at least 1) (failed with the updated jcheck configuration)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/11767/head:pull/11767` \
`$ git checkout pull/11767`

Update a local copy of the PR: \
`$ git checkout pull/11767` \
`$ git pull https://git.openjdk.org/jdk.git pull/11767/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11767`

View PR using the GUI difftool: \
`$ git pr show -t 11767`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11767.diff">https://git.openjdk.org/jdk/pull/11767.diff</a>

</details>
