### PR TITLE
8298472: AArch64: Detect Ampere-1 and Ampere-1A CPUs and set default options

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -132,7 +132,7 @@ void VM_Version::initialize() {
   // Enable vendor specific features
 
   // Ampere eMAG
-  if (_cpu == CPU_AMCC && (_model == 0) && (_variant == 0x3)) {
+  if (_cpu == CPU_AMCC && (_model == CPU_MODEL_EMAG) && (_variant == 0x3)) {
     if (FLAG_IS_DEFAULT(AvoidUnalignedAccesses)) {
       FLAG_SET_DEFAULT(AvoidUnalignedAccesses, true);
     }
@@ -141,6 +141,13 @@ void VM_Version::initialize() {
     }
     if (FLAG_IS_DEFAULT(UseSIMDForArrayEquals)) {
       FLAG_SET_DEFAULT(UseSIMDForArrayEquals, !(_revision == 1 || _revision == 2));
+    }
+  }
+
+  // Ampere CPUs: Ampere-1 and Ampere-1A
+  if (_cpu == CPU_AMPERE && ((_model == CPU_MODEL_AMPERE_1) || (_model == CPU_MODEL_AMPERE_1A))) {
+    if (FLAG_IS_DEFAULT(UseSIMDForMemoryOps)) {
+      FLAG_SET_DEFAULT(UseSIMDForMemoryOps, true);
     }
   }
 

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -101,6 +101,14 @@ public:
     CPU_INTEL     = 'i',
     CPU_APPLE     = 'a',
   };
+
+enum Ampere_CPU_Model {
+    CPU_MODEL_EMAG      = 0x0,   /* CPU implementer is CPU_AMCC */
+    CPU_MODEL_ALTRA     = 0xd0c, /* CPU implementer is CPU_ARM, Neoverse N1 */
+    CPU_MODEL_ALTRAMAX  = 0xd0c, /* CPU implementer is CPU_ARM, Neoverse N1 */
+    CPU_MODEL_AMPERE_1  = 0xac3, /* CPU implementer is CPU_AMPERE */
+    CPU_MODEL_AMPERE_1A = 0xac4  /* CPU implementer is CPU_AMPERE */
+};
 
 #define CPU_FEATURE_FLAGS(decl)               \
     decl(FP,            fp,            0)     \


### PR DESCRIPTION
This patch is to add CPU detection for Ampere-1 and Ampere-1A and set -XX:+UseSIMDForMemoryOps by default. In addition, an `enum Ampere_CPU_Model ` got introduced in order to clearly describe all Ampere CPUs in `src/hotspot/cpu/aarch64/vm_version_aarch64.hpp`.

Tests done:
1. Jtreg tier1 sanity check on Ampere Altra AArch64 platforms, and Ampere-1 systems as well. No new issue found.
4. GitHub Actions (GHA) sanity tests: https://github.com/cnqpzhang/jdk/actions/runs/3845722221
3. OpenJDK bundled JMH, `make run-test TEST="micro:java.lang.ArrayCopy*" `, SIMD vs NoSIMD ratios are mostly positive. For example, `java.lang.ArrayCopyAligned.testChar` with `-p length=600` showed +42% improvement on Ampere-1. 
2. Ran [JMH JDK Microbenchmarks](https://github.com/openjdk/jmh-jdk-microbenchmarks), ~1500 cases. No obvious perf regression found.

Signed-off-by: Patrick Zhang <patrick@os.amperecomputing.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298472](https://bugs.openjdk.org/browse/JDK-8298472): AArch64: Detect Ampere-1 and Ampere-1A CPUs and set default options


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**) ⚠️ Review applies to [eb584df1](https://git.openjdk.org/jdk/pull/11878/files/eb584df1a8ce9453767f957f846351cf7d93e568)
 * [Nick Gasson](https://openjdk.org/census#ngasson) (@nick-arm - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11878/head:pull/11878` \
`$ git checkout pull/11878`

Update a local copy of the PR: \
`$ git checkout pull/11878` \
`$ git pull https://git.openjdk.org/jdk pull/11878/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11878`

View PR using the GUI difftool: \
`$ git pr show -t 11878`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11878.diff">https://git.openjdk.org/jdk/pull/11878.diff</a>

</details>
