### PR TITLE
8299326: LinkResolver::resolve_field resolved_klass cannot be null

### DIFF
--- a/src/hotspot/share/interpreter/linkResolver.cpp
+++ b/src/hotspot/share/interpreter/linkResolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -814,7 +814,7 @@ static void trace_method_resolution(const char* prefix,
   st->print("%s%s, compile-time-class:%s, method:%s, method_holder:%s, access_flags: ",
             prefix,
             (klass == NULL ? "<NULL>" : klass->internal_name()),
-            (resolved_klass == NULL ? "<NULL>" : resolved_klass->internal_name()),
+            resolved_klass->internal_name(),
             Method::name_and_sig_as_C_string(resolved_klass,
                                              method->name(),
                                              method->signature()),
@@ -969,11 +969,6 @@ void LinkResolver::resolve_field(fieldDescriptor& fd,
   Klass* resolved_klass = link_info.resolved_klass();
   Symbol* field = link_info.name();
   Symbol* sig = link_info.signature();
-
-  if (resolved_klass == NULL) {
-    ResourceMark rm(THREAD);
-    THROW_MSG(vmSymbols::java_lang_NoSuchFieldError(), field->as_C_string());
-  }
 
   // Resolve instance field
   Klass* sel_klass = resolved_klass->find_field(field, sig, &fd);

--- a/src/hotspot/share/interpreter/linkResolver.hpp
+++ b/src/hotspot/share/interpreter/linkResolver.hpp
@@ -175,7 +175,7 @@ class LinkInfo : public StackObj {
 
   // Case where we just find the method and don't check access against the current class, used by JavaCalls
   LinkInfo(Klass* resolved_klass, Symbol*name, Symbol* signature) :
-    LinkInfo(resolved_klass, name, signature, (Klass*)nullptr, AccessCheck::skip, LoaderConstraintCheck::skip,
+    LinkInfo(resolved_klass, name, signature, nullptr, AccessCheck::skip, LoaderConstraintCheck::skip,
              JVM_CONSTANT_Invalid) {}
 
   // accessors

--- a/src/hotspot/share/interpreter/linkResolver.hpp
+++ b/src/hotspot/share/interpreter/linkResolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -154,26 +154,29 @@ class LinkInfo : public StackObj {
            AccessCheck check_access = AccessCheck::required,
            LoaderConstraintCheck check_loader_constraints = LoaderConstraintCheck::required,
            constantTag tag = JVM_CONSTANT_Invalid) :
-    _name(name),
-    _signature(signature), _resolved_klass(resolved_klass), _current_klass(current_klass), _current_method(methodHandle()),
-    _check_access(check_access == AccessCheck::required),
-    _check_loader_constraints(check_loader_constraints == LoaderConstraintCheck::required), _tag(tag) {}
+      _name(name),
+      _signature(signature),
+      _resolved_klass(resolved_klass),
+      _current_klass(current_klass),
+      _current_method(methodHandle()),
+      _check_access(check_access == AccessCheck::required),
+      _check_loader_constraints(check_loader_constraints == LoaderConstraintCheck::required),
+      _tag(tag) {
+    assert(_resolved_klass != nullptr, "must always have a resolved_klass");
+  }
 
   LinkInfo(Klass* resolved_klass, Symbol* name, Symbol* signature, const methodHandle& current_method,
            AccessCheck check_access = AccessCheck::required,
            LoaderConstraintCheck check_loader_constraints = LoaderConstraintCheck::required,
            constantTag tag = JVM_CONSTANT_Invalid) :
-    _name(name),
-    _signature(signature), _resolved_klass(resolved_klass), _current_klass(current_method->method_holder()), _current_method(current_method),
-    _check_access(check_access == AccessCheck::required),
-    _check_loader_constraints(check_loader_constraints == LoaderConstraintCheck::required), _tag(tag) {}
+    LinkInfo(resolved_klass, name, signature, current_method->method_holder(), check_access, check_loader_constraints, tag) {
+    _current_method = current_method;
+  }
 
-
-  // Case where we just find the method and don't check access against the current class
+  // Case where we just find the method and don't check access against the current class, used by JavaCalls
   LinkInfo(Klass* resolved_klass, Symbol*name, Symbol* signature) :
-    _name(name),
-    _signature(signature), _resolved_klass(resolved_klass), _current_klass(NULL), _current_method(methodHandle()),
-    _check_access(false), _check_loader_constraints(false), _tag(JVM_CONSTANT_Invalid) {}
+    LinkInfo(resolved_klass, name, signature, (Klass*)nullptr, AccessCheck::skip, LoaderConstraintCheck::skip,
+             JVM_CONSTANT_Invalid) {}
 
   // accessors
   Symbol* name() const                  { return _name; }


### PR DESCRIPTION
Removed the code checking for null and add an assert for the creation of LinkInfo that the resolved_klass can't be null.  Use delegating constructors for LinkInfo.
Tested with tier1-7.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299326](https://bugs.openjdk.org/browse/JDK-8299326): LinkResolver::resolve_field resolved_klass cannot be null


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11832/head:pull/11832` \
`$ git checkout pull/11832`

Update a local copy of the PR: \
`$ git checkout pull/11832` \
`$ git pull https://git.openjdk.org/jdk pull/11832/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11832`

View PR using the GUI difftool: \
`$ git pr show -t 11832`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11832.diff">https://git.openjdk.org/jdk/pull/11832.diff</a>

</details>
