### PR TITLE
8299671: speed up compiler/intrinsics/string/TestStringLatin1IndexOfChar.java

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/string/TestStringLatin1IndexOfChar.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/string/TestStringLatin1IndexOfChar.java
@@ -41,7 +41,7 @@
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:DisableIntrinsic=_indexOfL_char compiler.intrinsics.string.TestStringLatin1IndexOfChar
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *                   -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:UseSSE=0 compiler.intrinsics.string.TestStringLatin1IndexOfChar
+ *                   -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:UseAVX=0 compiler.intrinsics.string.TestStringLatin1IndexOfChar
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:UseAVX=1 compiler.intrinsics.string.TestStringLatin1IndexOfChar
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI

--- a/test/hotspot/jtreg/compiler/intrinsics/string/TestStringLatin1IndexOfChar.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/string/TestStringLatin1IndexOfChar.java
@@ -32,24 +32,57 @@
  *
  * Run with varing levels of AVX and SSE support, also without the intrinsic at all
  *
- * @library /compiler/patches /test/lib
- * @run main/othervm -Xbatch -XX:Tier4InvocationThreshold=200 -XX:CompileThreshold=100 compiler.intrinsics.string.TestStringLatin1IndexOfChar
- * @run main/othervm -Xbatch -XX:Tier4InvocationThreshold=200 -XX:CompileThreshold=100 -XX:+UnlockDiagnosticVMOptions -XX:DisableIntrinsic=_indexOfL_char compiler.intrinsics.string.TestStringLatin1IndexOfChar
- * @run main/othervm -Xbatch -XX:Tier4InvocationThreshold=200 -XX:CompileThreshold=100 -XX:+IgnoreUnrecognizedVMOptions -XX:UseSSE=0 compiler.intrinsics.string.TestStringLatin1IndexOfChar
- * @run main/othervm -Xbatch -XX:Tier4InvocationThreshold=200 -XX:CompileThreshold=100 -XX:+IgnoreUnrecognizedVMOptions -XX:UseAVX=1 compiler.intrinsics.string.TestStringLatin1IndexOfChar
- * @run main/othervm -Xbatch -XX:Tier4InvocationThreshold=200 -XX:CompileThreshold=100 -XX:+IgnoreUnrecognizedVMOptions -XX:UseAVX=2 compiler.intrinsics.string.TestStringLatin1IndexOfChar
- * @run main/othervm -Xbatch -XX:Tier4InvocationThreshold=200 -XX:CompileThreshold=100 -XX:+IgnoreUnrecognizedVMOptions -XX:UseAVX=3 compiler.intrinsics.string.TestStringLatin1IndexOfChar
+ * @requires vm.compiler2.enabled
+ * @library /compiler/patches /test/lib /
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -Xbatch compiler.intrinsics.string.TestStringLatin1IndexOfChar
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:DisableIntrinsic=_indexOfL_char compiler.intrinsics.string.TestStringLatin1IndexOfChar
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:UseSSE=0 compiler.intrinsics.string.TestStringLatin1IndexOfChar
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:UseAVX=1 compiler.intrinsics.string.TestStringLatin1IndexOfChar
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:UseAVX=2 compiler.intrinsics.string.TestStringLatin1IndexOfChar
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:UseAVX=3 compiler.intrinsics.string.TestStringLatin1IndexOfChar
  */
 
 package compiler.intrinsics.string;
 
 import jdk.test.lib.Asserts;
+import jdk.test.whitebox.WhiteBox;
+import java.lang.reflect.Method;
+import compiler.whitebox.CompilerWhiteBoxTest;
 
 public class TestStringLatin1IndexOfChar{
+    private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
     private final static int MAX_LENGTH = 2048;//future proof for AVX-512 instructions
 
     public static void main(String[] args) throws Exception {
-        for (int i = 0; i < 1_000; ++i) {//repeat such that we enter into C2 code...
+        Method methodFindOneItem    = TestStringLatin1IndexOfChar.class.getDeclaredMethod("findOneItem");
+        Method methodWithOffsetTest = TestStringLatin1IndexOfChar.class.getDeclaredMethod("withOffsetTest");
+        Method methodTestEmpty      = TestStringLatin1IndexOfChar.class.getDeclaredMethod("testEmpty");
+        Asserts.assertNotNull(methodFindOneItem);
+        Asserts.assertNotNull(methodWithOffsetTest);
+        Asserts.assertNotNull(methodTestEmpty);
+
+        // Warmup - profiling must inline the methods
+        for (int i = 0; i < 10; ++i) {
+            findOneItem();
+            withOffsetTest();
+            testEmpty();
+        }
+
+        // Compile
+        WHITE_BOX.enqueueMethodForCompilation(methodFindOneItem,    CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION);
+        WHITE_BOX.enqueueMethodForCompilation(methodWithOffsetTest, CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION);
+        WHITE_BOX.enqueueMethodForCompilation(methodTestEmpty,      CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION);
+
+        // Run compiled method
+        for (int i = 0; i < 10; ++i) {
             findOneItem();
             withOffsetTest();
             testEmpty();


### PR DESCRIPTION
This test took very long, it was the slowest compiler test.
In total it took almost 3 minutes on my laptop. Now it is down to half a minute. The run statements also are about 10x faster now.

We could parallelize the run statements, but given that it is already fairly small the benefit is not so big, and it would imply overheads of parallelization, like loading libraries multiple times.

Goal of this test: trigger `indexOfChar` intrinsic inside the test functions. To trigger this reliably without too many repetitions of the test functions, we had set the flags `-XX:Tier4InvocationThreshold=200 -XX:CompileThreshold=100`. But this also triggers lots of other compilations, and makes everything slow.

I removed those flags, and used the white-box API to trigger compilation of the test functions. With sufficient warm-up, the paths to the intrinsic is hot, and we get intrinsification of `indexOfChar`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299671](https://bugs.openjdk.org/browse/JDK-8299671): Speed up compiler/intrinsics/string/TestStringLatin1IndexOfChar.java


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11862/head:pull/11862` \
`$ git checkout pull/11862`

Update a local copy of the PR: \
`$ git checkout pull/11862` \
`$ git pull https://git.openjdk.org/jdk pull/11862/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11862`

View PR using the GUI difftool: \
`$ git pr show -t 11862`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11862.diff">https://git.openjdk.org/jdk/pull/11862.diff</a>

</details>
