### PR TITLE
8299329: Assertion failure with fastdebug build when trying to use CDS without classpath

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -883,7 +883,7 @@ unsigned int FileMapInfo::longest_common_app_classpath_prefix_len(int num_paths,
       // search backward for the pos before the file separator char
       while (pos > 0) {
         if (rp_array->at(0)[--pos] == *os::file_separator()) {
-          return pos+1;
+          return pos + 1;
         }
       }
       return 0;

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -880,11 +880,13 @@ unsigned int FileMapInfo::longest_common_app_classpath_prefix_len(int num_paths,
       if (rp_array->at(i)[pos] != '\0' && rp_array->at(i)[pos] == rp_array->at(0)[pos]) {
         continue;
       }
-
       // search backward for the pos before the file separator char
-      while (pos > 0 && rp_array->at(0)[--pos] != *os::file_separator());
-      // return the file separator char position
-      return pos + 1;
+      while (pos > 0) {
+        if (rp_array->at(0)[--pos] == *os::file_separator()) {
+          return pos+1;
+        }
+      }
+      return 0;
     }
   }
   return 0;
@@ -1022,8 +1024,12 @@ bool FileMapInfo::validate_app_class_paths(int shared_app_paths_len) {
       //     java -Xshare:auto -cp /x/y/Foo.jar:/x/y/b/Bar.jar  ...
       unsigned int dumptime_prefix_len = header()->common_app_classpath_prefix_size();
       unsigned int runtime_prefix_len = longest_common_app_classpath_prefix_len(shared_app_paths_len, rp_array);
-      mismatch = check_paths(j, shared_app_paths_len, rp_array,
-                             dumptime_prefix_len, runtime_prefix_len);
+      if (dumptime_prefix_len != 0 || runtime_prefix_len != 0) {
+        log_info(class, path)("LCP length for app classpath (dumptime: %u, runtime: %u)",
+                              dumptime_prefix_len, runtime_prefix_len);
+        mismatch = check_paths(j, shared_app_paths_len, rp_array,
+                               dumptime_prefix_len, runtime_prefix_len);
+      }
       if (mismatch) {
         return classpath_failure("[APP classpath mismatch, actual: -Djava.class.path=", appcp);
       }

--- a/test/hotspot/jtreg/runtime/cds/appcds/JarBuilder.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/JarBuilder.java
@@ -250,7 +250,7 @@ public class JarBuilder {
         File jarFile = new File(source);
         if (!jarFile.exists()) {
             throw new RuntimeException("jar file to be copied does not exist");
-	}
+        }
         File targetFile = new File(target);
         Files.copy(jarFile.toPath(), targetFile.toPath(), StandardCopyOption.COPY_ATTRIBUTES);
     }

--- a/test/hotspot/jtreg/runtime/cds/appcds/JarBuilder.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/JarBuilder.java
@@ -38,7 +38,9 @@ import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.helpers.ClassFileInstaller;
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.spi.ToolProvider;
 
