### PR TITLE
JDK-8299386: Refactor metaprogramming to use <type_traits>

### DIFF
--- a/src/hotspot/share/metaprogramming/conditional.hpp
+++ b/src/hotspot/share/metaprogramming/conditional.hpp
@@ -25,19 +25,12 @@
 #ifndef SHARE_METAPROGRAMMING_CONDITIONAL_HPP
 #define SHARE_METAPROGRAMMING_CONDITIONAL_HPP
 
-#include "memory/allStatic.hpp"
+#include <type_traits>
 
 // This trait evaluates its typedef called "type" to TrueType iff the condition
 // is true. Otherwise it evaluates to FalseType.
 
-template <bool condition, typename TrueType, typename FalseType>
-struct Conditional: AllStatic {
-  typedef TrueType type;
-};
-
-template <typename TrueType, typename FalseType>
-struct Conditional<false, TrueType, FalseType>: AllStatic {
-  typedef FalseType type;
-};
+template <bool Condition, typename TrueType, typename FalseType>
+using Conditional = std::conditional<Condition, TrueType, FalseType>;
 
 #endif // SHARE_METAPROGRAMMING_CONDITIONAL_HPP

--- a/src/hotspot/share/metaprogramming/decay.hpp
+++ b/src/hotspot/share/metaprogramming/decay.hpp
@@ -25,17 +25,10 @@
 #ifndef SHARE_METAPROGRAMMING_DECAY_HPP
 #define SHARE_METAPROGRAMMING_DECAY_HPP
 
-#include "memory/allStatic.hpp"
-#include "metaprogramming/removeCV.hpp"
-#include "metaprogramming/removeReference.hpp"
+#include <type_traits>
 
 // This trait trims the type from CV qualifiers and references.
-// This trait provides a subset of the functionality of std::decay;
-// array types and function types are not supported here.
-
 template <typename T>
-struct Decay: AllStatic {
-  typedef typename RemoveCV<typename RemoveReference<T>::type>::type type;
-};
+using Decay = std::decay<T>;
 
 #endif // SHARE_METAPROGRAMMING_DECAY_HPP

--- a/src/hotspot/share/metaprogramming/enableIf.hpp
+++ b/src/hotspot/share/metaprogramming/enableIf.hpp
@@ -25,14 +25,13 @@
 #ifndef SHARE_METAPROGRAMMING_ENABLEIF_HPP
 #define SHARE_METAPROGRAMMING_ENABLEIF_HPP
 
-#include "metaprogramming/logical.hpp"
 #include <type_traits>
 
 // Retained temporarily for backward compatibility.
 // For function template SFINAE, use the ENABLE_IF macro below.
 // For class template SFINAE, use std::enable_if_t directly.
-template<bool cond, typename T = void>
-using EnableIf = std::enable_if<cond, T>;
+template <bool Condition, typename T = void>
+using EnableIf = std::enable_if<Condition, T>;
 
 // ENABLE_IF(Condition...)
 // ENABLE_IF_SDEFN(Condition...)

--- a/src/hotspot/share/metaprogramming/integralConstant.hpp
+++ b/src/hotspot/share/metaprogramming/integralConstant.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_METAPROGRAMMING_INTEGRALCONSTANT_HPP
 #define SHARE_METAPROGRAMMING_INTEGRALCONSTANT_HPP
 
+#include <type_traits>
 
 // An Integral Constant is a class providing a compile-time value of an
 // integral type.  An Integral Constant is also a nullary metafunction,
@@ -42,18 +43,13 @@
 // A model of the Integer Constant concept.
 // T is an integral type, and is the value_type.
 // v is an integral constant, and is the value.
-template<typename T, T v>
-struct IntegralConstant {
-  typedef T value_type;
-  static const value_type value = v;
-  typedef IntegralConstant<T, v> type;
-  operator value_type() { return value; }
-};
+template<typename T, T V>
+using IntegralConstant = std::integral_constant<T, V>;
 
 // A bool valued IntegralConstant whose value is true.
