### PR TITLE
JDK-8299554: Remove EnableIf from metaprogramming/enableIf.hpp

### DIFF
--- a/src/hotspot/share/metaprogramming/enableIf.hpp
+++ b/src/hotspot/share/metaprogramming/enableIf.hpp
@@ -25,14 +25,9 @@
 #ifndef SHARE_METAPROGRAMMING_ENABLEIF_HPP
 #define SHARE_METAPROGRAMMING_ENABLEIF_HPP
 
-#include "metaprogramming/logical.hpp"
-#include <type_traits>
+#include "utilities/globalDefinitions.hpp"
 
-// Retained temporarily for backward compatibility.
-// For function template SFINAE, use the ENABLE_IF macro below.
-// For class template SFINAE, use std::enable_if_t directly.
-template<bool cond, typename T = void>
-using EnableIf = std::enable_if<cond, T>;
+#include <type_traits>
 
 // ENABLE_IF(Condition...)
 // ENABLE_IF_SDEFN(Condition...)

--- a/src/hotspot/share/oops/access.inline.hpp
+++ b/src/hotspot/share/oops/access.inline.hpp
@@ -31,6 +31,8 @@
 #include "gc/shared/barrierSetConfig.inline.hpp"
 #include "oops/accessBackend.inline.hpp"
 
+#include <type_traits>
+
 // This file outlines the last 2 steps of the template pipeline of accesses going through
 // the Access API.
 // * Step 5.a: Barrier resolution. This step is invoked the first time a runtime-dispatch
