### PR TITLE
8299789: Compilation of gtest causes build to fail if runtime libraries are in different dirs

### DIFF
--- a/make/hotspot/test/GtestImage.gmk
+++ b/make/hotspot/test/GtestImage.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -41,10 +41,22 @@ ifeq ($(call isTargetOs, windows), true)
   $(foreach v, $(JVM_VARIANTS), \
     $(eval $(call SetupCopyFiles, COPY_GTEST_MSVCR_$v, \
         DEST := $(TEST_IMAGE_DIR)/hotspot/gtest/$v, \
-        FILES := $(MSVCR_DLL) $(VCRUNTIME_1_DLL) $(MSVCP_DLL), \
+        FILES := $(MSVCR_DLL), \
         FLATTEN := true, \
     )) \
     $(eval TARGETS += $$(COPY_GTEST_MSVCR_$v)) \
+    $(eval $(call SetupCopyFiles, COPY_GTEST_VCRUNTIME_1_$v, \
+        DEST := $(TEST_IMAGE_DIR)/hotspot/gtest/$v, \
+        FILES := $(VCRUNTIME_1_DLL), \
+        FLATTEN := true, \
+    )) \
+    $(eval TARGETS += $$(COPY_GTEST_VCRUNTIME_1_$v)) \
+    $(eval $(call SetupCopyFiles, COPY_GTEST_MSVCP_$v, \
+        DEST := $(TEST_IMAGE_DIR)/hotspot/gtest/$v, \
+        FILES := $(MSVCP_DLL), \
+        FLATTEN := true, \
+    )) \
+    $(eval TARGETS += $$(COPY_GTEST_MSVCP_$v)) \
     $(if $(call equals, $(COPY_DEBUG_SYMBOLS), true), \
       $(eval $(call SetupCopyFiles, COPY_GTEST_PDB_$v, \
           SRC := $(HOTSPOT_OUTPUTDIR)/variant-$v/libjvm/gtest, \


### PR DESCRIPTION
The `GtestImage.gmk` is updated to use separate macro calls in case the runtime libraries are not in the same directory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299789](https://bugs.openjdk.org/browse/JDK-8299789): Compilation of gtest causes build to fail if runtime libraries are in different dirs


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11899/head:pull/11899` \
`$ git checkout pull/11899`

Update a local copy of the PR: \
`$ git checkout pull/11899` \
`$ git pull https://git.openjdk.org/jdk pull/11899/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11899`

View PR using the GUI difftool: \
`$ git pr show -t 11899`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11899.diff">https://git.openjdk.org/jdk/pull/11899.diff</a>

</details>
