### PR TITLE
8282217: Key events (key char and key code) changed for Swiss keyboard

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
@@ -3617,7 +3617,10 @@ UINT AwtComponent::WindowsKeyToJavaChar(UINT wkey, UINT modifiers, TransOps ops,
     WORD wChar[2];
     int converted = 1;
     UINT ch = ::MapVirtualKeyEx(wkey, 2, GetKeyboardLayout());
-    if (deadKeyActive) {
+    if (ch & 0x80000000 && ch != 0x800000A8) {
+        // Dead key which is handled as a normal key
+        isDeadKey = deadKeyActive = TRUE;
+    } else if (deadKeyActive) {
         // We cannot use ::ToUnicodeEx if dead key is active because this will
         // break dead key function
         wChar[0] = shiftIsDown ? ch : tolower(ch);

--- a/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
@@ -3617,10 +3617,7 @@ UINT AwtComponent::WindowsKeyToJavaChar(UINT wkey, UINT modifiers, TransOps ops,
     WORD wChar[2];
     int converted = 1;
     UINT ch = ::MapVirtualKeyEx(wkey, 2, GetKeyboardLayout());
-    if (ch & 0x80000000) {
-        // Dead key which is handled as a normal key
-        isDeadKey = deadKeyActive = TRUE;
-    } else if (deadKeyActive) {
+    if (deadKeyActive) {
         // We cannot use ::ToUnicodeEx if dead key is active because this will
         // break dead key function
         wChar[0] = shiftIsDown ? ch : tolower(ch);


### PR DESCRIPTION
Removed check for MapVirtualKeyEx return value causing some keys to become undefined

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282217](https://bugs.openjdk.org/browse/JDK-8282217): Key events (key char and key code) changed for Swiss keyboard


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11887/head:pull/11887` \
`$ git checkout pull/11887`

Update a local copy of the PR: \
`$ git checkout pull/11887` \
`$ git pull https://git.openjdk.org/jdk pull/11887/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11887`

View PR using the GUI difftool: \
`$ git pr show -t 11887`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11887.diff">https://git.openjdk.org/jdk/pull/11887.diff</a>

</details>
