### PR TITLE
8299835: (jrtfs) Unnecessary null check in JrtPath.getAttributes

### DIFF
--- a/src/java.base/share/classes/jdk/internal/jrtfs/JrtPath.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/JrtPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/jrtfs/JrtPath.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/JrtPath.java
@@ -649,11 +649,7 @@ final class JrtPath implements Path {
     }
 
     final JrtFileAttributes getAttributes(LinkOption... options) throws IOException {
-        JrtFileAttributes zfas = jrtfs.getFileAttributes(this, options);
-        if (zfas == null) {
-            throw new NoSuchFileException(toString());
-        }
-        return zfas;
+        return jrtfs.getFileAttributes(this, options);
     }
 
     final void setAttribute(String attribute, Object value, LinkOption... options)


### PR DESCRIPTION
`jdk.internal.jrtfs.JrtFileSystem#getFileAttributes` never return `null`

https://github.com/openjdk/jdk/blob/679e485838881c1364845072af305fb60d95e60a/src/java.base/share/classes/jdk/internal/jrtfs/JrtFileSystem.java#L206-L213
So, no need to check for `null` its result.
Seems it was copied from ZipPath (name of variable suggests that) - https://github.com/openjdk/jdk/blob/master/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipPath.java#L769. But for ZipFileSystem `null` is expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299835](https://bugs.openjdk.org/browse/JDK-8299835): (jrtfs) Unnecessary null check in JrtPath.getAttributes


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [6237726d](https://git.openjdk.org/jdk/pull/11911/files/6237726d1d1826b44ac002b453e2f808aa7286e1)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11911/head:pull/11911` \
`$ git checkout pull/11911`

Update a local copy of the PR: \
`$ git checkout pull/11911` \
`$ git pull https://git.openjdk.org/jdk pull/11911/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11911`

View PR using the GUI difftool: \
`$ git pr show -t 11911`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11911.diff">https://git.openjdk.org/jdk/pull/11911.diff</a>

</details>
