### PR TITLE
8299444  java.util.Set.copyOf allocates needlessly for empty input collections

### DIFF
--- a/src/java.base/share/classes/java/util/ImmutableCollections.java
+++ b/src/java.base/share/classes/java/util/ImmutableCollections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -168,6 +168,8 @@ class ImmutableCollections {
     static <E> List<E> listCopy(Collection<? extends E> coll) {
         if (coll instanceof List12 || (coll instanceof ListN && ! ((ListN<?>)coll).allowNulls)) {
             return (List<E>)coll;
+        } else if (coll.isEmpty()) { // implicit nullcheck of coll
+            return List.of();
         } else {
             return (List<E>)List.of(coll.toArray()); // implicit nullcheck of coll
         }

--- a/src/java.base/share/classes/java/util/ImmutableCollections.java
+++ b/src/java.base/share/classes/java/util/ImmutableCollections.java
@@ -171,7 +171,7 @@ class ImmutableCollections {
         } else if (coll.isEmpty()) { // implicit nullcheck of coll
             return List.of();
         } else {
-            return (List<E>)List.of(coll.toArray()); // implicit nullcheck of coll
+            return (List<E>)List.of(coll.toArray());
         }
     }
 

--- a/src/java.base/share/classes/java/util/ImmutableCollections.java
+++ b/src/java.base/share/classes/java/util/ImmutableCollections.java
@@ -166,7 +166,7 @@ class ImmutableCollections {
      */
     @SuppressWarnings("unchecked")
     static <E> List<E> listCopy(Collection<? extends E> coll) {
-        if (coll instanceof List12 || (coll instanceof ListN && ! ((ListN<?>)coll).allowNulls)) {
+        if (coll instanceof List12 || (coll instanceof ListN<?> c && !c.allowNulls)) {
             return (List<E>)coll;
         } else if (coll.isEmpty()) { // implicit nullcheck of coll
             return List.of();

--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1728,6 +1728,8 @@ public interface Map<K, V> {
     static <K, V> Map<K, V> copyOf(Map<? extends K, ? extends V> map) {
         if (map instanceof ImmutableCollections.AbstractImmutableMap) {
             return (Map<K,V>)map;
+        } else if (map.isEmpty()) {
+            return Map.of();
         } else {
             return (Map<K,V>)Map.ofEntries(map.entrySet().toArray(new Entry[0]));
         }

--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -1728,7 +1728,7 @@ public interface Map<K, V> {
     static <K, V> Map<K, V> copyOf(Map<? extends K, ? extends V> map) {
         if (map instanceof ImmutableCollections.AbstractImmutableMap) {
             return (Map<K,V>)map;
-        } else if (map.isEmpty()) {
+        } else if (map.isEmpty()) { // Implicit nullcheck of map
             return Map.of();
         } else {
             return (Map<K,V>)Map.ofEntries(map.entrySet().toArray(new Entry[0]));

--- a/src/java.base/share/classes/java/util/Set.java
+++ b/src/java.base/share/classes/java/util/Set.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -728,6 +728,8 @@ public interface Set<E> extends Collection<E> {
     static <E> Set<E> copyOf(Collection<? extends E> coll) {
         if (coll instanceof ImmutableCollections.AbstractImmutableSet) {
             return (Set<E>)coll;
+        } else if (coll.isEmpty()) {
+            return Set.of();
         } else {
             return (Set<E>)Set.of(new HashSet<>(coll).toArray());
         }

--- a/src/java.base/share/classes/java/util/Set.java
+++ b/src/java.base/share/classes/java/util/Set.java
@@ -728,7 +728,7 @@ public interface Set<E> extends Collection<E> {
     static <E> Set<E> copyOf(Collection<? extends E> coll) {
         if (coll instanceof ImmutableCollections.AbstractImmutableSet) {
             return (Set<E>)coll;
-        } else if (coll.isEmpty()) {
+        } else if (coll.isEmpty()) { // Implicit nullcheck of coll
             return Set.of();
         } else {
             return (Set<E>)Set.of(new HashSet<>(coll).toArray());


### PR DESCRIPTION
Currently Set.copyOf allocates both a HashSet and a new empty array when the input collection is empty.

This patch avoids allocating anything for the case where the parameter collection's isEmpty returns true.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299444](https://bugs.openjdk.org/browse/JDK-8299444): java.util.Set.copyOf allocates needlessly for empty input collections


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [52a87a2b](https://git.openjdk.org/jdk/pull/11847/files/52a87a2b49f57fc7104e711271e947861ac50dbc)
 * [Stuart Marks](https://openjdk.org/census#smarks) (@stuart-marks - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11847/head:pull/11847` \
`$ git checkout pull/11847`

Update a local copy of the PR: \
`$ git checkout pull/11847` \
`$ git pull https://git.openjdk.org/jdk pull/11847/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11847`

View PR using the GUI difftool: \
`$ git pr show -t 11847`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11847.diff">https://git.openjdk.org/jdk/pull/11847.diff</a>

</details>
