### PR TITLE
8294403: [REDO] make test should report only on executed tests

### DIFF
--- a/doc/testing.html
+++ b/doc/testing.html
@@ -494,6 +494,9 @@ allows to pass the tests with intermittent failures. Defaults to 0.</p>
 <p>Repeat the tests up to a set number of times, stopping at first
 failure. This helps to reproduce intermittent test failures. Defaults to
 0.</p>
+<h4 id="report">REPORT</h4>
+<p>Use this report style when reporting test results (sent to JTReg as
+<code>-report</code>). Defaults to <code>files</code>.</p>
 <h3 id="gtest-keywords">Gtest keywords</h3>
 <h4 id="repeat">REPEAT</h4>
 <p>The number of times to repeat the tests

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -484,6 +484,11 @@ Repeat the tests up to a set number of times, stopping at first failure.
 This helps to reproduce intermittent test failures.
 Defaults to 0.
 
+#### REPORT
+
+Use this report style when reporting test results (sent to JTReg as `-report`).
+Defaults to `files`.
+
 ### Gtest keywords
 
 #### REPEAT

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -196,11 +196,12 @@ $(eval $(call SetTestOpt,JAVA_OPTIONS,JTREG))
 $(eval $(call SetTestOpt,JOBS,JTREG))
 $(eval $(call SetTestOpt,TIMEOUT_FACTOR,JTREG))
 $(eval $(call SetTestOpt,FAILURE_HANDLER_TIMEOUT,JTREG))
+$(eval $(call SetTestOpt,REPORT,JTREG))
 
 $(eval $(call ParseKeywordVariable, JTREG, \
     SINGLE_KEYWORDS := JOBS TIMEOUT_FACTOR FAILURE_HANDLER_TIMEOUT \
         TEST_MODE ASSERT VERBOSE RETAIN MAX_MEM RUN_PROBLEM_LISTS \
-        RETRY_COUNT REPEAT_COUNT MAX_OUTPUT $(CUSTOM_JTREG_SINGLE_KEYWORDS), \
+        RETRY_COUNT REPEAT_COUNT MAX_OUTPUT REPORT $(CUSTOM_JTREG_SINGLE_KEYWORDS), \
     STRING_KEYWORDS := OPTIONS JAVA_OPTIONS VM_OPTIONS KEYWORDS \
         EXTRA_PROBLEM_LISTS LAUNCHER_OPTIONS \
         $(CUSTOM_JTREG_STRING_KEYWORDS), \
@@ -745,6 +746,7 @@ define SetupRunJtregTestBody
   JTREG_RUN_PROBLEM_LISTS ?= false
   JTREG_RETRY_COUNT ?= 0
   JTREG_REPEAT_COUNT ?= 0
+  JTREG_REPORT ?= files
 
   ifneq ($$(JTREG_RETRY_COUNT), 0)
     ifneq ($$(JTREG_REPEAT_COUNT), 0)
@@ -857,6 +859,7 @@ define SetupRunJtregTestBody
           -dir:$$(JTREG_TOPDIR) \
           -reportDir:$$($1_TEST_RESULTS_DIR) \
           -workDir:$$($1_TEST_SUPPORT_DIR) \
+          -report:$${JTREG_REPORT} \
           $$$${JTREG_STATUS} \
           $$(JTREG_OPTIONS) \
           $$(JTREG_FAILURE_HANDLER_OPTIONS) \


### PR DESCRIPTION
This should help to speed up tests significantly. Currently, if we run "make test" with a subset of tests, JTReg would still read the entirety of test root to report on tests that were not run. Even with current suite of tests it gets expensive. If you add more tests to suite -- for example, mounting a large test archive like pre-generated fuzzer tests -- it starts to take a lot of time.

The reasonable default for older jtreg is `-report:executed`. My own CI -- that has millions of tests mounted in `test/` -- was running with `JTREG="OPTIONS=-report:executed"` for years now. [CODETOOLS-7903323](https://bugs.openjdk.org/browse/CODETOOLS-7903323) provides a new reporting option, `-report:files`, which makes this whole business easier. This requires new jtreg.

Motivational improvements:

```
$ time CONF=linux-x86_64-server-release make run-test TEST=gc/epsilon/TestHelloWorld.java

# Default JDK tree

# Baseline
real	0m9.086s
user	0m22.857s
sys	0m4.202s

# Patched
real	0m6.406s   ; +40% faster
user	0m17.156s
sys	0m3.193s

# +100K fuzzer tests in tree

# Baseline
real	3m1.997s
user	3m16.643s
sys	0m10.490s

# Patched
real	0m8.919s   ; 20x faster
user	0m17.904s
sys	0m4.860s
```

Additional testing:
 - [x] Ad-hoc timing tests (see above)
 - [x] Reproducer from [CODETOOLS-7903331](https://bugs.openjdk.org/browse/CODETOOLS-7903331)
 - [x] Eyeballing the test results on passing tests with REPEAT_COUNT > 1
 - [x] Eyeballing the test results on intermittently failing tests with RETRY_COUNT > 1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294403](https://bugs.openjdk.org/browse/JDK-8294403): [REDO] make test should report only on executed tests


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [a803958f](https://git.openjdk.org/jdk/pull/11824/files/a803958f1af3551ac71f9fb3e8c28f31335eb146)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [a803958f](https://git.openjdk.org/jdk/pull/11824/files/a803958f1af3551ac71f9fb3e8c28f31335eb146)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11824/head:pull/11824` \
`$ git checkout pull/11824`

Update a local copy of the PR: \
`$ git checkout pull/11824` \
`$ git pull https://git.openjdk.org/jdk pull/11824/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11824`

View PR using the GUI difftool: \
`$ git pr show -t 11824`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11824.diff">https://git.openjdk.org/jdk/pull/11824.diff</a>

</details>
