### PR TITLE
8299772: The ColorModel.getRGBdefault() method is not thread-safe

### DIFF
--- a/src/java.desktop/share/classes/java/awt/image/ColorModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/ColorModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -221,7 +221,6 @@ public abstract class ColorModel implements Transparency{
         loadLibraries();
         initIDs();
     }
-    private static ColorModel RGBdefault;
 
     /**
      * Returns a {@code DirectColorModel} that describes the default
@@ -240,15 +239,13 @@ public abstract class ColorModel implements Transparency{
      *          RGB values.
      */
     public static ColorModel getRGBdefault() {
-        if (RGBdefault == null) {
-            RGBdefault = new DirectColorModel(32,
-                                              0x00ff0000,       // Red
-                                              0x0000ff00,       // Green
-                                              0x000000ff,       // Blue
-                                              0xff000000        // Alpha
-                                              );
+        interface RGBdefault {
+            ColorModel INSTANCE = new DirectColorModel(32, 0x00ff0000,  // Red
+                                                           0x0000ff00,  // Green
+                                                           0x000000ff,  // Blue
+                                                           0xff000000); // Alpha
         }
-        return RGBdefault;
+        return RGBdefault.INSTANCE;
     }
 
     /**

--- a/test/jdk/java/awt/image/ColorModel/RGBdefaultSingleton.java
+++ b/test/jdk/java/awt/image/ColorModel/RGBdefaultSingleton.java
@@ -33,7 +33,7 @@ import java.util.concurrent.CountDownLatch;
  * @summary "ColorModel.getRGBdefault()" should always return the same object
  */
 public final class RGBdefaultSingleton {
-    
+
     private static volatile boolean failed;
     private static final Map<ColorModel, ?> map =
             Collections.synchronizedMap(new IdentityHashMap<>(1));

--- a/test/jdk/java/awt/image/ColorModel/RGBdefaultSingleton.java
+++ b/test/jdk/java/awt/image/ColorModel/RGBdefaultSingleton.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.image.ColorModel;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * @test
+ * @bug 8299772
+ * @summary "ColorModel.getRGBdefault()" should always return the same object
+ */
+public final class RGBdefaultSingleton {
+    
+    private static volatile boolean failed;
+    private static final Map<ColorModel, ?> map =
+            Collections.synchronizedMap(new IdentityHashMap<>(1));
+
+    public static void main(String[] args) throws Exception {
+        Thread[] ts = new Thread[10];
+        CountDownLatch latch = new CountDownLatch(ts.length);
+        for (int i = 0; i < ts.length; i++) {
+            ts[i] = new Thread(() -> {
+                latch.countDown();
+                try {
+                    ColorModel cm;
+                    latch.await();
+                    cm = ColorModel.getRGBdefault();
+                    map.put(cm, null);
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                    failed = true;
+                }
+            });
+        }
+        for (Thread t : ts) {
+            t.start();
+        }
+        for (Thread t : ts) {
+            t.join();
+        }
+        if (failed) {
+            throw new RuntimeException("Unexpected exception");
+        } else if (map.size() != 1) {
+            throw new RuntimeException("The size of the map != 1");
+        }
+    }
+}


### PR DESCRIPTION
The getRGBdefault() was made thread safe via holder implemented as a local interface.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299772](https://bugs.openjdk.org/browse/JDK-8299772): The ColorModel.getRGBdefault() method is not thread-safe


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11895/head:pull/11895` \
`$ git checkout pull/11895`

Update a local copy of the PR: \
`$ git checkout pull/11895` \
`$ git pull https://git.openjdk.org/jdk pull/11895/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11895`

View PR using the GUI difftool: \
`$ git pr show -t 11895`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11895.diff">https://git.openjdk.org/jdk/pull/11895.diff</a>

</details>
