### PR TITLE
8284825: sun/java2d/DirectX/MultiPaintEventTest/MultiPaintEventTest.java failed with "RuntimeException: Processed unnecessary paint()."

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -222,7 +222,6 @@ java/awt/image/DrawImage/IncorrectAlphaSurface2SW.java 8056077 linux-all
 java/awt/print/Headless/HeadlessPrinterJob.java 8196088 windows-all
 sun/awt/datatransfer/SuplementaryCharactersTransferTest.java 8011371 generic-all
 sun/awt/shell/ShellFolderMemoryLeak.java 8197794 windows-all
-sun/java2d/DirectX/MultiPaintEventTest/MultiPaintEventTest.java 8284825 windows-all
 sun/java2d/DirectX/OverriddenInsetsTest/OverriddenInsetsTest.java 8196102 generic-all
 sun/java2d/DirectX/RenderingToCachedGraphicsTest/RenderingToCachedGraphicsTest.java 8196180 windows-all,macosx-all
 sun/java2d/SunGraphics2D/EmptyClipRenderingTest.java 8144029 macosx-all,linux-all


### PR DESCRIPTION
Now that [commit](https://git.openjdk.org/jdk/commit/4072412c1fd1e28febff71c6b37a9813f22bdc4b)
has reverted [JDK-8275715](https://bugs.openjdk.org/browse/JDK-8275715)  along with the test
there's no need of keeping the non-existent test problemlisted, which we can remove

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284825](https://bugs.openjdk.org/browse/JDK-8284825): sun/java2d/DirectX/MultiPaintEventTest/MultiPaintEventTest.java failed with "RuntimeException: Processed unnecessary paint()."


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11933/head:pull/11933` \
`$ git checkout pull/11933`

Update a local copy of the PR: \
`$ git checkout pull/11933` \
`$ git pull https://git.openjdk.org/jdk pull/11933/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11933`

View PR using the GUI difftool: \
`$ git pr show -t 11933`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11933.diff">https://git.openjdk.org/jdk/pull/11933.diff</a>

</details>
