### PR TITLE
8299499: Usage of constructors of primitive wrapper classes should be avoided in java.net API docs

### DIFF
--- a/src/java.base/share/classes/java/net/SocketOptions.java
+++ b/src/java.base/share/classes/java/net/SocketOptions.java
@@ -54,9 +54,9 @@ public interface SocketOptions {
      * <BR><PRE>
      * SocketImpl s;
      * ...
-     * s.setOption(SO_LINGER, new Integer(10));
+     * s.setOption(SO_LINGER, Integer.valueOf(10));
      *    // OK - set SO_LINGER w/ timeout of 10 sec.
-     * s.setOption(SO_LINGER, new Double(10));
+     * s.setOption(SO_LINGER, Double.valueOf(10));
      *    // ERROR - expects java.lang.Integer
      *</PRE>
      * If the requested option is binary, it can be set using this method by


### PR DESCRIPTION
Replacing deprecated constructors of primitive wrapper classes. Used valueOf() method as replacement.

Alternatively, auto boxing could have been used here as well. It would be beneficial to set a precedent for the other related doc bugs.