### PR TITLE
8189338: JMX RMI Remote Mbean server connection hangs if the server stops responding during a SSL Handshake

### DIFF
--- a/src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPChannel.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/rmi/transport/handshakeTimeout/HandshakeTimeout.java
+++ b/test/jdk/java/rmi/transport/handshakeTimeout/HandshakeTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/rmi/transport/handshakeTimeout/HandshakeTimeout.java
+++ b/test/jdk/java/rmi/transport/handshakeTimeout/HandshakeTimeout.java
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4322806
+ * @bug 4322806 8189338
  * @summary When an RMI (JRMP) connection is made to a TCP address that is
  * listening, so the connection is accepted, but the server never responds
  * to the initial JRMP handshake (nor does it terminate the connection),
@@ -38,8 +38,11 @@
  *          java.rmi/sun.rmi.transport
  *          java.rmi/sun.rmi.transport.tcp
  * @run main/othervm HandshakeTimeout
+ * @run main/othervm HandshakeTimeout SSL
  */
 
+import javax.rmi.ssl.SslRMIClientSocketFactory;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.rmi.ConnectException;
 import java.rmi.ConnectIOException;
@@ -60,12 +63,19 @@ public class HandshakeTimeout {
          * Listen on port, but never process connections made to it.
          */
         ServerSocket serverSocket = new ServerSocket(0);
-        int port = serverSocket.getLocalPort();
+        InetSocketAddress address = (InetSocketAddress) serverSocket.getLocalSocketAddress();
 
         /*
          * Attempt RMI call to port in separate thread.
          */
-        Registry registry = LocateRegistry.getRegistry(port);
+        Registry registry;
+        if (args.length == 0) {
+            registry = LocateRegistry.getRegistry(address.getPort());
+        } else {
+            registry = LocateRegistry.getRegistry(address.getHostString(),
+                    address.getPort(), new SslRMIClientSocketFactory());
+        }
+
         Connector connector = new Connector(registry);
         Thread t = new Thread(connector);
         t.setDaemon(true);


### PR DESCRIPTION
This patch introduces a time limit for establishing a secure connection to a RMI server.

The existing implementation uses the configured `sun.rmi.transport.tcp.handshakeTimeout` during RMI handshake only; there's no time limit for SSL handshake.
With this patch, the configuration option `sun.rmi.transport.tcp.handshakeTimeout` is also used as a socket read timeout during the SSL handshake.

I modified the existing `HandshakeTimeout` test to verify both non-SSL and SSL connections; the test passes with my changes, fails without them.

Existing tier1-3 tests continue to pass.

While working on the patch I noticed that `conn.isReusable()` always returns true. I can remove all references to `isReusable` here or in another PR; it would simplify the code a bit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8189338](https://bugs.openjdk.org/browse/JDK-8189338): JMX RMI Remote Mbean server connection hangs if the server stops responding during a SSL Handshake


### Reviewers
 * [Stuart Marks](https://openjdk.org/census#smarks) (@stuart-marks - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11829/head:pull/11829` \
`$ git checkout pull/11829`

Update a local copy of the PR: \
`$ git checkout pull/11829` \
`$ git pull https://git.openjdk.org/jdk pull/11829/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11829`

View PR using the GUI difftool: \
`$ git pr show -t 11829`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11829.diff">https://git.openjdk.org/jdk/pull/11829.diff</a>

</details>
