### PR TITLE
8299437: Make InetSocketAddressHolder shallowly immutable

### DIFF
--- a/src/java.base/share/classes/java/net/InetSocketAddress.java
+++ b/src/java.base/share/classes/java/net/InetSocketAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,13 +53,13 @@ public class InetSocketAddress
     extends SocketAddress
 {
     // Private implementation class pointed to by all public methods.
-    private static class InetSocketAddressHolder {
+    private static final class InetSocketAddressHolder {
         // The hostname of the Socket Address
-        private String hostname;
+        private final String hostname;
         // The IP address of the Socket Address
-        private InetAddress addr;
+        private final InetAddress addr;
         // The port number of the Socket Address
-        private int port;
+        private final int port;
 
         private InetSocketAddressHolder(String hostname, InetAddress addr, int port) {
             this.hostname = hostname;


### PR DESCRIPTION
This PR proposes to make the class `java.net.InetSocketAddress.InetSocketAddressHolder` shallowly immutable

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299437](https://bugs.openjdk.org/browse/JDK-8299437): Make InetSocketAddressHolder shallowly immutable


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - Committer)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11809/head:pull/11809` \
`$ git checkout pull/11809`

Update a local copy of the PR: \
`$ git checkout pull/11809` \
`$ git pull https://git.openjdk.org/jdk pull/11809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11809`

View PR using the GUI difftool: \
`$ git pr show -t 11809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11809.diff">https://git.openjdk.org/jdk/pull/11809.diff</a>

</details>