-typedef IntegralConstant<bool, true> TrueType;
+using TrueType = std::true_type;
 
 // A bool valued IntegralConstant whose value is false.
-typedef IntegralConstant<bool, false> FalseType;
+using FalseType = std::false_type;
 
 #endif // SHARE_METAPROGRAMMING_INTEGRALCONSTANT_HPP

--- a/src/hotspot/share/metaprogramming/isArray.hpp
+++ b/src/hotspot/share/metaprogramming/isArray.hpp
@@ -27,9 +27,9 @@
 
 #include "metaprogramming/integralConstant.hpp"
 
-template <typename T> struct IsArray: public FalseType {};
+#include <type_traits>
 
-template <typename T> struct IsArray<T[]>: public TrueType {};
-template <typename T, size_t S> struct IsArray<T[S]>: public TrueType {};
+template <typename T>
+using IsArray = std::is_array<T>;
 
 #endif // SHARE_METAPROGRAMMING_ISARRAY_HPP

--- a/src/hotspot/share/metaprogramming/isConst.hpp
+++ b/src/hotspot/share/metaprogramming/isConst.hpp
@@ -27,7 +27,9 @@
 
 #include "metaprogramming/integralConstant.hpp"
 
-template <typename T> struct IsConst: public FalseType {};
-template <typename T> struct IsConst<const T>: public TrueType {};
+#include <type_traits>
+
+template <typename T>
+using IsConst = std::is_const<T>;
 
 #endif // SHARE_METAPROGRAMMING_ISCONST_HPP

--- a/src/hotspot/share/metaprogramming/isFloatingPoint.hpp
+++ b/src/hotspot/share/metaprogramming/isFloatingPoint.hpp
@@ -27,24 +27,12 @@
 
 #include "metaprogramming/integralConstant.hpp"
 
+#include <type_traits>
+
 // This metafunction returns true iff the type T (irrespective of CV qualifiers)
 // is a floating point type.
 
-template <typename T> struct IsFloatingPoint: public FalseType {};
-
-template <> struct IsFloatingPoint<float>: public TrueType {};
-template <> struct IsFloatingPoint<const float>: public TrueType {};
-template <> struct IsFloatingPoint<volatile float>: public TrueType {};
-template <> struct IsFloatingPoint<const volatile float>: public TrueType {};
-
-template <> struct IsFloatingPoint<double>: public TrueType {};
-template <> struct IsFloatingPoint<const double>: public TrueType {};
-template <> struct IsFloatingPoint<volatile double>: public TrueType {};
-template <> struct IsFloatingPoint<const volatile double>: public TrueType {};
-
-template <> struct IsFloatingPoint<long double>: public TrueType {};
-template <> struct IsFloatingPoint<const long double>: public TrueType {};
-template <> struct IsFloatingPoint<volatile long double>: public TrueType {};
-template <> struct IsFloatingPoint<const volatile long double>: public TrueType {};
+template <typename T>
+using IsFloatingPoint = std::is_floating_point<T>;
 
 #endif // SHARE_METAPROGRAMMING_ISFLOATINGPOINT_HPP

--- a/src/hotspot/share/metaprogramming/isIntegral.hpp
+++ b/src/hotspot/share/metaprogramming/isIntegral.hpp
@@ -28,16 +28,14 @@
 
 #include "metaprogramming/integralConstant.hpp"
 #include "metaprogramming/isSigned.hpp"
-#include "metaprogramming/removeCV.hpp"
-#include <limits>
+
+#include <type_traits>
 
 // This metafunction returns true iff the type T (irrespective of CV qualifiers)
 // is an integral type. Note that this is false for enums.
 
 template<typename T>
-struct IsIntegral
-  : public IntegralConstant<bool, std::numeric_limits<typename RemoveCV<T>::type>::is_integer>
-{};
+using IsIntegral = std::is_integral<T>;
 
 // This metafunction returns true iff the type T (irrespective of CV qualifiers)
 // is a signed integral type. Note that this is false for enums.

