### PR TITLE
8297877: jfr functions should check JavaValue result before use

### DIFF
--- a/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
+++ b/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
@@ -244,6 +244,7 @@ void JfrDCmd::print_help(const char* name) const {
   JavaValue result(T_OBJECT);
   JfrJavaArguments printHelp(&result, javaClass(), "printHelp", signature, thread);
   invoke(printHelp, thread);
+  assert(result.get_type() == T_OBJECT, "just checking");
   handle_dcmd_result(output(), result.get_oop(), DCmd_Source_MBean, thread);
 }
 

--- a/src/hotspot/share/jfr/jni/jfrJavaSupport.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJavaSupport.cpp
@@ -486,18 +486,20 @@ void JfrJavaSupport::get_field_local_ref(JfrJavaArguments* args, TRAPS) {
   }
 }
 
-void JfrJavaSupport::get_field_global_ref(JfrJavaArguments* args, TRAPS) {
+bool JfrJavaSupport::get_field_global_ref(JfrJavaArguments* args, TRAPS) {
   assert(args != NULL, "invariant");
   DEBUG_ONLY(check_java_thread_in_vm(THREAD));
 
   JavaValue* const result = args->result();
   assert(result != NULL, "invariant");
   assert(result->get_type() == T_OBJECT, "invariant");
-  read_field(args, result, CHECK);
+  read_field(args, result, CHECK_(false));
   const oop obj = result->get_oop();
   if (obj != NULL) {
     result->set_jobject(global_jni_handle(obj, THREAD));
+    return true;
   }
+  return false;
 }
 
 /*

--- a/src/hotspot/share/jfr/jni/jfrJavaSupport.hpp
+++ b/src/hotspot/share/jfr/jni/jfrJavaSupport.hpp
@@ -62,7 +62,7 @@ class JfrJavaSupport : public AllStatic {
 
   // global jni handle result
   static void new_object_global_ref(JfrJavaArguments* args, TRAPS);
-  static void get_field_global_ref(JfrJavaArguments* args, TRAPS);
+  static bool get_field_global_ref(JfrJavaArguments* args, TRAPS);
 
   // local jni handle result
   static void new_object_local_ref(JfrJavaArguments* args, TRAPS);

--- a/src/hotspot/share/jfr/recorder/repository/jfrChunkRotation.cpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrChunkRotation.cpp
@@ -42,8 +42,10 @@ static jobject install_chunk_monitor(JavaThread* thread) {
   static const char signature[] = "Ljava/lang/Object;";
   JavaValue result(T_OBJECT);
   JfrJavaArguments field_args(&result, klass, field, signature, thread);
-  JfrJavaSupport::get_field_global_ref(&field_args, thread);
-  chunk_monitor = result.get_jobject();
+  bool success = JfrJavaSupport::get_field_global_ref(&field_args, thread);
+  if (success) {
+    chunk_monitor = result.get_jobject();
+  }
   return chunk_monitor;
 }
 


### PR DESCRIPTION
Please review this changeset including:
1) change `JfrJavaSupport::get_field_global_ref()` to return a `bool` so that in `install_chunk_monitor()` in `jfrChunkRotation.cpp`, it checks the return status before doing `result.get_jobject()`.
2) add an `assert` in `JfrDCmd::print_help()` to make sure the `result` is of `T_OBJECT` type.

Passed tiers 1 - 4 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297877](https://bugs.openjdk.org/browse/JDK-8297877): jfr functions should check JavaValue result before use


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11934/head:pull/11934` \
`$ git checkout pull/11934`

Update a local copy of the PR: \
`$ git checkout pull/11934` \
`$ git pull https://git.openjdk.org/jdk pull/11934/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11934`

View PR using the GUI difftool: \
`$ git pr show -t 11934`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11934.diff">https://git.openjdk.org/jdk/pull/11934.diff</a>

</details>
