### PR TITLE
JDK-8299520: TestPrintXML.java output error messages in case compare fails

### DIFF
--- a/test/jdk/jdk/jfr/tool/TestPrintXML.java
+++ b/test/jdk/jdk/jfr/tool/TestPrintXML.java
@@ -132,6 +132,8 @@ public class TestPrintXML {
             Map<String, Object> xmlMap = (Map<String, Object>) xmlObject;
             List<ValueDescriptor> fields = re.getFields();
             if (fields.size() != xmlMap.size()) {
+                System.err.println("Size of fields of recorded object (" + fields.size() +
+                                   ") and reference (" + xmlMap.size() + ") differ");
                 return false;
             }
             for (ValueDescriptor v : fields) {
@@ -154,6 +156,7 @@ public class TestPrintXML {
                     expectedValue = Long.toUnsignedString(re.getLong(name));
                 }
                 if (!compare(expectedValue, xmlValue)) {
+                    System.err.println("Expcted value " + expectedValue + " differs from " + xmlValue);
                     return false;
                 }
             }
@@ -163,10 +166,14 @@ public class TestPrintXML {
             Object[] array = (Object[]) eventObject;
             Object[] xmlArray = (Object[]) xmlObject;
             if (array.length != xmlArray.length) {
+                System.err.println("Array length " + array.length + " differs from length " +
+                                   xmlArray.length);
                 return false;
             }
             for (int i = 0; i < array.length; i++) {
                 if (!compare(array[i], xmlArray[i])) {
+                    System.err.println("Array element " + i + "(" + array[i] +
+                                       ") differs from element " + xmlArray[i]);
                     return false;
                 }
             }
@@ -174,7 +181,11 @@ public class TestPrintXML {
         }
         String s1 = String.valueOf(eventObject);
         String s2 = (String) xmlObject;
-        return s1.equals(s2);
+        boolean res = s1.equals(s2);
+        if (! res) {
+            System.err.println("Event object string " + s1 + " differs from " + s2);
+        }
+        return res;
     }
 
     static class XMLEvent {


### PR DESCRIPTION
Currently the compare function in the jfr related test TestPrintXML.java does not output anything in case of failing event comparisons. This should be enhanced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299520](https://bugs.openjdk.org/browse/JDK-8299520): TestPrintXML.java output error messages in case compare fails


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11827/head:pull/11827` \
`$ git checkout pull/11827`

Update a local copy of the PR: \
`$ git checkout pull/11827` \
`$ git pull https://git.openjdk.org/jdk pull/11827/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11827`

View PR using the GUI difftool: \
`$ git pr show -t 11827`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11827.diff">https://git.openjdk.org/jdk/pull/11827.diff</a>

</details>
