### PR TITLE
8296789: <TAB>-completion in jshell fails to expose synthetic bridge methods

### DIFF
--- a/test/langtools/jdk/jshell/CompletionSuggestionTest.java
+++ b/test/langtools/jdk/jshell/CompletionSuggestionTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8131025 8141092 8153761 8145263 8131019 8175886 8176184 8176241 8176110 8177466 8197439 8221759 8234896 8240658 8278039 8286206
+ * @bug 8131025 8141092 8153761 8145263 8131019 8175886 8176184 8176241 8176110 8177466 8197439 8221759 8234896 8240658 8278039 8286206 8296789
  * @summary Test Completion and Documentation
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -790,5 +790,11 @@ public class CompletionSuggestionTest extends KullaTesting {
 
     public void testRecord() {
         assertCompletion("record R() implements Ru|", true, "Runnable");
+    }
+
+    //JDK-8296789
+    public void testParentMembers() {
+        assertEval("var sb=new StringBuilder();");
+        assertCompletionIncludesExcludes("sb.|", true, Set.of("capacity()", "setLength("), Set.of("maybeLatin1"));
     }
 }


### PR DESCRIPTION
Jshell does not propose completion for members declared in inaccessible parent classes (for example AbstractStringBuilder).

This patch fixes the completion in SourceCodeAnalysisImpl using MethodSymbols and VarSymbols clones with altered enclosing elements. For documentation purpose (print of the enclosing classes) the original enclosing element is restored.

The patch also includes new CompletionSuggestionTest::testPerentMembers
 
Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296789](https://bugs.openjdk.org/browse/JDK-8296789): <TAB>-completion in jshell fails to expose synthetic bridge methods


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11814/head:pull/11814` \
`$ git checkout pull/11814`

Update a local copy of the PR: \
`$ git checkout pull/11814` \
`$ git pull https://git.openjdk.org/jdk pull/11814/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11814`

View PR using the GUI difftool: \
`$ git pr show -t 11814`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11814.diff">https://git.openjdk.org/jdk/pull/11814.diff</a>

</details>
