### PR TITLE
8299441: Fix typos in some test files under core-libs component

### DIFF
--- a/test/jdk/javax/script/GetInterfaceTest.java
+++ b/test/jdk/javax/script/GetInterfaceTest.java
@@ -35,7 +35,7 @@ public class GetInterfaceTest {
         ScriptEngine engine = manager.getEngineByName("nashorn");
 
         if (engine == null) {
-            System.out.println("Warning: No js engine engine found; test vacuously passes.");
+            System.out.println("Warning: No js engine found; test vacuously passes.");
             return;
         }
 

--- a/test/jdk/javax/sql/testng/test/rowset/cachedrowset/CommonCachedRowSetTests.java
+++ b/test/jdk/javax/sql/testng/test/rowset/cachedrowset/CommonCachedRowSetTests.java
@@ -1401,7 +1401,7 @@ public abstract class CommonCachedRowSetTests extends CommonRowSetTests {
         rs.updateString(2, coffee);
         rs.updateInt(5, sales);
         // MetaData should match
-        try ( // Get the original original RowSet and validate that the changes
+        try ( // Get the original RowSet and validate that the changes
                 // are only made to the current, not the original
                 ResultSet rs1 = rs.getOriginal()) {
             // MetaData should match
@@ -1444,7 +1444,7 @@ public abstract class CommonCachedRowSetTests extends CommonRowSetTests {
         rs.updateString(2, coffee);
         rs.updateInt(5, sales);
         // MetaData should match
-        try ( // Get the original original row and validate that the changes
+        try ( // Get the original row and validate that the changes
                 // are only made to the current, not the original
                 ResultSet rs1 = rs.getOriginalRow()) {
             // MetaData should match

--- a/test/jdk/javax/sql/testng/test/rowset/serial/SerialDataLinkTests.java
+++ b/test/jdk/javax/sql/testng/test/rowset/serial/SerialDataLinkTests.java
@@ -99,7 +99,7 @@ public class SerialDataLinkTests extends BaseTest {
 
     /**
      * Validate that a SerialDatalink that is serialized & deserialized is not equal
-     * to to a SerialDatalink created using a different URL
+     * to a SerialDatalink created using a different URL
      */
     @Test
     public void test05() throws Exception {

--- a/test/micro/org/openjdk/bench/java/lang/ArrayFiddle.java
+++ b/test/micro/org/openjdk/bench/java/lang/ArrayFiddle.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
  * simple_copyLoop is surprisingly 5x slower.  The array copying intrinsics
  * are very effective and a naive loop does not get optimized the same way.
  * OTOH there is no intrinsic for Arrays.fill but the naive array zeroing loop
- * *does* get optimized to something a little faster than than arraycopy.
+ * *does* get optimized to something a little faster than arraycopy.
  *
  * System.arraycopy and Arrays.fill have such outstanding performance that
  * one should use them to replace handwritten loops whenever possible.


### PR DESCRIPTION
Can I please get a review of this change which fixes the final few typos in test files in the core-libs area? This addresses the remaining core-libs related typos from the original PR https://github.com/openjdk/jdk/pull/10029.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299441](https://bugs.openjdk.org/browse/JDK-8299441): Fix typos in some test files under core-libs component


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Contributors
 * Michael Ernst `<mernst@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11810/head:pull/11810` \
`$ git checkout pull/11810`

Update a local copy of the PR: \
`$ git checkout pull/11810` \
`$ git pull https://git.openjdk.org/jdk pull/11810/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11810`

View PR using the GUI difftool: \
`$ git pr show -t 11810`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11810.diff">https://git.openjdk.org/jdk/pull/11810.diff</a>

</details>