--- a/src/hotspot/share/metaprogramming/isPointer.hpp
+++ b/src/hotspot/share/metaprogramming/isPointer.hpp
@@ -27,14 +27,12 @@
 
 #include "metaprogramming/integralConstant.hpp"
 
+#include <type_traits>
+
 // This metafunction returns true iff the type T is (irrespective of CV qualifiers)
 // a pointer type.
 
-template <typename T> class IsPointer: public FalseType {};
-
-template <typename T> class IsPointer<T*>: public TrueType {};
-template <typename T> class IsPointer<T* const>: public TrueType {};
-template <typename T> class IsPointer<T* volatile>: public TrueType {};
-template <typename T> class IsPointer<T* const volatile>: public TrueType {};
+template <typename T>
+using IsPointer = std::is_pointer<T>;
 
 #endif // SHARE_METAPROGRAMMING_ISPOINTER_HPP

--- a/src/hotspot/share/metaprogramming/isSame.hpp
+++ b/src/hotspot/share/metaprogramming/isSame.hpp
@@ -27,12 +27,11 @@
 
 #include "metaprogramming/integralConstant.hpp"
 
+#include <type_traits>
+
 // This trait returns true iff the two types X and Y are the same
 
 template <typename X, typename Y>
-struct IsSame: public FalseType {};
-
-template <typename X>
-struct IsSame<X, X>: public TrueType {};
+using IsSame = std::is_same<X, Y>;
 
 #endif // SHARE_METAPROGRAMMING_ISSAME_HPP

--- a/src/hotspot/share/metaprogramming/isSigned.hpp
+++ b/src/hotspot/share/metaprogramming/isSigned.hpp
@@ -26,12 +26,10 @@
 #define SHARE_METAPROGRAMMING_ISSIGNED_HPP
 
 #include "metaprogramming/integralConstant.hpp"
-#include "metaprogramming/removeCV.hpp"
-#include <limits>
+
+#include <type_traits>
 
 template<typename T>
-struct IsSigned
-  : public IntegralConstant<bool, std::numeric_limits<typename RemoveCV<T>::type>::is_signed>
-{};
+using IsSigned = std::is_signed<T>;
 
 #endif // SHARE_METAPROGRAMMING_ISSIGNED_HPP

--- a/src/hotspot/share/metaprogramming/isVolatile.hpp
+++ b/src/hotspot/share/metaprogramming/isVolatile.hpp
@@ -27,7 +27,9 @@
 
 #include "metaprogramming/integralConstant.hpp"
 
-template <typename T> struct IsVolatile: public FalseType {};
-template <typename T> struct IsVolatile<volatile T>: public TrueType {};
+#include <type_traits>
+
+template <typename T>
+using IsVolatile = std::is_volatile<T>;
 
 #endif // SHARE_METAPROGRAMMING_ISVOLATILE_HPP

--- a/src/hotspot/share/metaprogramming/removeCV.hpp
+++ b/src/hotspot/share/metaprogramming/removeCV.hpp
@@ -27,6 +27,7 @@
 
 #include <type_traits>
 
+template <typename T>
 using RemoveCV = std::remove_cv<T>;
 
 #endif // SHARE_METAPROGRAMMING_REMOVECV_HPP

--- a/src/hotspot/share/metaprogramming/removeCV.hpp
+++ b/src/hotspot/share/metaprogramming/removeCV.hpp
@@ -25,26 +25,8 @@
 #ifndef SHARE_METAPROGRAMMING_REMOVECV_HPP
 #define SHARE_METAPROGRAMMING_REMOVECV_HPP
 
-#include "memory/allStatic.hpp"
+#include <type_traits>
 
-template <typename T>
-struct RemoveCV: AllStatic {
-  typedef T type;
-};
-
-template <typename T>
-struct RemoveCV<const T>: AllStatic {
-  typedef T type;
-};
-
-template <typename T>
-struct RemoveCV<volatile T>: AllStatic {
-  typedef T type;
-};
-
-template <typename T>
-struct RemoveCV<const volatile T>: AllStatic {
-  typedef T type;
-};
+using RemoveCV = std::remove_cv<T>;
 
 #endif // SHARE_METAPROGRAMMING_REMOVECV_HPP

