### PR TITLE
8299513: Clean up java.io

### DIFF
--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/BufferedOutputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/BufferedOutputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedOutputStream.java
@@ -48,7 +48,7 @@ public class BufferedOutputStream extends FilterOutputStream {
     /**
      * The internal buffer where data is stored.
      */
-    protected byte buf[];
+    protected byte[] buf;
 
     /**
      * The number of valid bytes in the buffer. This value is always

--- a/src/java.base/share/classes/java/io/BufferedReader.java
+++ b/src/java.base/share/classes/java/io/BufferedReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/BufferedReader.java
+++ b/src/java.base/share/classes/java/io/BufferedReader.java
@@ -85,8 +85,8 @@ public class BufferedReader extends Reader {
     /** The skipLF flag when the mark was set */
     private boolean markedSkipLF = false;
 
-    private static int defaultCharBufferSize = 8192;
-    private static int defaultExpectedLineLength = 80;
+    private static final int DEFAULT_CHAR_BUFFER_SIZE = 8192;
+    private static final int DEFAULT_EXPECTED_LINE_LENGTH = 80;
 
     /**
      * Creates a buffering character-input stream that uses an input buffer of
@@ -113,7 +113,7 @@ public class BufferedReader extends Reader {
      * @param  in   A Reader
      */
     public BufferedReader(Reader in) {
-        this(in, defaultCharBufferSize);
+        this(in, DEFAULT_CHAR_BUFFER_SIZE);
     }
 
     /** Checks to make sure that the stream has not been closed */
@@ -277,7 +277,7 @@ public class BufferedReader extends Reader {
      * however, the buffer is empty, the mark is not valid, and the requested
      * length is at least as large as the buffer, then this method will read
      * characters directly from the underlying stream into the given array.
-     * Thus redundant {@code BufferedReader}s will not copy data
+     * Thus, redundant {@code BufferedReader}s will not copy data
      * unnecessarily.
      *
      * @param      cbuf  {@inheritDoc}
@@ -414,7 +414,7 @@ public class BufferedReader extends Reader {
             }
 
             if (s == null)
-                s = new StringBuilder(defaultExpectedLineLength);
+                s = new StringBuilder(DEFAULT_EXPECTED_LINE_LENGTH);
             s.append(cb, startChar, i - startChar);
         }
     }
