### PR TITLE
8299502: Usage of constructors of primitive wrapper classes should be avoided in javax.xml API docs

### DIFF
--- a/src/java.xml/share/classes/javax/xml/stream/XMLOutputFactory.java
+++ b/src/java.xml/share/classes/javax/xml/stream/XMLOutputFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.xml/share/classes/javax/xml/stream/XMLOutputFactory.java
+++ b/src/java.xml/share/classes/javax/xml/stream/XMLOutputFactory.java
@@ -56,7 +56,7 @@ import javax.xml.transform.Result;
  * <p>The following paragraphs describe the namespace and prefix repair algorithm:
  *
  * <p>The property can be set with the following code line:
- * {@code setProperty("javax.xml.stream.isRepairingNamespaces", new Boolean(true|false));}
+ * {@code setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.TRUE|Boolean.FALSE);}
  *
  * <p>This property specifies that the writer default namespace prefix declarations.
  * The default value is false.

--- a/src/java.xml/share/classes/javax/xml/stream/XMLOutputFactory.java
+++ b/src/java.xml/share/classes/javax/xml/stream/XMLOutputFactory.java
@@ -56,7 +56,7 @@ import javax.xml.transform.Result;
  * <p>The following paragraphs describe the namespace and prefix repair algorithm:
  *
  * <p>The property can be set with the following code line:
- * {@code setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.TRUE|Boolean.FALSE);}
+ * {@code setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.TRUE);}
  *
  * <p>This property specifies that the writer default namespace prefix declarations.
  * The default value is false.


### PR DESCRIPTION
Removed constructors of primitive wrapper classes (deprecated for removal) in _javax.xml.stream.XMLOutputFactory_ 

Replaced with Boolean static fields: Boolean.TRUE and Boolean.FALSE

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299502](https://bugs.openjdk.org/browse/JDK-8299502): Usage of constructors of primitive wrapper classes should be avoided in javax.xml API docs


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11872/head:pull/11872` \
`$ git checkout pull/11872`

Update a local copy of the PR: \
`$ git checkout pull/11872` \
`$ git pull https://git.openjdk.org/jdk pull/11872/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11872`

View PR using the GUI difftool: \
`$ git pr show -t 11872`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11872.diff">https://git.openjdk.org/jdk/pull/11872.diff</a>

</details>
