### PR TITLE
8299525: RISC-V: Add backend support for half float conversion intrinsics

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -798,6 +798,8 @@ enum operand_size { int8, int16, int32, uint32, int64 };
   INSN(fsqrt_d,  0b1010011, 0b00000, 0b0101101);
   INSN(fcvt_s_d, 0b1010011, 0b00001, 0b0100000);
   INSN(fcvt_d_s, 0b1010011, 0b00000, 0b0100001);
+  INSN(fcvt_s_h, 0b1010011, 0b00010, 0b0100000);
+  INSN(fcvt_h_s, 0b1010011, 0b00000, 0b0100010);
 #undef INSN
 
 // Immediate Instruction
@@ -1054,6 +1056,7 @@ enum operand_size { int8, int16, int32, uint32, int64 };
 
   INSN(fmv_w_x,  0b1010011, 0b000, 0b00000, 0b1111000);
   INSN(fmv_d_x,  0b1010011, 0b000, 0b00000, 0b1111001);
+  INSN(fmv_h_x,  0b1010011, 0b000, 0b00000, 0b1111010);
 
 #undef INSN
 
@@ -1074,6 +1077,7 @@ enum operand_size { int8, int16, int32, uint32, int64 };
   INSN(fclass_d, 0b1010011, 0b001, 0b00000, 0b1110001);
   INSN(fmv_x_w,  0b1010011, 0b000, 0b00000, 0b1110000);
   INSN(fmv_x_d,  0b1010011, 0b000, 0b00000, 0b1110001);
+  INSN(fmv_x_h,  0b1010011, 0b000, 0b00000, 0b1110010);
 
 #undef INSN
 

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -103,6 +103,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, UseZba, false, EXPERIMENTAL, "Use Zba instructions")             \
   product(bool, UseZbb, false, EXPERIMENTAL, "Use Zbb instructions")             \
   product(bool, UseZbs, false, EXPERIMENTAL, "Use Zbs instructions")             \
+  product(bool, UseZfh, false, EXPERIMENTAL, "Use Zfh instructions")             \
   product(bool, UseZic64b, false, EXPERIMENTAL, "Use Zic64b instructions")       \
   product(bool, UseZicbom, false, EXPERIMENTAL, "Use Zicbom instructions")       \
   product(bool, UseZicbop, false, EXPERIMENTAL, "Use Zicbop instructions")       \

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -103,7 +103,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, UseZba, false, EXPERIMENTAL, "Use Zba instructions")             \
   product(bool, UseZbb, false, EXPERIMENTAL, "Use Zbb instructions")             \
   product(bool, UseZbs, false, EXPERIMENTAL, "Use Zbs instructions")             \
-  product(bool, UseZfh, false, EXPERIMENTAL, "Use Zfh instructions")             \
+  product(bool, UseZfhmin, false, EXPERIMENTAL, "Use Zfhmin instructions")       \
   product(bool, UseZic64b, false, EXPERIMENTAL, "Use Zic64b instructions")       \
   product(bool, UseZicbom, false, EXPERIMENTAL, "Use Zicbom instructions")       \
   product(bool, UseZicbop, false, EXPERIMENTAL, "Use Zicbop instructions")       \

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1842,6 +1842,10 @@ const bool Matcher::match_rule_supported(int opcode) {
     case Op_CountTrailingZerosI:
     case Op_CountTrailingZerosL:
       return UseZbb;
+
+    case Op_ConvF2HF:
+    case Op_ConvHF2F:
+      return UseZfh;
   }
 
   return true; // Per default match rules are supported.
@@ -8133,6 +8137,44 @@ instruct convL2F_reg_reg(fRegF dst, iRegL src) %{
   %}
 
   ins_pipe(fp_l2f);
