### PR TITLE
JDK-8299475: Enhance SocketException by cause where it is missing in net and nio area

### DIFF
--- a/src/java.base/share/classes/java/net/ServerSocket.java
+++ b/src/java.base/share/classes/java/net/ServerSocket.java
@@ -694,7 +694,7 @@ public class ServerSocket implements java.io.Closeable {
             Thread thread = Thread.currentThread();
             if (thread.isVirtual() && thread.isInterrupted()) {
                 close();
-                throw new SocketException("Closed by interrupt", e);
+                throw new SocketException("Closed by interrupt");
             }
             throw e;
         }

--- a/src/java.base/share/classes/java/net/ServerSocket.java
+++ b/src/java.base/share/classes/java/net/ServerSocket.java
@@ -299,7 +299,7 @@ public class ServerSocket implements java.io.Closeable {
                     } catch (SocketException e) {
                         throw e;
                     } catch (IOException e) {
-                        throw new SocketException(e.getMessage());
+                        throw new SocketException(e.getMessage(), e);
                     }
                     created = true;
                 }
@@ -694,7 +694,7 @@ public class ServerSocket implements java.io.Closeable {
             Thread thread = Thread.currentThread();
             if (thread.isVirtual() && thread.isInterrupted()) {
                 close();
-                throw new SocketException("Closed by interrupt");
+                throw new SocketException("Closed by interrupt", e);
             }
             throw e;
         }

--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -532,7 +532,7 @@ public class Socket implements java.io.Closeable {
             impl.create(stream);
             created = true;
         } catch (IOException e) {
-            throw new SocketException(e.getMessage());
+            throw new SocketException(e.getMessage(), e);
         }
     }
 
@@ -670,7 +670,7 @@ public class Socket implements java.io.Closeable {
             Thread thread = Thread.currentThread();
             if (thread.isVirtual() && thread.isInterrupted()) {
                 close();
-                throw new SocketException("Closed by interrupt");
+                throw new SocketException("Closed by interrupt", e);
             }
             throw e;
         }
@@ -1029,7 +1029,7 @@ public class Socket implements java.io.Closeable {
                 Thread thread = Thread.currentThread();
                 if (thread.isVirtual() && thread.isInterrupted()) {
                     close();
-                    throw new SocketException("Closed by interrupt");
+                    throw new SocketException("Closed by interrupt", e);
                 }
                 throw e;
             }
@@ -1122,7 +1122,7 @@ public class Socket implements java.io.Closeable {
                 Thread thread = Thread.currentThread();
                 if (thread.isVirtual() && thread.isInterrupted()) {
                     close();
-                    throw new SocketException("Closed by interrupt");
+                    throw new SocketException("Closed by interrupt", e);
                 }
                 throw e;
             }

--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -670,7 +670,7 @@ public class Socket implements java.io.Closeable {
             Thread thread = Thread.currentThread();
             if (thread.isVirtual() && thread.isInterrupted()) {
                 close();
-                throw new SocketException("Closed by interrupt", e);
+                throw new SocketException("Closed by interrupt");
             }
             throw e;
         }
@@ -1029,7 +1029,7 @@ public class Socket implements java.io.Closeable {
                 Thread thread = Thread.currentThread();
                 if (thread.isVirtual() && thread.isInterrupted()) {
                     close();
-                    throw new SocketException("Closed by interrupt", e);
+                    throw new SocketException("Closed by interrupt");
                 }
                 throw e;
             }
@@ -1122,7 +1122,7 @@ public class Socket implements java.io.Closeable {
                 Thread thread = Thread.currentThread();
                 if (thread.isVirtual() && thread.isInterrupted()) {
                     close();
-                    throw new SocketException("Closed by interrupt", e);
+                    throw new SocketException("Closed by interrupt");
                 }
                 throw e;
             }

--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -531,8 +531,10 @@ public class Socket implements java.io.Closeable {
         try {
             impl.create(stream);
             created = true;
+        } catch (SocketException e) {
+            throw e;
         } catch (IOException e) {
-            throw new SocketException(e.getMessage(), e);
+            throw new SocketException(e.getMessage());
         }
     }
 

--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -534,7 +534,7 @@ public class Socket implements java.io.Closeable {
         } catch (SocketException e) {
             throw e;
         } catch (IOException e) {
-            throw new SocketException(e.getMessage());
+            throw new SocketException(e.getMessage(), e);
         }
     }
 

--- a/src/java.base/share/classes/java/net/SocksSocketImpl.java
+++ b/src/java.base/share/classes/java/net/SocksSocketImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -363,7 +363,7 @@ class SocksSocketImpl extends DelegatingSocketImpl implements SocksConsts {
             try {
                 privilegedConnect(server, serverPort, remainingMillis(deadlineMillis));
             } catch (IOException e) {
-                throw new SocketException(e.getMessage());
+                throw new SocketException(e.getMessage(), e);
             }
         }
 

