### PR TITLE
6381945: (cal) Japanese calendar unit test system should avoid multiple static imports

### DIFF
--- a/test/jdk/java/util/Calendar/CalendarTestScripts/Symbol.java
+++ b/test/jdk/java/util/Calendar/CalendarTestScripts/Symbol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/Calendar/CalendarTestScripts/Symbol.java
+++ b/test/jdk/java/util/Calendar/CalendarTestScripts/Symbol.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
-import static java.util.Calendar.*;
 import static java.util.GregorianCalendar.*;
 
 public class Symbol {


### PR DESCRIPTION
Calendar does not need to be imported, GregorianCalendar alone handles all the static imports