### PR TITLE
4934362: see also refers to self

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -2265,6 +2265,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
      * @param d the dimension specifying the new size
      *          of this component
      * @throws NullPointerException if {@code d} is {@code null}
+     * @see #setSize(int, int)
      * @see #getSize
      * @see #setBounds
      * @see #invalidate

--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -2265,7 +2265,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
      * @param d the dimension specifying the new size
      *          of this component
      * @throws NullPointerException if {@code d} is {@code null}
-     * @see #setSize
+     * @see #getSize
      * @see #setBounds
      * @see #invalidate
      * @since 1.1
@@ -8562,7 +8562,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
      *
      * @see #addPropertyChangeListener
      * @see #getPropertyChangeListeners
-     * @see #removePropertyChangeListener(java.lang.String,java.beans.PropertyChangeListener)
+     * @see #removePropertyChangeListener(java.lang.String, java.beans.PropertyChangeListener)
      */
     public void removePropertyChangeListener(
                                                           PropertyChangeListener listener) {
@@ -8626,7 +8626,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
      *
      * @see #removePropertyChangeListener(java.lang.String, java.beans.PropertyChangeListener)
      * @see #getPropertyChangeListeners(java.lang.String)
-     * @see #addPropertyChangeListener(java.lang.String, java.beans.PropertyChangeListener)
+     * @see #addPropertyChangeListener(java.beans.PropertyChangeListener)
      */
     public void addPropertyChangeListener(
                                                        String propertyName,

--- a/src/java.desktop/share/classes/java/awt/List.java
+++ b/src/java.desktop/share/classes/java/awt/List.java
@@ -1697,7 +1697,7 @@ public class List extends Component implements ItemSelectable, Accessible {
              * Set the background color of this object.
              *
              * @param c the new Color for the background
-             * @see #setBackground
+             * @see #getBackground
              */
             public void setBackground(Color c) {
                 parent.setBackground(c);

--- a/src/java.desktop/share/classes/java/awt/MediaTracker.java
+++ b/src/java.desktop/share/classes/java/awt/MediaTracker.java
@@ -526,7 +526,7 @@ public class MediaTracker implements java.io.Serializable {
      * @return      {@code true} if all images have finished loading,
      *                       have been aborted, or have encountered
      *                       an error; {@code false} otherwise
-     * @see         java.awt.MediaTracker#checkID(int, boolean, boolean)
+     * @see         java.awt.MediaTracker#checkID(int)
      * @see         java.awt.MediaTracker#checkAll()
      * @see         java.awt.MediaTracker#isErrorAny()
      * @see         java.awt.MediaTracker#isErrorID(int)

--- a/src/java.desktop/share/classes/java/awt/MediaTracker.java
+++ b/src/java.desktop/share/classes/java/awt/MediaTracker.java
@@ -418,7 +418,6 @@ public class MediaTracker implements java.io.Serializable {
      * @return      {@code true} if all images were successfully
      *                       loaded; {@code false} otherwise
      * @see         java.awt.MediaTracker#waitForID(int)
-     * @see         java.awt.MediaTracker#waitForAll(long)
      * @see         java.awt.MediaTracker#isErrorAny
      * @see         java.awt.MediaTracker#isErrorID
      * @throws   InterruptedException  if any thread has
@@ -527,7 +526,7 @@ public class MediaTracker implements java.io.Serializable {
      * @return      {@code true} if all images have finished loading,
      *                       have been aborted, or have encountered
      *                       an error; {@code false} otherwise
-     * @see         java.awt.MediaTracker#checkID(int, boolean)
+     * @see         java.awt.MediaTracker#checkID(int, boolean, boolean)
      * @see         java.awt.MediaTracker#checkAll()
      * @see         java.awt.MediaTracker#isErrorAny()
      * @see         java.awt.MediaTracker#isErrorID(int)

--- a/src/java.desktop/share/classes/javax/accessibility/AccessibleComponent.java
+++ b/src/java.desktop/share/classes/javax/accessibility/AccessibleComponent.java
@@ -67,7 +67,7 @@ public interface AccessibleComponent {
      * Sets the background color of this object.
      *
      * @param  c the new color for the background
-     * @see #setBackground
+     * @see #getBackground
      */
     public void setBackground(Color c);
 

--- a/src/java.desktop/share/classes/javax/accessibility/AccessibleState.java
+++ b/src/java.desktop/share/classes/javax/accessibility/AccessibleState.java
@@ -288,7 +288,7 @@ public class AccessibleState extends AccessibleBundle {
      * Indicates the orientation of this object is vertical. This is usually
      * associated with objects such as scrollbars, sliders, and progress bars.
      *
-     * @see #VERTICAL
+     * @see #HORIZONTAL
      * @see AccessibleRole#SCROLL_BAR
      * @see AccessibleRole#SLIDER
      * @see AccessibleRole#PROGRESS_BAR
@@ -300,7 +300,7 @@ public class AccessibleState extends AccessibleBundle {
      * Indicates the orientation of this object is horizontal. This is usually
      * associated with objects such as scrollbars, sliders, and progress bars.
      *
-     * @see #HORIZONTAL
+     * @see #VERTICAL
      * @see AccessibleRole#SCROLL_BAR
      * @see AccessibleRole#SLIDER
      * @see AccessibleRole#PROGRESS_BAR

--- a/src/java.desktop/share/classes/javax/swing/JComboBox.java
+++ b/src/java.desktop/share/classes/javax/swing/JComboBox.java
@@ -155,6 +155,7 @@ implements ItemSelectable,ListDataListener,ActionListener, Accessible {
      * This protected field is implementation specific. Do not access directly
      * or override. Use the accessor methods instead.
      *
+     * @see #isEditable()
      * @see #setEditable
      */
     protected boolean isEditable  = false;

--- a/src/java.desktop/share/classes/javax/swing/JComboBox.java
+++ b/src/java.desktop/share/classes/javax/swing/JComboBox.java
@@ -155,7 +155,6 @@ implements ItemSelectable,ListDataListener,ActionListener, Accessible {
      * This protected field is implementation specific. Do not access directly
      * or override. Use the accessor methods instead.
      *
-     * @see #isEditable
      * @see #setEditable
      */
     protected boolean isEditable  = false;

--- a/src/java.desktop/share/classes/javax/swing/JList.java
+++ b/src/java.desktop/share/classes/javax/swing/JList.java
@@ -717,7 +717,7 @@ public class JList<E> extends JComponent implements Scrollable, Accessible
      *
      * @param width the width to be used for all cells in the list
      * @see #setPrototypeCellValue
-     * @see #setFixedCellWidth
+     * @see #getFixedCellWidth
      * @see JComponent#addPropertyChangeListener
      */
     @BeanProperty(visualUpdate = true, description

--- a/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
@@ -542,7 +542,7 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
      *
      * @param label a string specifying the label for the popup menu
      *
-     * @see #setLabel
+     * @see #getLabel
      */
     @BeanProperty(description
             = "The label for the popup menu.")

--- a/src/java.desktop/share/classes/javax/swing/table/DefaultTableModel.java
+++ b/src/java.desktop/share/classes/javax/swing/table/DefaultTableModel.java
@@ -517,7 +517,7 @@ public class DefaultTableModel extends AbstractTableModel implements Serializabl
      *
      *  @param columnCount  the new number of columns in the model
      *
-     *  @see #setColumnCount
+     *  @see #setRowCount
      * @since 1.3
      */
     public void setColumnCount(int columnCount) {

--- a/src/java.desktop/share/classes/javax/swing/text/View.java
+++ b/src/java.desktop/share/classes/javax/swing/text/View.java
@@ -349,7 +349,6 @@ public abstract class View implements SwingConstants {
      * returns 0.
      *
      * @return the number of views &gt;= 0
-     * @see View#getViewCount
      */
     public int getViewCount() {
         return 0;
@@ -698,7 +697,8 @@ public abstract class View implements SwingConstants {
      * @param e the change information from the associated document
      * @param a the current allocation of the view
      * @param f the factory to use to rebuild if the view has children
-     * @see View#insertUpdate
+     * @see View#removeUpdate
+     * @see View#changedUpdate
      */
     public void insertUpdate(DocumentEvent e, Shape a, ViewFactory f) {
         if (getViewCount() > 0) {
@@ -739,7 +739,8 @@ public abstract class View implements SwingConstants {
      * @param e the change information from the associated document
      * @param a the current allocation of the view
      * @param f the factory to use to rebuild if the view has children
-     * @see View#removeUpdate
+     * @see View#insertUpdate
+     * @see View#changedUpdate
      */
     public void removeUpdate(DocumentEvent e, Shape a, ViewFactory f) {
         if (getViewCount() > 0) {
@@ -780,7 +781,8 @@ public abstract class View implements SwingConstants {
      * @param e the change information from the associated document
      * @param a the current allocation of the view
      * @param f the factory to use to rebuild if the view has children
-     * @see View#changedUpdate
+     * @see View#insertUpdate
+     * @see View#removeUpdate
      */
     public void changedUpdate(DocumentEvent e, Shape a, ViewFactory f) {
         if (getViewCount() > 0) {
@@ -802,7 +804,6 @@ public abstract class View implements SwingConstants {
      * Fetches the model associated with the view.
      *
      * @return the view model, <code>null</code> if none
-     * @see View#getDocument
      */
     public Document getDocument() {
         return elem.getDocument();
@@ -813,7 +814,7 @@ public abstract class View implements SwingConstants {
      * responsible.
      *
      * @return the starting offset into the model &gt;= 0
-     * @see View#getStartOffset
+     * @see View#getEndOffset
      */
     public int getStartOffset() {
         return elem.getStartOffset();
@@ -824,7 +825,7 @@ public abstract class View implements SwingConstants {
      * responsible.
      *
      * @return the ending offset into the model &gt;= 0
-     * @see View#getEndOffset
+     * @see View#getStartOffset
      */
     public int getEndOffset() {
         return elem.getEndOffset();
@@ -836,7 +837,6 @@ public abstract class View implements SwingConstants {
      * entire portion of the element.
      *
      * @return the subject
-     * @see View#getElement
      */
     public Element getElement() {
         return elem;
@@ -1339,7 +1339,7 @@ public abstract class View implements SwingConstants {
      * @return the bounding box of the given position is returned
      * @throws BadLocationException  if the given position does
      *   not represent a valid location in the associated document
-     * @see View#modelToView
+     * @see View#viewToModel
      * @deprecated
      */
     @Deprecated
@@ -1357,7 +1357,7 @@ public abstract class View implements SwingConstants {
      * @param a the allocated region in which to render
      * @return the location within the model that best represents the
      *  given point in the view &gt;= 0
-     * @see View#viewToModel
+     * @see View#modelToView
      * @deprecated
      */
     @Deprecated


### PR DESCRIPTION
Some methods and constants has a hyperreference to self in javadoc which is rectified to reference proper methods

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-4934362](https://bugs.openjdk.org/browse/JDK-4934362): see also refers to self


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [5c9bd461](https://git.openjdk.org/jdk/pull/11820/files/5c9bd4613fa4081f811cd99cab53ac0b86db9e8a)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11820/head:pull/11820` \
`$ git checkout pull/11820`

Update a local copy of the PR: \
`$ git checkout pull/11820` \
`$ git pull https://git.openjdk.org/jdk pull/11820/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11820`

View PR using the GUI difftool: \
`$ git pr show -t 11820`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11820.diff">https://git.openjdk.org/jdk/pull/11820.diff</a>

</details>
