### PR TITLE
JDK-8299387: CompressedClassPointers.java still fails on ppc with 'Narrow klass shift: 0' missing

### DIFF
--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
@@ -126,7 +126,7 @@ public class CompressedClassPointers {
         if (testNarrowKlassBase()) {
             if (!(Platform.isAArch64() && Platform.isOSX())) { // see JDK-8262895
                 output.shouldContain("Narrow klass base: 0x0000000000000000");
-                if (!Platform.isAArch64() && !Platform.isOSX()) {
+                if (!Platform.isAArch64() && !Platform.isPPC() && !Platform.isOSX()) {
                     output.shouldContain("Narrow klass shift: 0");
                 }
             }


### PR DESCRIPTION
After https://bugs.openjdk.org/browse/JDK-8283249 there seems to remain one place in the CompressedClassPointers.java test where we still sometimes run into Narrow klass shift: 3  (instead of 0) on ppc64. So the test should we relaxed in the same way we do it for aarch64 .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299387](https://bugs.openjdk.org/browse/JDK-8299387): CompressedClassPointers.java still fails on ppc with 'Narrow klass shift: 0' missing


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11795/head:pull/11795` \
`$ git checkout pull/11795`

Update a local copy of the PR: \
`$ git checkout pull/11795` \
`$ git pull https://git.openjdk.org/jdk pull/11795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11795`

View PR using the GUI difftool: \
`$ git pr show -t 11795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11795.diff">https://git.openjdk.org/jdk/pull/11795.diff</a>

</details>
