### PR TITLE
8299593: getprotobyname should not be used

### DIFF
--- a/src/jdk.jdwp.agent/unix/native/libdt_socket/socket_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libdt_socket/socket_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdwp.agent/unix/native/libdt_socket/socket_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libdt_socket/socket_md.c
@@ -189,11 +189,9 @@ int
 dbgsysSetSocketOption(int fd, jint cmd, jboolean on, jvalue value)
 {
     if (cmd == TCP_NODELAY) {
-        struct protoent *proto = getprotobyname("TCP");
-        int tcp_level = (proto == 0 ? IPPROTO_TCP: proto->p_proto);
         uint32_t onl = (uint32_t)on;
 
-        if (setsockopt(fd, tcp_level, TCP_NODELAY,
+        if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY,
                        (char *)&onl, sizeof(uint32_t)) < 0) {
                 return SYS_ERR;
         }

--- a/src/jdk.jdwp.agent/windows/native/libdt_socket/socket_md.c
+++ b/src/jdk.jdwp.agent/windows/native/libdt_socket/socket_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdwp.agent/windows/native/libdt_socket/socket_md.c
+++ b/src/jdk.jdwp.agent/windows/native/libdt_socket/socket_md.c
@@ -268,11 +268,9 @@ int
 dbgsysSetSocketOption(int fd, jint cmd, jboolean on, jvalue value)
 {
     if (cmd == TCP_NODELAY) {
-        struct protoent *proto = getprotobyname("TCP");
-        int tcp_level = (proto == 0 ? IPPROTO_TCP: proto->p_proto);
         long onl = (long)on;
 
-        if (setsockopt(fd, tcp_level, TCP_NODELAY,
+        if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY,
                        (char *)&onl, sizeof(long)) < 0) {
                 return SYS_ERR;
         }


### PR DESCRIPTION
Please review this patch that removes the remaining uses of non-reentrant `getprotobyname` function.

While the protocol number for TCP could theoretically be modified to something other than the default `IPPROTO_TCP`, that scenario would likely not work, and is not something that we are willing to support. [Existing code](https://github.com/openjdk/jdk/blob/2f3f3b618500b5f112fabca30d4c6780b2a8e723/src/java.base/unix/native/libnet/net_util_md.c#L355) in networking area is using `IPPROTO_TCP` for `TCP_NODELAY`, and no issues were reported.

Tier 1-3 tests still pass.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299593](https://bugs.openjdk.org/browse/JDK-8299593): getprotobyname should not be used


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11842/head:pull/11842` \
`$ git checkout pull/11842`

Update a local copy of the PR: \
`$ git checkout pull/11842` \
`$ git pull https://git.openjdk.org/jdk pull/11842/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11842`

View PR using the GUI difftool: \
`$ git pr show -t 11842`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11842.diff">https://git.openjdk.org/jdk/pull/11842.diff</a>

</details>
