### PR TITLE
8299274: Add elements to resolved_references consistently

### DIFF
--- a/src/hotspot/share/cds/cdsProtectionDomain.cpp
+++ b/src/hotspot/share/cds/cdsProtectionDomain.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -293,7 +293,7 @@ void CDSProtectionDomain::atomic_set_array_index(OopHandle array, int index, oop
   // The important thing here is that all threads pick up the same result.
   // It doesn't matter which racing thread wins, as long as only one
   // result is used by all threads, and all future queries.
-  ((objArrayOop)array.resolve())->atomic_compare_exchange_oop(index, o, NULL);
+  ((objArrayOop)array.resolve())->replace_if_null(index, o);
 }
 
 oop CDSProtectionDomain::shared_protection_domain(int index) {

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -692,7 +692,7 @@ ciConstant ciEnv::unbox_primitive_value(ciObject* cibox, BasicType expected_bt) 
 //
 ciConstant ciEnv::get_resolved_constant(const constantPoolHandle& cpool, int obj_index) {
   assert(obj_index >= 0, "");
-  oop obj = cpool->resolved_references_at(obj_index);
+  oop obj = cpool->resolved_reference_at(obj_index);
   if (obj == NULL) {
     // Unresolved constant. It is resolved when the corresponding slot contains a non-null reference.
     // Null constant is represented as a sentinel (non-null) value.

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -692,7 +692,7 @@ ciConstant ciEnv::unbox_primitive_value(ciObject* cibox, BasicType expected_bt) 
 //
 ciConstant ciEnv::get_resolved_constant(const constantPoolHandle& cpool, int obj_index) {
   assert(obj_index >= 0, "");
-  oop obj = cpool->resolved_references()->obj_at(obj_index);
+  oop obj = cpool->resolved_references_at(obj_index);
   if (obj == NULL) {
     // Unresolved constant. It is resolved when the corresponding slot contains a non-null reference.
     // Null constant is represented as a sentinel (non-null) value.

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -194,7 +194,7 @@ JRT_ENTRY(void, InterpreterRuntime::resolve_ldc(JavaThread* current, Bytecodes::
     if (rindex < 0)
       rindex = m->constants()->cp_to_object_index(ldc2.pool_index());
     if (rindex >= 0) {
-      oop coop = m->constants()->resolved_references_at(rindex);
+      oop coop = m->constants()->resolved_reference_at(rindex);
       oop roop = (result == NULL ? Universe::the_null_sentinel() : result);
       assert(roop == coop, "expected result for assembly code");
     }

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -194,7 +194,7 @@ JRT_ENTRY(void, InterpreterRuntime::resolve_ldc(JavaThread* current, Bytecodes::
     if (rindex < 0)
       rindex = m->constants()->cp_to_object_index(ldc2.pool_index());
     if (rindex >= 0) {
-      oop coop = m->constants()->resolved_references()->obj_at(rindex);
+      oop coop = m->constants()->resolved_references_at(rindex);
       oop roop = (result == NULL ? Universe::the_null_sentinel() : result);
       assert(roop == coop, "expected result for assembly code");
     }

--- a/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
@@ -2127,7 +2127,7 @@ run:
 
           case JVM_CONSTANT_String:
             {
-              oop result = constants->resolved_references()->obj_at(index);
+              oop result = constants->resolved_references_at(index);
               if (result == NULL) {
                 CALL_VM(InterpreterRuntime::resolve_ldc(THREAD, (Bytecodes::Code) opcode), handle_exception);
                 SET_STACK_OBJECT(THREAD->vm_result(), 0);
@@ -2232,7 +2232,7 @@ run:
         // This kind of CP cache entry does not need to match the flags byte, because
         // there is a 1-1 relation between bytecode type and CP entry type.
         ConstantPool* constants = METHOD->constants();
-        oop result = constants->resolved_references()->obj_at(index);
+        oop result = constants->resolved_references_at(index);
         if (result == NULL) {
           CALL_VM(InterpreterRuntime::resolve_ldc(THREAD, (Bytecodes::Code) opcode),
                   handle_exception);

--- a/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
@@ -2127,7 +2127,7 @@ run:
 
           case JVM_CONSTANT_String:
             {
-              oop result = constants->resolved_references_at(index);
+              oop result = constants->resolved_reference_at(index);
               if (result == NULL) {
                 CALL_VM(InterpreterRuntime::resolve_ldc(THREAD, (Bytecodes::Code) opcode), handle_exception);
                 SET_STACK_OBJECT(THREAD->vm_result(), 0);
@@ -2232,7 +2232,7 @@ run:
         // This kind of CP cache entry does not need to match the flags byte, because
         // there is a 1-1 relation between bytecode type and CP entry type.
         ConstantPool* constants = METHOD->constants();
-        oop result = constants->resolved_references_at(index);
+        oop result = constants->resolved_reference_at(index);
         if (result == NULL) {
           CALL_VM(InterpreterRuntime::resolve_ldc(THREAD, (Bytecodes::Code) opcode),
                   handle_exception);

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -171,14 +171,14 @@ objArrayOop ConstantPool::resolved_references_or_null() const {
   }
 }
 
-oop ConstantPool::resolved_references_at(int index) const {
+oop ConstantPool::resolved_reference_at(int index) const {
   oop result = resolved_references()->obj_at(index);
   assert(oopDesc::is_oop_or_null(result), "Must be oop");
   return result;
 }
 
 // Use a CAS for multithreaded access
-oop ConstantPool::set_resolved_references_at(int index, oop new_result) {
+oop ConstantPool::set_resolved_reference_at(int index, oop new_result) {
   assert(oopDesc::is_oop_or_null(new_result), "Must be oop");
   return resolved_references()->replace_if_null(index, new_result);
 }
@@ -458,7 +458,7 @@ int ConstantPool::cp_to_object_index(int cp_index) {
 }
 
 void ConstantPool::string_at_put(int which, int obj_index, oop str) {
-  oop result = set_resolved_references_at(obj_index, str);
+  oop result = set_resolved_reference_at(obj_index, str);
   assert(result == nullptr || result == str, "Only set once or to the same string.");
 }
 
@@ -949,7 +949,7 @@ oop ConstantPool::resolve_constant_at_impl(const constantPoolHandle& this_cp,
   assert(index == _no_index_sentinel || index >= 0, "");
 
   if (cache_index >= 0) {
-    result_oop = this_cp->resolved_references_at(cache_index);
+    result_oop = this_cp->resolved_reference_at(cache_index);
     if (result_oop != NULL) {
       if (result_oop == Universe::the_null_sentinel()) {
         DEBUG_ONLY(int temp_index = (index >= 0 ? index : this_cp->object_to_cp_index(cache_index)));
@@ -1172,7 +1172,7 @@ oop ConstantPool::resolve_constant_at_impl(const constantPoolHandle& this_cp,
     // It doesn't matter which racing thread wins, as long as only one
     // result is used by all threads, and all future queries.
     oop new_result = (result_oop == NULL ? Universe::the_null_sentinel() : result_oop);
-    oop old_result = this_cp->set_resolved_references_at(cache_index, new_result);
+    oop old_result = this_cp->set_resolved_reference_at(cache_index, new_result);
     if (old_result == nullptr) {
       return result_oop;  // was installed
     } else {
@@ -1234,7 +1234,7 @@ void ConstantPool::copy_bootstrap_arguments_at_impl(const constantPoolHandle& th
 
 oop ConstantPool::string_at_impl(const constantPoolHandle& this_cp, int which, int obj_index, TRAPS) {
   // If the string has already been interned, this entry will be non-null
-  oop str = this_cp->resolved_references_at(obj_index);
+  oop str = this_cp->resolved_reference_at(obj_index);
   assert(str != Universe::the_null_sentinel(), "");
   if (str != NULL) return str;
   Symbol* sym = this_cp->unresolved_string_at(which);

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -158,7 +158,7 @@ void ConstantPool::metaspace_pointers_do(MetaspaceClosure* it) {
 }
 
 objArrayOop ConstantPool::resolved_references() const {
-  return (objArrayOop)_cache->resolved_references();
+  return _cache->resolved_references();
 }
 
 // Called from outside constant pool resolution where a resolved_reference array
@@ -167,8 +167,20 @@ objArrayOop ConstantPool::resolved_references_or_null() const {
   if (_cache == NULL) {
     return NULL;
   } else {
-    return (objArrayOop)_cache->resolved_references();
+    return _cache->resolved_references();
   }
+}
+
+oop ConstantPool::resolved_references_at(int index) const {
+  oop result = resolved_references()->obj_at(index);
+  assert(oopDesc::is_oop_or_null(result), "Must be oop");
+  return result;
+}
+
+// Use a CAS for multithreaded access
+oop ConstantPool::set_resolved_references_at(int index, oop new_result, oop old_result) {
+  assert(oopDesc::is_oop_or_null(new_result), "Must be oop");
+  return resolved_references()->atomic_compare_exchange_oop(index, new_result, old_result);
 }
 
 // Create resolved_references array and mapping array for original cp indexes
@@ -446,7 +458,8 @@ int ConstantPool::cp_to_object_index(int cp_index) {
 }
 
 void ConstantPool::string_at_put(int which, int obj_index, oop str) {
-  resolved_references()->obj_at_put(obj_index, str);
+  oop result = set_resolved_references_at(obj_index, str, nullptr);
+  assert(result == nullptr || result == str, "Only set once or to the same string.");
 }
 
 void ConstantPool::trace_class_resolution(const constantPoolHandle& this_cp, Klass* k) {
@@ -936,7 +949,7 @@ oop ConstantPool::resolve_constant_at_impl(const constantPoolHandle& this_cp,
   assert(index == _no_index_sentinel || index >= 0, "");
 
   if (cache_index >= 0) {
-    result_oop = this_cp->resolved_references()->obj_at(cache_index);
+    result_oop = this_cp->resolved_references_at(cache_index);
     if (result_oop != NULL) {
       if (result_oop == Universe::the_null_sentinel()) {
         DEBUG_ONLY(int temp_index = (index >= 0 ? index : this_cp->object_to_cp_index(cache_index)));
@@ -1159,9 +1172,8 @@ oop ConstantPool::resolve_constant_at_impl(const constantPoolHandle& this_cp,
     // It doesn't matter which racing thread wins, as long as only one
     // result is used by all threads, and all future queries.
     oop new_result = (result_oop == NULL ? Universe::the_null_sentinel() : result_oop);
-    oop old_result = this_cp->resolved_references()
-      ->atomic_compare_exchange_oop(cache_index, new_result, NULL);
-    if (old_result == NULL) {
+    oop old_result = this_cp->set_resolved_references_at(cache_index, new_result, nullptr);
+    if (old_result == nullptr) {
       return result_oop;  // was installed
     } else {
       // Return the winning thread's result.  This can be different than
@@ -1222,7 +1234,7 @@ void ConstantPool::copy_bootstrap_arguments_at_impl(const constantPoolHandle& th
 
 oop ConstantPool::string_at_impl(const constantPoolHandle& this_cp, int which, int obj_index, TRAPS) {
   // If the string has already been interned, this entry will be non-null
-  oop str = this_cp->resolved_references()->obj_at(obj_index);
+  oop str = this_cp->resolved_references_at(obj_index);
   assert(str != Universe::the_null_sentinel(), "");
   if (str != NULL) return str;
   Symbol* sym = this_cp->unresolved_string_at(which);

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -237,7 +237,7 @@ class ConstantPool : public Metadata {
   objArrayOop resolved_references()  const;
   objArrayOop resolved_references_or_null()  const;
   oop resolved_references_at(int obj_index) const;
-  oop set_resolved_references_at(int index, oop new_value, oop old_value);
+  oop set_resolved_references_at(int index, oop new_value);
 
   // mapping resolved object array indexes to cp indexes and back.
   int object_to_cp_index(int index)         { return reference_map()->at(index); }

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -236,8 +236,8 @@ class ConstantPool : public Metadata {
   // resolved strings, methodHandles and callsite objects from the constant pool
   objArrayOop resolved_references()  const;
   objArrayOop resolved_references_or_null()  const;
-  oop resolved_references_at(int obj_index) const;
-  oop set_resolved_references_at(int index, oop new_value);
+  oop resolved_reference_at(int obj_index) const;
+  oop set_resolved_reference_at(int index, oop new_value);
 
   // mapping resolved object array indexes to cp indexes and back.
   int object_to_cp_index(int index)         { return reference_map()->at(index); }
@@ -477,7 +477,7 @@ class ConstantPool : public Metadata {
     // behind our back, lest we later load stale values thru the oop.
     // we might want a volatile_obj_at in ObjArrayKlass.
     int obj_index = cp_to_object_index(which);
-    return resolved_references_at(obj_index);
+    return resolved_reference_at(obj_index);
   }
 
   Symbol* unresolved_string_at(int which) {

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -236,6 +236,9 @@ class ConstantPool : public Metadata {
   // resolved strings, methodHandles and callsite objects from the constant pool
   objArrayOop resolved_references()  const;
   objArrayOop resolved_references_or_null()  const;
+  oop resolved_references_at(int obj_index) const;
+  oop set_resolved_references_at(int index, oop new_value, oop old_value);
+
   // mapping resolved object array indexes to cp indexes and back.
   int object_to_cp_index(int index)         { return reference_map()->at(index); }
   int cp_to_object_index(int index);
@@ -474,7 +477,7 @@ class ConstantPool : public Metadata {
     // behind our back, lest we later load stale values thru the oop.
     // we might want a volatile_obj_at in ObjArrayKlass.
     int obj_index = cp_to_object_index(which);
-    return resolved_references()->obj_at(obj_index);
+    return resolved_references_at(obj_index);
   }
 
   Symbol* unresolved_string_at(int which) {

--- a/src/hotspot/share/oops/cpCache.cpp
+++ b/src/hotspot/share/oops/cpCache.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/oops/cpCache.cpp
+++ b/src/hotspot/share/oops/cpCache.cpp
@@ -432,7 +432,7 @@ void ConstantPoolCacheEntry::set_method_handle_common(const constantPoolHandle& 
   // Store appendix, if any.
   if (has_appendix) {
     const int appendix_index = f2_as_index();
-    oop old_oop = cpool->set_resolved_references_at(appendix_index, appendix());
+    oop old_oop = cpool->set_resolved_reference_at(appendix_index, appendix());
     assert(old_oop == nullptr, "init just once");
   }
 
@@ -529,7 +529,7 @@ oop ConstantPoolCacheEntry::appendix_if_resolved(const constantPoolHandle& cpool
   if (!has_appendix())
     return NULL;
   const int ref_index = f2_as_index();
-  return cpool->resolved_references_at(ref_index);
+  return cpool->resolved_reference_at(ref_index);
 }
 
 

--- a/src/hotspot/share/oops/cpCache.cpp
+++ b/src/hotspot/share/oops/cpCache.cpp
@@ -432,7 +432,7 @@ void ConstantPoolCacheEntry::set_method_handle_common(const constantPoolHandle& 
   // Store appendix, if any.
   if (has_appendix) {
     const int appendix_index = f2_as_index();
-    oop old_oop = cpool->set_resolved_references_at(appendix_index, appendix(), nullptr);
+    oop old_oop = cpool->set_resolved_references_at(appendix_index, appendix());
     assert(old_oop == nullptr, "init just once");
   }
 

--- a/src/hotspot/share/oops/cpCache.cpp
+++ b/src/hotspot/share/oops/cpCache.cpp
@@ -432,10 +432,8 @@ void ConstantPoolCacheEntry::set_method_handle_common(const constantPoolHandle& 
   // Store appendix, if any.
   if (has_appendix) {
     const int appendix_index = f2_as_index();
-    objArrayOop resolved_references = cpool->resolved_references();
-    assert(appendix_index >= 0 && appendix_index < resolved_references->length(), "oob");
-    assert(resolved_references->obj_at(appendix_index) == NULL, "init just once");
-    resolved_references->obj_at_put(appendix_index, appendix());
+    oop old_oop = cpool->set_resolved_references_at(appendix_index, appendix(), nullptr);
+    assert(old_oop == nullptr, "init just once");
   }
 
   release_set_f1(adapter);  // This must be the last one to set (see NOTE above)!
@@ -531,8 +529,7 @@ oop ConstantPoolCacheEntry::appendix_if_resolved(const constantPoolHandle& cpool
   if (!has_appendix())
     return NULL;
   const int ref_index = f2_as_index();
-  objArrayOop resolved_references = cpool->resolved_references();
-  return resolved_references->obj_at(ref_index);
+  return cpool->resolved_references_at(ref_index);
 }
 
 

--- a/src/hotspot/share/oops/cpCache.hpp
+++ b/src/hotspot/share/oops/cpCache.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/oops/cpCache.hpp
+++ b/src/hotspot/share/oops/cpCache.hpp
@@ -447,7 +447,7 @@ class ConstantPoolCache: public MetaspaceObj {
   void set_archived_references(oop o) NOT_CDS_JAVA_HEAP_RETURN;
   void clear_archived_references() NOT_CDS_JAVA_HEAP_RETURN;
 
-  inline oop resolved_references();
+  inline objArrayOop resolved_references();
   void set_resolved_references(OopHandle s) { _resolved_references = s; }
   Array<u2>* reference_map() const        { return _reference_map; }
   void set_reference_map(Array<u2>* o)    { _reference_map = o; }

--- a/src/hotspot/share/oops/cpCache.inline.hpp
+++ b/src/hotspot/share/oops/cpCache.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/oops/cpCache.inline.hpp
+++ b/src/hotspot/share/oops/cpCache.inline.hpp
@@ -99,6 +99,10 @@ inline ConstantPoolCache::ConstantPoolCache(int length,
   }
 }
 
-inline oop ConstantPoolCache::resolved_references() { return _resolved_references.resolve(); }
+inline objArrayOop ConstantPoolCache::resolved_references() {
+  oop obj = _resolved_references.resolve();
+  assert(obj == nullptr || obj->is_objArray(), "should be objArray");
+  return (objArrayOop)obj;
+}
 
 #endif // SHARE_OOPS_CPCACHE_INLINE_HPP

--- a/src/hotspot/share/oops/objArrayOop.cpp
+++ b/src/hotspot/share/oops/objArrayOop.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,15 +28,14 @@
 #include "oops/objArrayOop.inline.hpp"
 #include "oops/oop.inline.hpp"
 
-oop objArrayOopDesc::atomic_compare_exchange_oop(int index, oop exchange_value,
-                                                 oop compare_value) {
+oop objArrayOopDesc::replace_if_null(int index, oop exchange_value) {
   ptrdiff_t offs;
   if (UseCompressedOops) {
     offs = objArrayOopDesc::obj_at_offset<narrowOop>(index);
   } else {
     offs = objArrayOopDesc::obj_at_offset<oop>(index);
   }
-  return HeapAccess<IS_ARRAY>::oop_atomic_cmpxchg_at(as_oop(), offs, compare_value, exchange_value);
+  return HeapAccess<IS_ARRAY>::oop_atomic_cmpxchg_at(as_oop(), offs, (oop)nullptr, exchange_value);
 }
 
 Klass* objArrayOopDesc::element_klass() {

--- a/src/hotspot/share/oops/objArrayOop.hpp
+++ b/src/hotspot/share/oops/objArrayOop.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,7 +90,7 @@ private:
 
   void obj_at_put(int index, oop value);
 
-  oop atomic_compare_exchange_oop(int index, oop exchange_value, oop compare_value);
+  oop replace_if_null(int index, oop exchange_value);
 
   // Sizing
   static int header_size()    { return arrayOopDesc::header_size(T_OBJECT); }


### PR DESCRIPTION
I added a resolved_references_at and set_resolved_references_at() functions to use for accesses to the resolved_references array, except for the CDS usages. This has an assert that the element is an oop and oob checks and setting elements use a CAS consistently.
These asserts seem useful for finding the bug causing https://bugs.openjdk.org/browse/JDK-8296915.
Tested with tiers1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299274](https://bugs.openjdk.org/browse/JDK-8299274): Add elements to resolved_references consistently


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**) ⚠️ Review applies to [50ff492c](https://git.openjdk.org/jdk/pull/11834/files/50ff492c7d022aa591407544ac0cd6d6da1f1236)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer) ⚠️ Review applies to [d10796da](https://git.openjdk.org/jdk/pull/11834/files/d10796da140394fe5d4dbb7e4efbc6a778e8536f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11834/head:pull/11834` \
`$ git checkout pull/11834`

Update a local copy of the PR: \
`$ git checkout pull/11834` \
`$ git pull https://git.openjdk.org/jdk pull/11834/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11834`

View PR using the GUI difftool: \
`$ git pr show -t 11834`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11834.diff">https://git.openjdk.org/jdk/pull/11834.diff</a>

</details>