+%}
+
+// float <-> half float
+
+instruct convHF2F_reg_reg(fRegF dst, iRegINoSp src, fRegF tmp) %{
+  predicate(UseZfh);
+  match(Set dst (ConvHF2F src));
+  effect(TEMP tmp);
+
+  ins_cost(XFER_COST);
+  format %{ "fmv.h.x $tmp, $src\t#@convHF2F_reg_reg\n\t"
+            "fcvt.s.h $dst, $tmp\t#@convHF2F_reg_reg"
+  %}
+
+  ins_encode %{
+      __ fmv_h_x($tmp$$FloatRegister, $src$$Register);
+      __ fcvt_s_h($dst$$FloatRegister, $tmp$$FloatRegister);
+  %}
+
+  ins_pipe(fp_f2d);
+%}
+
+instruct convF2HF_reg_reg(iRegINoSp dst, fRegF src, fRegF tmp) %{
+  predicate(UseZfh);
+  match(Set dst (ConvF2HF src));
+  effect(TEMP tmp);
+
+  ins_cost(XFER_COST);
+  format %{ "fcvt.h.s $tmp, $src\t#@convF2HF_reg_reg\n\t"
+            "fmv.x.h $dst, $tmp\t#@convF2HF_reg_reg"
+  %}
+
+  ins_encode %{
+      __ fcvt_h_s($tmp$$FloatRegister, $src$$FloatRegister);
+      __ fmv_x_h($dst$$Register, $tmp$$FloatRegister);
+  %}
+
+  ins_pipe(fp_f2d);
 %}
 
 // double <-> int

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -8152,11 +8152,11 @@ instruct convHF2F_reg_reg(fRegF dst, iRegINoSp src, fRegF tmp) %{
   %}
 
   ins_encode %{
-      __ fmv_h_x($tmp$$FloatRegister, $src$$Register);
-      __ fcvt_s_h($dst$$FloatRegister, $tmp$$FloatRegister);
+    __ fmv_h_x($tmp$$FloatRegister, $src$$Register);
+    __ fcvt_s_h($dst$$FloatRegister, $tmp$$FloatRegister);
   %}
 
-  ins_pipe(fp_f2d);
+  ins_pipe(fp_i2f);
 %}
 
 instruct convF2HF_reg_reg(iRegINoSp dst, fRegF src, fRegF tmp) %{
@@ -8170,11 +8170,11 @@ instruct convF2HF_reg_reg(iRegINoSp dst, fRegF src, fRegF tmp) %{
   %}
 
   ins_encode %{
-      __ fcvt_h_s($tmp$$FloatRegister, $src$$FloatRegister);
-      __ fmv_x_h($dst$$Register, $tmp$$FloatRegister);
+    __ fcvt_h_s($tmp$$FloatRegister, $src$$FloatRegister);
+    __ fmv_x_h($dst$$Register, $tmp$$FloatRegister);
   %}
 
-  ins_pipe(fp_f2d);
+  ins_pipe(fp_f2i);
 %}
 
 // double <-> int

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1845,7 +1845,7 @@ const bool Matcher::match_rule_supported(int opcode) {
 
     case Op_ConvF2HF:
     case Op_ConvHF2F:
-      return UseZfh;
+      return UseZfhmin;
   }
 
   return true; // Per default match rules are supported.
