### PR TITLE
8297753: AArch64: Add optimized rules for vector compare with zero on NEON

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_vector.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_vector.ad
@@ -1,6 +1,6 @@
 //
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
-// Copyright (c) 2020, 2022, Arm Limited. All rights reserved.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2020, 2023, Arm Limited. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -5087,6 +5087,57 @@ instruct vmaskcmp_neon(vReg dst, vReg src1, vReg src2, immI cond) %{
     __ neon_compare($dst$$FloatRegister, bt, $src1$$FloatRegister,
                     $src2$$FloatRegister, (int)($cond$$constant),
                     /* isQ */ length_in_bytes == 16);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmaskcmp_zeroI_neon(vReg dst, vReg src, immI0 zero, immI cond) %{
+  predicate(UseSVE == 0);
+  match(Set dst (VectorMaskCmp (Binary src (ReplicateB zero)) cond));
+  match(Set dst (VectorMaskCmp (Binary src (ReplicateS zero)) cond));
+  match(Set dst (VectorMaskCmp (Binary src (ReplicateI zero)) cond));
+  format %{ "vmaskcmp_zeroI_neon $dst, $src, #0" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    uint length_in_bytes = Matcher::vector_length_in_bytes(this);
+    __ neon_compare_zero($dst$$FloatRegister, bt, $src$$FloatRegister,
+                         (int)($cond$$constant), /* isQ */ length_in_bytes == 16);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmaskcmp_zeroL_neon(vReg dst, vReg src, immL0 zero, immI cond) %{
+  predicate(UseSVE == 0);
+  match(Set dst (VectorMaskCmp (Binary src (ReplicateL zero)) cond));
+  format %{ "vmaskcmp_zeroL_neon $dst, $src, #0" %}
+  ins_encode %{
+    uint length_in_bytes = Matcher::vector_length_in_bytes(this);
+    __ neon_compare_zero($dst$$FloatRegister, T_LONG, $src$$FloatRegister,
+                         (int)($cond$$constant), /* isQ */ length_in_bytes == 16);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmaskcmp_zeroF_neon(vReg dst, vReg src, immF0 zero, immI cond) %{
+  predicate(UseSVE == 0);
+  match(Set dst (VectorMaskCmp (Binary src (ReplicateF zero)) cond));
+  format %{ "vmaskcmp_zeroF_neon $dst, $src, #0" %}
+  ins_encode %{
+    uint length_in_bytes = Matcher::vector_length_in_bytes(this);
+    __ neon_compare_zero($dst$$FloatRegister, T_FLOAT, $src$$FloatRegister,
+                         (int)($cond$$constant), /* isQ */ length_in_bytes == 16);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmaskcmp_zeroD_neon(vReg dst, vReg src, immD0 zero, immI cond) %{
+  predicate(UseSVE == 0);
+  match(Set dst (VectorMaskCmp (Binary src (ReplicateD zero)) cond));
+  format %{ "vmaskcmp_zeroD_neon $dst, $src, #0" %}
+  ins_encode %{
+    uint length_in_bytes = Matcher::vector_length_in_bytes(this);
+    __ neon_compare_zero($dst$$FloatRegister, T_DOUBLE, $src$$FloatRegister,
+                         (int)($cond$$constant), /* isQ */ length_in_bytes == 16);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2021, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -3158,6 +3158,11 @@ public:
   INSN(fcvtas, 0, 0b00, 0b01, 0b11100);
   INSN(fcvtzs, 0, 0b10, 0b01, 0b11011);
   INSN(fcvtms, 0, 0b00, 0b01, 0b11011);
+  INSN(fcmgt,  0, 0b10, 0b01, 0b01100); // Floating-point compare greater than zero (vector)
+  INSN(fcmeq,  0, 0b10, 0b01, 0b01101); // Floating-point compare equal to zero (vector)
+  INSN(fcmlt,  0, 0b10, 0b01, 0b01110); // Floating-point compare less than zero (vector)
+  INSN(fcmge,  1, 0b10, 0b01, 0b01100); // Floating-point compare greater than or equal to zero (vector)
+  INSN(fcmle,  1, 0b10, 0b01, 0b01101); // Floating-point compare less than or equal to zero (vector)
 #undef ASSERTION
 
 #define ASSERTION (T == T8B || T == T16B || T == T4H || T == T8H || T == T2S || T == T4S)

--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -915,7 +915,7 @@ void C2_MacroAssembler::neon_compare(FloatRegister dst, BasicType bt, FloatRegis
       case BoolTest::eq: fcmeq(dst, size, src1, src2); break;
       case BoolTest::ne: {
         fcmeq(dst, size, src1, src2);
-        notr(dst, T16B, dst);
+        notr(dst, isQ ? T16B : T8B, dst);
         break;
       }
       case BoolTest::ge: fcmge(dst, size, src1, src2); break;
@@ -931,7 +931,7 @@ void C2_MacroAssembler::neon_compare(FloatRegister dst, BasicType bt, FloatRegis
       case BoolTest::eq: cmeq(dst, size, src1, src2); break;
       case BoolTest::ne: {
         cmeq(dst, size, src1, src2);
-        notr(dst, T16B, dst);
+        notr(dst, isQ ? T16B : T8B, dst);
         break;
       }
       case BoolTest::ge: cmge(dst, size, src1, src2); break;
@@ -942,6 +942,44 @@ void C2_MacroAssembler::neon_compare(FloatRegister dst, BasicType bt, FloatRegis
       case BoolTest::ugt: cmhi(dst, size, src1, src2); break;
       case BoolTest::ult: cmhi(dst, size, src2, src1); break;
       case BoolTest::ule: cmhs(dst, size, src2, src1); break;
+      default:
+        assert(false, "unsupported");
+        ShouldNotReachHere();
+    }
+  }
+}
+
+void C2_MacroAssembler::neon_compare_zero(FloatRegister dst, BasicType bt, FloatRegister src,
+                                          int cond, bool isQ) {
+  SIMD_Arrangement size = esize2arrangement((unsigned)type2aelembytes(bt), isQ);
+  if (bt == T_FLOAT || bt == T_DOUBLE) {
+    switch (cond) {
+      case BoolTest::eq: fcmeq(dst, size, src); break;
+      case BoolTest::ne: {
+        fcmeq(dst, size, src);
+        notr(dst, isQ ? T16B : T8B, dst);
+        break;
+      }
+      case BoolTest::ge: fcmge(dst, size, src); break;
+      case BoolTest::gt: fcmgt(dst, size, src); break;
+      case BoolTest::le: fcmle(dst, size, src); break;
+      case BoolTest::lt: fcmlt(dst, size, src); break;
+      default:
+        assert(false, "unsupported");
+        ShouldNotReachHere();
+    }
+  } else {
+    switch (cond) {
+      case BoolTest::eq: cmeq(dst, size, src); break;
+      case BoolTest::ne: {
+        cmeq(dst, size, src);
+        notr(dst, isQ ? T16B : T8B, dst);
+        break;
+      }
+      case BoolTest::ge: cmge(dst, size, src); break;
+      case BoolTest::gt: cmgt(dst, size, src); break;
+      case BoolTest::le: cmle(dst, size, src); break;
+      case BoolTest::lt: cmlt(dst, size, src); break;
       default:
         assert(false, "unsupported");
         ShouldNotReachHere();

--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,6 +81,9 @@
   // SIMD&FP comparison
   void neon_compare(FloatRegister dst, BasicType bt, FloatRegister src1,
                     FloatRegister src2, int cond, bool isQ);
+
+  void neon_compare_zero(FloatRegister dst, BasicType bt, FloatRegister src,
+                         int cond, bool isQ);
 
   void sve_compare(PRegister pd, BasicType bt, PRegister pg,
                    FloatRegister zn, FloatRegister zm, int cond);

--- a/test/hotspot/gtest/aarch64/asmtest.out.h
+++ b/test/hotspot/gtest/aarch64/asmtest.out.h
@@ -604,170 +604,222 @@
     __ fminp(v0, v1, __ S);                            //       fminp   s0, v1.2S
     __ fminp(v17, v18, __ D);                          //       fminp   d17, v18.2D
 
+// NEONCompareWithZero
+    __ cmgt(v28, __ T8B, v29);                         //       cmgt    v28.8B, v29.8B, #0
+    __ cmgt(v25, __ T16B, v26);                        //       cmgt    v25.16B, v26.16B, #0
+    __ cmgt(v9, __ T4H, v10);                          //       cmgt    v9.4H, v10.4H, #0
+    __ cmgt(v25, __ T8H, v26);                         //       cmgt    v25.8H, v26.8H, #0
+    __ cmgt(v12, __ T2S, v13);                         //       cmgt    v12.2S, v13.2S, #0
+    __ cmgt(v15, __ T4S, v16);                         //       cmgt    v15.4S, v16.4S, #0
+    __ cmgt(v11, __ T2D, v12);                         //       cmgt    v11.2D, v12.2D, #0
+    __ cmge(v10, __ T8B, v11);                         //       cmge    v10.8B, v11.8B, #0
+    __ cmge(v17, __ T16B, v18);                        //       cmge    v17.16B, v18.16B, #0
+    __ cmge(v24, __ T4H, v25);                         //       cmge    v24.4H, v25.4H, #0
+    __ cmge(v21, __ T8H, v22);                         //       cmge    v21.8H, v22.8H, #0
+    __ cmge(v23, __ T2S, v24);                         //       cmge    v23.2S, v24.2S, #0
+    __ cmge(v0, __ T4S, v1);                           //       cmge    v0.4S, v1.4S, #0
+    __ cmge(v16, __ T2D, v17);                         //       cmge    v16.2D, v17.2D, #0
+    __ cmeq(v10, __ T8B, v11);                         //       cmeq    v10.8B, v11.8B, #0
+    __ cmeq(v6, __ T16B, v7);                          //       cmeq    v6.16B, v7.16B, #0
+    __ cmeq(v28, __ T4H, v29);                         //       cmeq    v28.4H, v29.4H, #0
+    __ cmeq(v6, __ T8H, v7);                           //       cmeq    v6.8H, v7.8H, #0
+    __ cmeq(v5, __ T2S, v6);                           //       cmeq    v5.2S, v6.2S, #0
+    __ cmeq(v5, __ T4S, v6);                           //       cmeq    v5.4S, v6.4S, #0
+    __ cmeq(v20, __ T2D, v21);                         //       cmeq    v20.2D, v21.2D, #0
+    __ cmlt(v17, __ T8B, v18);                         //       cmlt    v17.8B, v18.8B, #0
+    __ cmlt(v15, __ T16B, v16);                        //       cmlt    v15.16B, v16.16B, #0
+    __ cmlt(v17, __ T4H, v18);                         //       cmlt    v17.4H, v18.4H, #0
+    __ cmlt(v29, __ T8H, v30);                         //       cmlt    v29.8H, v30.8H, #0
+    __ cmlt(v26, __ T2S, v27);                         //       cmlt    v26.2S, v27.2S, #0
+    __ cmlt(v28, __ T4S, v29);                         //       cmlt    v28.4S, v29.4S, #0
+    __ cmlt(v1, __ T2D, v2);                           //       cmlt    v1.2D, v2.2D, #0
+    __ cmle(v27, __ T8B, v28);                         //       cmle    v27.8B, v28.8B, #0
+    __ cmle(v0, __ T16B, v1);                          //       cmle    v0.16B, v1.16B, #0
+    __ cmle(v20, __ T4H, v21);                         //       cmle    v20.4H, v21.4H, #0
+    __ cmle(v28, __ T8H, v29);                         //       cmle    v28.8H, v29.8H, #0
+    __ cmle(v15, __ T2S, v16);                         //       cmle    v15.2S, v16.2S, #0
+    __ cmle(v12, __ T4S, v13);                         //       cmle    v12.4S, v13.4S, #0
+    __ cmle(v10, __ T2D, v11);                         //       cmle    v10.2D, v11.2D, #0
+    __ fcmgt(v28, __ T2S, v29);                        //       fcmgt   v28.2S, v29.2S, #0
+    __ fcmgt(v28, __ T4S, v29);                        //       fcmgt   v28.4S, v29.4S, #0
+    __ fcmgt(v19, __ T2D, v20);                        //       fcmgt   v19.2D, v20.2D, #0
+    __ fcmge(v22, __ T2S, v23);                        //       fcmge   v22.2S, v23.2S, #0
+    __ fcmge(v10, __ T4S, v11);                        //       fcmge   v10.4S, v11.4S, #0
+    __ fcmge(v4, __ T2D, v5);                          //       fcmge   v4.2D, v5.2D, #0
+    __ fcmeq(v30, __ T2S, v31);                        //       fcmeq   v30.2S, v31.2S, #0
+    __ fcmeq(v20, __ T4S, v21);                        //       fcmeq   v20.4S, v21.4S, #0
+    __ fcmeq(v8, __ T2D, v9);                          //       fcmeq   v8.2D, v9.2D, #0
+    __ fcmlt(v30, __ T2S, v31);                        //       fcmlt   v30.2S, v31.2S, #0
+    __ fcmlt(v17, __ T4S, v18);                        //       fcmlt   v17.4S, v18.4S, #0
+    __ fcmlt(v10, __ T2D, v11);                        //       fcmlt   v10.2D, v11.2D, #0
+    __ fcmle(v27, __ T2S, v28);                        //       fcmle   v27.2S, v28.2S, #0
+    __ fcmle(v2, __ T4S, v3);                          //       fcmle   v2.4S, v3.4S, #0
+    __ fcmle(v24, __ T2D, v25);                        //       fcmle   v24.2D, v25.2D, #0
+
 // TwoRegNEONOp
-    __ absr(v28, __ T8B, v29);                         //       abs     v28.8B, v29.8B
-    __ absr(v25, __ T16B, v26);                        //       abs     v25.16B, v26.16B
-    __ absr(v9, __ T4H, v10);                          //       abs     v9.4H, v10.4H
-    __ absr(v25, __ T8H, v26);                         //       abs     v25.8H, v26.8H
-    __ absr(v12, __ T2S, v13);                         //       abs     v12.2S, v13.2S
-    __ absr(v15, __ T4S, v16);                         //       abs     v15.4S, v16.4S
-    __ absr(v11, __ T2D, v12);                         //       abs     v11.2D, v12.2D
-    __ fabs(v10, __ T2S, v11);                         //       fabs    v10.2S, v11.2S
-    __ fabs(v17, __ T4S, v18);                         //       fabs    v17.4S, v18.4S
-    __ fabs(v24, __ T2D, v25);                         //       fabs    v24.2D, v25.2D
-    __ fneg(v21, __ T2S, v22);                         //       fneg    v21.2S, v22.2S
-    __ fneg(v23, __ T4S, v24);                         //       fneg    v23.4S, v24.4S
-    __ fneg(v0, __ T2D, v1);                           //       fneg    v0.2D, v1.2D
-    __ fsqrt(v16, __ T2S, v17);                        //       fsqrt   v16.2S, v17.2S
-    __ fsqrt(v10, __ T4S, v11);                        //       fsqrt   v10.4S, v11.4S
-    __ fsqrt(v6, __ T2D, v7);                          //       fsqrt   v6.2D, v7.2D
-    __ notr(v28, __ T8B, v29);                         //       not     v28.8B, v29.8B
-    __ notr(v6, __ T16B, v7);                          //       not     v6.16B, v7.16B
+    __ absr(v4, __ T8B, v5);                           //       abs     v4.8B, v5.8B
+    __ absr(v3, __ T16B, v4);                          //       abs     v3.16B, v4.16B
+    __ absr(v8, __ T4H, v9);                           //       abs     v8.4H, v9.4H
+    __ absr(v22, __ T8H, v23);                         //       abs     v22.8H, v23.8H
+    __ absr(v17, __ T2S, v18);                         //       abs     v17.2S, v18.2S
+    __ absr(v13, __ T4S, v14);                         //       abs     v13.4S, v14.4S
+    __ absr(v4, __ T2D, v5);                           //       abs     v4.2D, v5.2D
+    __ fabs(v28, __ T2S, v29);                         //       fabs    v28.2S, v29.2S
+    __ fabs(v23, __ T4S, v24);                         //       fabs    v23.4S, v24.4S
+    __ fabs(v21, __ T2D, v22);                         //       fabs    v21.2D, v22.2D
+    __ fneg(v25, __ T2S, v26);                         //       fneg    v25.2S, v26.2S
+    __ fneg(v24, __ T4S, v25);                         //       fneg    v24.4S, v25.4S
+    __ fneg(v3, __ T2D, v4);                           //       fneg    v3.2D, v4.2D
+    __ fsqrt(v23, __ T2S, v24);                        //       fsqrt   v23.2S, v24.2S
+    __ fsqrt(v26, __ T4S, v27);                        //       fsqrt   v26.4S, v27.4S
+    __ fsqrt(v23, __ T2D, v24);                        //       fsqrt   v23.2D, v24.2D
+    __ notr(v14, __ T8B, v15);                         //       not     v14.8B, v15.8B
+    __ notr(v21, __ T16B, v22);                        //       not     v21.16B, v22.16B
 
 // ThreeRegNEONOp
-    __ andr(v5, __ T8B, v6, v7);                       //       and     v5.8B, v6.8B, v7.8B
-    __ andr(v5, __ T16B, v6, v7);                      //       and     v5.16B, v6.16B, v7.16B
-    __ orr(v20, __ T8B, v21, v22);                     //       orr     v20.8B, v21.8B, v22.8B
-    __ orr(v17, __ T16B, v18, v19);                    //       orr     v17.16B, v18.16B, v19.16B
-    __ eor(v15, __ T8B, v16, v17);                     //       eor     v15.8B, v16.8B, v17.8B
-    __ eor(v17, __ T16B, v18, v19);                    //       eor     v17.16B, v18.16B, v19.16B
-    __ addv(v29, __ T8B, v30, v31);                    //       add     v29.8B, v30.8B, v31.8B
-    __ addv(v26, __ T16B, v27, v28);                   //       add     v26.16B, v27.16B, v28.16B
-    __ addv(v28, __ T4H, v29, v30);                    //       add     v28.4H, v29.4H, v30.4H
-    __ addv(v1, __ T8H, v2, v3);                       //       add     v1.8H, v2.8H, v3.8H
-    __ addv(v27, __ T2S, v28, v29);                    //       add     v27.2S, v28.2S, v29.2S
-    __ addv(v0, __ T4S, v1, v2);                       //       add     v0.4S, v1.4S, v2.4S
-    __ addv(v20, __ T2D, v21, v22);                    //       add     v20.2D, v21.2D, v22.2D
-    __ fadd(v28, __ T2S, v29, v30);                    //       fadd    v28.2S, v29.2S, v30.2S
-    __ fadd(v15, __ T4S, v16, v17);                    //       fadd    v15.4S, v16.4S, v17.4S
-    __ fadd(v12, __ T2D, v13, v14);                    //       fadd    v12.2D, v13.2D, v14.2D
-    __ subv(v10, __ T8B, v11, v12);                    //       sub     v10.8B, v11.8B, v12.8B
-    __ subv(v28, __ T16B, v29, v30);                   //       sub     v28.16B, v29.16B, v30.16B
-    __ subv(v28, __ T4H, v29, v30);                    //       sub     v28.4H, v29.4H, v30.4H
-    __ subv(v19, __ T8H, v20, v21);                    //       sub     v19.8H, v20.8H, v21.8H
-    __ subv(v22, __ T2S, v23, v24);                    //       sub     v22.2S, v23.2S, v24.2S
-    __ subv(v10, __ T4S, v11, v12);                    //       sub     v10.4S, v11.4S, v12.4S
-    __ subv(v4, __ T2D, v5, v6);                       //       sub     v4.2D, v5.2D, v6.2D
-    __ fsub(v30, __ T2S, v31, v0);                     //       fsub    v30.2S, v31.2S, v0.2S
-    __ fsub(v20, __ T4S, v21, v22);                    //       fsub    v20.4S, v21.4S, v22.4S
-    __ fsub(v8, __ T2D, v9, v10);                      //       fsub    v8.2D, v9.2D, v10.2D
-    __ mulv(v30, __ T8B, v31, v0);                     //       mul     v30.8B, v31.8B, v0.8B
-    __ mulv(v17, __ T16B, v18, v19);                   //       mul     v17.16B, v18.16B, v19.16B
-    __ mulv(v10, __ T4H, v11, v12);                    //       mul     v10.4H, v11.4H, v12.4H
-    __ mulv(v27, __ T8H, v28, v29);                    //       mul     v27.8H, v28.8H, v29.8H
-    __ mulv(v2, __ T2S, v3, v4);                       //       mul     v2.2S, v3.2S, v4.2S
-    __ mulv(v24, __ T4S, v25, v26);                    //       mul     v24.4S, v25.4S, v26.4S
-    __ fabd(v4, __ T2S, v5, v6);                       //       fabd    v4.2S, v5.2S, v6.2S
-    __ fabd(v3, __ T4S, v4, v5);                       //       fabd    v3.4S, v4.4S, v5.4S
-    __ fabd(v8, __ T2D, v9, v10);                      //       fabd    v8.2D, v9.2D, v10.2D
-    __ faddp(v22, __ T2S, v23, v24);                   //       faddp   v22.2S, v23.2S, v24.2S
-    __ faddp(v17, __ T4S, v18, v19);                   //       faddp   v17.4S, v18.4S, v19.4S
-    __ faddp(v13, __ T2D, v14, v15);                   //       faddp   v13.2D, v14.2D, v15.2D
-    __ fmul(v4, __ T2S, v5, v6);                       //       fmul    v4.2S, v5.2S, v6.2S
-    __ fmul(v28, __ T4S, v29, v30);                    //       fmul    v28.4S, v29.4S, v30.4S
-    __ fmul(v23, __ T2D, v24, v25);                    //       fmul    v23.2D, v24.2D, v25.2D
-    __ mlav(v21, __ T4H, v22, v23);                    //       mla     v21.4H, v22.4H, v23.4H
+    __ andr(v3, __ T8B, v4, v5);                       //       and     v3.8B, v4.8B, v5.8B
+    __ andr(v23, __ T16B, v24, v25);                   //       and     v23.16B, v24.16B, v25.16B
+    __ orr(v8, __ T8B, v9, v10);                       //       orr     v8.8B, v9.8B, v10.8B
+    __ orr(v24, __ T16B, v25, v26);                    //       orr     v24.16B, v25.16B, v26.16B
+    __ eor(v19, __ T8B, v20, v21);                     //       eor     v19.8B, v20.8B, v21.8B
+    __ eor(v15, __ T16B, v16, v17);                    //       eor     v15.16B, v16.16B, v17.16B
+    __ addv(v16, __ T8B, v17, v18);                    //       add     v16.8B, v17.8B, v18.8B
+    __ addv(v2, __ T16B, v3, v4);                      //       add     v2.16B, v3.16B, v4.16B
+    __ addv(v1, __ T4H, v2, v3);                       //       add     v1.4H, v2.4H, v3.4H
+    __ addv(v0, __ T8H, v1, v2);                       //       add     v0.8H, v1.8H, v2.8H
+    __ addv(v24, __ T2S, v25, v26);                    //       add     v24.2S, v25.2S, v26.2S
+    __ addv(v4, __ T4S, v5, v6);                       //       add     v4.4S, v5.4S, v6.4S
+    __ addv(v3, __ T2D, v4, v5);                       //       add     v3.2D, v4.2D, v5.2D
+    __ fadd(v11, __ T2S, v12, v13);                    //       fadd    v11.2S, v12.2S, v13.2S
+    __ fadd(v30, __ T4S, v31, v0);                     //       fadd    v30.4S, v31.4S, v0.4S
+    __ fadd(v27, __ T2D, v28, v29);                    //       fadd    v27.2D, v28.2D, v29.2D
+    __ subv(v9, __ T8B, v10, v11);                     //       sub     v9.8B, v10.8B, v11.8B
+    __ subv(v25, __ T16B, v26, v27);                   //       sub     v25.16B, v26.16B, v27.16B
+    __ subv(v2, __ T4H, v3, v4);                       //       sub     v2.4H, v3.4H, v4.4H
+    __ subv(v12, __ T8H, v13, v14);                    //       sub     v12.8H, v13.8H, v14.8H
+    __ subv(v17, __ T2S, v18, v19);                    //       sub     v17.2S, v18.2S, v19.2S
+    __ subv(v30, __ T4S, v31, v0);                     //       sub     v30.4S, v31.4S, v0.4S
+    __ subv(v1, __ T2D, v2, v3);                       //       sub     v1.2D, v2.2D, v3.2D
+    __ fsub(v12, __ T2S, v13, v14);                    //       fsub    v12.2S, v13.2S, v14.2S
+    __ fsub(v28, __ T4S, v29, v30);                    //       fsub    v28.4S, v29.4S, v30.4S
+    __ fsub(v0, __ T2D, v1, v2);                       //       fsub    v0.2D, v1.2D, v2.2D
+    __ mulv(v17, __ T8B, v18, v19);                    //       mul     v17.8B, v18.8B, v19.8B
+    __ mulv(v12, __ T16B, v13, v14);                   //       mul     v12.16B, v13.16B, v14.16B
+    __ mulv(v17, __ T4H, v18, v19);                    //       mul     v17.4H, v18.4H, v19.4H
+    __ mulv(v21, __ T8H, v22, v23);                    //       mul     v21.8H, v22.8H, v23.8H
+    __ mulv(v12, __ T2S, v13, v14);                    //       mul     v12.2S, v13.2S, v14.2S
+    __ mulv(v27, __ T4S, v28, v29);                    //       mul     v27.4S, v28.4S, v29.4S
+    __ fabd(v29, __ T2S, v30, v31);                    //       fabd    v29.2S, v30.2S, v31.2S
+    __ fabd(v30, __ T4S, v31, v0);                     //       fabd    v30.4S, v31.4S, v0.4S
+    __ fabd(v1, __ T2D, v2, v3);                       //       fabd    v1.2D, v2.2D, v3.2D
+    __ faddp(v25, __ T2S, v26, v27);                   //       faddp   v25.2S, v26.2S, v27.2S
+    __ faddp(v27, __ T4S, v28, v29);                   //       faddp   v27.4S, v28.4S, v29.4S
+    __ faddp(v4, __ T2D, v5, v6);                      //       faddp   v4.2D, v5.2D, v6.2D
+    __ fmul(v29, __ T2S, v30, v31);                    //       fmul    v29.2S, v30.2S, v31.2S
+    __ fmul(v3, __ T4S, v4, v5);                       //       fmul    v3.4S, v4.4S, v5.4S
+    __ fmul(v6, __ T2D, v7, v8);                       //       fmul    v6.2D, v7.2D, v8.2D
+    __ mlav(v29, __ T4H, v30, v31);                    //       mla     v29.4H, v30.4H, v31.4H
     __ mlav(v25, __ T8H, v26, v27);                    //       mla     v25.8H, v26.8H, v27.8H
-    __ mlav(v24, __ T2S, v25, v26);                    //       mla     v24.2S, v25.2S, v26.2S
-    __ mlav(v3, __ T4S, v4, v5);                       //       mla     v3.4S, v4.4S, v5.4S
-    __ fmla(v23, __ T2S, v24, v25);                    //       fmla    v23.2S, v24.2S, v25.2S
-    __ fmla(v26, __ T4S, v27, v28);                    //       fmla    v26.4S, v27.4S, v28.4S
-    __ fmla(v23, __ T2D, v24, v25);                    //       fmla    v23.2D, v24.2D, v25.2D
-    __ mlsv(v14, __ T4H, v15, v16);                    //       mls     v14.4H, v15.4H, v16.4H
-    __ mlsv(v21, __ T8H, v22, v23);                    //       mls     v21.8H, v22.8H, v23.8H
-    __ mlsv(v3, __ T2S, v4, v5);                       //       mls     v3.2S, v4.2S, v5.2S
-    __ mlsv(v23, __ T4S, v24, v25);                    //       mls     v23.4S, v24.4S, v25.4S
-    __ fmls(v8, __ T2S, v9, v10);                      //       fmls    v8.2S, v9.2S, v10.2S
-    __ fmls(v24, __ T4S, v25, v26);                    //       fmls    v24.4S, v25.4S, v26.4S
-    __ fmls(v19, __ T2D, v20, v21);                    //       fmls    v19.2D, v20.2D, v21.2D
-    __ fdiv(v15, __ T2S, v16, v17);                    //       fdiv    v15.2S, v16.2S, v17.2S
-    __ fdiv(v16, __ T4S, v17, v18);                    //       fdiv    v16.4S, v17.4S, v18.4S
-    __ fdiv(v2, __ T2D, v3, v4);                       //       fdiv    v2.2D, v3.2D, v4.2D
-    __ maxv(v1, __ T8B, v2, v3);                       //       smax    v1.8B, v2.8B, v3.8B
-    __ maxv(v0, __ T16B, v1, v2);                      //       smax    v0.16B, v1.16B, v2.16B
-    __ maxv(v24, __ T4H, v25, v26);                    //       smax    v24.4H, v25.4H, v26.4H
-    __ maxv(v4, __ T8H, v5, v6);                       //       smax    v4.8H, v5.8H, v6.8H
-    __ maxv(v3, __ T2S, v4, v5);                       //       smax    v3.2S, v4.2S, v5.2S
-    __ maxv(v11, __ T4S, v12, v13);                    //       smax    v11.4S, v12.4S, v13.4S
-    __ smaxp(v30, __ T8B, v31, v0);                    //       smaxp   v30.8B, v31.8B, v0.8B
-    __ smaxp(v27, __ T16B, v28, v29);                  //       smaxp   v27.16B, v28.16B, v29.16B
-    __ smaxp(v9, __ T4H, v10, v11);                    //       smaxp   v9.4H, v10.4H, v11.4H
-    __ smaxp(v25, __ T8H, v26, v27);                   //       smaxp   v25.8H, v26.8H, v27.8H
-    __ smaxp(v2, __ T2S, v3, v4);                      //       smaxp   v2.2S, v3.2S, v4.2S
-    __ smaxp(v12, __ T4S, v13, v14);                   //       smaxp   v12.4S, v13.4S, v14.4S
-    __ fmax(v17, __ T2S, v18, v19);                    //       fmax    v17.2S, v18.2S, v19.2S
-    __ fmax(v30, __ T4S, v31, v0);                     //       fmax    v30.4S, v31.4S, v0.4S
-    __ fmax(v1, __ T2D, v2, v3);                       //       fmax    v1.2D, v2.2D, v3.2D
+    __ mlav(v17, __ T2S, v18, v19);                    //       mla     v17.2S, v18.2S, v19.2S
+    __ mlav(v8, __ T4S, v9, v10);                      //       mla     v8.4S, v9.4S, v10.4S
+    __ fmla(v7, __ T2S, v8, v9);                       //       fmla    v7.2S, v8.2S, v9.2S
+    __ fmla(v12, __ T4S, v13, v14);                    //       fmla    v12.4S, v13.4S, v14.4S
+    __ fmla(v0, __ T2D, v1, v2);                       //       fmla    v0.2D, v1.2D, v2.2D
+    __ mlsv(v19, __ T4H, v20, v21);                    //       mls     v19.4H, v20.4H, v21.4H
+    __ mlsv(v1, __ T8H, v2, v3);                       //       mls     v1.8H, v2.8H, v3.8H
+    __ mlsv(v23, __ T2S, v24, v25);                    //       mls     v23.2S, v24.2S, v25.2S
+    __ mlsv(v2, __ T4S, v3, v4);                       //       mls     v2.4S, v3.4S, v4.4S
+    __ fmls(v0, __ T2S, v1, v2);                       //       fmls    v0.2S, v1.2S, v2.2S
+    __ fmls(v8, __ T4S, v9, v10);                      //       fmls    v8.4S, v9.4S, v10.4S
+    __ fmls(v23, __ T2D, v24, v25);                    //       fmls    v23.2D, v24.2D, v25.2D
+    __ fdiv(v25, __ T2S, v26, v27);                    //       fdiv    v25.2S, v26.2S, v27.2S
+    __ fdiv(v15, __ T4S, v16, v17);                    //       fdiv    v15.4S, v16.4S, v17.4S
+    __ fdiv(v29, __ T2D, v30, v31);                    //       fdiv    v29.2D, v30.2D, v31.2D
+    __ maxv(v3, __ T8B, v4, v5);                       //       smax    v3.8B, v4.8B, v5.8B
+    __ maxv(v10, __ T16B, v11, v12);                   //       smax    v10.16B, v11.16B, v12.16B
+    __ maxv(v22, __ T4H, v23, v24);                    //       smax    v22.4H, v23.4H, v24.4H
+    __ maxv(v10, __ T8H, v11, v12);                    //       smax    v10.8H, v11.8H, v12.8H
+    __ maxv(v4, __ T2S, v5, v6);                       //       smax    v4.2S, v5.2S, v6.2S
+    __ maxv(v17, __ T4S, v18, v19);                    //       smax    v17.4S, v18.4S, v19.4S
+    __ smaxp(v1, __ T8B, v2, v3);                      //       smaxp   v1.8B, v2.8B, v3.8B
+    __ smaxp(v11, __ T16B, v12, v13);                  //       smaxp   v11.16B, v12.16B, v13.16B
+    __ smaxp(v7, __ T4H, v8, v9);                      //       smaxp   v7.4H, v8.4H, v9.4H
+    __ smaxp(v10, __ T8H, v11, v12);                   //       smaxp   v10.8H, v11.8H, v12.8H
+    __ smaxp(v15, __ T2S, v16, v17);                   //       smaxp   v15.2S, v16.2S, v17.2S
+    __ smaxp(v16, __ T4S, v17, v18);                   //       smaxp   v16.4S, v17.4S, v18.4S
+    __ fmax(v2, __ T2S, v3, v4);                       //       fmax    v2.2S, v3.2S, v4.2S
+    __ fmax(v9, __ T4S, v10, v11);                     //       fmax    v9.4S, v10.4S, v11.4S
+    __ fmax(v11, __ T2D, v12, v13);                    //       fmax    v11.2D, v12.2D, v13.2D
     __ minv(v12, __ T8B, v13, v14);                    //       smin    v12.8B, v13.8B, v14.8B
-    __ minv(v28, __ T16B, v29, v30);                   //       smin    v28.16B, v29.16B, v30.16B
-    __ minv(v0, __ T4H, v1, v2);                       //       smin    v0.4H, v1.4H, v2.4H
-    __ minv(v17, __ T8H, v18, v19);                    //       smin    v17.8H, v18.8H, v19.8H
-    __ minv(v12, __ T2S, v13, v14);                    //       smin    v12.2S, v13.2S, v14.2S
-    __ minv(v17, __ T4S, v18, v19);                    //       smin    v17.4S, v18.4S, v19.4S
-    __ sminp(v21, __ T8B, v22, v23);                   //       sminp   v21.8B, v22.8B, v23.8B
-    __ sminp(v12, __ T16B, v13, v14);                  //       sminp   v12.16B, v13.16B, v14.16B
-    __ sminp(v27, __ T4H, v28, v29);                   //       sminp   v27.4H, v28.4H, v29.4H
-    __ sminp(v29, __ T8H, v30, v31);                   //       sminp   v29.8H, v30.8H, v31.8H
-    __ sminp(v30, __ T2S, v31, v0);                    //       sminp   v30.2S, v31.2S, v0.2S
-    __ sminp(v1, __ T4S, v2, v3);                      //       sminp   v1.4S, v2.4S, v3.4S
-    __ fmin(v25, __ T2S, v26, v27);                    //       fmin    v25.2S, v26.2S, v27.2S
-    __ fmin(v27, __ T4S, v28, v29);                    //       fmin    v27.4S, v28.4S, v29.4S
-    __ fmin(v4, __ T2D, v5, v6);                       //       fmin    v4.2D, v5.2D, v6.2D
-    __ cmeq(v29, __ T8B, v30, v31);                    //       cmeq    v29.8B, v30.8B, v31.8B
-    __ cmeq(v3, __ T16B, v4, v5);                      //       cmeq    v3.16B, v4.16B, v5.16B
-    __ cmeq(v6, __ T4H, v7, v8);                       //       cmeq    v6.4H, v7.4H, v8.4H
-    __ cmeq(v29, __ T8H, v30, v31);                    //       cmeq    v29.8H, v30.8H, v31.8H
-    __ cmeq(v25, __ T2S, v26, v27);                    //       cmeq    v25.2S, v26.2S, v27.2S
-    __ cmeq(v17, __ T4S, v18, v19);                    //       cmeq    v17.4S, v18.4S, v19.4S
-    __ cmeq(v8, __ T2D, v9, v10);                      //       cmeq    v8.2D, v9.2D, v10.2D
-    __ fcmeq(v7, __ T2S, v8, v9);                      //       fcmeq   v7.2S, v8.2S, v9.2S
-    __ fcmeq(v12, __ T4S, v13, v14);                   //       fcmeq   v12.4S, v13.4S, v14.4S
-    __ fcmeq(v0, __ T2D, v1, v2);                      //       fcmeq   v0.2D, v1.2D, v2.2D
-    __ cmgt(v19, __ T8B, v20, v21);                    //       cmgt    v19.8B, v20.8B, v21.8B
+    __ minv(v14, __ T16B, v15, v16);                   //       smin    v14.16B, v15.16B, v16.16B
+    __ minv(v13, __ T4H, v14, v15);                    //       smin    v13.4H, v14.4H, v15.4H
+    __ minv(v2, __ T8H, v3, v4);                       //       smin    v2.8H, v3.8H, v4.8H
+    __ minv(v6, __ T2S, v7, v8);                       //       smin    v6.2S, v7.2S, v8.2S
+    __ minv(v19, __ T4S, v20, v21);                    //       smin    v19.4S, v20.4S, v21.4S
+    __ sminp(v25, __ T8B, v26, v27);                   //       sminp   v25.8B, v26.8B, v27.8B
+    __ sminp(v15, __ T16B, v16, v17);                  //       sminp   v15.16B, v16.16B, v17.16B
+    __ sminp(v4, __ T4H, v5, v6);                      //       sminp   v4.4H, v5.4H, v6.4H
+    __ sminp(v2, __ T8H, v3, v4);                      //       sminp   v2.8H, v3.8H, v4.8H
+    __ sminp(v4, __ T2S, v5, v6);                      //       sminp   v4.2S, v5.2S, v6.2S
+    __ sminp(v11, __ T4S, v12, v13);                   //       sminp   v11.4S, v12.4S, v13.4S
+    __ fmin(v17, __ T2S, v18, v19);                    //       fmin    v17.2S, v18.2S, v19.2S
+    __ fmin(v20, __ T4S, v21, v22);                    //       fmin    v20.4S, v21.4S, v22.4S
+    __ fmin(v16, __ T2D, v17, v18);                    //       fmin    v16.2D, v17.2D, v18.2D
+    __ cmeq(v17, __ T8B, v18, v19);                    //       cmeq    v17.8B, v18.8B, v19.8B
+    __ cmeq(v10, __ T16B, v11, v12);                   //       cmeq    v10.16B, v11.16B, v12.16B
+    __ cmeq(v20, __ T4H, v21, v22);                    //       cmeq    v20.4H, v21.4H, v22.4H
+    __ cmeq(v22, __ T8H, v23, v24);                    //       cmeq    v22.8H, v23.8H, v24.8H
+    __ cmeq(v12, __ T2S, v13, v14);                    //       cmeq    v12.2S, v13.2S, v14.2S
+    __ cmeq(v25, __ T4S, v26, v27);                    //       cmeq    v25.4S, v26.4S, v27.4S
+    __ cmeq(v23, __ T2D, v24, v25);                    //       cmeq    v23.2D, v24.2D, v25.2D
+    __ fcmeq(v28, __ T2S, v29, v30);                   //       fcmeq   v28.2S, v29.2S, v30.2S
+    __ fcmeq(v14, __ T4S, v15, v16);                   //       fcmeq   v14.4S, v15.4S, v16.4S
+    __ fcmeq(v10, __ T2D, v11, v12);                   //       fcmeq   v10.2D, v11.2D, v12.2D
+    __ cmgt(v24, __ T8B, v25, v26);                    //       cmgt    v24.8B, v25.8B, v26.8B
     __ cmgt(v1, __ T16B, v2, v3);                      //       cmgt    v1.16B, v2.16B, v3.16B
-    __ cmgt(v23, __ T4H, v24, v25);                    //       cmgt    v23.4H, v24.4H, v25.4H
-    __ cmgt(v2, __ T8H, v3, v4);                       //       cmgt    v2.8H, v3.8H, v4.8H
-    __ cmgt(v0, __ T2S, v1, v2);                       //       cmgt    v0.2S, v1.2S, v2.2S
-    __ cmgt(v8, __ T4S, v9, v10);                      //       cmgt    v8.4S, v9.4S, v10.4S
-    __ cmgt(v23, __ T2D, v24, v25);                    //       cmgt    v23.2D, v24.2D, v25.2D
-    __ cmhi(v25, __ T8B, v26, v27);                    //       cmhi    v25.8B, v26.8B, v27.8B
-    __ cmhi(v15, __ T16B, v16, v17);                   //       cmhi    v15.16B, v16.16B, v17.16B
-    __ cmhi(v29, __ T4H, v30, v31);                    //       cmhi    v29.4H, v30.4H, v31.4H
-    __ cmhi(v3, __ T8H, v4, v5);                       //       cmhi    v3.8H, v4.8H, v5.8H
-    __ cmhi(v10, __ T2S, v11, v12);                    //       cmhi    v10.2S, v11.2S, v12.2S
-    __ cmhi(v22, __ T4S, v23, v24);                    //       cmhi    v22.4S, v23.4S, v24.4S
-    __ cmhi(v10, __ T2D, v11, v12);                    //       cmhi    v10.2D, v11.2D, v12.2D
-    __ cmhs(v4, __ T8B, v5, v6);                       //       cmhs    v4.8B, v5.8B, v6.8B
-    __ cmhs(v17, __ T16B, v18, v19);                   //       cmhs    v17.16B, v18.16B, v19.16B
-    __ cmhs(v1, __ T4H, v2, v3);                       //       cmhs    v1.4H, v2.4H, v3.4H
-    __ cmhs(v11, __ T8H, v12, v13);                    //       cmhs    v11.8H, v12.8H, v13.8H
-    __ cmhs(v7, __ T2S, v8, v9);                       //       cmhs    v7.2S, v8.2S, v9.2S
-    __ cmhs(v10, __ T4S, v11, v12);                    //       cmhs    v10.4S, v11.4S, v12.4S
-    __ cmhs(v15, __ T2D, v16, v17);                    //       cmhs    v15.2D, v16.2D, v17.2D
-    __ fcmgt(v16, __ T2S, v17, v18);                   //       fcmgt   v16.2S, v17.2S, v18.2S
-    __ fcmgt(v2, __ T4S, v3, v4);                      //       fcmgt   v2.4S, v3.4S, v4.4S
-    __ fcmgt(v9, __ T2D, v10, v11);                    //       fcmgt   v9.2D, v10.2D, v11.2D
-    __ cmge(v11, __ T8B, v12, v13);                    //       cmge    v11.8B, v12.8B, v13.8B
-    __ cmge(v12, __ T16B, v13, v14);                   //       cmge    v12.16B, v13.16B, v14.16B
-    __ cmge(v14, __ T4H, v15, v16);                    //       cmge    v14.4H, v15.4H, v16.4H
-    __ cmge(v13, __ T8H, v14, v15);                    //       cmge    v13.8H, v14.8H, v15.8H
-    __ cmge(v2, __ T2S, v3, v4);                       //       cmge    v2.2S, v3.2S, v4.2S
-    __ cmge(v6, __ T4S, v7, v8);                       //       cmge    v6.4S, v7.4S, v8.4S
-    __ cmge(v19, __ T2D, v20, v21);                    //       cmge    v19.2D, v20.2D, v21.2D
-    __ fcmge(v25, __ T2S, v26, v27);                   //       fcmge   v25.2S, v26.2S, v27.2S
-    __ fcmge(v15, __ T4S, v16, v17);                   //       fcmge   v15.4S, v16.4S, v17.4S
-    __ fcmge(v4, __ T2D, v5, v6);                      //       fcmge   v4.2D, v5.2D, v6.2D
-    __ facgt(v2, __ T2S, v3, v4);                      //       facgt   v2.2S, v3.2S, v4.2S
-    __ facgt(v4, __ T4S, v5, v6);                      //       facgt   v4.4S, v5.4S, v6.4S
-    __ facgt(v11, __ T2D, v12, v13);                   //       facgt   v11.2D, v12.2D, v13.2D
+    __ cmgt(v11, __ T4H, v12, v13);                    //       cmgt    v11.4H, v12.4H, v13.4H
+    __ cmgt(v30, __ T8H, v31, v0);                     //       cmgt    v30.8H, v31.8H, v0.8H
+    __ cmgt(v10, __ T2S, v11, v12);                    //       cmgt    v10.2S, v11.2S, v12.2S
+    __ cmgt(v15, __ T4S, v16, v17);                    //       cmgt    v15.4S, v16.4S, v17.4S
+    __ cmgt(v7, __ T2D, v8, v9);                       //       cmgt    v7.2D, v8.2D, v9.2D
+    __ cmhi(v2, __ T8B, v3, v4);                       //       cmhi    v2.8B, v3.8B, v4.8B
+    __ cmhi(v3, __ T16B, v4, v5);                      //       cmhi    v3.16B, v4.16B, v5.16B
+    __ cmhi(v13, __ T4H, v14, v15);                    //       cmhi    v13.4H, v14.4H, v15.4H
+    __ cmhi(v19, __ T8H, v20, v21);                    //       cmhi    v19.8H, v20.8H, v21.8H
+    __ cmhi(v16, __ T2S, v17, v18);                    //       cmhi    v16.2S, v17.2S, v18.2S
+    __ cmhi(v16, __ T4S, v17, v18);                    //       cmhi    v16.4S, v17.4S, v18.4S
+    __ cmhi(v3, __ T2D, v4, v5);                       //       cmhi    v3.2D, v4.2D, v5.2D
+    __ cmhs(v1, __ T8B, v2, v3);                       //       cmhs    v1.8B, v2.8B, v3.8B
+    __ cmhs(v11, __ T16B, v12, v13);                   //       cmhs    v11.16B, v12.16B, v13.16B
+    __ cmhs(v29, __ T4H, v30, v31);                    //       cmhs    v29.4H, v30.4H, v31.4H
+    __ cmhs(v5, __ T8H, v6, v7);                       //       cmhs    v5.8H, v6.8H, v7.8H
+    __ cmhs(v8, __ T2S, v9, v10);                      //       cmhs    v8.2S, v9.2S, v10.2S
+    __ cmhs(v14, __ T4S, v15, v16);                    //       cmhs    v14.4S, v15.4S, v16.4S
+    __ cmhs(v28, __ T2D, v29, v30);                    //       cmhs    v28.2D, v29.2D, v30.2D
+    __ fcmgt(v29, __ T2S, v30, v31);                   //       fcmgt   v29.2S, v30.2S, v31.2S
+    __ fcmgt(v0, __ T4S, v1, v2);                      //       fcmgt   v0.4S, v1.4S, v2.4S
+    __ fcmgt(v20, __ T2D, v21, v22);                   //       fcmgt   v20.2D, v21.2D, v22.2D
+    __ cmge(v7, __ T8B, v8, v9);                       //       cmge    v7.8B, v8.8B, v9.8B
+    __ cmge(v20, __ T16B, v21, v22);                   //       cmge    v20.16B, v21.16B, v22.16B
+    __ cmge(v23, __ T4H, v24, v25);                    //       cmge    v23.4H, v24.4H, v25.4H
+    __ cmge(v27, __ T8H, v28, v29);                    //       cmge    v27.8H, v28.8H, v29.8H
+    __ cmge(v21, __ T2S, v22, v23);                    //       cmge    v21.2S, v22.2S, v23.2S
+    __ cmge(v26, __ T4S, v27, v28);                    //       cmge    v26.4S, v27.4S, v28.4S
+    __ cmge(v24, __ T2D, v25, v26);                    //       cmge    v24.2D, v25.2D, v26.2D
+    __ fcmge(v4, __ T2S, v5, v6);                      //       fcmge   v4.2S, v5.2S, v6.2S
+    __ fcmge(v1, __ T4S, v2, v3);                      //       fcmge   v1.4S, v2.4S, v3.4S
+    __ fcmge(v22, __ T2D, v23, v24);                   //       fcmge   v22.2D, v23.2D, v24.2D
+    __ facgt(v16, __ T2S, v17, v18);                   //       facgt   v16.2S, v17.2S, v18.2S
+    __ facgt(v30, __ T4S, v31, v0);                    //       facgt   v30.4S, v31.4S, v0.4S
+    __ facgt(v5, __ T2D, v6, v7);                      //       facgt   v5.2D, v6.2D, v7.2D
 
 // SVEComparisonWithZero
-    __ sve_fcm(Assembler::EQ, p9, __ D, p4, z20, 0.0); //       fcmeq   p9.d, p4/z, z20.d, #0.0
-    __ sve_fcm(Assembler::GT, p5, __ D, p3, z20, 0.0); //       fcmgt   p5.d, p3/z, z20.d, #0.0
-    __ sve_fcm(Assembler::GE, p13, __ D, p3, z23, 0.0); //      fcmge   p13.d, p3/z, z23.d, #0.0
-    __ sve_fcm(Assembler::LT, p5, __ S, p3, z24, 0.0); //       fcmlt   p5.s, p3/z, z24.s, #0.0
-    __ sve_fcm(Assembler::LE, p15, __ D, p1, z10, 0.0); //      fcmle   p15.d, p1/z, z10.d, #0.0
-    __ sve_fcm(Assembler::NE, p1, __ S, p4, z3, 0.0);  //       fcmne   p1.s, p4/z, z3.s, #0.0
+    __ sve_fcm(Assembler::EQ, p6, __ D, p3, z8, 0.0);  //       fcmeq   p6.d, p3/z, z8.d, #0.0
+    __ sve_fcm(Assembler::GT, p14, __ D, p4, z21, 0.0); //      fcmgt   p14.d, p4/z, z21.d, #0.0
+    __ sve_fcm(Assembler::GE, p15, __ S, p4, z5, 0.0); //       fcmge   p15.s, p4/z, z5.s, #0.0
+    __ sve_fcm(Assembler::LT, p15, __ D, p5, z17, 0.0); //      fcmlt   p15.d, p5/z, z17.d, #0.0
+    __ sve_fcm(Assembler::LE, p8, __ S, p2, z12, 0.0); //       fcmle   p8.s, p2/z, z12.s, #0.0
+    __ sve_fcm(Assembler::NE, p3, __ D, p6, z29, 0.0); //       fcmne   p3.d, p6/z, z29.d, #0.0
 
 // SpecialCases
     __ ccmn(zr, zr, 3u, Assembler::LE);                //       ccmn    xzr, xzr, #3, LE
@@ -1018,215 +1070,215 @@
     __ fmovd(v0, -1.0625);                             //       fmov d0, #-1.0625
 
 // LSEOp
-    __ swp(Assembler::xword, r17, r16, r3);            //       swp     x17, x16, [x3]
-    __ ldadd(Assembler::xword, r1, r11, r30);          //       ldadd   x1, x11, [x30]
-    __ ldbic(Assembler::xword, r5, r8, r15);           //       ldclr   x5, x8, [x15]
-    __ ldeor(Assembler::xword, r29, r30, r0);          //       ldeor   x29, x30, [x0]
-    __ ldorr(Assembler::xword, r20, r7, r20);          //       ldset   x20, x7, [x20]
-    __ ldsmin(Assembler::xword, r23, r28, r21);        //       ldsmin  x23, x28, [x21]
-    __ ldsmax(Assembler::xword, r27, r25, r5);         //       ldsmax  x27, x25, [x5]
-    __ ldumin(Assembler::xword, r1, r23, r16);         //       ldumin  x1, x23, [x16]
-    __ ldumax(Assembler::xword, zr, r5, r12);          //       ldumax  xzr, x5, [x12]
+    __ swp(Assembler::xword, r28, r30, r7);            //       swp     x28, x30, [x7]
+    __ ldadd(Assembler::xword, r10, r20, r10);         //       ldadd   x10, x20, [x10]
+    __ ldbic(Assembler::xword, r4, r24, r17);          //       ldclr   x4, x24, [x17]
+    __ ldeor(Assembler::xword, r17, r22, r3);          //       ldeor   x17, x22, [x3]
+    __ ldorr(Assembler::xword, r29, r15, r22);         //       ldset   x29, x15, [x22]
+    __ ldsmin(Assembler::xword, r19, r19, r22);        //       ldsmin  x19, x19, [x22]
+    __ ldsmax(Assembler::xword, r2, r15, r6);          //       ldsmax  x2, x15, [x6]
+    __ ldumin(Assembler::xword, r12, r16, r11);        //       ldumin  x12, x16, [x11]
+    __ ldumax(Assembler::xword, r13, r23, r1);         //       ldumax  x13, x23, [x1]
 
 // LSEOp
-    __ swpa(Assembler::xword, r9, r28, r15);           //       swpa    x9, x28, [x15]
-    __ ldadda(Assembler::xword, r29, r22, sp);         //       ldadda  x29, x22, [sp]
-    __ ldbica(Assembler::xword, r19, zr, r5);          //       ldclra  x19, xzr, [x5]
-    __ ldeora(Assembler::xword, r14, r16, sp);         //       ldeora  x14, x16, [sp]
-    __ ldorra(Assembler::xword, r16, r27, r20);        //       ldseta  x16, x27, [x20]
-    __ ldsmina(Assembler::xword, r16, r12, r11);       //       ldsmina x16, x12, [x11]
-    __ ldsmaxa(Assembler::xword, r9, r6, r30);         //       ldsmaxa x9, x6, [x30]
-    __ ldumina(Assembler::xword, r17, r27, r28);       //       ldumina x17, x27, [x28]
-    __ ldumaxa(Assembler::xword, r30, r7, r10);        //       ldumaxa x30, x7, [x10]
+    __ swpa(Assembler::xword, r30, r19, r5);           //       swpa    x30, x19, [x5]
+    __ ldadda(Assembler::xword, r17, r2, r16);         //       ldadda  x17, x2, [x16]
+    __ ldbica(Assembler::xword, r22, r13, r10);        //       ldclra  x22, x13, [x10]
+    __ ldeora(Assembler::xword, r21, r29, r27);        //       ldeora  x21, x29, [x27]
+    __ ldorra(Assembler::xword, r12, r27, r3);         //       ldseta  x12, x27, [x3]
+    __ ldsmina(Assembler::xword, r1, zr, r24);         //       ldsmina x1, xzr, [x24]
+    __ ldsmaxa(Assembler::xword, r19, r17, r9);        //       ldsmaxa x19, x17, [x9]
+    __ ldumina(Assembler::xword, r28, r27, r15);       //       ldumina x28, x27, [x15]
+    __ ldumaxa(Assembler::xword, r7, r21, r23);        //       ldumaxa x7, x21, [x23]
 
 // LSEOp
-    __ swpal(Assembler::xword, r20, r10, r4);          //       swpal   x20, x10, [x4]
-    __ ldaddal(Assembler::xword, r24, r17, r17);       //       ldaddal x24, x17, [x17]
-    __ ldbical(Assembler::xword, r22, r3, r29);        //       ldclral x22, x3, [x29]
-    __ ldeoral(Assembler::xword, r15, r22, r19);       //       ldeoral x15, x22, [x19]
-    __ ldorral(Assembler::xword, r19, r22, r2);        //       ldsetal x19, x22, [x2]
-    __ ldsminal(Assembler::xword, r15, r6, r12);       //       ldsminal        x15, x6, [x12]
-    __ ldsmaxal(Assembler::xword, r16, r11, r13);      //       ldsmaxal        x16, x11, [x13]
-    __ lduminal(Assembler::xword, r23, r1, r30);       //       lduminal        x23, x1, [x30]
-    __ ldumaxal(Assembler::xword, r19, r5, r17);       //       ldumaxal        x19, x5, [x17]
+    __ swpal(Assembler::xword, zr, r25, r2);           //       swpal   xzr, x25, [x2]
+    __ ldaddal(Assembler::xword, zr, r27, r15);        //       ldaddal xzr, x27, [x15]
+    __ ldbical(Assembler::xword, r10, r23, r19);       //       ldclral x10, x23, [x19]
+    __ ldeoral(Assembler::xword, r3, r16, r0);         //       ldeoral x3, x16, [x0]
+    __ ldorral(Assembler::xword, r25, r26, r23);       //       ldsetal x25, x26, [x23]
+    __ ldsminal(Assembler::xword, r2, r16, r12);       //       ldsminal        x2, x16, [x12]
+    __ ldsmaxal(Assembler::xword, r4, r28, r30);       //       ldsmaxal        x4, x28, [x30]
+    __ lduminal(Assembler::xword, r29, r16, r27);      //       lduminal        x29, x16, [x27]
+    __ ldumaxal(Assembler::xword, r6, r9, r29);        //       ldumaxal        x6, x9, [x29]
 
 // LSEOp
-    __ swpl(Assembler::xword, r2, r16, r22);           //       swpl    x2, x16, [x22]
-    __ ldaddl(Assembler::xword, r13, r10, r21);        //       ldaddl  x13, x10, [x21]
-    __ ldbicl(Assembler::xword, r29, r27, r12);        //       ldclrl  x29, x27, [x12]
-    __ ldeorl(Assembler::xword, r27, r3, r1);          //       ldeorl  x27, x3, [x1]
-    __ ldorrl(Assembler::xword, zr, r24, r19);         //       ldsetl  xzr, x24, [x19]
-    __ ldsminl(Assembler::xword, r17, r9, r28);        //       ldsminl x17, x9, [x28]
-    __ ldsmaxl(Assembler::xword, r27, r15, r7);        //       ldsmaxl x27, x15, [x7]
-    __ lduminl(Assembler::xword, r21, r23, sp);        //       lduminl x21, x23, [sp]
-    __ ldumaxl(Assembler::xword, r25, r2, sp);         //       ldumaxl x25, x2, [sp]
+    __ swpl(Assembler::xword, r16, r7, r4);            //       swpl    x16, x7, [x4]
+    __ ldaddl(Assembler::xword, r7, r15, r9);          //       ldaddl  x7, x15, [x9]
+    __ ldbicl(Assembler::xword, r23, r8, r2);          //       ldclrl  x23, x8, [x2]
+    __ ldeorl(Assembler::xword, r28, r21, sp);         //       ldeorl  x28, x21, [sp]
+    __ ldorrl(Assembler::xword, r5, r27, r0);          //       ldsetl  x5, x27, [x0]
+    __ ldsminl(Assembler::xword, r17, r15, r4);        //       ldsminl x17, x15, [x4]
+    __ ldsmaxl(Assembler::xword, r26, r8, r28);        //       ldsmaxl x26, x8, [x28]
+    __ lduminl(Assembler::xword, r22, r27, r27);       //       lduminl x22, x27, [x27]
+    __ ldumaxl(Assembler::xword, r25, r23, r0);        //       ldumaxl x25, x23, [x0]
 
 // LSEOp
-    __ swp(Assembler::word, r27, r16, r10);            //       swp     w27, w16, [x10]
-    __ ldadd(Assembler::word, r23, r19, r3);           //       ldadd   w23, w19, [x3]
-    __ ldbic(Assembler::word, r16, r0, r25);           //       ldclr   w16, w0, [x25]
-    __ ldeor(Assembler::word, r26, r23, r2);           //       ldeor   w26, w23, [x2]
-    __ ldorr(Assembler::word, r16, r12, r4);           //       ldset   w16, w12, [x4]
-    __ ldsmin(Assembler::word, r28, r30, r29);         //       ldsmin  w28, w30, [x29]
-    __ ldsmax(Assembler::word, r16, r27, r6);          //       ldsmax  w16, w27, [x6]
-    __ ldumin(Assembler::word, r9, r29, r15);          //       ldumin  w9, w29, [x15]
-    __ ldumax(Assembler::word, r7, r4, r7);            //       ldumax  w7, w4, [x7]
+    __ swp(Assembler::word, r4, r6, r15);              //       swp     w4, w6, [x15]
+    __ ldadd(Assembler::word, r0, r4, r15);            //       ldadd   w0, w4, [x15]
+    __ ldbic(Assembler::word, r1, r10, r7);            //       ldclr   w1, w10, [x7]
+    __ ldeor(Assembler::word, r5, r10, r28);           //       ldeor   w5, w10, [x28]
+    __ ldorr(Assembler::word, r7, r20, r23);           //       ldset   w7, w20, [x23]
+    __ ldsmin(Assembler::word, r21, r6, r11);          //       ldsmin  w21, w6, [x11]
+    __ ldsmax(Assembler::word, r8, r17, sp);           //       ldsmax  w8, w17, [sp]
+    __ ldumin(Assembler::word, r6, r17, r2);           //       ldumin  w6, w17, [x2]
+    __ ldumax(Assembler::word, r12, r30, r29);         //       ldumax  w12, w30, [x29]
 
 // LSEOp
-    __ swpa(Assembler::word, r15, r9, r23);            //       swpa    w15, w9, [x23]
-    __ ldadda(Assembler::word, r8, r2, r28);           //       ldadda  w8, w2, [x28]
-    __ ldbica(Assembler::word, r21, zr, r5);           //       ldclra  w21, wzr, [x5]
-    __ ldeora(Assembler::word, r27, r0, r17);          //       ldeora  w27, w0, [x17]
-    __ ldorra(Assembler::word, r15, r4, r26);          //       ldseta  w15, w4, [x26]
-    __ ldsmina(Assembler::word, r8, r28, r22);         //       ldsmina w8, w28, [x22]
-    __ ldsmaxa(Assembler::word, r27, r27, r25);        //       ldsmaxa w27, w27, [x25]
-    __ ldumina(Assembler::word, r23, r0, r4);          //       ldumina w23, w0, [x4]
-    __ ldumaxa(Assembler::word, r6, r16, r0);          //       ldumaxa w6, w16, [x0]
+    __ swpa(Assembler::word, r3, r27, r22);            //       swpa    w3, w27, [x22]
+    __ ldadda(Assembler::word, r29, r14, r13);         //       ldadda  w29, w14, [x13]
+    __ ldbica(Assembler::word, r28, r17, r24);         //       ldclra  w28, w17, [x24]
+    __ ldeora(Assembler::word, r5, r2, r14);           //       ldeora  w5, w2, [x14]
+    __ ldorra(Assembler::word, r10, r16, r11);         //       ldseta  w10, w16, [x11]
+    __ ldsmina(Assembler::word, r27, r23, r12);        //       ldsmina w27, w23, [x12]
+    __ ldsmaxa(Assembler::word, r4, r22, r17);         //       ldsmaxa w4, w22, [x17]
+    __ ldumina(Assembler::word, r4, r1, r19);          //       ldumina w4, w1, [x19]
+    __ ldumaxa(Assembler::word, r16, r16, r13);        //       ldumaxa w16, w16, [x13]
 
 // LSEOp
-    __ swpal(Assembler::word, r4, r15, r1);            //       swpal   w4, w15, [x1]
-    __ ldaddal(Assembler::word, r10, r7, r5);          //       ldaddal w10, w7, [x5]
-    __ ldbical(Assembler::word, r10, r28, r7);         //       ldclral w10, w28, [x7]
-    __ ldeoral(Assembler::word, r20, r23, r21);        //       ldeoral w20, w23, [x21]
-    __ ldorral(Assembler::word, r6, r11, r8);          //       ldsetal w6, w11, [x8]
-    __ ldsminal(Assembler::word, r17, zr, r6);         //       ldsminal        w17, wzr, [x6]
-    __ ldsmaxal(Assembler::word, r17, r2, r12);        //       ldsmaxal        w17, w2, [x12]
-    __ lduminal(Assembler::word, r30, r29, r3);        //       lduminal        w30, w29, [x3]
-    __ ldumaxal(Assembler::word, r27, r22, r29);       //       ldumaxal        w27, w22, [x29]
+    __ swpal(Assembler::word, r14, r12, r2);           //       swpal   w14, w12, [x2]
+    __ ldaddal(Assembler::word, r17, r3, r21);         //       ldaddal w17, w3, [x21]
+    __ ldbical(Assembler::word, r23, r5, r6);          //       ldclral w23, w5, [x6]
+    __ ldeoral(Assembler::word, r7, r19, r13);         //       ldeoral w7, w19, [x13]
+    __ ldorral(Assembler::word, r28, r17, r16);        //       ldsetal w28, w17, [x16]
+    __ ldsminal(Assembler::word, r6, r2, r29);         //       ldsminal        w6, w2, [x29]
+    __ ldsmaxal(Assembler::word, r3, r4, r6);          //       ldsmaxal        w3, w4, [x6]
+    __ lduminal(Assembler::word, r16, r20, r13);       //       lduminal        w16, w20, [x13]
+    __ ldumaxal(Assembler::word, r12, r20, r8);        //       ldumaxal        w12, w20, [x8]
 
 // LSEOp
-    __ swpl(Assembler::word, r14, r13, r28);           //       swpl    w14, w13, [x28]
-    __ ldaddl(Assembler::word, r17, r24, r5);          //       ldaddl  w17, w24, [x5]
-    __ ldbicl(Assembler::word, r2, r14, r10);          //       ldclrl  w2, w14, [x10]
-    __ ldeorl(Assembler::word, r16, r11, r27);         //       ldeorl  w16, w11, [x27]
-    __ ldorrl(Assembler::word, r23, r12, r4);          //       ldsetl  w23, w12, [x4]
-    __ ldsminl(Assembler::word, r22, r17, r4);         //       ldsminl w22, w17, [x4]
-    __ ldsmaxl(Assembler::word, r1, r19, r16);         //       ldsmaxl w1, w19, [x16]
-    __ lduminl(Assembler::word, r16, r13, r14);        //       lduminl w16, w13, [x14]
-    __ ldumaxl(Assembler::word, r12, r2, r17);         //       ldumaxl w12, w2, [x17]
+    __ swpl(Assembler::word, r25, r20, r19);           //       swpl    w25, w20, [x19]
+    __ ldaddl(Assembler::word, r0, r11, r24);          //       ldaddl  w0, w11, [x24]
+    __ ldbicl(Assembler::word, r6, r20, sp);           //       ldclrl  w6, w20, [sp]
+    __ ldeorl(Assembler::word, r14, r16, r6);          //       ldeorl  w14, w16, [x6]
+    __ ldorrl(Assembler::word, r0, r7, r15);           //       ldsetl  w0, w7, [x15]
+    __ ldsminl(Assembler::word, r19, r26, r9);         //       ldsminl w19, w26, [x9]
+    __ ldsmaxl(Assembler::word, r10, r23, r21);        //       ldsmaxl w10, w23, [x21]
+    __ lduminl(Assembler::word, r22, r28, r2);         //       lduminl w22, w28, [x2]
+    __ ldumaxl(Assembler::word, r3, r15, r19);         //       ldumaxl w3, w15, [x19]
 
 // SHA3SIMDOp
-    __ bcax(v3, __ T16B, v20, v23, v5);                //       bcax            v3.16B, v20.16B, v23.16B, v5.16B
-    __ eor3(v6, __ T16B, v7, v17, v12);                //       eor3            v6.16B, v7.16B, v17.16B, v12.16B
-    __ rax1(v27, __ T2D, v16, v16);                    //       rax1            v27.2D, v16.2D, v16.2D
-    __ xar(v6, __ T2D, v2, v28, 6);                    //       xar             v6.2D, v2.2D, v28.2D, #6
+    __ bcax(v20, __ T16B, v7, v4, v28);                //       bcax            v20.16B, v7.16B, v4.16B, v28.16B
+    __ eor3(v7, __ T16B, v0, v8, v16);                 //       eor3            v7.16B, v0.16B, v8.16B, v16.16B
+    __ rax1(v19, __ T2D, v22, v4);                     //       rax1            v19.2D, v22.2D, v4.2D
+    __ xar(v15, __ T2D, v9, v22, 23);                  //       xar             v15.2D, v9.2D, v22.2D, #23
 
 // SHA512SIMDOp
-    __ sha512h(v4, __ T2D, v6, v17);                   //       sha512h         q4, q6, v17.2D
-    __ sha512h2(v19, __ T2D, v13, v12);                //       sha512h2                q19, q13, v12.2D
-    __ sha512su0(v19, __ T2D, v8);                     //       sha512su0               v19.2D, v8.2D
-    __ sha512su1(v24, __ T2D, v19, v17);               //       sha512su1               v24.2D, v19.2D, v17.2D
+    __ sha512h(v25, __ T2D, v5, v30);                  //       sha512h         q25, q5, v30.2D
+    __ sha512h2(v16, __ T2D, v13, v22);                //       sha512h2                q16, q13, v22.2D
+    __ sha512su0(v11, __ T2D, v1);                     //       sha512su0               v11.2D, v1.2D
+    __ sha512su1(v13, __ T2D, v8, v20);                //       sha512su1               v13.2D, v8.2D, v20.2D
 
 // SVEBinaryImmOp
-    __ sve_add(z0, __ H, 196u);                        //       add     z0.h, z0.h, #0xc4
-    __ sve_sub(z6, __ S, 249u);                        //       sub     z6.s, z6.s, #0xf9
-    __ sve_and(z13, __ S, 1u);                         //       and     z13.s, z13.s, #0x1
-    __ sve_eor(z7, __ H, 63489u);                      //       eor     z7.h, z7.h, #0xf801
-    __ sve_orr(z8, __ H, 51199u);                      //       orr     z8.h, z8.h, #0xc7ff
+    __ sve_add(z16, __ D, 125u);                       //       add     z16.d, z16.d, #0x7d
+    __ sve_sub(z4, __ B, 146u);                        //       sub     z4.b, z4.b, #0x92
+    __ sve_and(z8, __ B, 12u);                         //       and     z8.b, z8.b, #0xc
+    __ sve_eor(z28, __ S, 4294049777u);                //       eor     z28.s, z28.s, #0xfff1fff1
+    __ sve_orr(z9, __ H, 8064u);                       //       orr     z9.h, z9.h, #0x1f80
 
 // SVEBinaryImmOp
-    __ sve_add(z22, __ D, 22u);                        //       add     z22.d, z22.d, #0x16
-    __ sve_sub(z3, __ H, 156u);                        //       sub     z3.h, z3.h, #0x9c
-    __ sve_and(z20, __ B, 254u);                       //       and     z20.b, z20.b, #0xfe
-    __ sve_eor(z7, __ B, 131u);                        //       eor     z7.b, z7.b, #0x83
-    __ sve_orr(z19, __ S, 2147484159u);                //       orr     z19.s, z19.s, #0x800001ff
+    __ sve_add(z28, __ B, 62u);                        //       add     z28.b, z28.b, #0x3e
+    __ sve_sub(z1, __ D, 174u);                        //       sub     z1.d, z1.d, #0xae
+    __ sve_and(z17, __ H, 49663u);                     //       and     z17.h, z17.h, #0xc1ff
+    __ sve_eor(z21, __ D, 18302628885642084351u);      //       eor     z21.d, z21.d, #0xfe000000007fffff
+    __ sve_orr(z21, __ S, 2151677951u);                //       orr     z21.s, z21.s, #0x803fffff
 
 // SVEBinaryImmOp
-    __ sve_add(z9, __ S, 92u);                         //       add     z9.s, z9.s, #0x5c
-    __ sve_sub(z25, __ B, 254u);                       //       sub     z25.b, z25.b, #0xfe
-    __ sve_and(z16, __ H, 16368u);                     //       and     z16.h, z16.h, #0x3ff0
-    __ sve_eor(z1, __ H, 51199u);                      //       eor     z1.h, z1.h, #0xc7ff
-    __ sve_orr(z16, __ D, 274877904896u);              //       orr     z16.d, z16.d, #0x3ffffff800
+    __ sve_add(z29, __ S, 160u);                       //       add     z29.s, z29.s, #0xa0
+    __ sve_sub(z0, __ B, 153u);                        //       sub     z0.b, z0.b, #0x99
+    __ sve_and(z23, __ B, 12u);                        //       and     z23.b, z23.b, #0xc
+    __ sve_eor(z23, __ D, 66977792u);                  //       eor     z23.d, z23.d, #0x3fe0000
+    __ sve_orr(z8, __ H, 57855u);                      //       orr     z8.h, z8.h, #0xe1ff
 
 // SVEBinaryImmOp
-    __ sve_add(z4, __ S, 67u);                         //       add     z4.s, z4.s, #0x43
-    __ sve_sub(z6, __ D, 35u);                         //       sub     z6.d, z6.d, #0x23
-    __ sve_and(z28, __ S, 4294049777u);                //       and     z28.s, z28.s, #0xfff1fff1
-    __ sve_eor(z9, __ H, 8064u);                       //       eor     z9.h, z9.h, #0x1f80
-    __ sve_orr(z28, __ B, 1u);                         //       orr     z28.b, z28.b, #0x1
+    __ sve_add(z17, __ D, 181u);                       //       add     z17.d, z17.d, #0xb5
+    __ sve_sub(z4, __ D, 15u);                         //       sub     z4.d, z4.d, #0xf
+    __ sve_and(z10, __ S, 63u);                        //       and     z10.s, z10.s, #0x3f
+    __ sve_eor(z9, __ B, 225u);                        //       eor     z9.b, z9.b, #0xe1
+    __ sve_orr(z4, __ D, 9007199254739968u);           //       orr     z4.d, z4.d, #0x1ffffffffffc00
 
 // SVEBinaryImmOp
-    __ sve_add(z26, __ S, 150u);                       //       add     z26.s, z26.s, #0x96
-    __ sve_sub(z14, __ H, 149u);                       //       sub     z14.h, z14.h, #0x95
-    __ sve_and(z21, __ D, 18302628885642084351u);      //       and     z21.d, z21.d, #0xfe000000007fffff
-    __ sve_eor(z21, __ S, 2151677951u);                //       eor     z21.s, z21.s, #0x803fffff
-    __ sve_orr(z29, __ S, 1u);                         //       orr     z29.s, z29.s, #0x1
+    __ sve_add(z27, __ D, 107u);                       //       add     z27.d, z27.d, #0x6b
+    __ sve_sub(z16, __ D, 181u);                       //       sub     z16.d, z16.d, #0xb5
+    __ sve_and(z22, __ S, 4294950919u);                //       and     z22.s, z22.s, #0xffffc007
+    __ sve_eor(z9, __ H, 1008u);                       //       eor     z9.h, z9.h, #0x3f0
+    __ sve_orr(z20, __ D, 72057594037895168u);         //       orr     z20.d, z20.d, #0xffffffffff8000
 
 // SVEBinaryImmOp
-    __ sve_add(z4, __ S, 196u);                        //       add     z4.s, z4.s, #0xc4
-    __ sve_sub(z4, __ S, 39u);                         //       sub     z4.s, z4.s, #0x27
-    __ sve_and(z23, __ D, 66977792u);                  //       and     z23.d, z23.d, #0x3fe0000
-    __ sve_eor(z8, __ H, 57855u);                      //       eor     z8.h, z8.h, #0xe1ff
-    __ sve_orr(z17, __ D, 274877904896u);              //       orr     z17.d, z17.d, #0x3ffffff800
+    __ sve_add(z13, __ H, 164u);                       //       add     z13.h, z13.h, #0xa4
+    __ sve_sub(z1, __ D, 73u);                         //       sub     z1.d, z1.d, #0x49
+    __ sve_and(z19, __ H, 49663u);                     //       and     z19.h, z19.h, #0xc1ff
+    __ sve_eor(z16, __ B, 12u);                        //       eor     z16.b, z16.b, #0xc
+    __ sve_orr(z11, __ H, 32256u);                     //       orr     z11.h, z11.h, #0x7e00
 
 // SVEVectorOp
-    __ sve_add(z30, __ S, z1, z10);                    //       add     z30.s, z1.s, z10.s
-    __ sve_sub(z12, __ B, z0, z9);                     //       sub     z12.b, z0.b, z9.b
-    __ sve_fadd(z24, __ D, z17, z4);                   //       fadd    z24.d, z17.d, z4.d
-    __ sve_fmul(z6, __ D, z9, z27);                    //       fmul    z6.d, z9.d, z27.d
-    __ sve_fsub(z13, __ D, z16, z30);                  //       fsub    z13.d, z16.d, z30.d
-    __ sve_abs(z22, __ D, p5, z30);                    //       abs     z22.d, p5/m, z30.d
-    __ sve_add(z9, __ B, p3, z19);                     //       add     z9.b, p3/m, z9.b, z19.b
-    __ sve_and(z20, __ H, p7, z9);                     //       and     z20.h, p7/m, z20.h, z9.h
-    __ sve_asr(z13, __ B, p3, z19);                    //       asr     z13.b, p3/m, z13.b, z19.b
-    __ sve_bic(z24, __ H, p2, z19);                    //       bic     z24.h, p2/m, z24.h, z19.h
-    __ sve_clz(z17, __ B, p4, z16);                    //       clz     z17.b, p4/m, z16.b
-    __ sve_cnt(z0, __ H, p0, z11);                     //       cnt     z0.h, p0/m, z11.h
-    __ sve_eor(z15, __ B, p3, z15);                    //       eor     z15.b, p3/m, z15.b, z15.b
-    __ sve_lsl(z15, __ B, p7, z5);                     //       lsl     z15.b, p7/m, z15.b, z5.b
-    __ sve_lsr(z10, __ B, p5, z26);                    //       lsr     z10.b, p5/m, z10.b, z26.b
-    __ sve_mul(z0, __ D, p2, z19);                     //       mul     z0.d, p2/m, z0.d, z19.d
-    __ sve_neg(z10, __ S, p6, z3);                     //       neg     z10.s, p6/m, z3.s
-    __ sve_not(z7, __ H, p6, z28);                     //       not     z7.h, p6/m, z28.h
-    __ sve_orr(z21, __ H, p2, z26);                    //       orr     z21.h, p2/m, z21.h, z26.h
-    __ sve_rbit(z17, __ H, p7, z17);                   //       rbit    z17.h, p7/m, z17.h
-    __ sve_revb(z2, __ D, p7, z16);                    //       revb    z2.d, p7/m, z16.d
-    __ sve_smax(z20, __ B, p1, z19);                   //       smax    z20.b, p1/m, z20.b, z19.b
-    __ sve_smin(z1, __ H, p6, z17);                    //       smin    z1.h, p6/m, z1.h, z17.h
-    __ sve_sub(z16, __ B, p4, z21);                    //       sub     z16.b, p4/m, z16.b, z21.b
-    __ sve_fabs(z4, __ S, p0, z23);                    //       fabs    z4.s, p0/m, z23.s
-    __ sve_fadd(z6, __ S, p2, z20);                    //       fadd    z6.s, p2/m, z6.s, z20.s
-    __ sve_fdiv(z16, __ S, p7, z12);                   //       fdiv    z16.s, p7/m, z16.s, z12.s
-    __ sve_fmax(z3, __ S, p5, z9);                     //       fmax    z3.s, p5/m, z3.s, z9.s
-    __ sve_fmin(z24, __ D, p7, z3);                    //       fmin    z24.d, p7/m, z24.d, z3.d
-    __ sve_fmul(z22, __ D, p1, z25);                   //       fmul    z22.d, p1/m, z22.d, z25.d
-    __ sve_fneg(z13, __ D, p1, z7);                    //       fneg    z13.d, p1/m, z7.d
-    __ sve_frintm(z5, __ D, p5, z17);                  //       frintm  z5.d, p5/m, z17.d
-    __ sve_frintn(z0, __ D, p0, z9);                   //       frintn  z0.d, p0/m, z9.d
-    __ sve_frintp(z11, __ S, p2, z11);                 //       frintp  z11.s, p2/m, z11.s
-    __ sve_fsqrt(z17, __ S, p4, z11);                  //       fsqrt   z17.s, p4/m, z11.s
-    __ sve_fsub(z24, __ D, p4, z30);                   //       fsub    z24.d, p4/m, z24.d, z30.d
-    __ sve_fmad(z8, __ D, p4, z14, z26);               //       fmad    z8.d, p4/m, z14.d, z26.d
-    __ sve_fmla(z27, __ S, p5, z7, z8);                //       fmla    z27.s, p5/m, z7.s, z8.s
-    __ sve_fmls(z27, __ S, p7, z10, z0);               //       fmls    z27.s, p7/m, z10.s, z0.s
-    __ sve_fmsb(z24, __ S, p5, z20, z0);               //       fmsb    z24.s, p5/m, z20.s, z0.s
-    __ sve_fnmad(z22, __ D, p6, z5, z25);              //       fnmad   z22.d, p6/m, z5.d, z25.d
-    __ sve_fnmsb(z17, __ S, p4, z1, z12);              //       fnmsb   z17.s, p4/m, z1.s, z12.s
-    __ sve_fnmla(z29, __ S, p3, z0, z17);              //       fnmla   z29.s, p3/m, z0.s, z17.s
-    __ sve_fnmls(z30, __ D, p5, z22, z21);             //       fnmls   z30.d, p5/m, z22.d, z21.d
-    __ sve_mla(z12, __ H, p2, z2, z0);                 //       mla     z12.h, p2/m, z2.h, z0.h
-    __ sve_mls(z23, __ D, p5, z0, z19);                //       mls     z23.d, p5/m, z0.d, z19.d
-    __ sve_and(z26, z23, z12);                         //       and     z26.d, z23.d, z12.d
-    __ sve_eor(z21, z1, z1);                           //       eor     z21.d, z1.d, z1.d
-    __ sve_orr(z19, z11, z19);                         //       orr     z19.d, z11.d, z19.d
-    __ sve_bic(z23, z8, z30);                          //       bic     z23.d, z8.d, z30.d
-    __ sve_uzp1(z19, __ B, z19, z20);                  //       uzp1    z19.b, z19.b, z20.b
-    __ sve_uzp2(z20, __ S, z13, z30);                  //       uzp2    z20.s, z13.s, z30.s
-    __ sve_fabd(z30, __ D, p7, z25);                   //       fabd    z30.d, p7/m, z30.d, z25.d
-    __ sve_bext(z17, __ H, z14, z11);                  //       bext    z17.h, z14.h, z11.h
-    __ sve_bdep(z28, __ B, z20, z5);                   //       bdep    z28.b, z20.b, z5.b
-    __ sve_eor3(z13, z13, z2);                         //       eor3    z13.d, z13.d, z13.d, z2.d
+    __ sve_add(z15, __ D, z4, z15);                    //       add     z15.d, z4.d, z15.d
+    __ sve_sub(z5, __ S, z0, z10);                     //       sub     z5.s, z0.s, z10.s
+    __ sve_fadd(z26, __ S, z3, z0);                    //       fadd    z26.s, z3.s, z0.s
+    __ sve_fmul(z19, __ D, z28, z10);                  //       fmul    z19.d, z28.d, z10.d
+    __ sve_fsub(z3, __ D, z19, z7);                    //       fsub    z3.d, z19.d, z7.d
+    __ sve_abs(z28, __ H, p3, z21);                    //       abs     z28.h, p3/m, z21.h
+    __ sve_add(z26, __ D, p3, z17);                    //       add     z26.d, p3/m, z26.d, z17.d
+    __ sve_and(z17, __ D, p3, z2);                     //       and     z17.d, p3/m, z17.d, z2.d
+    __ sve_asr(z16, __ B, p5, z20);                    //       asr     z16.b, p5/m, z16.b, z20.b
+    __ sve_bic(z19, __ D, p0, z1);                     //       bic     z19.d, p0/m, z19.d, z1.d
+    __ sve_clz(z17, __ S, p2, z16);                    //       clz     z17.s, p2/m, z16.s
+    __ sve_cnt(z21, __ B, p0, z4);                     //       cnt     z21.b, p0/m, z4.b
+    __ sve_eor(z23, __ H, p3, z6);                     //       eor     z23.h, p3/m, z23.h, z6.h
+    __ sve_lsl(z20, __ D, p3, z16);                    //       lsl     z20.d, p3/m, z20.d, z16.d
+    __ sve_lsr(z12, __ S, p0, z3);                     //       lsr     z12.s, p0/m, z12.s, z3.s
+    __ sve_mul(z9, __ D, p0, z24);                     //       mul     z9.d, p0/m, z9.d, z24.d
+    __ sve_neg(z3, __ B, p4, z22);                     //       neg     z3.b, p4/m, z22.b
+    __ sve_not(z25, __ B, p5, z13);                    //       not     z25.b, p5/m, z13.b
+    __ sve_orr(z7, __ S, p6, z5);                      //       orr     z7.s, p6/m, z7.s, z5.s
+    __ sve_rbit(z17, __ B, p4, z0);                    //       rbit    z17.b, p4/m, z0.b
+    __ sve_revb(z9, __ H, p5, z11);                    //       revb    z9.h, p5/m, z11.h
+    __ sve_smax(z11, __ S, p3, z17);                   //       smax    z11.s, p3/m, z11.s, z17.s
+    __ sve_smin(z11, __ S, p3, z24);                   //       smin    z11.s, p3/m, z11.s, z24.s
+    __ sve_sub(z30, __ S, p4, z8);                     //       sub     z30.s, p4/m, z30.s, z8.s
+    __ sve_fabs(z14, __ D, p6, z22);                   //       fabs    z14.d, p6/m, z22.d
+    __ sve_fadd(z22, __ S, p2, z8);                    //       fadd    z22.s, p2/m, z22.s, z8.s
+    __ sve_fdiv(z27, __ S, p7, z10);                   //       fdiv    z27.s, p7/m, z27.s, z10.s
+    __ sve_fmax(z14, __ D, p6, z21);                   //       fmax    z14.d, p6/m, z14.d, z21.d
+    __ sve_fmin(z0, __ D, p0, z22);                    //       fmin    z0.d, p0/m, z0.d, z22.d
+    __ sve_fmul(z5, __ D, p6, z29);                    //       fmul    z5.d, p6/m, z5.d, z29.d
+    __ sve_fneg(z17, __ S, p0, z12);                   //       fneg    z17.s, p0/m, z12.s
+    __ sve_frintm(z29, __ D, p3, z0);                  //       frintm  z29.d, p3/m, z0.d
+    __ sve_frintn(z2, __ D, p7, z20);                  //       frintn  z2.d, p7/m, z20.d
+    __ sve_frintp(z21, __ S, p7, z12);                 //       frintp  z21.s, p7/m, z12.s
+    __ sve_fsqrt(z2, __ D, p0, z14);                   //       fsqrt   z2.d, p0/m, z14.d
+    __ sve_fsub(z22, __ D, p0, z19);                   //       fsub    z22.d, p0/m, z22.d, z19.d
+    __ sve_fmad(z26, __ D, p6, z12, z21);              //       fmad    z26.d, p6/m, z12.d, z21.d
+    __ sve_fmla(z1, __ S, p0, z10, z19);               //       fmla    z1.s, p0/m, z10.s, z19.s
+    __ sve_fmls(z19, __ D, p6, z23, z8);               //       fmls    z19.d, p6/m, z23.d, z8.d
+    __ sve_fmsb(z17, __ S, p5, z19, z20);              //       fmsb    z17.s, p5/m, z19.s, z20.s
+    __ sve_fnmad(z20, __ D, p3, z30, z22);             //       fnmad   z20.d, p3/m, z30.d, z22.d
+    __ sve_fnmsb(z30, __ S, p6, z17, z17);             //       fnmsb   z30.s, p6/m, z17.s, z17.s
+    __ sve_fnmla(z11, __ S, p3, z28, z20);             //       fnmla   z11.s, p3/m, z28.s, z20.s
+    __ sve_fnmls(z1, __ S, p3, z13, z2);               //       fnmls   z1.s, p3/m, z13.s, z2.s
+    __ sve_mla(z10, __ D, p3, z19, z4);                //       mla     z10.d, p3/m, z19.d, z4.d
+    __ sve_mls(z15, __ B, p0, z3, z29);                //       mls     z15.b, p0/m, z3.b, z29.b
+    __ sve_and(z20, z5, z20);                          //       and     z20.d, z5.d, z20.d
+    __ sve_eor(z28, z13, z13);                         //       eor     z28.d, z13.d, z13.d
+    __ sve_orr(z13, z29, z1);                          //       orr     z13.d, z29.d, z1.d
+    __ sve_bic(z27, z3, z3);                           //       bic     z27.d, z3.d, z3.d
+    __ sve_uzp1(z8, __ B, z24, z9);                    //       uzp1    z8.b, z24.b, z9.b
+    __ sve_uzp2(z25, __ B, z10, z14);                  //       uzp2    z25.b, z10.b, z14.b
+    __ sve_fabd(z20, __ D, p6, z6);                    //       fabd    z20.d, p6/m, z20.d, z6.d
+    __ sve_bext(z19, __ D, z16, z6);                   //       bext    z19.d, z16.d, z6.d
+    __ sve_bdep(z13, __ H, z1, z28);                   //       bdep    z13.h, z1.h, z28.h
+    __ sve_eor3(z9, z1, z1);                           //       eor3    z9.d, z9.d, z1.d, z1.d
 
 // SVEReductionOp
-    __ sve_andv(v10, __ B, p3, z19);                   //       andv b10, p3, z19.b
-    __ sve_orv(v25, __ B, p3, z2);                     //       orv b25, p3, z2.b
-    __ sve_eorv(v29, __ B, p0, z20);                   //       eorv b29, p0, z20.b
-    __ sve_smaxv(v20, __ H, p7, z28);                  //       smaxv h20, p7, z28.h
-    __ sve_sminv(v13, __ D, p2, z13);                  //       sminv d13, p2, z13.d
-    __ sve_fminv(v1, __ S, p3, z27);                   //       fminv s1, p3, z27.s
-    __ sve_fmaxv(v3, __ D, p6, z8);                    //       fmaxv d3, p6, z8.d
-    __ sve_fadda(v9, __ S, p0, z25);                   //       fadda s9, p0, s9, z25.s
-    __ sve_uaddv(v14, __ D, p0, z20);                  //       uaddv d14, p0, z20.d
+    __ sve_andv(v27, __ B, p6, z14);                   //       andv b27, p6, z14.b
+    __ sve_orv(v4, __ D, p7, z17);                     //       orv d4, p7, z17.d
+    __ sve_eorv(v2, __ B, p0, z24);                    //       eorv b2, p0, z24.b
+    __ sve_smaxv(v25, __ B, p7, z13);                  //       smaxv b25, p7, z13.b
+    __ sve_sminv(v22, __ D, p3, z15);                  //       sminv d22, p3, z15.d
+    __ sve_fminv(v16, __ D, p1, z11);                  //       fminv d16, p1, z11.d
+    __ sve_fmaxv(v15, __ S, p0, z15);                  //       fmaxv s15, p0, z15.s
+    __ sve_fadda(v27, __ D, p1, z22);                  //       fadda d27, p1, d27, z22.d
+    __ sve_uaddv(v27, __ S, p4, z10);                  //       uaddv d27, p4, z10.s
 
     __ bind(forth);
 
@@ -1245,30 +1297,30 @@
     0x9101a1a0,     0xb10a5cc8,     0xd10810aa,     0xf10fd061,
     0x120cb166,     0x321764bc,     0x52174681,     0x720c0227,
     0x9241018e,     0xb25a2969,     0xd278b411,     0xf26aad01,
-    0x14000000,     0x17ffffd7,     0x14000405,     0x94000000,
-    0x97ffffd4,     0x94000402,     0x3400000a,     0x34fffa2a,
-    0x34007fea,     0x35000008,     0x35fff9c8,     0x35007f88,
-    0xb400000b,     0xb4fff96b,     0xb4007f2b,     0xb500001d,
-    0xb5fff91d,     0xb5007edd,     0x10000013,     0x10fff8b3,
-    0x10007e73,     0x90000013,     0x36300016,     0x3637f836,
-    0x36307df6,     0x3758000c,     0x375ff7cc,     0x37587d8c,
+    0x14000000,     0x17ffffd7,     0x14000437,     0x94000000,
+    0x97ffffd4,     0x94000434,     0x3400000a,     0x34fffa2a,
+    0x3400862a,     0x35000008,     0x35fff9c8,     0x350085c8,
+    0xb400000b,     0xb4fff96b,     0xb400856b,     0xb500001d,
+    0xb5fff91d,     0xb500851d,     0x10000013,     0x10fff8b3,
+    0x100084b3,     0x90000013,     0x36300016,     0x3637f836,
+    0x36308436,     0x3758000c,     0x375ff7cc,     0x375883cc,
     0x128313a0,     0x528a32c7,     0x7289173b,     0x92ab3acc,
     0xd2a0bf94,     0xf2c285e8,     0x9358722f,     0x330e652f,
     0x53067f3b,     0x93577c53,     0xb34a1aac,     0xd35a4016,
     0x13946c63,     0x93c3dbc8,     0x54000000,     0x54fff5a0,
-    0x54007b60,     0x54000001,     0x54fff541,     0x54007b01,
-    0x54000002,     0x54fff4e2,     0x54007aa2,     0x54000002,
-    0x54fff482,     0x54007a42,     0x54000003,     0x54fff423,
-    0x540079e3,     0x54000003,     0x54fff3c3,     0x54007983,
-    0x54000004,     0x54fff364,     0x54007924,     0x54000005,
-    0x54fff305,     0x540078c5,     0x54000006,     0x54fff2a6,
-    0x54007866,     0x54000007,     0x54fff247,     0x54007807,
-    0x54000008,     0x54fff1e8,     0x540077a8,     0x54000009,
-    0x54fff189,     0x54007749,     0x5400000a,     0x54fff12a,
-    0x540076ea,     0x5400000b,     0x54fff0cb,     0x5400768b,
-    0x5400000c,     0x54fff06c,     0x5400762c,     0x5400000d,
-    0x54fff00d,     0x540075cd,     0x5400000e,     0x54ffefae,
-    0x5400756e,     0x5400000f,     0x54ffef4f,     0x5400750f,
+    0x540081a0,     0x54000001,     0x54fff541,     0x54008141,
+    0x54000002,     0x54fff4e2,     0x540080e2,     0x54000002,
+    0x54fff482,     0x54008082,     0x54000003,     0x54fff423,
+    0x54008023,     0x54000003,     0x54fff3c3,     0x54007fc3,
+    0x54000004,     0x54fff364,     0x54007f64,     0x54000005,
+    0x54fff305,     0x54007f05,     0x54000006,     0x54fff2a6,
+    0x54007ea6,     0x54000007,     0x54fff247,     0x54007e47,
+    0x54000008,     0x54fff1e8,     0x54007de8,     0x54000009,
+    0x54fff189,     0x54007d89,     0x5400000a,     0x54fff12a,
+    0x54007d2a,     0x5400000b,     0x54fff0cb,     0x54007ccb,
+    0x5400000c,     0x54fff06c,     0x54007c6c,     0x5400000d,
+    0x54fff00d,     0x54007c0d,     0x5400000e,     0x54ffefae,
+    0x54007bae,     0x5400000f,     0x54ffef4f,     0x54007b4f,
     0xd40658e1,     0xd4014d22,     0xd4046543,     0xd4273f60,
     0xd44cad80,     0xd503201f,     0xd503203f,     0xd503205f,
     0xd503209f,     0xd50320bf,     0xd503219f,     0xd50323bf,
@@ -1358,150 +1410,163 @@
     0x4e31ab38,     0x6e31a820,     0x0e71ab9b,     0x2e71abdd,
     0x4e71a8c5,     0x6e71a8c5,     0x4eb1abdd,     0x6eb1a98b,
     0x6eb0fb59,     0x7e30f820,     0x7e70fbfe,     0x7eb0f820,
-    0x7ef0fa51,     0x0e20bbbc,     0x4e20bb59,     0x0e60b949,
-    0x4e60bb59,     0x0ea0b9ac,     0x4ea0ba0f,     0x4ee0b98b,
-    0x0ea0f96a,     0x4ea0fa51,     0x4ee0fb38,     0x2ea0fad5,
-    0x6ea0fb17,     0x6ee0f820,     0x2ea1fa30,     0x6ea1f96a,
-    0x6ee1f8e6,     0x2e205bbc,     0x6e2058e6,     0x0e271cc5,
-    0x4e271cc5,     0x0eb61eb4,     0x4eb31e51,     0x2e311e0f,
-    0x6e331e51,     0x0e3f87dd,     0x4e3c877a,     0x0e7e87bc,
-    0x4e638441,     0x0ebd879b,     0x4ea28420,     0x4ef686b4,
-    0x0e3ed7bc,     0x4e31d60f,     0x4e6ed5ac,     0x2e2c856a,
-    0x6e3e87bc,     0x2e7e87bc,     0x6e758693,     0x2eb886f6,
-    0x6eac856a,     0x6ee684a4,     0x0ea0d7fe,     0x4eb6d6b4,
-    0x4eead528,     0x0e209ffe,     0x4e339e51,     0x0e6c9d6a,
-    0x4e7d9f9b,     0x0ea49c62,     0x4eba9f38,     0x2ea6d4a4,
-    0x6ea5d483,     0x6eead528,     0x2e38d6f6,     0x6e33d651,
-    0x6e6fd5cd,     0x2e26dca4,     0x6e3edfbc,     0x6e79df17,
-    0x0e7796d5,     0x4e7b9759,     0x0eba9738,     0x4ea59483,
-    0x0e39cf17,     0x4e3ccf7a,     0x4e79cf17,     0x2e7095ee,
-    0x6e7796d5,     0x2ea59483,     0x6eb99717,     0x0eaacd28,
-    0x4ebacf38,     0x4ef5ce93,     0x2e31fe0f,     0x6e32fe30,
-    0x6e64fc62,     0x0e236441,     0x4e226420,     0x0e7a6738,
-    0x4e6664a4,     0x0ea56483,     0x4ead658b,     0x0e20a7fe,
-    0x4e3da79b,     0x0e6ba549,     0x4e7ba759,     0x0ea4a462,
-    0x4eaea5ac,     0x0e33f651,     0x4e20f7fe,     0x4e63f441,
-    0x0e2e6dac,     0x4e3e6fbc,     0x0e626c20,     0x4e736e51,
-    0x0eae6dac,     0x4eb36e51,     0x0e37aed5,     0x4e2eadac,
-    0x0e7daf9b,     0x4e7fafdd,     0x0ea0affe,     0x4ea3ac41,
-    0x0ebbf759,     0x4ebdf79b,     0x4ee6f4a4,     0x2e3f8fdd,
-    0x6e258c83,     0x2e688ce6,     0x6e7f8fdd,     0x2ebb8f59,
-    0x6eb38e51,     0x6eea8d28,     0x0e29e507,     0x4e2ee5ac,
-    0x4e62e420,     0x0e353693,     0x4e233441,     0x0e793717,
-    0x4e643462,     0x0ea23420,     0x4eaa3528,     0x4ef93717,
-    0x2e3b3759,     0x6e31360f,     0x2e7f37dd,     0x6e653483,
-    0x2eac356a,     0x6eb836f6,     0x6eec356a,     0x2e263ca4,
-    0x6e333e51,     0x2e633c41,     0x6e6d3d8b,     0x2ea93d07,
-    0x6eac3d6a,     0x6ef13e0f,     0x2eb2e630,     0x6ea4e462,
-    0x6eebe549,     0x0e2d3d8b,     0x4e2e3dac,     0x0e703dee,
-    0x4e6f3dcd,     0x0ea43c62,     0x4ea83ce6,     0x4ef53e93,
-    0x2e3be759,     0x6e31e60f,     0x6e66e4a4,     0x2ea4ec62,
-    0x6ea6eca4,     0x6eeded8b,     0x65d23289,     0x65d02e95,
-    0x65d02eed,     0x65912f05,     0x65d1255f,     0x65933061,
-    0xba5fd3e3,     0x3a5f03e5,     0xfa411be4,     0x7a42cbe2,
-    0x93df03ff,     0xc820ffff,     0x8822fc7f,     0xc8247cbf,
-    0x88267fff,     0x4e010fe0,     0x5e040420,     0x4e081fe1,
-    0x4e0c1fe1,     0x4e0a1fe1,     0x4e071fe1,     0x4e042c20,
-    0x4e062c20,     0x4e052c20,     0x4e083c20,     0x0e0c3c20,
-    0x0e0a3c20,     0x0e073c20,     0x9eae0020,     0x0f03f409,
-    0x6f03f40e,     0x4cc0ac3f,     0x0ea1b820,     0x4e21c862,
-    0x4e61b8a4,     0x05a08020,     0x05104fe0,     0x05505001,
-    0x05906fe2,     0x05d03005,     0x05101fea,     0x05901feb,
-    0x04b0e3e0,     0x0470e7e1,     0x042f9c20,     0x043f9c35,
-    0x047f9c20,     0x04ff9c20,     0x04299420,     0x04319160,
-    0x0461943e,     0x04a19020,     0x04038100,     0x040381a0,
-    0x040387e1,     0x04438be2,     0x04c38fe3,     0x040181e0,
-    0x04018100,     0x04018621,     0x04418b22,     0x04418822,
-    0x04818c23,     0x040081e0,     0x04008120,     0x04008761,
-    0x04008621,     0x04408822,     0x04808c23,     0x042053ff,
-    0x047f5401,     0x25208028,     0x2538cfe0,     0x2578d001,
-    0x25b8efe2,     0x25f8f007,     0x2538dfea,     0x25b8dfeb,
-    0xa400a3e0,     0xa420a7e0,     0xa4484be0,     0xa467afe0,
-    0xa4a8a7ea,     0xa547a814,     0xa4084ffe,     0xa55c53e0,
-    0xa5e1540b,     0xe400fbf6,     0xe408ffff,     0xe420e7e0,
-    0xe4484be0,     0xe460efe0,     0xe547e400,     0xe4014be0,
-    0xe4a84fe0,     0xe5f15000,     0x858043e0,     0x85a043ff,
-    0xe59f5d08,     0x0420e3e9,     0x0460e3ea,     0x04a0e3eb,
-    0x04e0e3ec,     0x25104042,     0x25104871,     0x25904861,
-    0x25904c92,     0x05344020,     0x05744041,     0x05b44062,
-    0x05f44083,     0x252c8840,     0x253c1420,     0x25681572,
-    0x25a21ce3,     0x25ea1e34,     0x253c0421,     0x25680572,
-    0x25a20ce3,     0x25ea0e34,     0x0522c020,     0x05e6c0a4,
-    0x2401a001,     0x2443a051,     0x24858881,     0x24c78cd1,
-    0x24850891,     0x24c70cc1,     0x250f9001,     0x25508051,
-    0x25802491,     0x25df28c1,     0x25850c81,     0x251e10d1,
-    0x65816001,     0x65c36051,     0x65854891,     0x65c74cc1,
-    0x05733820,     0x05b238a4,     0x05f138e6,     0x0570396a,
-    0x65d0a001,     0x65d6a443,     0x65d4a826,     0x6594ac26,
-    0x6554ac26,     0x6556ac26,     0x6552ac26,     0x65cbac85,
-    0x65caac01,     0x65dea833,     0x659ca509,     0x65d8a801,
-    0x65dcac01,     0x655cb241,     0x0520a1e0,     0x0521a601,
-    0x052281e0,     0x05238601,     0x04a14026,     0x042244a6,
-    0x046344a6,     0x04a444a6,     0x04e544a7,     0x0568aca7,
-    0x05b23230,     0x853040af,     0xc5b040af,     0xe57080af,
-    0xe5b080af,     0x25034440,     0x254054c4,     0x25034640,
-    0x25415a05,     0x25834440,     0x25c54489,     0x250b5d3a,
-    0x2550dc20,     0x2518e3e1,     0x2518e021,     0x2518e0a1,
-    0x2518e121,     0x2518e1a1,     0x2558e3e2,     0x2558e042,
-    0x2558e0c2,     0x2558e142,     0x2598e3e3,     0x2598e063,
-    0x2598e0e3,     0x2598e163,     0x25d8e3e4,     0x25d8e084,
-    0x25d8e104,     0x25d8e184,     0x2518e407,     0x05214800,
-    0x05614800,     0x05a14800,     0x05e14800,     0x05214c00,
-    0x05614c00,     0x05a14c00,     0x05e14c00,     0x05304001,
-    0x05314001,     0x05a18610,     0x05e18610,     0x05271e11,
-    0x6545e891,     0x6585e891,     0x65c5e891,     0x6545c891,
-    0x6585c891,     0x65c5c891,     0x45b0c210,     0x45f1c231,
-    0x1e601000,     0x1e603000,     0x1e621000,     0x1e623000,
-    0x1e641000,     0x1e643000,     0x1e661000,     0x1e663000,
-    0x1e681000,     0x1e683000,     0x1e6a1000,     0x1e6a3000,
-    0x1e6c1000,     0x1e6c3000,     0x1e6e1000,     0x1e6e3000,
-    0x1e701000,     0x1e703000,     0x1e721000,     0x1e723000,
-    0x1e741000,     0x1e743000,     0x1e761000,     0x1e763000,
-    0x1e781000,     0x1e783000,     0x1e7a1000,     0x1e7a3000,
-    0x1e7c1000,     0x1e7c3000,     0x1e7e1000,     0x1e7e3000,
-    0xf8318070,     0xf82103cb,     0xf82511e8,     0xf83d201e,
-    0xf8343287,     0xf83752bc,     0xf83b40b9,     0xf8217217,
-    0xf83f6185,     0xf8a981fc,     0xf8bd03f6,     0xf8b310bf,
-    0xf8ae23f0,     0xf8b0329b,     0xf8b0516c,     0xf8a943c6,
-    0xf8b1739b,     0xf8be6147,     0xf8f4808a,     0xf8f80231,
-    0xf8f613a3,     0xf8ef2276,     0xf8f33056,     0xf8ef5186,
-    0xf8f041ab,     0xf8f773c1,     0xf8f36225,     0xf86282d0,
-    0xf86d02aa,     0xf87d119b,     0xf87b2023,     0xf87f3278,
-    0xf8715389,     0xf87b40ef,     0xf87573f7,     0xf87963e2,
-    0xb83b8150,     0xb8370073,     0xb8301320,     0xb83a2057,
-    0xb830308c,     0xb83c53be,     0xb83040db,     0xb82971fd,
-    0xb82760e4,     0xb8af82e9,     0xb8a80382,     0xb8b510bf,
-    0xb8bb2220,     0xb8af3344,     0xb8a852dc,     0xb8bb433b,
-    0xb8b77080,     0xb8a66010,     0xb8e4802f,     0xb8ea00a7,
-    0xb8ea10fc,     0xb8f422b7,     0xb8e6310b,     0xb8f150df,
-    0xb8f14182,     0xb8fe707d,     0xb8fb63b6,     0xb86e838d,
-    0xb87100b8,     0xb862114e,     0xb870236b,     0xb877308c,
-    0xb8765091,     0xb8614213,     0xb87071cd,     0xb86c6222,
-    0xce371683,     0xce1130e6,     0xce708e1b,     0xce9c1846,
-    0xce7180c4,     0xce6c85b3,     0xcec08113,     0xce718a78,
-    0x2560d880,     0x25a1df26,     0x0580000d,     0x05402ca7,
-    0x05001588,     0x25e0c2d6,     0x2561d383,     0x05803ed4,
-    0x05400e47,     0x05000933,     0x25a0cb89,     0x2521dfd9,
-    0x05806530,     0x05401581,     0x0503ab50,     0x25a0c864,
-    0x25e1c466,     0x0580659c,     0x05404ca9,     0x0500061c,
-    0x25a0d2da,     0x2561d2ae,     0x05823bb5,     0x05400ad5,
-    0x0500001d,     0x25a0d884,     0x25a1c4e4,     0x05837917,
-    0x05401d68,     0x0503ab51,     0x04aa003e,     0x0429040c,
-    0x65c40238,     0x65db0926,     0x65de060d,     0x04d6b7d6,
-    0x04000e69,     0x045a1d34,     0x04108e6d,     0x045b0a78,
-    0x0419b211,     0x045aa160,     0x04190def,     0x04139caf,
-    0x0411974a,     0x04d00a60,     0x0497b86a,     0x045ebb87,
-    0x04580b55,     0x05679e31,     0x05e49e02,     0x04080674,
-    0x044a1a21,     0x040112b0,     0x049ca2e4,     0x65808a86,
-    0x658d9d90,     0x65869523,     0x65c79c78,     0x65c28736,
-    0x04dda4ed,     0x65c2b625,     0x65c0a120,     0x6581a96b,
-    0x658db171,     0x65c193d8,     0x65fa91c8,     0x65a814fb,
-    0x65a03d5b,     0x65a0b698,     0x65f9d8b6,     0x65acf031,
-    0x65b14c1d,     0x65f576de,     0x0440484c,     0x04d37417,
-    0x042c32fa,     0x04a13035,     0x04733173,     0x04fe3117,
-    0x05346a73,     0x05be6db4,     0x65c89f3e,     0x454bb1d1,
-    0x4505b69c,     0x042d384d,     0x041a2e6a,     0x04182c59,
-    0x0419229d,     0x04483f94,     0x04ca29ad,     0x65872f61,
-    0x65c63903,     0x65982329,     0x04c1228e,
+    0x7ef0fa51,     0x0e208bbc,     0x4e208b59,     0x0e608949,
+    0x4e608b59,     0x0ea089ac,     0x4ea08a0f,     0x4ee0898b,
+    0x2e20896a,     0x6e208a51,     0x2e608b38,     0x6e608ad5,
+    0x2ea08b17,     0x6ea08820,     0x6ee08a30,     0x0e20996a,
+    0x4e2098e6,     0x0e609bbc,     0x4e6098e6,     0x0ea098c5,
+    0x4ea098c5,     0x4ee09ab4,     0x0e20aa51,     0x4e20aa0f,
+    0x0e60aa51,     0x4e60abdd,     0x0ea0ab7a,     0x4ea0abbc,
+    0x4ee0a841,     0x2e209b9b,     0x6e209820,     0x2e609ab4,
+    0x6e609bbc,     0x2ea09a0f,     0x6ea099ac,     0x6ee0996a,
+    0x0ea0cbbc,     0x4ea0cbbc,     0x4ee0ca93,     0x2ea0caf6,
+    0x6ea0c96a,     0x6ee0c8a4,     0x0ea0dbfe,     0x4ea0dab4,
+    0x4ee0d928,     0x0ea0ebfe,     0x4ea0ea51,     0x4ee0e96a,
+    0x2ea0db9b,     0x6ea0d862,     0x6ee0db38,     0x0e20b8a4,
+    0x4e20b883,     0x0e60b928,     0x4e60baf6,     0x0ea0ba51,
+    0x4ea0b9cd,     0x4ee0b8a4,     0x0ea0fbbc,     0x4ea0fb17,
+    0x4ee0fad5,     0x2ea0fb59,     0x6ea0fb38,     0x6ee0f883,
+    0x2ea1fb17,     0x6ea1fb7a,     0x6ee1fb17,     0x2e2059ee,
+    0x6e205ad5,     0x0e251c83,     0x4e391f17,     0x0eaa1d28,
+    0x4eba1f38,     0x2e351e93,     0x6e311e0f,     0x0e328630,
+    0x4e248462,     0x0e638441,     0x4e628420,     0x0eba8738,
+    0x4ea684a4,     0x4ee58483,     0x0e2dd58b,     0x4e20d7fe,
+    0x4e7dd79b,     0x2e2b8549,     0x6e3b8759,     0x2e648462,
+    0x6e6e85ac,     0x2eb38651,     0x6ea087fe,     0x6ee38441,
+    0x0eaed5ac,     0x4ebed7bc,     0x4ee2d420,     0x0e339e51,
+    0x4e2e9dac,     0x0e739e51,     0x4e779ed5,     0x0eae9dac,
+    0x4ebd9f9b,     0x2ebfd7dd,     0x6ea0d7fe,     0x6ee3d441,
+    0x2e3bd759,     0x6e3dd79b,     0x6e66d4a4,     0x2e3fdfdd,
+    0x6e25dc83,     0x6e68dce6,     0x0e7f97dd,     0x4e7b9759,
+    0x0eb39651,     0x4eaa9528,     0x0e29cd07,     0x4e2ecdac,
+    0x4e62cc20,     0x2e759693,     0x6e639441,     0x2eb99717,
+    0x6ea49462,     0x0ea2cc20,     0x4eaacd28,     0x4ef9cf17,
+    0x2e3bff59,     0x6e31fe0f,     0x6e7fffdd,     0x0e256483,
+    0x4e2c656a,     0x0e7866f6,     0x4e6c656a,     0x0ea664a4,
+    0x4eb36651,     0x0e23a441,     0x4e2da58b,     0x0e69a507,
+    0x4e6ca56a,     0x0eb1a60f,     0x4eb2a630,     0x0e24f462,
+    0x4e2bf549,     0x4e6df58b,     0x0e2e6dac,     0x4e306dee,
+    0x0e6f6dcd,     0x4e646c62,     0x0ea86ce6,     0x4eb56e93,
+    0x0e3baf59,     0x4e31ae0f,     0x0e66aca4,     0x4e64ac62,
+    0x0ea6aca4,     0x4eadad8b,     0x0eb3f651,     0x4eb6f6b4,
+    0x4ef2f630,     0x2e338e51,     0x6e2c8d6a,     0x2e768eb4,
+    0x6e788ef6,     0x2eae8dac,     0x6ebb8f59,     0x6ef98f17,
+    0x0e3ee7bc,     0x4e30e5ee,     0x4e6ce56a,     0x0e3a3738,
+    0x4e233441,     0x0e6d358b,     0x4e6037fe,     0x0eac356a,
+    0x4eb1360f,     0x4ee93507,     0x2e243462,     0x6e253483,
+    0x2e6f35cd,     0x6e753693,     0x2eb23630,     0x6eb23630,
+    0x6ee53483,     0x2e233c41,     0x6e2d3d8b,     0x2e7f3fdd,
+    0x6e673cc5,     0x2eaa3d28,     0x6eb03dee,     0x6efe3fbc,
+    0x2ebfe7dd,     0x6ea2e420,     0x6ef6e6b4,     0x0e293d07,
+    0x4e363eb4,     0x0e793f17,     0x4e7d3f9b,     0x0eb73ed5,
+    0x4ebc3f7a,     0x4efa3f38,     0x2e26e4a4,     0x6e23e441,
+    0x6e78e6f6,     0x2eb2ee30,     0x6ea0effe,     0x6ee7ecc5,
+    0x65d22d06,     0x65d032be,     0x659030af,     0x65d1362f,
+    0x65912998,     0x65d33ba3,     0xba5fd3e3,     0x3a5f03e5,
+    0xfa411be4,     0x7a42cbe2,     0x93df03ff,     0xc820ffff,
+    0x8822fc7f,     0xc8247cbf,     0x88267fff,     0x4e010fe0,
+    0x5e040420,     0x4e081fe1,     0x4e0c1fe1,     0x4e0a1fe1,
+    0x4e071fe1,     0x4e042c20,     0x4e062c20,     0x4e052c20,
+    0x4e083c20,     0x0e0c3c20,     0x0e0a3c20,     0x0e073c20,
+    0x9eae0020,     0x0f03f409,     0x6f03f40e,     0x4cc0ac3f,
+    0x0ea1b820,     0x4e21c862,     0x4e61b8a4,     0x05a08020,
+    0x05104fe0,     0x05505001,     0x05906fe2,     0x05d03005,
+    0x05101fea,     0x05901feb,     0x04b0e3e0,     0x0470e7e1,
+    0x042f9c20,     0x043f9c35,     0x047f9c20,     0x04ff9c20,
+    0x04299420,     0x04319160,     0x0461943e,     0x04a19020,
+    0x04038100,     0x040381a0,     0x040387e1,     0x04438be2,
+    0x04c38fe3,     0x040181e0,     0x04018100,     0x04018621,
+    0x04418b22,     0x04418822,     0x04818c23,     0x040081e0,
+    0x04008120,     0x04008761,     0x04008621,     0x04408822,
+    0x04808c23,     0x042053ff,     0x047f5401,     0x25208028,
+    0x2538cfe0,     0x2578d001,     0x25b8efe2,     0x25f8f007,
+    0x2538dfea,     0x25b8dfeb,     0xa400a3e0,     0xa420a7e0,
+    0xa4484be0,     0xa467afe0,     0xa4a8a7ea,     0xa547a814,
+    0xa4084ffe,     0xa55c53e0,     0xa5e1540b,     0xe400fbf6,
+    0xe408ffff,     0xe420e7e0,     0xe4484be0,     0xe460efe0,
+    0xe547e400,     0xe4014be0,     0xe4a84fe0,     0xe5f15000,
+    0x858043e0,     0x85a043ff,     0xe59f5d08,     0x0420e3e9,
+    0x0460e3ea,     0x04a0e3eb,     0x04e0e3ec,     0x25104042,
+    0x25104871,     0x25904861,     0x25904c92,     0x05344020,
+    0x05744041,     0x05b44062,     0x05f44083,     0x252c8840,
+    0x253c1420,     0x25681572,     0x25a21ce3,     0x25ea1e34,
+    0x253c0421,     0x25680572,     0x25a20ce3,     0x25ea0e34,
+    0x0522c020,     0x05e6c0a4,     0x2401a001,     0x2443a051,
+    0x24858881,     0x24c78cd1,     0x24850891,     0x24c70cc1,
+    0x250f9001,     0x25508051,     0x25802491,     0x25df28c1,
+    0x25850c81,     0x251e10d1,     0x65816001,     0x65c36051,
+    0x65854891,     0x65c74cc1,     0x05733820,     0x05b238a4,
+    0x05f138e6,     0x0570396a,     0x65d0a001,     0x65d6a443,
+    0x65d4a826,     0x6594ac26,     0x6554ac26,     0x6556ac26,
+    0x6552ac26,     0x65cbac85,     0x65caac01,     0x65dea833,
+    0x659ca509,     0x65d8a801,     0x65dcac01,     0x655cb241,
+    0x0520a1e0,     0x0521a601,     0x052281e0,     0x05238601,
+    0x04a14026,     0x042244a6,     0x046344a6,     0x04a444a6,
+    0x04e544a7,     0x0568aca7,     0x05b23230,     0x853040af,
+    0xc5b040af,     0xe57080af,     0xe5b080af,     0x25034440,
+    0x254054c4,     0x25034640,     0x25415a05,     0x25834440,
+    0x25c54489,     0x250b5d3a,     0x2550dc20,     0x2518e3e1,
+    0x2518e021,     0x2518e0a1,     0x2518e121,     0x2518e1a1,
+    0x2558e3e2,     0x2558e042,     0x2558e0c2,     0x2558e142,
+    0x2598e3e3,     0x2598e063,     0x2598e0e3,     0x2598e163,
+    0x25d8e3e4,     0x25d8e084,     0x25d8e104,     0x25d8e184,
+    0x2518e407,     0x05214800,     0x05614800,     0x05a14800,
+    0x05e14800,     0x05214c00,     0x05614c00,     0x05a14c00,
+    0x05e14c00,     0x05304001,     0x05314001,     0x05a18610,
+    0x05e18610,     0x05271e11,     0x6545e891,     0x6585e891,
+    0x65c5e891,     0x6545c891,     0x6585c891,     0x65c5c891,
+    0x45b0c210,     0x45f1c231,     0x1e601000,     0x1e603000,
+    0x1e621000,     0x1e623000,     0x1e641000,     0x1e643000,
+    0x1e661000,     0x1e663000,     0x1e681000,     0x1e683000,
+    0x1e6a1000,     0x1e6a3000,     0x1e6c1000,     0x1e6c3000,
+    0x1e6e1000,     0x1e6e3000,     0x1e701000,     0x1e703000,
+    0x1e721000,     0x1e723000,     0x1e741000,     0x1e743000,
+    0x1e761000,     0x1e763000,     0x1e781000,     0x1e783000,
+    0x1e7a1000,     0x1e7a3000,     0x1e7c1000,     0x1e7c3000,
+    0x1e7e1000,     0x1e7e3000,     0xf83c80fe,     0xf82a0154,
+    0xf8241238,     0xf8312076,     0xf83d32cf,     0xf83352d3,
+    0xf82240cf,     0xf82c7170,     0xf82d6037,     0xf8be80b3,
+    0xf8b10202,     0xf8b6114d,     0xf8b5237d,     0xf8ac307b,
+    0xf8a1531f,     0xf8b34131,     0xf8bc71fb,     0xf8a762f5,
+    0xf8ff8059,     0xf8ff01fb,     0xf8ea1277,     0xf8e32010,
+    0xf8f932fa,     0xf8e25190,     0xf8e443dc,     0xf8fd7370,
+    0xf8e663a9,     0xf8708087,     0xf867012f,     0xf8771048,
+    0xf87c23f5,     0xf865301b,     0xf871508f,     0xf87a4388,
+    0xf876737b,     0xf8796017,     0xb82481e6,     0xb82001e4,
+    0xb82110ea,     0xb825238a,     0xb82732f4,     0xb8355166,
+    0xb82843f1,     0xb8267051,     0xb82c63be,     0xb8a382db,
+    0xb8bd01ae,     0xb8bc1311,     0xb8a521c2,     0xb8aa3170,
+    0xb8bb5197,     0xb8a44236,     0xb8a47261,     0xb8b061b0,
+    0xb8ee804c,     0xb8f102a3,     0xb8f710c5,     0xb8e721b3,
+    0xb8fc3211,     0xb8e653a2,     0xb8e340c4,     0xb8f071b4,
+    0xb8ec6114,     0xb8798274,     0xb860030b,     0xb86613f4,
+    0xb86e20d0,     0xb86031e7,     0xb873513a,     0xb86a42b7,
+    0xb876705c,     0xb863626f,     0xce2470f4,     0xce084007,
+    0xce648ed3,     0xce965d2f,     0xce7e80b9,     0xce7685b0,
+    0xcec0802b,     0xce74890d,     0x25e0cfb0,     0x2521d244,
+    0x05803628,     0x0540659c,     0x05004ca9,     0x2520c7dc,
+    0x25e1d5c1,     0x05801551,     0x05423bb5,     0x05000ad5,
+    0x25a0d41d,     0x2521d320,     0x05803637,     0x05437917,
+    0x05001d68,     0x25e0d6b1,     0x25e1c1e4,     0x058000aa,
+    0x05401e69,     0x0503b544,     0x25e0cd7b,     0x25e1d6b0,
+    0x05809296,     0x054064a9,     0x05038d14,     0x2560d48d,
+    0x25e1c921,     0x05801553,     0x05403630,     0x05003cab,
+    0x04ef008f,     0x04aa0405,     0x6580007a,     0x65ca0b93,
+    0x65c70663,     0x0456aebc,     0x04c00e3a,     0x04da0c51,
+    0x04109690,     0x04db0033,     0x0499aa11,     0x041aa095,
+    0x04590cd7,     0x04d38e14,     0x0491806c,     0x04d00309,
+    0x0417b2c3,     0x041eb5b9,     0x049818a7,     0x05279011,
+    0x05649569,     0x04880e2b,     0x048a0f0b,     0x0481111e,
+    0x04dcbace,     0x65808916,     0x658d9d5b,     0x65c69aae,
+    0x65c782c0,     0x65c29ba5,     0x049da191,     0x65c2ac1d,
+    0x65c0be82,     0x6581bd95,     0x65cda1c2,     0x65c18276,
+    0x65f5999a,     0x65b30141,     0x65e83af3,     0x65b4b671,
+    0x65f6cfd4,     0x65b1fa3e,     0x65b44f8b,     0x65a26da1,
+    0x04c44e6a,     0x041d606f,     0x043430b4,     0x04ad31bc,
+    0x046133ad,     0x04e3307b,     0x05296b08,     0x052e6d59,
+    0x65c898d4,     0x45c6b213,     0x455cb42d,     0x04213829,
+    0x041a39db,     0x04d83e24,     0x04192302,     0x04083db9,
+    0x04ca2df6,     0x65c72570,     0x658621ef,     0x65d826db,
+    0x0481315b,
   };
 // END  Generated code -- do not edit

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1167,6 +1167,26 @@ public class IRNode {
     public static final String VMLS_MASKED = PREFIX + "VMLS_MASKED" + POSTFIX;
     static {
         machOnlyNameRegex(VMLS_MASKED, "vmls_masked");
+    }
+
+    public static final String VMASK_CMP_ZERO_I_NEON = PREFIX + "VMASK_CMP_ZERO_I_NEON" + POSTFIX;
+    static {
+        machOnlyNameRegex(VMASK_CMP_ZERO_I_NEON, "vmaskcmp_zeroI_neon");
+    }
+
+    public static final String VMASK_CMP_ZERO_L_NEON = PREFIX + "VMASK_CMP_ZERO_L_NEON" + POSTFIX;
+    static {
+        machOnlyNameRegex(VMASK_CMP_ZERO_L_NEON, "vmaskcmp_zeroL_neon");
+    }
+
+    public static final String VMASK_CMP_ZERO_F_NEON = PREFIX + "VMASK_CMP_ZERO_F_NEON" + POSTFIX;
+    static {
+        machOnlyNameRegex(VMASK_CMP_ZERO_F_NEON, "vmaskcmp_zeroF_neon");
+    }
+
+    public static final String VMASK_CMP_ZERO_D_NEON = PREFIX + "VMASK_CMP_ZERO_D_NEON" + POSTFIX;
+    static {
+        machOnlyNameRegex(VMASK_CMP_ZERO_D_NEON, "vmaskcmp_zeroD_neon");
     }
 
     public static final String VNOT_I_MASKED = PREFIX + "VNOT_I_MASKED" + POSTFIX;

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorCompareWithZeroTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorCompareWithZeroTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import compiler.lib.ir_framework.*;
+
+import java.util.Random;
+
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.DoubleVector;
+import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.LongVector;
+import jdk.incubator.vector.ShortVector;
+import jdk.incubator.vector.VectorSpecies;
+import jdk.incubator.vector.VectorOperators;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
+
+/**
+ * @test
+ * @bug 8297753
+ * @key randomness
+ * @library /test/lib /
+ * @requires os.arch=="aarch64"
+ * @summary Add optimized rules for vector compare with zero on NEON
+ * @modules jdk.incubator.vector
+ *
+ * @run driver compiler.vectorapi.VectorCompareWithZeroTest
+ */
+
+public class VectorCompareWithZeroTest {
+    private static final VectorSpecies<Byte> B_SPECIES = ByteVector.SPECIES_PREFERRED;
+    private static final VectorSpecies<Short> S_SPECIES = ShortVector.SPECIES_PREFERRED;
+    private static final VectorSpecies<Integer> I_SPECIES = IntVector.SPECIES_PREFERRED;
+    private static final VectorSpecies<Long> L_SPECIES = LongVector.SPECIES_PREFERRED;
+    private static final VectorSpecies<Float> F_SPECIES = FloatVector.SPECIES_PREFERRED;
+    private static final VectorSpecies<Double> D_SPECIES = DoubleVector.SPECIES_PREFERRED;
+    private static final int LENGTH = 1024;
+    private static final Random RD = Utils.getRandomInstance();
+    private static byte[] ba;
+    private static short[] sa;
+    private static int[] ia;
+    private static long[] la;
+    private static float[] fa;
+    private static double[] da;
+
+    static {
+        ba = new byte[LENGTH];
+        sa = new short[LENGTH];
+        ia = new int[LENGTH];
+        la = new long[LENGTH];
+        fa = new float[LENGTH];
+        da = new double[LENGTH];
+
+        for (int i = 0; i < LENGTH; i++) {
+            ba[i] = (byte) RD.nextInt(25);
+            sa[i] = (short) RD.nextInt(25);
+            ia[i] = RD.nextInt(25);
+            la[i] = RD.nextLong(25);
+            fa[i] = RD.nextFloat(25.0F);
+            da[i] = RD.nextDouble(25.0);
+        }
+    }
+
+    interface ByteOp {
+        boolean apply(byte a);
+    }
+
+    interface ShortOp {
+        boolean apply(short a);
+    }
+
+    interface IntOp {
+        boolean apply(int a);
+    }
+
+    interface LongOp {
+        boolean apply(long a);
+    }
+
+    interface FloatOp {
+        boolean apply(float a);
+    }
+
+    interface DoubleOp {
+        boolean apply(double a);
+    }
+
+    private static void assertArrayEquals(byte[] a, boolean[] r, ByteOp f) {
+        for (int i = 0; i < B_SPECIES.length(); i++) {
+            Asserts.assertEquals(f.apply(a[i]), r[i]);
+        }
+    }
+
+    private static void assertArrayEquals(short[] a, boolean[] r, ShortOp f) {
+        for (int i = 0; i < S_SPECIES.length(); i++) {
+            Asserts.assertEquals(f.apply(a[i]), r[i]);
+        }
+    }
+
+    private static void assertArrayEquals(int[] a, boolean[] r, IntOp f) {
+        for (int i = 0; i < I_SPECIES.length(); i++) {
+            Asserts.assertEquals(f.apply(a[i]), r[i]);
+        }
+    }
+
+    private static void assertArrayEquals(long[] a, boolean[] r, LongOp f) {
+        for (int i = 0; i < L_SPECIES.length(); i++) {
+            Asserts.assertEquals(f.apply(a[i]), r[i]);
+        }
+    }
+
+    private static void assertArrayEquals(float[] a, boolean[] r, FloatOp f) {
+        for (int i = 0; i < F_SPECIES.length(); i++) {
+            Asserts.assertEquals(f.apply(a[i]), r[i]);
+        }
+    }
+
+    private static void assertArrayEquals(double[] a, boolean[] r, DoubleOp f) {
+        for (int i = 0; i < D_SPECIES.length(); i++) {
+            Asserts.assertEquals(f.apply(a[i]), r[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = { IRNode.VMASK_CMP_ZERO_I_NEON, ">= 1" })
+    public static void testByteVectorEqualToZero() {
+        boolean[] r = new boolean[LENGTH];
+        ByteVector av = ByteVector.fromArray(B_SPECIES, ba, 0);
+        av.compare(VectorOperators.EQ, 0).intoArray(r, 0);
+        assertArrayEquals(ba, r, (a) -> (a == (byte) 0 ? true : false));
+    }
+
+    @Test
+    @IR(counts = { IRNode.VMASK_CMP_ZERO_I_NEON, ">= 1" })
+    public static void testShortVectorNotEqualToZero() {
+        boolean[] r = new boolean[LENGTH];
+        ShortVector av = ShortVector.fromArray(S_SPECIES, sa, 0);
+        av.compare(VectorOperators.NE, 0).intoArray(r, 0);
+        assertArrayEquals(sa, r, (a) -> (a != (short) 0 ? true : false));
+    }
+
+    @Test
+    @IR(counts = { IRNode.VMASK_CMP_ZERO_I_NEON, ">= 1" })
+    public static void testIntVectorGreaterEqualToZero() {
+        boolean[] r = new boolean[LENGTH];
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        av.compare(VectorOperators.GE, 0).intoArray(r, 0);
+        assertArrayEquals(ia, r, (a) -> (a >= 0 ? true : false));
+    }
+
+    @Test
+    @IR(counts = { IRNode.VMASK_CMP_ZERO_L_NEON, ">= 1" })
+    public static void testLongVectorGreaterThanZero() {
+        boolean[] r = new boolean[LENGTH];
+        LongVector av = LongVector.fromArray(L_SPECIES, la, 0);
+        av.compare(VectorOperators.GT, 0).intoArray(r, 0);
+        assertArrayEquals(la, r, (a) -> (a > 0 ? true : false));
+    }
+
+    @Test
+    @IR(counts = { IRNode.VMASK_CMP_ZERO_F_NEON, ">= 1" })
+    public static void testFloatVectorLessEqualToZero() {
+        boolean[] r = new boolean[LENGTH];
+        FloatVector av = FloatVector.fromArray(F_SPECIES, fa, 0);
+        av.compare(VectorOperators.LE, 0).intoArray(r, 0);
+        assertArrayEquals(fa, r, (a) -> (a <= 0.0F ? true : false));
+    }
+
+    @Test
+    @IR(counts = { IRNode.VMASK_CMP_ZERO_D_NEON, ">= 1" })
+    public static void testDoubleVectorLessThanZero() {
+        boolean[] r = new boolean[LENGTH];
+        DoubleVector av = DoubleVector.fromArray(D_SPECIES, da, 0);
+        av.compare(VectorOperators.LT, 0).intoArray(r, 0);
+        assertArrayEquals(da, r, (a) -> (a < 0.0 ? true : false));
+    }
+
+    public static void main(String[] args) {
+        TestFramework testFramework = new TestFramework();
+        testFramework.setDefaultWarmup(10000)
+                    .addFlags("--add-modules=jdk.incubator.vector")
+                    .addFlags("-XX:UseSVE=0")
+                    .start();
+    }
+}


### PR DESCRIPTION
We can use the compare-with-zero instructions like cmgt(zero)[1] immediately to avoid the extra scalar2vector operations.

The following instruction sequence
```
movi  v16.4s, #0x0
cmgt  v16.4s, v17.4s, v16.4s
```
can be optimized to:
```
cmgt v16.4s, v17.4s, #0x0
```
This patch does the following:
1. Add NEON floating-point compare-with-zero instructions.
2. Add optimized match rules to generate the compare-with-zero instructions.

[1]: https://developer.arm.com/documentation/ddi0602/2022-06/SIMD-FP-Instructions/CMGT--zero---Compare-signed-Greater-than-zero--vector--

Change-Id: If026b477a0cad809bd201feafbfc9ab301a1b569