### PR TITLE
8299853: Serial: Use more concrete type for TenuredGeneration::_the_space

### DIFF
--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -486,7 +486,7 @@ void TenuredGeneration::object_iterate(ObjectClosure* blk) {
 
 void TenuredGeneration::complete_loaded_archive_space(MemRegion archive_space) {
   // Create the BOT for the archive space.
-  TenuredSpace* space = (TenuredSpace*)_the_space;
+  TenuredSpace* space = _the_space;
   space->initialize_threshold();
   HeapWord* start = archive_space.start();
   while (start < archive_space.end()) {

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -65,13 +65,13 @@ class TenuredGeneration: public Generation {
 
   void assert_correct_size_change_locking();
 
-  ContiguousSpace*    _the_space;       // Actual space holding objects
+  TenuredSpace*    _the_space;       // Actual space holding objects
 
   GenerationCounters* _gen_counters;
   CSpaceCounters*     _space_counters;
 
   // Accessing spaces
-  ContiguousSpace* space() const { return _the_space; }
+  TenuredSpace* space() const { return _the_space; }
 
   // Attempt to expand the generation by "bytes".  Expand by at a
   // minimum "expand_bytes".  Return true if some amount (not

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -65,7 +65,7 @@ class TenuredGeneration: public Generation {
 
   void assert_correct_size_change_locking();
 
-  TenuredSpace*    _the_space;       // Actual space holding objects
+  TenuredSpace*       _the_space;       // Actual space holding objects
 
   GenerationCounters* _gen_counters;
   CSpaceCounters*     _space_counters;

--- a/src/hotspot/share/gc/serial/vmStructs_serial.hpp
+++ b/src/hotspot/share/gc/serial/vmStructs_serial.hpp
@@ -37,7 +37,7 @@
   nonstatic_field(TenuredGeneration,           _capacity_at_prologue,  size_t)                  \
   nonstatic_field(TenuredGeneration,           _used_at_prologue,      size_t)                  \
   nonstatic_field(TenuredGeneration,           _min_heap_delta_bytes,  size_t)                  \
-  nonstatic_field(TenuredGeneration,           _the_space,             ContiguousSpace*)        \
+  nonstatic_field(TenuredGeneration,           _the_space,             TenuredSpace*)           \
                                                                                                 \
   nonstatic_field(DefNewGeneration,            _old_gen,               Generation*)             \
   nonstatic_field(DefNewGeneration,            _tenuring_threshold,    uint)                    \

--- a/src/hotspot/share/gc/shared/cardTableRS.cpp
+++ b/src/hotspot/share/gc/shared/cardTableRS.cpp
@@ -111,7 +111,7 @@ void ClearNoncleanCardWrapper::do_MemRegion(MemRegion mr) {
   }
 }
 
-void CardTableRS::younger_refs_in_space_iterate(ContiguousSpace* sp,
+void CardTableRS::younger_refs_in_space_iterate(TenuredSpace* sp,
                                                 HeapWord* gen_boundary,
                                                 OopIterateClosure* cl) {
   verify_used_region_at_save_marks(sp);
@@ -440,7 +440,7 @@ void CardTableRS::initialize() {
   CardTable::initialize();
 }
 
-void CardTableRS::non_clean_card_iterate(ContiguousSpace* sp,
+void CardTableRS::non_clean_card_iterate(TenuredSpace* sp,
                                          HeapWord* gen_boundary,
                                          MemRegion mr,
                                          OopIterateClosure* cl,

--- a/src/hotspot/share/gc/shared/cardTableRS.hpp
+++ b/src/hotspot/share/gc/shared/cardTableRS.hpp
@@ -29,10 +29,10 @@
 #include "memory/memRegion.hpp"
 #include "oops/oop.hpp"
 
-class ContiguousSpace;
 class DirtyCardToOopClosure;
 class Generation;
 class Space;
+class TenuredSpace;
 // This RemSet uses a card table both as shared data structure
 // for a mod ref barrier set and for the rem set information.
 
@@ -47,7 +47,7 @@ class CardTableRS : public CardTable {
 public:
   CardTableRS(MemRegion whole_heap);
 
-  void younger_refs_in_space_iterate(ContiguousSpace* sp, HeapWord* gen_boundary, OopIterateClosure* cl);
+  void younger_refs_in_space_iterate(TenuredSpace* sp, HeapWord* gen_boundary, OopIterateClosure* cl);
 
   virtual void verify_used_region_at_save_marks(Space* sp) const NOT_DEBUG_RETURN;
 
@@ -70,7 +70,7 @@ public:
   // Iterate over the portion of the card-table which covers the given
   // region mr in the given space and apply cl to any dirty sub-regions
   // of mr. Clears the dirty cards as they are processed.
-  void non_clean_card_iterate(ContiguousSpace* sp,
+  void non_clean_card_iterate(TenuredSpace* sp,
                               HeapWord* gen_boundary,
                               MemRegion mr,
                               OopIterateClosure* cl,

--- a/src/hotspot/share/gc/shared/cardTableRS.hpp
+++ b/src/hotspot/share/gc/shared/cardTableRS.hpp
@@ -33,6 +33,7 @@ class DirtyCardToOopClosure;
 class Generation;
 class Space;
 class TenuredSpace;
+
 // This RemSet uses a card table both as shared data structure
 // for a mod ref barrier set and for the rem set information.
 

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbField.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbField.java
@@ -56,7 +56,7 @@ public class ClhsdbField {
                 "field InstanceKlass _constants ConstantPool*",
                 "field Klass _name Symbol*",
                 "field JavaThread _osthread OSThread*",
-                "field TenuredGeneration _the_space ContiguousSpace*",
+                "field TenuredGeneration _the_space TenuredSpace*",
                 "field VirtualSpace _low_boundary char*",
                 "field MethodCounters _backedge_counter InvocationCounter",
                 "field nmethod _entry_bci int",


### PR DESCRIPTION
Simple change of using the actual type for a field.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299853](https://bugs.openjdk.org/browse/JDK-8299853): Serial: Use more concrete type for TenuredGeneration::_the_space


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [f2356ce3](https://git.openjdk.org/jdk/pull/11925/files/f2356ce3cefb09c3f3007b69c3f05492fb4cae00)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to [f2356ce3](https://git.openjdk.org/jdk/pull/11925/files/f2356ce3cefb09c3f3007b69c3f05492fb4cae00)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11925/head:pull/11925` \
`$ git checkout pull/11925`

Update a local copy of the PR: \
`$ git checkout pull/11925` \
`$ git pull https://git.openjdk.org/jdk pull/11925/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11925`

View PR using the GUI difftool: \
`$ git pr show -t 11925`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11925.diff">https://git.openjdk.org/jdk/pull/11925.diff</a>

</details>
