### PR TITLE
8299845: Remove obsolete comments in DirtyCardToOopClosure::get_actual_top

### DIFF
--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -58,10 +58,6 @@ HeapWord* DirtyCardToOopClosure::get_actual_top(HeapWord* top,
         // Otherwise, it is possible that the object starting on the dirty
         // card spans the entire card, and that the store happened on a
         // later card.  Figure out where the object ends.
-        // Use the block_size() method of the space over which
-        // the iteration is being done.  That space (e.g. CMS) may have
-        // specific requirements on object sizes which will
-        // be reflected in the block_size() method.
         top = top_obj + cast_to_oop(top_obj)->size();
       }
     } else {


### PR DESCRIPTION
Trivial removing stable comments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299845](https://bugs.openjdk.org/browse/JDK-8299845): Remove obsolete comments in DirtyCardToOopClosure::get_actual_top


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)


### Contributors
 * Y. Srinivas Ramakrishna `<ysr@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11918/head:pull/11918` \
`$ git checkout pull/11918`

Update a local copy of the PR: \
`$ git checkout pull/11918` \
`$ git pull https://git.openjdk.org/jdk pull/11918/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11918`

View PR using the GUI difftool: \
`$ git pr show -t 11918`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11918.diff">https://git.openjdk.org/jdk/pull/11918.diff</a>

</details>
