### PR TITLE
8297874: get_dump_directory() in jfrEmergencyDump.cpp should pass correct length to jio_snprintf

### DIFF
--- a/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
@@ -78,7 +78,7 @@ static size_t get_dump_directory() {
   }
   const size_t path_len = strlen(_path_buffer);
   const int result = jio_snprintf(_path_buffer + path_len,
-                                  sizeof(_path_buffer),
+                                  sizeof(_path_buffer) - path_len,
                                   "%s",
                                   os::file_separator());
   return (result == -1) ? 0 : strlen(_path_buffer);


### PR DESCRIPTION
Please review this simple fix for correcting the length passing to` jio_snprintf `in the `get_dump_directory()` function in `jfrEmergencyDump.cpp`.

Passed tiers 1 - 4 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297874](https://bugs.openjdk.org/browse/JDK-8297874): get_dump_directory() in jfrEmergencyDump.cpp should pass correct length to jio_snprintf


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11916/head:pull/11916` \
`$ git checkout pull/11916`

Update a local copy of the PR: \
`$ git checkout pull/11916` \
`$ git pull https://git.openjdk.org/jdk pull/11916/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11916`

View PR using the GUI difftool: \
`$ git pr show -t 11916`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11916.diff">https://git.openjdk.org/jdk/pull/11916.diff</a>

</details>
