### PR TITLE
7131166: SynthListUI / SynthInternalFrameTitlePane updateStyle() ignores method argument

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthInternalFrameTitlePane.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthInternalFrameTitlePane.java
@@ -128,7 +128,7 @@ class SynthInternalFrameTitlePane extends BasicInternalFrameTitlePane
     }
 
     private void updateStyle(JComponent c) {
-        SynthContext context = getContext(this, ENABLED);
+        SynthContext context = getContext(c, ENABLED);
         SynthStyle oldStyle = style;
         style = SynthLookAndFeel.updateStyle(context, this);
         if (style != oldStyle) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthListUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthListUI.java
@@ -140,7 +140,7 @@ public class SynthListUI extends BasicListUI
     }
 
     private void updateStyle(JComponent c) {
-        SynthContext context = getContext(list, ENABLED);
+        SynthContext context = getContext(c, ENABLED);
         SynthStyle oldStyle = style;
 
         style = SynthLookAndFeel.updateStyle(context, this);


### PR DESCRIPTION
It seems Synth has two cases of updateStyle() where its argument is not passed to the getContext() call. It seems to be an oversight as in other Synth classes, the component argument passed to updateStyle is being passed to getContext().

CI tests are ok with this change and there is no new regeression with CI tests run in NimbusL&F by default..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-7131166](https://bugs.openjdk.org/browse/JDK-7131166): SynthListUI / SynthInternalFrameTitlePane updateStyle() ignores method argument


### Reviewers
 * @SWinxy (no known openjdk.org user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11875/head:pull/11875` \
`$ git checkout pull/11875`

Update a local copy of the PR: \
`$ git checkout pull/11875` \
`$ git pull https://git.openjdk.org/jdk pull/11875/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11875`

View PR using the GUI difftool: \
`$ git pr show -t 11875`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11875.diff">https://git.openjdk.org/jdk/pull/11875.diff</a>

</details>
