### PR TITLE
8300111: Add rpath for common lib locations for jpackageapplauncher

### DIFF
--- a/make/modules/jdk.jpackage/Lib.gmk
+++ b/make/modules/jdk.jpackage/Lib.gmk
@@ -73,7 +73,7 @@ $(eval $(call SetupJdkExecutable, BUILD_JPACKAGE_APPLAUNCHEREXE, \
     CXXFLAGS_windows := $(JPACKAGE_CXXFLAGS_windows), \
     CFLAGS_windows := $(JPACKAGE_CFLAGS_windows), \
     LDFLAGS := $(LDFLAGS_JDKEXE), \
-    LIBS_macosx := $(LIBCXX) -framework Cocoa, \
+    LIBS_macosx := $(LIBCXX) -framework Cocoa  -rpath @executable_path/../Frameworks/ -rpath @executable_path/../PlugIns/, \
     LIBS_windows := $(LIBCXX) user32.lib ole32.lib msi.lib shlwapi.lib \
         Shell32.lib, \
     LIBS_linux := -ldl, \


### PR DESCRIPTION
This patch adds the `-headerpad_max_install_names` linker argument to the build of the `jpackageapplauncher` binary (osx only)

Adding this argument allows the user to use the `install_name_tool` to add search paths for the dynamic linker to the launcher binary. This is required for certain use cases where a native library loads other dynamic native libraries via `dlopen`.

The change has been successfully tested on osx on aarch64:
```
make jdk.jpackage
install_name_tool -add_rpath @executable_path/../Frameworks/ jpackageapplauncher
otool -l jpackageapplauncher

Load command 19
          cmd LC_RPATH
      cmdsize 48
         path @executable_path/../Frameworks/ (offset 12)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8300111](https://bugs.openjdk.org/browse/JDK-8300111): Add rpath for common lib locations for jpackageapplauncher


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11922/head:pull/11922` \
`$ git checkout pull/11922`

Update a local copy of the PR: \
`$ git checkout pull/11922` \
`$ git pull https://git.openjdk.org/jdk pull/11922/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11922`

View PR using the GUI difftool: \
`$ git pr show -t 11922`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11922.diff">https://git.openjdk.org/jdk/pull/11922.diff</a>

</details>
