### PR TITLE
8258776: ThreadLocal#initialValue() Javadoc is unaware of ThreadLocal#withInitial()

### DIFF
--- a/src/java.base/share/classes/java/lang/ThreadLocal.java
+++ b/src/java.base/share/classes/java/lang/ThreadLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,13 +120,15 @@ public class ThreadLocal<T> {
      * most once per thread, but it may be invoked again in case of
      * subsequent invocations of {@link #remove} followed by {@link #get}.
      *
-     * <p>This implementation simply returns {@code null}; if the
+     * @implSpec
+     * This implementation simply returns {@code null}; if the
      * programmer desires thread-local variables to have an initial
-     * value other than {@code null}, {@code ThreadLocal} must be
-     * subclassed, and this method overridden.  Typically, an
-     * anonymous inner class will be used.
+     * value other than {@code null}, then either {@code ThreadLocal} can be
+     * subclassed and this method overridden or {@link ThreadLocal#withInitial(Supplier)} method
+     * can be used to construct a {@code ThreadLocal}.
      *
      * @return the initial value for this thread-local
+     * @see #withInitial(java.util.function.Supplier)
      */
     protected T initialValue() {
         return null;
@@ -159,8 +161,7 @@ public class ThreadLocal<T> {
      * current thread, it is first initialized to the value returned
      * by an invocation of the {@link #initialValue} method.
      * If the current thread does not support thread locals then
-     * this method returns its {@link #initialValue} (or {@code null}
-     * if the {@code initialValue} method is not overridden).
+     * this method returns its {@link #initialValue}.
      *
      * @return the current thread's value of this thread-local
      * @see Thread.Builder#allowSetThreadLocals(boolean)

--- a/src/java.base/share/classes/java/lang/ThreadLocal.java
+++ b/src/java.base/share/classes/java/lang/ThreadLocal.java
@@ -123,9 +123,10 @@ public class ThreadLocal<T> {
      * @implSpec
      * This implementation simply returns {@code null}; if the
      * programmer desires thread-local variables to have an initial
-     * value other than {@code null}, then either {@code ThreadLocal} can be
-     * subclassed and this method overridden or {@link ThreadLocal#withInitial(Supplier)} method
-     * can be used to construct a {@code ThreadLocal}.
+     * value other than {@code null}, then either {@code ThreadLocal}
+     * can be subclassed and this method overridden or the method
+     * {@link ThreadLocal#withInitial(Supplier)} can be used to
+     * construct a {@code ThreadLocal}.
      *
      * @return the initial value for this thread-local
      * @see #withInitial(java.util.function.Supplier)


### PR DESCRIPTION
Can I please get a review of this doc only change which addresses the javadoc issue noted in https://bugs.openjdk.org/browse/JDK-8258776? 

As noted in that issue, the `ThreadLocal.initialValue()` API javadoc suggests subclassing `ThreadLocal` and overriding the `initialValue()` method instead of recommending the `withInitial` method that was added in Java 8.

The commit here updates the javadoc of `initialValue()` method to note that `withInitial` method is available for use if the programmer wants to provide an initial value. The updated javadoc continues to note that the `ThreadLocal` can be subclassed and the method overriden as the other way of providing an initial value. This change now uses the `@implSpec` construct to state this default behaviour of the `initialValue()` method.

Additionally, the `get()` method's javadoc has also been updated to account for the semantics of `initialValue()`. In fact, in its current form, before the changes in this PR, the `get()` method states:

> If the current thread does not support thread locals then
> this method returns its {@link #initialValue} (or {@code null}
> if the {@code initialValue} method is not overridden).

which isn't accurate, since the `get()` will return a non-null value if the ThreadLocal was constructed through `ThreadLocal.withInitial`. Here's a trivial code which contradicts this current javadoc:

```java
public class Test {
  public static void main(final String[] args) throws Exception {
    Thread.ofPlatform().name("hello").allowSetThreadLocals(false).start(() -> {
	var t = ThreadLocal.withInitial(() -> 2);
	System.out.println("Thread local value is " + t.get());
    });
  }
}
```
Running this with `java --enable-preview --source 21 Test.java` returns:
```console
Thread local value is 2
```

The updated javadoc of `get()` in this PR now matches the behaviour of this method. I believe this will need a CSR, which I'll open once we have an agreement on these changes.

Furthermore, the class level javadoc of `ThreadLocal` has an example of providing an initial value which uses the subclassing strategy. I haven't updated that part. Should we update that to show the `withInitialValue` usage instead (and maybe convert it to a snippet)?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8258776](https://bugs.openjdk.org/browse/JDK-8258776): ThreadLocal#initialValue() Javadoc is unaware of ThreadLocal#withInitial()
 * [JDK-8299714](https://bugs.openjdk.org/browse/JDK-8299714): ThreadLocal#initialValue() Javadoc is unaware of ThreadLocal#withInitial() (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11846/head:pull/11846` \
`$ git checkout pull/11846`

Update a local copy of the PR: \
`$ git checkout pull/11846` \
`$ git pull https://git.openjdk.org/jdk pull/11846/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11846`

View PR using the GUI difftool: \
`$ git pr show -t 11846`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11846.diff">https://git.openjdk.org/jdk/pull/11846.diff</a>

</details>
