### PR TITLE
8299337: The java.awt.image.ColorModel#pData field is unused

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ImageSurfaceData.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ImageSurfaceData.m
@@ -100,7 +100,6 @@ static ImageInfo sDefaultImageInfo[sun_java2d_OSXOffScreenSurfaceData_TYPE_3BYTE
 
 static jfieldID        rgbID;
 static jfieldID        mapSizeID;
-static jfieldID        CMpDataID;
 static jfieldID        allGrayID;
 
 static jclass jc_OSXOffScreenSurfaceData = NULL;
@@ -1614,7 +1613,6 @@ JNIEXPORT void JNICALL Java_sun_java2d_OSXOffScreenSurfaceData_initIDs(JNIEnv *e
         CHECK_NULL(rgbID = (*env)->GetFieldID(env, icm, "rgb", "[I"));
         CHECK_NULL(allGrayID = (*env)->GetFieldID(env, icm, "allgrayopaque", "Z"));
         CHECK_NULL(mapSizeID = (*env)->GetFieldID(env, icm, "map_size", "I"));
-        CHECK_NULL(CMpDataID = (*env)->GetFieldID(env, icm, "pData", "J"));
     }
 
     gColorspaceRGB = CGColorSpaceCreateWithName(kCGColorSpaceGenericRGB);

--- a/src/java.desktop/share/classes/java/awt/image/ColorModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/ColorModel.java
@@ -156,7 +156,6 @@ import sun.java2d.cmm.PCMM;
  * @see DataBuffer
  */
 public abstract class ColorModel implements Transparency{
-    private long pData;         // Placeholder for data for native functions
 
     /**
      * The total number of bits in the pixel.

--- a/src/java.desktop/share/native/libawt/awt/image/imageInitIDs.c
+++ b/src/java.desktop/share/native/libawt/awt/image/imageInitIDs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,7 +105,6 @@ Java_java_awt_image_SinglePixelPackedSampleModel_initIDs(JNIEnv *env, jclass cls
 
 JNIEXPORT void JNICALL
 Java_java_awt_image_ColorModel_initIDs(JNIEnv *env, jclass cls) {
-    CHECK_NULL(g_CMpDataID = (*env)->GetFieldID (env, cls, "pData", "J"));
     CHECK_NULL(g_CMnBitsID  = (*env)->GetFieldID(env, cls, "nBits", "[I"));
     CHECK_NULL(g_CMcspaceID = (*env)->GetFieldID(env, cls, "colorSpace",
                                     "Ljava/awt/color/ColorSpace;"));

--- a/src/java.desktop/share/native/libawt/awt/image/imageInitIDs.h
+++ b/src/java.desktop/share/native/libawt/awt/image/imageInitIDs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,6 @@ IMGEXTERN jfieldID g_ICRtypeID;
 
 /* Color Model ids */
 JNIEXPORT
-IMGEXTERN jfieldID g_CMpDataID;
 IMGEXTERN jfieldID g_CMnBitsID;
 IMGEXTERN jfieldID g_CMcspaceID;
 IMGEXTERN jfieldID g_CMnumComponentsID;

--- a/src/java.desktop/unix/native/common/awt/X11Color.c
+++ b/src/java.desktop/unix/native/common/awt/X11Color.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1224,11 +1224,6 @@ jobject awtJNI_GetColorModel(JNIEnv *env, AwtGraphicsConfigDataPtr aData)
             (*env)->PopLocalFrame(env, 0);
             return NULL;
         }
-
-        /* Set pData field of ColorModel to point to ColorData */
-        JNU_SetLongFieldFromPtr(env, awt_colormodel, g_CMpDataID,
-                                aData->color_data);
-
     }
 
     return (*env)->PopLocalFrame(env, awt_colormodel);


### PR DESCRIPTION
I have found that we store the native pointer in the "java.awt.image.ColorModel#pData" field and never update/clean it. We can check how and when the native data is deallocated and reset the pointer, but it will be easy just to delete the field as unused.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299337](https://bugs.openjdk.org/browse/JDK-8299337): The java.awt.image.ColorModel#pData field is unused


### Reviewers
 * @SWinxy (no known github.com user name / role)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11785/head:pull/11785` \
`$ git checkout pull/11785`

Update a local copy of the PR: \
`$ git checkout pull/11785` \
`$ git pull https://git.openjdk.org/jdk pull/11785/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11785`

View PR using the GUI difftool: \
`$ git pr show -t 11785`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11785.diff">https://git.openjdk.org/jdk/pull/11785.diff</a>

</details>
