### PR TITLE
8299774: SYNTH_BUTTON_UI_KEY field is unused

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthButtonUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthButtonUI.java
@@ -46,8 +46,6 @@ public class SynthButtonUI extends BasicButtonUI implements
                                  PropertyChangeListener, SynthUI {
     private SynthStyle style;
 
-    private static final Object SYNTH_BUTTON_UI_KEY = new Object();
-
     /**
      * Constructs a {@code SynthButtonUI}.
      */


### PR DESCRIPTION
Added in JDK-8192888, and became unused in JDK-8213843.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299774](https://bugs.openjdk.org/browse/JDK-8299774): SYNTH_BUTTON_UI_KEY field is unused


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11890/head:pull/11890` \
`$ git checkout pull/11890`

Update a local copy of the PR: \
`$ git checkout pull/11890` \
`$ git pull https://git.openjdk.org/jdk pull/11890/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11890`

View PR using the GUI difftool: \
`$ git pr show -t 11890`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11890.diff">https://git.openjdk.org/jdk/pull/11890.diff</a>

</details>
