### PR TITLE
JDK-8299470: sun/jvm/hotspot/SALauncher.java handling of negative rmiport args

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/SAGetopt.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/SAGetopt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/SAGetopt.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/SAGetopt.java
@@ -59,7 +59,7 @@ public class SAGetopt {
         }
 
         if (! _argv[_optind].isEmpty() && _argv[_optind].charAt(0) == '-') {
-            throw new SAGetoptException("Argument is expected for '" + opt + "'");
+            throw new SAGetoptException("Successor argument without leading - is expected for '" + opt + "' but we got " + _argv[_optind]);
         }
 
         _optarg = _argv[_optind];

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/SAGetopt.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/SAGetopt.java
@@ -59,7 +59,8 @@ public class SAGetopt {
         }
 
         if (! _argv[_optind].isEmpty() && _argv[_optind].charAt(0) == '-') {
-            throw new SAGetoptException("Successor argument without leading - is expected for '" + opt + "' but we got " + _argv[_optind]);
+            throw new SAGetoptException("Successor argument without leading - is expected for '" + opt +
+                                        "' but we got '" + _argv[_optind] + "'");
         }
 
         _optarg = _argv[_optind];

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/SALauncher.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/SALauncher.java
@@ -422,9 +422,6 @@ public class SALauncher {
                 throw new SAGetoptException("Invalid RMI connector port: " + rmiPortString);
             }
         }
-        if (rmiPort < 0) {
-            System.err.println("Warning - negative rmiport " + rmiPort + " can lead to errors");
-        }
 
         final HotSpotAgent agent = new HotSpotAgent();
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/SALauncher.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/SALauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -422,6 +422,9 @@ public class SALauncher {
                 throw new SAGetoptException("Invalid RMI connector port: " + rmiPortString);
             }
         }
+        if (rmiPort < 0) {
+            System.err.println("Warning - negative rmiport " + rmiPort + " can lead to errors");
+        }
 
         final HotSpotAgent agent = new HotSpotAgent();
 
@@ -500,6 +503,8 @@ public class SALauncher {
                 func.accept(oldArgs);
             }
         } catch (SAGetoptException e) {
+            System.err.println("SA agent option related exception occured");
+            e.printStackTrace();
             System.err.println(e.getMessage());
             toolHelp(args[0]);
             // Exit with error status

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/SALauncher.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/SALauncher.java
@@ -500,7 +500,7 @@ public class SALauncher {
                 func.accept(oldArgs);
             }
         } catch (SAGetoptException e) {
-            System.err.println("SA agent option related exception occured: " + e.getMessage());
+            System.err.println("SA agent option related exception occurred: " + e.getMessage());
             e.printStackTrace();
             toolHelp(args[0]);
             // Exit with error status

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/SALauncher.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/SALauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -500,9 +500,8 @@ public class SALauncher {
                 func.accept(oldArgs);
             }
         } catch (SAGetoptException e) {
-            System.err.println("SA agent option related exception occured");
+            System.err.println("SA agent option related exception occured: " + e.getMessage());
             e.printStackTrace();
-            System.err.println(e.getMessage());
             toolHelp(args[0]);
             // Exit with error status
             System.exit(1);

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/SADebugDTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/SADebugDTest.java
@@ -102,7 +102,7 @@ public class SADebugDTest {
                 if (useRegistryPort) {
                     registryPort = Utils.findUnreservedFreePort(REGISTRY_DEFAULT_PORT);
                     if (registryPort == -1) {
-                        throw new RuntimeException("Cannot find an registryPort, findUnreservedFreePort returns -1");
+                        throw new RuntimeException("Cannot find a registryPort, findUnreservedFreePort returns -1");
                     }
                     jhsdbLauncher.addToolArg("--registryport");
                     jhsdbLauncher.addToolArg(Integer.toString(registryPort));

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/SADebugDTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/SADebugDTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,12 +101,18 @@ public class SADebugDTest {
                 int registryPort = REGISTRY_DEFAULT_PORT;
                 if (useRegistryPort) {
                     registryPort = Utils.findUnreservedFreePort(REGISTRY_DEFAULT_PORT);
+                    if (registryPort == -1) {
+                        throw new RuntimeException("Cannot find an registryPort, findUnreservedFreePort returns -1");
+                    }
                     jhsdbLauncher.addToolArg("--registryport");
                     jhsdbLauncher.addToolArg(Integer.toString(registryPort));
                 }
 
                 final int rmiPort = useRmiPort ? Utils.findUnreservedFreePort(REGISTRY_DEFAULT_PORT, registryPort) : -1;
                 if (useRmiPort) {
+                    if (rmiPort == -1) {
+                        throw new RuntimeException("Cannot find an rmiPort, findUnreservedFreePort returns -1");
+                    }
                     jhsdbLauncher.addToolArg("--rmiport");
                     jhsdbLauncher.addToolArg(Integer.toString(rmiPort));
                 }


### PR DESCRIPTION
The test serviceability/sa/sadebugd/SADebugDTest.java can pass under some circumstances a negative rmiport (--rmiport -1) to SALauncher.java.
This leads to a somewhat misleading message 
`[debugd] Argument is expected for 'rmiport' `
(we set an argument [-1] but probably this is not what is really expected) and additionally the real exception is not shown.
Probably also a warning in case of negative rmiport values should be printed because they seem to lead to errors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299470](https://bugs.openjdk.org/browse/JDK-8299470): sun/jvm/hotspot/SALauncher.java handling of negative rmiport args


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) ⚠️ Review applies to [d42cc159](https://git.openjdk.org/jdk/pull/11811/files/d42cc1596afe3b8fd9d1625057d9f38f09be10c7)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11811/head:pull/11811` \
`$ git checkout pull/11811`

Update a local copy of the PR: \
`$ git checkout pull/11811` \
`$ git pull https://git.openjdk.org/jdk pull/11811/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11811`

View PR using the GUI difftool: \
`$ git pr show -t 11811`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11811.diff">https://git.openjdk.org/jdk/pull/11811.diff</a>

</details>
