### PR TITLE
8299844: RISC-V: Implement _onSpinWait intrinsic

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 1997, 2012, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/riscv/assembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 1997, 2012, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -682,14 +682,18 @@ public:
     unsigned insn = 0;
     guarantee(predecessor < 16, "predecessor is invalid");
     guarantee(successor < 16, "successor is invalid");
-    patch((address)&insn, 6, 0, 0b001111);
-    patch((address)&insn, 11, 7, 0b00000);
+    patch((address)&insn, 6, 0, 0b001111);      // opcode
+    patch((address)&insn, 11, 7, 0b00000);      // rd
     patch((address)&insn, 14, 12, 0b000);
-    patch((address)&insn, 19, 15, 0b00000);
-    patch((address)&insn, 23, 20, successor);
-    patch((address)&insn, 27, 24, predecessor);
-    patch((address)&insn, 31, 28, 0b0000);
+    patch((address)&insn, 19, 15, 0b00000);     // rs1
+    patch((address)&insn, 23, 20, successor);   // succ
+    patch((address)&insn, 27, 24, predecessor); // pred
+    patch((address)&insn, 31, 28, 0b0000);      // fm
     emit(insn);
+  }
+
+  void pause() {
+    fence(w, 0);
   }
 
 #define INSN(NAME, op, funct3, funct7)                      \

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -690,10 +690,6 @@ public:
     patch((address)&insn, 27, 24, predecessor); // pred
     patch((address)&insn, 31, 28, 0b0000);      // fm
     emit(insn);
-  }
-
-  void pause() {
-    fence(w, 0);
   }
 
 #define INSN(NAME, op, funct3, funct7)                      \

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -1924,7 +1924,7 @@ void LIR_Assembler::membar_loadstore() { __ membar(MacroAssembler::LoadStore); }
 void LIR_Assembler::membar_storeload() { __ membar(MacroAssembler::StoreLoad); }
 
 void LIR_Assembler::on_spin_wait() {
-  Unimplemented();
+  __ pause();
 }
 
 void LIR_Assembler::get_thread(LIR_Opr result_reg) {

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -108,6 +108,8 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, UseZicbom, false, EXPERIMENTAL, "Use Zicbom instructions")       \
   product(bool, UseZicbop, false, EXPERIMENTAL, "Use Zicbop instructions")       \
   product(bool, UseZicboz, false, EXPERIMENTAL, "Use Zicboz instructions")       \
