### PR TITLE
8297306: Incorrect brackets in Javadoc for a constructor of IteratorSpliterator

### DIFF
--- a/src/java.base/share/classes/java/util/Spliterators.java
+++ b/src/java.base/share/classes/java/util/Spliterators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1817,11 +1817,11 @@ public final class Spliterators {
 
         /**
          * Creates a spliterator using the given
-         * collection's {@link java.util.Collection#iterator()) for traversal,
-         * and reporting its {@link java.util.Collection#size()) as its initial
+         * collection's {@link java.util.Collection#iterator() iterator} for traversal,
+         * and reporting its {@link java.util.Collection#size() size} as its initial
          * size.
          *
-         * @param c the collection
+         * @param collection the collection
          * @param characteristics properties of this spliterator's
          *        source or elements.
          */

--- a/src/java.base/share/classes/java/util/Spliterators.java
+++ b/src/java.base/share/classes/java/util/Spliterators.java
@@ -399,8 +399,8 @@ public final class Spliterators {
 
     /**
      * Creates a {@code Spliterator} using the given collection's
-     * {@link java.util.Collection#iterator()} as the source of elements, and
-     * reporting its {@link java.util.Collection#size()} as its initial size.
+     * {@link java.util.Collection#iterator() iterator} as the source of elements, and
+     * reporting its {@link java.util.Collection#size() size} as its initial size.
      *
      * <p>The spliterator is
      * <em><a href="Spliterator.html#binding">late-binding</a></em>, inherits


### PR DESCRIPTION
Can I please get a review of this change which fixes an issue in the javadoc text of the internal class IteratorSpliterator? This addresses the issue reported at  https://bugs.openjdk.org/browse/JDK-8297306.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297306](https://bugs.openjdk.org/browse/JDK-8297306): Incorrect brackets in Javadoc for a constructor of IteratorSpliterator


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [b887f417](https://git.openjdk.org/jdk/pull/11876/files/b887f41788339aa699a124e9a38d244b3dd27d5e)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [b887f417](https://git.openjdk.org/jdk/pull/11876/files/b887f41788339aa699a124e9a38d244b3dd27d5e)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11876/head:pull/11876` \
`$ git checkout pull/11876`

Update a local copy of the PR: \
`$ git checkout pull/11876` \
`$ git pull https://git.openjdk.org/jdk pull/11876/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11876`

View PR using the GUI difftool: \
`$ git pr show -t 11876`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11876.diff">https://git.openjdk.org/jdk/pull/11876.diff</a>

</details>
