### PR TITLE
JDK-8299424: containers/docker/TestMemoryWithCgroupV1.java fails on SLES12 ppc64le when testing Memory and Swap Limit

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestMemoryWithCgroupV1.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryWithCgroupV1.java
@@ -85,10 +85,14 @@ public class TestMemoryWithCgroupV1 {
         // capabilities or the cgroup is not mounted. Memory limited without swap."
         // we only have Memory and Swap Limit is: <huge integer> in the output
         try {
-            out.shouldContain("Memory and Swap Limit is: " + expectedReadLimit)
-                .shouldContain(
+            if (out.getOutput().contains("memory_and_swap_limit_in_bytes: not supported")) {
+                System.out.println("memory_and_swap_limit_in_bytes not supported, avoiding Memory and Swap Limit check");
+            } else {
+                out.shouldContain("Memory and Swap Limit is: " + expectedReadLimit)
+                    .shouldContain(
                         "Memory and Swap Limit has been reset to " + expectedResetLimit + " because swappiness is 0")
-                .shouldContain("Memory & Swap Limit: " + expectedLimit);
+                    .shouldContain("Memory & Swap Limit: " + expectedLimit);
+            }
         } catch (RuntimeException ex) {
             System.out.println("Expected Memory and Swap Limit output missing.");
             System.out.println("You may need to add 'cgroup_enable=memory swapaccount=1' to the Linux kernel boot parameters.");


### PR DESCRIPTION
On the old SLES12 ppc64le machine we do not have memory.memsw.limit_in_bytes :
ls -alL /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes
ls: cannot access /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes: No such file or directory

This leads to

[0.163s][trace][os,container] Memory and Swap Limit is: 18446744073709551614
memory_and_swap_limit_in_bytes: not supported

And the check in containers/docker/TestMemoryWithCgroupV1.java fails :

java.lang.RuntimeException: 'Memory and Swap Limit is: 157286400' missing from stdout/stderr
at jdk.test.lib.process.OutputAnalyzer.shouldContain(OutputAnalyzer.java:221)
at TestMemoryWithCgroupV1.testMemoryLimitWithSwappiness(TestMemoryWithCgroupV1.java:88)
at TestMemoryWithCgroupV1.main(TestMemoryWithCgroupV1.java:61)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.base/java.lang.reflect.Method.invoke(Method.java:578)
at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:312)
at java.base/java.lang.Thread.run(Thread.java:1623)

Probably we should handle this situation and check for "memory_and_swap_limit_in_bytes: not supported" or something similar .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299424](https://bugs.openjdk.org/browse/JDK-8299424): containers/docker/TestMemoryWithCgroupV1.java fails on SLES12 ppc64le when testing Memory and Swap Limit


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11805/head:pull/11805` \
`$ git checkout pull/11805`

Update a local copy of the PR: \
`$ git checkout pull/11805` \
`$ git pull https://git.openjdk.org/jdk pull/11805/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11805`

View PR using the GUI difftool: \
`$ git pr show -t 11805`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11805.diff">https://git.openjdk.org/jdk/pull/11805.diff</a>

</details>
