### PR TITLE
8299183: Invokers.checkExactType passes parameters to create WMTE in opposite order

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/Invokers.java
+++ b/src/java.base/share/classes/java/lang/invoke/Invokers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -494,8 +494,7 @@ class Invokers {
     @Hidden
     static MethodHandle checkVarHandleGenericType(VarHandle handle, VarHandle.AccessDescriptor ad) {
         if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
+            throw newWrongMethodTypeException(handle.accessModeType(ad.type), ad.symbolicMethodTypeExact);
         }
         // Test for exact match on invoker types
         // TODO match with erased types and add cast of return value to lambda form
@@ -518,18 +517,18 @@ class Invokers {
     }
 
     /*non-public*/
-    static WrongMethodTypeException newWrongMethodTypeException(MethodType actual, MethodType expected) {
+    static WrongMethodTypeException newWrongMethodTypeException(MethodType targetType, MethodType callSiteType) {
         // FIXME: merge with JVM logic for throwing WMTE
-        return new WrongMethodTypeException("expected "+expected+" but found "+actual);
+        return new WrongMethodTypeException("handle's method type " + targetType + " but found " + callSiteType);
     }
 
     /** Static definition of MethodHandle.invokeExact checking code. */
     @ForceInline
     /*non-public*/
     static void checkExactType(MethodHandle mh, MethodType expected) {
-        MethodType actual = mh.type();
-        if (actual != expected)
-            throw newWrongMethodTypeException(actual, expected);
+        MethodType targetType = mh.type();
+        if (targetType != expected)
+            throw newWrongMethodTypeException(targetType, expected);
     }
 
     /** Static definition of MethodHandle.invokeGeneric checking code.

--- a/src/java.base/share/classes/java/lang/invoke/Invokers.java
+++ b/src/java.base/share/classes/java/lang/invoke/Invokers.java
@@ -529,7 +529,7 @@ class Invokers {
     static void checkExactType(MethodHandle mh, MethodType expected) {
         MethodType actual = mh.type();
         if (actual != expected)
-            throw newWrongMethodTypeException(expected, actual);
+            throw newWrongMethodTypeException(actual, expected);
     }
 
     /** Static definition of MethodHandle.invokeGeneric checking code.

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2083,8 +2083,8 @@ public abstract sealed class VarHandle implements Constable
 
     @DontInline
     private final void throwWrongMethodTypeException(VarHandle.AccessDescriptor ad) {
-        throw new WrongMethodTypeException("expected " + accessModeType(ad.type) + " but found "
-                + ad.symbolicMethodTypeExact);
+        throw new WrongMethodTypeException("handle's method type " + accessModeType(ad.type)
+                + " but found " + ad.symbolicMethodTypeExact);
     }
 
     @ForceInline

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestExact.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestExact.java
@@ -101,7 +101,7 @@ public class VarHandleTestExact {
         doTest(vh,
             tvh -> tvh.set(w, testValue),
             tvh -> setter.set(tvh, w, testValue),
-            ".*\\Qexpected (Widget," + fieldType.getSimpleName() + ")void \\E.*");
+            ".*\\Qhandle's method type (Widget," + fieldType.getSimpleName() + ")void \\E.*");
     }
 
     @Test(dataProvider = "dataObjectAccess")
@@ -115,7 +115,7 @@ public class VarHandleTestExact {
         doTest(vh,
             tvh -> tvh.get(w),
             tvh -> getter.get(tvh, w),
-            ".*\\Qexpected (Widget)" + fieldType.getSimpleName() + " \\E.*");
+            ".*\\Qhandle's method type (Widget)" + fieldType.getSimpleName() + " \\E.*");
     }
 
     @Test(dataProvider = "dataObjectAccess")
@@ -129,7 +129,7 @@ public class VarHandleTestExact {
         doTest(vh,
             tvh -> tvh.set(testValue),
             tvh -> staticSetter.set(tvh, testValue),
-            ".*\\Qexpected (" + fieldType.getSimpleName() + ")void \\E.*");
+            ".*\\Qhandle's method type (" + fieldType.getSimpleName() + ")void \\E.*");
     }
 
     @Test(dataProvider = "dataObjectAccess")
@@ -142,7 +142,7 @@ public class VarHandleTestExact {
         doTest(vh,
             tvh -> tvh.get(),
             tvh -> staticGetter.get(tvh),
-            ".*\\Qexpected ()" + fieldType.getSimpleName() + " \\E.*");
+            ".*\\Qhandle's method type ()" + fieldType.getSimpleName() + " \\E.*");
     }
 
     @Test(dataProvider = "dataSetArray")
@@ -153,7 +153,7 @@ public class VarHandleTestExact {
         doTest(vh,
             tvh -> tvh.set(arr, 0, testValue),
             tvh -> setter.set(tvh, arr, testValue),
-            ".*\\Qexpected (" + arrayClass.getSimpleName() + ",int," + arrayClass.componentType().getSimpleName() + ")void \\E.*");
+            ".*\\Qhandle's method type (" + arrayClass.getSimpleName() + ",int," + arrayClass.componentType().getSimpleName() + ")void \\E.*");
     }
 
     @Test(dataProvider = "dataSetBuffer")
@@ -164,7 +164,7 @@ public class VarHandleTestExact {
         doTest(vh,
             tvh -> tvh.set(buff, 0, testValue),
             tvh -> setter.set(tvh, buff, testValue),
-            ".*\\Qexpected (ByteBuffer,int," + arrayClass.componentType().getSimpleName() + ")void \\E.*");
+            ".*\\Qhandle's method type (ByteBuffer,int," + arrayClass.componentType().getSimpleName() + ")void \\E.*");
     }
 
     @Test(dataProvider = "dataSetMemorySegment")
@@ -175,7 +175,7 @@ public class VarHandleTestExact {
             doTest(vh,
                 tvh -> tvh.set(seg, 0L, testValue),
                 tvh -> setter.set(tvh, seg, 0L, testValue),
-                ".*\\Qexpected (MemorySegment,long," + carrier.getSimpleName() + ")void \\E.*");
+                ".*\\Qhandle's method type (MemorySegment,long," + carrier.getSimpleName() + ")void \\E.*");
         }
     }
 

--- a/test/jdk/java/lang/invoke/WrongMethodTypeTest.java
+++ b/test/jdk/java/lang/invoke/WrongMethodTypeTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/jdk/java/lang/invoke/WrongMethodTypeTest.java
+++ b/test/jdk/java/lang/invoke/WrongMethodTypeTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test 8299183
+ * @run testng WrongMethodTypeTest
+ */
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.VarHandle;
+import java.lang.invoke.WrongMethodTypeException;
+
+import static java.lang.invoke.MethodType.methodType;
+
+import static org.testng.AssertJUnit.*;
+
+import org.testng.annotations.*;
+
+public class WrongMethodTypeTest {
+    static final Lookup LOOKUP = MethodHandles.lookup();
+
+    @Test
+    public void checkExactType() throws Throwable {
+        String expectedMessage = "handle's method type (int)int but found ()boolean";
+        try {
+            MethodHandle mh = LOOKUP.findStatic(WrongMethodTypeTest.class, "m", methodType(int.class, int.class));
+            boolean b = (boolean)mh.invokeExact();
+            fail("Expected WrongMethodTypeException");
+        } catch (WrongMethodTypeException ex) {
+            assertEquals(expectedMessage, ex.getMessage());
+        }
+    }
+
+    @Test
+    public void checkAccessModeInvokeExact() throws Throwable {
+        String expectedMessage = "handle's method type ()int but found ()Void";
+        VarHandle vh = LOOKUP.findStaticVarHandle(WrongMethodTypeTest.class, "x", int.class)
+                             .withInvokeExactBehavior();
+        try {
+            Void o = (Void) vh.get();
+        } catch (WrongMethodTypeException ex) {
+            assertEquals(expectedMessage, ex.getMessage());
+        }
+    }
+
+    @Test
+    public void checkVarHandleInvokeExact() throws Throwable {
+        String expectedMessage = "handle's method type (WrongMethodTypeTest)boolean but found (WrongMethodTypeTest)int";
+        VarHandle vh = LOOKUP.findVarHandle(WrongMethodTypeTest.class, "y", boolean.class)
+                             .withInvokeExactBehavior();
+        try {
+            int o = (int) vh.get(new WrongMethodTypeTest());
+        } catch (WrongMethodTypeException ex) {
+            assertEquals(expectedMessage, ex.getMessage());
+        }
+    }
+
+    static int m(int x) {
+        return x;
+    }
+
+    static int x = 200;
+    boolean y = false;
+}


### PR DESCRIPTION
Trivial fix.  Fix `Invokers.checkExactType` to call `newWrongMethodTypeException(actual, expected)` with parameters in right order.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299183](https://bugs.openjdk.org/browse/JDK-8299183): Invokers.checkExactType passes parameters to create WMTE in opposite order


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [3d074593](https://git.openjdk.org/jdk/pull/11870/files/3d074593d355a418fcfc4686c9b7c4d9534de17a)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11870/head:pull/11870` \
`$ git checkout pull/11870`

Update a local copy of the PR: \
`$ git checkout pull/11870` \
`$ git pull https://git.openjdk.org/jdk pull/11870/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11870`

View PR using the GUI difftool: \
`$ git pr show -t 11870`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11870.diff">https://git.openjdk.org/jdk/pull/11870.diff</a>

</details>
