### PR TITLE
8299807: String.newStringUTF8NoRepl and getBytesUTF8NoRepl always copy arrays

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -709,6 +709,8 @@ public final class String
             dp = StringCoding.countPositives(bytes, offset, length);
             int sl = offset + length;
             if (dp == length) {
+                if (offset == 0 && length == bytes.length)
+                    return new String(bytes, LATIN1);
                 return new String(Arrays.copyOfRange(bytes, offset, offset + length), LATIN1);
             }
             dst = new byte[length];
@@ -920,7 +922,12 @@ public final class String
      * Throws iae, instead of replacing, if unmappable.
      */
     static byte[] getBytesUTF8NoRepl(String s) {
-        return encodeUTF8(s.coder(), s.value(), false);
+        byte[] val = s.value();
+        byte coder = s.coder();
+        if (coder == LATIN1 && isASCII(val)) {
+            return val;
+        }
+        return encodeUTF8(coder, val, false);
     }
 
     private static boolean isASCII(byte[] src) {


### PR DESCRIPTION
`JavaLangAccess::newStringUTF8NoRepl` and `JavaLangAccess::getBytesUTF8NoRepl` are not implemented correctly. They always copy arrays, rather than avoiding copying as much as possible as javadoc says.

I ran the tier1 test without any new errors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299807](https://bugs.openjdk.org/browse/JDK-8299807): String.newStringUTF8NoRepl and getBytesUTF8NoRepl always copy arrays


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11897/head:pull/11897` \
`$ git checkout pull/11897`

Update a local copy of the PR: \
`$ git checkout pull/11897` \
`$ git pull https://git.openjdk.org/jdk pull/11897/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11897`

View PR using the GUI difftool: \
`$ git pr show -t 11897`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11897.diff">https://git.openjdk.org/jdk/pull/11897.diff</a>

</details>
