### PR TITLE
8177418: NPE is not apparent for methods in java.util.TimeZone API docs

### DIFF
--- a/src/java.base/share/classes/java/util/SimpleTimeZone.java
+++ b/src/java.base/share/classes/java/util/SimpleTimeZone.java
@@ -839,9 +839,12 @@ public class SimpleTimeZone extends TimeZone {
 
     /**
      * Queries if the given date is in daylight saving time.
+     * @implSpec The default implementation throws a
+     * {@code NullPointerException} if {@code date} is {@code null}
      * @return true if daylight saving time is in effective at the
      * given date; false otherwise.
-     * @throws NullPointerException if {@code date} is {@code null}
+     * @throws NullPointerException This method may throw a
+     * {@code NullPointerException} if {@code date} is {@code null}
      */
     public boolean inDaylightTime(Date date)
     {

--- a/src/java.base/share/classes/java/util/SimpleTimeZone.java
+++ b/src/java.base/share/classes/java/util/SimpleTimeZone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/SimpleTimeZone.java
+++ b/src/java.base/share/classes/java/util/SimpleTimeZone.java
@@ -841,7 +841,7 @@ public class SimpleTimeZone extends TimeZone {
      * Queries if the given date is in daylight saving time.
      * @return true if daylight saving time is in effective at the
      * given date; false otherwise.
-     * @throws NullPointerException {@inheritDoc}
+     * @throws NullPointerException if {@code date} is {@code null}
      */
     public boolean inDaylightTime(Date date)
     {

--- a/src/java.base/share/classes/java/util/SimpleTimeZone.java
+++ b/src/java.base/share/classes/java/util/SimpleTimeZone.java
@@ -841,6 +841,7 @@ public class SimpleTimeZone extends TimeZone {
      * Queries if the given date is in daylight saving time.
      * @return true if daylight saving time is in effective at the
      * given date; false otherwise.
+     * @throws NullPointerException {@inheritDoc}
      */
     public boolean inDaylightTime(Date date)
     {

--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -293,9 +293,9 @@ public abstract class TimeZone implements Serializable, Cloneable {
     /**
      * Sets the time zone ID. This does not change any other data in
      * the time zone object.
-     * @param ID the new time zone ID.
      * @implSpec The default implementation throws a
      * {@code NullPointerException} if {@code ID} is {@code null}
+     * @param ID the new time zone ID.
      * @throws NullPointerException This method may throw a
      * {@code NullPointerException} if {@code ID} is {@code null}
      */
@@ -395,16 +395,15 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * found, the name is returned. Otherwise, a string in the
      * <a href="#NormalizedCustomID">normalized custom ID format</a> is returned.
      *
+     * @implSpec The default implementation throws an
+     * {@code IllegalArgumentException} if {@code style} is invalid or a
+     * {@code NullPointerException} if {@code ID} is {@code null}.
      * @param daylight {@code true} specifying a Daylight Saving Time name, or
      *                 {@code false} specifying a Standard Time name
      * @param style either {@link #LONG} or {@link #SHORT}
      * @param locale   the locale in which to supply the display name.
-     * @implSpec The default implementation throws a
-     * {@code NullPointerException} if {@code ID} is {@code null}.
-     * Additionally, an {@code IllegalArgumentException} will be thrown if
-     * {@code style} is invalid.
      * @return the human-readable name of this time zone in the given locale.
-     * @throws IllegalArgumentException This method may throw a
+     * @throws IllegalArgumentException This method may throw an
      * {@code IllegalArgumentException} if {@code style} is invalid.
      * @throws NullPointerException This method may throw a
      * {@code NullPointerException} if {@code ID} is {@code null}

--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -294,6 +294,8 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * Sets the time zone ID. This does not change any other data in
      * the time zone object.
      * @param ID the new time zone ID.
+     * @implNote The default implementation throws a
+     * {@code NullPointerException} if {@code ID} is {@code null}
      * @throws NullPointerException if {@code ID} is {@code null}
      */
     public void setID(String ID)
@@ -523,6 +525,8 @@ public abstract class TimeZone implements Serializable, Cloneable {
      *
      * @return the specified {@code TimeZone}, or the GMT zone if the given ID
      * cannot be understood.
+     * @implNote The default implementation throws a
+     * {@code NullPointerException} if {@code ID} is {@code null}
      * @throws NullPointerException if {@code ID} is {@code null}
      */
     public static synchronized TimeZone getTimeZone(String ID) {

--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -294,9 +294,10 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * Sets the time zone ID. This does not change any other data in
      * the time zone object.
      * @param ID the new time zone ID.
-     * @implNote The default implementation throws a
+     * @implSpec The default implementation throws a
      * {@code NullPointerException} if {@code ID} is {@code null}
-     * @throws NullPointerException if {@code ID} is {@code null}
+     * @throws NullPointerException This method may throw a
+     * {@code NullPointerException}, if {@code ID} is {@code null}
      */
     public void setID(String ID)
     {
@@ -398,9 +399,15 @@ public abstract class TimeZone implements Serializable, Cloneable {
      *                 {@code false} specifying a Standard Time name
      * @param style either {@link #LONG} or {@link #SHORT}
      * @param locale   the locale in which to supply the display name.
+     * @implSpec The default implementation throws a
+     * {@code NullPointerException}, if {@code ID} is {@code null}.
+     * Additionally, an {@code IllegalArgumentException} will be thrown if
+     * {@code style} is invalid.
      * @return the human-readable name of this time zone in the given locale.
-     * @throws    IllegalArgumentException if {@code style} is invalid.
-     * @throws    NullPointerException if {@code locale} is {@code null}.
+     * @throws IllegalArgumentException This method may throw a
+     * {@code IllegalArgumentException}, if {@code style} is invalid.
+     * @throws NullPointerException This method may throw a
+     * {@code NullPointerException}, if {@code ID} is {@code null}
      * @since 1.2
      * @see java.text.DateFormatSymbols#getZoneStrings()
      */
@@ -510,7 +517,7 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * @param date the given Date.
      * @return {@code true} if the given date is in Daylight Saving Time,
      *         {@code false}, otherwise.
-     * @throws NullPointerException This method may throw
+     * @throws NullPointerException This method may throw a
      * {@code NullPointerException}, if {@code date} is {@code null}
      */
     public abstract boolean inDaylightTime(Date date);
@@ -525,8 +532,6 @@ public abstract class TimeZone implements Serializable, Cloneable {
      *
      * @return the specified {@code TimeZone}, or the GMT zone if the given ID
      * cannot be understood.
-     * @implNote The default implementation throws a
-     * {@code NullPointerException} if {@code ID} is {@code null}
      * @throws NullPointerException if {@code ID} is {@code null}
      */
     public static synchronized TimeZone getTimeZone(String ID) {

--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -297,7 +297,7 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * @implSpec The default implementation throws a
      * {@code NullPointerException} if {@code ID} is {@code null}
      * @throws NullPointerException This method may throw a
-     * {@code NullPointerException}, if {@code ID} is {@code null}
+     * {@code NullPointerException} if {@code ID} is {@code null}
      */
     public void setID(String ID)
     {
@@ -400,14 +400,14 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * @param style either {@link #LONG} or {@link #SHORT}
      * @param locale   the locale in which to supply the display name.
      * @implSpec The default implementation throws a
-     * {@code NullPointerException}, if {@code ID} is {@code null}.
+     * {@code NullPointerException} if {@code ID} is {@code null}.
      * Additionally, an {@code IllegalArgumentException} will be thrown if
      * {@code style} is invalid.
      * @return the human-readable name of this time zone in the given locale.
      * @throws IllegalArgumentException This method may throw a
-     * {@code IllegalArgumentException}, if {@code style} is invalid.
+     * {@code IllegalArgumentException} if {@code style} is invalid.
      * @throws NullPointerException This method may throw a
-     * {@code NullPointerException}, if {@code ID} is {@code null}
+     * {@code NullPointerException} if {@code ID} is {@code null}
      * @since 1.2
      * @see java.text.DateFormatSymbols#getZoneStrings()
      */
@@ -518,7 +518,7 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * @return {@code true} if the given date is in Daylight Saving Time,
      *         {@code false}, otherwise.
      * @throws NullPointerException This method may throw a
-     * {@code NullPointerException}, if {@code date} is {@code null}
+     * {@code NullPointerException} if {@code date} is {@code null}
      */
     public abstract boolean inDaylightTime(Date date);
 

--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -508,6 +508,7 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * @param date the given Date.
      * @return {@code true} if the given date is in Daylight Saving Time,
      *         {@code false}, otherwise.
+     * @throws NullPointerException if {@code date} is {@code null}
      */
     public abstract boolean inDaylightTime(Date date);
 

--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -508,7 +508,8 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * @param date the given Date.
      * @return {@code true} if the given date is in Daylight Saving Time,
      *         {@code false}, otherwise.
-     * @throws NullPointerException if {@code date} is {@code null}
+     * @throws NullPointerException This method may throw
+     * {@code NullPointerException}, if {@code date} is {@code null}
      */
     public abstract boolean inDaylightTime(Date date);
 

--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -294,6 +294,7 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * Sets the time zone ID. This does not change any other data in
      * the time zone object.
      * @param ID the new time zone ID.
+     * @throws NullPointerException if {@code ID} is {@code null}
      */
     public void setID(String ID)
     {

--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -520,6 +520,7 @@ public abstract class TimeZone implements Serializable, Cloneable {
      *
      * @return the specified {@code TimeZone}, or the GMT zone if the given ID
      * cannot be understood.
+     * @throws NullPointerException if {@code ID} is {@code null}
      */
     public static synchronized TimeZone getTimeZone(String ID) {
         return getTimeZone(ID, true);


### PR DESCRIPTION
When their input is null, the following methods in java.util.TimeZone throw a NullPointerException:

_TimeZone.getTimeZone(String ID)
TimeZone.setID(String ID)
TimeZone.inDaylightTime(Date date)_

For example, 

```
String someID = null;
TimeZone tz1 = TimeZone.getTimeZone(someID);
``` 

throws a `NullPointerException`


This PR adds the missing  _@throws:_ for the mentioned methods. The wording and specification is also adjusted for the overridable methods in TZ to use "_may throw_" over "_will throw_" because of the possibility of external sub-classes that may override the method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8299830](https://bugs.openjdk.org/browse/JDK-8299830) to be approved

### Issues
 * [JDK-8177418](https://bugs.openjdk.org/browse/JDK-8177418): NPE is not apparent for methods in java.util.TimeZone API docs
 * [JDK-8299830](https://bugs.openjdk.org/browse/JDK-8299830): NPE is not apparent for methods in java.util.TimeZone API docs (**CSR**)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [19bd4fae](https://git.openjdk.org/jdk/pull/11888/files/19bd4faee8abae8e95f84c4983f523134b43ec89)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11888/head:pull/11888` \
`$ git checkout pull/11888`

Update a local copy of the PR: \
`$ git checkout pull/11888` \
`$ git pull https://git.openjdk.org/jdk pull/11888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11888`

View PR using the GUI difftool: \
`$ git pr show -t 11888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11888.diff">https://git.openjdk.org/jdk/pull/11888.diff</a>

</details>
