### PR TITLE
8299237: add ArraysSupport.newLength test to a test group

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -126,6 +126,7 @@ jdk_util = \
 jdk_util_other = \
     java/util \
     sun/util \
+    jdk/internal/util \
     -:jdk_collections \
     -:jdk_concurrent \
     -:jdk_stream


### PR DESCRIPTION
This test isn't part of any test group, so it isn't being run regularly! I'm adding it to the jdk_util_other test group.