### PR TITLE
8299608: Add Register + imm32 orq to x86_64 assembler

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -13453,6 +13453,11 @@ void Assembler::orq(Register dst, int32_t imm32) {
   emit_arith(0x81, 0xC8, dst, imm32);
 }
 
+void Assembler::orq_imm32(Register dst, int32_t imm32) {
+  (void) prefixq_and_encode(dst->encoding());
+  emit_arith_imm32(0x81, 0xC8, dst, imm32);
+}
+
 void Assembler::orq(Register dst, Address src) {
   InstructionMark im(this);
   emit_int16(get_prefixq(src, dst), 0x0B);

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -1736,6 +1736,7 @@ private:
   void orq(Address dst, int32_t imm32);
   void orq(Address dst, Register src);
   void orq(Register dst, int32_t imm32);
+  void orq_imm32(Register dst, int32_t imm32);
   void orq(Register dst, Address src);
   void orq(Register dst, Register src);
 


### PR DESCRIPTION
The current x86_64 orq Register + imm32 uses emit_arith, which is rather clever and checks if it can use imm8 instead. However, sometimes you really want it to be imm32 regardless, for example if you are going to patch the code. Such functionality should be added.

Since there seems to be a precedent distinguishing this with testl_imm32(Register, imm32) vs testl(Register, imm32), my proposed patch similarly adds an orq_imm32 that uses emit_arith_imm32.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299608](https://bugs.openjdk.org/browse/JDK-8299608): Add Register + imm32 orq to x86_64 assembler


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [c7f6e63c](https://git.openjdk.org/jdk/pull/11850/files/c7f6e63c65e82c9992f64e32787b19dff249a2e7)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**) ⚠️ Review applies to [c7f6e63c](https://git.openjdk.org/jdk/pull/11850/files/c7f6e63c65e82c9992f64e32787b19dff249a2e7)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [c7f6e63c](https://git.openjdk.org/jdk/pull/11850/files/c7f6e63c65e82c9992f64e32787b19dff249a2e7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11850/head:pull/11850` \
`$ git checkout pull/11850`

Update a local copy of the PR: \
`$ git checkout pull/11850` \
`$ git pull https://git.openjdk.org/jdk pull/11850/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11850`

View PR using the GUI difftool: \
`$ git pr show -t 11850`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11850.diff">https://git.openjdk.org/jdk/pull/11850.diff</a>

</details>