@@ -206,9 +208,9 @@ namespace AccessInternal {
   template <DecoratorSet decorators, typename FunctionPointerT, BarrierType barrier_type>
   struct BarrierResolver: public AllStatic {
     template <DecoratorSet ds>
-    static typename EnableIf<
+    static std::enable_if_t<
       HasDecorator<ds, INTERNAL_VALUE_IS_OOP>::value,
-      FunctionPointerT>::type
+      FunctionPointerT>
     resolve_barrier_gc() {
       BarrierSet* bs = BarrierSet::barrier_set();
       assert(bs != NULL, "GC barriers invoked before BarrierSet is set");
@@ -229,9 +231,9 @@ namespace AccessInternal {
     }
 
     template <DecoratorSet ds>
-    static typename EnableIf<
+    static std::enable_if_t<
       !HasDecorator<ds, INTERNAL_VALUE_IS_OOP>::value,
-      FunctionPointerT>::type
+      FunctionPointerT>
     resolve_barrier_gc() {
       BarrierSet* bs = BarrierSet::barrier_set();
       assert(bs != NULL, "GC barriers invoked before BarrierSet is set");

--- a/src/hotspot/share/oops/accessBackend.hpp
+++ b/src/hotspot/share/oops/accessBackend.hpp
@@ -191,14 +191,14 @@ protected:
 protected:
   // Only encode if INTERNAL_VALUE_IS_OOP
   template <DecoratorSet idecorators, typename T>
-  static inline typename EnableIf<
-    AccessInternal::MustConvertCompressedOop<idecorators, T>::value,
+  static inline std::enable_if_t<
+    AccessInternal::MustConvertCompressedOop<idecorators, T>,
     typename HeapOopType<idecorators>::type>::type
   encode_internal(T value);
 
   template <DecoratorSet idecorators, typename T>
-  static inline typename EnableIf<
-    !AccessInternal::MustConvertCompressedOop<idecorators, T>::value, T>::type
+  static inline std::enable_if_t<
+    !AccessInternal::MustConvertCompressedOop<idecorators, T>::value, T>
   encode_internal(T value) {
     return value;
   }
@@ -211,13 +211,13 @@ protected:
 
   // Only decode if INTERNAL_VALUE_IS_OOP
   template <DecoratorSet idecorators, typename T>
-  static inline typename EnableIf<
-    AccessInternal::MustConvertCompressedOop<idecorators, T>::value, T>::type
+  static inline std::enable_if_t<
+    AccessInternal::MustConvertCompressedOop<idecorators, T>::value, T>
   decode_internal(typename HeapOopType<idecorators>::type value);
 
   template <DecoratorSet idecorators, typename T>
-  static inline typename EnableIf<
-    !AccessInternal::MustConvertCompressedOop<idecorators, T>::value, T>::type
+  static inline std::enable_if_t<
+    !AccessInternal::MustConvertCompressedOop<idecorators, T>::value, T>
   decode_internal(T value) {
     return value;
   }
@@ -229,62 +229,62 @@ protected:
 
 protected:
   template <DecoratorSet ds, typename T>
-  static typename EnableIf<
-    HasDecorator<ds, MO_SEQ_CST>::value, T>::type
+  static std::enable_if_t<
+    HasDecorator<ds, MO_SEQ_CST>::value, T>
   load_internal(void* addr);
 
   template <DecoratorSet ds, typename T>
-  static typename EnableIf<
-    HasDecorator<ds, MO_ACQUIRE>::value, T>::type
+  static std::enable_if_t<
+    HasDecorator<ds, MO_ACQUIRE>::value, T>
   load_internal(void* addr);
 
   template <DecoratorSet ds, typename T>
-  static typename EnableIf<
-    HasDecorator<ds, MO_RELAXED>::value, T>::type
+  static std::enable_if_t<
+    HasDecorator<ds, MO_RELAXED>::value, T>
   load_internal(void* addr);
 
   template <DecoratorSet ds, typename T>
-  static inline typename EnableIf<
-    HasDecorator<ds, MO_UNORDERED>::value, T>::type
+  static inline std::enable_if_t<
+    HasDecorator<ds, MO_UNORDERED>::value, T>
   load_internal(void* addr) {
     return *reinterpret_cast<T*>(addr);
   }
 
   template <DecoratorSet ds, typename T>
-  static typename EnableIf<
-    HasDecorator<ds, MO_SEQ_CST>::value>::type
+  static std::enable_if_t<
+    HasDecorator<ds, MO_SEQ_CST>::value>
   store_internal(void* addr, T value);
 
   template <DecoratorSet ds, typename T>
-  static typename EnableIf<
-    HasDecorator<ds, MO_RELEASE>::value>::type
+  static std::enable_if_t<
+    HasDecorator<ds, MO_RELEASE>::value>
   store_internal(void* addr, T value);
 
   template <DecoratorSet ds, typename T>
-  static typename EnableIf<
-    HasDecorator<ds, MO_RELAXED>::value>::type
+  static std::enable_if_t<
+    HasDecorator<ds, MO_RELAXED>::value>
   store_internal(void* addr, T value);
 
   template <DecoratorSet ds, typename T>
-  static inline typename EnableIf<
-    HasDecorator<ds, MO_UNORDERED>::value>::type
+  static inline std::enable_if_t<
+    HasDecorator<ds, MO_UNORDERED>::value>
   store_internal(void* addr, T value) {
     *reinterpret_cast<T*>(addr) = value;
   }
 
   template <DecoratorSet ds, typename T>
-  static typename EnableIf<
-    HasDecorator<ds, MO_SEQ_CST>::value, T>::type
+  static std::enable_if_t<
+    HasDecorator<ds, MO_SEQ_CST>::value, T>
   atomic_cmpxchg_internal(void* addr, T compare_value, T new_value);
 
   template <DecoratorSet ds, typename T>
-  static typename EnableIf<
-    HasDecorator<ds, MO_RELAXED>::value, T>::type
+  static std::enable_if_t<
+    HasDecorator<ds, MO_RELAXED>::value, T>
   atomic_cmpxchg_internal(void* addr, T compare_value, T new_value);
 
   template <DecoratorSet ds, typename T>
-  static typename EnableIf<
-    HasDecorator<ds, MO_SEQ_CST>::value, T>::type
+  static std::enable_if_t<
+    HasDecorator<ds, MO_SEQ_CST>::value, T>
   atomic_xchg_internal(void* addr, T new_value);
 
   // The following *_locked mechanisms serve the purpose of handling atomic operations
@@ -292,27 +292,27 @@ protected:
   // a slower path using a mutex to perform the operation.
 
   template <DecoratorSet ds, typename T>
-  static inline typename EnableIf<
-    !AccessInternal::PossiblyLockedAccess<T>::value, T>::type
+  static inline std::enable_if_t<
+    !AccessInternal::PossiblyLockedAccess<T>::value, T>
   atomic_cmpxchg_maybe_locked(void* addr, T compare_value, T new_value) {
     return atomic_cmpxchg_internal<ds>(addr, compare_value, new_value);
   }
 
   template <DecoratorSet ds, typename T>
-  static typename EnableIf<
-    AccessInternal::PossiblyLockedAccess<T>::value, T>::type
+  static std::enable_if_t<
+    AccessInternal::PossiblyLockedAccess<T>::value, T>
   atomic_cmpxchg_maybe_locked(void* addr, T compare_value, T new_value);
 
   template <DecoratorSet ds, typename T>
-  static inline typename EnableIf<
-    !AccessInternal::PossiblyLockedAccess<T>::value, T>::type
+  static inline std::enable_if_t<
+    !AccessInternal::PossiblyLockedAccess<T>::value, T>
   atomic_xchg_maybe_locked(void* addr, T new_value) {
     return atomic_xchg_internal<ds>(addr, new_value);
   }
 
   template <DecoratorSet ds, typename T>
-  static typename EnableIf<
-    AccessInternal::PossiblyLockedAccess<T>::value, T>::type
+  static std::enable_if_t<
+    AccessInternal::PossiblyLockedAccess<T>::value, T>
   atomic_xchg_maybe_locked(void* addr, T new_value);
 
 public:
@@ -646,8 +646,8 @@ namespace AccessInternal {
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      HasDecorator<decorators, AS_RAW>::value && CanHardwireRaw<decorators>::value>::type
+    inline static std::enable_if_t<
+      HasDecorator<decorators, AS_RAW>::value && CanHardwireRaw<decorators>::value>
     store(void* addr, T value) {
       typedef RawAccessBarrier<decorators & RAW_DECORATOR_MASK> Raw;
       if (HasDecorator<decorators, INTERNAL_VALUE_IS_OOP>::value) {
@@ -658,8 +658,8 @@ namespace AccessInternal {
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      HasDecorator<decorators, AS_RAW>::value && !CanHardwireRaw<decorators>::value>::type
+    inline static std::enable_if_t<
+      HasDecorator<decorators, AS_RAW>::value && !CanHardwireRaw<decorators>::value>
     store(void* addr, T value) {
       if (UseCompressedOops) {
         const DecoratorSet expanded_decorators = decorators | convert_compressed_oops;
@@ -671,8 +671,8 @@ namespace AccessInternal {
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      !HasDecorator<decorators, AS_RAW>::value>::type
+    inline static std::enable_if_t<
+      !HasDecorator<decorators, AS_RAW>::value>
     store(void* addr, T value) {
       if (is_hardwired_primitive<decorators>()) {
         const DecoratorSet expanded_decorators = decorators | AS_RAW;
@@ -683,15 +683,15 @@ namespace AccessInternal {
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      HasDecorator<decorators, AS_RAW>::value>::type
+    inline static std::enable_if_t<
+      HasDecorator<decorators, AS_RAW>::value>
     store_at(oop base, ptrdiff_t offset, T value) {
       store<decorators>(field_addr(base, offset), value);
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      !HasDecorator<decorators, AS_RAW>::value>::type
+    inline static std::enable_if_t<
+      !HasDecorator<decorators, AS_RAW>::value>
     store_at(oop base, ptrdiff_t offset, T value) {
       if (is_hardwired_primitive<decorators>()) {
         const DecoratorSet expanded_decorators = decorators | AS_RAW;
@@ -702,8 +702,8 @@ namespace AccessInternal {
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      HasDecorator<decorators, AS_RAW>::value && CanHardwireRaw<decorators>::value, T>::type
+    inline static std::enable_if_t<
+      HasDecorator<decorators, AS_RAW>::value && CanHardwireRaw<decorators>::value, T>
     load(void* addr) {
       typedef RawAccessBarrier<decorators & RAW_DECORATOR_MASK> Raw;
       if (HasDecorator<decorators, INTERNAL_VALUE_IS_OOP>::value) {
@@ -714,8 +714,8 @@ namespace AccessInternal {
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      HasDecorator<decorators, AS_RAW>::value && !CanHardwireRaw<decorators>::value, T>::type
+    inline static std::enable_if_t<
+      HasDecorator<decorators, AS_RAW>::value && !CanHardwireRaw<decorators>::value, T>
     load(void* addr) {
       if (UseCompressedOops) {
         const DecoratorSet expanded_decorators = decorators | convert_compressed_oops;
@@ -727,8 +727,8 @@ namespace AccessInternal {
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      !HasDecorator<decorators, AS_RAW>::value, T>::type
+    inline static std::enable_if_t<
+      !HasDecorator<decorators, AS_RAW>::value, T>
     load(void* addr) {
       if (is_hardwired_primitive<decorators>()) {
         const DecoratorSet expanded_decorators = decorators | AS_RAW;
@@ -739,15 +739,15 @@ namespace AccessInternal {
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      HasDecorator<decorators, AS_RAW>::value, T>::type
+    inline static std::enable_if_t<
+      HasDecorator<decorators, AS_RAW>::value, T>
     load_at(oop base, ptrdiff_t offset) {
       return load<decorators, T>(field_addr(base, offset));
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      !HasDecorator<decorators, AS_RAW>::value, T>::type
+    inline static std::enable_if_t<
+      !HasDecorator<decorators, AS_RAW>::value, T>
     load_at(oop base, ptrdiff_t offset) {
       if (is_hardwired_primitive<decorators>()) {
         const DecoratorSet expanded_decorators = decorators | AS_RAW;
@@ -758,8 +758,8 @@ namespace AccessInternal {
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      HasDecorator<decorators, AS_RAW>::value && CanHardwireRaw<decorators>::value, T>::type
+    inline static std::enable_if_t<
+      HasDecorator<decorators, AS_RAW>::value && CanHardwireRaw<decorators>::value, T>
     atomic_cmpxchg(void* addr, T compare_value, T new_value) {
       typedef RawAccessBarrier<decorators & RAW_DECORATOR_MASK> Raw;
       if (HasDecorator<decorators, INTERNAL_VALUE_IS_OOP>::value) {
@@ -770,8 +770,8 @@ namespace AccessInternal {
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      HasDecorator<decorators, AS_RAW>::value && !CanHardwireRaw<decorators>::value, T>::type
+    inline static std::enable_if_t<
+      HasDecorator<decorators, AS_RAW>::value && !CanHardwireRaw<decorators>::value, T>
     atomic_cmpxchg(void* addr, T compare_value, T new_value) {
       if (UseCompressedOops) {
         const DecoratorSet expanded_decorators = decorators | convert_compressed_oops;
@@ -783,8 +783,8 @@ namespace AccessInternal {
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      !HasDecorator<decorators, AS_RAW>::value, T>::type
+    inline static std::enable_if_t<
+      !HasDecorator<decorators, AS_RAW>::value, T>
     atomic_cmpxchg(void* addr, T compare_value, T new_value) {
       if (is_hardwired_primitive<decorators>()) {
         const DecoratorSet expanded_decorators = decorators | AS_RAW;
@@ -795,15 +795,15 @@ namespace AccessInternal {
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      HasDecorator<decorators, AS_RAW>::value, T>::type
+    inline static std::enable_if_t<
+      HasDecorator<decorators, AS_RAW>::value, T>
     atomic_cmpxchg_at(oop base, ptrdiff_t offset, T compare_value, T new_value) {
       return atomic_cmpxchg<decorators>(field_addr(base, offset), compare_value, new_value);
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      !HasDecorator<decorators, AS_RAW>::value, T>::type
+    inline static std::enable_if_t<
+      !HasDecorator<decorators, AS_RAW>::value, T>
     atomic_cmpxchg_at(oop base, ptrdiff_t offset, T compare_value, T new_value) {
       if (is_hardwired_primitive<decorators>()) {
         const DecoratorSet expanded_decorators = decorators | AS_RAW;
@@ -814,8 +814,8 @@ namespace AccessInternal {
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      HasDecorator<decorators, AS_RAW>::value && CanHardwireRaw<decorators>::value, T>::type
+    inline static std::enable_if_t<
+      HasDecorator<decorators, AS_RAW>::value && CanHardwireRaw<decorators>::value, T>
     atomic_xchg(void* addr, T new_value) {
       typedef RawAccessBarrier<decorators & RAW_DECORATOR_MASK> Raw;
       if (HasDecorator<decorators, INTERNAL_VALUE_IS_OOP>::value) {
@@ -826,8 +826,8 @@ namespace AccessInternal {
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      HasDecorator<decorators, AS_RAW>::value && !CanHardwireRaw<decorators>::value, T>::type
+    inline static std::enable_if_t<
+      HasDecorator<decorators, AS_RAW>::value && !CanHardwireRaw<decorators>::value, T>
     atomic_xchg(void* addr, T new_value) {
       if (UseCompressedOops) {
         const DecoratorSet expanded_decorators = decorators | convert_compressed_oops;
@@ -839,8 +839,8 @@ namespace AccessInternal {
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      !HasDecorator<decorators, AS_RAW>::value, T>::type
+    inline static std::enable_if_t<
+      !HasDecorator<decorators, AS_RAW>::value, T>
     atomic_xchg(void* addr, T new_value) {
       if (is_hardwired_primitive<decorators>()) {
         const DecoratorSet expanded_decorators = decorators | AS_RAW;
@@ -851,15 +851,15 @@ namespace AccessInternal {
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      HasDecorator<decorators, AS_RAW>::value, T>::type
+    inline static std::enable_if_t<
+      HasDecorator<decorators, AS_RAW>::value, T>
     atomic_xchg_at(oop base, ptrdiff_t offset, T new_value) {
       return atomic_xchg<decorators>(field_addr(base, offset), new_value);
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      !HasDecorator<decorators, AS_RAW>::value, T>::type
+    inline static std::enable_if_t<
+      !HasDecorator<decorators, AS_RAW>::value, T>
     atomic_xchg_at(oop base, ptrdiff_t offset, T new_value) {
       if (is_hardwired_primitive<decorators>()) {
         const DecoratorSet expanded_decorators = decorators | AS_RAW;
@@ -870,8 +870,8 @@ namespace AccessInternal {
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      HasDecorator<decorators, AS_RAW>::value && CanHardwireRaw<decorators>::value, bool>::type
+    inline static std::enable_if_t<
+      HasDecorator<decorators, AS_RAW>::value && CanHardwireRaw<decorators>::value, bool>
     arraycopy(arrayOop src_obj, size_t src_offset_in_bytes, T* src_raw,
               arrayOop dst_obj, size_t dst_offset_in_bytes, T* dst_raw,
               size_t length) {
@@ -888,8 +888,8 @@ namespace AccessInternal {
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      HasDecorator<decorators, AS_RAW>::value && !CanHardwireRaw<decorators>::value, bool>::type
+    inline static std::enable_if_t<
+      HasDecorator<decorators, AS_RAW>::value && !CanHardwireRaw<decorators>::value, bool>
     arraycopy(arrayOop src_obj, size_t src_offset_in_bytes, T* src_raw,
               arrayOop dst_obj, size_t dst_offset_in_bytes, T* dst_raw,
               size_t length) {
@@ -907,8 +907,8 @@ namespace AccessInternal {
     }
 
     template <DecoratorSet decorators, typename T>
-    inline static typename EnableIf<
-      !HasDecorator<decorators, AS_RAW>::value, bool>::type
+    inline static std::enable_if_t<
+      !HasDecorator<decorators, AS_RAW>::value, bool>
     arraycopy(arrayOop src_obj, size_t src_offset_in_bytes, T* src_raw,
               arrayOop dst_obj, size_t dst_offset_in_bytes, T* dst_raw,
               size_t length) {
@@ -925,16 +925,16 @@ namespace AccessInternal {
     }
 
     template <DecoratorSet decorators>
-    inline static typename EnableIf<
-      HasDecorator<decorators, AS_RAW>::value>::type
+    inline static std::enable_if_t<
+      HasDecorator<decorators, AS_RAW>::value>
     clone(oop src, oop dst, size_t size) {
       typedef RawAccessBarrier<decorators & RAW_DECORATOR_MASK> Raw;
       Raw::clone(src, dst, size);
     }
 
     template <DecoratorSet decorators>
-    inline static typename EnableIf<
-      !HasDecorator<decorators, AS_RAW>::value>::type
+    inline static std::enable_if_t<
+      !HasDecorator<decorators, AS_RAW>::value>
     clone(oop src, oop dst, size_t size) {
       RuntimeDispatch<decorators, oop, BARRIER_CLONE>::clone(src, dst, size);
     }

--- a/src/hotspot/share/oops/accessBackend.hpp
+++ b/src/hotspot/share/oops/accessBackend.hpp
@@ -192,7 +192,7 @@ protected:
   // Only encode if INTERNAL_VALUE_IS_OOP
   template <DecoratorSet idecorators, typename T>
   static inline std::enable_if_t<
-    AccessInternal::MustConvertCompressedOop<idecorators, T>,
+    AccessInternal::MustConvertCompressedOop<idecorators, T>::value,
     typename HeapOopType<idecorators>::type>
   encode_internal(T value);
 

--- a/src/hotspot/share/oops/accessBackend.hpp
+++ b/src/hotspot/share/oops/accessBackend.hpp
@@ -193,7 +193,7 @@ protected:
   template <DecoratorSet idecorators, typename T>
   static inline std::enable_if_t<
     AccessInternal::MustConvertCompressedOop<idecorators, T>,
-    typename HeapOopType<idecorators>::type>::type
+    typename HeapOopType<idecorators>::type>
   encode_internal(T value);
 
   template <DecoratorSet idecorators, typename T>

--- a/src/hotspot/share/oops/accessBackend.inline.hpp
+++ b/src/hotspot/share/oops/accessBackend.inline.hpp
@@ -34,10 +34,12 @@
 #include "runtime/atomic.hpp"
 #include "runtime/orderAccess.hpp"
 
+#include <type_traits>
+
 template <DecoratorSet decorators>
 template <DecoratorSet idecorators, typename T>
-inline typename EnableIf<
-  AccessInternal::MustConvertCompressedOop<idecorators, T>::value, T>::type
+inline std::enable_if_t<
+  AccessInternal::MustConvertCompressedOop<idecorators, T>::value, T>
 RawAccessBarrier<decorators>::decode_internal(typename HeapOopType<idecorators>::type value) {
   if (HasDecorator<decorators, IS_NOT_NULL>::value) {
     return CompressedOops::decode_not_null(value);
@@ -48,9 +50,9 @@ RawAccessBarrier<decorators>::decode_internal(typename HeapOopType<idecorators>:
 
 template <DecoratorSet decorators>
 template <DecoratorSet idecorators, typename T>
-inline typename EnableIf<
+inline std::enable_if_t<
   AccessInternal::MustConvertCompressedOop<idecorators, T>::value,
-  typename HeapOopType<idecorators>::type>::type
+  typename HeapOopType<idecorators>::type>
 RawAccessBarrier<decorators>::encode_internal(T value) {
   if (HasDecorator<decorators, IS_NOT_NULL>::value) {
     return CompressedOops::encode_not_null(value);
@@ -132,8 +134,8 @@ inline bool RawAccessBarrier<decorators>::oop_arraycopy(arrayOop src_obj, size_t
 
 template <DecoratorSet decorators>
 template <DecoratorSet ds, typename T>
-inline typename EnableIf<
-  HasDecorator<ds, MO_SEQ_CST>::value, T>::type
+inline std::enable_if_t<
+  HasDecorator<ds, MO_SEQ_CST>::value, T>
 RawAccessBarrier<decorators>::load_internal(void* addr) {
   if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
     OrderAccess::fence();
@@ -143,48 +145,48 @@ RawAccessBarrier<decorators>::load_internal(void* addr) {
 
 template <DecoratorSet decorators>
 template <DecoratorSet ds, typename T>
-inline typename EnableIf<
-  HasDecorator<ds, MO_ACQUIRE>::value, T>::type
+inline std::enable_if_t<
+  HasDecorator<ds, MO_ACQUIRE>::value, T>
 RawAccessBarrier<decorators>::load_internal(void* addr) {
   return Atomic::load_acquire(reinterpret_cast<const volatile T*>(addr));
 }
 
 template <DecoratorSet decorators>
 template <DecoratorSet ds, typename T>
-inline typename EnableIf<
-  HasDecorator<ds, MO_RELAXED>::value, T>::type
+inline std::enable_if_t<
+  HasDecorator<ds, MO_RELAXED>::value, T>
 RawAccessBarrier<decorators>::load_internal(void* addr) {
   return Atomic::load(reinterpret_cast<const volatile T*>(addr));
 }
 
 template <DecoratorSet decorators>
 template <DecoratorSet ds, typename T>
-inline typename EnableIf<
-  HasDecorator<ds, MO_SEQ_CST>::value>::type
+inline std::enable_if_t<
+  HasDecorator<ds, MO_SEQ_CST>::value>
 RawAccessBarrier<decorators>::store_internal(void* addr, T value) {
   Atomic::release_store_fence(reinterpret_cast<volatile T*>(addr), value);
 }
 
 template <DecoratorSet decorators>
 template <DecoratorSet ds, typename T>
-inline typename EnableIf<
-  HasDecorator<ds, MO_RELEASE>::value>::type
+inline std::enable_if_t<
+  HasDecorator<ds, MO_RELEASE>::value>
 RawAccessBarrier<decorators>::store_internal(void* addr, T value) {
   Atomic::release_store(reinterpret_cast<volatile T*>(addr), value);
 }
 
 template <DecoratorSet decorators>
 template <DecoratorSet ds, typename T>
-inline typename EnableIf<
-  HasDecorator<ds, MO_RELAXED>::value>::type
+inline std::enable_if_t<
+  HasDecorator<ds, MO_RELAXED>::value>
 RawAccessBarrier<decorators>::store_internal(void* addr, T value) {
   Atomic::store(reinterpret_cast<volatile T*>(addr), value);
 }
 
 template <DecoratorSet decorators>
 template <DecoratorSet ds, typename T>
-inline typename EnableIf<
-  HasDecorator<ds, MO_RELAXED>::value, T>::type
+inline std::enable_if_t<
+  HasDecorator<ds, MO_RELAXED>::value, T>
 RawAccessBarrier<decorators>::atomic_cmpxchg_internal(void* addr, T compare_value, T new_value) {
   return Atomic::cmpxchg(reinterpret_cast<volatile T*>(addr),
                          compare_value,
@@ -194,8 +196,8 @@ RawAccessBarrier<decorators>::atomic_cmpxchg_internal(void* addr, T compare_valu
 
 template <DecoratorSet decorators>
 template <DecoratorSet ds, typename T>
-inline typename EnableIf<
-  HasDecorator<ds, MO_SEQ_CST>::value, T>::type
+inline std::enable_if_t<
+  HasDecorator<ds, MO_SEQ_CST>::value, T>
 RawAccessBarrier<decorators>::atomic_cmpxchg_internal(void* addr, T compare_value, T new_value) {
   return Atomic::cmpxchg(reinterpret_cast<volatile T*>(addr),
                          compare_value,
@@ -205,8 +207,8 @@ RawAccessBarrier<decorators>::atomic_cmpxchg_internal(void* addr, T compare_valu
 
 template <DecoratorSet decorators>
 template <DecoratorSet ds, typename T>
-inline typename EnableIf<
-  HasDecorator<ds, MO_SEQ_CST>::value, T>::type
+inline std::enable_if_t<
+  HasDecorator<ds, MO_SEQ_CST>::value, T>
 RawAccessBarrier<decorators>::atomic_xchg_internal(void* addr, T new_value) {
   return Atomic::xchg(reinterpret_cast<volatile T*>(addr),
                       new_value);
@@ -218,8 +220,8 @@ RawAccessBarrier<decorators>::atomic_xchg_internal(void* addr, T new_value) {
 
 template <DecoratorSet ds>
 template <DecoratorSet decorators, typename T>
-inline typename EnableIf<
-  AccessInternal::PossiblyLockedAccess<T>::value, T>::type
+inline std::enable_if_t<
+  AccessInternal::PossiblyLockedAccess<T>::value, T>
 RawAccessBarrier<ds>::atomic_xchg_maybe_locked(void* addr, T new_value) {
   if (!AccessInternal::wide_atomic_needs_locking()) {
     return atomic_xchg_internal<ds>(addr, new_value);
@@ -234,8 +236,8 @@ RawAccessBarrier<ds>::atomic_xchg_maybe_locked(void* addr, T new_value) {
 
 template <DecoratorSet ds>
 template <DecoratorSet decorators, typename T>
-inline typename EnableIf<
-  AccessInternal::PossiblyLockedAccess<T>::value, T>::type
+inline std::enable_if_t<
+  AccessInternal::PossiblyLockedAccess<T>::value, T>
 RawAccessBarrier<ds>::atomic_cmpxchg_maybe_locked(void* addr, T compare_value, T new_value) {
   if (!AccessInternal::wide_atomic_needs_locking()) {
     return atomic_cmpxchg_internal<ds>(addr, compare_value, new_value);
@@ -254,8 +256,8 @@ class RawAccessBarrierArrayCopy: public AllStatic {
   template<typename T> struct IsHeapWordSized: public IntegralConstant<bool, sizeof(T) == HeapWordSize> { };
 public:
   template <DecoratorSet decorators, typename T>
-  static inline typename EnableIf<
-    HasDecorator<decorators, INTERNAL_VALUE_IS_OOP>::value>::type
+  static inline std::enable_if_t<
+    HasDecorator<decorators, INTERNAL_VALUE_IS_OOP>::value>
   arraycopy(arrayOop src_obj, size_t src_offset_in_bytes, T* src_raw,
             arrayOop dst_obj, size_t dst_offset_in_bytes, T* dst_raw,
             size_t length) {
@@ -273,9 +275,9 @@ public:
   }
 
   template <DecoratorSet decorators, typename T>
-  static inline typename EnableIf<
+  static inline std::enable_if_t<
     !HasDecorator<decorators, INTERNAL_VALUE_IS_OOP>::value &&
-    HasDecorator<decorators, ARRAYCOPY_ARRAYOF>::value>::type
+    HasDecorator<decorators, ARRAYCOPY_ARRAYOF>::value>
   arraycopy(arrayOop src_obj, size_t src_offset_in_bytes, T* src_raw,
             arrayOop dst_obj, size_t dst_offset_in_bytes, T* dst_raw,
             size_t length) {
@@ -286,9 +288,9 @@ public:
   }
 
   template <DecoratorSet decorators, typename T>
-  static inline typename EnableIf<
+  static inline std::enable_if_t<
     !HasDecorator<decorators, INTERNAL_VALUE_IS_OOP>::value &&
-    HasDecorator<decorators, ARRAYCOPY_DISJOINT>::value && IsHeapWordSized<T>::value>::type
+    HasDecorator<decorators, ARRAYCOPY_DISJOINT>::value && IsHeapWordSized<T>::value>
   arraycopy(arrayOop src_obj, size_t src_offset_in_bytes, T* src_raw,
             arrayOop dst_obj, size_t dst_offset_in_bytes, T* dst_raw,
             size_t length) {
@@ -304,11 +306,11 @@ public:
   }
 
   template <DecoratorSet decorators, typename T>
-  static inline typename EnableIf<
+  static inline std::enable_if_t<
     !HasDecorator<decorators, INTERNAL_VALUE_IS_OOP>::value &&
     !(HasDecorator<decorators, ARRAYCOPY_DISJOINT>::value && IsHeapWordSized<T>::value) &&
     !HasDecorator<decorators, ARRAYCOPY_ARRAYOF>::value &&
-    !HasDecorator<decorators, ARRAYCOPY_ATOMIC>::value>::type
+    !HasDecorator<decorators, ARRAYCOPY_ATOMIC>::value>
   arraycopy(arrayOop src_obj, size_t src_offset_in_bytes, T* src_raw,
             arrayOop dst_obj, size_t dst_offset_in_bytes, T* dst_raw,
             size_t length) {
@@ -319,11 +321,11 @@ public:
   }
 
   template <DecoratorSet decorators, typename T>
-  static inline typename EnableIf<
+  static inline std::enable_if_t<
     !HasDecorator<decorators, INTERNAL_VALUE_IS_OOP>::value &&
     !(HasDecorator<decorators, ARRAYCOPY_DISJOINT>::value && IsHeapWordSized<T>::value) &&
     !HasDecorator<decorators, ARRAYCOPY_ARRAYOF>::value &&
-    HasDecorator<decorators, ARRAYCOPY_ATOMIC>::value>::type
+    HasDecorator<decorators, ARRAYCOPY_ATOMIC>::value>
   arraycopy(arrayOop src_obj, size_t src_offset_in_bytes, T* src_raw,
             arrayOop dst_obj, size_t dst_offset_in_bytes, T* dst_raw,
             size_t length) {

--- a/src/hotspot/share/runtime/atomic.hpp
+++ b/src/hotspot/share/runtime/atomic.hpp
@@ -694,7 +694,7 @@ struct Atomic::AddImpl<
 template<typename P, typename I>
 struct Atomic::AddImpl<
   P*, I,
-  td::enable_if_t<IsIntegral<I>::value && (sizeof(I) <= sizeof(P*))>>
+  std::enable_if_t<IsIntegral<I>::value && (sizeof(I) <= sizeof(P*))>>
 {
   STATIC_ASSERT(sizeof(intptr_t) == sizeof(P*));
   STATIC_ASSERT(sizeof(uintptr_t) == sizeof(P*));

--- a/src/hotspot/share/runtime/atomic.hpp
+++ b/src/hotspot/share/runtime/atomic.hpp
@@ -393,7 +393,7 @@ template<typename T, typename PlatformOp>
 struct Atomic::LoadImpl<
   T,
   PlatformOp,
-  typename EnableIf<IsIntegral<T>::value || IsPointer<T>::value>::type>
+  std::enable_if_t<IsIntegral<T>::value || IsPointer<T>::value>>
 {
   T operator()(T const volatile* dest) const {
     // Forward to the platform handler for the size of T.
@@ -412,7 +412,7 @@ template<typename T, typename PlatformOp>
 struct Atomic::LoadImpl<
   T,
   PlatformOp,
-  typename EnableIf<PrimitiveConversions::Translate<T>::value>::type>
+  std::enable_if_t<PrimitiveConversions::Translate<T>::value>>
 {
   T operator()(T const volatile* dest) const {
     typedef PrimitiveConversions::Translate<T> Translator;
@@ -445,7 +445,7 @@ template<typename T, typename PlatformOp>
 struct Atomic::StoreImpl<
   T, T,
   PlatformOp,
-  typename EnableIf<IsIntegral<T>::value>::type>
+  std::enable_if_t<IsIntegral<T>::value>>
 {
   void operator()(T volatile* dest, T new_value) const {
     // Forward to the platform handler for the size of T.
@@ -462,7 +462,7 @@ template<typename D, typename T, typename PlatformOp>
 struct Atomic::StoreImpl<
   D*, T*,
   PlatformOp,
-  typename EnableIf<Atomic::IsPointerConvertible<T*, D*>::value>::type>
+  std::enable_if_t<Atomic::IsPointerConvertible<T*, D*>::value>>
 {
   void operator()(D* volatile* dest, T* new_value) const {
     // Allow derived to base conversion, and adding cv-qualifiers.
@@ -481,7 +481,7 @@ template<typename T, typename PlatformOp>
 struct Atomic::StoreImpl<
   T, T,
   PlatformOp,
-  typename EnableIf<PrimitiveConversions::Translate<T>::value>::type>
+  std::enable_if_t<PrimitiveConversions::Translate<T>::value>>
 {
   void operator()(T volatile* dest, T new_value) const {
     typedef PrimitiveConversions::Translate<T> Translator;
@@ -676,10 +676,10 @@ inline D Atomic::fetch_and_add(D volatile* dest, I add_value,
 template<typename D, typename I>
 struct Atomic::AddImpl<
   D, I,
-  typename EnableIf<IsIntegral<I>::value &&
+  std::enable_if_t<IsIntegral<I>::value &&
                     IsIntegral<D>::value &&
                     (sizeof(I) <= sizeof(D)) &&
-                    (IsSigned<I>::value == IsSigned<D>::value)>::type>
+                    (IsSigned<I>::value == IsSigned<D>::value)>>
 {
   static D add_and_fetch(D volatile* dest, I add_value, atomic_memory_order order) {
     D addend = add_value;
@@ -694,7 +694,7 @@ struct Atomic::AddImpl<
 template<typename P, typename I>
 struct Atomic::AddImpl<
   P*, I,
-  typename EnableIf<IsIntegral<I>::value && (sizeof(I) <= sizeof(P*))>::type>
+  td::enable_if_t<IsIntegral<I>::value && (sizeof(I) <= sizeof(P*))>>
 {
   STATIC_ASSERT(sizeof(intptr_t) == sizeof(P*));
   STATIC_ASSERT(sizeof(uintptr_t) == sizeof(P*));
@@ -769,7 +769,7 @@ inline bool Atomic::replace_if_null(D* volatile* dest, T* value,
 template<typename T>
 struct Atomic::CmpxchgImpl<
   T, T, T,
-  typename EnableIf<IsIntegral<T>::value>::type>
+  std::enable_if_t<IsIntegral<T>::value>>
 {
   T operator()(T volatile* dest, T compare_value, T exchange_value,
                atomic_memory_order order) const {
@@ -793,9 +793,9 @@ struct Atomic::CmpxchgImpl<
 template<typename D, typename U, typename T>
 struct Atomic::CmpxchgImpl<
   D*, U*, T*,
-  typename EnableIf<Atomic::IsPointerConvertible<T*, D*>::value &&
+  std::enable_if_t<Atomic::IsPointerConvertible<T*, D*>::value &&
                     IsSame<std::remove_cv_t<D>,
-                           std::remove_cv_t<U>>::value>::type>
+                           std::remove_cv_t<U>>::value>>
 {
   D* operator()(D* volatile* dest, U* compare_value, T* exchange_value,
                atomic_memory_order order) const {
@@ -818,7 +818,7 @@ struct Atomic::CmpxchgImpl<
 template<typename T>
 struct Atomic::CmpxchgImpl<
   T, T, T,
-  typename EnableIf<PrimitiveConversions::Translate<T>::value>::type>
+  std::enable_if_t<PrimitiveConversions::Translate<T>::value>>
 {
   T operator()(T volatile* dest, T compare_value, T exchange_value,
                atomic_memory_order order) const {
@@ -904,7 +904,7 @@ inline T Atomic::CmpxchgByteUsingInt::operator()(T volatile* dest,
 template<typename T>
 struct Atomic::XchgImpl<
   T, T,
-  typename EnableIf<IsIntegral<T>::value>::type>
+  std::enable_if_t<IsIntegral<T>::value>>
 {
   T operator()(T volatile* dest, T exchange_value, atomic_memory_order order) const {
     // Forward to the platform handler for the size of T.
@@ -920,7 +920,7 @@ struct Atomic::XchgImpl<
 template<typename D, typename T>
 struct Atomic::XchgImpl<
   D*, T*,
-  typename EnableIf<Atomic::IsPointerConvertible<T*, D*>::value>::type>
+  std::enable_if_t<Atomic::IsPointerConvertible<T*, D*>::value>>
 {
   D* operator()(D* volatile* dest, T* exchange_value, atomic_memory_order order) const {
     // Allow derived to base conversion, and adding cv-qualifiers.
@@ -939,7 +939,7 @@ struct Atomic::XchgImpl<
 template<typename T>
 struct Atomic::XchgImpl<
   T, T,
-  typename EnableIf<PrimitiveConversions::Translate<T>::value>::type>
+  std::enable_if_t<PrimitiveConversions::Translate<T>::value>>
 {
   T operator()(T volatile* dest, T exchange_value, atomic_memory_order order) const {
     typedef PrimitiveConversions::Translate<T> Translator;

--- a/src/hotspot/share/utilities/devirtualizer.inline.hpp
+++ b/src/hotspot/share/utilities/devirtualizer.inline.hpp
@@ -31,6 +31,8 @@
 #include "oops/access.inline.hpp"
 #include "utilities/debug.hpp"
 
+#include <type_traits>
+
 // Implementation of the non-virtual do_oop dispatch.
 //
 // The same implementation is used for do_metadata, do_klass, and do_cld.
@@ -73,13 +75,13 @@
 //   p       - The oop (or narrowOop) field to pass to the closure
 
 template <typename T, typename Receiver, typename Base, typename OopClosureType>
-static typename EnableIf<IsSame<Receiver, Base>::value, void>::type
+static std::enable_if_t<IsSame<Receiver, Base>::value, void>
 call_do_oop(void (Receiver::*)(T*), void (Base::*)(T*), OopClosureType* closure, T* p) {
   closure->do_oop(p);
 }
 
 template <typename T, typename Receiver, typename Base, typename OopClosureType>
-static typename EnableIf<!IsSame<Receiver, Base>::value, void>::type
+static std::enable_if_t<!IsSame<Receiver, Base>::value, void>
 call_do_oop(void (Receiver::*)(T*), void (Base::*)(T*), OopClosureType* closure, T* p) {
   // Sanity check
   STATIC_ASSERT((!IsSame<OopClosureType, OopIterateClosure>::value));
@@ -94,13 +96,13 @@ inline void Devirtualizer::do_oop(OopClosureType* closure, T* p) {
 // Implementation of the non-virtual do_metadata dispatch.
 
 template <typename Receiver, typename Base, typename OopClosureType>
-static typename EnableIf<IsSame<Receiver, Base>::value, bool>::type
+static std::enable_if_t<IsSame<Receiver, Base>::value, bool>
 call_do_metadata(bool (Receiver::*)(), bool (Base::*)(), OopClosureType* closure) {
   return closure->do_metadata();
 }
 
 template <typename Receiver, typename Base, typename OopClosureType>
-static typename EnableIf<!IsSame<Receiver, Base>::value, bool>::type
+static std::enable_if_t<!IsSame<Receiver, Base>::value, bool>
 call_do_metadata(bool (Receiver::*)(), bool (Base::*)(), OopClosureType* closure) {
   return closure->OopClosureType::do_metadata();
 }
@@ -113,13 +115,13 @@ inline bool Devirtualizer::do_metadata(OopClosureType* closure) {
 // Implementation of the non-virtual do_klass dispatch.
 
 template <typename Receiver, typename Base, typename OopClosureType>
-static typename EnableIf<IsSame<Receiver, Base>::value, void>::type
+static std::enable_if_t<IsSame<Receiver, Base>::value, void>
 call_do_klass(void (Receiver::*)(Klass*), void (Base::*)(Klass*), OopClosureType* closure, Klass* k) {
   closure->do_klass(k);
 }
 
 template <typename Receiver, typename Base, typename OopClosureType>
-static typename EnableIf<!IsSame<Receiver, Base>::value, void>::type
+static std::enable_if_t<!IsSame<Receiver, Base>::value, void>
 call_do_klass(void (Receiver::*)(Klass*), void (Base::*)(Klass*), OopClosureType* closure, Klass* k) {
   closure->OopClosureType::do_klass(k);
 }
@@ -132,13 +134,13 @@ inline void Devirtualizer::do_klass(OopClosureType* closure, Klass* k) {
 // Implementation of the non-virtual do_cld dispatch.
 
 template <typename Receiver, typename Base, typename OopClosureType>
-static typename EnableIf<IsSame<Receiver, Base>::value, void>::type
+static std::enable_if_t<IsSame<Receiver, Base>::value, void>
 call_do_cld(void (Receiver::*)(ClassLoaderData*), void (Base::*)(ClassLoaderData*), OopClosureType* closure, ClassLoaderData* cld) {
   closure->do_cld(cld);
 }
 
 template <typename Receiver, typename Base, typename OopClosureType>
-static typename EnableIf<!IsSame<Receiver, Base>::value, void>::type
+static std::enable_if_t<!IsSame<Receiver, Base>::value, void>
 call_do_cld(void (Receiver::*)(ClassLoaderData*), void (Base::*)(ClassLoaderData*), OopClosureType* closure, ClassLoaderData* cld) {
   closure->OopClosureType::do_cld(cld);
 }
@@ -151,13 +153,13 @@ void Devirtualizer::do_cld(OopClosureType* closure, ClassLoaderData* cld) {
 // Implementation of the non-virtual do_derived_oop dispatch.
 
 template <typename Receiver, typename Base, typename DerivedOopClosureType>
-static typename EnableIf<IsSame<Receiver, Base>::value, void>::type
+static std::enable_if_t<IsSame<Receiver, Base>::value, void>
 call_do_derived_oop(void (Receiver::*)(oop*, derived_pointer*), void (Base::*)(oop*, derived_pointer*), DerivedOopClosureType* closure, oop* base, derived_pointer* derived) {
   closure->do_derived_oop(base, derived);
 }
 
 template <typename Receiver, typename Base, typename DerivedOopClosureType>
-static typename EnableIf<!IsSame<Receiver, Base>::value, void>::type
+static std::enable_if_t<!IsSame<Receiver, Base>::value, void>
 call_do_derived_oop(void (Receiver::*)(oop*, derived_pointer*), void (Base::*)(oop*, derived_pointer*), DerivedOopClosureType* closure, oop* base, derived_pointer* derived) {
   closure->DerivedOopClosureType::do_derived_oop(base, derived);
 }

--- a/test/hotspot/gtest/metaprogramming/test_enableIf.cpp
+++ b/test/hotspot/gtest/metaprogramming/test_enableIf.cpp
@@ -34,9 +34,9 @@ class EnableIfTest: AllStatic {
   class A: AllStatic {
   public:
     template <bool condition>
-    static typename EnableIf<condition, char>::type test();
+    static std::enable_if_t<condition, char> test();
     template <bool condition>
-    static typename EnableIf<!condition, long>::type test();
+    static std::enable_if_t<!condition, long> test();
   };
 
   static const bool A_test_true_is_char = sizeof(A::test<true>()) == sizeof(char);


### PR DESCRIPTION
As the title says, remove `EnableIf` type alias from `metaprogramming/enableIf.hpp` leaving only `ENABLE_IF` and `ENABLE_IF_SDEFN`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299554](https://bugs.openjdk.org/browse/JDK-8299554): Remove EnableIf from metaprogramming/enableIf.hpp


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11835/head:pull/11835` \
`$ git checkout pull/11835`

Update a local copy of the PR: \
`$ git checkout pull/11835` \
`$ git pull https://git.openjdk.org/jdk pull/11835/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11835`

View PR using the GUI difftool: \
`$ git pr show -t 11835`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11835.diff">https://git.openjdk.org/jdk/pull/11835.diff</a>

</details>
