### PR TITLE
8300166: Unused array allocation in ProcessPath.doProcessPath

### DIFF
--- a/src/java.desktop/share/classes/sun/java2d/loops/ProcessPath.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/ProcessPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1469,7 +1469,6 @@ public class ProcessPath {
         float[] coords = new float[8];
         float[] tCoords = new float[8];
         float[] closeCoord = new float[] {0.0f, 0.0f};
-        float[] firstCoord = new float[2];
         int[] pixelInfo = new int[5];
         boolean subpathStarted = false;
         boolean skip = false;


### PR DESCRIPTION
I don't see this array in `src/java.desktop/share/native/libawt/java2d/loops/ProcessPath.c` too. Seems leftovers from refactoring?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300166](https://bugs.openjdk.org/browse/JDK-8300166): Unused array allocation in ProcessPath.doProcessPath


### Reviewers
 * @SWinxy (no known github.com user name / role)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11894/head:pull/11894` \
`$ git checkout pull/11894`

Update a local copy of the PR: \
`$ git checkout pull/11894` \
`$ git pull https://git.openjdk.org/jdk pull/11894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11894`

View PR using the GUI difftool: \
`$ git pr show -t 11894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11894.diff">https://git.openjdk.org/jdk/pull/11894.diff</a>

</details>
