### PR TITLE
8299692: G1: Remove unused G1BlockOffsetTable::is_card_boundary

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -49,12 +49,6 @@ G1BlockOffsetTable::G1BlockOffsetTable(MemRegion heap, G1RegionToSpaceMapper* st
                      p2i(bot_reserved.start()), bot_reserved.byte_size(), p2i(bot_reserved.end()));
 }
 
-bool G1BlockOffsetTable::is_card_boundary(HeapWord* p) const {
-  assert(p >= _reserved.start(), "just checking");
-  size_t delta = pointer_delta(p, _reserved.start());
-  return (delta & right_n_bits((int)BOTConstants::log_card_size_in_words())) == (size_t)NoBits;
-}
-
 #ifdef ASSERT
 void G1BlockOffsetTable::check_index(size_t index, const char* msg) const {
   assert((index) < (_reserved.word_size() >> BOTConstants::log_card_size_in_words()),

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -71,8 +71,6 @@ private:
 
   inline void set_offset_array(size_t left, size_t right, u_char offset);
 
-  bool is_card_boundary(HeapWord* p) const;
-
   void check_index(size_t index, const char* msg) const NOT_DEBUG_RETURN;
 
 public:


### PR DESCRIPTION
Trivial change of removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299692](https://bugs.openjdk.org/browse/JDK-8299692): G1: Remove unused G1BlockOffsetTable::is_card_boundary


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11867/head:pull/11867` \
`$ git checkout pull/11867`

Update a local copy of the PR: \
`$ git checkout pull/11867` \
`$ git pull https://git.openjdk.org/jdk pull/11867/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11867`

View PR using the GUI difftool: \
`$ git pr show -t 11867`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11867.diff">https://git.openjdk.org/jdk/pull/11867.diff</a>

</details>
