### PR TITLE
8299309: Test "java/awt/Dialog/ModalDialogTest/ModalDialogTest.java" fails because new frame was not displayed when "New Frame" button was clicked

### DIFF
--- a/test/jdk/java/awt/Dialog/ModalDialogTest/ModalDialogTest.java
+++ b/test/jdk/java/awt/Dialog/ModalDialogTest/ModalDialogTest.java
@@ -211,7 +211,7 @@ class WindowPanel extends Panel {
         win.add(center, BorderLayout.CENTER);
         win.add(bottom, BorderLayout.SOUTH);
         win.pack();
-        if (windows != 0) {
+        if (windows != 0 || frames != 1 || dialogs != 0 || modalDialogs != 0) {
             win.setVisible(true);
         }
 


### PR DESCRIPTION
Windows count check was added as part of [JDK-8290469](https://bugs.openjdk.org/browse/JDK-8290469) fix, to avoid window positional shift which happens during application startup. The condition handled only for windows type of Window and not for Frame/Dialog which is the root cause for the bug. I have updated the condition for other Window types as a fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299309](https://bugs.openjdk.org/browse/JDK-8299309): Test "java/awt/Dialog/ModalDialogTest/ModalDialogTest.java" fails because new frame was not displayed when "New Frame" button was clicked


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Author)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11859/head:pull/11859` \
`$ git checkout pull/11859`

Update a local copy of the PR: \
`$ git checkout pull/11859` \
`$ git pull https://git.openjdk.org/jdk pull/11859/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11859`

View PR using the GUI difftool: \
`$ git pr show -t 11859`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11859.diff">https://git.openjdk.org/jdk/pull/11859.diff</a>

</details>
