### PR TITLE
8299333: Unify exceptions used by all variants of ICC_Profile.getInstance(null)

### DIFF
--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,7 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Objects;
 import java.util.StringTokenizer;
 
 import sun.awt.AWTAccessor;
@@ -850,10 +851,7 @@ public sealed class ICC_Profile implements Serializable
      * {@code java.class.path} property; finally, in a directory used to store
      * profiles always available, such as the profile for sRGB. Built-in
      * profiles use {@code .pf} as the file name extension for profiles, e.g.
-     * {@code sRGB.pf}. This method throws an {@code IOException} if the
-     * specified file cannot be opened or if an I/O error occurs while reading
-     * the file. It throws an {@code IllegalArgumentException} if the file does
-     * not contain valid ICC Profile data.
+     * {@code sRGB.pf}.
      *
      * @param  fileName the file that contains the data for the profile
      * @return an {@code ICC_Profile} object corresponding to the data in the
@@ -864,6 +862,7 @@ public sealed class ICC_Profile implements Serializable
      *         Profile data
      * @throws SecurityException If a security manager is installed and it does
      *         not permit read access to the given file
+     * @throws NullPointerException if {@code fileName} is {@code null}
      */
     public static ICC_Profile getInstance(String fileName) throws IOException {
         InputStream is;
@@ -883,10 +882,7 @@ public sealed class ICC_Profile implements Serializable
 
     /**
      * Constructs an {@code ICC_Profile} corresponding to the data in an
-     * {@code InputStream}. This method throws an
-     * {@code IllegalArgumentException} if the stream does not contain valid ICC
-     * Profile data. It throws an {@code IOException} if an I/O error occurs
-     * while reading the stream.
+     * {@code InputStream}.
      *
      * @param  s the input stream from which to read the profile data
      * @return an {@code ICC_Profile} object corresponding to the data in the
@@ -894,8 +890,10 @@ public sealed class ICC_Profile implements Serializable
      * @throws IOException If an I/O error occurs while reading the stream
      * @throws IllegalArgumentException If the stream does not contain valid ICC
      *         Profile data
+     * @throws NullPointerException if {@code s} is {@code null}
      */
     public static ICC_Profile getInstance(InputStream s) throws IOException {
+        Objects.requireNonNull(s);
         return getInstance(getProfileDataFromStream(s));
     }
 
@@ -1046,6 +1044,7 @@ public sealed class ICC_Profile implements Serializable
      * @param  fileName the file to write the profile data to
      * @throws IOException If the file cannot be opened for writing or an I/O
      *         error occurs while writing to the file
+     * @throws NullPointerException if {@code fileName} is {@code null}
      */
     public void write(String fileName) throws IOException {
         try (OutputStream out = new FileOutputStream(fileName)) {
@@ -1058,6 +1057,7 @@ public sealed class ICC_Profile implements Serializable
      *
      * @param  s the stream to write the profile data to
      * @throws IOException If an I/O error occurs while writing to the stream
+     * @throws NullPointerException if {@code s} is {@code null}
      */
     public void write(OutputStream s) throws IOException {
         s.write(getData());

--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -866,9 +866,6 @@ public sealed class ICC_Profile implements Serializable
      *         not permit read access to the given file
      */
     public static ICC_Profile getInstance(String fileName) throws IOException {
-        if (fileName == null) {
-            throw new IllegalArgumentException("null fileName");
-        }
         InputStream is;
         File f = getProfileFile(fileName);
         if (f != null) {
@@ -899,9 +896,6 @@ public sealed class ICC_Profile implements Serializable
      *         Profile data
      */
     public static ICC_Profile getInstance(InputStream s) throws IOException {
-        if (s == null) {
-            throw new IllegalArgumentException("null stream");
-        }
         return getInstance(getProfileDataFromStream(s));
     }
 

--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -866,6 +866,9 @@ public sealed class ICC_Profile implements Serializable
      *         not permit read access to the given file
      */
     public static ICC_Profile getInstance(String fileName) throws IOException {
+        if (fileName == null) {
+            throw new IllegalArgumentException("null fileName");
+        }
         InputStream is;
         File f = getProfileFile(fileName);
         if (f != null) {
@@ -896,6 +899,9 @@ public sealed class ICC_Profile implements Serializable
      *         Profile data
      */
     public static ICC_Profile getInstance(InputStream s) throws IOException {
+        if (s == null) {
+            throw new IllegalArgumentException("null stream");
+        }
         return getInstance(getProfileDataFromStream(s));
     }
 

--- a/test/jdk/java/awt/color/GetInstanceNullData.java
+++ b/test/jdk/java/awt/color/GetInstanceNullData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,11 +24,10 @@
 import java.awt.color.ICC_Profile;
 import java.awt.color.ICC_ProfileGray;
 import java.awt.color.ICC_ProfileRGB;
-import java.io.InputStream;
 
 /**
  * @test
- * @bug 4176618 7042594 6211198 8299333
+ * @bug 4176618 7042594 6211198
  * @summary This interactive test verifies that passing null to
  *          ICC_ProfileRGB.getInstance() does not crash the VM.
  *          An IllegalArgumentException: Invalid ICC Profile Data should be
@@ -36,7 +35,7 @@ import java.io.InputStream;
  */
 public final class GetInstanceNullData {
 
-    public static void main(String[] argv) throws Exception {
+    public static void main(String[] argv) {
         byte b[] = null;
         try {
             ICC_ProfileRGB p = (ICC_ProfileRGB) ICC_ProfileRGB.getInstance(b);
@@ -52,18 +51,6 @@ public final class GetInstanceNullData {
         }
         try {
             ICC_Profile p = ICC_Profile.getInstance(b);
-            throw new RuntimeException("IllegalArgumentException is expected");
-        } catch (IllegalArgumentException ignored) {
-            // expected
-        }
-        try {
-            ICC_Profile p = ICC_Profile.getInstance((String) null);
-            throw new RuntimeException("IllegalArgumentException is expected");
-        } catch (IllegalArgumentException ignored) {
-            // expected
-        }
-        try {
-            ICC_Profile p = ICC_Profile.getInstance((InputStream) null);
             throw new RuntimeException("IllegalArgumentException is expected");
         } catch (IllegalArgumentException ignored) {
             // expected

--- a/test/jdk/java/awt/color/GetInstanceNullData.java
+++ b/test/jdk/java/awt/color/GetInstanceNullData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,10 +24,11 @@
 import java.awt.color.ICC_Profile;
 import java.awt.color.ICC_ProfileGray;
 import java.awt.color.ICC_ProfileRGB;
+import java.io.InputStream;
 
 /**
  * @test
- * @bug 4176618 7042594 6211198
+ * @bug 4176618 7042594 6211198 8299333
  * @summary This interactive test verifies that passing null to
  *          ICC_ProfileRGB.getInstance() does not crash the VM.
  *          An IllegalArgumentException: Invalid ICC Profile Data should be
@@ -35,7 +36,7 @@ import java.awt.color.ICC_ProfileRGB;
  */
 public final class GetInstanceNullData {
 
-    public static void main(String[] argv) {
+    public static void main(String[] argv) throws Exception {
         byte b[] = null;
         try {
             ICC_ProfileRGB p = (ICC_ProfileRGB) ICC_ProfileRGB.getInstance(b);
@@ -51,6 +52,18 @@ public final class GetInstanceNullData {
         }
         try {
             ICC_Profile p = ICC_Profile.getInstance(b);
+            throw new RuntimeException("IllegalArgumentException is expected");
+        } catch (IllegalArgumentException ignored) {
+            // expected
+        }
+        try {
+            ICC_Profile p = ICC_Profile.getInstance((String) null);
+            throw new RuntimeException("IllegalArgumentException is expected");
+        } catch (IllegalArgumentException ignored) {
+            // expected
+        }
+        try {
+            ICC_Profile p = ICC_Profile.getInstance((InputStream) null);
             throw new RuntimeException("IllegalArgumentException is expected");
         } catch (IllegalArgumentException ignored) {
             // expected

--- a/test/jdk/java/awt/color/ICC_Profile/ExpectedNPEOnNull.java
+++ b/test/jdk/java/awt/color/ICC_Profile/ExpectedNPEOnNull.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.color.ColorSpace;
+import java.awt.color.ICC_Profile;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * @test
+ * @bug 6211108 6211105 8299333
+ */
+public final class ExpectedNPEOnNull {
+
+    public static void main(String[] args) throws Exception {
+        // static methods
+        try {
+            ICC_Profile.getInstance((String) null);
+            throw new RuntimeException("NPE is expected");
+        } catch (NullPointerException ignored) {
+            // expected
+        }
+        try {
+            ICC_Profile.getInstance((InputStream) null);
+            throw new RuntimeException("NPE is expected");
+        } catch (NullPointerException ignored) {
+            // expected
+        }
+        // instance methods
+        test(ICC_Profile.getInstance(ColorSpace.CS_sRGB));
+        test(ICC_Profile.getInstance(ColorSpace.CS_LINEAR_RGB));
+        test(ICC_Profile.getInstance(ColorSpace.CS_CIEXYZ));
+        test(ICC_Profile.getInstance(ColorSpace.CS_PYCC));
+        test(ICC_Profile.getInstance(ColorSpace.CS_GRAY));
+    }
+
+    private static void test(ICC_Profile profile) throws Exception {
+        try {
+            profile.write((String) null);
+            throw new RuntimeException("NPE is expected");
+        } catch (NullPointerException ignored) {
+            // expected
+        }
+        try {
+            profile.write((OutputStream) null);
+            throw new RuntimeException("NPE is expected");
+        } catch (NullPointerException ignored) {
+            // expected
+        }
+    }
+}


### PR DESCRIPTION
I tried to clean up the documentation in the `java.awt.color` package and specify how the `null` parameters are handled here and there. But it looks like the `ICC_profile` class is too specific so I would like to discuss it separately.

The ICC_Profile has these methods:
 * `getInstance(int)`      - always throws specified `IllegalArgumentException` on the wrong constant
 * `getInstance(byte[])` - always throws specified `IllegalArgumentException` on `null`
 * `getInstance(String fileName)` - always throws unspecified `NullPointerException` on `null`
 * `getInstance(InputStream)`      - thrown unspecified `NullPointerException` before [JDK-8227816](https://github.com/openjdk/jdk/commit/af20c6b9c4a3a21c1e2c7f56721e1077e7d8f388) and now throws specified but misleading `IOException: Stream closed` exception on `null`

So we have 3 methods that can get null as a parameter and each throw a different exception.

Note that all of the specs for the methods above have this part:

> @throws IllegalArgumentException If the stream does not contain valid ICC Profile data

So I have an idea to change `getInstance(String)` and `getInstance(InputStream)` to throw `IllegalArgumentException`  even if I personally prefer NPE to be thrown.

From another point of view the `ICC_Profile` profile has other methods:
 * `write(String fileName)` - always throws unspecified `NullPointerException` on `null`
 * `write(OutputStream) `  - always throws unspecified `NullPointerException` on `null`

I am not sure we can throw `IllegalArgumentException` from the `write` methods, so the specification for `getInstance(String)` and `getInstance(InputStream)` could be updated to throw NPE on null same as related `write`.

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8300804](https://bugs.openjdk.org/browse/JDK-8300804) to be approved

### Issues
 * [JDK-8299333](https://bugs.openjdk.org/browse/JDK-8299333): Unify exceptions used by all variants of ICC_Profile.getInstance(null)
 * [JDK-8300804](https://bugs.openjdk.org/browse/JDK-8300804): Unify exceptions used by all variants of ICC_Profile.getInstance(null) (**CSR**)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11784/head:pull/11784` \
`$ git checkout pull/11784`

Update a local copy of the PR: \
`$ git checkout pull/11784` \
`$ git pull https://git.openjdk.org/jdk pull/11784/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11784`

View PR using the GUI difftool: \
`$ git pr show -t 11784`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11784.diff">https://git.openjdk.org/jdk/pull/11784.diff</a>

</details>
