### PR TITLE
8299576: Reimplement java.io.Bits using VarHandle access

### DIFF
--- a/src/java.base/share/classes/java/io/Bits.java
+++ b/src/java.base/share/classes/java/io/Bits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/Bits.java
+++ b/src/java.base/share/classes/java/io/Bits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/Bits.java
+++ b/src/java.base/share/classes/java/io/Bits.java
@@ -39,8 +39,6 @@ final class Bits {
     private static final VarHandle SHORT = create(short[].class);
     private static final VarHandle INT = create(int[].class);
     private static final VarHandle LONG = create(long[].class);
-    private static final VarHandle FLOAT = create(float[].class);
-    private static final VarHandle DOUBLE = create(double[].class);
 
     /*
      * Methods for unpacking primitive values from byte arrays starting at
@@ -64,7 +62,9 @@ final class Bits {
     }
 
     static float getFloat(byte[] b, int off) {
-        return (float) FLOAT.get(b, off);
+        // Using Float.floatToIntBits collapses NaN values to a single
+        // "canonical" NaN value
+        return Float.intBitsToFloat((int) INT.get(b, off));
     }
 
     static long getLong(byte[] b, int off) {
@@ -72,7 +72,9 @@ final class Bits {
     }
 
     static double getDouble(byte[] b, int off) {
-        return (double) DOUBLE.get(b, off);
+        // Using Double.doubleToLongBits collapses NaN values to a single
+        // "canonical" NaN value
+        return Double.longBitsToDouble((long) LONG.get(b, off));
     }
 
     /*

--- a/src/java.base/share/classes/java/io/Bits.java
+++ b/src/java.base/share/classes/java/io/Bits.java
@@ -97,7 +97,9 @@ final class Bits {
     }
 
     static void putFloat(byte[] b, int off, float val) {
-        FLOAT.set(b, off, val);
+        // Using Float.floatToIntBits collapses NaN values to a single
+        // "canonical" NaN value
+        INT.set(b, off, Float.floatToIntBits(val));
     }
 
     static void putLong(byte[] b, int off, long val) {
@@ -105,7 +107,9 @@ final class Bits {
     }
 
     static void putDouble(byte[] b, int off, double val) {
-        DOUBLE.set(b, off, val);
+        // Using Double.doubleToLongBits collapses NaN values to a single
+        // "canonical" NaN value
+        LONG.set(b, off, Double.doubleToLongBits(val));
     }
 
     private static VarHandle create(Class<?> viewArrayClass) {

--- a/src/java.base/share/classes/java/io/Bits.java
+++ b/src/java.base/share/classes/java/io/Bits.java
@@ -62,7 +62,7 @@ final class Bits {
     }
 
     static float getFloat(byte[] b, int off) {
-        // Using Float.floatToIntBits collapses NaN values to a single
+        // Using Float.intBitsToFloat collapses NaN values to a single
         // "canonical" NaN value
         return Float.intBitsToFloat((int) INT.get(b, off));
     }
@@ -72,7 +72,7 @@ final class Bits {
     }
 
     static double getDouble(byte[] b, int off) {
-        // Using Double.doubleToLongBits collapses NaN values to a single
+        // Using Double.longBitsToDouble collapses NaN values to a single
         // "canonical" NaN value
         return Double.longBitsToDouble((long) LONG.get(b, off));
     }

--- a/test/jdk/java/io/Bits/ReadWriteValues.java
+++ b/test/jdk/java/io/Bits/ReadWriteValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/io/Bits/ReadWriteValues.java
+++ b/test/jdk/java/io/Bits/ReadWriteValues.java
@@ -32,6 +32,7 @@ import java.io.BitsProxy;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.DoubleStream;
 import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.*;
 
@@ -126,8 +127,7 @@ final class ReadWriteValues {
 
     @Test
     void testGetFloat() {
-        doubles().forEach(d -> {
-            float expected = (float) d;
+        floats().forEach(expected -> {
             RefImpl.putFloat(BUFF, OFFSET, expected);
             float actual = BitsProxy.getFloat(BUFF, OFFSET);
             assertEquals(expected, actual);
@@ -136,8 +136,7 @@ final class ReadWriteValues {
 
     @Test
     void testPutFloat() {
-        doubles().forEach(d -> {
-            float expected = (float) d;
+        floats().forEach(expected -> {
             BitsProxy.putFloat(BUFF, OFFSET, expected);
             float actual = RefImpl.getFloat(BUFF, OFFSET);
             assertEquals(expected, actual);
@@ -187,7 +186,28 @@ final class ReadWriteValues {
     }
 
     static DoubleStream doubles() {
-        return ThreadLocalRandom.current().doubles(ITERATIONS);
+        return DoubleStream.concat(
+                ThreadLocalRandom.current().doubles(ITERATIONS),
+                DoubleStream.of(Double.NaN,
+                        Double.NEGATIVE_INFINITY,
+                        Double.POSITIVE_INFINITY,
+                        Double.MAX_VALUE,
+                        Double.MIN_VALUE,
+                        -0.0d
+                        +0.0d)
+        );
+    }
+    static Stream<Float> floats() {
+        return Stream.concat(
+                ThreadLocalRandom.current().doubles(ITERATIONS).mapToObj(d -> (float)d),
+                Stream.of(Float.NaN,
+                        Float.NEGATIVE_INFINITY,
+                        Float.POSITIVE_INFINITY,
+                        Float.MAX_VALUE,
+                        Float.MIN_VALUE,
+                        -0.0f
+                        +0.0f)
+        );
     }
 
     @FunctionalInterface

--- a/test/jdk/java/io/Bits/ReadWriteValues.java
+++ b/test/jdk/java/io/Bits/ReadWriteValues.java
@@ -50,7 +50,7 @@ final class ReadWriteValues {
     void testGetShort() {
         longs().forEach(l -> {
             short expected = (short) l;
-            putShort(BUFF, OFFSET, expected);
+            RefImpl.putShort(BUFF, OFFSET, expected);
             short actual = BitsProxy.getShort(BUFF, OFFSET);
             assertEquals(expected, actual);
         });
@@ -61,7 +61,7 @@ final class ReadWriteValues {
         longs().forEach(l -> {
             short expected = (short) l;
             BitsProxy.putShort(BUFF, OFFSET, expected);
-            short actual = getShort(BUFF, OFFSET);
+            short actual = RefImpl.getShort(BUFF, OFFSET);
             assertEquals(expected, actual);
         });
     }
@@ -70,7 +70,7 @@ final class ReadWriteValues {
     void testGetChar() {
         longs().forEach(l -> {
             char expected = (char) l;
-            putChar(BUFF, OFFSET, expected);
+            RefImpl.putChar(BUFF, OFFSET, expected);
             char actual = BitsProxy.getChar(BUFF, OFFSET);
             assertEquals(expected, actual);
         });
@@ -81,7 +81,7 @@ final class ReadWriteValues {
         longs().forEach(l -> {
             char expected = (char) l;
             BitsProxy.putChar(BUFF, OFFSET, expected);
-            char actual = getChar(BUFF, OFFSET);
+            char actual = RefImpl.getChar(BUFF, OFFSET);
             assertEquals(expected, actual);
         });
     }
@@ -90,7 +90,7 @@ final class ReadWriteValues {
     void testGetInt() {
         longs().forEach(l -> {
             int expected = (int) l;
-            putInt(BUFF, OFFSET, expected);
+            RefImpl.putInt(BUFF, OFFSET, expected);
             int actual = BitsProxy.getInt(BUFF, OFFSET);
             assertEquals(expected, actual);
         });
@@ -101,7 +101,7 @@ final class ReadWriteValues {
         longs().forEach(l -> {
             int expected = (int) l;
             BitsProxy.putInt(BUFF, OFFSET, expected);
-            int actual = getInt(BUFF, OFFSET);
+            int actual = RefImpl.getInt(BUFF, OFFSET);
             assertEquals(expected, actual);
         });
     }
@@ -109,7 +109,7 @@ final class ReadWriteValues {
     @Test
     void testGetLong() {
         longs().forEach(expected -> {
-            putLong(BUFF, OFFSET, expected);
+            RefImpl.putLong(BUFF, OFFSET, expected);
             long actual = BitsProxy.getLong(BUFF, OFFSET);
             assertEquals(expected, actual);
         });
@@ -119,7 +119,7 @@ final class ReadWriteValues {
     void testPutLong() {
         longs().forEach(expected -> {
             BitsProxy.putLong(BUFF, OFFSET, expected);
-            long actual = getLong(BUFF, OFFSET);
+            long actual = RefImpl.getLong(BUFF, OFFSET);
             assertEquals(expected, actual);
         });
     }
@@ -128,7 +128,7 @@ final class ReadWriteValues {
     void testGetFloat() {
         doubles().forEach(d -> {
             float expected = (float) d;
-            putFloat(BUFF, OFFSET, expected);
+            RefImpl.putFloat(BUFF, OFFSET, expected);
             float actual = BitsProxy.getFloat(BUFF, OFFSET);
             assertEquals(expected, actual);
         });
@@ -139,7 +139,7 @@ final class ReadWriteValues {
         doubles().forEach(d -> {
             float expected = (float) d;
             BitsProxy.putFloat(BUFF, OFFSET, expected);
-            float actual = getFloat(BUFF, OFFSET);
+            float actual = RefImpl.getFloat(BUFF, OFFSET);
             assertEquals(expected, actual);
         });
     }
@@ -147,7 +147,7 @@ final class ReadWriteValues {
     @Test
     void testGetDouble() {
         doubles().forEach(expected -> {
-            putDouble(BUFF, OFFSET, expected);
+            RefImpl.putDouble(BUFF, OFFSET, expected);
             double actual = BitsProxy.getDouble(BUFF, OFFSET);
             assertEquals(expected, actual);
         });
@@ -157,7 +157,7 @@ final class ReadWriteValues {
     void testPutDouble() {
         doubles().forEach(expected -> {
             BitsProxy.putDouble(BUFF, OFFSET, expected);
-            double actual = getDouble(BUFF, OFFSET);
+            double actual = RefImpl.getDouble(BUFF, OFFSET);
             assertEquals(expected, actual);
         });
     }
@@ -211,83 +211,88 @@ final class ReadWriteValues {
 
     }
 
-    // Equivalent methods from the old java.io.Bits implementation
+    /**
+    * Reference implementation from the old java.io.Bits implementation
+    */
+    private static final class RefImpl {
+        private RefImpl() {}
 
-    static char getChar(byte[] b, int off) {
-        return (char) ((b[off + 1] & 0xFF) +
-                (b[off] << 8));
-    }
+        static char getChar(byte[] b, int off) {
+            return (char) ((b[off + 1] & 0xFF) +
+                    (b[off] << 8));
+        }
 
-    static short getShort(byte[] b, int off) {
-        return (short) ((b[off + 1] & 0xFF) +
-                (b[off] << 8));
-    }
+        static short getShort(byte[] b, int off) {
+            return (short) ((b[off + 1] & 0xFF) +
+                    (b[off] << 8));
+        }
 
-    static int getInt(byte[] b, int off) {
-        return ((b[off + 3] & 0xFF)) +
-                ((b[off + 2] & 0xFF) << 8) +
-                ((b[off + 1] & 0xFF) << 16) +
-                ((b[off]) << 24);
-    }
+        static int getInt(byte[] b, int off) {
+            return ((b[off + 3] & 0xFF)) +
+                    ((b[off + 2] & 0xFF) << 8) +
+                    ((b[off + 1] & 0xFF) << 16) +
+                    ((b[off]) << 24);
+        }
 
-    static float getFloat(byte[] b, int off) {
-        return Float.intBitsToFloat(getInt(b, off));
-    }
+        static float getFloat(byte[] b, int off) {
+            return Float.intBitsToFloat(getInt(b, off));
+        }
 
-    static long getLong(byte[] b, int off) {
-        return ((b[off + 7] & 0xFFL)) +
-                ((b[off + 6] & 0xFFL) << 8) +
-                ((b[off + 5] & 0xFFL) << 16) +
-                ((b[off + 4] & 0xFFL) << 24) +
-                ((b[off + 3] & 0xFFL) << 32) +
-                ((b[off + 2] & 0xFFL) << 40) +
-                ((b[off + 1] & 0xFFL) << 48) +
-                (((long) b[off]) << 56);
-    }
+        static long getLong(byte[] b, int off) {
+            return ((b[off + 7] & 0xFFL)) +
+                    ((b[off + 6] & 0xFFL) << 8) +
+                    ((b[off + 5] & 0xFFL) << 16) +
+                    ((b[off + 4] & 0xFFL) << 24) +
+                    ((b[off + 3] & 0xFFL) << 32) +
+                    ((b[off + 2] & 0xFFL) << 40) +
+                    ((b[off + 1] & 0xFFL) << 48) +
+                    (((long) b[off]) << 56);
+        }
 
-    static double getDouble(byte[] b, int off) {
-        return Double.longBitsToDouble(getLong(b, off));
-    }
+        static double getDouble(byte[] b, int off) {
+            return Double.longBitsToDouble(getLong(b, off));
+        }
 
-    /*
-     * Methods for packing primitive values into byte arrays starting at given
-     * offsets.
-     */
+        /*
+         * Methods for packing primitive values into byte arrays starting at given
+         * offsets.
+         */
 
-    static void putChar(byte[] b, int off, char val) {
-        b[off + 1] = (byte) (val);
-        b[off] = (byte) (val >>> 8);
-    }
+        static void putChar(byte[] b, int off, char val) {
+            b[off + 1] = (byte) (val);
+            b[off] = (byte) (val >>> 8);
+        }
 
-    static void putShort(byte[] b, int off, short val) {
-        b[off + 1] = (byte) (val);
-        b[off] = (byte) (val >>> 8);
-    }
+        static void putShort(byte[] b, int off, short val) {
+            b[off + 1] = (byte) (val);
+            b[off] = (byte) (val >>> 8);
+        }
 
-    static void putInt(byte[] b, int off, int val) {
-        b[off + 3] = (byte) (val);
-        b[off + 2] = (byte) (val >>> 8);
-        b[off + 1] = (byte) (val >>> 16);
-        b[off] = (byte) (val >>> 24);
-    }
+        static void putInt(byte[] b, int off, int val) {
+            b[off + 3] = (byte) (val);
+            b[off + 2] = (byte) (val >>> 8);
+            b[off + 1] = (byte) (val >>> 16);
+            b[off] = (byte) (val >>> 24);
+        }
 
-    static void putFloat(byte[] b, int off, float val) {
-        putInt(b, off, Float.floatToIntBits(val));
-    }
+        static void putFloat(byte[] b, int off, float val) {
+            putInt(b, off, Float.floatToIntBits(val));
+        }
 
-    static void putLong(byte[] b, int off, long val) {
-        b[off + 7] = (byte) (val);
-        b[off + 6] = (byte) (val >>> 8);
-        b[off + 5] = (byte) (val >>> 16);
-        b[off + 4] = (byte) (val >>> 24);
-        b[off + 3] = (byte) (val >>> 32);
-        b[off + 2] = (byte) (val >>> 40);
-        b[off + 1] = (byte) (val >>> 48);
-        b[off] = (byte) (val >>> 56);
-    }
+        static void putLong(byte[] b, int off, long val) {
+            b[off + 7] = (byte) (val);
+            b[off + 6] = (byte) (val >>> 8);
+            b[off + 5] = (byte) (val >>> 16);
+            b[off + 4] = (byte) (val >>> 24);
+            b[off + 3] = (byte) (val >>> 32);
+            b[off + 2] = (byte) (val >>> 40);
+            b[off + 1] = (byte) (val >>> 48);
+            b[off] = (byte) (val >>> 56);
+        }
 
-    static void putDouble(byte[] b, int off, double val) {
-        putLong(b, off, Double.doubleToLongBits(val));
+        static void putDouble(byte[] b, int off, double val) {
+            putLong(b, off, Double.doubleToLongBits(val));
+        }
     }
 
 }

--- a/test/jdk/java/io/Bits/ReadWriteValues.java
+++ b/test/jdk/java/io/Bits/ReadWriteValues.java
@@ -24,10 +24,11 @@
 /*
  * @test
  * @summary Verify that reads and writes of primitives are correct
+ * @compile/module=java.base java/io/BitsProxy.java
  * @run junit/othervm --add-opens java.base/java.io=ALL-UNNAMED ReadWriteValues
  */
 
-import java.lang.reflect.Method;
+import java.io.BitsProxy;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.DoubleStream;
 import java.util.stream.LongStream;
@@ -165,43 +166,20 @@ final class ReadWriteValues {
 
     @Test
     void testNullArray() {
-        assertThrowsOriginal(NullPointerException.class, () -> method("getInt").invoke(null, null, OFFSET));
-        assertThrowsOriginal(NullPointerException.class, () -> method("putInt", int.class).invoke(null, BUFF, OFFSET, 1));
+        assertThrowsOriginal(NullPointerException.class, () -> BitsProxy.getInt(null, OFFSET));
+        assertThrowsOriginal(NullPointerException.class, () -> BitsProxy.putInt(null, OFFSET, 1));
     }
 
     @Test
     void testNegArg() {
-        assertThrowsOriginal(IndexOutOfBoundsException.class, () -> method("getInt").invoke(null, BUFF, -1));
-        assertThrowsOriginal(IndexOutOfBoundsException.class, () -> method("putInt", int.class).invoke(null, BUFF, -1, 1));
+        assertThrowsOriginal(IndexOutOfBoundsException.class, () -> BitsProxy.getInt(BUFF, -1));
+        assertThrowsOriginal(IndexOutOfBoundsException.class, () -> BitsProxy.putInt(BUFF, -1, 1));
     }
 
     @Test
     void testOutOfBounds() {
-        assertThrowsOriginal(IndexOutOfBoundsException.class, () -> method("getInt").invoke(null, BUFF, BUFF.length));
-        assertThrowsOriginal(IndexOutOfBoundsException.class, () -> method("putInt", int.class).invoke(null, BUFF, BUFF.length, 1));
-    }
-
-    static Method method(String name) {
-        try {
-            Class<?> bits = Class.forName("java.io.Bits");
-            Method method = bits.getDeclaredMethod(name, byte[].class, int.class);
-            method.setAccessible(true);
-            return method;
-        } catch (Exception e) {
-            throw new AssertionError(e);
-        }
-    }
-
-    static Method method(String name,
-                         Class<?> primitiveType) {
-        try {
-            Class<?> bits = Class.forName("java.io.Bits");
-            Method method = bits.getDeclaredMethod(name, byte[].class, int.class, primitiveType);
-            method.setAccessible(true);
-            return method;
-        } catch (Exception e) {
-            throw new AssertionError(e);
-        }
+        assertThrowsOriginal(IndexOutOfBoundsException.class, () -> BitsProxy.getInt(BUFF, BUFF.length));
+        assertThrowsOriginal(IndexOutOfBoundsException.class, () -> BitsProxy.putInt(BUFF, BUFF.length, 1));
     }
 
     static LongStream longs() {
@@ -229,100 +207,6 @@ final class ReadWriteValues {
                 return;
             }
             throw new AssertionError(e);
-        }
-
-    }
-
-    // Wrapper methods to test package private methods
-
-    private static final class BitsProxy {
-
-        private BitsProxy() {
-        }
-
-        static char getChar(byte[] b, int off) {
-            return (char) invoke("getChar", b, off);
-        }
-
-        static short getShort(byte[] b, int off) {
-            return (short) invoke("getShort", b, off);
-        }
-
-        static int getInt(byte[] b, int off) {
-            return (int) invoke("getInt", b, off);
-        }
-
-        static float getFloat(byte[] b, int off) {
-            return (float) invoke("getFloat", b, off);
-        }
-
-        static long getLong(byte[] b, int off) {
-            return (long) invoke("getLong", b, off);
-        }
-
-        static double getDouble(byte[] b, int off) {
-            return (double) invoke("getDouble", b, off);
-        }
-
-        /*
-         * Methods for packing primitive values into byte arrays starting at given
-         * offsets.
-         */
-
-        static void putChar(byte[] b, int off, char val) {
-            try {
-                method("putChar", char.class).invoke(null, b, off, val);
-            } catch (Exception e) {
-                throw new AssertionError(e);
-            }
-        }
-
-        static void putShort(byte[] b, int off, short val) {
-            try {
-                method("putShort", short.class).invoke(null, b, off, val);
-            } catch (Exception e) {
-                throw new AssertionError(e);
-            }
-        }
-
-        static void putInt(byte[] b, int off, int val) {
-            try {
-                method("putInt", int.class).invoke(null, b, off, val);
-            } catch (Exception e) {
-                throw new AssertionError(e);
-            }
-        }
-
-        static void putFloat(byte[] b, int off, float val) {
-            try {
-                method("putFloat", float.class).invoke(null, b, off, val);
-            } catch (Exception e) {
-                throw new AssertionError(e);
-            }
-        }
-
-        static void putLong(byte[] b, int off, long val) {
-            try {
-                method("putLong", long.class).invoke(null, b, off, val);
-            } catch (Exception e) {
-                throw new AssertionError(e);
-            }
-        }
-
-        static void putDouble(byte[] b, int off, double val) {
-            try {
-                method("putDouble", double.class).invoke(null, b, off, val);
-            } catch (Exception e) {
-                throw new AssertionError(e);
-            }
-        }
-
-        static Object invoke(String name, byte[] b, int off) {
-            try {
-                return method(name).invoke(null, b, off);
-            } catch (Exception e) {
-                throw new AssertionError(e);
-            }
         }
 
     }

--- a/test/jdk/java/io/Bits/ReadWriteValues.java
+++ b/test/jdk/java/io/Bits/ReadWriteValues.java
@@ -23,9 +23,10 @@
 
 /*
  * @test
+ * @bug 8299576
  * @summary Verify that reads and writes of primitives are correct
  * @compile/module=java.base java/io/BitsProxy.java
- * @run junit/othervm --add-opens java.base/java.io=ALL-UNNAMED ReadWriteValues
+ * @run junit ReadWriteValues
  */
 
 import java.io.BitsProxy;

--- a/test/jdk/java/io/Bits/java.base/java/io/BitsProxy.java
+++ b/test/jdk/java/io/Bits/java.base/java/io/BitsProxy.java
@@ -21,16 +21,7 @@
  * questions.
  */
 
-/*
- * @test
- * @summary Verify that reads and writes of primitives are correct
- * @compile/module=java.base java/io/ReadWriteValues.java
- * @run junit/othervm --add-opens java.base/java.io=ALL-UNNAMED ReadWriteValues
- */
-
 package java.io;
-
-import java.io.Bits;
 
 /**
  * Class to allow public access to package-private methods.

--- a/test/jdk/java/io/Bits/java.base/java/io/BitsProxy.java
+++ b/test/jdk/java/io/Bits/java.base/java/io/BitsProxy.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Verify that reads and writes of primitives are correct
+ * @compile/module=java.base java/io/ReadWriteValues.java
+ * @run junit/othervm --add-opens java.base/java.io=ALL-UNNAMED ReadWriteValues
+ */
+
+package java.io;
+
+import java.io.Bits;
+
+/**
+ * Class to allow public access to package-private methods.
+ */
+public final class BitsProxy {
+
+    public static boolean getBoolean(byte[] b, int off) {
+        return Bits.getBoolean(b, off);
+    }
+
+    public static char getChar(byte[] b, int off) {
+        return Bits.getChar(b, off);
+    }
+
+    public static short getShort(byte[] b, int off) {
+        return Bits.getShort(b, off);
+    }
+
+    public static int getInt(byte[] b, int off) {
+        return Bits.getInt(b, off);
+    }
+
+    public static float getFloat(byte[] b, int off) {
+        return Bits.getFloat(b, off);
+    }
+
+    public static long getLong(byte[] b, int off) {
+        return Bits.getLong(b, off);
+    }
+
+    public static double getDouble(byte[] b, int off) {
+        return Bits.getDouble(b, off);
+    }
+
+
+    public static void putBoolean(byte[] b, int off, boolean val) {
+        Bits.putBoolean(b, off, val);
+    }
+
+    public static void putChar(byte[] b, int off, char val) {
+        Bits.putChar(b, off, val);
+    }
+
+    public static void putShort(byte[] b, int off, short val) {
+        Bits.putShort(b, off, val);
+    }
+
+    public static void putInt(byte[] b, int off, int val) {
+        Bits.putInt(b, off, val);
+    }
+
+    public static void putFloat(byte[] b, int off, float val) {
+        Bits.putFloat(b, off, val);
+    }
+
+    public static void putLong(byte[] b, int off, long val) {
+        Bits.putLong(b, off, val);
+    }
+
+    public static void putDouble(byte[] b, int off, double val) {
+        Bits.putDouble(b, off, val);
+    }
+
+}


### PR DESCRIPTION
Currently, `java.io.Bits` is using explicit logic to read/write various primitive types to/from byte arrays. Switching to the use of `VarHandle` access would provide better performance and less code. 

Also, using a standard API for these conversions means future `VarHandle` improvements will benefit `Bits` too. 

Improvements in `Bits` will propagate to `ObjectInputStream`, `ObjectOutputStream` and `RandomAccessFile`.

Initial benchmarks and performance discussions can be found here: https://github.com/openjdk/panama-foreign/pull/762

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299576](https://bugs.openjdk.org/browse/JDK-8299576): Reimplement java.io.Bits using VarHandle access


### Reviewers
 * [Uwe Schindler](https://openjdk.org/census#uschindler) (@uschindler - Author) ⚠️ Review applies to [ec2e7c99](https://git.openjdk.org/jdk/pull/11840/files/ec2e7c99181453c4c8086b17594b765005403683)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11840/head:pull/11840` \
`$ git checkout pull/11840`

Update a local copy of the PR: \
`$ git checkout pull/11840` \
`$ git pull https://git.openjdk.org/jdk pull/11840/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11840`

View PR using the GUI difftool: \
`$ git pr show -t 11840`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11840.diff">https://git.openjdk.org/jdk/pull/11840.diff</a>

</details>
