### PR TITLE
8299323: Allow extended registers for cmpw

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -1763,8 +1763,9 @@ void Assembler::cmpl_imm32(Address dst, int32_t imm32) {
 
 void Assembler::cmpw(Address dst, int imm16) {
   InstructionMark im(this);
-  assert(!dst.base_needs_rex() && !dst.index_needs_rex(), "no extended registers");
-  emit_int16(0x66, (unsigned char)0x81);
+  emit_int8(0x66);
+  prefix(dst);
+  emit_int8((unsigned char)0x81);
   emit_operand(rdi, dst, 2);
   emit_int16(imm16);
 }


### PR DESCRIPTION
The current instruction encoder for cmpw(Address, int16_t) on x64 does not allow rex extended registers. Generational ZGC needs to use this for arbitrary registers. Let's add support for it instead of asserting the input Address uses a subset of registers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299323](https://bugs.openjdk.org/browse/JDK-8299323): Allow extended registers for cmpw


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11776/head:pull/11776` \
`$ git checkout pull/11776`

Update a local copy of the PR: \
`$ git checkout pull/11776` \
`$ git pull https://git.openjdk.org/jdk pull/11776/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11776`

View PR using the GUI difftool: \
`$ git pr show -t 11776`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11776.diff">https://git.openjdk.org/jdk/pull/11776.diff</a>

</details>