@@ -8142,7 +8142,7 @@ instruct convL2F_reg_reg(fRegF dst, iRegL src) %{
 // float <-> half float
 
 instruct convHF2F_reg_reg(fRegF dst, iRegINoSp src, fRegF tmp) %{
-  predicate(UseZfh);
+  predicate(UseZfhmin);
   match(Set dst (ConvHF2F src));
   effect(TEMP tmp);
 
@@ -8160,7 +8160,7 @@ instruct convHF2F_reg_reg(fRegF dst, iRegINoSp src, fRegF tmp) %{
 %}
 
 instruct convF2HF_reg_reg(iRegINoSp dst, fRegF src, fRegF tmp) %{
-  predicate(UseZfh);
+  predicate(UseZfhmin);
   match(Set dst (ConvF2HF src));
   effect(TEMP tmp);
 

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -71,6 +71,9 @@ void VM_Version::initialize() {
     if (FLAG_IS_DEFAULT(UseZicboz)) {
       FLAG_SET_DEFAULT(UseZicboz, true);
     }
+    if (FLAG_IS_DEFAULT(UseZfhmin)) {
+      FLAG_SET_DEFAULT(UseZfhmin, true);
+    }
   }
 
   if (UseZic64b) {

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -59,6 +59,9 @@ void VM_Version::initialize() {
     if (FLAG_IS_DEFAULT(UseZbb)) {
       FLAG_SET_DEFAULT(UseZbb, true);
     }
+    if (FLAG_IS_DEFAULT(UseZbs)) {
+      FLAG_SET_DEFAULT(UseZbs, true);
+    }
     if (FLAG_IS_DEFAULT(UseZic64b)) {
       FLAG_SET_DEFAULT(UseZic64b, true);
     }


### PR DESCRIPTION
This patch adds RISC-V backend support for library intrinsics that implement conversions between half-precision and single-precision floats by using RISC-V Zfhmin Extension, which was already ratified by November 2021 (https://wiki.riscv.org/display/HOME/Recently+Ratified+Extensions) and one of RVA22U64 Mandatory Extensions (https://github.com/riscv/riscv-profiles/blob/main/profiles.adoc#rva22-profiles).

The C2 output for PrintOptoAssembly:
0dc      B10: #  out( B33 B11 ) <- in( B9 )  Freq: 1.99802
0dc +   flw  F1, [R29, #16]     # float, #@loadF
0e0 +   fcvt.h.s F0, F1 #@convF2HF_reg_reg
             fmv.x.h R8, F0  #@convF2HF_reg_reg

0dc      B10: #  out( B33 B11 ) <- in( B9 )  Freq: 1.99801
0dc +   lh  R12, [R11, #16]     # short, #@loadS
0e0 +   fmv.h.x F0, R12 #@convHF2F_reg_reg
             fcvt.s.h F1, F0 #@convHF2F_reg_reg

We don't have any hardware supporting yet, so ran the following benchmarks in Qemu for unreliable reference:

VM options: -XX:+UnlockExperimentalVMOptions -XX:-UseZfhmin
Benchmark                                           (size)   Mode  Samples      Score  Score error   Units
o.s.Fp16ConversionBenchmark.float16ToFloat            2048  thrpt       15     44.523        0.116  ops/ms
o.s.Fp16ConversionBenchmark.float16ToFloatMemory      2048  thrpt       15   8379.835       27.309  ops/ms
o.s.Fp16ConversionBenchmark.floatToFloat16            2048  thrpt       15      7.370        0.028  ops/ms
o.s.Fp16ConversionBenchmark.floatToFloat16Memory      2048  thrpt       15  11292.278       11.962  ops/ms

VM options: -XX:+UnlockExperimentalVMOptions -XX:+UseZfhmin
Benchmark                                           (size)   Mode  Samples      Score  Score error   Units
o.s.Fp16ConversionBenchmark.float16ToFloat            2048  thrpt       15     12.357        0.153  ops/ms
o.s.Fp16ConversionBenchmark.float16ToFloatMemory      2048  thrpt       15  10213.944       69.222  ops/ms
o.s.Fp16ConversionBenchmark.floatToFloat16            2048  thrpt       15     11.728        0.067  ops/ms
o.s.Fp16ConversionBenchmark.floatToFloat16Memory      2048  thrpt       15  15008.550       13.917  ops/ms

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299525](https://bugs.openjdk.org/browse/JDK-8299525): RISC-V: Add backend support for half float conversion intrinsics


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11828/head:pull/11828` \
`$ git checkout pull/11828`

Update a local copy of the PR: \
`$ git checkout pull/11828` \
`$ git pull https://git.openjdk.org/jdk pull/11828/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11828`

View PR using the GUI difftool: \
`$ git pr show -t 11828`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11828.diff">https://git.openjdk.org/jdk/pull/11828.diff</a>

</details>
