### PR TITLE
JDK-8262994: Refactor String.split to help method inlining

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -3131,6 +3131,9 @@ public final class String
         {
             // All the checks above can potentially be constant folded by
             // a JIT/AOT compiler when the regex is a constant string.
+            // That requires method inlining of the checks, which is only
+            // possible when the actual split logic is in a separate method
+            // because the large split loop can usually not be inlined.
             return split(ch, limit);
         }
         return Pattern.compile(regex).split(this, limit);

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -3129,41 +3129,47 @@ public final class String
             (ch < Character.MIN_HIGH_SURROGATE ||
              ch > Character.MAX_LOW_SURROGATE))
         {
-            int off = 0;
-            int next = 0;
-            boolean limited = limit > 0;
-            ArrayList<String> list = new ArrayList<>();
-            while ((next = indexOf(ch, off)) != -1) {
-                if (!limited || list.size() < limit - 1) {
-                    list.add(substring(off, next));
-                    off = next + 1;
-                } else {    // last one
-                    //assert (list.size() == limit - 1);
-                    int last = length();
-                    list.add(substring(off, last));
-                    off = last;
-                    break;
-                }
-            }
-            // If no match was found, return this
-            if (off == 0)
-                return new String[]{this};
-
-            // Add remaining segment
-            if (!limited || list.size() < limit)
-                list.add(substring(off, length()));
-
-            // Construct result
-            int resultSize = list.size();
-            if (limit == 0) {
-                while (resultSize > 0 && list.get(resultSize - 1).isEmpty()) {
-                    resultSize--;
-                }
-            }
-            String[] result = new String[resultSize];
-            return list.subList(0, resultSize).toArray(result);
+            // All the checks above can potentially be constant folded by
+            // a JIT/AOT compiler when the regex is a constant string.
+            return split(ch, limit);
         }
         return Pattern.compile(regex).split(this, limit);
+    }
+
+    private String[] split(char ch, int limit) {
+        int off = 0;
+        int next = 0;
+        boolean limited = limit > 0;
+        ArrayList<String> list = new ArrayList<>();
+        while ((next = indexOf(ch, off)) != -1) {
+            if (!limited || list.size() < limit - 1) {
+                list.add(substring(off, next));
+                off = next + 1;
+            } else {    // last one
+                //assert (list.size() == limit - 1);
+                int last = length();
+                list.add(substring(off, last));
+                off = last;
+                break;
+            }
+        }
+        // If no match was found, return this
+        if (off == 0)
+            return new String[]{this};
+
+        // Add remaining segment
+        if (!limited || list.size() < limit)
+            list.add(substring(off, length()));
+
+        // Construct result
+        int resultSize = list.size();
+        if (limit == 0) {
+            while (resultSize > 0 && list.get(resultSize - 1).isEmpty()) {
+                resultSize--;
+            }
+        }
+        String[] result = new String[resultSize];
+        return list.subList(0, resultSize).toArray(result);
     }
 
     /**


### PR DESCRIPTION
The method `String.split` contains a fast-path when the regular expression parameter is not really a regular expression, but just a single split character.
This fast path vs. slow path check can be constant folded when the regular expression parameter is a literal constant - a quite frequent pattern (for example, all JDK usages of `String.split` have a constant expression parameter). But method inlining in JIT and AOT compilers can usually not inline `String.split` because the method body is too large. Factoring out the actual fast-path splitting logic into a separate method solves this problem: the JIT or AOT compiler can inline `String.split`, constant-fold the fast/slow path check, and then only the invoke of either the fast path or the slow path remains.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8262994](https://bugs.openjdk.org/browse/JDK-8262994): Refactor String.split to help method inlining


### Reviewers
 * [Peter Levart](https://openjdk.org/census#plevart) (@plevart - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11791/head:pull/11791` \
`$ git checkout pull/11791`

Update a local copy of the PR: \
`$ git checkout pull/11791` \
`$ git pull https://git.openjdk.org/jdk pull/11791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11791`

View PR using the GUI difftool: \
`$ git pr show -t 11791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11791.diff">https://git.openjdk.org/jdk/pull/11791.diff</a>

</details>