@@ -551,7 +551,7 @@ public class BufferedReader extends Reader {
      *                         A limit value larger than the size of the input
      *                         buffer will cause a new buffer to be allocated
      *                         whose size is no smaller than limit.
-     *                         Therefore large values should be used with care.
+     *                         Therefore, large values should be used with care.
      *
      * @throws     IllegalArgumentException  If {@code readAheadLimit < 0}
      * @throws     IOException  If an I/O error occurs

--- a/src/java.base/share/classes/java/io/BufferedWriter.java
+++ b/src/java.base/share/classes/java/io/BufferedWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/BufferedWriter.java
+++ b/src/java.base/share/classes/java/io/BufferedWriter.java
@@ -73,8 +73,9 @@ public class BufferedWriter extends Writer {
 
     private Writer out;
 
-    private char cb[];
-    private int nChars, nextChar;
+    private char[] cb;
+    private int nChars;
+    private int nextChar;
     private final int maxChars;  // maximum number of buffers chars
 
     /**

--- a/src/java.base/share/classes/java/io/ByteArrayInputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ public class ByteArrayInputStream extends InputStream {
 
     /**
      * The index of the next character to read from the input stream buffer.
-     * This value should always be non-negative
+     * This value should always be nonnegative
      * and not larger than the value of {@code count}.
      * The next byte to be read from the input stream buffer
      * will be {@code buf[pos]}.
@@ -82,7 +82,7 @@ public class ByteArrayInputStream extends InputStream {
     /**
      * The index one greater than the last valid character in the input
      * stream buffer.
-     * This value should always be non-negative
+     * This value should always be nonnegative
      * and not larger than the length of {@code buf}.
      * It  is one greater than the position of
      * the last byte within {@code buf} that

--- a/src/java.base/share/classes/java/io/ByteArrayInputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayInputStream.java
@@ -53,11 +53,11 @@ public class ByteArrayInputStream extends InputStream {
      * stream;  element {@code buf[pos]} is
      * the next byte to be read.
      */
-    protected byte buf[];
+    protected byte[] buf;
 
     /**
      * The index of the next character to read from the input stream buffer.
-     * This value should always be nonnegative
+     * This value should always be non-negative
      * and not larger than the value of {@code count}.
      * The next byte to be read from the input stream buffer
      * will be {@code buf[pos]}.
@@ -82,7 +82,7 @@ public class ByteArrayInputStream extends InputStream {
     /**
      * The index one greater than the last valid character in the input
      * stream buffer.
-     * This value should always be nonnegative
+     * This value should always be non-negative
      * and not larger than the length of {@code buf}.
      * It  is one greater than the position of
      * the last byte within {@code buf} that

--- a/src/java.base/share/classes/java/io/ByteArrayOutputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/ByteArrayOutputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayOutputStream.java
@@ -51,7 +51,7 @@ public class ByteArrayOutputStream extends OutputStream {
     /**
      * The buffer where data is stored.
      */
-    protected byte buf[];
+    protected byte[] buf;
 
     /**
      * The number of valid bytes in the buffer.

--- a/src/java.base/share/classes/java/io/CharArrayWriter.java
+++ b/src/java.base/share/classes/java/io/CharArrayWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/CharArrayWriter.java
+++ b/src/java.base/share/classes/java/io/CharArrayWriter.java
@@ -43,7 +43,7 @@ public class CharArrayWriter extends Writer {
     /**
      * The buffer where data is stored.
      */
-    protected char buf[];
+    protected char[] buf;
 
     /**
      * The number of chars in the buffer.

--- a/src/java.base/share/classes/java/io/DataInputStream.java
+++ b/src/java.base/share/classes/java/io/DataInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/DataInputStream.java
+++ b/src/java.base/share/classes/java/io/DataInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/DataInputStream.java
+++ b/src/java.base/share/classes/java/io/DataInputStream.java
@@ -579,7 +579,7 @@ loop:   while (true) {
      *               valid modified UTF-8 encoding of a Unicode string.
      * @see        java.io.DataInputStream#readUnsignedShort()
      */
-    public static final String readUTF(DataInput in) throws IOException {
+    public static String readUTF(DataInput in) throws IOException {
         int utflen = in.readUnsignedShort();
         byte[] bytearr = null;
         char[] chararr = null;

--- a/src/java.base/share/classes/java/io/DataInputStream.java
+++ b/src/java.base/share/classes/java/io/DataInputStream.java
@@ -579,7 +579,7 @@ loop:   while (true) {
      *               valid modified UTF-8 encoding of a Unicode string.
      * @see        java.io.DataInputStream#readUnsignedShort()
      */
-    public static String readUTF(DataInput in) throws IOException {
+    public static final String readUTF(DataInput in) throws IOException {
         int utflen = in.readUnsignedShort();
         byte[] bytearr = null;
         char[] chararr = null;

--- a/src/java.base/share/classes/java/io/DeleteOnExitHook.java
+++ b/src/java.base/share/classes/java/io/DeleteOnExitHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/DeleteOnExitHook.java
+++ b/src/java.base/share/classes/java/io/DeleteOnExitHook.java
@@ -39,7 +39,7 @@ class DeleteOnExitHook {
     static {
         // DeleteOnExitHook must be the last shutdown hook to be invoked.
         // Application shutdown hooks may add the first file to the
-        // delete on exit list and cause the DeleteOnExitHook to be
+        // delete-on-exit list and cause the DeleteOnExitHook to be
         // registered during shutdown in progress. So set the
         // registerShutdownInProgress parameter to true.
         SharedSecrets.getJavaLangAccess()

--- a/src/java.base/share/classes/java/io/ExpiringCache.java
+++ b/src/java.base/share/classes/java/io/ExpiringCache.java
@@ -28,18 +28,17 @@
 
 package java.io;
 
-import java.util.Iterator;
 import java.util.Map;
 import java.util.LinkedHashMap;
 import java.util.Set;
 
 final class ExpiringCache {
+    private static final int QUERY_OVERFLOW = 300;
+    private static final int MAX_ENTRIES = 200;
     private final long millisUntilExpiration;
     private final Map<String,Entry> map;
     // Clear out old entries every few queries
     private int queryCount;
-    private final int queryOverflow = 300;
-    private static final int MAX_ENTRIES = 200;
 
     static final class Entry {
         private long   timestamp;
@@ -72,7 +71,7 @@ final class ExpiringCache {
     }
 
     synchronized String get(String key) {
-        if (++queryCount >= queryOverflow) {
+        if (++queryCount >= QUERY_OVERFLOW) {
             cleanup();
         }
         Entry entry = entryFor(key);
@@ -83,7 +82,7 @@ final class ExpiringCache {
     }
 
     synchronized void put(String key, String val) {
-        if (++queryCount >= queryOverflow) {
+        if (++queryCount >= QUERY_OVERFLOW) {
             cleanup();
         }
         Entry entry = entryFor(key);

--- a/src/java.base/share/classes/java/io/ExpiringCache.java
+++ b/src/java.base/share/classes/java/io/ExpiringCache.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.LinkedHashMap;
 import java.util.Set;
 
-class ExpiringCache {
+final class ExpiringCache {
     private final long millisUntilExpiration;
     private final Map<String,Entry> map;
     // Clear out old entries every few queries

--- a/src/java.base/share/classes/java/io/ExpiringCache.java
+++ b/src/java.base/share/classes/java/io/ExpiringCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/ExpiringCache.java
+++ b/src/java.base/share/classes/java/io/ExpiringCache.java
@@ -34,14 +34,14 @@ import java.util.LinkedHashMap;
 import java.util.Set;
 
 class ExpiringCache {
-    private long millisUntilExpiration;
-    private Map<String,Entry> map;
+    private final long millisUntilExpiration;
+    private final Map<String,Entry> map;
     // Clear out old entries every few queries
     private int queryCount;
-    private int queryOverflow = 300;
-    private int MAX_ENTRIES = 200;
+    private final int queryOverflow = 300;
+    private static final int MAX_ENTRIES = 200;
 
-    static class Entry {
+    static final class Entry {
         private long   timestamp;
         private String val;
 

--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -152,7 +152,7 @@ public class File
     /**
      * The FileSystem object representing the platform's local file system.
      */
-    private static final FileSystem fs = DefaultFileSystem.getFileSystem();
+    private static final FileSystem FS = DefaultFileSystem.getFileSystem();
 
     /**
      * This abstract pathname's normalized pathname string. A normalized
@@ -166,7 +166,7 @@ public class File
     /**
      * Enum type that indicates the status of a file path.
      */
-    private static enum PathStatus { INVALID, CHECKED };
+    private enum PathStatus { INVALID, CHECKED };
 
     /**
      * The flag indicating whether the file path is invalid.
@@ -185,7 +185,7 @@ public class File
     final boolean isInvalid() {
         PathStatus s = status;
         if (s == null) {
-            s = fs.isInvalid(this) ? PathStatus.INVALID : PathStatus.CHECKED;
+            s = FS.isInvalid(this) ? PathStatus.INVALID : PathStatus.CHECKED;
             status = s;
         }
         return s == PathStatus.INVALID;
@@ -213,7 +213,7 @@ public class File
      *
      * @see     java.lang.System#getProperty(java.lang.String)
      */
-    public static final char separatorChar = fs.getSeparator();
+    public static final char separatorChar = FS.getSeparator();
 
     /**
      * The system-dependent default name-separator character, represented as a
@@ -232,7 +232,7 @@ public class File
      *
      * @see     java.lang.System#getProperty(java.lang.String)
      */
-    public static final char pathSeparatorChar = fs.getPathSeparator();
+    public static final char pathSeparatorChar = FS.getPathSeparator();
 
     /**
      * The system-dependent path-separator character, represented as a string
@@ -260,7 +260,7 @@ public class File
     private File(String child, File parent) {
         assert parent.path != null;
         assert (!parent.path.isEmpty());
-        this.path = fs.resolve(parent.path, child);
+        this.path = FS.resolve(parent.path, child);
         this.prefixLength = parent.prefixLength;
     }
 
@@ -277,8 +277,8 @@ public class File
         if (pathname == null) {
             throw new NullPointerException();
         }
-        this.path = fs.normalize(pathname);
-        this.prefixLength = fs.prefixLength(this.path);
+        this.path = FS.normalize(pathname);
+        this.prefixLength = FS.prefixLength(this.path);
     }
 
     /* Note: The two-argument File constructors do not interpret an empty
@@ -319,16 +319,16 @@ public class File
         }
         if (parent != null) {
             if (parent.isEmpty()) {
-                this.path = fs.resolve(fs.getDefaultParent(),
-                                       fs.normalize(child));
+                this.path = FS.resolve(FS.getDefaultParent(),
+                                       FS.normalize(child));
             } else {
-                this.path = fs.resolve(fs.normalize(parent),
-                                       fs.normalize(child));
+                this.path = FS.resolve(FS.normalize(parent),
+                                       FS.normalize(child));
             }
         } else {
-            this.path = fs.normalize(child);
+            this.path = FS.normalize(child);
         }
-        this.prefixLength = fs.prefixLength(this.path);
+        this.prefixLength = FS.prefixLength(this.path);
     }
 
     /**
@@ -362,16 +362,16 @@ public class File
         }
         if (parent != null) {
             if (parent.path.isEmpty()) {
-                this.path = fs.resolve(fs.getDefaultParent(),
-                                       fs.normalize(child));
+                this.path = FS.resolve(FS.getDefaultParent(),
+                                       FS.normalize(child));
             } else {
-                this.path = fs.resolve(parent.path,
-                                       fs.normalize(child));
+                this.path = FS.resolve(parent.path,
+                                       FS.normalize(child));
             }
         } else {
-            this.path = fs.normalize(child);
+            this.path = FS.normalize(child);
         }
-        this.prefixLength = fs.prefixLength(this.path);
+        this.prefixLength = FS.prefixLength(this.path);
     }
 
     /**
@@ -432,11 +432,11 @@ public class File
             throw new IllegalArgumentException("URI path component is empty");
 
         // Okay, now initialize
-        p = fs.fromURIPath(p);
+        p = FS.fromURIPath(p);
         if (File.separatorChar != '/')
             p = p.replace('/', File.separatorChar);
-        this.path = fs.normalize(p);
-        this.prefixLength = fs.prefixLength(this.path);
+        this.path = FS.normalize(p);
+        this.prefixLength = FS.prefixLength(this.path);
     }
 
 
@@ -501,7 +501,7 @@ public class File
         String p = this.getParent();
         if (p == null) return null;
         if (getClass() != File.class) {
-            p = fs.normalize(p);
+            p = FS.normalize(p);
         }
         return new File(p, this.prefixLength);
     }
@@ -531,7 +531,7 @@ public class File
      *          {@code false} otherwise
      */
     public boolean isAbsolute() {
-        return fs.isAbsolute(this);
+        return FS.isAbsolute(this);
     }
 
     /**
@@ -558,7 +558,7 @@ public class File
      * @see     java.io.File#isAbsolute()
      */
     public String getAbsolutePath() {
-        return fs.resolve(this);
+        return FS.resolve(this);
     }
 
     /**
@@ -576,9 +576,9 @@ public class File
     public File getAbsoluteFile() {
         String absPath = getAbsolutePath();
         if (getClass() != File.class) {
-            absPath = fs.normalize(absPath);
+            absPath = FS.normalize(absPath);
         }
-        return new File(absPath, fs.prefixLength(absPath));
+        return new File(absPath, FS.prefixLength(absPath));
     }
 
     /**
@@ -623,7 +623,7 @@ public class File
         if (isInvalid()) {
             throw new IOException("Invalid file path");
         }
-        return fs.canonicalize(fs.resolve(this));
+        return FS.canonicalize(FS.resolve(this));
     }
 
     /**
@@ -650,9 +650,9 @@ public class File
     public File getCanonicalFile() throws IOException {
         String canonPath = getCanonicalPath();
         if (getClass() != File.class) {
-            canonPath = fs.normalize(canonPath);
+            canonPath = FS.normalize(canonPath);
         }
-        return new File(canonPath, fs.prefixLength(canonPath));
+        return new File(canonPath, FS.prefixLength(canonPath));
     }
 
     private static String slashify(String path, boolean isDirectory) {
@@ -780,7 +780,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.checkAccess(this, FileSystem.ACCESS_READ);
+        return FS.checkAccess(this, FileSystem.ACCESS_READ);
     }
 
     /**
@@ -809,7 +809,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.checkAccess(this, FileSystem.ACCESS_WRITE);
+        return FS.checkAccess(this, FileSystem.ACCESS_WRITE);
     }
 
     /**
@@ -833,7 +833,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.hasBooleanAttributes(this, FileSystem.BA_EXISTS);
+        return FS.hasBooleanAttributes(this, FileSystem.BA_EXISTS);
     }
 
     /**
@@ -864,7 +864,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.hasBooleanAttributes(this, FileSystem.BA_DIRECTORY);
+        return FS.hasBooleanAttributes(this, FileSystem.BA_DIRECTORY);
     }
 
     /**
@@ -897,7 +897,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.hasBooleanAttributes(this, FileSystem.BA_REGULAR);
+        return FS.hasBooleanAttributes(this, FileSystem.BA_REGULAR);
     }
 
     /**
@@ -927,7 +927,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.hasBooleanAttributes(this, FileSystem.BA_HIDDEN);
+        return FS.hasBooleanAttributes(this, FileSystem.BA_HIDDEN);
     }
 
     /**
@@ -971,7 +971,7 @@ public class File
         if (isInvalid()) {
             return 0L;
         }
-        return fs.getLastModifiedTime(this);
+        return FS.getLastModifiedTime(this);
     }
 
     /**
@@ -1003,7 +1003,7 @@ public class File
         if (isInvalid()) {
             return 0L;
         }
-        return fs.getLength(this);
+        return FS.getLength(this);
     }
 
 
@@ -1042,7 +1042,7 @@ public class File
         if (isInvalid()) {
             throw new IOException("Invalid file path");
         }
-        return fs.createFileExclusively(path);
+        return FS.createFileExclusively(path);
     }
 
     /**
@@ -1072,7 +1072,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.delete(this);
+        return FS.delete(this);
     }
 
     /**
@@ -1175,11 +1175,11 @@ public class File
         if (isInvalid()) {
             return null;
         }
-        String[] s = fs.list(this);
+        String[] s = FS.list(this);
         if (s != null && getClass() != File.class) {
             String[] normalized = new String[s.length];
             for (int i = 0; i < s.length; i++) {
-                normalized[i] = fs.normalize(s[i]);
+                normalized[i] = FS.normalize(s[i]);
             }
             s = normalized;
         }
@@ -1216,7 +1216,7 @@ public class File
      * @see java.nio.file.Files#newDirectoryStream(Path,String)
      */
     public String[] list(FilenameFilter filter) {
-        String names[] = normalizedList();
+        String[] names = normalizedList();
         if ((names == null) || (filter == null)) {
             return names;
         }
@@ -1309,7 +1309,7 @@ public class File
      * @see java.nio.file.Files#newDirectoryStream(Path,String)
      */
     public File[] listFiles(FilenameFilter filter) {
-        String ss[] = normalizedList();
+        String[] ss = normalizedList();
         if (ss == null) return null;
         ArrayList<File> files = new ArrayList<>();
         for (String s : ss)
@@ -1347,7 +1347,7 @@ public class File
      * @see java.nio.file.Files#newDirectoryStream(Path,java.nio.file.DirectoryStream.Filter)
      */
     public File[] listFiles(FileFilter filter) {
-        String ss[] = normalizedList();
+        String[] ss = normalizedList();
         if (ss == null) return null;
         ArrayList<File> files = new ArrayList<>();
         for (String s : ss) {
@@ -1378,7 +1378,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.createDirectory(this);
+        return FS.createDirectory(this);
     }
 
     /**
@@ -1462,7 +1462,7 @@ public class File
         if (this.isInvalid() || dest.isInvalid()) {
             return false;
         }
-        return fs.rename(this, dest);
+        return FS.rename(this, dest);
     }
 
     /**
@@ -1501,7 +1501,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.setLastModifiedTime(this, time);
+        return FS.setLastModifiedTime(this, time);
     }
 
     /**
@@ -1532,7 +1532,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.setReadOnly(this);
+        return FS.setReadOnly(this);
     }
 
     /**
@@ -1576,7 +1576,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.setPermission(this, FileSystem.ACCESS_WRITE, writable, ownerOnly);
+        return FS.setPermission(this, FileSystem.ACCESS_WRITE, writable, ownerOnly);
     }
 
     /**
@@ -1655,7 +1655,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.setPermission(this, FileSystem.ACCESS_READ, readable, ownerOnly);
+        return FS.setPermission(this, FileSystem.ACCESS_READ, readable, ownerOnly);
     }
 
     /**
@@ -1737,7 +1737,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.setPermission(this, FileSystem.ACCESS_EXECUTE, executable, ownerOnly);
+        return FS.setPermission(this, FileSystem.ACCESS_EXECUTE, executable, ownerOnly);
     }
 
     /**
@@ -1779,7 +1779,7 @@ public class File
      * Tests whether the application can execute the file denoted by this
      * abstract pathname. On some platforms it may be possible to start the
      * Java virtual machine with special privileges that allow it to execute
-     * files that are not marked executable. Consequently this method may return
+     * files that are not marked executable. Consequently, this method may return
      * {@code true} even though the file does not have execute permissions.
      *
      * @return  {@code true} if and only if the abstract pathname exists
@@ -1801,7 +1801,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.checkAccess(this, FileSystem.ACCESS_EXECUTE);
+        return FS.checkAccess(this, FileSystem.ACCESS_EXECUTE);
     }
 
 
@@ -1850,7 +1850,7 @@ public class File
      * @see java.nio.file.FileStore
      */
     public static File[] listRoots() {
-        return fs.listRoots();
+        return FS.listRoots();
     }
 
 
@@ -1885,7 +1885,7 @@ public class File
         if (isInvalid()) {
             return 0L;
         }
-        long space = fs.getSpace(this, FileSystem.SPACE_TOTAL);
+        long space = FS.getSpace(this, FileSystem.SPACE_TOTAL);
         return space >= 0L ? space : Long.MAX_VALUE;
     }
 
@@ -1929,7 +1929,7 @@ public class File
         if (isInvalid()) {
             return 0L;
         }
-        long space = fs.getSpace(this, FileSystem.SPACE_FREE);
+        long space = FS.getSpace(this, FileSystem.SPACE_FREE);
         return space >= 0L ? space : Long.MAX_VALUE;
     }
 
@@ -1976,20 +1976,20 @@ public class File
         if (isInvalid()) {
             return 0L;
         }
-        long space = fs.getSpace(this, FileSystem.SPACE_USABLE);
+        long space = FS.getSpace(this, FileSystem.SPACE_USABLE);
         return space >= 0L ? space : Long.MAX_VALUE;
     }
 
     /* -- Temporary files -- */
 
-    private static class TempDirectory {
+    private static final class TempDirectory {
         private TempDirectory() { }
 
         // temporary directory location
-        private static final File tmpdir = new File(StaticProperty.javaIoTmpDir());
+        private static final File TMP_DIR = new File(StaticProperty.javaIoTmpDir());
 
         static File location() {
-            return tmpdir;
+            return TMP_DIR;
         }
 
         // file name generation
@@ -2017,7 +2017,7 @@ public class File
             int suffixLength = suffix.length();
 
             String name;
-            int nameMax = fs.getNameMax(dir.getPath());
+            int nameMax = FS.getNameMax(dir.getPath());
             int excess = prefixLength + nusLength + suffixLength - nameMax;
             if (excess <= 0) {
                 name = prefix + nus + suffix;
@@ -2055,7 +2055,7 @@ public class File
             }
 
             // Normalize the path component
-            name = fs.normalize(name);
+            name = FS.normalize(name);
 
             File f = new File(dir, name);
             if (!name.equals(f.getName()) || f.isInvalid()) {
@@ -2176,9 +2176,9 @@ public class File
                     throw se;
                 }
             }
-        } while (fs.hasBooleanAttributes(f, FileSystem.BA_EXISTS));
+        } while (FS.hasBooleanAttributes(f, FileSystem.BA_EXISTS));
 
-        if (!fs.createFileExclusively(f.getPath()))
+        if (!FS.createFileExclusively(f.getPath()))
             throw new IOException("Unable to create temporary file");
 
         return f;
@@ -2247,7 +2247,7 @@ public class File
      * @since   1.2
      */
     public int compareTo(File pathname) {
-        return fs.compare(this, pathname);
+        return FS.compare(this, pathname);
     }
 
     /**
@@ -2293,7 +2293,7 @@ public class File
      * @return  A hash code for this abstract pathname
      */
     public int hashCode() {
-        return fs.hashCode(this);
+        return FS.hashCode(this);
     }
 
     /**
@@ -2327,7 +2327,7 @@ public class File
     /**
      * readObject is called to restore this filename.
      * The original separator character is read.  If it is different
-     * than the separator character on this system, then the old separator
+     * from the separator character on this system, then the old separator
      * is replaced by the local separator.
      *
      * @param  s the {@code ObjectInputStream} from which data is read
@@ -2343,9 +2343,9 @@ public class File
         char sep = s.readChar(); // read the previous separator char
         if (sep != separatorChar)
             pathField = pathField.replace(sep, separatorChar);
-        String path = fs.normalize(pathField);
+        String path = FS.normalize(pathField);
         UNSAFE.putReference(this, PATH_OFFSET, path);
-        UNSAFE.putIntVolatile(this, PREFIX_LENGTH_OFFSET, fs.prefixLength(path));
+        UNSAFE.putIntVolatile(this, PREFIX_LENGTH_OFFSET, FS.prefixLength(path));
     }
 
     private static final jdk.internal.misc.Unsafe UNSAFE

--- a/src/java.base/share/classes/java/io/FileOutputStream.java
+++ b/src/java.base/share/classes/java/io/FileOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/FileOutputStream.java
+++ b/src/java.base/share/classes/java/io/FileOutputStream.java
@@ -72,7 +72,7 @@ public class FileOutputStream extends OutputStream
     /**
      * Access to FileDescriptor internals.
      */
-    private static final JavaIOFileDescriptorAccess fdAccess =
+    private static final JavaIOFileDescriptorAccess FD_ACCESS =
         SharedSecrets.getJavaIOFileDescriptorAccess();
 
     /**
@@ -316,7 +316,7 @@ public class FileOutputStream extends OutputStream
      */
     @Override
     public void write(int b) throws IOException {
-        boolean append = fdAccess.getAppend(fd);
+        boolean append = FD_ACCESS.getAppend(fd);
         long comp = Blocker.begin();
         try {
             write(b, append);
@@ -346,7 +346,7 @@ public class FileOutputStream extends OutputStream
      */
     @Override
     public void write(byte[] b) throws IOException {
-        boolean append = fdAccess.getAppend(fd);
+        boolean append = FD_ACCESS.getAppend(fd);
         long comp = Blocker.begin();
         try {
             writeBytes(b, 0, b.length, append);
@@ -367,7 +367,7 @@ public class FileOutputStream extends OutputStream
      */
     @Override
     public void write(byte[] b, int off, int len) throws IOException {
-        boolean append = fdAccess.getAppend(fd);
+        boolean append = FD_ACCESS.getAppend(fd);
         long comp = Blocker.begin();
         try {
             writeBytes(b, off, len, append);

--- a/src/java.base/share/classes/java/io/LineNumberReader.java
+++ b/src/java.base/share/classes/java/io/LineNumberReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/LineNumberReader.java
+++ b/src/java.base/share/classes/java/io/LineNumberReader.java
@@ -265,7 +265,7 @@ public class LineNumberReader extends BufferedReader {
     private static final int maxSkipBufferSize = 8192;
 
     /** Skip buffer, null until allocated */
-    private char skipBuffer[] = null;
+    private char[] skipBuffer = null;
 
     /**
      * {@inheritDoc}

--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -1093,9 +1093,9 @@ public class ObjectInputStream
     }
 
     /**
-     * Reads an 8 bit byte.
+     * Reads an 8-bit byte.
      *
-     * @return  the 8 bit byte read.
+     * @return  the 8-bit byte read.
      * @throws  EOFException If end of file is reached.
      * @throws  IOException If other I/O error has occurred.
      */
@@ -1104,9 +1104,9 @@ public class ObjectInputStream
     }
 
     /**
-     * Reads an unsigned 8 bit byte.
+     * Reads an unsigned 8-bit byte.
      *
-     * @return  the 8 bit byte read.
+     * @return  the 8-bit byte read.
      * @throws  EOFException If end of file is reached.
      * @throws  IOException If other I/O error has occurred.
      */
@@ -1115,9 +1115,9 @@ public class ObjectInputStream
     }
 
     /**
-     * Reads a 16 bit char.
+     * Reads a 16-bit char.
      *
-     * @return  the 16 bit char read.
+     * @return  the 16-bit char read.
      * @throws  EOFException If end of file is reached.
      * @throws  IOException If other I/O error has occurred.
      */
@@ -1126,9 +1126,9 @@ public class ObjectInputStream
     }
 
     /**
-     * Reads a 16 bit short.
+     * Reads a 16-bit short.
      *
-     * @return  the 16 bit short read.
+     * @return  the 16-bit short read.
      * @throws  EOFException If end of file is reached.
      * @throws  IOException If other I/O error has occurred.
      */
@@ -1137,9 +1137,9 @@ public class ObjectInputStream
     }
 
     /**
-     * Reads an unsigned 16 bit short.
+     * Reads an unsigned 16-bit short.
      *
-     * @return  the 16 bit short read.
+     * @return  the 16-bit short read.
      * @throws  EOFException If end of file is reached.
      * @throws  IOException If other I/O error has occurred.
      */
@@ -1148,9 +1148,9 @@ public class ObjectInputStream
     }
 
     /**
-     * Reads a 32 bit int.
+     * Reads a 32-bit int.
      *
-     * @return  the 32 bit integer read.
+     * @return  the 32-bit integer read.
      * @throws  EOFException If end of file is reached.
      * @throws  IOException If other I/O error has occurred.
      */
@@ -1159,9 +1159,9 @@ public class ObjectInputStream
     }
 
     /**
-     * Reads a 64 bit long.
+     * Reads a 64-bit long.
      *
-     * @return  the read 64 bit long.
+     * @return  the read 64-bit long.
      * @throws  EOFException If end of file is reached.
      * @throws  IOException If other I/O error has occurred.
      */
@@ -1170,9 +1170,9 @@ public class ObjectInputStream
     }
 
     /**
-     * Reads a 32 bit float.
+     * Reads a 32-bit float.
      *
-     * @return  the 32 bit float read.
+     * @return  the 32-bit float read.
      * @throws  EOFException If end of file is reached.
      * @throws  IOException If other I/O error has occurred.
      */
@@ -1181,9 +1181,9 @@ public class ObjectInputStream
     }
 
     /**
-     * Reads a 64 bit double.
+     * Reads a 64-bit double.
      *
-     * @return  the 64 bit double read.
+     * @return  the 64-bit double read.
      * @throws  EOFException If end of file is reached.
      * @throws  IOException If other I/O error has occurred.
      */
@@ -3862,7 +3862,7 @@ public class ObjectInputStream
      * as memory conservation, it does not enforce this constraint.
      */
     // REMIND: add full description of exception propagation algorithm?
-    private static class HandleTable {
+    private static final class HandleTable {
 
         /* status codes indicating whether object has associated exception */
         private static final byte STATUS_OK = 1;

--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -1863,11 +1863,11 @@ public class ObjectInputStream
         if (bin.readByte() != TC_REFERENCE) {
             throw new InternalError();
         }
-        passHandle = bin.readInt() - BASE_WIRE_HANDLE;
+        passHandle = bin.readInt() - baseWireHandle;
         if (passHandle < 0 || passHandle >= handles.size()) {
             throw new StreamCorruptedException(
                 String.format("invalid handle value: %08X", passHandle +
-                        BASE_WIRE_HANDLE));
+                        baseWireHandle));
         }
         if (unshared) {
             // REMIND: what type of exception to throw here?

--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -1863,11 +1863,11 @@ public class ObjectInputStream
         if (bin.readByte() != TC_REFERENCE) {
             throw new InternalError();
         }
-        passHandle = bin.readInt() - baseWireHandle;
+        passHandle = bin.readInt() - BASE_WIRE_HANDLE;
         if (passHandle < 0 || passHandle >= handles.size()) {
             throw new StreamCorruptedException(
                 String.format("invalid handle value: %08X", passHandle +
-                baseWireHandle));
+                        BASE_WIRE_HANDLE));
         }
         if (unshared) {
             // REMIND: what type of exception to throw here?

--- a/src/java.base/share/classes/java/io/ObjectOutput.java
+++ b/src/java.base/share/classes/java/io/ObjectOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/ObjectOutput.java
+++ b/src/java.base/share/classes/java/io/ObjectOutput.java
@@ -44,7 +44,7 @@ public interface ObjectOutput extends DataOutput, AutoCloseable {
      * @param     obj the object to be written
      * @throws    IOException Any of the usual Input/Output related exceptions.
      */
-    public void writeObject(Object obj)
+    void writeObject(Object obj)
       throws IOException;
 
     /**
@@ -53,7 +53,7 @@ public interface ObjectOutput extends DataOutput, AutoCloseable {
      * @param     b the byte
      * @throws    IOException If an I/O error has occurred.
      */
-    public void write(int b) throws IOException;
+    void write(int b) throws IOException;
 
     /**
      * Writes an array of bytes. This method will block until the bytes
@@ -61,7 +61,7 @@ public interface ObjectOutput extends DataOutput, AutoCloseable {
      * @param     b the data to be written
      * @throws    IOException If an I/O error has occurred.
      */
-    public void write(byte[] b) throws IOException;
+    void write(byte[] b) throws IOException;
 
     /**
      * Writes a sub array of bytes.
@@ -71,14 +71,14 @@ public interface ObjectOutput extends DataOutput, AutoCloseable {
      * @throws    IOException If an I/O error has occurred.
      * @throws    IndexOutOfBoundsException {@inheritDoc}
      */
-    public void write(byte[] b, int off, int len) throws IOException;
+    void write(byte[] b, int off, int len) throws IOException;
 
     /**
      * Flushes the stream. This will write any buffered
      * output bytes.
      * @throws    IOException If an I/O error has occurred.
      */
-    public void flush() throws IOException;
+    void flush() throws IOException;
 
     /**
      * Closes the stream. This method must be called
@@ -86,5 +86,5 @@ public interface ObjectOutput extends DataOutput, AutoCloseable {
      * stream.
      * @throws    IOException If an I/O error has occurred.
      */
-    public void close() throws IOException;
+    void close() throws IOException;
 }

--- a/src/java.base/share/classes/java/io/ObjectOutputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/ObjectOutputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectOutputStream.java
@@ -768,7 +768,7 @@ public class ObjectOutputStream
     }
 
     /**
-     * Writes an 8 bit byte.
+     * Writes an 8-bit byte.
      *
      * @param   val the byte value to be written
      * @throws  IOException if I/O errors occur while writing to the underlying
@@ -779,7 +779,7 @@ public class ObjectOutputStream
     }
 
     /**
-     * Writes a 16 bit short.
+     * Writes a 16-bit short.
      *
      * @param   val the short value to be written
      * @throws  IOException if I/O errors occur while writing to the underlying
@@ -790,7 +790,7 @@ public class ObjectOutputStream
     }
 
     /**
-     * Writes a 16 bit char.
+     * Writes a 16-bit char.
      *
      * @param   val the char value to be written
      * @throws  IOException if I/O errors occur while writing to the underlying
@@ -801,7 +801,7 @@ public class ObjectOutputStream
     }
 
     /**
-     * Writes a 32 bit int.
+     * Writes a 32-bit int.
      *
      * @param   val the integer value to be written
      * @throws  IOException if I/O errors occur while writing to the underlying
@@ -812,7 +812,7 @@ public class ObjectOutputStream
     }
 
     /**
-     * Writes a 64 bit long.
+     * Writes a 64-bit long.
      *
      * @param   val the long value to be written
      * @throws  IOException if I/O errors occur while writing to the underlying
@@ -823,7 +823,7 @@ public class ObjectOutputStream
     }
 
     /**
-     * Writes a 32 bit float.
+     * Writes a 32-bit float.
      *
      * @param   val the float value to be written
      * @throws  IOException if I/O errors occur while writing to the underlying
@@ -834,7 +834,7 @@ public class ObjectOutputStream
     }
 
     /**
-     * Writes a 64 bit double.
+     * Writes a 64-bit double.
      *
      * @param   val the double value to be written
      * @throws  IOException if I/O errors occur while writing to the underlying
@@ -1171,7 +1171,7 @@ public class ObjectOutputStream
                     writeHandle(h);
                     return;
                 } else if (obj instanceof Class) {
-                    writeClass((Class) obj, unshared);
+                    writeClass((Class<?>) obj, unshared);
                     return;
                 } else if (obj instanceof ObjectStreamClass) {
                     writeClassDesc((ObjectStreamClass) obj, unshared);
@@ -1754,7 +1754,7 @@ public class ObjectOutputStream
      * bracketed by block data markers (see object serialization specification
      * for details).
      */
-    private static class BlockDataOutputStream
+    private static final class BlockDataOutputStream
         extends OutputStream implements DataOutput
     {
         /** maximum data block length */
@@ -2260,7 +2260,7 @@ public class ObjectOutputStream
      * Lightweight identity hash table which maps objects to integer handles,
      * assigned in ascending order.
      */
-    private static class HandleTable {
+    private static final class HandleTable {
 
         /* number of mappings in table/next available handle */
         private int size;
@@ -2385,7 +2385,7 @@ public class ObjectOutputStream
      * Lightweight identity hash table which maps objects to replacement
      * objects.
      */
-    private static class ReplaceTable {
+    private static final class ReplaceTable {
 
         /* maps object -> index */
         private final HandleTable htab;
@@ -2449,7 +2449,7 @@ public class ObjectOutputStream
      * Stack to keep debug information about the state of the
      * serialization process, for embedding in exception messages.
      */
-    private static class DebugTraceInfoStack {
+    private static final class DebugTraceInfoStack {
         private final List<String> stack;
 
         DebugTraceInfoStack() {

--- a/src/java.base/share/classes/java/io/ObjectOutputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectOutputStream.java
@@ -1214,7 +1214,7 @@ public class ObjectOutputStream
      */
     private void writeHandle(int handle) throws IOException {
         bout.writeByte(TC_REFERENCE);
-        bout.writeInt(BASE_WIRE_HANDLE + handle);
+        bout.writeInt(baseWireHandle + handle);
     }
 
     /**

--- a/src/java.base/share/classes/java/io/ObjectOutputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectOutputStream.java
@@ -1214,7 +1214,7 @@ public class ObjectOutputStream
      */
     private void writeHandle(int handle) throws IOException {
         bout.writeByte(TC_REFERENCE);
-        bout.writeInt(baseWireHandle + handle);
+        bout.writeInt(BASE_WIRE_HANDLE + handle);
     }
 
     /**

--- a/src/java.base/share/classes/java/io/ObjectStreamClass.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/ObjectStreamClass.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamClass.java
@@ -291,7 +291,7 @@ public final class ObjectStreamClass implements Serializable {
                 }
             );
         }
-        return suid.longValue();
+        return suid;
     }
 
     /**
@@ -688,7 +688,7 @@ public final class ObjectStreamClass implements Serializable {
         }
         serializable = externalizable || sflag;
         isEnum = ((flags & ObjectStreamConstants.SC_ENUM) != 0);
-        if (isEnum && suid.longValue() != 0L) {
+        if (isEnum && suid != 0L) {
             throw new InvalidClassException(name,
                 "enum descriptor has non-zero serialVersionUID: " + suid);
         }
@@ -1067,7 +1067,7 @@ public final class ObjectStreamClass implements Serializable {
         requireInitialized();
         if (writeObjectMethod != null) {
             try {
-                writeObjectMethod.invoke(obj, new Object[]{ out });
+                writeObjectMethod.invoke(obj, out);
             } catch (InvocationTargetException ex) {
                 Throwable th = ex.getCause();
                 if (th instanceof IOException) {
@@ -1097,7 +1097,7 @@ public final class ObjectStreamClass implements Serializable {
         requireInitialized();
         if (readObjectMethod != null) {
             try {
-                readObjectMethod.invoke(obj, new Object[]{ in });
+                readObjectMethod.invoke(obj, in);
             } catch (InvocationTargetException ex) {
                 Throwable th = ex.getCause();
                 if (th instanceof ClassNotFoundException) {
@@ -1128,7 +1128,7 @@ public final class ObjectStreamClass implements Serializable {
         requireInitialized();
         if (readObjectNoDataMethod != null) {
             try {
-                readObjectNoDataMethod.invoke(obj, (Object[]) null);
+                readObjectNoDataMethod.invoke(obj);
             } catch (InvocationTargetException ex) {
                 Throwable th = ex.getCause();
                 if (th instanceof ObjectStreamException) {
@@ -1871,7 +1871,7 @@ public final class ObjectStreamClass implements Serializable {
      * Class for computing and caching field/constructor/method signatures
      * during serialVersionUID calculation.
      */
-    private static class MemberSignature {
+    private static final class MemberSignature {
 
         public final Member member;
         public final String name;
@@ -1902,10 +1902,10 @@ public final class ObjectStreamClass implements Serializable {
      * Class for setting and retrieving serializable field values in batch.
      */
     // REMIND: dynamically generate these?
-    private static class FieldReflector {
+    private static final class FieldReflector {
 
         /** handle for performing unsafe operations */
-        private static final Unsafe unsafe = Unsafe.getUnsafe();
+        private static final Unsafe UNSAFE = Unsafe.getUnsafe();
 
         /** fields to operate on */
         private final ObjectStreamField[] fields;
@@ -1944,7 +1944,7 @@ public final class ObjectStreamClass implements Serializable {
                 ObjectStreamField f = fields[i];
                 Field rf = f.getField();
                 long key = (rf != null) ?
-                    unsafe.objectFieldOffset(rf) : Unsafe.INVALID_FIELD_OFFSET;
+                    UNSAFE.objectFieldOffset(rf) : Unsafe.INVALID_FIELD_OFFSET;
                 readKeys[i] = key;
                 writeKeys[i] = usedKeys.add(key) ?
                     key : Unsafe.INVALID_FIELD_OFFSET;
@@ -1986,14 +1986,14 @@ public final class ObjectStreamClass implements Serializable {
                 long key = readKeys[i];
                 int off = offsets[i];
                 switch (typeCodes[i]) {
-                    case 'Z' -> Bits.putBoolean(buf, off, unsafe.getBoolean(obj, key));
-                    case 'B' -> buf[off] = unsafe.getByte(obj, key);
-                    case 'C' -> Bits.putChar(buf, off, unsafe.getChar(obj, key));
-                    case 'S' -> Bits.putShort(buf, off, unsafe.getShort(obj, key));
-                    case 'I' -> Bits.putInt(buf, off, unsafe.getInt(obj, key));
-                    case 'F' -> Bits.putFloat(buf, off, unsafe.getFloat(obj, key));
-                    case 'J' -> Bits.putLong(buf, off, unsafe.getLong(obj, key));
-                    case 'D' -> Bits.putDouble(buf, off, unsafe.getDouble(obj, key));
+                    case 'Z' -> Bits.putBoolean(buf, off, UNSAFE.getBoolean(obj, key));
+                    case 'B' -> buf[off] = UNSAFE.getByte(obj, key);
+                    case 'C' -> Bits.putChar(buf, off, UNSAFE.getChar(obj, key));
+                    case 'S' -> Bits.putShort(buf, off, UNSAFE.getShort(obj, key));
+                    case 'I' -> Bits.putInt(buf, off, UNSAFE.getInt(obj, key));
+                    case 'F' -> Bits.putFloat(buf, off, UNSAFE.getFloat(obj, key));
+                    case 'J' -> Bits.putLong(buf, off, UNSAFE.getLong(obj, key));
+                    case 'D' -> Bits.putDouble(buf, off, UNSAFE.getDouble(obj, key));
                     default  -> throw new InternalError();
                 }
             }
@@ -2015,14 +2015,14 @@ public final class ObjectStreamClass implements Serializable {
                 }
                 int off = offsets[i];
                 switch (typeCodes[i]) {
-                    case 'Z' -> unsafe.putBoolean(obj, key, Bits.getBoolean(buf, off));
-                    case 'B' -> unsafe.putByte(obj, key, buf[off]);
-                    case 'C' -> unsafe.putChar(obj, key, Bits.getChar(buf, off));
-                    case 'S' -> unsafe.putShort(obj, key, Bits.getShort(buf, off));
-                    case 'I' -> unsafe.putInt(obj, key, Bits.getInt(buf, off));
-                    case 'F' -> unsafe.putFloat(obj, key, Bits.getFloat(buf, off));
-                    case 'J' -> unsafe.putLong(obj, key, Bits.getLong(buf, off));
-                    case 'D' -> unsafe.putDouble(obj, key, Bits.getDouble(buf, off));
+                    case 'Z' -> UNSAFE.putBoolean(obj, key, Bits.getBoolean(buf, off));
+                    case 'B' -> UNSAFE.putByte(obj, key, buf[off]);
+                    case 'C' -> UNSAFE.putChar(obj, key, Bits.getChar(buf, off));
+                    case 'S' -> UNSAFE.putShort(obj, key, Bits.getShort(buf, off));
+                    case 'I' -> UNSAFE.putInt(obj, key, Bits.getInt(buf, off));
+                    case 'F' -> UNSAFE.putFloat(obj, key, Bits.getFloat(buf, off));
+                    case 'J' -> UNSAFE.putLong(obj, key, Bits.getLong(buf, off));
+                    case 'D' -> UNSAFE.putDouble(obj, key, Bits.getDouble(buf, off));
                     default  -> throw new InternalError();
                 }
             }
@@ -2043,7 +2043,7 @@ public final class ObjectStreamClass implements Serializable {
              */
             for (int i = numPrimFields; i < fields.length; i++) {
                 vals[offsets[i]] = switch (typeCodes[i]) {
-                    case 'L', '[' -> unsafe.getReference(obj, readKeys[i]);
+                    case 'L', '[' -> UNSAFE.getReference(obj, readKeys[i]);
                     default       -> throw new InternalError();
                 };
             }
@@ -2094,7 +2094,7 @@ public final class ObjectStreamClass implements Serializable {
                                 obj.getClass().getName());
                         }
                         if (!dryRun)
-                            unsafe.putReference(obj, key, val);
+                            UNSAFE.putReference(obj, key, val);
                     }
                     default -> throw new InternalError();
                 }
@@ -2136,7 +2136,7 @@ public final class ObjectStreamClass implements Serializable {
      * FieldReflector cache lookup key.  Keys are considered equal if they
      * refer to equivalent field formats.
      */
-    private static class FieldReflectorKey {
+    private static final class FieldReflectorKey {
 
         private final String[] sigs;
         private final int hash;

--- a/src/java.base/share/classes/java/io/ObjectStreamConstants.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/ObjectStreamConstants.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamConstants.java
@@ -35,12 +35,12 @@ public interface ObjectStreamConstants {
     /**
      * Magic number that is written to the stream header.
      */
-    static final short STREAM_MAGIC = (short)0xaced;
+    short STREAM_MAGIC = (short)0xaced;
 
     /**
      * Version number that is written to the stream header.
      */
-    static final short STREAM_VERSION = 5;
+    short STREAM_VERSION = 5;
 
     /* Each item in the stream is preceded by a tag
      */
@@ -48,95 +48,95 @@ public interface ObjectStreamConstants {
     /**
      * First tag value.
      */
-    static final byte TC_BASE = 0x70;
+    byte TC_BASE = 0x70;
 
     /**
      * Null object reference.
      */
-    static final byte TC_NULL =         (byte)0x70;
+    byte TC_NULL =         (byte)0x70;
 
     /**
      * Reference to an object already written into the stream.
      */
-    static final byte TC_REFERENCE =    (byte)0x71;
+    byte TC_REFERENCE =    (byte)0x71;
 
     /**
      * new Class Descriptor.
      */
-    static final byte TC_CLASSDESC =    (byte)0x72;
+    byte TC_CLASSDESC =    (byte)0x72;
 
     /**
      * new Object.
      */
-    static final byte TC_OBJECT =       (byte)0x73;
+    byte TC_OBJECT =       (byte)0x73;
 
     /**
      * new String.
      */
-    static final byte TC_STRING =       (byte)0x74;
+    byte TC_STRING =       (byte)0x74;
 
     /**
      * new Array.
      */
-    static final byte TC_ARRAY =        (byte)0x75;
+    byte TC_ARRAY =        (byte)0x75;
 
     /**
      * Reference to Class.
      */
-    static final byte TC_CLASS =        (byte)0x76;
+    byte TC_CLASS =        (byte)0x76;
 
     /**
      * Block of optional data. Byte following tag indicates number
      * of bytes in this block data.
      */
-    static final byte TC_BLOCKDATA =    (byte)0x77;
+    byte TC_BLOCKDATA =    (byte)0x77;
 
     /**
      * End of optional block data blocks for an object.
      */
-    static final byte TC_ENDBLOCKDATA = (byte)0x78;
+    byte TC_ENDBLOCKDATA = (byte)0x78;
 
     /**
      * Reset stream context. All handles written into stream are reset.
      */
-    static final byte TC_RESET =        (byte)0x79;
+    byte TC_RESET =        (byte)0x79;
 
     /**
      * long Block data. The long following the tag indicates the
      * number of bytes in this block data.
      */
-    static final byte TC_BLOCKDATALONG= (byte)0x7A;
+    byte TC_BLOCKDATALONG= (byte)0x7A;
 
     /**
      * Exception during write.
      */
-    static final byte TC_EXCEPTION =    (byte)0x7B;
+    byte TC_EXCEPTION =    (byte)0x7B;
 
     /**
      * Long string.
      */
-    static final byte TC_LONGSTRING =   (byte)0x7C;
+    byte TC_LONGSTRING =   (byte)0x7C;
 
     /**
      * new Proxy Class Descriptor.
      */
-    static final byte TC_PROXYCLASSDESC =       (byte)0x7D;
+    byte TC_PROXYCLASSDESC =       (byte)0x7D;
 
     /**
      * new Enum constant.
      * @since 1.5
      */
-    static final byte TC_ENUM =         (byte)0x7E;
+    byte TC_ENUM =         (byte)0x7E;
 
     /**
      * Last tag value.
      */
-    static final byte TC_MAX =          (byte)0x7E;
+    byte TC_MAX =          (byte)0x7E;
 
     /**
      * First wire handle to be assigned.
      */
-    static final int baseWireHandle = 0x7e0000;
+    int baseWireHandle = 0x7e0000;
 
 
     /******************************************************/
@@ -146,7 +146,7 @@ public interface ObjectStreamConstants {
      * Bit mask for ObjectStreamClass flag. Indicates a Serializable class
      * defines its own writeObject method.
      */
-    static final byte SC_WRITE_METHOD = 0x01;
+    byte SC_WRITE_METHOD = 0x01;
 
     /**
      * Bit mask for ObjectStreamClass flag. Indicates Externalizable data
@@ -156,23 +156,23 @@ public interface ObjectStreamConstants {
      * @see #PROTOCOL_VERSION_2
      * @since 1.2
      */
-    static final byte SC_BLOCK_DATA = 0x08;
+    byte SC_BLOCK_DATA = 0x08;
 
     /**
      * Bit mask for ObjectStreamClass flag. Indicates class is Serializable.
      */
-    static final byte SC_SERIALIZABLE = 0x02;
+    byte SC_SERIALIZABLE = 0x02;
 
     /**
      * Bit mask for ObjectStreamClass flag. Indicates class is Externalizable.
      */
-    static final byte SC_EXTERNALIZABLE = 0x04;
+    byte SC_EXTERNALIZABLE = 0x04;
 
     /**
      * Bit mask for ObjectStreamClass flag. Indicates class is an enum type.
      * @since 1.5
      */
-    static final byte SC_ENUM = 0x10;
+    byte SC_ENUM = 0x10;
 
 
     /* *******************************************************************/
@@ -186,7 +186,7 @@ public interface ObjectStreamConstants {
      * @see java.io.ObjectInputStream#enableResolveObject(boolean)
      * @since 1.2
      */
-    static final SerializablePermission SUBSTITUTION_PERMISSION =
+    SerializablePermission SUBSTITUTION_PERMISSION =
                            new SerializablePermission("enableSubstitution");
 
     /**
@@ -196,7 +196,7 @@ public interface ObjectStreamConstants {
      * @see java.io.ObjectInputStream#readObjectOverride()
      * @since 1.2
      */
-    static final SerializablePermission SUBCLASS_IMPLEMENTATION_PERMISSION =
+    SerializablePermission SUBCLASS_IMPLEMENTATION_PERMISSION =
                     new SerializablePermission("enableSubclassImplementation");
 
     /**
@@ -205,7 +205,7 @@ public interface ObjectStreamConstants {
      * @see java.io.ObjectInputFilter.Config#setSerialFilter(ObjectInputFilter)
      * @since 9
      */
-    static final SerializablePermission SERIAL_FILTER_PERMISSION =
+    SerializablePermission SERIAL_FILTER_PERMISSION =
             new SerializablePermission("serialFilter");
 
    /**
@@ -219,7 +219,7 @@ public interface ObjectStreamConstants {
     * @see java.io.ObjectOutputStream#useProtocolVersion(int)
     * @since 1.2
     */
-    public static final int PROTOCOL_VERSION_1 = 1;
+    int PROTOCOL_VERSION_1 = 1;
 
 
    /**
@@ -240,5 +240,5 @@ public interface ObjectStreamConstants {
     * @see #SC_BLOCK_DATA
     * @since 1.2
     */
-    public static final int PROTOCOL_VERSION_2 = 2;
+    int PROTOCOL_VERSION_2 = 2;
 }

--- a/src/java.base/share/classes/java/io/ObjectStreamConstants.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamConstants.java
@@ -136,7 +136,7 @@ public interface ObjectStreamConstants {
     /**
      * First wire handle to be assigned.
      */
-    static int BASE_WIRE_HANDLE = 0x7e0000;
+    static int baseWireHandle = 0x7e0000;
 
 
     /* *******************************************************************/

--- a/src/java.base/share/classes/java/io/ObjectStreamConstants.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamConstants.java
@@ -35,12 +35,12 @@ public interface ObjectStreamConstants {
     /**
      * Magic number that is written to the stream header.
      */
-    short STREAM_MAGIC = (short)0xaced;
+    static short STREAM_MAGIC = (short)0xaced;
 
     /**
      * Version number that is written to the stream header.
      */
-    short STREAM_VERSION = 5;
+    static short STREAM_VERSION = 5;
 
     /* Each item in the stream is preceded by a tag
      */
@@ -48,105 +48,105 @@ public interface ObjectStreamConstants {
     /**
      * First tag value.
      */
-    byte TC_BASE = 0x70;
+    static byte TC_BASE = 0x70;
 
     /**
      * Null object reference.
      */
-    byte TC_NULL =         (byte)0x70;
+    static byte TC_NULL =         (byte)0x70;
 
     /**
      * Reference to an object already written into the stream.
      */
-    byte TC_REFERENCE =    (byte)0x71;
+    static byte TC_REFERENCE =    (byte)0x71;
 
     /**
      * new Class Descriptor.
      */
-    byte TC_CLASSDESC =    (byte)0x72;
+    static byte TC_CLASSDESC =    (byte)0x72;
 
     /**
      * new Object.
      */
-    byte TC_OBJECT =       (byte)0x73;
+    static byte TC_OBJECT =       (byte)0x73;
 
     /**
      * new String.
      */
-    byte TC_STRING =       (byte)0x74;
+    static byte TC_STRING =       (byte)0x74;
 
     /**
      * new Array.
      */
-    byte TC_ARRAY =        (byte)0x75;
+    static byte TC_ARRAY =        (byte)0x75;
 
     /**
      * Reference to Class.
      */
-    byte TC_CLASS =        (byte)0x76;
+    static byte TC_CLASS =        (byte)0x76;
 
     /**
      * Block of optional data. Byte following tag indicates number
      * of bytes in this block data.
      */
-    byte TC_BLOCKDATA =    (byte)0x77;
+    static byte TC_BLOCKDATA =    (byte)0x77;
 
     /**
      * End of optional block data blocks for an object.
      */
-    byte TC_ENDBLOCKDATA = (byte)0x78;
+    static byte TC_ENDBLOCKDATA = (byte)0x78;
 
     /**
      * Reset stream context. All handles written into stream are reset.
      */
-    byte TC_RESET =        (byte)0x79;
+    static byte TC_RESET =        (byte)0x79;
 
     /**
      * long Block data. The long following the tag indicates the
      * number of bytes in this block data.
      */
-    byte TC_BLOCKDATALONG= (byte)0x7A;
+    static byte TC_BLOCKDATALONG= (byte)0x7A;
 
     /**
      * Exception during write.
      */
-    byte TC_EXCEPTION =    (byte)0x7B;
+    static byte TC_EXCEPTION =    (byte)0x7B;
 
     /**
      * Long string.
      */
-    byte TC_LONGSTRING =   (byte)0x7C;
+    static byte TC_LONGSTRING =   (byte)0x7C;
 
     /**
      * new Proxy Class Descriptor.
      */
-    byte TC_PROXYCLASSDESC =       (byte)0x7D;
+    static byte TC_PROXYCLASSDESC =       (byte)0x7D;
 
     /**
      * new Enum constant.
      * @since 1.5
      */
-    byte TC_ENUM =         (byte)0x7E;
+    static byte TC_ENUM =         (byte)0x7E;
 
     /**
      * Last tag value.
      */
-    byte TC_MAX =          (byte)0x7E;
+    static byte TC_MAX =          (byte)0x7E;
 
     /**
      * First wire handle to be assigned.
      */
-    int baseWireHandle = 0x7e0000;
+    static int baseWireHandle = 0x7e0000;
 
 
-    /******************************************************/
-    /* Bit masks for ObjectStreamClass flag.*/
+    /* *******************************************************************/
+    /* Bit masks for ObjectStreamClass flag. */
 
     /**
      * Bit mask for ObjectStreamClass flag. Indicates a Serializable class
      * defines its own writeObject method.
      */
-    byte SC_WRITE_METHOD = 0x01;
+    static byte SC_WRITE_METHOD = 0x01;
 
     /**
      * Bit mask for ObjectStreamClass flag. Indicates Externalizable data
@@ -156,23 +156,23 @@ public interface ObjectStreamConstants {
      * @see #PROTOCOL_VERSION_2
      * @since 1.2
      */
-    byte SC_BLOCK_DATA = 0x08;
+    static byte SC_BLOCK_DATA = 0x08;
 
     /**
      * Bit mask for ObjectStreamClass flag. Indicates class is Serializable.
      */
-    byte SC_SERIALIZABLE = 0x02;
+    static byte SC_SERIALIZABLE = 0x02;
 
     /**
      * Bit mask for ObjectStreamClass flag. Indicates class is Externalizable.
      */
-    byte SC_EXTERNALIZABLE = 0x04;
+    static byte SC_EXTERNALIZABLE = 0x04;
 
     /**
      * Bit mask for ObjectStreamClass flag. Indicates class is an enum type.
      * @since 1.5
      */
-    byte SC_ENUM = 0x10;
+    static byte SC_ENUM = 0x10;
 
 
     /* *******************************************************************/
@@ -186,7 +186,7 @@ public interface ObjectStreamConstants {
      * @see java.io.ObjectInputStream#enableResolveObject(boolean)
      * @since 1.2
      */
-    SerializablePermission SUBSTITUTION_PERMISSION =
+    static SerializablePermission SUBSTITUTION_PERMISSION =
                            new SerializablePermission("enableSubstitution");
 
     /**
@@ -196,7 +196,7 @@ public interface ObjectStreamConstants {
      * @see java.io.ObjectInputStream#readObjectOverride()
      * @since 1.2
      */
-    SerializablePermission SUBCLASS_IMPLEMENTATION_PERMISSION =
+    static SerializablePermission SUBCLASS_IMPLEMENTATION_PERMISSION =
                     new SerializablePermission("enableSubclassImplementation");
 
     /**
@@ -205,7 +205,7 @@ public interface ObjectStreamConstants {
      * @see java.io.ObjectInputFilter.Config#setSerialFilter(ObjectInputFilter)
      * @since 9
      */
-    SerializablePermission SERIAL_FILTER_PERMISSION =
+    static SerializablePermission SERIAL_FILTER_PERMISSION =
             new SerializablePermission("serialFilter");
 
    /**
@@ -219,7 +219,7 @@ public interface ObjectStreamConstants {
     * @see java.io.ObjectOutputStream#useProtocolVersion(int)
     * @since 1.2
     */
-    int PROTOCOL_VERSION_1 = 1;
+    static int PROTOCOL_VERSION_1 = 1;
 
 
    /**
@@ -240,5 +240,5 @@ public interface ObjectStreamConstants {
     * @see #SC_BLOCK_DATA
     * @since 1.2
     */
-    int PROTOCOL_VERSION_2 = 2;
+    static int PROTOCOL_VERSION_2 = 2;
 }

--- a/src/java.base/share/classes/java/io/ObjectStreamConstants.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamConstants.java
@@ -53,90 +53,90 @@ public interface ObjectStreamConstants {
     /**
      * Null object reference.
      */
-    static byte TC_NULL =         (byte)0x70;
+    static byte TC_NULL = 0x70;
 
     /**
      * Reference to an object already written into the stream.
      */
-    static byte TC_REFERENCE =    (byte)0x71;
+    static byte TC_REFERENCE = 0x71;
 
     /**
      * new Class Descriptor.
      */
-    static byte TC_CLASSDESC =    (byte)0x72;
+    static byte TC_CLASSDESC = 0x72;
 
     /**
      * new Object.
      */
-    static byte TC_OBJECT =       (byte)0x73;
+    static byte TC_OBJECT = 0x73;
 
     /**
      * new String.
      */
-    static byte TC_STRING =       (byte)0x74;
+    static byte TC_STRING = 0x74;
 
     /**
      * new Array.
      */
-    static byte TC_ARRAY =        (byte)0x75;
+    static byte TC_ARRAY = 0x75;
 
     /**
      * Reference to Class.
      */
-    static byte TC_CLASS =        (byte)0x76;
+    static byte TC_CLASS = 0x76;
 
     /**
      * Block of optional data. Byte following tag indicates number
      * of bytes in this block data.
      */
-    static byte TC_BLOCKDATA =    (byte)0x77;
+    static byte TC_BLOCKDATA = 0x77;
 
     /**
      * End of optional block data blocks for an object.
      */
-    static byte TC_ENDBLOCKDATA = (byte)0x78;
+    static byte TC_ENDBLOCKDATA = 0x78;
 
     /**
      * Reset stream context. All handles written into stream are reset.
      */
-    static byte TC_RESET =        (byte)0x79;
+    static byte TC_RESET = 0x79;
 
     /**
      * long Block data. The long following the tag indicates the
      * number of bytes in this block data.
      */
-    static byte TC_BLOCKDATALONG= (byte)0x7A;
+    static byte TC_BLOCKDATALONG= 0x7A;
 
     /**
      * Exception during write.
      */
-    static byte TC_EXCEPTION =    (byte)0x7B;
+    static byte TC_EXCEPTION = 0x7B;
 
     /**
      * Long string.
      */
-    static byte TC_LONGSTRING =   (byte)0x7C;
+    static byte TC_LONGSTRING = 0x7C;
 
     /**
      * new Proxy Class Descriptor.
      */
-    static byte TC_PROXYCLASSDESC =       (byte)0x7D;
+    static byte TC_PROXYCLASSDESC = 0x7D;
 
     /**
      * new Enum constant.
      * @since 1.5
      */
-    static byte TC_ENUM =         (byte)0x7E;
+    static byte TC_ENUM = 0x7E;
 
     /**
      * Last tag value.
      */
-    static byte TC_MAX =          (byte)0x7E;
+    static byte TC_MAX = 0x7E;
 
     /**
      * First wire handle to be assigned.
      */
-    static int baseWireHandle = 0x7e0000;
+    static int BASE_WIRE_HANDLE = 0x7e0000;
 
 
     /* *******************************************************************/
@@ -226,12 +226,12 @@ public interface ObjectStreamConstants {
     * A Stream Protocol Version. <p>
     *
     * This protocol is written by JVM 1.2.
-    *
+    * <p>
     * Externalizable data is written in block data mode and is
     * terminated with TC_ENDBLOCKDATA. Externalizable class descriptor
     * flags has SC_BLOCK_DATA enabled. JVM 1.1.6 and greater can
     * read this format change.
-    *
+    * <p>
     * Enables writing a nonSerializable class descriptor into the
     * stream. The serialVersionUID of a nonSerializable class is
     * set to 0L.

--- a/src/java.base/share/classes/java/io/ObjectStreamConstants.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamConstants.java
@@ -105,7 +105,7 @@ public interface ObjectStreamConstants {
      * long Block data. The long following the tag indicates the
      * number of bytes in this block data.
      */
-    static byte TC_BLOCKDATALONG= 0x7A;
+    static byte TC_BLOCKDATALONG = 0x7A;
 
     /**
      * Exception during write.

--- a/src/java.base/share/classes/java/io/OutputStreamWriter.java
+++ b/src/java.base/share/classes/java/io/OutputStreamWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/OutputStreamWriter.java
+++ b/src/java.base/share/classes/java/io/OutputStreamWriter.java
@@ -246,8 +246,8 @@ public class OutputStreamWriter extends Writer {
 
     @Override
     public Writer append(CharSequence csq) throws IOException {
-        if (csq instanceof CharBuffer) {
-            se.write((CharBuffer) csq);
+        if (csq instanceof CharBuffer cb) {
+            se.write(cb);
         } else {
             se.write(String.valueOf(csq));
         }

--- a/src/java.base/share/classes/java/io/PipedReader.java
+++ b/src/java.base/share/classes/java/io/PipedReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/PipedReader.java
+++ b/src/java.base/share/classes/java/io/PipedReader.java
@@ -54,7 +54,7 @@ public class PipedReader extends Reader {
     /**
      * The circular buffer into which incoming data is placed.
      */
-    char buffer[];
+    char[] buffer;
 
     /**
      * The index of the position in the circular buffer at which the
@@ -341,11 +341,7 @@ public class PipedReader extends Reader {
                    && !closedByWriter && (in < 0)) {
             throw new IOException("Write end dead");
         }
-        if (in < 0) {
-            return false;
-        } else {
-            return true;
-        }
+        return in >= 0;
     }
 
     /**

--- a/src/java.base/share/classes/java/io/ProxyingConsole.java
+++ b/src/java.base/share/classes/java/io/ProxyingConsole.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/ProxyingConsole.java
+++ b/src/java.base/share/classes/java/io/ProxyingConsole.java
@@ -145,7 +145,7 @@ final class ProxyingConsole extends Console {
         return delegate.charset();
     }
 
-    private static class WrappingReader extends Reader {
+    private static final class WrappingReader extends Reader {
         private final Reader r;
         private final Object lock;
 
@@ -168,7 +168,7 @@ final class ProxyingConsole extends Console {
         }
     }
 
-    private static class WrappingWriter extends PrintWriter {
+    private static final class WrappingWriter extends PrintWriter {
         private final PrintWriter pw;
         private final Object lock;
 

--- a/src/java.base/share/classes/java/io/SerialCallbackContext.java
+++ b/src/java.base/share/classes/java/io/SerialCallbackContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/SerialCallbackContext.java
+++ b/src/java.base/share/classes/java/io/SerialCallbackContext.java
@@ -45,29 +45,29 @@ final class SerialCallbackContext {
      */
     private Thread thread;
 
-    public SerialCallbackContext(Object obj, ObjectStreamClass desc) {
+    SerialCallbackContext(Object obj, ObjectStreamClass desc) {
         this.obj = obj;
         this.desc = desc;
         this.thread = Thread.currentThread();
     }
 
-    public Object getObj() throws NotActiveException {
+    Object getObj() throws NotActiveException {
         checkAndSetUsed();
         return obj;
     }
 
-    public ObjectStreamClass getDesc() {
+    ObjectStreamClass getDesc() {
         return desc;
     }
 
-    public void check() throws NotActiveException {
+    void check() throws NotActiveException {
         if (thread != null && thread != Thread.currentThread()) {
             throw new NotActiveException(
                 "expected thread: " + thread + ", but got: " + Thread.currentThread());
         }
     }
 
-    public void checkAndSetUsed() throws NotActiveException {
+    void checkAndSetUsed() throws NotActiveException {
         if (thread != Thread.currentThread()) {
              throw new NotActiveException(
               "not in readObject invocation or fields already read");
@@ -75,7 +75,7 @@ final class SerialCallbackContext {
         thread = null;
     }
 
-    public void setUsed() {
+    void setUsed() {
         thread = null;
     }
 }

--- a/src/java.base/share/classes/java/io/StreamTokenizer.java
+++ b/src/java.base/share/classes/java/io/StreamTokenizer.java
@@ -68,7 +68,7 @@ public class StreamTokenizer {
     private Reader reader = null;
     private InputStream input = null;
 
-    private char buf[] = new char[20];
+    private char[] buf = new char[20];
 
     /**
      * The next character to be considered by the nextToken method.  May also
@@ -91,7 +91,7 @@ public class StreamTokenizer {
     private boolean slashSlashCommentsP = false;
     private boolean slashStarCommentsP = false;
 
-    private byte ctype[] = new byte[256];
+    private final byte[] ctype = new byte[256];
     private static final byte CT_WHITESPACE = 1;
     private static final byte CT_DIGIT = 2;
     private static final byte CT_ALPHA = 4;
@@ -527,7 +527,7 @@ public class StreamTokenizer {
             pushedBack = false;
             return ttype;
         }
-        byte ct[] = ctype;
+        byte[] ct = ctype;
         sval = null;
 
         int c = peekc;
@@ -794,7 +794,7 @@ public class StreamTokenizer {
                 if (ttype < 256 && ((ctype[ttype] & CT_QUOTE) != 0)) {
                     yield sval;
                 }
-                char s[] = new char[3];
+                char[] s = new char[3];
                 s[0] = s[2] = '\'';
                 s[1] = (char) ttype;
                 yield new String(s);

--- a/src/java.base/share/classes/java/io/StreamTokenizer.java
+++ b/src/java.base/share/classes/java/io/StreamTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/StringReader.java
+++ b/src/java.base/share/classes/java/io/StringReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/StringReader.java
+++ b/src/java.base/share/classes/java/io/StringReader.java
@@ -37,7 +37,7 @@ import java.util.Objects;
 public class StringReader extends Reader {
 
     private String str;
-    private int length;
+    private final int length;
     private int next = 0;
     private int mark = 0;
 

--- a/src/java.base/share/classes/java/io/StringWriter.java
+++ b/src/java.base/share/classes/java/io/StringWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,8 +47,8 @@ public class StringWriter extends Writer {
      * size.
      */
     public StringWriter() {
-        super(new StringBuffer());
-        buf = (StringBuffer) lock;
+        buf = new StringBuffer();
+        lock = buf;
     }
 
     /**
@@ -63,8 +63,11 @@ public class StringWriter extends Writer {
      *         If {@code initialSize} is negative
      */
     public StringWriter(int initialSize) {
-        super(new StringBuffer(requireNonNegative(initialSize, "Negative buffer size: ")));
-        buf = (StringBuffer) lock;
+        if (initialSize < 0) {
+            throw new IllegalArgumentException("Negative buffer size: " + initialSize);
+        }
+        buf = new StringBuffer(initialSize);
+        lock = buf;
     }
 
     /**
@@ -238,13 +241,6 @@ public class StringWriter extends Writer {
      * an {@code IOException}.
      */
     public void close() throws IOException {
-    }
-
-    private static int requireNonNegative(int value, String message) {
-        if (value < 0) {
-            throw new IllegalArgumentException(message + value);
-        }
-        return value;
     }
 
 }

--- a/src/java.base/share/classes/java/io/StringWriter.java
+++ b/src/java.base/share/classes/java/io/StringWriter.java
@@ -40,15 +40,15 @@ package java.io;
 
 public class StringWriter extends Writer {
 
-    private StringBuffer buf;
+    private final StringBuffer buf;
 
     /**
      * Create a new string writer using the default initial string-buffer
      * size.
      */
     public StringWriter() {
-        buf = new StringBuffer();
-        lock = buf;
+        super(new StringBuffer());
+        buf = (StringBuffer) lock;
     }
 
     /**
@@ -63,11 +63,8 @@ public class StringWriter extends Writer {
      *         If {@code initialSize} is negative
      */
     public StringWriter(int initialSize) {
-        if (initialSize < 0) {
-            throw new IllegalArgumentException("Negative buffer size");
-        }
-        buf = new StringBuffer(initialSize);
-        lock = buf;
+        super(new StringBuffer(checkSize(initialSize)));
+        buf = (StringBuffer) lock;
     }
 
     /**
@@ -241,6 +238,13 @@ public class StringWriter extends Writer {
      * an {@code IOException}.
      */
     public void close() throws IOException {
+    }
+
+    private static int checkSize(int initialSize) {
+        if (initialSize < 0) {
+            throw new IllegalArgumentException("Negative buffer size");
+        }
+        return initialSize;
     }
 
 }

--- a/src/java.base/share/classes/java/io/StringWriter.java
+++ b/src/java.base/share/classes/java/io/StringWriter.java
@@ -63,7 +63,7 @@ public class StringWriter extends Writer {
      *         If {@code initialSize} is negative
      */
     public StringWriter(int initialSize) {
-        super(new StringBuffer(checkSize(initialSize)));
+        super(new StringBuffer(requireNonNegative(initialSize, "Negative buffer size: ")));
         buf = (StringBuffer) lock;
     }
 
@@ -240,11 +240,11 @@ public class StringWriter extends Writer {
     public void close() throws IOException {
     }
 
-    private static int checkSize(int initialSize) {
-        if (initialSize < 0) {
-            throw new IllegalArgumentException("Negative buffer size");
+    private static int requireNonNegative(int value, String message) {
+        if (value < 0) {
+            throw new IllegalArgumentException(message + value);
         }
-        return initialSize;
+        return value;
     }
 
 }


### PR DESCRIPTION
Code in java.io contains many legacy constructs and semantics not recommended including: 

* C-style array declaration 
* Unnecessary visibility 
* Redundant keywords in interfaces (e.g. public, static) 
* Non-standard naming for constants 
* Javadoc typos 
* Missing final declaration 

These should be fixed as a sanity effort.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299513](https://bugs.openjdk.org/browse/JDK-8299513): Clean up java.io


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [a0e80355](https://git.openjdk.org/jdk/pull/11848/files/a0e8035543af6508a0767cdaa3fdffb7470e6bbe)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to [a0e80355](https://git.openjdk.org/jdk/pull/11848/files/a0e8035543af6508a0767cdaa3fdffb7470e6bbe)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to [f231c16b](https://git.openjdk.org/jdk/pull/11848/files/f231c16b9074c711ed6a417331a35a205516532a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11848/head:pull/11848` \
`$ git checkout pull/11848`

Update a local copy of the PR: \
`$ git checkout pull/11848` \
`$ git pull https://git.openjdk.org/jdk pull/11848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11848`

View PR using the GUI difftool: \
`$ git pr show -t 11848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11848.diff">https://git.openjdk.org/jdk/pull/11848.diff</a>

</details>
