### PR TITLE
8299721: [Vector API] assert in switch-default of LibraryCallKit::arch_supports_vector_rotate is too weak to catch bugs

### DIFF
--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -128,8 +128,7 @@ bool LibraryCallKit::arch_supports_vector_rotate(int opc, int num_elem, BasicTyp
       lshiftopc = Op_LShiftL;
       rshiftopc = Op_URShiftL;
       break;
-    default:
-      assert(false, "Unexpected type");
+    default: fatal("Unexpected type: %s", type2name(elem_bt));
   }
   int lshiftvopc = VectorNode::opcode(lshiftopc, elem_bt);
   int rshiftvopc = VectorNode::opcode(rshiftopc, elem_bt);


### PR DESCRIPTION
Hi all,

The switch-default path of LibraryCallKit::arch_supports_vector_rotate means runtime error.
This is because `lshiftopc`@Line136 and `rshiftopc`@Line137 would be undefined if the switch-default path is taken.

```cpp
 115   int lshiftopc, rshiftopc;
 116   switch(elem_bt) {
 117     case T_BYTE:
 118       lshiftopc = Op_LShiftI;
 119       rshiftopc = Op_URShiftB;
 120       break;
 121     case T_SHORT:
 122       lshiftopc = Op_LShiftI;
 123       rshiftopc = Op_URShiftS;
 124       break;
 125     case T_INT:
 126       lshiftopc = Op_LShiftI;
 127       rshiftopc = Op_URShiftI;
 128       break;
 129     case T_LONG:
 130       lshiftopc = Op_LShiftL;
 131       rshiftopc = Op_URShiftL;
 132       break;
 133     default:
 134       assert(false, "Unexpected type");
 135   }
 136   int lshiftvopc = VectorNode::opcode(lshiftopc, elem_bt);   <--- lshiftopc is undefine with the default path
 137   int rshiftvopc = VectorNode::opcode(rshiftopc, elem_bt);   <--- rshiftopc is undefine with the default path
```

So to prevent potential bugs, it would be better to stop and print an error msg even with release VMs, which is done by other switch-default statements in the file.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299721](https://bugs.openjdk.org/browse/JDK-8299721): [Vector API] assert in switch-default of LibraryCallKit::arch_supports_vector_rotate is too weak to catch bugs


### Reviewers
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11877/head:pull/11877` \
`$ git checkout pull/11877`

Update a local copy of the PR: \
`$ git checkout pull/11877` \
`$ git pull https://git.openjdk.org/jdk pull/11877/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11877`

View PR using the GUI difftool: \
`$ git pr show -t 11877`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11877.diff">https://git.openjdk.org/jdk/pull/11877.diff</a>

</details>
