### PR TITLE
[PATCH] Unnecessary Vector usage in FontConfiguration.splitSequence

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
+++ b/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
@@ -37,6 +37,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -45,7 +46,6 @@ import java.util.Locale;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
-import java.util.Vector;
 import sun.font.CompositeFontDescriptor;
 import sun.font.SunFontManager;
 import sun.font.FontUtilities;
@@ -837,9 +837,9 @@ public abstract class FontConfiguration {
         }
     }
 
-    private static Vector<String> splitSequence(String sequence) {
-        //String.split would be more convenient, but incurs big performance penalty
-        Vector<String> parts = new Vector<>();
+    private static String[] splitSequence(String sequence) {
+        //String.split would be more convenient, but it behaves slightly different
+        ArrayList<String> parts = new ArrayList<>();
         int start = 0;
         int end;
         while ((end = sequence.indexOf(',', start)) >= 0) {
@@ -849,7 +849,7 @@ public abstract class FontConfiguration {
         if (sequence.length() > start) {
             parts.add(sequence.substring(start));
         }
-        return parts;
+        return parts.toArray(EMPTY_STRING_ARRAY);
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -2115,7 +2115,7 @@ public abstract class FontConfiguration {
                 boolean has1252 = false;
 
                 //get the scriptID list
-                String[] ss = splitSequence(value).toArray(EMPTY_STRING_ARRAY);
+                String[] ss = splitSequence(value);
                 short [] sa = new short[ss.length];
                 for (int i = 0; i < ss.length; i++) {
                     if ("alphabetic/default".equals(ss[i])) {


### PR DESCRIPTION
Method FontConfiguration.splitSequence is used only in one place, where Vector immediately converted to an array.
We can use ArrayList to temporary store elements before conversion to an array.
Vector is a legacy synchronized collection. It's recommended to use ArrayList if a thread-safe implementation is not needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11771/head:pull/11771` \
`$ git checkout pull/11771`

Update a local copy of the PR: \
`$ git checkout pull/11771` \
`$ git pull https://git.openjdk.org/jdk pull/11771/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11771`

View PR using the GUI difftool: \
`$ git pr show -t 11771`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11771.diff">https://git.openjdk.org/jdk/pull/11771.diff</a>

</details>
