### PR TITLE
8298321: 2 File Leak defect groups in 2 files

### DIFF
--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -1205,7 +1205,7 @@ static void mmap_attach_shared(int vmid, char** addr, size_t* sizep, TRAPS) {
   FREE_C_HEAP_ARRAY(char, dirname);
   FREE_C_HEAP_ARRAY(char, filename);
 
-  if (fd == OS_ERR || HAS_PENDING_EXCEPTION) {
+  if (fd == OS_ERR) {
     return;
   }
 

--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -1208,6 +1208,7 @@ static void mmap_attach_shared(int vmid, char** addr, size_t* sizep, TRAPS) {
   if (fd == OS_ERR) {
     return;
   }
+  assert(!HAS_PENDING_EXCEPTION, "must be");
 
   size_t size;
   if (*sizep == 0) {

--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -1205,10 +1205,12 @@ static void mmap_attach_shared(int vmid, char** addr, size_t* sizep, TRAPS) {
   FREE_C_HEAP_ARRAY(char, dirname);
   FREE_C_HEAP_ARRAY(char, filename);
 
+  if (HAS_PENDING_EXCEPTION) {
+    assert(fd == OS_ERR, "open_sharedmem_file always return OS_ERR on exceptions");
+  }
   if (fd == OS_ERR) {
     return;
   }
-  assert(!HAS_PENDING_EXCEPTION, "must be");
 
   size_t size;
   if (*sizep == 0) {

--- a/src/hotspot/share/compiler/directivesParser.cpp
+++ b/src/hotspot/share/compiler/directivesParser.cpp
@@ -102,6 +102,7 @@ bool DirectivesParser::parse_from_file_inner(const char* filename, outputStream*
         ::close(file_handle);
         return parse_string(buffer, stream) > 0;
       }
+      ::close(file_handle);
     }
   }
   return false;

--- a/src/hotspot/share/compiler/directivesParser.cpp
+++ b/src/hotspot/share/compiler/directivesParser.cpp
@@ -96,13 +96,11 @@ bool DirectivesParser::parse_from_file_inner(const char* filename, outputStream*
       // read contents into resource array
       char* buffer = NEW_RESOURCE_ARRAY(char, st.st_size+1);
       ssize_t num_read = ::read(file_handle, (char*) buffer, st.st_size);
+      ::close(file_handle);
       if (num_read >= 0) {
         buffer[num_read] = '\0';
-        // close file
-        ::close(file_handle);
         return parse_string(buffer, stream) > 0;
       }
-      ::close(file_handle);
     }
   }
   return false;


### PR DESCRIPTION
Please review this simple change for fixing two file leak warnings: 
1) DirectivesParser::parse_from_file_inner() in open/src/hotspot/share/compiler/directivesParser.cpp 
2) mmap_attach_shared() in open/src/hotspot/os/posix/perfMemory_posix.cpp

Please refer to the [comment](https://bugs.openjdk.org/browse/JDK-8298321?focusedCommentId=14549361&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14549361) in the bug report for details.

Passed tiers 1 and 2 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298321](https://bugs.openjdk.org/browse/JDK-8298321): 2 File Leak defect groups in 2 files


### Reviewers
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**) ⚠️ Review applies to [754a8870](https://git.openjdk.org/jdk/pull/11909/files/754a88706e22a37eb8e88f1af73493dcbff77979)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to [56980b79](https://git.openjdk.org/jdk/pull/11909/files/56980b7929263f18eb5600be3441ea9f64212889)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11909/head:pull/11909` \
`$ git checkout pull/11909`

Update a local copy of the PR: \
`$ git checkout pull/11909` \
`$ git pull https://git.openjdk.org/jdk pull/11909/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11909`

View PR using the GUI difftool: \
`$ git pr show -t 11909`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11909.diff">https://git.openjdk.org/jdk/pull/11909.diff</a>

</details>
