### PR TITLE
8255119: Monitor::wait takes signed integer as timeout

### DIFF
--- a/src/hotspot/os/posix/mutex_posix.hpp
+++ b/src/hotspot/os/posix/mutex_posix.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,7 +133,7 @@ class PlatformMonitor : public PlatformMutex {
   NONCOPYABLE(PlatformMonitor);
 
  public:
-  int wait(jlong millis);
+  int wait(uint64_t millis);
   void notify();
   void notify_all();
 };

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1869,17 +1869,17 @@ PlatformMonitor::~PlatformMonitor() {
 #endif // PLATFORM_MONITOR_IMPL_INDIRECT
 
 // Must already be locked
-int PlatformMonitor::wait(jlong millis) {
-  assert(millis >= 0, "negative timeout");
+int PlatformMonitor::wait(uint64_t millis) {
   if (millis > 0) {
     struct timespec abst;
     // We have to watch for overflow when converting millis to nanos,
     // but if millis is that large then we will end up limiting to
-    // MAX_SECS anyway, so just do that here.
+    // MAX_SECS anyway, so just do that here. This also handles values
+    // larger than int64_t max.
     if (millis / MILLIUNITS > MAX_SECS) {
-      millis = jlong(MAX_SECS) * MILLIUNITS;
+      millis = uint64_t(MAX_SECS) * MILLIUNITS;
     }
-    to_abstime(&abst, millis_to_nanos(millis), false, false);
+    to_abstime(&abst, millis_to_nanos(int64_t(millis)), false, false);
 
     int ret = OS_TIMEOUT;
     int status = pthread_cond_timedwait(cond(), mutex(), &abst);

--- a/src/hotspot/os/windows/mutex_windows.hpp
+++ b/src/hotspot/os/windows/mutex_windows.hpp
@@ -56,7 +56,7 @@ class PlatformMonitor : public PlatformMutex {
  public:
   PlatformMonitor();
   ~PlatformMonitor();
-  int wait(jlong millis);
+  int wait(uint64_t millis);
   void notify();
   void notify_all();
 };

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -5360,11 +5360,12 @@ void Parker::unpark() {
 // Must already be locked
 int PlatformMonitor::wait(uint64_t millis) {
   int ret = OS_TIMEOUT;
+  // The timeout parameter for SleepConditionVariableCS is a DWORD
   if (millis > UINT_MAX) {
     millis = UINT_MAX;
   }
   int status = SleepConditionVariableCS(&_cond, &_mutex,
-                                        millis == 0 ? INFINITE : millis);
+                                        millis == 0 ? INFINITE : (DWORD)millis);
   if (status != 0) {
     ret = OS_OK;
   }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -5358,9 +5358,11 @@ void Parker::unpark() {
 // Platform Monitor implementation
 
 // Must already be locked
-int PlatformMonitor::wait(jlong millis) {
-  assert(millis >= 0, "negative timeout");
+int PlatformMonitor::wait(uint64_t millis) {
   int ret = OS_TIMEOUT;
+  if (millis > UINT_MAX) {
+    millis = UINT_MAX;
+  }
   int status = SleepConditionVariableCS(&_cond, &_mutex,
                                         millis == 0 ? INFINITE : millis);
   if (status != 0) {

--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -209,11 +209,10 @@ void Monitor::notify_all() {
   _lock.notify_all();
 }
 
-bool Monitor::wait_without_safepoint_check(int64_t timeout) {
+// timeout is in milliseconds - with zero meaning never timeout
+bool Monitor::wait_without_safepoint_check(uint64_t timeout) {
   Thread* const self = Thread::current();
 
-  // timeout is in milliseconds - with zero meaning never timeout
-  assert(timeout >= 0, "negative timeout");
   assert_owner(self);
   check_rank(self);
 
@@ -229,13 +228,12 @@ bool Monitor::wait_without_safepoint_check(int64_t timeout) {
   return wait_status != 0;          // return true IFF timeout
 }
 
-bool Monitor::wait(int64_t timeout) {
+// timeout is in milliseconds - with zero meaning never timeout
+bool Monitor::wait(uint64_t timeout) {
   JavaThread* const self = JavaThread::current();
   // Safepoint checking logically implies an active JavaThread.
   assert(self->is_active_Java_thread(), "invariant");
 
-  // timeout is in milliseconds - with zero meaning never timeout
-  assert(timeout >= 0, "negative timeout");
   assert_owner(self);
   check_rank(self);
 

--- a/src/hotspot/share/runtime/mutex.hpp
+++ b/src/hotspot/share/runtime/mutex.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -212,8 +212,8 @@ class Monitor : public Mutex {
   // Wait until monitor is notified (or times out).
   // Defaults are to make safepoint checks, wait time is forever (i.e.,
   // zero). Returns true if wait times out; otherwise returns false.
-  bool wait(int64_t timeout = 0);
-  bool wait_without_safepoint_check(int64_t timeout = 0);
+  bool wait(uint64_t timeout = 0);
+  bool wait_without_safepoint_check(uint64_t timeout = 0);
   void notify();
   void notify_all();
 };


### PR DESCRIPTION
Please review this simple cleanup of the JVM `Monitor`/`PlatformMonitor` code so that timeouts are expressed as unsigned rather than signed values i.e. `int64_t`/`jlong` -> `uint64_t`.

Testing:
 - tiers 1-3
 - all builds in Oracle CI in tiers 1-5, plus shenandoah GC on LInux x64

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8255119](https://bugs.openjdk.org/browse/JDK-8255119): Monitor::wait takes signed integer as timeout


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - Committer) ⚠️ Review applies to [674892df](https://git.openjdk.org/jdk/pull/11898/files/674892df036866f991069bb63ee99a00d77e590e)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [674892df](https://git.openjdk.org/jdk/pull/11898/files/674892df036866f991069bb63ee99a00d77e590e)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [674892df](https://git.openjdk.org/jdk/pull/11898/files/674892df036866f991069bb63ee99a00d77e590e)
 * [Gerard Ziemski](https://openjdk.org/census#gziemski) (@gerard-ziemski - Committer) ⚠️ Review applies to [674892df](https://git.openjdk.org/jdk/pull/11898/files/674892df036866f991069bb63ee99a00d77e590e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11898/head:pull/11898` \
`$ git checkout pull/11898`

Update a local copy of the PR: \
`$ git checkout pull/11898` \
`$ git pull https://git.openjdk.org/jdk pull/11898/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11898`

View PR using the GUI difftool: \
`$ git pr show -t 11898`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11898.diff">https://git.openjdk.org/jdk/pull/11898.diff</a>

</details>
