### PR TITLE
8299308: Add Assembler::testw register + immediate function for x86

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -6187,6 +6187,19 @@ void Assembler::testb(Address dst, int imm8) {
   emit_int8(imm8);
 }
 
+void Assembler::testw(Register dst, int16_t imm16) {
+  int encode = dst->encoding();
+  InstructionMark im(this);
+  emit_int8(0x66);
+  if (encode == 0) {
+    emit_int8((unsigned char)0xA9);
+  } else {
+    encode = prefix_and_encode(encode);
+    emit_int16((unsigned char)0xF7, (0xC0 | encode));
+  }
+  emit_int16(imm16);
+}
+
 void Assembler::testl(Address dst, int32_t imm32) {
   InstructionMark im(this);
   prefix(dst);

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -2173,6 +2173,8 @@ private:
   void testb(Address dst, int imm8);
   void testb(Register dst, int imm8);
 
+  void testw(Register dst, int16_t imm16);
+
   void testl(Address dst, int32_t imm32);
   void testl(Register dst, int32_t imm32);
   void testl(Register dst, Register src);


### PR DESCRIPTION
The testw register + immediate instruction is missing in the x86 assembler. It's used by generational ZGC. Let's add it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299308](https://bugs.openjdk.org/browse/JDK-8299308): Add Assembler::testw register + immediate function for x86


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11772/head:pull/11772` \
`$ git checkout pull/11772`

Update a local copy of the PR: \
`$ git checkout pull/11772` \
`$ git pull https://git.openjdk.org/jdk pull/11772/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11772`

View PR using the GUI difftool: \
`$ git pr show -t 11772`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11772.diff">https://git.openjdk.org/jdk/pull/11772.diff</a>

</details>