--- a/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
@@ -410,7 +410,9 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
         } catch (InterruptedIOException e) {
             throw e;
         } catch (IOException ioe) {
-            throw new SocketException(ioe.getMessage(), ioe);
+            var e = new SocketException(ioe.getMessage());
+            e.setStackTrace(ioe.getStackTrace());
+            throw e;
         } finally {
             endWrite(n > 0);
         }

--- a/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
@@ -312,7 +312,8 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
             connectionReset = true;
             throw new SocketException("Connection reset");
         } catch (IOException ioe) {
-            throw new SocketException(ioe.getMessage(), ioe);
+            // throw SocketException to maintain compatibility
+            throw asSocketException(ioe);
         } finally {
             endRead(n > 0);
         }
@@ -410,9 +411,8 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
         } catch (InterruptedIOException e) {
             throw e;
         } catch (IOException ioe) {
-            var e = new SocketException(ioe.getMessage());
-            e.setStackTrace(ioe.getStackTrace());
-            throw e;
+            // throw SocketException to maintain compatibility
+            throw asSocketException(ioe);
         } finally {
             endWrite(n > 0);
         }
@@ -1086,7 +1086,7 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
             } catch (SocketException e) {
                 throw e;
             } catch (IllegalArgumentException | IOException e) {
-                throw new SocketException(e.getMessage(), e);
+                throw asSocketException(e);
             }
         }
     }
@@ -1138,7 +1138,7 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
             } catch (SocketException e) {
                 throw e;
             } catch (IllegalArgumentException | IOException e) {
-                throw new SocketException(e.getMessage(), e);
+                throw asSocketException(e);
             }
         }
     }
@@ -1249,6 +1249,19 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
         if (interrupted)
             Thread.currentThread().interrupt();
         return remainingNanos;
+    }
+
+    /**
+     * Creates a SocketException from the given exception.
+     */
+    private static SocketException asSocketException(Exception e) {
+        if (e instanceof SocketException se) {
+            return se;
+        } else {
+            var se = new SocketException(e.getMessage());
+            se.setStackTrace(e.getStackTrace());
+            return se;
+        }
     }
 
     /**

--- a/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
@@ -310,7 +310,7 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
             throw e;
         } catch (ConnectionResetException e) {
             connectionReset = true;
-            throw new SocketException("Connection reset", e);
+            throw new SocketException("Connection reset");
         } catch (IOException ioe) {
             throw new SocketException(ioe.getMessage(), ioe);
         } finally {

--- a/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
@@ -310,9 +310,9 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
             throw e;
         } catch (ConnectionResetException e) {
             connectionReset = true;
-            throw new SocketException("Connection reset");
+            throw new SocketException("Connection reset", e);
         } catch (IOException ioe) {
-            throw new SocketException(ioe.getMessage());
+            throw new SocketException(ioe.getMessage(), ioe);
         } finally {
             endRead(n > 0);
         }
@@ -410,7 +410,7 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
         } catch (InterruptedIOException e) {
             throw e;
         } catch (IOException ioe) {
-            throw new SocketException(ioe.getMessage());
+            throw new SocketException(ioe.getMessage(), ioe);
         } finally {
             endWrite(n > 0);
         }
@@ -1084,7 +1084,7 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
             } catch (SocketException e) {
                 throw e;
             } catch (IllegalArgumentException | IOException e) {
-                throw new SocketException(e.getMessage());
+                throw new SocketException(e.getMessage(), e);
             }
         }
     }
@@ -1136,7 +1136,7 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
             } catch (SocketException e) {
                 throw e;
             } catch (IllegalArgumentException | IOException e) {
-                throw new SocketException(e.getMessage());
+                throw new SocketException(e.getMessage(), e);
             }
         }
     }


### PR DESCRIPTION
We have a couple of places where a SocketException is thrown but the cause is omitted. It would be beneficial for example in error analysis not to throw away the cause (causing exception) but to add it to the created SocketException.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299475](https://bugs.openjdk.org/browse/JDK-8299475): Enhance SocketException by cause where it is missing in net and nio area


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11813/head:pull/11813` \
`$ git checkout pull/11813`

Update a local copy of the PR: \
`$ git checkout pull/11813` \
`$ git pull https://git.openjdk.org/jdk pull/11813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11813`

View PR using the GUI difftool: \
`$ git pr show -t 11813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11813.diff">https://git.openjdk.org/jdk/pull/11813.diff</a>

</details>
