### PR TITLE
8299378: sprintf is deprecated in Xcode 14

### DIFF
--- a/test/hotspot/gtest/logging/test_logDecorators.cpp
+++ b/test/hotspot/gtest/logging/test_logDecorators.cpp
@@ -174,7 +174,7 @@ TEST(LogDecorators, combine_with) {
 
   // Select first and third decorator for dec1
   char input[64];
-  sprintf(input, "%s,%s", decorator_name_array[0], decorator_name_array[3]);
+  os::snprintf_checked(input, sizeof(input), "%s,%s", decorator_name_array[0], decorator_name_array[3]);
   dec1.parse(input);
   EXPECT_TRUE(dec1.is_decorator(decorator_array[0]));
   EXPECT_TRUE(dec1.is_decorator(decorator_array[3]));

--- a/test/hotspot/gtest/logging/test_logMessageTest.cpp
+++ b/test/hotspot/gtest/logging/test_logMessageTest.cpp
@@ -146,11 +146,12 @@ TEST_VM_F(LogMessageTest, long_message) {
   char* data = NEW_C_HEAP_ARRAY(char, size, mtLogging);
 
   // fill buffer with start_marker...some data...end_marker
-  sprintf(data, "%s", start_marker);
+  os::snprintf_checked(data, size, "%s", start_marker);
   for (size_t i = strlen(start_marker); i < size; i++) {
     data[i] = '0' + (i % 10);
   }
-  sprintf(data + size - strlen(end_marker) - 1, "%s", end_marker);
+  int remaining_size = strlen(end_marker) + 1;
+  os::snprintf_checked(data + size - remaining_size, remaining_size, "%s", end_marker);
 
   msg.trace("%s", data); // Adds a newline, making the message exactly 10K in length.
   _log.write(msg);

--- a/test/hotspot/gtest/logging/test_logMessageTest.cpp
+++ b/test/hotspot/gtest/logging/test_logMessageTest.cpp
@@ -150,7 +150,7 @@ TEST_VM_F(LogMessageTest, long_message) {
   for (size_t i = strlen(start_marker); i < size; i++) {
     data[i] = '0' + (i % 10);
   }
-  int remaining_size = strlen(end_marker) + 1;
+  size_t remaining_size = strlen(end_marker) + 1;
   os::snprintf_checked(data + size - remaining_size, remaining_size, "%s", end_marker);
 
   msg.trace("%s", data); // Adds a newline, making the message exactly 10K in length.

--- a/test/hotspot/gtest/utilities/test_unsigned5.cpp
+++ b/test/hotspot/gtest/utilities/test_unsigned5.cpp
@@ -251,7 +251,7 @@ TEST_VM(unsigned5, reader) {
     printer.print_on(&st, 4, "(", ")");
     std::string st_s(st.base(), st.size());
     char buf2[sizeof(stbuf)];
-    sprintf(buf2, "(%d %d %d %d)", ints[0], ints[1], ints[2], ints[3]);
+    os::snprintf_checked(buf2, sizeof(buf2), "(%d %d %d %d)", ints[0], ints[1], ints[2], ints[3]);
     std::string exp_s(buf2, strlen(buf2));
     ASSERT_EQ(exp_s, st_s);
   }

--- a/test/hotspot/gtest/utilities/test_unsigned5.cpp
+++ b/test/hotspot/gtest/utilities/test_unsigned5.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "precompiled.hpp"
+#include "runtime/os.hpp"
 #include "memory/allocation.hpp"
 #include "utilities/unsigned5.hpp"
 #include "unittest.hpp"

--- a/test/hotspot/gtest/utilities/test_unsigned5.cpp
+++ b/test/hotspot/gtest/utilities/test_unsigned5.cpp
@@ -22,8 +22,8 @@
  */
 
 #include "precompiled.hpp"
-#include "runtime/os.hpp"
 #include "memory/allocation.hpp"
+#include "runtime/os.hpp"
 #include "utilities/unsigned5.hpp"
 #include "unittest.hpp"
 


### PR DESCRIPTION
The `sprintf` is deprecated in Xcode 14 because of security concerns. The issue was addressed in [JDK-8296812](https://bugs.openjdk.org/browse/JDK-8296812), but the test was not covered. The failure was [reported later](https://github.com/openjdk/jdk/pull/11115#issuecomment-1344973773), while gtest is enabled for building.

This patch is just to make sure the building could pass.   Other than that, the use of `sprintf` in other places are not touched.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299378](https://bugs.openjdk.org/browse/JDK-8299378): sprintf is deprecated in Xcode 14


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to [3d5f9d43](https://git.openjdk.org/jdk/pull/11793/files/3d5f9d43885fd83923a6eab9759358a28d494008)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [3d5f9d43](https://git.openjdk.org/jdk/pull/11793/files/3d5f9d43885fd83923a6eab9759358a28d494008)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11793/head:pull/11793` \
`$ git checkout pull/11793`

Update a local copy of the PR: \
`$ git checkout pull/11793` \
`$ git pull https://git.openjdk.org/jdk pull/11793/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11793`

View PR using the GUI difftool: \
`$ git pr show -t 11793`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11793.diff">https://git.openjdk.org/jdk/pull/11793.diff</a>

</details>
