### PR TITLE
8299879: CollectedHeap hierarchy should use override

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilonHeap.hpp
+++ b/src/hotspot/share/gc/epsilon/epsilonHeap.hpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, 2022, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -56,89 +57,89 @@ public:
           _memory_manager("Epsilon Heap", ""),
           _space(NULL) {};
 
-  virtual Name kind() const {
+  Name kind() const override {
     return CollectedHeap::Epsilon;
   }
 
-  virtual const char* name() const {
+  const char* name() const override {
     return "Epsilon";
   }
 
-  virtual SoftRefPolicy* soft_ref_policy() {
+  SoftRefPolicy* soft_ref_policy() override {
     return &_soft_ref_policy;
   }
 
-  virtual jint initialize();
-  virtual void initialize_serviceability();
+  jint initialize() override;
+  void initialize_serviceability() override;
 
-  virtual GrowableArray<GCMemoryManager*> memory_managers();
-  virtual GrowableArray<MemoryPool*> memory_pools();
+  GrowableArray<GCMemoryManager*> memory_managers() override;
+  GrowableArray<MemoryPool*> memory_pools() override;
 
-  virtual size_t max_capacity() const { return _virtual_space.reserved_size();  }
-  virtual size_t capacity()     const { return _virtual_space.committed_size(); }
-  virtual size_t used()         const { return _space->used(); }
+  size_t max_capacity() const override { return _virtual_space.reserved_size();  }
+  size_t capacity()     const override { return _virtual_space.committed_size(); }
+  size_t used()         const override { return _space->used(); }
 
-  virtual bool is_in(const void* p) const {
+  bool is_in(const void* p) const override {
     return _space->is_in(p);
   }
 
-  virtual bool requires_barriers(stackChunkOop obj) const { return false; }
+  bool requires_barriers(stackChunkOop obj) const override { return false; }
 
-  virtual bool is_maximal_no_gc() const {
+  bool is_maximal_no_gc() const override {
     // No GC is going to happen. Return "we are at max", when we are about to fail.
     return used() == capacity();
   }
 
   // Allocation
   HeapWord* allocate_work(size_t size, bool verbose = true);
-  virtual HeapWord* mem_allocate(size_t size, bool* gc_overhead_limit_was_exceeded);
-  virtual HeapWord* allocate_new_tlab(size_t min_size,
-                                      size_t requested_size,
-                                      size_t* actual_size);
+  HeapWord* mem_allocate(size_t size, bool* gc_overhead_limit_was_exceeded) override;
+  HeapWord* allocate_new_tlab(size_t min_size,
+                              size_t requested_size,
+                              size_t* actual_size) override;
 
   // TLAB allocation
-  virtual size_t tlab_capacity(Thread* thr)         const { return capacity();     }
-  virtual size_t tlab_used(Thread* thr)             const { return used();         }
-  virtual size_t max_tlab_size()                    const { return _max_tlab_size; }
-  virtual size_t unsafe_max_tlab_alloc(Thread* thr) const;
+  size_t tlab_capacity(Thread* thr)         const override { return capacity();     }
+  size_t tlab_used(Thread* thr)             const override { return used();         }
+  size_t max_tlab_size()                    const override { return _max_tlab_size; }
+  size_t unsafe_max_tlab_alloc(Thread* thr) const override;
 
-  virtual void collect(GCCause::Cause cause);
-  virtual void do_full_collection(bool clear_all_soft_refs);
+  void collect(GCCause::Cause cause) override;
+  void do_full_collection(bool clear_all_soft_refs) override;
 
   // Heap walking support
-  virtual void object_iterate(ObjectClosure* cl);
+  void object_iterate(ObjectClosure* cl) override;
 
   // Object pinning support: every object is implicitly pinned
-  virtual bool supports_object_pinning() const           { return true; }
-  virtual oop pin_object(JavaThread* thread, oop obj)    { return obj; }
-  virtual void unpin_object(JavaThread* thread, oop obj) { }
+  bool supports_object_pinning() const           override { return true; }
+  oop pin_object(JavaThread* thread, oop obj)    override { return obj; }
+  void unpin_object(JavaThread* thread, oop obj) override { }
 
   // No support for block parsing.
   HeapWord* block_start(const void* addr) const { return NULL;  }
   bool block_is_obj(const HeapWord* addr) const { return false; }
 
   // No GC threads
-  virtual void gc_threads_do(ThreadClosure* tc) const {}
+  void gc_threads_do(ThreadClosure* tc) const override {}
 
   // No nmethod handling
-  virtual void register_nmethod(nmethod* nm) {}
-  virtual void unregister_nmethod(nmethod* nm) {}
-  virtual void verify_nmethod(nmethod* nm) {}
+  void register_nmethod(nmethod* nm) override {}
+  void unregister_nmethod(nmethod* nm) override {}
+  void verify_nmethod(nmethod* nm) override {}
 
   // No heap verification
-  virtual void prepare_for_verify() {}
-  virtual void verify(VerifyOption option) {}
+  void prepare_for_verify() override {}
+  void verify(VerifyOption option) override {}
 
   MemRegion reserved_region() const { return _reserved; }
   bool is_in_reserved(const void* addr) const { return _reserved.contains(addr); }
 
   // Support for loading objects from CDS archive into the heap
-  virtual bool can_load_archived_objects() const { return UseCompressedOops; }
-  virtual HeapWord* allocate_loaded_archive_space(size_t size);
+  bool can_load_archived_objects() const override { return UseCompressedOops; }
+  HeapWord* allocate_loaded_archive_space(size_t size) override;
 
-  virtual void print_on(outputStream* st) const;
-  virtual void print_tracing_info() const;
-  virtual bool print_location(outputStream* st, void* addr) const;
+  void print_on(outputStream* st) const override;
+  void print_tracing_info() const override;
+  bool print_location(outputStream* st, void* addr) const override;
 
 private:
   void print_heap_info(size_t used) const;

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,17 +93,17 @@ class ParallelScavengeHeap : public CollectedHeap {
 
   WorkerThreads _workers;
 
-  virtual void initialize_serviceability();
+  void initialize_serviceability() override;
 
   void trace_actual_reserved_page_size(const size_t reserved_heap_size, const ReservedSpace rs);
-  void trace_heap(GCWhen::Type when, const GCTracer* tracer);
+  void trace_heap(GCWhen::Type when, const GCTracer* tracer) override;
 
   // Allocate in oldgen and record the allocation with the size_policy.
   HeapWord* allocate_old_gen_and_record(size_t word_size);
 
  protected:
   static inline size_t total_invocations();
-  HeapWord* allocate_new_tlab(size_t min_size, size_t requested_size, size_t* actual_size);
+  HeapWord* allocate_new_tlab(size_t min_size, size_t requested_size, size_t* actual_size) override;
 
   inline bool should_alloc_in_eden(size_t size) const;
   inline void death_march_check(HeapWord* const result, size_t size);
@@ -126,23 +126,23 @@ class ParallelScavengeHeap : public CollectedHeap {
     MarkSweep
   };
 
-  virtual Name kind() const {
+  Name kind() const override {
     return CollectedHeap::Parallel;
   }
 
-  virtual const char* name() const {
+  const char* name() const override {
     return "Parallel";
   }
 
-  virtual SoftRefPolicy* soft_ref_policy() { return &_soft_ref_policy; }
+  SoftRefPolicy* soft_ref_policy() override { return &_soft_ref_policy; }
 
-  virtual GrowableArray<GCMemoryManager*> memory_managers();
-  virtual GrowableArray<MemoryPool*> memory_pools();
+  GrowableArray<GCMemoryManager*> memory_managers() override;
+  GrowableArray<MemoryPool*> memory_pools() override;
 
   static PSYoungGen* young_gen() { return _young_gen; }
   static PSOldGen* old_gen()     { return _old_gen; }
 
-  virtual PSAdaptiveSizePolicy* size_policy() { return _size_policy; }
+  PSAdaptiveSizePolicy* size_policy() { return _size_policy; }
 
   static PSGCAdaptivePolicyCounters* gc_policy_counters() { return _gc_policy_counters; }
 
@@ -154,38 +154,38 @@ class ParallelScavengeHeap : public CollectedHeap {
   PSCardTable* card_table();
 
   // Returns JNI_OK on success
-  virtual jint initialize();
+  jint initialize() override;
 
-  virtual void safepoint_synchronize_begin();
-  virtual void safepoint_synchronize_end();
+  void safepoint_synchronize_begin() override;
+  void safepoint_synchronize_end() override;
 
-  void post_initialize();
+  void post_initialize() override;
   void update_counters();
 
-  size_t capacity() const;
-  size_t used() const;
+  size_t capacity() const override;
+  size_t used() const override;
 
   // Return "true" if all generations have reached the
   // maximal committed limit that they can reach, without a garbage
   // collection.
-  virtual bool is_maximal_no_gc() const;
+  bool is_maximal_no_gc() const override;
 
-  virtual void register_nmethod(nmethod* nm);
-  virtual void unregister_nmethod(nmethod* nm);
-  virtual void verify_nmethod(nmethod* nm);
+  void register_nmethod(nmethod* nm) override;
+  void unregister_nmethod(nmethod* nm) override;
+  void verify_nmethod(nmethod* nm) override;
 
   void prune_scavengable_nmethods();
 
-  size_t max_capacity() const;
+  size_t max_capacity() const override;
 
   // Whether p is in the allocated part of the heap
-  bool is_in(const void* p) const;
+  bool is_in(const void* p) const override;
 
   bool is_in_reserved(const void* p) const;
 
   bool is_in_young(const void* p) const;
 
-  virtual bool requires_barriers(stackChunkOop obj) const;
+  bool requires_barriers(stackChunkOop obj) const override;
 
   MemRegion reserved_region() const { return _reserved; }
   HeapWord* base() const { return _reserved.start(); }
@@ -195,7 +195,7 @@ class ParallelScavengeHeap : public CollectedHeap {
   // an excessive amount of time is being spent doing collections
   // and caused a NULL to be returned.  If a NULL is not returned,
   // "gc_time_limit_was_exceeded" has an undefined meaning.
-  HeapWord* mem_allocate(size_t size, bool* gc_overhead_limit_was_exceeded);
+  HeapWord* mem_allocate(size_t size, bool* gc_overhead_limit_was_exceeded) override;
 
   // Allocation attempt(s) during a safepoint. It should never be called
   // to allocate a new TLAB as this allocation might be satisfied out
@@ -203,7 +203,7 @@ class ParallelScavengeHeap : public CollectedHeap {
   HeapWord* failed_mem_allocate(size_t size);
 
   // Support for System.gc()
-  void collect(GCCause::Cause cause);
+  void collect(GCCause::Cause cause) override;
 
   // These also should be called by the vm thread at a safepoint (e.g., from a
   // VM operation).
@@ -215,38 +215,38 @@ class ParallelScavengeHeap : public CollectedHeap {
   inline void invoke_scavenge();
 
   // Perform a full collection
-  virtual void do_full_collection(bool clear_all_soft_refs);
+  void do_full_collection(bool clear_all_soft_refs) override;
 
-  void ensure_parsability(bool retire_tlabs);
-  void resize_all_tlabs();
+  void ensure_parsability(bool retire_tlabs) override;
+  void resize_all_tlabs() override;
 
-  size_t tlab_capacity(Thread* thr) const;
-  size_t tlab_used(Thread* thr) const;
-  size_t unsafe_max_tlab_alloc(Thread* thr) const;
+  size_t tlab_capacity(Thread* thr) const override;
+  size_t tlab_used(Thread* thr) const override;
+  size_t unsafe_max_tlab_alloc(Thread* thr) const override;
 
-  void object_iterate(ObjectClosure* cl);
+  void object_iterate(ObjectClosure* cl) override;
   void object_iterate_parallel(ObjectClosure* cl, HeapBlockClaimer* claimer);
-  virtual ParallelObjectIteratorImpl* parallel_object_iterator(uint thread_num);
+  ParallelObjectIteratorImpl* parallel_object_iterator(uint thread_num) override;
 
   HeapWord* block_start(const void* addr) const;
   bool block_is_obj(const HeapWord* addr) const;
 
-  void prepare_for_verify();
+  void prepare_for_verify() override;
   PSHeapSummary create_ps_heap_summary();
-  virtual void print_on(outputStream* st) const;
-  virtual void print_on_error(outputStream* st) const;
-  virtual void gc_threads_do(ThreadClosure* tc) const;
-  virtual void print_tracing_info() const;
+  void print_on(outputStream* st) const override;
+  void print_on_error(outputStream* st) const override;
+  void gc_threads_do(ThreadClosure* tc) const override;
+  void print_tracing_info() const override;
 
-  virtual WorkerThreads* safepoint_workers() { return &_workers; }
+  WorkerThreads* safepoint_workers() override { return &_workers; }
 
   PreGenGCValues get_pre_gc_values() const;
   void print_heap_change(const PreGenGCValues& pre_gc_values) const;
 
   // Used to print information about locations in the hs_err file.
-  virtual bool print_location(outputStream* st, void* addr) const;
+  bool print_location(outputStream* st, void* addr) const override;
 
-  void verify(VerifyOption option /* ignored */);
+  void verify(VerifyOption option /* ignored */) override;
 
   // Resize the young generation.  The reserved space for the
   // generation may be expanded in preparation for the resize.
@@ -270,9 +270,9 @@ class ParallelScavengeHeap : public CollectedHeap {
   }
 
   // Support for loading objects from CDS archive into the heap
-  bool can_load_archived_objects() const { return UseCompressedOops; }
-  HeapWord* allocate_loaded_archive_space(size_t size);
-  void complete_loaded_archive_space(MemRegion archive_space);
+  bool can_load_archived_objects() const override { return UseCompressedOops; }
+  HeapWord* allocate_loaded_archive_space(size_t size) override;
+  void complete_loaded_archive_space(MemRegion archive_space) override;
 };
 
 // Class that can be used to print information about the

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,23 +61,23 @@ private:
   MemoryPool* _survivor_pool;
   MemoryPool* _old_pool;
 
-  virtual void initialize_serviceability();
+  void initialize_serviceability() override;
 
 public:
   static SerialHeap* heap();
 
   SerialHeap();
 
-  virtual Name kind() const {
+  Name kind() const override {
     return CollectedHeap::Serial;
   }
 
-  virtual const char* name() const {
+  const char* name() const override {
     return "Serial";
   }
 
-  virtual GrowableArray<GCMemoryManager*> memory_managers();
-  virtual GrowableArray<MemoryPool*> memory_pools();
+  GrowableArray<GCMemoryManager*> memory_managers() override;
+  GrowableArray<MemoryPool*> memory_pools() override;
 
   DefNewGeneration* young_gen() const {
     assert(_young_gen->kind() == Generation::DefNew, "Wrong generation type");
@@ -101,13 +101,13 @@ public:
                            OopIterateClosure* old_gen_closure,
                            CLDClosure* cld_closure);
 
-  virtual void safepoint_synchronize_begin();
-  virtual void safepoint_synchronize_end();
+  void safepoint_synchronize_begin() override;
+  void safepoint_synchronize_end() override;
 
   // Support for loading objects from CDS archive into the heap
-  bool can_load_archived_objects() const { return UseCompressedOops; }
-  HeapWord* allocate_loaded_archive_space(size_t size);
-  void complete_loaded_archive_space(MemRegion archive_space);
+  bool can_load_archived_objects() const override { return UseCompressedOops; }
+  HeapWord* allocate_loaded_archive_space(size_t size) override;
+  void complete_loaded_archive_space(MemRegion archive_space) override;
 };
 
 #endif // SHARE_GC_SERIAL_SERIALHEAP_HPP

--- a/src/hotspot/share/gc/shared/genCollectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -125,7 +125,7 @@ protected:
 
   // Callback from VM_GenCollectFull operation.
   // Perform a full collection of the first max_level+1 generations.
-  virtual void do_full_collection(bool clear_all_soft_refs);
+  void do_full_collection(bool clear_all_soft_refs) override;
   void do_full_collection(bool clear_all_soft_refs, GenerationType max_generation);
 
   // Does the "cause" of GC indicate that
@@ -139,7 +139,7 @@ protected:
 public:
 
   // Returns JNI_OK on success
-  virtual jint initialize();
+  jint initialize() override;
   virtual CardTableRS* create_rem_set(const MemRegion& reserved_region);
 
   void initialize_size_policy(size_t init_eden_size,
@@ -147,7 +147,7 @@ public:
                               size_t init_survivor_size);
 
   // Does operations required after initialization has been done.
-  void post_initialize();
+  void post_initialize() override;
 
   Generation* young_gen() const { return _young_gen; }
   Generation* old_gen()   const { return _old_gen; }
@@ -161,7 +161,7 @@ public:
   GenerationSpec* young_gen_spec() const;
   GenerationSpec* old_gen_spec() const;
 
-  virtual SoftRefPolicy* soft_ref_policy() { return &_soft_ref_gen_policy; }
+  SoftRefPolicy* soft_ref_policy() override { return &_soft_ref_gen_policy; }
 
   // Adaptive size policy
   virtual AdaptiveSizePolicy* size_policy() {
@@ -171,47 +171,47 @@ public:
   // Performance Counter support
   GCPolicyCounters* counters()     { return _gc_policy_counters; }
 
-  size_t capacity() const;
-  size_t used() const;
+  size_t capacity() const override;
+  size_t used() const override;
 
   // Save the "used_region" for both generations.
   void save_used_regions();
 
-  size_t max_capacity() const;
+  size_t max_capacity() const override;
 
-  HeapWord* mem_allocate(size_t size, bool*  gc_overhead_limit_was_exceeded);
+  HeapWord* mem_allocate(size_t size, bool*  gc_overhead_limit_was_exceeded) override;
 
   // Perform a full collection of the heap; intended for use in implementing
   // "System.gc". This implies as full a collection as the CollectedHeap
   // supports. Caller does not hold the Heap_lock on entry.
-  virtual void collect(GCCause::Cause cause);
+  void collect(GCCause::Cause cause) override;
 
   // Returns "TRUE" iff "p" points into the committed areas of the heap.
   // The methods is_in() and is_in_youngest() may be expensive to compute
   // in general, so, to prevent their inadvertent use in product jvm's, we
   // restrict their use to assertion checking or verification only.
-  bool is_in(const void* p) const;
+  bool is_in(const void* p) const override;
 
   // Returns true if p points into the reserved space for the young generation.
   // Assumes the young gen address range is less than that of the old gen.
   bool is_in_young(const void* p) const;
 
-  virtual bool requires_barriers(stackChunkOop obj) const;
+  bool requires_barriers(stackChunkOop obj) const override;
 
 #ifdef ASSERT
   bool is_in_partial_collection(const void* p);
 #endif
 
   // Optimized nmethod scanning support routines
-  virtual void register_nmethod(nmethod* nm);
-  virtual void unregister_nmethod(nmethod* nm);
-  virtual void verify_nmethod(nmethod* nm);
+  void register_nmethod(nmethod* nm) override;
+  void unregister_nmethod(nmethod* nm) override;
+  void verify_nmethod(nmethod* nm) override;
 
   void prune_scavengable_nmethods();
 
   // Iteration functions.
   void oop_iterate(OopIterateClosure* cl);
-  void object_iterate(ObjectClosure* cl);
+  void object_iterate(ObjectClosure* cl) override;
   Space* space_containing(const void* addr) const;
 
   // A CollectedHeap is divided into a dense sequence of "blocks"; that is,
@@ -236,12 +236,12 @@ public:
   bool block_is_obj(const HeapWord* addr) const;
 
   // Section on TLAB's.
-  virtual size_t tlab_capacity(Thread* thr) const;
-  virtual size_t tlab_used(Thread* thr) const;
-  virtual size_t unsafe_max_tlab_alloc(Thread* thr) const;
-  virtual HeapWord* allocate_new_tlab(size_t min_size,
-                                      size_t requested_size,
-                                      size_t* actual_size);
+  size_t tlab_capacity(Thread* thr) const override;
+  size_t tlab_used(Thread* thr) const override;
+  size_t unsafe_max_tlab_alloc(Thread* thr) const override;
+  HeapWord* allocate_new_tlab(size_t min_size,
+                              size_t requested_size,
+                              size_t* actual_size) override;
 
   // The "requestor" generation is performing some garbage collection
   // action for which it would be useful to have scratch space.  The
@@ -254,8 +254,8 @@ public:
   // contributed as it needs.
   void release_scratch();
 
-  // Ensure parsability: override
-  virtual void ensure_parsability(bool retire_tlabs);
+  // Ensure parsability
+  void ensure_parsability(bool retire_tlabs) override;
 
   // Total number of full collections completed.
   unsigned int total_full_collections_completed() {
@@ -274,19 +274,15 @@ public:
 
   bool no_gc_in_progress() { return !is_gc_active(); }
 
-  // Override.
-  void prepare_for_verify();
+  void prepare_for_verify() override;
+  void verify(VerifyOption option) override;
 
-  // Override.
-  void verify(VerifyOption option);
-
-  // Override.
-  virtual void print_on(outputStream* st) const;
-  virtual void gc_threads_do(ThreadClosure* tc) const;
-  virtual void print_tracing_info() const;
+  void print_on(outputStream* st) const override;
+  void gc_threads_do(ThreadClosure* tc) const override;
+  void print_tracing_info() const override;
 
   // Used to print information about locations in the hs_err file.
-  virtual bool print_location(outputStream* st, void* addr) const;
+  bool print_location(outputStream* st, void* addr) const override;
 
   void print_heap_change(const PreGenGCValues& pre_gc_values) const;
 
@@ -306,7 +302,7 @@ public:
   // Return "true" if all generations have reached the
   // maximal committed limit that they can reach, without a garbage
   // collection.
-  virtual bool is_maximal_no_gc() const;
+  virtual bool is_maximal_no_gc() const override;
 
   // This function returns the CardTableRS object that allows us to scan
   // generations in a fully generational heap.

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013, 2021, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -143,29 +144,29 @@ public:
 public:
   static ShenandoahHeap* heap();
 
-  const char* name()          const { return "Shenandoah"; }
-  ShenandoahHeap::Name kind() const { return CollectedHeap::Shenandoah; }
+  const char* name()          const override { return "Shenandoah"; }
+  ShenandoahHeap::Name kind() const override { return CollectedHeap::Shenandoah; }
 
   ShenandoahHeap(ShenandoahCollectorPolicy* policy);
-  jint initialize();
-  void post_initialize();
+  jint initialize() override;
+  void post_initialize() override;
   void initialize_mode();
   void initialize_heuristics();
 
-  void initialize_serviceability();
+  void initialize_serviceability() override;
 
-  void print_on(outputStream* st)              const;
-  void print_extended_on(outputStream *st)     const;
-  void print_tracing_info()                    const;
+  void print_on(outputStream* st)              const override;
+  void print_extended_on(outputStream *st)     const override;
+  void print_tracing_info()                    const override;
   void print_heap_regions_on(outputStream* st) const;
 
-  void stop();
+  void stop() override;
 
-  void prepare_for_verify();
-  void verify(VerifyOption vo);
+  void prepare_for_verify() override;
+  void verify(VerifyOption vo) override;
 
 // WhiteBox testing support.
-  bool supports_concurrent_gc_breakpoints() const {
+  bool supports_concurrent_gc_breakpoints() const override {
     return true;
   }
 
@@ -194,11 +195,11 @@ public:
   void reset_bytes_allocated_since_gc_start();
 
   size_t min_capacity()      const;
-  size_t max_capacity()      const;
+  size_t max_capacity()      const override;
   size_t soft_max_capacity() const;
   size_t initial_capacity()  const;
-  size_t capacity()          const;
-  size_t used()              const;
+  size_t capacity()          const override;
+  size_t used()              const override;
   size_t committed()         const;
 
   void set_soft_max_capacity(size_t v);
@@ -215,9 +216,9 @@ public:
   void assert_gc_workers(uint nworker) NOT_DEBUG_RETURN;
 
   WorkerThreads* workers() const;
-  WorkerThreads* safepoint_workers();
+  WorkerThreads* safepoint_workers() override;
 
-  void gc_threads_do(ThreadClosure* tcl) const;
+  void gc_threads_do(ThreadClosure* tcl) const override;
 
 // ---------- Heap regions handling machinery
 //
@@ -417,14 +418,14 @@ private:
   // For exporting to SA
   int                          _log_min_obj_alignment_in_bytes;
 public:
-  ShenandoahMonitoringSupport* monitoring_support() { return _monitoring_support;    }
-  GCMemoryManager* cycle_memory_manager()           { return &_cycle_memory_manager; }
-  GCMemoryManager* stw_memory_manager()             { return &_stw_memory_manager;   }
-  SoftRefPolicy* soft_ref_policy()                  { return &_soft_ref_policy;      }
+  ShenandoahMonitoringSupport* monitoring_support()          { return _monitoring_support;    }
+  GCMemoryManager* cycle_memory_manager()                    { return &_cycle_memory_manager; }
+  GCMemoryManager* stw_memory_manager()                      { return &_stw_memory_manager;   }
+  SoftRefPolicy* soft_ref_policy()                  override { return &_soft_ref_policy;      }
 
-  GrowableArray<GCMemoryManager*> memory_managers();
-  GrowableArray<MemoryPool*> memory_pools();
-  MemoryUsage memory_usage();
+  GrowableArray<GCMemoryManager*> memory_managers() override;
+  GrowableArray<MemoryPool*> memory_pools() override;
+  MemoryUsage memory_usage() override;
   GCTracer* tracer();
   ConcurrentGCTimer* gc_timer() const;
 
@@ -465,53 +466,52 @@ private:
 // and can be stubbed out.
 //
 public:
-  AdaptiveSizePolicy* size_policy() shenandoah_not_implemented_return(NULL);
-  bool is_maximal_no_gc() const shenandoah_not_implemented_return(false);
+  bool is_maximal_no_gc() const override shenandoah_not_implemented_return(false);
 
-  bool is_in(const void* p) const;
+  bool is_in(const void* p) const override;
 
-  bool requires_barriers(stackChunkOop obj) const;
+  bool requires_barriers(stackChunkOop obj) const override;
 
   MemRegion reserved_region() const { return _reserved; }
   bool is_in_reserved(const void* addr) const { return _reserved.contains(addr); }
 
-  void collect(GCCause::Cause cause);
-  void do_full_collection(bool clear_all_soft_refs);
+  void collect(GCCause::Cause cause) override;
+  void do_full_collection(bool clear_all_soft_refs) override;
 
   // Used for parsing heap during error printing
   HeapWord* block_start(const void* addr) const;
   bool block_is_obj(const HeapWord* addr) const;
-  bool print_location(outputStream* st, void* addr) const;
+  bool print_location(outputStream* st, void* addr) const override;
 
   // Used for native heap walkers: heap dumpers, mostly
-  void object_iterate(ObjectClosure* cl);
+  void object_iterate(ObjectClosure* cl) override;
   // Parallel heap iteration support
-  virtual ParallelObjectIteratorImpl* parallel_object_iterator(uint workers);
+  ParallelObjectIteratorImpl* parallel_object_iterator(uint workers) override;
 
   // Keep alive an object that was loaded with AS_NO_KEEPALIVE.
-  void keep_alive(oop obj);
+  void keep_alive(oop obj) override;
 
 // ---------- Safepoint interface hooks
 //
 public:
-  void safepoint_synchronize_begin();
-  void safepoint_synchronize_end();
+  void safepoint_synchronize_begin() override;
+  void safepoint_synchronize_end() override;
 
 // ---------- Code roots handling hooks
 //
 public:
-  void register_nmethod(nmethod* nm);
-  void unregister_nmethod(nmethod* nm);
-  void verify_nmethod(nmethod* nm) {}
+  void register_nmethod(nmethod* nm) override;
+  void unregister_nmethod(nmethod* nm) override;
+  void verify_nmethod(nmethod* nm) override {}
 
 // ---------- Pinning hooks
 //
 public:
   // Shenandoah supports per-object (per-region) pinning
-  bool supports_object_pinning() const { return true; }
+  bool supports_object_pinning() const override { return true; }
 
-  oop pin_object(JavaThread* thread, oop obj);
-  void unpin_object(JavaThread* thread, oop obj);
+  oop pin_object(JavaThread* thread, oop obj) override;
+  void unpin_object(JavaThread* thread, oop obj) override;
 
   void sync_pinned_region_status();
   void assert_pinned_region_status() NOT_DEBUG_RETURN;
@@ -519,7 +519,7 @@ public:
 // ---------- Concurrent Stack Processing support
 //
 public:
-  bool uses_stack_watermark_barrier() const { return true; }
+  bool uses_stack_watermark_barrier() const override { return true; }
 
 // ---------- Allocation support
 //
@@ -531,20 +531,20 @@ private:
 
 public:
   HeapWord* allocate_memory(ShenandoahAllocRequest& request);
-  HeapWord* mem_allocate(size_t size, bool* what);
+  HeapWord* mem_allocate(size_t size, bool* what) override;
   MetaWord* satisfy_failed_metadata_allocation(ClassLoaderData* loader_data,
                                                size_t size,
-                                               Metaspace::MetadataType mdtype);
+                                               Metaspace::MetadataType mdtype) override;
 
   void notify_mutator_alloc_words(size_t words, bool waste);
 
-  HeapWord* allocate_new_tlab(size_t min_size, size_t requested_size, size_t* actual_size);
-  size_t tlab_capacity(Thread *thr) const;
-  size_t unsafe_max_tlab_alloc(Thread *thread) const;
-  size_t max_tlab_size() const;
-  size_t tlab_used(Thread* ignored) const;
+  HeapWord* allocate_new_tlab(size_t min_size, size_t requested_size, size_t* actual_size) override;
+  size_t tlab_capacity(Thread *thr) const override;
+  size_t unsafe_max_tlab_alloc(Thread *thread) const override;
+  size_t max_tlab_size() const override;
+  size_t tlab_used(Thread* ignored) const override;
 
-  void ensure_parsability(bool retire_labs);
+  void ensure_parsability(bool retire_labs) override;
 
   void labs_make_parsable();
   void tlabs_retire(bool resize);

--- a/src/hotspot/share/gc/z/zCollectedHeap.hpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,79 +50,79 @@ private:
   ZStat*            _stat;
   ZRuntimeWorkers   _runtime_workers;
 
-  virtual HeapWord* allocate_new_tlab(size_t min_size,
-                                      size_t requested_size,
-                                      size_t* actual_size);
+  HeapWord* allocate_new_tlab(size_t min_size,
+                              size_t requested_size,
+                              size_t* actual_size) override;
 
 public:
   static ZCollectedHeap* heap();
 
   ZCollectedHeap();
-  virtual Name kind() const;
-  virtual const char* name() const;
-  virtual jint initialize();
-  virtual void initialize_serviceability();
-  virtual void stop();
+  Name kind() const override;
+  const char* name() const override;
+  jint initialize() override;
+  void initialize_serviceability() override;
+  void stop() override;
 
-  virtual SoftRefPolicy* soft_ref_policy();
+  SoftRefPolicy* soft_ref_policy() override;
 
-  virtual size_t max_capacity() const;
-  virtual size_t capacity() const;
-  virtual size_t used() const;
-  virtual size_t unused() const;
+  size_t max_capacity() const override;
+  size_t capacity() const override;
+  size_t used() const override;
+  size_t unused() const override;
 
-  virtual bool is_maximal_no_gc() const;
-  virtual bool is_in(const void* p) const;
-  virtual bool requires_barriers(stackChunkOop obj) const;
+  bool is_maximal_no_gc() const override;
+  bool is_in(const void* p) const override;
+  bool requires_barriers(stackChunkOop obj) const override;
 
-  virtual oop array_allocate(Klass* klass, size_t size, int length, bool do_zero, TRAPS);
-  virtual HeapWord* mem_allocate(size_t size, bool* gc_overhead_limit_was_exceeded);
-  virtual MetaWord* satisfy_failed_metadata_allocation(ClassLoaderData* loader_data,
-                                                       size_t size,
-                                                       Metaspace::MetadataType mdtype);
-  virtual void collect(GCCause::Cause cause);
-  virtual void collect_as_vm_thread(GCCause::Cause cause);
-  virtual void do_full_collection(bool clear_all_soft_refs);
+  oop array_allocate(Klass* klass, size_t size, int length, bool do_zero, TRAPS) override;
+  HeapWord* mem_allocate(size_t size, bool* gc_overhead_limit_was_exceeded) override;
+  MetaWord* satisfy_failed_metadata_allocation(ClassLoaderData* loader_data,
+                                               size_t size,
+                                               Metaspace::MetadataType mdtype) override;
+  void collect(GCCause::Cause cause) override;
+  void collect_as_vm_thread(GCCause::Cause cause) override;
+  void do_full_collection(bool clear_all_soft_refs) override;
 
-  virtual size_t tlab_capacity(Thread* thr) const;
-  virtual size_t tlab_used(Thread* thr) const;
-  virtual size_t max_tlab_size() const;
-  virtual size_t unsafe_max_tlab_alloc(Thread* thr) const;
+  size_t tlab_capacity(Thread* thr) const override;
+  size_t tlab_used(Thread* thr) const override;
+  size_t max_tlab_size() const override;
+  size_t unsafe_max_tlab_alloc(Thread* thr) const override;
 
-  virtual bool uses_stack_watermark_barrier() const;
+  bool uses_stack_watermark_barrier() const override;
 
-  virtual MemoryUsage memory_usage();
-  virtual GrowableArray<GCMemoryManager*> memory_managers();
-  virtual GrowableArray<MemoryPool*> memory_pools();
+  MemoryUsage memory_usage() override;
+  GrowableArray<GCMemoryManager*> memory_managers() override;
+  GrowableArray<MemoryPool*> memory_pools() override;
 
-  virtual void object_iterate(ObjectClosure* cl);
-  virtual ParallelObjectIteratorImpl* parallel_object_iterator(uint nworkers);
+  void object_iterate(ObjectClosure* cl) override;
+  ParallelObjectIteratorImpl* parallel_object_iterator(uint nworkers) override;
 
-  virtual void keep_alive(oop obj);
+  void keep_alive(oop obj) override;
 
-  virtual void register_nmethod(nmethod* nm);
-  virtual void unregister_nmethod(nmethod* nm);
-  virtual void verify_nmethod(nmethod* nmethod);
+  void register_nmethod(nmethod* nm) override;
+  void unregister_nmethod(nmethod* nm) override;
+  void verify_nmethod(nmethod* nmethod) override;
 
-  virtual WorkerThreads* safepoint_workers();
+  WorkerThreads* safepoint_workers() override;
 
-  virtual void gc_threads_do(ThreadClosure* tc) const;
+  void gc_threads_do(ThreadClosure* tc) const override;
 
-  virtual VirtualSpaceSummary create_heap_space_summary();
+  VirtualSpaceSummary create_heap_space_summary() override;
 
-  virtual void safepoint_synchronize_begin();
-  virtual void safepoint_synchronize_end();
+  void safepoint_synchronize_begin() override;
+  void safepoint_synchronize_end() override;
 
-  virtual void print_on(outputStream* st) const;
-  virtual void print_on_error(outputStream* st) const;
-  virtual void print_extended_on(outputStream* st) const;
-  virtual void print_tracing_info() const;
-  virtual bool print_location(outputStream* st, void* addr) const;
+  void print_on(outputStream* st) const override;
+  void print_on_error(outputStream* st) const override;
+  void print_extended_on(outputStream* st) const override;
+  void print_tracing_info() const override;
+  bool print_location(outputStream* st, void* addr) const override;
 
-  virtual void prepare_for_verify();
-  virtual void verify(VerifyOption option /* ignored */);
-  virtual bool is_oop(oop object) const;
-  virtual bool supports_concurrent_gc_breakpoints() const;
+  void prepare_for_verify() override;
+  void verify(VerifyOption option /* ignored */) override;
+  bool is_oop(oop object) const override;
+  bool supports_concurrent_gc_breakpoints() const override;
 };
 
 #endif // SHARE_GC_Z_ZCOLLECTEDHEAP_HPP


### PR DESCRIPTION
The CollectedHeap class declares a bunch of virtual methods that are overridden in its subclasses. Now that we can, we should convert this code to use "override" consistently, to help making the code more robust.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299879](https://bugs.openjdk.org/browse/JDK-8299879): CollectedHeap hierarchy should use override


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [c3fe1188](https://git.openjdk.org/jdk/pull/11937/files/c3fe11884571aaf86e0dae950a324ed5cea2aec0)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11937/head:pull/11937` \
`$ git checkout pull/11937`

Update a local copy of the PR: \
`$ git checkout pull/11937` \
`$ git pull https://git.openjdk.org/jdk pull/11937/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11937`

View PR using the GUI difftool: \
`$ git pr show -t 11937`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11937.diff">https://git.openjdk.org/jdk/pull/11937.diff</a>

</details>