--- a/src/hotspot/share/metaprogramming/removeExtent.hpp
+++ b/src/hotspot/share/metaprogramming/removeExtent.hpp
@@ -25,11 +25,9 @@
 #ifndef SHARE_METAPROGRAMMING_REMOVEEXTENT_HPP
 #define SHARE_METAPROGRAMMING_REMOVEEXTENT_HPP
 
-#include "memory/allStatic.hpp"
+#include <type_traits>
 
-template <typename T> struct RemoveExtent: AllStatic { typedef T type; };
-
-template <typename T> struct RemoveExtent<T[]>: AllStatic { typedef T type; };
-template <typename T, size_t S> struct RemoveExtent<T[S]>: AllStatic { typedef T type; };
+template <typename T>
+using RemoveExtent = std::remove_extent<T>;
 
 #endif // SHARE_METAPROGRAMMING_REMOVEEXTENT_HPP

--- a/src/hotspot/share/metaprogramming/removePointer.hpp
+++ b/src/hotspot/share/metaprogramming/removePointer.hpp
@@ -25,17 +25,13 @@
 #ifndef SHARE_METAPROGRAMMING_REMOVEPOINTER_HPP
 #define SHARE_METAPROGRAMMING_REMOVEPOINTER_HPP
 
-#include "memory/allStatic.hpp"
+#include <type_traits>
 
 // This metafunction returns for a type T either the underlying type behind
 // the pointer iff T is a pointer type (irrespective of CV qualifiers),
 // or the same type T if T is not a pointer type.
 
-template <typename T> struct RemovePointer: AllStatic { typedef T type; };
-
-template <typename T> struct RemovePointer<T*>: AllStatic { typedef T type; };
-template <typename T> struct RemovePointer<T* const>: AllStatic { typedef T type; };
-template <typename T> struct RemovePointer<T* volatile>: AllStatic { typedef T type; };
-template <typename T> struct RemovePointer<T* const volatile>: AllStatic { typedef T type; };
+template <typename T>
+using RemovePointer = std::remove_pointer<T>;
 
 #endif // SHARE_METAPROGRAMMING_REMOVEPOINTER_HPP

--- a/src/hotspot/share/metaprogramming/removeReference.hpp
+++ b/src/hotspot/share/metaprogramming/removeReference.hpp
@@ -25,14 +25,13 @@
 #ifndef SHARE_METAPROGRAMMING_REMOVEREFERENCE_HPP
 #define SHARE_METAPROGRAMMING_REMOVEREFERENCE_HPP
 
-#include "memory/allStatic.hpp"
+#include <type_traits>
 
 // This metafunction returns for a type T either the underlying type behind
 // the reference iff T is a reference type, or the same type T if T is not
 // a reference type.
 
-template <typename T> struct RemoveReference: AllStatic { typedef T type; };
-
-template <typename T> struct RemoveReference<T&>: AllStatic { typedef T type; };
+template <typename T>
+using RemoveReference = std::remove_reference<T>;
 
 #endif // SHARE_METAPROGRAMMING_REMOVEREFERENCE_HPP


### PR DESCRIPTION
Cleanup `metaprogramming/` to just use implementations from `<type_traits>` that are available in C++11 and onward.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299386](https://bugs.openjdk.org/browse/JDK-8299386): Refactor metaprogramming to use <type_traits>


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11794/head:pull/11794` \
`$ git checkout pull/11794`

Update a local copy of the PR: \
`$ git checkout pull/11794` \
`$ git pull https://git.openjdk.org/jdk pull/11794/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11794`

View PR using the GUI difftool: \
`$ git pr show -t 11794`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11794.diff">https://git.openjdk.org/jdk/pull/11794.diff</a>

</details>
