### PR TITLE
8299699: Test runtime/cds/appcds/WrongClasspath.java fails after JDK-8299329

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
@@ -42,6 +42,7 @@ import java.nio.file.Files;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.ArrayList;
@@ -357,6 +358,8 @@ public class TestCommon extends CDSTestUtils {
         if (n > 0) {
             firstJar = firstJar.substring(0, n);
         }
+        // get the real path in case the firstJar is specified as a relative path
+        firstJar = Paths.get(firstJar).toRealPath().toString();
         String classDir = System.getProperty("test.classes");
         String expected = getOutputDir() + File.separator;
 


### PR DESCRIPTION
Failure happens because `TestCommon#patchJarForDynamicDump(String cp)` expects the jar files passed in `cp` parameter are with absolute path. The new test case added for JDK 8299329 passed jar files using path relative to work dir.

```
        if (!firstJar.startsWith(expected)) {
            throw new RuntimeException("FIXME: jar file not at a supported location ('"
                                       + expected + "'): " + firstJar);
        }
```

This fix converts `firstJar` into real path using `Path.toRealPath()` before doing `firstJar.startsWith(expected)`.
This way all relative paths are also converted to absolute paths before the check is performed.

I tested this fix by running WrongClasspath test with `-Dtest.dynamic.cds.archive=true` as:
```
$ java -jar /work/jtreg/build/images/jtreg/lib/jtreg.jar -Dtest.dynamic.cds.archive=true -jdk:/work/jdk/build/JDK-8299329-fd/images/jdk test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
```
Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299699](https://bugs.openjdk.org/browse/JDK-8299699): Test runtime/cds/appcds/WrongClasspath.java fails after JDK-8299329


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11882/head:pull/11882` \
`$ git checkout pull/11882`

Update a local copy of the PR: \
`$ git checkout pull/11882` \
`$ git pull https://git.openjdk.org/jdk pull/11882/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11882`

View PR using the GUI difftool: \
`$ git pr show -t 11882`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11882.diff">https://git.openjdk.org/jdk/pull/11882.diff</a>

</details>
