### PR TITLE
8299836: Make `user.timezone` system property searchable

### DIFF
--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -631,7 +631,7 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * time zone.
      *
      * <ul>
-     * <li>Use the {@code user.timezone} property value as the default
+     * <li>Use the {@systemProperty user.timezone} property value as the default
      * time zone ID if it's available.</li>
      * <li>Detect the platform time zone ID. The source of the
      * platform time zone and ID mapping may vary with implementation.</li>

--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -640,7 +640,7 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * </ul>
      *
      * <p>The default {@code TimeZone} created from the ID is cached,
-     * and its clone is returned. The {@systemProperty user.timezone} property
+     * and its clone is returned. The {@code user.timezone} property
      * value is set to the ID upon return.
      *
      * @return the default {@code TimeZone}
@@ -712,7 +712,7 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * Sets the {@code TimeZone} that is returned by the {@code getDefault}
      * method. {@code zone} is cached. If {@code zone} is null, the cached
      * default {@code TimeZone} is cleared. This method doesn't change the value
-     * of the {@systemProperty user.timezone} property.
+     * of the {@code user.timezone} property.
      *
      * @param zone the new default {@code TimeZone}, or null
      * @throws SecurityException if the security manager's {@code checkPermission}

--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -640,7 +640,7 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * </ul>
      *
      * <p>The default {@code TimeZone} created from the ID is cached,
-     * and its clone is returned. The {@code user.timezone} property
+     * and its clone is returned. The {@systemProperty user.timezone} property
      * value is set to the ID upon return.
      *
      * @return the default {@code TimeZone}

--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -712,7 +712,7 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * Sets the {@code TimeZone} that is returned by the {@code getDefault}
      * method. {@code zone} is cached. If {@code zone} is null, the cached
      * default {@code TimeZone} is cleared. This method doesn't change the value
-     * of the {@code user.timezone} property.
+     * of the {@systemProperty user.timezone} property.
      *
      * @param zone the new default {@code TimeZone}, or null
      * @throws SecurityException if the security manager's {@code checkPermission}


### PR DESCRIPTION
The system property _user.timezone_ is specified in the _TimeZone.getDefault()_ and _TimeZone.setDefault()_  methods. The javadoc search box should be able to match on the system property name.

This change replaces the **@code** tag with the **@systemProperty** tag for instances of _user.timezone_ when appropriate.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299836](https://bugs.openjdk.org/browse/JDK-8299836): Make `user.timezone` system property searchable


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11915/head:pull/11915` \
`$ git checkout pull/11915`

Update a local copy of the PR: \
`$ git checkout pull/11915` \
`$ git pull https://git.openjdk.org/jdk pull/11915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11915`

View PR using the GUI difftool: \
`$ git pr show -t 11915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11915.diff">https://git.openjdk.org/jdk/pull/11915.diff</a>

</details>
