### PR TITLE
8299739: HashedPasswordFileTest.java and ExceptionTest.java can fail with java.lang.NullPointerException

### DIFF
--- a/test/jdk/javax/management/MBeanServer/ExceptionTest.java
+++ b/test/jdk/javax/management/MBeanServer/ExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,10 +123,13 @@ public class ExceptionTest {
         } finally {
             try {
                 // Close JMX Connector Client
-                cc.close();
+                if (cc != null) {
+                    cc.close();
+                }
                 // Stop connertor server
-                cs.stop();
-
+                if (cs != null) {
+                    cs.stop();
+                }
             } catch (Exception e) {
                 Utils.printThrowable(e, true);
                 throw new RuntimeException(

--- a/test/jdk/javax/management/security/HashedPasswordFileTest.java
+++ b/test/jdk/javax/management/security/HashedPasswordFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -200,6 +200,12 @@ public class HashedPasswordFileTest {
         return cs.getAddress();
     }
 
+    private void stopServerSide() throws IOException {
+        if (cs != null) {
+            cs.stop();
+        }
+    }
+
     @Test
     public void testClearTextPasswordFile() throws IOException {
         Boolean[] bvals = new Boolean[]{true, false};
@@ -217,7 +223,7 @@ public class HashedPasswordFileTest {
                 }
                 Assert.assertEquals(isPasswordFileHashed(), bval);
             } finally {
-                cs.stop();
+                stopServerSide();
             }
         }
     }
@@ -241,7 +247,7 @@ public class HashedPasswordFileTest {
                 }
                 Assert.assertEquals(isPasswordFileHashed(), false);
             } finally {
-                cs.stop();
+                stopServerSide();
             }
         }
     }
@@ -263,7 +269,7 @@ public class HashedPasswordFileTest {
                     }
                 }
             } finally {
-                cs.stop();
+                stopServerSide();
             }
         }
     }
@@ -400,7 +406,7 @@ public class HashedPasswordFileTest {
                 }
             }
         } finally {
-            cs.stop();
+            stopServerSide();
         }
     }
 


### PR DESCRIPTION
Exceptions during setup of these tests could leave e.g. JMXConnector cs as null.
But, we call cs.close() during a finally block and fail with an NPE, obscuring the real failure.
We must only call close if this is not null.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299739](https://bugs.openjdk.org/browse/JDK-8299739): HashedPasswordFileTest.java and ExceptionTest.java can fail with java.lang.NullPointerException


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11881/head:pull/11881` \
`$ git checkout pull/11881`

Update a local copy of the PR: \
`$ git checkout pull/11881` \
`$ git pull https://git.openjdk.org/jdk pull/11881/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11881`

View PR using the GUI difftool: \
`$ git pr show -t 11881`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11881.diff">https://git.openjdk.org/jdk/pull/11881.diff</a>

</details>
