### PR TITLE
JDK-8299657: sun/tools/jhsdb/SAGetoptTest.java fails after 8299470

### DIFF
--- a/test/jdk/sun/tools/jhsdb/SAGetoptTest.java
+++ b/test/jdk/sun/tools/jhsdb/SAGetoptTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -146,13 +146,13 @@ public class SAGetoptTest {
 
         // Bad options test
         String[] optionSet4 = {"-abd", "-c"};
-        badOptionsTest(4, optionSet4, "Argument is expected for 'd'");
+        badOptionsTest(4, optionSet4, "Successor argument without leading - is expected for 'd' but we got '-c'");
 
         String[] optionSet5 = {"-exe", "bla", "--core"};
         badOptionsTest(5, optionSet5, "Invalid option 'x'");
 
         String[] optionSet6 = {"--exe", "--core", "bla_core"};
-        badOptionsTest(6, optionSet6, "Argument is expected for 'exe'");
+        badOptionsTest(6, optionSet6, "Successor argument without leading - is expected for 'exe' but we got '--core'");
 
         String[] optionSet7 = {"--exe"};
         badOptionsTest(7, optionSet7, "Argument is expected for 'exe'");


### PR DESCRIPTION
Some exception/error message changed with 8299470 so we have to adjust the test.
Current error is 

Unexpected error 'Successor argument without leading - is expected for 'd' but we got '-c''
java.lang.RuntimeException: Bad option test 4 failed
at SAGetoptTest.badOptionsTest(SAGetoptTest.java:124)
at SAGetoptTest.main(SAGetoptTest.java:149)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.base/java.lang.reflect.Method.invoke(Method.java:578)
at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:125)
at java.base/java.lang.Thread.run(Thread.java:1623)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299657](https://bugs.openjdk.org/browse/JDK-8299657): sun/tools/jhsdb/SAGetoptTest.java fails after 8299470


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11860/head:pull/11860` \
`$ git checkout pull/11860`

Update a local copy of the PR: \
`$ git checkout pull/11860` \
`$ git pull https://git.openjdk.org/jdk pull/11860/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11860`

View PR using the GUI difftool: \
`$ git pr show -t 11860`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11860.diff">https://git.openjdk.org/jdk/pull/11860.diff</a>

</details>
