### PR TITLE
8264684: os::get_summary_cpu_info padded with spaces

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1886,6 +1886,10 @@ void os::get_summary_cpu_info(char* buf, size_t buflen) {
     status = RegQueryValueEx(key, "ProcessorNameString", NULL, NULL, (byte*)buf, &size);
     if (status != ERROR_SUCCESS) {
         strncpy(buf, "## __CPU__", buflen);
+    } else {
+      if (size < buflen) {
+        buf[size] = '\0';
+      }
     }
     RegCloseKey(key);
   } else {


### PR DESCRIPTION
### Description
Issue: There are some padded spaces in Host info strings in JVM's outputs on Windows platforms.
Reason: 
In Windows, the strings read from Registry entries may be shorter than the buffer given to the API to fill in. In these cases, the actual size is written to the `size` parameter by the API. 

### Patch
The given buffer is null terminated at the position of the returned `size`, if it is not longer than the buffer length.

### Tests
local: linux-x64 some tests that crashed and wrote the Host info using the changed code.
mach5: tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8264684](https://bugs.openjdk.org/browse/JDK-8264684): os::get_summary_cpu_info padded with spaces


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11920/head:pull/11920` \
`$ git checkout pull/11920`

Update a local copy of the PR: \
`$ git checkout pull/11920` \
`$ git pull https://git.openjdk.org/jdk pull/11920/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11920`

View PR using the GUI difftool: \
`$ git pr show -t 11920`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11920.diff">https://git.openjdk.org/jdk/pull/11920.diff</a>

</details>