@@ -51,6 +53,10 @@ public class JarBuilder {
 
     public static String getJarFilePath(String jarName) {
         return CDSTestUtils.getOutputDir() +  File.separator + jarName + ".jar";
+    }
+
+    public static String getJarFilePathInWorkDir(String jarName) {
+        return System.getProperty("user.dir") + File.separator + jarName + ".jar";
     }
 
     // jar all files under dir, with manifest file man, with an optional versionArgs
@@ -88,6 +94,12 @@ public class JarBuilder {
         throws Exception {
 
         return createSimpleJar(classDir, getJarFilePath(jarName), classNames);
+    }
+
+    public static String buildInWorkDir(String jarName, String ...classNames)
+        throws Exception {
+
+        return createSimpleJar(classDir, getJarFilePathInWorkDir(jarName), classNames);
     }
 
     public static String build(boolean classesInWorkDir, String jarName, String ...classNames)
@@ -222,6 +234,25 @@ public class JarBuilder {
         } else {
             return build("hello", "Hello");
         }
+    }
+    public static String getOrCreateHelloJarInWorkDir() throws Exception {
+        String jarPath = getJarFilePathInWorkDir("hello");
+
+        File jarFile = new File(jarPath);
+        if (jarFile.exists()) {
+            return jarPath;
+        } else {
+            return buildInWorkDir("hello", "Hello");
+        }
+    }
+
+    public static void copyJar(String source, String target) throws Exception {
+        File jarFile = new File(source);
+        if (!jarFile.exists()) {
+            throw new RuntimeException("jar file to be copied does not exist");
+	}
+        File targetFile = new File(target);
+        Files.copy(jarFile.toPath(), targetFile.toPath(), StandardCopyOption.COPY_ATTRIBUTES);
     }
 
     public static void compile(String dstPath, String source, String... extraArgs) throws Exception {

--- a/test/hotspot/jtreg/runtime/cds/appcds/JarBuilder.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/JarBuilder.java
@@ -38,9 +38,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.helpers.ClassFileInstaller;
 import java.io.File;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.spi.ToolProvider;
 
@@ -53,10 +51,6 @@ public class JarBuilder {
 
     public static String getJarFilePath(String jarName) {
         return CDSTestUtils.getOutputDir() +  File.separator + jarName + ".jar";
-    }
-
-    public static String getJarFilePathInWorkDir(String jarName) {
-        return System.getProperty("user.dir") + File.separator + jarName + ".jar";
     }
 
     // jar all files under dir, with manifest file man, with an optional versionArgs
@@ -94,12 +88,6 @@ public class JarBuilder {
         throws Exception {
 
         return createSimpleJar(classDir, getJarFilePath(jarName), classNames);
-    }
-
-    public static String buildInWorkDir(String jarName, String ...classNames)
-        throws Exception {
-
-        return createSimpleJar(classDir, getJarFilePathInWorkDir(jarName), classNames);
     }
 
     public static String build(boolean classesInWorkDir, String jarName, String ...classNames)
@@ -234,25 +222,6 @@ public class JarBuilder {
         } else {
             return build("hello", "Hello");
         }
-    }
-    public static String getOrCreateHelloJarInWorkDir() throws Exception {
-        String jarPath = getJarFilePathInWorkDir("hello");
-
-        File jarFile = new File(jarPath);
-        if (jarFile.exists()) {
-            return jarPath;
-        } else {
-            return buildInWorkDir("hello", "Hello");
-        }
-    }
-
-    public static void copyJar(String source, String target) throws Exception {
-        File jarFile = new File(source);
-        if (!jarFile.exists()) {
-            throw new RuntimeException("jar file to be copied does not exist");
-        }
-        File targetFile = new File(target);
-        Files.copy(jarFile.toPath(), targetFile.toPath(), StandardCopyOption.COPY_ATTRIBUTES);
     }
 
     public static void compile(String dstPath, String source, String... extraArgs) throws Exception {

--- a/test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
@@ -40,9 +40,21 @@ public class WrongClasspath {
 
   public static void main(String[] args) throws Exception {
     String appJar = JarBuilder.getOrCreateHelloJar();
+    String appJarInWorkDir = JarBuilder.getOrCreateHelloJarInWorkDir();
     String unableToUseMsg = "Unable to use shared archive";
     String mismatchMsg = "shared class paths mismatch";
     String hintMsg = "(hint: enable -Xlog:class+path=info to diagnose the failure)";
+
+    // Dump CDS archive with hello.jar
+    // Run with a jar file that differs from the original jar file by the first character only: -cp mello.jar
+    // Shared class paths mismatch should be detected.
+    String mellojar = appJarInWorkDir.replace("hello.jar", "mello.jar");
+    JarBuilder.copyJar(appJarInWorkDir, mellojar);
+    TestCommon.testDump("hello.jar", TestCommon.list("Hello"));
+    TestCommon.run("-cp", "mello.jar",
+        "-Xlog:cds",
+        "Hello")
+        .assertAbnormalExit(unableToUseMsg, mismatchMsg, hintMsg);
 
     // Dump an archive with a specified JAR file in -classpath
     TestCommon.testDump(appJar, TestCommon.list("Hello"));

--- a/test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
@@ -48,6 +48,9 @@ public class WrongClasspath {
     TestCommon.testDump(appJar, TestCommon.list("Hello"));
 
     // Then try to execute the archive without -classpath -- it should fail
+    // To run without classpath, set the property test.noclasspath to true
+    // so that ProcessTools won't append the classpath of the jtreg process to the test process
+    System.setProperty("test.noclasspath", "true");
     TestCommon.run(
         /* "-cp", appJar, */ // <- uncomment this and the execution should succeed
         "-Xlog:cds",
@@ -70,6 +73,7 @@ public class WrongClasspath {
                .shouldContain(mismatchMsg)
                .shouldNotContain(hintMsg);
         });
+    System.clearProperty("test.noclasspath");
 
     // Dump CDS archive with 2 jars: -cp hello.jar:jar2.jar
     // Run with 2 jars but the second jar doesn't exist: -cp hello.jarjar2.jarx

--- a/test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
@@ -33,6 +33,9 @@
  */
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.helpers.ClassFileInstaller;
 
@@ -40,7 +43,6 @@ public class WrongClasspath {
 
   public static void main(String[] args) throws Exception {
     String appJar = JarBuilder.getOrCreateHelloJar();
-    String appJarInWorkDir = JarBuilder.getOrCreateHelloJarInWorkDir();
     String unableToUseMsg = "Unable to use shared archive";
     String mismatchMsg = "shared class paths mismatch";
     String hintMsg = "(hint: enable -Xlog:class+path=info to diagnose the failure)";
@@ -48,10 +50,12 @@ public class WrongClasspath {
     // Dump CDS archive with hello.jar
     // Run with a jar file that differs from the original jar file by the first character only: -cp mello.jar
     // Shared class paths mismatch should be detected.
-    String mellojar = appJarInWorkDir.replace("hello.jar", "mello.jar");
-    JarBuilder.copyJar(appJarInWorkDir, mellojar);
-    TestCommon.testDump("hello.jar", TestCommon.list("Hello"));
-    TestCommon.run("-cp", "mello.jar",
+    String hellojar = "hello.jar";
+    String mellojar = "mello.jar";
+    Files.copy(Paths.get(appJar), Paths.get(hellojar), StandardCopyOption.COPY_ATTRIBUTES);
+    Files.copy(Paths.get(appJar), Paths.get(mellojar), StandardCopyOption.COPY_ATTRIBUTES);
+    TestCommon.testDump(hellojar, TestCommon.list("Hello"));
+    TestCommon.run("-cp", mellojar,
         "-Xlog:cds",
         "Hello")
         .assertAbnormalExit(unableToUseMsg, mismatchMsg, hintMsg);

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -363,7 +363,7 @@ public final class ProcessTools {
         if (!noCP) {
             args.add("-cp");
             args.add(System.getProperty("java.class.path"));
-	}
+        }
 
         String mainWrapper = System.getProperty("main.wrapper");
         if (mainWrapper != null) {

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -358,8 +358,12 @@ public final class ProcessTools {
         ArrayList<String> args = new ArrayList<>();
         args.add(javapath);
 
-        args.add("-cp");
-        args.add(System.getProperty("java.class.path"));
+        String noCPString = System.getProperty("test.noclasspath", "false");
+        boolean noCP = Boolean.valueOf(noCPString);
+        if (!noCP) {
+            args.add("-cp");
+            args.add(System.getProperty("java.class.path"));
+	}
 
         String mainWrapper = System.getProperty("main.wrapper");
         if (mainWrapper != null) {
@@ -374,7 +378,12 @@ public final class ProcessTools {
             cmdLine.append(cmd).append(' ');
         System.out.println("Command line: [" + cmdLine.toString() + "]");
 
-        return new ProcessBuilder(args);
+        ProcessBuilder pb = new ProcessBuilder(args);
+        if (noCP) {
+            // clear CLASSPATH from the env
+            pb.environment().remove("CLASSPATH");
+        }
+        return pb;
     }
 
     private static void printStack(Thread t, StackTraceElement[] stack) {


### PR DESCRIPTION
It appears longest_common_app_classpath_prefix_len() is not returning correct value when there is no file separator in the path being searched backwards. Instead of returning 0 it return 1.

In case of empty classpath, it can result in assertion failure in check_paths():

`assert(strlen(rp_array->at(i)) > (size_t)runtime_prefix_len, "sanity");`

It can also result in incorrectly validating the app classpaths if they only differ by first character. Eg:

Dump time:
  -cp hello.jar
Run time:
  -cp mello.jar

This would not result in classpath mismatch!

This fix updates longest_common_app_classpath_prefix_len() to return 0 if no file separator character is found.

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299329](https://bugs.openjdk.org/browse/JDK-8299329): Assertion failure with fastdebug build when trying to use CDS without classpath


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to [e4fec7e7](https://git.openjdk.org/jdk/pull/11781/files/e4fec7e703b695e6e7338f5cda6db83f68ea65da)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**) ⚠️ Review applies to [e4fec7e7](https://git.openjdk.org/jdk/pull/11781/files/e4fec7e703b695e6e7338f5cda6db83f68ea65da)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11781/head:pull/11781` \
`$ git checkout pull/11781`

Update a local copy of the PR: \
`$ git checkout pull/11781` \
`$ git pull https://git.openjdk.org/jdk pull/11781/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11781`

View PR using the GUI difftool: \
`$ git pr show -t 11781`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11781.diff">https://git.openjdk.org/jdk/pull/11781.diff</a>

</details>
