### PR TITLE
JDK-8299672: Enhance HeapDump JFR event

### DIFF
--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -1144,11 +1144,14 @@
     <Field type="ulong" contentType="bytes" name="size" label="Size Written" />
   </Event>
 
-  <Event name="HeapDump" category="Java Virtual Machine, Diagnostics" label="Heap Dump" stackTrace="true" thread="true">
-    <Field type="string" name="destination" label="Destination" />
+  <Event name="HeapDump" category="Java Virtual Machine, Diagnostics" label="Heap Dump" description="Information about a successfully written Java Heap dump"
+    stackTrace="true" thread="true">
+    <Field type="string" name="destination" label="Destination path of the dump" />
     <Field type="long" name="size" label="Size" />
     <Field type="boolean" name="gcBeforeDump" label="GC Before Dump" />
-    <Field type="boolean" name="onOutOfMemoryError" label="On Out of Memory Error" />
+    <Field type="boolean" name="onOutOfMemoryError" label="Heap dump on Out of Memory Error" />
+    <Field type="boolean" name="overwrite" label="Overwrite" description="Heap dump will overwrite previous file location if it exists" />
+    <Field type="int" name="compression" label="Compression Level" description="Compression level of the Dump, if larger than 0 we use gzip compressoion with this level" />
   </Event>
 
   <Event name="GCLocker" category="Java Virtual Machine, GC, Detailed" label="GC Locker" startTime="true" thread="true" stackTrace="true">

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -1150,7 +1150,7 @@
     <Field type="long" name="size" label="Size" />
     <Field type="boolean" name="gcBeforeDump" label="GC Before Dump" />
     <Field type="boolean" name="onOutOfMemoryError" label="Heap dump on Out of Memory Error" />
-    <Field type="boolean" name="overwrite" label="Overwrite" description="Heap dump will overwrite previous file location if it exists" />
+    <Field type="boolean" name="overwrite" label="Overwrite" description="Heap dump overwrites previous file location if it exists" />
     <Field type="int" name="compression" label="Compression Level" description="Compression level of the Dump, if larger than 0 we use gzip compressoion with this level" />
   </Event>
 

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -1144,14 +1144,14 @@
     <Field type="ulong" contentType="bytes" name="size" label="Size Written" />
   </Event>
 
-  <Event name="HeapDump" category="Java Virtual Machine, Diagnostics" label="Heap Dump" description="Information about a successfully written Java Heap dump"
+  <Event name="HeapDump" category="Java Virtual Machine, Diagnostics" label="Heap Dump" description="Information about a successfully written Java heap dump"
     stackTrace="true" thread="true">
-    <Field type="string" name="destination" label="Destination path of the dump" />
+    <Field type="string" name="destination" label="Destination Path of the Dump" />
     <Field type="long" name="size" label="Size" />
     <Field type="boolean" name="gcBeforeDump" label="GC Before Dump" />
-    <Field type="boolean" name="onOutOfMemoryError" label="Heap dump on Out of Memory Error" />
+    <Field type="boolean" name="onOutOfMemoryError" label="Heap Dump on Out of Memory Error" />
     <Field type="boolean" name="overwrite" label="Overwrite" description="Heap dump overwrites previous file location if it exists" />
-    <Field type="int" name="compression" label="Compression Level" description="Compression level of the Dump, if larger than 0 we use gzip compressoion with this level" />
+    <Field type="int" name="compression" label="Compression Level" description="Compression level of the dump, if larger than 0 we use gzip compression with this level" />
   </Event>
 
   <Event name="GCLocker" category="Java Virtual Machine, GC, Detailed" label="GC Locker" startTime="true" thread="true" stackTrace="true">

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
- Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2425,7 +2425,11 @@ int HeapDumper::dump(const char* path, outputStream* out, int compression, bool 
     event.set_gcBeforeDump(_gc_before_heap_dump);
     event.set_size(writer.bytes_written());
     event.set_onOutOfMemoryError(_oome);
+    event.set_overwrite(overwrite);
+    event.set_compression(compression);
     event.commit();
+  } else {
+    log_debug(cds, heap)("Error %s while dumping heap", error());
   }
 
   // print message in interactive case

--- a/test/jdk/jdk/jfr/event/diagnostics/TestHeapDump.java
+++ b/test/jdk/jdk/jfr/event/diagnostics/TestHeapDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,6 +65,8 @@ public class TestHeapDump {
             Events.assertField(e, "gcBeforeDump").equal(true);
             Events.assertField(e, "onOutOfMemoryError").equal(false);
             Events.assertField(e, "size").equal(Files.size(path));
+            Events.assertField(e, "compression").equal(-1);
+            Events.assertField(e, "overwrite").equal(false);
             System.out.println(e);
         }
     }

--- a/test/jdk/jdk/jfr/event/diagnostics/TestHeapDump.java
+++ b/test/jdk/jdk/jfr/event/diagnostics/TestHeapDump.java
@@ -65,7 +65,7 @@ public class TestHeapDump {
             Events.assertField(e, "gcBeforeDump").equal(true);
             Events.assertField(e, "onOutOfMemoryError").equal(false);
             Events.assertField(e, "size").equal(Files.size(path));
-            Events.assertField(e, "compression").equal(-1);
+            Events.assertField(e, "compression").below(1);
             Events.assertField(e, "overwrite").equal(false);
             System.out.println(e);
         }


### PR DESCRIPTION
Enhance the JFR Event HeapDump  with the additional interesting fields, compression and overwrite.
Add some UL logging in case the heap dump writing failed .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299672](https://bugs.openjdk.org/browse/JDK-8299672): Enhance HeapDump JFR event


### Reviewers
 * [Ralf Schmelter](https://openjdk.org/census#rschmelter) (@schmelter-sap - **Reviewer**) ⚠️ Review applies to [750ccf90](https://git.openjdk.org/jdk/pull/11864/files/750ccf90d744541fee6d83f0bdcc81a5c1b23869)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) ⚠️ Review applies to [76fc3a9c](https://git.openjdk.org/jdk/pull/11864/files/76fc3a9c236c508f987a7b40d6a006a32817e46e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11864/head:pull/11864` \
`$ git checkout pull/11864`

Update a local copy of the PR: \
`$ git checkout pull/11864` \
`$ git pull https://git.openjdk.org/jdk pull/11864/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11864`

View PR using the GUI difftool: \
`$ git pr show -t 11864`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11864.diff">https://git.openjdk.org/jdk/pull/11864.diff</a>

</details>
