### PR TITLE
8299677: Formatter.format might take a long time to format an integer or floating-point

### DIFF
--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -4596,10 +4596,9 @@ public final class Formatter implements Closeable, Flushable {
             }
 
             // apply zero padding
-            if (width != -1 && Flags.contains(f, Flags.ZERO_PAD)) {
-                for (int k = sb.length(); k < width; k++) {
-                    sb.insert(begin, zero);
-                }
+            if (width > sb.length() && Flags.contains(f, Flags.ZERO_PAD)) {
+                String zeros = Character.toString(zero).repeat(width - sb.length());
+                sb.insert(begin, zeros);
             }
 
             return sb;

--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -4597,7 +4597,7 @@ public final class Formatter implements Closeable, Flushable {
 
             // apply zero padding
             if (width > sb.length() && Flags.contains(f, Flags.ZERO_PAD)) {
-                String zeros = Character.toString(zero).repeat(width - sb.length());
+                String zeros = String.valueOf(zero).repeat(width - sb.length());
                 sb.insert(begin, zeros);
             }
 

--- a/test/jdk/java/util/Formatter/Padding.java
+++ b/test/jdk/java/util/Formatter/Padding.java
@@ -23,340 +23,291 @@
 
 /*
  * @test
+ * @bug 4906370
+ * @summary Tests to excercise padding on int and double values,
+ *      with various flag combinations.
  * @run junit Padding
  */
 
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class Padding {
 
-    @Nested
-    class BlankPaddingInt {
+    static Arguments[] padding() {
+        return new Arguments[] {
+                /* blank padding, right adjusted, optional plus sign */
+                arguments("12", "%1d", 12),
+                arguments("12", "%2d", 12),
+                arguments(" 12", "%3d", 12),
+                arguments("  12", "%4d", 12),
+                arguments("   12", "%5d", 12),
+                arguments("        12", "%10d", 12),
 
-        @Test
-        void blankPad_d() {
-            assertEquals("12", String.format("%1d", 12));
-            assertEquals("12", String.format("%2d", 12));
-            assertEquals(" 12", String.format("%3d", 12));
-            assertEquals("  12", String.format("%4d", 12));
-            assertEquals("   12", String.format("%5d", 12));
-            assertEquals("        12", String.format("%10d", 12));
+                arguments("-12", "%1d", -12),
+                arguments("-12", "%2d", -12),
+                arguments("-12", "%3d", -12),
+                arguments(" -12", "%4d", -12),
+                arguments("  -12", "%5d", -12),
+                arguments("       -12", "%10d", -12),
 
-            assertEquals("-12", String.format("%1d", -12));
-            assertEquals("-12", String.format("%2d", -12));
-            assertEquals("-12", String.format("%3d", -12));
-            assertEquals(" -12", String.format("%4d", -12));
-            assertEquals("  -12", String.format("%5d", -12));
-            assertEquals("       -12", String.format("%10d", -12));
-        }
+                arguments("1.2", "%1.1f", 1.2),
+                arguments("1.2", "%2.1f", 1.2),
+                arguments("1.2", "%3.1f", 1.2),
+                arguments(" 1.2", "%4.1f", 1.2),
+                arguments("  1.2", "%5.1f", 1.2),
+                arguments("       1.2", "%10.1f", 1.2),
 
-        @Test
-        void blankPad_plus_d() {
-            assertEquals("+12", String.format("%+1d", 12));
-            assertEquals("+12", String.format("%+2d", 12));
-            assertEquals("+12", String.format("%+3d", 12));
-            assertEquals(" +12", String.format("%+4d", 12));
-            assertEquals("  +12", String.format("%+5d", 12));
-            assertEquals("       +12", String.format("%+10d", 12));
+                arguments("-1.2", "%1.1f", -1.2),
+                arguments("-1.2", "%2.1f", -1.2),
+                arguments("-1.2", "%3.1f", -1.2),
+                arguments("-1.2", "%4.1f", -1.2),
+                arguments(" -1.2", "%5.1f", -1.2),
+                arguments("      -1.2", "%10.1f", -1.2),
 
-            assertEquals("-12", String.format("%+1d", -12));
-            assertEquals("-12", String.format("%+2d", -12));
-            assertEquals("-12", String.format("%+3d", -12));
-            assertEquals(" -12", String.format("%+4d", -12));
-            assertEquals("  -12", String.format("%+5d", -12));
-            assertEquals("       -12", String.format("%+10d", -12));
-        }
+                /* blank padding, right adjusted, mandatory plus sign */
+                arguments("+12", "%+1d", 12),
+                arguments("+12", "%+2d", 12),
+                arguments("+12", "%+3d", 12),
+                arguments(" +12", "%+4d", 12),
+                arguments("  +12", "%+5d", 12),
+                arguments("       +12", "%+10d", 12),
 
-        @Test
-        void blankPad_blank_d() {
-            assertEquals(" 12", String.format("% 1d", 12));
-            assertEquals(" 12", String.format("% 2d", 12));
-            assertEquals(" 12", String.format("% 3d", 12));
-            assertEquals("  12", String.format("% 4d", 12));
-            assertEquals("   12", String.format("% 5d", 12));
-            assertEquals("        12", String.format("% 10d", 12));
+                arguments("-12", "%+1d", -12),
+                arguments("-12", "%+2d", -12),
+                arguments("-12", "%+3d", -12),
+                arguments(" -12", "%+4d", -12),
+                arguments("  -12", "%+5d", -12),
+                arguments("       -12", "%+10d", -12),
 
-            assertEquals("-12", String.format("% 1d", -12));
-            assertEquals("-12", String.format("% 2d", -12));
-            assertEquals("-12", String.format("% 3d", -12));
-            assertEquals(" -12", String.format("% 4d", -12));
-            assertEquals("  -12", String.format("% 5d", -12));
-            assertEquals("       -12", String.format("% 10d", -12));
-        }
+                arguments("+1.2", "%+1.1f", 1.2),
+                arguments("+1.2", "%+2.1f", 1.2),
+                arguments("+1.2", "%+3.1f", 1.2),
+                arguments("+1.2", "%+4.1f", 1.2),
+                arguments(" +1.2", "%+5.1f", 1.2),
+                arguments("      +1.2", "%+10.1f", 1.2),
 
-        @Test
-        void blankPad_minus_d() {
-            assertEquals("12", String.format("%-1d", 12));
-            assertEquals("12", String.format("%-2d", 12));
-            assertEquals("12 ", String.format("%-3d", 12));
-            assertEquals("12  ", String.format("%-4d", 12));
-            assertEquals("12   ", String.format("%-5d", 12));
-            assertEquals("12        ", String.format("%-10d", 12));
+                arguments("-1.2", "%+1.1f", -1.2),
+                arguments("-1.2", "%+2.1f", -1.2),
+                arguments("-1.2", "%+3.1f", -1.2),
+                arguments("-1.2", "%+4.1f", -1.2),
+                arguments(" -1.2", "%+5.1f", -1.2),
+                arguments("      -1.2", "%+10.1f", -1.2),
 
-            assertEquals("-12", String.format("%-1d", -12));
-            assertEquals("-12", String.format("%-2d", -12));
-            assertEquals("-12", String.format("%-3d", -12));
-            assertEquals("-12 ", String.format("%-4d", -12));
-            assertEquals("-12  ", String.format("%-5d", -12));
-            assertEquals("-12       ", String.format("%-10d", -12));
-        }
+                /* blank padding, right adjusted, mandatory blank sign */
+                arguments(" 12", "% 1d", 12),
+                arguments(" 12", "% 2d", 12),
+                arguments(" 12", "% 3d", 12),
+                arguments("  12", "% 4d", 12),
+                arguments("   12", "% 5d", 12),
+                arguments("        12", "% 10d", 12),
 
-        @Test
-        void blankPad_minus_plus_d() {
-            assertEquals("+12", String.format("%-+1d", 12));
-            assertEquals("+12", String.format("%-+2d", 12));
-            assertEquals("+12", String.format("%-+3d", 12));
-            assertEquals("+12 ", String.format("%-+4d", 12));
-            assertEquals("+12  ", String.format("%-+5d", 12));
-            assertEquals("+12       ", String.format("%-+10d", 12));
+                arguments("-12", "% 1d", -12),
+                arguments("-12", "% 2d", -12),
+                arguments("-12", "% 3d", -12),
+                arguments(" -12", "% 4d", -12),
+                arguments("  -12", "% 5d", -12),
+                arguments("       -12", "% 10d", -12),
 
-            assertEquals("-12", String.format("%-+1d", -12));
-            assertEquals("-12", String.format("%-+2d", -12));
-            assertEquals("-12", String.format("%-+3d", -12));
-            assertEquals("-12 ", String.format("%-+4d", -12));
-            assertEquals("-12  ", String.format("%-+5d", -12));
-            assertEquals("-12       ", String.format("%-+10d", -12));
-        }
+                arguments(" 1.2", "% 1.1f", 1.2),
+                arguments(" 1.2", "% 2.1f", 1.2),
+                arguments(" 1.2", "% 3.1f", 1.2),
+                arguments(" 1.2", "% 4.1f", 1.2),
+                arguments("  1.2", "% 5.1f", 1.2),
+                arguments("       1.2", "% 10.1f", 1.2),
 
-        @Test
-        void blankPad_minus_blank_d() {
-            assertEquals(" 12", String.format("%- 1d", 12));
-            assertEquals(" 12", String.format("%- 2d", 12));
-            assertEquals(" 12", String.format("%- 3d", 12));
-            assertEquals(" 12 ", String.format("%- 4d", 12));
-            assertEquals(" 12  ", String.format("%- 5d", 12));
-            assertEquals(" 12       ", String.format("%- 10d", 12));
+                arguments("-1.2", "% 1.1f", -1.2),
+                arguments("-1.2", "% 2.1f", -1.2),
+                arguments("-1.2", "% 3.1f", -1.2),
+                arguments("-1.2", "% 4.1f", -1.2),
+                arguments(" -1.2", "% 5.1f", -1.2),
+                arguments("      -1.2", "% 10.1f", -1.2),
 
-            assertEquals("-12", String.format("%- 1d", -12));
-            assertEquals("-12", String.format("%- 2d", -12));
-            assertEquals("-12", String.format("%- 3d", -12));
-            assertEquals("-12 ", String.format("%- 4d", -12));
-            assertEquals("-12  ", String.format("%- 5d", -12));
-            assertEquals("-12       ", String.format("%- 10d", -12));
-        }
+                /* blank padding, left adjusted, optional sign */
+                arguments("12", "%-1d", 12),
+                arguments("12", "%-2d", 12),
+                arguments("12 ", "%-3d", 12),
+                arguments("12  ", "%-4d", 12),
+                arguments("12   ", "%-5d", 12),
+                arguments("12        ", "%-10d", 12),
 
+                arguments("-12", "%-1d", -12),
+                arguments("-12", "%-2d", -12),
+                arguments("-12", "%-3d", -12),
+                arguments("-12 ", "%-4d", -12),
+                arguments("-12  ", "%-5d", -12),
+                arguments("-12       ", "%-10d", -12),
+
+                arguments("1.2", "%-1.1f", 1.2),
+                arguments("1.2", "%-2.1f", 1.2),
+                arguments("1.2", "%-3.1f", 1.2),
+                arguments("1.2 ", "%-4.1f", 1.2),
+                arguments("1.2  ", "%-5.1f", 1.2),
+                arguments("1.2       ", "%-10.1f", 1.2),
+
+                arguments("-1.2", "%-1.1f", -1.2),
+                arguments("-1.2", "%-2.1f", -1.2),
+                arguments("-1.2", "%-3.1f", -1.2),
+                arguments("-1.2", "%-4.1f", -1.2),
+                arguments("-1.2 ", "%-5.1f", -1.2),
+                arguments("-1.2      ", "%-10.1f", -1.2),
+
+                /* blank padding, left adjusted, mandatory plus sign */
+                arguments("+12", "%-+1d", 12),
+                arguments("+12", "%-+2d", 12),
+                arguments("+12", "%-+3d", 12),
+                arguments("+12 ", "%-+4d", 12),
+                arguments("+12  ", "%-+5d", 12),
+                arguments("+12       ", "%-+10d", 12),
+
+                arguments("-12", "%-+1d", -12),
+                arguments("-12", "%-+2d", -12),
+                arguments("-12", "%-+3d", -12),
+                arguments("-12 ", "%-+4d", -12),
+                arguments("-12  ", "%-+5d", -12),
+                arguments("-12       ", "%-+10d", -12),
+
+                arguments("+1.2", "%-+1.1f", 1.2),
+                arguments("+1.2", "%-+2.1f", 1.2),
+                arguments("+1.2", "%-+3.1f", 1.2),
+                arguments("+1.2", "%-+4.1f", 1.2),
+                arguments("+1.2 ", "%-+5.1f", 1.2),
+                arguments("+1.2      ", "%-+10.1f", 1.2),
+
+                arguments("-1.2", "%-+1.1f", -1.2),
+                arguments("-1.2", "%-+2.1f", -1.2),
+                arguments("-1.2", "%-+3.1f", -1.2),
+                arguments("-1.2", "%-+4.1f", -1.2),
+                arguments("-1.2 ", "%-+5.1f", -1.2),
+                arguments("-1.2      ", "%-+10.1f", -1.2),
+
+                /* blank padding, left adjusted, mandatory blank sign */
+                arguments(" 12", "%- 1d", 12),
+                arguments(" 12", "%- 2d", 12),
+                arguments(" 12", "%- 3d", 12),
+                arguments(" 12 ", "%- 4d", 12),
+                arguments(" 12  ", "%- 5d", 12),
+                arguments(" 12       ", "%- 10d", 12),
+
+                arguments("-12", "%- 1d", -12),
+                arguments("-12", "%- 2d", -12),
+                arguments("-12", "%- 3d", -12),
+                arguments("-12 ", "%- 4d", -12),
+                arguments("-12  ", "%- 5d", -12),
+                arguments("-12       ", "%- 10d", -12),
+
+                arguments(" 1.2", "%- 1.1f", 1.2),
+                arguments(" 1.2", "%- 2.1f", 1.2),
+                arguments(" 1.2", "%- 3.1f", 1.2),
+                arguments(" 1.2", "%- 4.1f", 1.2),
+                arguments(" 1.2 ", "%- 5.1f", 1.2),
+                arguments(" 1.2      ", "%- 10.1f", 1.2),
+
+                arguments("-1.2", "%- 1.1f", -1.2),
+                arguments("-1.2", "%- 2.1f", -1.2),
+                arguments("-1.2", "%- 3.1f", -1.2),
+                arguments("-1.2", "%- 4.1f", -1.2),
+                arguments("-1.2 ", "%- 5.1f", -1.2),
+                arguments("-1.2      ", "%- 10.1f", -1.2),
+
+                /* zero padding, right adjusted, optional sign */
+                arguments("12", "%01d", 12),
+                arguments("12", "%02d", 12),
+                arguments("012", "%03d", 12),
+                arguments("0012", "%04d", 12),
+                arguments("00012", "%05d", 12),
+                arguments("0000000012", "%010d", 12),
+
+                arguments("-12", "%01d", -12),
+                arguments("-12", "%02d", -12),
+                arguments("-12", "%03d", -12),
+                arguments("-012", "%04d", -12),
+                arguments("-0012", "%05d", -12),
+                arguments("-000000012", "%010d", -12),
+
+                arguments("1.2", "%01.1f", 1.2),
+                arguments("1.2", "%02.1f", 1.2),
+                arguments("1.2", "%03.1f", 1.2),
+                arguments("01.2", "%04.1f", 1.2),
+                arguments("001.2", "%05.1f", 1.2),
+                arguments("00000001.2", "%010.1f", 1.2),
+
+                arguments("-1.2", "%01.1f", -1.2),
+                arguments("-1.2", "%02.1f", -1.2),
+                arguments("-1.2", "%03.1f", -1.2),
+                arguments("-1.2", "%04.1f", -1.2),
+                arguments("-01.2", "%05.1f", -1.2),
+                arguments("-0000001.2", "%010.1f", -1.2),
+
+                /* zero padding, right adjusted, mandatory plus sign */
+                arguments("+12", "%+01d", 12),
+                arguments("+12", "%+02d", 12),
+                arguments("+12", "%+03d", 12),
+                arguments("+012", "%+04d", 12),
+                arguments("+0012", "%+05d", 12),
+                arguments("+000000012", "%+010d", 12),
+
+                arguments("-12", "%+01d", -12),
+                arguments("-12", "%+02d", -12),
+                arguments("-12", "%+03d", -12),
+                arguments("-012", "%+04d", -12),
+                arguments("-0012", "%+05d", -12),
+                arguments("-000000012", "%+010d", -12),
+
+                arguments("+1.2", "%+01.1f", 1.2),
+                arguments("+1.2", "%+02.1f", 1.2),
+                arguments("+1.2", "%+03.1f", 1.2),
+                arguments("+1.2", "%+04.1f", 1.2),
+                arguments("+01.2", "%+05.1f", 1.2),
+                arguments("+0000001.2", "%+010.1f", 1.2),
+
+                arguments("-1.2", "%+01.1f", -1.2),
+                arguments("-1.2", "%+02.1f", -1.2),
+                arguments("-1.2", "%+03.1f", -1.2),
+                arguments("-1.2", "%+04.1f", -1.2),
+                arguments("-01.2", "%+05.1f", -1.2),
+                arguments("-0000001.2", "%+010.1f", -1.2),
+
+                /* zero padding, right adjusted, mandatory blank sign */
+                arguments(" 12", "% 01d", 12),
+                arguments(" 12", "% 02d", 12),
+                arguments(" 12", "% 03d", 12),
+                arguments(" 012", "% 04d", 12),
+                arguments(" 0012", "% 05d", 12),
+                arguments(" 000000012", "% 010d", 12),
+
+                arguments("-12", "% 01d", -12),
+                arguments("-12", "% 02d", -12),
+                arguments("-12", "% 03d", -12),
+                arguments("-012", "% 04d", -12),
+                arguments("-0012", "% 05d", -12),
+                arguments("-000000012", "% 010d", -12),
+
+                arguments(" 1.2", "% 01.1f", 1.2),
+                arguments(" 1.2", "% 02.1f", 1.2),
+                arguments(" 1.2", "% 03.1f", 1.2),
+                arguments(" 1.2", "% 04.1f", 1.2),
+                arguments(" 01.2", "% 05.1f", 1.2),
+                arguments(" 0000001.2", "% 010.1f", 1.2),
+
+                arguments("-1.2", "% 01.1f", -1.2),
+                arguments("-1.2", "% 02.1f", -1.2),
+                arguments("-1.2", "% 03.1f", -1.2),
+                arguments("-1.2", "% 04.1f", -1.2),
+                arguments("-01.2", "% 05.1f", -1.2),
+                arguments("-0000001.2", "% 010.1f", -1.2),
+
+        };
     }
 
-    @Nested
-    class BlankPaddingDouble {
-
-        @Test
-        void blankPad_f() {
-            assertEquals("1.2", String.format("%1.1f", 1.2));
-            assertEquals("1.2", String.format("%2.1f", 1.2));
-            assertEquals("1.2", String.format("%3.1f", 1.2));
-            assertEquals(" 1.2", String.format("%4.1f", 1.2));
-            assertEquals("  1.2", String.format("%5.1f", 1.2));
-            assertEquals("       1.2", String.format("%10.1f", 1.2));
-
-            assertEquals("-1.2", String.format("%1.1f", -1.2));
-            assertEquals("-1.2", String.format("%2.1f", -1.2));
-            assertEquals("-1.2", String.format("%3.1f", -1.2));
-            assertEquals("-1.2", String.format("%4.1f", -1.2));
-            assertEquals(" -1.2", String.format("%5.1f", -1.2));
-            assertEquals("      -1.2", String.format("%10.1f", -1.2));
-        }
-
-        @Test
-        void blankPad_plus_f() {
-            assertEquals("+1.2", String.format("%+1.1f", 1.2));
-            assertEquals("+1.2", String.format("%+2.1f", 1.2));
-            assertEquals("+1.2", String.format("%+3.1f", 1.2));
-            assertEquals("+1.2", String.format("%+4.1f", 1.2));
-            assertEquals(" +1.2", String.format("%+5.1f", 1.2));
-            assertEquals("      +1.2", String.format("%+10.1f", 1.2));
-
-            assertEquals("-1.2", String.format("%+1.1f", -1.2));
-            assertEquals("-1.2", String.format("%+2.1f", -1.2));
-            assertEquals("-1.2", String.format("%+3.1f", -1.2));
-            assertEquals("-1.2", String.format("%+4.1f", -1.2));
-            assertEquals(" -1.2", String.format("%+5.1f", -1.2));
-            assertEquals("      -1.2", String.format("%+10.1f", -1.2));
-        }
-
-        @Test
-        void blankPad_blank_f() {
-            assertEquals(" 1.2", String.format("% 1.1f", 1.2));
-            assertEquals(" 1.2", String.format("% 2.1f", 1.2));
-            assertEquals(" 1.2", String.format("% 3.1f", 1.2));
-            assertEquals(" 1.2", String.format("% 4.1f", 1.2));
-            assertEquals("  1.2", String.format("% 5.1f", 1.2));
-            assertEquals("       1.2", String.format("% 10.1f", 1.2));
-
-            assertEquals("-1.2", String.format("% 1.1f", -1.2));
-            assertEquals("-1.2", String.format("% 2.1f", -1.2));
-            assertEquals("-1.2", String.format("% 3.1f", -1.2));
-            assertEquals("-1.2", String.format("% 4.1f", -1.2));
-            assertEquals(" -1.2", String.format("% 5.1f", -1.2));
-            assertEquals("      -1.2", String.format("% 10.1f", -1.2));
-        }
-
-        @Test
-        void blankPad_minus_f() {
-            assertEquals("1.2", String.format("%-1.1f", 1.2));
-            assertEquals("1.2", String.format("%-2.1f", 1.2));
-            assertEquals("1.2", String.format("%-3.1f", 1.2));
-            assertEquals("1.2 ", String.format("%-4.1f", 1.2));
-            assertEquals("1.2  ", String.format("%-5.1f", 1.2));
-            assertEquals("1.2       ", String.format("%-10.1f", 1.2));
-
-            assertEquals("-1.2", String.format("%-1.1f", -1.2));
-            assertEquals("-1.2", String.format("%-2.1f", -1.2));
-            assertEquals("-1.2", String.format("%-3.1f", -1.2));
-            assertEquals("-1.2", String.format("%-4.1f", -1.2));
-            assertEquals("-1.2 ", String.format("%-5.1f", -1.2));
-            assertEquals("-1.2      ", String.format("%-10.1f", -1.2));
-        }
-
-        @Test
-        void blankPad_minus_plus_f() {
-            assertEquals("+1.2", String.format("%-+1.1f", 1.2));
-            assertEquals("+1.2", String.format("%-+2.1f", 1.2));
-            assertEquals("+1.2", String.format("%-+3.1f", 1.2));
-            assertEquals("+1.2", String.format("%-+4.1f", 1.2));
-            assertEquals("+1.2 ", String.format("%-+5.1f", 1.2));
-            assertEquals("+1.2      ", String.format("%-+10.1f", 1.2));
-
-            assertEquals("-1.2", String.format("%-+1.1f", -1.2));
-            assertEquals("-1.2", String.format("%-+2.1f", -1.2));
-            assertEquals("-1.2", String.format("%-+3.1f", -1.2));
-            assertEquals("-1.2", String.format("%-+4.1f", -1.2));
-            assertEquals("-1.2 ", String.format("%-+5.1f", -1.2));
-            assertEquals("-1.2      ", String.format("%-+10.1f", -1.2));
-        }
-
-        @Test
-        void blankPad_minus_blank_f() {
-            assertEquals(" 1.2", String.format("%- 1.1f", 1.2));
-            assertEquals(" 1.2", String.format("%- 2.1f", 1.2));
-            assertEquals(" 1.2", String.format("%- 3.1f", 1.2));
-            assertEquals(" 1.2", String.format("%- 4.1f", 1.2));
-            assertEquals(" 1.2 ", String.format("%- 5.1f", 1.2));
-            assertEquals(" 1.2      ", String.format("%- 10.1f", 1.2));
-
-            assertEquals("-1.2", String.format("%- 1.1f", -1.2));
-            assertEquals("-1.2", String.format("%- 2.1f", -1.2));
-            assertEquals("-1.2", String.format("%- 3.1f", -1.2));
-            assertEquals("-1.2", String.format("%- 4.1f", -1.2));
-            assertEquals("-1.2 ", String.format("%- 5.1f", -1.2));
-            assertEquals("-1.2      ", String.format("%- 10.1f", -1.2));
-        }
-
-    }
-
-    @Nested
-    class ZeroPaddingInt {
-
-        @Test
-        void zeroPad_d() {
-            assertEquals("12", String.format("%01d", 12));
-            assertEquals("12", String.format("%02d", 12));
-            assertEquals("012", String.format("%03d", 12));
-            assertEquals("0012", String.format("%04d", 12));
-            assertEquals("00012", String.format("%05d", 12));
-            assertEquals("0000000012", String.format("%010d", 12));
-
-            assertEquals("-12", String.format("%01d", -12));
-            assertEquals("-12", String.format("%02d", -12));
-            assertEquals("-12", String.format("%03d", -12));
-            assertEquals("-012", String.format("%04d", -12));
-            assertEquals("-0012", String.format("%05d", -12));
-            assertEquals("-000000012", String.format("%010d", -12));
-        }
-
-        @Test
-        void zeroPad_plus_d() {
-            assertEquals("+12", String.format("%+01d", 12));
-            assertEquals("+12", String.format("%+02d", 12));
-            assertEquals("+12", String.format("%+03d", 12));
-            assertEquals("+012", String.format("%+04d", 12));
-            assertEquals("+0012", String.format("%+05d", 12));
-            assertEquals("+000000012", String.format("%+010d", 12));
-
-            assertEquals("-12", String.format("%+01d", -12));
-            assertEquals("-12", String.format("%+02d", -12));
-            assertEquals("-12", String.format("%+03d", -12));
-            assertEquals("-012", String.format("%+04d", -12));
-            assertEquals("-0012", String.format("%+05d", -12));
-            assertEquals("-000000012", String.format("%+010d", -12));
-        }
-
-        @Test
-        void zeroPad_blank_d() {
-            assertEquals(" 12", String.format("% 01d", 12));
-            assertEquals(" 12", String.format("% 02d", 12));
-            assertEquals(" 12", String.format("% 03d", 12));
-            assertEquals(" 012", String.format("% 04d", 12));
-            assertEquals(" 0012", String.format("% 05d", 12));
-            assertEquals(" 000000012", String.format("% 010d", 12));
-
-            assertEquals("-12", String.format("% 01d", -12));
-            assertEquals("-12", String.format("% 02d", -12));
-            assertEquals("-12", String.format("% 03d", -12));
-            assertEquals("-012", String.format("% 04d", -12));
-            assertEquals("-0012", String.format("% 05d", -12));
-            assertEquals("-000000012", String.format("% 010d", -12));
-        }
-
-    }
-
-    @Nested
-    class ZeroPaddingDouble {
-
-        @Test
-        void zeroPad_f() {
-            assertEquals("1.2", String.format("%01.1f", 1.2));
-            assertEquals("1.2", String.format("%02.1f", 1.2));
-            assertEquals("1.2", String.format("%03.1f", 1.2));
-            assertEquals("01.2", String.format("%04.1f", 1.2));
-            assertEquals("001.2", String.format("%05.1f", 1.2));
-            assertEquals("00000001.2", String.format("%010.1f", 1.2));
-
-            assertEquals("-1.2", String.format("%01.1f", -1.2));
-            assertEquals("-1.2", String.format("%02.1f", -1.2));
-            assertEquals("-1.2", String.format("%03.1f", -1.2));
-            assertEquals("-1.2", String.format("%04.1f", -1.2));
-            assertEquals("-01.2", String.format("%05.1f", -1.2));
-            assertEquals("-0000001.2", String.format("%010.1f", -1.2));
-        }
-
-        @Test
-        void zeroPad_plus_f() {
-            assertEquals("+1.2", String.format("%+01.1f", 1.2));
-            assertEquals("+1.2", String.format("%+02.1f", 1.2));
-            assertEquals("+1.2", String.format("%+03.1f", 1.2));
-            assertEquals("+1.2", String.format("%+04.1f", 1.2));
-            assertEquals("+01.2", String.format("%+05.1f", 1.2));
-            assertEquals("+0000001.2", String.format("%+010.1f", 1.2));
-
-            assertEquals("-1.2", String.format("%+01.1f", -1.2));
-            assertEquals("-1.2", String.format("%+02.1f", -1.2));
-            assertEquals("-1.2", String.format("%+03.1f", -1.2));
-            assertEquals("-1.2", String.format("%+04.1f", -1.2));
-            assertEquals("-01.2", String.format("%+05.1f", -1.2));
-            assertEquals("-0000001.2", String.format("%+010.1f", -1.2));
-        }
-
-        @Test
-        void zeroPad_blank_f() {
-            assertEquals(" 1.2", String.format("% 01.1f", 1.2));
-            assertEquals(" 1.2", String.format("% 02.1f", 1.2));
-            assertEquals(" 1.2", String.format("% 03.1f", 1.2));
-            assertEquals(" 1.2", String.format("% 04.1f", 1.2));
-            assertEquals(" 01.2", String.format("% 05.1f", 1.2));
-            assertEquals(" 0000001.2", String.format("% 010.1f", 1.2));
-
-            assertEquals("-1.2", String.format("% 01.1f", -1.2));
-            assertEquals("-1.2", String.format("% 02.1f", -1.2));
-            assertEquals("-1.2", String.format("% 03.1f", -1.2));
-            assertEquals("-1.2", String.format("% 04.1f", -1.2));
-            assertEquals("-01.2", String.format("% 05.1f", -1.2));
-            assertEquals("-0000001.2", String.format("% 010.1f", -1.2));
-        }
-
+    @ParameterizedTest
+    @MethodSource
+    void padding(String expected, String format, Object value) {
+        assertEquals(expected, String.format(format, value));
     }
 
 }

--- a/test/jdk/java/util/Formatter/Padding.java
+++ b/test/jdk/java/util/Formatter/Padding.java
@@ -144,7 +144,7 @@ public class Padding {
     class BlankPaddingDouble {
 
         @Test
-        void blankPad_d() {
+        void blankPad_f() {
             assertEquals("1.2", String.format("%1.1f", 1.2));
             assertEquals("1.2", String.format("%2.1f", 1.2));
             assertEquals("1.2", String.format("%3.1f", 1.2));
@@ -161,7 +161,7 @@ public class Padding {
         }
 
         @Test
-        void blankPad_plus_d() {
+        void blankPad_plus_f() {
             assertEquals("+1.2", String.format("%+1.1f", 1.2));
             assertEquals("+1.2", String.format("%+2.1f", 1.2));
             assertEquals("+1.2", String.format("%+3.1f", 1.2));
@@ -178,7 +178,7 @@ public class Padding {
         }
 
         @Test
-        void blankPad_blank_d() {
+        void blankPad_blank_f() {
             assertEquals(" 1.2", String.format("% 1.1f", 1.2));
             assertEquals(" 1.2", String.format("% 2.1f", 1.2));
             assertEquals(" 1.2", String.format("% 3.1f", 1.2));
@@ -195,7 +195,7 @@ public class Padding {
         }
 
         @Test
-        void blankPad_minus_d() {
+        void blankPad_minus_f() {
             assertEquals("1.2", String.format("%-1.1f", 1.2));
             assertEquals("1.2", String.format("%-2.1f", 1.2));
             assertEquals("1.2", String.format("%-3.1f", 1.2));
@@ -212,7 +212,7 @@ public class Padding {
         }
 
         @Test
-        void blankPad_minus_plus_d() {
+        void blankPad_minus_plus_f() {
             assertEquals("+1.2", String.format("%-+1.1f", 1.2));
             assertEquals("+1.2", String.format("%-+2.1f", 1.2));
             assertEquals("+1.2", String.format("%-+3.1f", 1.2));
@@ -229,7 +229,7 @@ public class Padding {
         }
 
         @Test
-        void blankPad_minus_blank_d() {
+        void blankPad_minus_blank_f() {
             assertEquals(" 1.2", String.format("%- 1.1f", 1.2));
             assertEquals(" 1.2", String.format("%- 2.1f", 1.2));
             assertEquals(" 1.2", String.format("%- 3.1f", 1.2));
@@ -307,7 +307,7 @@ public class Padding {
     class ZeroPaddingDouble {
 
         @Test
-        void zeroPad_d() {
+        void zeroPad_f() {
             assertEquals("1.2", String.format("%01.1f", 1.2));
             assertEquals("1.2", String.format("%02.1f", 1.2));
             assertEquals("1.2", String.format("%03.1f", 1.2));
@@ -324,7 +324,7 @@ public class Padding {
         }
 
         @Test
-        void zeroPad_plus_d() {
+        void zeroPad_plus_f() {
             assertEquals("+1.2", String.format("%+01.1f", 1.2));
             assertEquals("+1.2", String.format("%+02.1f", 1.2));
             assertEquals("+1.2", String.format("%+03.1f", 1.2));
@@ -341,7 +341,7 @@ public class Padding {
         }
 
         @Test
-        void zeroPad_blank_d() {
+        void zeroPad_blank_f() {
             assertEquals(" 1.2", String.format("% 01.1f", 1.2));
             assertEquals(" 1.2", String.format("% 02.1f", 1.2));
             assertEquals(" 1.2", String.format("% 03.1f", 1.2));

--- a/test/jdk/java/util/Formatter/Padding.java
+++ b/test/jdk/java/util/Formatter/Padding.java
@@ -50,7 +50,7 @@ public class Padding {
             assertEquals("-12", String.format("%3d", -12));
             assertEquals(" -12", String.format("%4d", -12));
             assertEquals("  -12", String.format("%5d", -12));
-            assertEquals("        12", String.format("%10d", 12));
+            assertEquals("       -12", String.format("%10d", -12));
         }
 
         @Test
@@ -243,6 +243,118 @@ public class Padding {
             assertEquals("-1.2", String.format("%- 4.1f", -1.2));
             assertEquals("-1.2 ", String.format("%- 5.1f", -1.2));
             assertEquals("-1.2      ", String.format("%- 10.1f", -1.2));
+        }
+
+    }
+
+    @Nested
+    class ZeroPaddingInt {
+
+        @Test
+        void zeroPad_d() {
+            assertEquals("12", String.format("%01d", 12));
+            assertEquals("12", String.format("%02d", 12));
+            assertEquals("012", String.format("%03d", 12));
+            assertEquals("0012", String.format("%04d", 12));
+            assertEquals("00012", String.format("%05d", 12));
+            assertEquals("0000000012", String.format("%010d", 12));
+
+            assertEquals("-12", String.format("%01d", -12));
+            assertEquals("-12", String.format("%02d", -12));
+            assertEquals("-12", String.format("%03d", -12));
+            assertEquals("-012", String.format("%04d", -12));
+            assertEquals("-0012", String.format("%05d", -12));
+            assertEquals("-000000012", String.format("%010d", -12));
+        }
+
+        @Test
+        void zeroPad_plus_d() {
+            assertEquals("+12", String.format("%+01d", 12));
+            assertEquals("+12", String.format("%+02d", 12));
+            assertEquals("+12", String.format("%+03d", 12));
+            assertEquals("+012", String.format("%+04d", 12));
+            assertEquals("+0012", String.format("%+05d", 12));
+            assertEquals("+000000012", String.format("%+010d", 12));
+
+            assertEquals("-12", String.format("%+01d", -12));
+            assertEquals("-12", String.format("%+02d", -12));
+            assertEquals("-12", String.format("%+03d", -12));
+            assertEquals("-012", String.format("%+04d", -12));
+            assertEquals("-0012", String.format("%+05d", -12));
+            assertEquals("-000000012", String.format("%+010d", -12));
+        }
+
+        @Test
+        void zeroPad_blank_d() {
+            assertEquals(" 12", String.format("% 01d", 12));
+            assertEquals(" 12", String.format("% 02d", 12));
+            assertEquals(" 12", String.format("% 03d", 12));
+            assertEquals(" 012", String.format("% 04d", 12));
+            assertEquals(" 0012", String.format("% 05d", 12));
+            assertEquals(" 000000012", String.format("% 010d", 12));
+
+            assertEquals("-12", String.format("% 01d", -12));
+            assertEquals("-12", String.format("% 02d", -12));
+            assertEquals("-12", String.format("% 03d", -12));
+            assertEquals("-012", String.format("% 04d", -12));
+            assertEquals("-0012", String.format("% 05d", -12));
+            assertEquals("-000000012", String.format("% 010d", -12));
+        }
+
+    }
+
+    @Nested
+    class ZeroPaddingDouble {
+
+        @Test
+        void zeroPad_d() {
+            assertEquals("1.2", String.format("%01.1f", 1.2));
+            assertEquals("1.2", String.format("%02.1f", 1.2));
+            assertEquals("1.2", String.format("%03.1f", 1.2));
+            assertEquals("01.2", String.format("%04.1f", 1.2));
+            assertEquals("001.2", String.format("%05.1f", 1.2));
+            assertEquals("00000001.2", String.format("%010.1f", 1.2));
+
+            assertEquals("-1.2", String.format("%01.1f", -1.2));
+            assertEquals("-1.2", String.format("%02.1f", -1.2));
+            assertEquals("-1.2", String.format("%03.1f", -1.2));
+            assertEquals("-1.2", String.format("%04.1f", -1.2));
+            assertEquals("-01.2", String.format("%05.1f", -1.2));
+            assertEquals("-0000001.2", String.format("%010.1f", -1.2));
+        }
+
+        @Test
+        void zeroPad_plus_d() {
+            assertEquals("+1.2", String.format("%+01.1f", 1.2));
+            assertEquals("+1.2", String.format("%+02.1f", 1.2));
+            assertEquals("+1.2", String.format("%+03.1f", 1.2));
+            assertEquals("+1.2", String.format("%+04.1f", 1.2));
+            assertEquals("+01.2", String.format("%+05.1f", 1.2));
+            assertEquals("+0000001.2", String.format("%+010.1f", 1.2));
+
+            assertEquals("-1.2", String.format("%+01.1f", -1.2));
+            assertEquals("-1.2", String.format("%+02.1f", -1.2));
+            assertEquals("-1.2", String.format("%+03.1f", -1.2));
+            assertEquals("-1.2", String.format("%+04.1f", -1.2));
+            assertEquals("-01.2", String.format("%+05.1f", -1.2));
+            assertEquals("-0000001.2", String.format("%+010.1f", -1.2));
+        }
+
+        @Test
+        void zeroPad_blank_d() {
+            assertEquals(" 1.2", String.format("% 01.1f", 1.2));
+            assertEquals(" 1.2", String.format("% 02.1f", 1.2));
+            assertEquals(" 1.2", String.format("% 03.1f", 1.2));
+            assertEquals(" 1.2", String.format("% 04.1f", 1.2));
+            assertEquals(" 01.2", String.format("% 05.1f", 1.2));
+            assertEquals(" 0000001.2", String.format("% 010.1f", 1.2));
+
+            assertEquals("-1.2", String.format("% 01.1f", -1.2));
+            assertEquals("-1.2", String.format("% 02.1f", -1.2));
+            assertEquals("-1.2", String.format("% 03.1f", -1.2));
+            assertEquals("-1.2", String.format("% 04.1f", -1.2));
+            assertEquals("-01.2", String.format("% 05.1f", -1.2));
+            assertEquals("-0000001.2", String.format("% 010.1f", -1.2));
         }
 
     }

--- a/test/jdk/java/util/Formatter/Padding.java
+++ b/test/jdk/java/util/Formatter/Padding.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @run junit Padding
+ */
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Padding {
+
+    @Nested
+    class BlankPaddingInt {
+
+        @Test
+        void blankPad_d() {
+            assertEquals("12", String.format("%1d", 12));
+            assertEquals("12", String.format("%2d", 12));
+            assertEquals(" 12", String.format("%3d", 12));
+            assertEquals("  12", String.format("%4d", 12));
+            assertEquals("   12", String.format("%5d", 12));
+            assertEquals("        12", String.format("%10d", 12));
+
+            assertEquals("-12", String.format("%1d", -12));
+            assertEquals("-12", String.format("%2d", -12));
+            assertEquals("-12", String.format("%3d", -12));
+            assertEquals(" -12", String.format("%4d", -12));
+            assertEquals("  -12", String.format("%5d", -12));
+            assertEquals("        12", String.format("%10d", 12));
+        }
+
+        @Test
+        void blankPad_plus_d() {
+            assertEquals("+12", String.format("%+1d", 12));
+            assertEquals("+12", String.format("%+2d", 12));
+            assertEquals("+12", String.format("%+3d", 12));
+            assertEquals(" +12", String.format("%+4d", 12));
+            assertEquals("  +12", String.format("%+5d", 12));
+            assertEquals("       +12", String.format("%+10d", 12));
+
+            assertEquals("-12", String.format("%+1d", -12));
+            assertEquals("-12", String.format("%+2d", -12));
+            assertEquals("-12", String.format("%+3d", -12));
+            assertEquals(" -12", String.format("%+4d", -12));
+            assertEquals("  -12", String.format("%+5d", -12));
+            assertEquals("       -12", String.format("%+10d", -12));
+        }
+
+        @Test
+        void blankPad_blank_d() {
+            assertEquals(" 12", String.format("% 1d", 12));
+            assertEquals(" 12", String.format("% 2d", 12));
+            assertEquals(" 12", String.format("% 3d", 12));
+            assertEquals("  12", String.format("% 4d", 12));
+            assertEquals("   12", String.format("% 5d", 12));
+            assertEquals("        12", String.format("% 10d", 12));
+
+            assertEquals("-12", String.format("% 1d", -12));
+            assertEquals("-12", String.format("% 2d", -12));
+            assertEquals("-12", String.format("% 3d", -12));
+            assertEquals(" -12", String.format("% 4d", -12));
+            assertEquals("  -12", String.format("% 5d", -12));
+            assertEquals("       -12", String.format("% 10d", -12));
+        }
+
+        @Test
+        void blankPad_minus_d() {
+            assertEquals("12", String.format("%-1d", 12));
+            assertEquals("12", String.format("%-2d", 12));
+            assertEquals("12 ", String.format("%-3d", 12));
+            assertEquals("12  ", String.format("%-4d", 12));
+            assertEquals("12   ", String.format("%-5d", 12));
+            assertEquals("12        ", String.format("%-10d", 12));
+
+            assertEquals("-12", String.format("%-1d", -12));
+            assertEquals("-12", String.format("%-2d", -12));
+            assertEquals("-12", String.format("%-3d", -12));
+            assertEquals("-12 ", String.format("%-4d", -12));
+            assertEquals("-12  ", String.format("%-5d", -12));
+            assertEquals("-12       ", String.format("%-10d", -12));
+        }
+
+        @Test
+        void blankPad_minus_plus_d() {
+            assertEquals("+12", String.format("%-+1d", 12));
+            assertEquals("+12", String.format("%-+2d", 12));
+            assertEquals("+12", String.format("%-+3d", 12));
+            assertEquals("+12 ", String.format("%-+4d", 12));
+            assertEquals("+12  ", String.format("%-+5d", 12));
+            assertEquals("+12       ", String.format("%-+10d", 12));
+
+            assertEquals("-12", String.format("%-+1d", -12));
+            assertEquals("-12", String.format("%-+2d", -12));
+            assertEquals("-12", String.format("%-+3d", -12));
+            assertEquals("-12 ", String.format("%-+4d", -12));
+            assertEquals("-12  ", String.format("%-+5d", -12));
+            assertEquals("-12       ", String.format("%-+10d", -12));
+        }
+
+        @Test
+        void blankPad_minus_blank_d() {
+            assertEquals(" 12", String.format("%- 1d", 12));
+            assertEquals(" 12", String.format("%- 2d", 12));
+            assertEquals(" 12", String.format("%- 3d", 12));
+            assertEquals(" 12 ", String.format("%- 4d", 12));
+            assertEquals(" 12  ", String.format("%- 5d", 12));
+            assertEquals(" 12       ", String.format("%- 10d", 12));
+
+            assertEquals("-12", String.format("%- 1d", -12));
+            assertEquals("-12", String.format("%- 2d", -12));
+            assertEquals("-12", String.format("%- 3d", -12));
+            assertEquals("-12 ", String.format("%- 4d", -12));
+            assertEquals("-12  ", String.format("%- 5d", -12));
+            assertEquals("-12       ", String.format("%- 10d", -12));
+        }
+
+    }
+
+    @Nested
+    class BlankPaddingDouble {
+
+        @Test
+        void blankPad_d() {
+            assertEquals("1.2", String.format("%1.1f", 1.2));
+            assertEquals("1.2", String.format("%2.1f", 1.2));
+            assertEquals("1.2", String.format("%3.1f", 1.2));
+            assertEquals(" 1.2", String.format("%4.1f", 1.2));
+            assertEquals("  1.2", String.format("%5.1f", 1.2));
+            assertEquals("       1.2", String.format("%10.1f", 1.2));
+
+            assertEquals("-1.2", String.format("%1.1f", -1.2));
+            assertEquals("-1.2", String.format("%2.1f", -1.2));
+            assertEquals("-1.2", String.format("%3.1f", -1.2));
+            assertEquals("-1.2", String.format("%4.1f", -1.2));
+            assertEquals(" -1.2", String.format("%5.1f", -1.2));
+            assertEquals("      -1.2", String.format("%10.1f", -1.2));
+        }
+
+        @Test
+        void blankPad_plus_d() {
+            assertEquals("+1.2", String.format("%+1.1f", 1.2));
+            assertEquals("+1.2", String.format("%+2.1f", 1.2));
+            assertEquals("+1.2", String.format("%+3.1f", 1.2));
+            assertEquals("+1.2", String.format("%+4.1f", 1.2));
+            assertEquals(" +1.2", String.format("%+5.1f", 1.2));
+            assertEquals("      +1.2", String.format("%+10.1f", 1.2));
+
+            assertEquals("-1.2", String.format("%+1.1f", -1.2));
+            assertEquals("-1.2", String.format("%+2.1f", -1.2));
+            assertEquals("-1.2", String.format("%+3.1f", -1.2));
+            assertEquals("-1.2", String.format("%+4.1f", -1.2));
+            assertEquals(" -1.2", String.format("%+5.1f", -1.2));
+            assertEquals("      -1.2", String.format("%+10.1f", -1.2));
+        }
+
+        @Test
+        void blankPad_blank_d() {
+            assertEquals(" 1.2", String.format("% 1.1f", 1.2));
+            assertEquals(" 1.2", String.format("% 2.1f", 1.2));
+            assertEquals(" 1.2", String.format("% 3.1f", 1.2));
+            assertEquals(" 1.2", String.format("% 4.1f", 1.2));
+            assertEquals("  1.2", String.format("% 5.1f", 1.2));
+            assertEquals("       1.2", String.format("% 10.1f", 1.2));
+
+            assertEquals("-1.2", String.format("% 1.1f", -1.2));
+            assertEquals("-1.2", String.format("% 2.1f", -1.2));
+            assertEquals("-1.2", String.format("% 3.1f", -1.2));
+            assertEquals("-1.2", String.format("% 4.1f", -1.2));
+            assertEquals(" -1.2", String.format("% 5.1f", -1.2));
+            assertEquals("      -1.2", String.format("% 10.1f", -1.2));
+        }
+
+        @Test
+        void blankPad_minus_d() {
+            assertEquals("1.2", String.format("%-1.1f", 1.2));
+            assertEquals("1.2", String.format("%-2.1f", 1.2));
+            assertEquals("1.2", String.format("%-3.1f", 1.2));
+            assertEquals("1.2 ", String.format("%-4.1f", 1.2));
+            assertEquals("1.2  ", String.format("%-5.1f", 1.2));
+            assertEquals("1.2       ", String.format("%-10.1f", 1.2));
+
+            assertEquals("-1.2", String.format("%-1.1f", -1.2));
+            assertEquals("-1.2", String.format("%-2.1f", -1.2));
+            assertEquals("-1.2", String.format("%-3.1f", -1.2));
+            assertEquals("-1.2", String.format("%-4.1f", -1.2));
+            assertEquals("-1.2 ", String.format("%-5.1f", -1.2));
+            assertEquals("-1.2      ", String.format("%-10.1f", -1.2));
+        }
+
+        @Test
+        void blankPad_minus_plus_d() {
+            assertEquals("+1.2", String.format("%-+1.1f", 1.2));
+            assertEquals("+1.2", String.format("%-+2.1f", 1.2));
+            assertEquals("+1.2", String.format("%-+3.1f", 1.2));
+            assertEquals("+1.2", String.format("%-+4.1f", 1.2));
+            assertEquals("+1.2 ", String.format("%-+5.1f", 1.2));
+            assertEquals("+1.2      ", String.format("%-+10.1f", 1.2));
+
+            assertEquals("-1.2", String.format("%-+1.1f", -1.2));
+            assertEquals("-1.2", String.format("%-+2.1f", -1.2));
+            assertEquals("-1.2", String.format("%-+3.1f", -1.2));
+            assertEquals("-1.2", String.format("%-+4.1f", -1.2));
+            assertEquals("-1.2 ", String.format("%-+5.1f", -1.2));
+            assertEquals("-1.2      ", String.format("%-+10.1f", -1.2));
+        }
+
+        @Test
+        void blankPad_minus_blank_d() {
+            assertEquals(" 1.2", String.format("%- 1.1f", 1.2));
+            assertEquals(" 1.2", String.format("%- 2.1f", 1.2));
+            assertEquals(" 1.2", String.format("%- 3.1f", 1.2));
+            assertEquals(" 1.2", String.format("%- 4.1f", 1.2));
+            assertEquals(" 1.2 ", String.format("%- 5.1f", 1.2));
+            assertEquals(" 1.2      ", String.format("%- 10.1f", 1.2));
+
+            assertEquals("-1.2", String.format("%- 1.1f", -1.2));
+            assertEquals("-1.2", String.format("%- 2.1f", -1.2));
+            assertEquals("-1.2", String.format("%- 3.1f", -1.2));
+            assertEquals("-1.2", String.format("%- 4.1f", -1.2));
+            assertEquals("-1.2 ", String.format("%- 5.1f", -1.2));
+            assertEquals("-1.2      ", String.format("%- 10.1f", -1.2));
+        }
+
+    }
+
+}


### PR DESCRIPTION
This change transforms a O(n^2) path to O(n) when prepending zero padding to decimal outputs, where n is the length of the padding.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299677](https://bugs.openjdk.org/browse/JDK-8299677): Formatter.format might take a long time to format an integer or floating-point


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [275582a9](https://git.openjdk.org/jdk/pull/11939/files/275582a9860c7da9deeb53a979109eaa304f6deb)
 * [Sergey Tsypanov](https://openjdk.org/census#stsypanov) (@stsypanov - Author)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11939/head:pull/11939` \
`$ git checkout pull/11939`

Update a local copy of the PR: \
`$ git checkout pull/11939` \
`$ git pull https://git.openjdk.org/jdk pull/11939/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11939`

View PR using the GUI difftool: \
`$ git pr show -t 11939`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11939.diff">https://git.openjdk.org/jdk/pull/11939.diff</a>

</details>
