### PR TITLE
8299227: host `exif.org` not found in link in doc comment

### DIFF
--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFImageWriteParam.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFImageWriteParam.java
@@ -78,7 +78,7 @@ import javax.imageio.ImageWriteParam;
  * <tr>
  * <td>Exif JPEG</td>
  * <td>Exif-specific JPEG compression (see note following this table)</td>
- * <td><a href="http://www.exif.org/Exif2-2.PDF">Exif 2.2 Specification</a>
+ * <td><a href="https://www.cipa.jp/std/documents/e/DC-008-2012_E.pdf">Exif 2.2 Specification</a>
  * (PDF), section 4.5.5, "Basic Structure of Thumbnail Data"</td>
  * </table>
  *

--- a/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/tiff_metadata.html
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/tiff_metadata.html
@@ -574,7 +574,8 @@ DEFLATE Compressed Data Format Specification</a></td>
 <th scope="row">9</th>
 <td>Exif JPEG</td>
 <td>Exif-specific JPEG compression (see note following this table)</td>
-<td><a href="http://www.exif.org/Exif2-2.PDF">Exif 2.2 Specification</a>
+<td><a href="https://www.cipa.jp/std/documents/e/DC-008-2012_E.pdf">
+    Exif 2.2 Specification</a>
 (PDF), section 4.5.5, "Basic Structure of Thumbnail Data"</td>
 </tbody>
 </table>

--- a/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
+++ b/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
@@ -1614,7 +1614,7 @@ Java_com_sun_imageio_plugins_jpeg_JPEGImageReader_setSource
 /*
  * For EXIF images, the APP1 will appear immediately after the SOI,
  * so it's safe to only look at the first marker in the list.
- * (see http://www.exif.org/Exif2-2.PDF, section 4.7, page 58)
+ * (see https://www.cipa.jp/std/documents/e/DC-008-2012_E.pdf, section 4.7, page 58)
  */
 #define IS_EXIF(c) \
     (((c)->marker_list != NULL) && ((c)->marker_list->marker == JPEG_APP1))
@@ -1715,7 +1715,7 @@ Java_com_sun_imageio_plugins_jpeg_JPEGImageReader_readImageHeader
              *  - we got JFIF image
              *     Must be YCbCr (see http://www.w3.org/Graphics/JPEG/jfif3.pdf, page 2)
              *  - we got EXIF image
-             *     Must be YCbCr (see http://www.exif.org/Exif2-2.PDF, section 4.7, page 63)
+             *     Must be YCbCr (see https://www.cipa.jp/std/documents/e/DC-008-2012_E.pdf, section 4.7, page 63)
              *  - something else
              *     Apply heuristical rules to identify actual colorspace.
              */


### PR DESCRIPTION
Broken links are replaced by the similar links fixed in [JDK-8288527](https://bugs.openjdk.org/browse/JDK-8288527) for file `src/java.desktop/share/classes/javax/imageio/plugins/tiff/ExifTIFFTagSet.java`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299227](https://bugs.openjdk.org/browse/JDK-8299227): host `exif.org` not found in link in doc comment


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11768/head:pull/11768` \
`$ git checkout pull/11768`

Update a local copy of the PR: \
`$ git checkout pull/11768` \
`$ git pull https://git.openjdk.org/jdk pull/11768/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11768`

View PR using the GUI difftool: \
`$ git pr show -t 11768`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11768.diff">https://git.openjdk.org/jdk/pull/11768.diff</a>

</details>