+  product(bool, UseZihintpause, false, EXPERIMENTAL,                             \
+          "Use Zihintpause instructions")                                        \
   product(bool, UseRVVForBigIntegerShiftIntrinsics, true,                        \
           "Use RVV instructions for left/right shift of BigInteger")
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -362,6 +362,10 @@ class MacroAssembler: public Assembler {
 
   static int pred_succ_to_membar_mask(uint32_t predecessor, uint32_t successor) {
     return ((predecessor & 0x3) << 2) | (successor & 0x3);
+  }
+
+  void pause() {
+    fence(w, 0);
   }
 
   // prints msg, dumps registers and stops execution

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -949,6 +949,7 @@ definitions %{
   int_def FDIV_COST            ( 2000, 20 * DEFAULT_COST);          // fdiv
   int_def FSQRT_COST           ( 2500, 25 * DEFAULT_COST);          // fsqrt
   int_def VOLATILE_REF_COST    ( 1000, 10 * DEFAULT_COST);
+  int_def CACHE_MISS_COST      ( 2000, 20 * DEFAULT_COST);          // typicall cache miss penalty
 %}
 
 
@@ -1815,6 +1816,8 @@ const bool Matcher::match_rule_supported(int opcode) {
   }
 
   switch (opcode) {
+    case Op_OnSpinWait:
+      return VM_Version::supports_on_spin_wait();
     case Op_CacheWB:           // fall through
     case Op_CacheWBPreSync:    // fall through
     case Op_CacheWBPostSync:
@@ -7865,6 +7868,20 @@ instruct membar_volatile() %{
   ins_encode %{
     __ block_comment("membar_volatile");
     __ membar(MacroAssembler::StoreLoad);
+  %}
+
+  ins_pipe(pipe_serial);
+%}
+
+instruct spin_wait() %{
+  predicate(UseZihintpause);
+  match(OnSpinWait);
+  ins_cost(CACHE_MISS_COST);
+
+  format %{ "spin_wait" %}
+
+  ins_encode %{
+    __ pause();
   %}
 
   ins_pipe(pipe_serial);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1,7 +1,7 @@
 //
 // Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
 // Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
-// Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
+// Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -77,6 +77,9 @@ void VM_Version::initialize() {
     if (FLAG_IS_DEFAULT(UseZfhmin)) {
       FLAG_SET_DEFAULT(UseZfhmin, true);
     }
+    if (FLAG_IS_DEFAULT(UseZihintpause)) {
+      FLAG_SET_DEFAULT(UseZihintpause, true);
+    }
   }
 
   if (UseZic64b) {

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -61,6 +61,8 @@ public:
 
   constexpr static bool supports_stack_watermark_barrier() { return true; }
 
+  static bool supports_on_spin_wait() { return UseZihintpause; }
+
   enum Feature_Flag {
 #define CPU_FEATURE_FLAGS(decl)               \
     decl(I,            "i",            8)     \

--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitRISCV64.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitRISCV64.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * Copyright (c) 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitRISCV64.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitRISCV64.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test TestOnSpinWaitRISCV64
+ * @summary Checks that java.lang.Thread.onSpinWait is intrinsified with instructions
+ * @library /test/lib
+ *
+ * @requires vm.flagless
+ * @requires os.arch=="riscv64"
+ *
+ * @run driver compiler.onSpinWait.TestOnSpinWaitRISCV64 c1
+ * @run driver compiler.onSpinWait.TestOnSpinWaitRISCV64 c2
+ */
+
+package compiler.onSpinWait;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.ListIterator;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestOnSpinWaitRISCV64 {
+    public static void main(String[] args) throws Exception {
+        String compiler = args[0];
+        ArrayList<String> command = new ArrayList<String>();
+        command.add("-XX:+IgnoreUnrecognizedVMOptions");
+        command.add("-showversion");
+        command.add("-XX:+UnlockDiagnosticVMOptions");
+        command.add("-XX:+PrintCompilation");
+        command.add("-XX:+PrintInlining");
+        command.add("-XX:+UnlockExperimentalVMOptions");
+        command.add("-XX:+UseZihintpause");
+        if (compiler.equals("c2")) {
+            command.add("-XX:-TieredCompilation");
+        } else if (compiler.equals("c1")) {
+            command.add("-XX:+TieredCompilation");
+            command.add("-XX:TieredStopAtLevel=1");
+        } else {
+            throw new RuntimeException("Unknown compiler: " + compiler);
+        }
+        command.add("-Xbatch");
+        command.add(Launcher.class.getName());
+
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(command);
+
+        OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
+
+        analyzer.shouldHaveExitValue(0);
+
+        if (compiler.equals("c2")) {
+            analyzer.shouldContain("java.lang.Thread::onSpinWait (1 bytes)   (intrinsic)");
+        } else {
+	    analyzer.shouldContain("java.lang.Thread::onSpinWait (1 bytes)   intrinsic");
+	}
+    }
+
+    static class Launcher {
+        public static void main(final String[] args) throws Exception {
+            int end = 20_000;
+
+            for (int i=0; i < end; i++) {
+                test();
+            }
+        }
+        static void test() {
+            java.lang.Thread.onSpinWait();
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitRISCV64.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitRISCV64.java
@@ -72,8 +72,8 @@ public class TestOnSpinWaitRISCV64 {
         if (compiler.equals("c2")) {
             analyzer.shouldContain("java.lang.Thread::onSpinWait (1 bytes)   (intrinsic)");
         } else {
-	    analyzer.shouldContain("java.lang.Thread::onSpinWait (1 bytes)   intrinsic");
-	}
+            analyzer.shouldContain("java.lang.Thread::onSpinWait (1 bytes)   intrinsic");
+        }
     }
 
     static class Launcher {


### PR DESCRIPTION
Implement _onSpinWait() intrinsic for RISC-V, and it can be implemented by using PAUSE instruction from Zihintpause Extension, which is ratified and a mandatory extension of RVA22U64 (https://github.com/riscv/riscv-profiles/blob/main/profiles.adoc#rva22u64-mandatory-extensions).
Software can use the PAUSE instruction to reduce energy consumption while executing spinwait
code sequences (https://github.com/riscv/riscv-isa-manual/blob/master/src/zihintpause.tex).

Add a test case of test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitRISCV64.java, passed on QEMU.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299844](https://bugs.openjdk.org/browse/JDK-8299844): RISC-V: Implement _onSpinWait intrinsic


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11921/head:pull/11921` \
`$ git checkout pull/11921`

Update a local copy of the PR: \
`$ git checkout pull/11921` \
`$ git pull https://git.openjdk.org/jdk pull/11921/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11921`

View PR using the GUI difftool: \
`$ git pr show -t 11921`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11921.diff">https://git.openjdk.org/jdk/pull/11921.diff</a>

</details>
