### PR TITLE
8299412 JNI call of getAccessibleActionCount on a wrong thread

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
@@ -519,6 +519,17 @@ class CAccessibility implements PropertyChangeListener {
         }, c);
     }
 
+    // This method is called from the native in CommonComponentAccessibility.m
+    private static int getAccessibleActionCount(final AccessibleAction aa, final Component c) {
+        if (aa == null) return 0;
+
+        return invokeAndWait(new Callable<Integer>() {
+            public Integer call() throws Exception {
+                return aa.getAccessibleActionCount();
+            }
+        }, c);
+    }
+
     public static boolean isEnabled(final Accessible a, final Component c) {
         if (a == null) return false;
 

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
@@ -523,11 +523,7 @@ class CAccessibility implements PropertyChangeListener {
     private static int getAccessibleActionCount(final AccessibleAction aa, final Component c) {
         if (aa == null) return 0;
 
-        return invokeAndWait(new Callable<Integer>() {
-            public Integer call() throws Exception {
-                return aa.getAccessibleActionCount();
-            }
-        }, c);
+        return invokeAndWait(aa::getAccessibleActionCount, c);
     }
 
     public static boolean isEnabled(final Accessible a, final Component c) {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -600,11 +600,9 @@ static jobject sAccessibilityClass = NULL;
     jobject axAction = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getAccessibleAction, fAccessible, fComponent);
     CHECK_EXCEPTION();
     if (axAction != NULL) {
-        jclass jc_AccessibleAction = NULL;
-        GET_CLASS(jc_AccessibleAction, "javax/accessibility/AccessibleAction");
-        jmethodID jm_getAccessibleActionCount = NULL;
-        GET_METHOD(jm_getAccessibleActionCount, jc_AccessibleAction, "getAccessibleActionCount", "()I");
-        jint count = (*env)->CallIntMethod(env, axAction, jm_getAccessibleActionCount);
+        DECLARE_STATIC_METHOD(jm_getAccessibleActionCount, sjc_CAccessibility, "getAccessibleActionCount", "(Ljavax/accessibility/AccessibleAction;Ljava/awt/Component;)I");
+        jint count = (*env)->CallStaticIntMethod(env, sjc_CAccessibility, jm_getAccessibleActionCount, axAction, fComponent);
+        CHECK_EXCEPTION();
         fActions = [[NSMutableDictionary alloc] initWithCapacity:count];
         fActionSelectors = [[NSMutableArray alloc] initWithCapacity:count];
         for (int i =0; i < count; i++) {


### PR DESCRIPTION
[CommonComponentAccessibility getActionsWithEnv:] defines the getAccessibleActionCount method on the AccessibleAction class, however the call should go through CAccessibility so that it is executed on the Event Dispatch thread.

@azuev-java @mrserb @prrace please review

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299412](https://bugs.openjdk.org/browse/JDK-8299412): JNI call of getAccessibleActionCount on a wrong thread


### Reviewers
 * @SWinxy (no known github.com user name / role)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11803/head:pull/11803` \
`$ git checkout pull/11803`

Update a local copy of the PR: \
`$ git checkout pull/11803` \
`$ git pull https://git.openjdk.org/jdk pull/11803/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11803`

View PR using the GUI difftool: \
`$ git pr show -t 11803`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11803.diff">https://git.openjdk.org/jdk/pull/11803.diff</a>

</details>
