### PR TITLE
8299380: conflict assert definitions

### DIFF
--- a/src/hotspot/share/jfr/periodic/jfrNetworkUtilization.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrNetworkUtilization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/periodic/jfrNetworkUtilization.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrNetworkUtilization.cpp
@@ -55,14 +55,14 @@ void JfrNetworkUtilization::destroy() {
 }
 
 static InterfaceEntry& new_entry(const NetworkInterface* iface, GrowableArray<InterfaceEntry>* interfaces) {
-  assert(iface != NULL, "invariant");
-  assert(interfaces != NULL, "invariant");
+  vmassert(iface != NULL, "invariant");
+  vmassert(interfaces != NULL, "invariant");
 
   // single threaded premise
   static traceid interface_id = 0;
 
   const char* name = iface->get_name();
-  assert(name != NULL, "invariant");
+  vmassert(name != NULL, "invariant");
 
   InterfaceEntry entry;
   const size_t length = strlen(name);
@@ -88,7 +88,7 @@ static InterfaceEntry& get_entry(const NetworkInterface* iface) {
   static int saved_index = -1;
 
   GrowableArray<InterfaceEntry>* interfaces = get_interfaces();
-  assert(interfaces != NULL, "invariant");
+  vmassert(interfaces != NULL, "invariant");
   for (int i = 0; i < _interfaces->length(); ++i) {
     saved_index = (saved_index + 1) % _interfaces->length();
     if (strcmp(_interfaces->at(saved_index).name, iface->get_name()) == 0) {
@@ -101,7 +101,7 @@ static InterfaceEntry& get_entry(const NetworkInterface* iface) {
 // If current counters are less than previous we assume the interface has been reset
 // If no bytes have been either sent or received, we'll also skip the event
 static uint64_t rate_per_second(uint64_t current, uint64_t old, const JfrTickspan& interval) {
-  assert(interval.value() > 0, "invariant");
+  vmassert(interval.value() > 0, "invariant");
   if (current <= old) {
     return 0;
   }
@@ -123,7 +123,7 @@ class JfrNetworkInterfaceName : public JfrSerializer {
 };
 
 static bool register_network_interface_name_serializer() {
-  assert(_interfaces != NULL, "invariant");
+  vmassert(_interfaces != NULL, "invariant");
   return JfrSerializer::register_serializer(TYPE_NETWORKINTERFACENAME,
     false, // disallow caching; we want a callback every rotation
     new JfrNetworkInterfaceName());


### PR DESCRIPTION
May I have this code cleanup reviewed?

The following failure occurs while building on MacOS M1:

```
In file included from /Users/xueleifan/workspace/jdk-dev/test/hotspot/gtest/jfr/test_networkUtilization.cpp:222:
/Users/xueleifan/workspace/jdk-dev/src/hotspot/share/jfr/periodic/jfrNetworkUtilization.cpp:59:25: error: too many arguments provided to function-like macro invocation
  assert(iface != NULL, "invariant");
                        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/assert.h:98:9: note: macro 'assert' defined here
#define assert(e) \
        ^
```
The assert() function used in jfrNetworkUtilization.cpp is conflicted with the assert definition in Xcode.  Alternatively, vmassert() could be used instead per the assert() definition in [hotspot](src/hotspot/share/utilities/debug.hpp).
```
// Note: message says "assert" rather than "vmassert" for backward
// compatibility with tools that parse/match the message text.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299380](https://bugs.openjdk.org/browse/JDK-8299380): conflict assert definitions


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11792/head:pull/11792` \
`$ git checkout pull/11792`

Update a local copy of the PR: \
`$ git checkout pull/11792` \
`$ git pull https://git.openjdk.org/jdk pull/11792/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11792`

View PR using the GUI difftool: \
`$ git pr show -t 11792`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11792.diff">https://git.openjdk.org/jdk/pull/11792.diff</a>

</details>
