### PR TITLE
8299306: Test "javax/swing/JFileChooser/FileSystemView/CustomFSVLinkTest.java" fails on Windows 10 x64 because there are some buttons did not display button name

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/FileSystemView/CustomFSVLinkTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileSystemView/CustomFSVLinkTest.java
@@ -81,6 +81,7 @@ public class CustomFSVLinkTest {
         PassFailJFrame.addTestWindow(frame);
         PassFailJFrame.positionTestWindow(frame, PassFailJFrame.Position.HORIZONTAL);
         frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+        jfc.setControlButtonsAreShown(false);
         jfc.setDialogType(JFileChooser.CUSTOM_DIALOG);
 
         frame.add(jfc, BorderLayout.CENTER);


### PR DESCRIPTION
When JFilechooser is added to a frame, the control buttons are disabled. Since in the test the control buttons are not required since JFilechooser is added to a JFrame and in turn frame disposal is handled by PassFailJFrame. The fix is to disable JFileChooser control buttons.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299306](https://bugs.openjdk.org/browse/JDK-8299306): Test "javax/swing/JFileChooser/FileSystemView/CustomFSVLinkTest.java" fails on Windows 10 x64 because there are some buttons did not display button name


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11821/head:pull/11821` \
`$ git checkout pull/11821`

Update a local copy of the PR: \
`$ git checkout pull/11821` \
`$ git pull https://git.openjdk.org/jdk pull/11821/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11821`

View PR using the GUI difftool: \
`$ git pr show -t 11821`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11821.diff">https://git.openjdk.org/jdk/pull/11821.diff</a>

</details>
