### PR TITLE
8299829: In jshell, the output of "0".repeat(49999)+"2" ends with a '0'

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/ExecutionControlForwarder.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/ExecutionControlForwarder.java
@@ -57,6 +57,10 @@ class ExecutionControlForwarder {
      */
     private static final int MAX_UTF_CHARS = 21844;
 
+    private static final int TRUNCATE_END = MAX_UTF_CHARS / 3;
+    private static final String TRUNCATE_JOIN = " ... ";
+    private static final int TRUNCATE_START = MAX_UTF_CHARS - TRUNCATE_JOIN.length() - TRUNCATE_END;
+
     private final ExecutionControl ec;
     private final ObjectInput in;
     private final ObjectOutput out;
@@ -108,7 +112,7 @@ class ExecutionControlForwarder {
             s = "";
         } else if (s.length() > MAX_UTF_CHARS) {
             // Truncate extremely long strings to prevent writeUTF from crashing the VM
-            s = s.substring(0, MAX_UTF_CHARS);
+            s = s.substring(0, TRUNCATE_START) + TRUNCATE_JOIN + s.substring(s.length() - TRUNCATE_END);
         }
         out.writeUTF(s);
     }

--- a/test/langtools/jdk/jshell/ToolFormatTest.java
+++ b/test/langtools/jdk/jshell/ToolFormatTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8148316 8148317 8151755 8152246 8153551 8154812 8157261 8163840 8166637 8161969 8173007
+ * @bug 8148316 8148317 8151755 8152246 8153551 8154812 8157261 8163840 8166637 8161969 8173007 8299829
  * @summary Tests for output customization
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -300,7 +300,8 @@ public class ToolFormatTest extends ReplToolTesting {
                     (a) -> assertCommand(a, "/var", "|    String s = \"ABACABADA"),
                     (a) -> assertCommand(a, "String r = s", "String:\"ABACABAD ... BAXYZ\""),
                     (a) -> assertCommand(a, "r", "String:\"ABACABADA"),
-                    (a) -> assertCommand(a, "r=s", "String:\"AB")
+                    (a) -> assertCommand(a, "r=s", "String:\"AB"),
+                    (a) -> assertCommand(a, "\"0\".repeat(49999)+\"2\"", "String:\"00000000 ... 00002\"")
             );
         } finally {
             assertCommandCheckOutput(false, "/set feedback normal", s -> {


### PR DESCRIPTION
"0".repeat(49999)+"2" correctly evaluates to a string with a terminating '2'. 
However, jshell outputs it with a terminating '0'.

Jshell provides double truncation of long Strings. 
One is performed in jdk.jshell.execution.ExecutionControlForwarder to fit into MAX_UTF_CHARS = 21844 (which is exactly the point where "2" disappears). 
Second truncation is performed in jdk.internal.jshell.tool.Feedback to fit presentation requirements. 
While ExecutionControlForwarder truncates right part of the String, Feedback truncated inner part in 2/3 and joins the parts with " ... ". 

Proposed patch fixes ExecutionControlForwarder to truncate long Strings the same way as Feedback, so the right part of any long String won't disappear and double or repeated truncation provides consistent results.

Please review :)

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299829](https://bugs.openjdk.org/browse/JDK-8299829): In jshell, the output of "0".repeat(49999)+"2" ends with a '0'


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11927/head:pull/11927` \
`$ git checkout pull/11927`

Update a local copy of the PR: \
`$ git checkout pull/11927` \
`$ git pull https://git.openjdk.org/jdk pull/11927/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11927`

View PR using the GUI difftool: \
`$ git pr show -t 11927`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11927.diff">https://git.openjdk.org/jdk/pull/11927.diff</a>

</details>
