### PR TITLE
8299746: Accept unknown signatureAlgorithm in PKCS7 SignerInfo

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs/SignerInfo.java
+++ b/src/java.base/share/classes/sun/security/pkcs/SignerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -537,7 +537,16 @@ public class SignerInfo implements DerEncoder {
                     digAlg = "SHA" + digAlg.substring(4);
                 }
                 if (keyAlg.equals("EC")) keyAlg = "ECDSA";
-                return digAlg + "with" + keyAlg;
+                String sigAlg = digAlg + "with" + keyAlg;
+                try {
+                    Signature.getInstance(sigAlg);
+                    return sigAlg;
+                } catch (NoSuchAlgorithmException e) {
+                    // Possibly an unknown modern signature algorithm,
+                    // in this case, encAlg should already be a signature
+                    // algorithm.
+                    return encAlg;
+                }
         }
     }
 

--- a/test/jdk/sun/security/pkcs/pkcs7/NewSigAlg.java
+++ b/test/jdk/sun/security/pkcs/pkcs7/NewSigAlg.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8299746
+ * @summary Accept unknown signatureAlgorithm in PKCS7 SignerInfo
+ * @modules java.base/sun.security.pkcs
+ *          java.base/sun.security.x509
+ * @library /test/lib
+ */
+
+import jdk.test.lib.Asserts;
+import sun.security.pkcs.SignerInfo;
+import sun.security.x509.AlgorithmId;
+
+public class NewSigAlg {
+    public static void main(String[] args) throws Exception {
+        test("SHA-1", "RSA", "SHA1withRSA");
+        test("SHA-1", "SHA1withRSA", "SHA1withRSA");
+        test("SHA-1", "SHA256withRSA", "SHA1withRSA");
+        // Sorry I have to use something that has an OID but not known
+        // as a signature algorithm.
+        test("SHA-1", "PBES2", "PBES2");
+    }
+
+    static void test(String d, String e, String s) throws Exception {
+        Asserts.assertEQ(s, SignerInfo.makeSigAlg(
+                AlgorithmId.get(d), AlgorithmId.get(s), false));
+    }
+}


### PR DESCRIPTION
Modern signature algorithms provided by a 3rd-party provider might not be recognized by JDK code yet.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299746](https://bugs.openjdk.org/browse/JDK-8299746): Accept unknown signatureAlgorithm in PKCS7 SignerInfo


### Reviewers
 * [Kevin Driver](https://openjdk.org/census#kdriver) (@driverkt - Author)
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11883/head:pull/11883` \
`$ git checkout pull/11883`

Update a local copy of the PR: \
`$ git checkout pull/11883` \
`$ git pull https://git.openjdk.org/jdk pull/11883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11883`

View PR using the GUI difftool: \
`$ git pr show -t 11883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11883.diff">https://git.openjdk.org/jdk/pull/11883.diff</a>

</details>
