### PR TITLE
JDK-8295406: C1 crash with -XX:TypeProfileArgsLimit=0 -XX:TypeProfileLevel=222

### DIFF
--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -1595,7 +1595,7 @@ int MethodData::profile_arguments_flag() {
 }
 
 bool MethodData::profile_arguments() {
-  return profile_arguments_flag() > no_type_profile && profile_arguments_flag() <= type_profile_all;
+  return profile_arguments_flag() > no_type_profile && profile_arguments_flag() <= type_profile_all && TypeProfileArgsLimit > 0;
 }
 
 bool MethodData::profile_arguments_jsr292_only() {

--- a/test/hotspot/jtreg/compiler/profiling/TestTypeProfileArgsLimit.java
+++ b/test/hotspot/jtreg/compiler/profiling/TestTypeProfileArgsLimit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/profiling/TestTypeProfileArgsLimit.java
+++ b/test/hotspot/jtreg/compiler/profiling/TestTypeProfileArgsLimit.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test TestTypeProfileArgsLimit
+ * @bug 8295406
+ * @summary Tests execution with TypeProfileArgsLimit=0 TypeProfileLevel=222.
+ *
+ * @run main/othervm -XX:TypeProfileArgsLimit=0 -XX:TypeProfileLevel=222 compiler.profiling.TestTypeProfileArgsLimit
+ * @run main/othervm -XX:TypeProfileArgsLimit=0 -XX:TypeProfileLevel=212 compiler.profiling.TestTypeProfileArgsLimit
+ * @run main/othervm -XX:TypeProfileArgsLimit=0 -XX:TypeProfileLevel=202 compiler.profiling.TestTypeProfileArgsLimit
+ * @run main/othervm -XX:TypeProfileParmsLimit=0 -XX:TypeProfileLevel=222 compiler.profiling.TestTypeProfileArgsLimit
+ * @run main/othervm -XX:TypeProfileParmsLimit=0 -XX:TypeProfileArgsLimit=0 -XX:TypeProfileLevel=222 compiler.profiling.TestTypeProfileArgsLimit
+ * @run main/othervm -XX:TypeProfileParmsLimit=-1 -XX:TypeProfileArgsLimit=0 -XX:TypeProfileLevel=222 compiler.profiling.TestTypeProfileArgsLimit
+ */
+
+package compiler.profiling;
+
+public class TestTypeProfileArgsLimit {
+    public static void main(String args[]) {
+        System.out.println("Passed");
+    }
+}
+


### PR DESCRIPTION
`-XX:TypeProfileArgsLimit=0 -XX:TypeProfileLevel=222` cause an assert to fail in `LIRGenerator::profile_arguments`.

`LIRGenerator::profile_arguments` actually checks if arguments need to be profiled but the `MethodData::profile_arguments` method doesn't take `TypeProfileArgsLimit=0` into account.

Adding a check for _TypeProfileArgsLimit>0_ to determine if arguments have to be profiled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295406](https://bugs.openjdk.org/browse/JDK-8295406): C1 crash with -XX:TypeProfileArgsLimit=0 -XX:TypeProfileLevel=222


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11843/head:pull/11843` \
`$ git checkout pull/11843`

Update a local copy of the PR: \
`$ git checkout pull/11843` \
`$ git pull https://git.openjdk.org/jdk pull/11843/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11843`

View PR using the GUI difftool: \
`$ git pr show -t 11843`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11843.diff">https://git.openjdk.org/jdk/pull/11843.diff</a>

</details>
