### PR TITLE
JDK-8299388: java/util/regex/NegativeArraySize.java fails on Alpine and sometimes Windows

### DIFF
--- a/test/jdk/java/util/regex/NegativeArraySize.java
+++ b/test/jdk/java/util/regex/NegativeArraySize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8223174
  * @summary Pattern.compile() can throw confusing NegativeArraySizeException
- * @requires os.maxMemory >= 5g & vm.bits == 64
+ * @requires os.maxMemory >= 6g & vm.bits == 64  & !vm.musl
  * @run testng/othervm -Xms5G -Xmx5G NegativeArraySize
  */
 

--- a/test/jdk/java/util/regex/NegativeArraySize.java
+++ b/test/jdk/java/util/regex/NegativeArraySize.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8223174
  * @summary Pattern.compile() can throw confusing NegativeArraySizeException
- * @requires os.maxMemory >= 6g & vm.bits == 64  & !vm.musl
+ * @requires os.maxMemory >= 6g & vm.bits == 64 & !vm.musl
  * @run testng/othervm -Xms5G -Xmx5G NegativeArraySize
  */
 


### PR DESCRIPTION
The test java/util/regex/NegativeArraySize.java seems to have high memory requirements, and these requirements lead to some errors.
On Alpine Linux we run regularly into this error when executing the test:
result: Failed. Unexpected exit from test [exit code: 137]
This seems to be OOM related.
Probably we should avoid running the test on Alpine.

On Windows the test usually works, but seems to depend as well on the memory situation of the machine.
Once we got this error recently :
OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00000006c0000000, 5368709120, 0) failed; error='The paging file is too small for this operation to complete' (DOS error/errno=1455)
OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00000006c0000000, 5368709120, 0) failed; error='The paging file is too small for this operation to complete' (DOS error/errno=1455)
result: Failed. Unexpected exit from test [exit code: 1]

The hs_err file generated showed :

```
# There is insufficient memory for the Java Runtime Environment to continue.
# Native memory allocation (mmap) failed to map 5368709120 bytes for G1 virtual space
# Possible reasons:
# The system is out of physical RAM or swap space
# The process is running with CompressedOops enabled, and the Java Heap may be blocking the growth of the native heap

```
So it looks like having 5g maxMemory as a requirement is not sufficient for the test (the reported mmap value is already slightly above 5g).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299388](https://bugs.openjdk.org/browse/JDK-8299388): java/util/regex/NegativeArraySize.java fails on Alpine and sometimes Windows


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [8d947dae](https://git.openjdk.org/jdk/pull/11796/files/8d947dae2bc5183ec0451799fb168ed804a51352)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11796/head:pull/11796` \
`$ git checkout pull/11796`

Update a local copy of the PR: \
`$ git checkout pull/11796` \
`$ git pull https://git.openjdk.org/jdk pull/11796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11796`

View PR using the GUI difftool: \
`$ git pr show -t 11796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11796.diff">https://git.openjdk.org/jdk/pull/11796.diff</a>

</details>
