### PR TITLE
8081474: SwingWorker calls 'done' before the 'doInBackground' is finished

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/SwingWorker.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingWorker.java
@@ -309,6 +309,7 @@ public abstract class SwingWorker<T, V> implements RunnableFuture<T> {
                         }
                     }
                 };
+
        future = new FutureTask<T>(callable);
        state = StateValue.PENDING;
        propertyChangeSupport = new SwingWorkerPropertyChangeSupport(this);
@@ -549,6 +550,7 @@ public abstract class SwingWorker<T, V> implements RunnableFuture<T> {
      * {@inheritDoc}
      */
     public final boolean cancel(boolean mayInterruptIfRunning) {
+        setState(StateValue.DONE);
         return future.cancel(mayInterruptIfRunning);
     }
 
@@ -563,7 +565,7 @@ public abstract class SwingWorker<T, V> implements RunnableFuture<T> {
      * {@inheritDoc}
      */
     public final boolean isDone() {
-        return future.isDone();
+        return future.isDone() && state == StateValue.DONE;
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/SwingWorker.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingWorker.java
@@ -310,7 +310,7 @@ public abstract class SwingWorker<T, V> implements RunnableFuture<T> {
                     }
                 };
 
-        future = new FutureTask<T>(callable);
+       future = new FutureTask<T>(callable);
 
        state = StateValue.PENDING;
        propertyChangeSupport = new SwingWorkerPropertyChangeSupport(this);

--- a/src/java.desktop/share/classes/javax/swing/SwingWorker.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingWorker.java
@@ -126,9 +126,9 @@ import sun.swing.AccumulativeRunnable;
  * Before the {@code doInBackground} method is invoked on a <i>worker</i> thread,
  * {@code SwingWorker} notifies any {@code PropertyChangeListeners} about the
  * {@code state} property change to {@code StateValue.STARTED}.  After the
- * {@code doInBackground} method is finished, {@code SwingWorker} notifies
- * any {@code PropertyChangeListeners} about the {@code state} property
- * change to {@code StateValue.DONE}. Finally, {@code done} method is executed.
+ * {@code doInBackground} method is finished the {@code done} method is
+ * executed.  Then {@code SwingWorker} notifies any {@code PropertyChangeListeners}
+ * about the {@code state} property change to {@code StateValue.DONE}.
  *
  * <p>
  * {@code SwingWorker} is only designed to be executed once.  Executing a
@@ -301,16 +301,17 @@ public abstract class SwingWorker<T, V> implements RunnableFuture<T> {
                 new Callable<T>() {
                     public T call() throws Exception {
                         setState(StateValue.STARTED);
-                        try {
+			try {
                             return doInBackground();
                         } finally {
-                            setState(StateValue.DONE);
                             doneEDT();
+                            setState(StateValue.DONE);
                         }
                     }
                 };
 
-       future = new FutureTask<T>(callable);
+        future = new FutureTask<T>(callable);
+
        state = StateValue.PENDING;
        propertyChangeSupport = new SwingWorkerPropertyChangeSupport(this);
        doProcess = null;

--- a/src/java.desktop/share/classes/javax/swing/SwingWorker.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingWorker.java
@@ -550,7 +550,6 @@ public abstract class SwingWorker<T, V> implements RunnableFuture<T> {
      * {@inheritDoc}
      */
     public final boolean cancel(boolean mayInterruptIfRunning) {
-        setState(StateValue.DONE);
         return future.cancel(mayInterruptIfRunning);
     }
 
@@ -565,7 +564,7 @@ public abstract class SwingWorker<T, V> implements RunnableFuture<T> {
      * {@inheritDoc}
      */
     public final boolean isDone() {
-        return future.isDone() && state == StateValue.DONE;
+        return future.isDone();
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/SwingWorker.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/SwingWorker.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingWorker.java
@@ -301,7 +301,7 @@ public abstract class SwingWorker<T, V> implements RunnableFuture<T> {
                 new Callable<T>() {
                     public T call() throws Exception {
                         setState(StateValue.STARTED);
-			try {
+                        try {
                             return doInBackground();
                         } finally {
                             doneEDT();

--- a/src/java.desktop/share/classes/javax/swing/SwingWorker.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingWorker.java
@@ -126,9 +126,9 @@ import sun.swing.AccumulativeRunnable;
  * Before the {@code doInBackground} method is invoked on a <i>worker</i> thread,
  * {@code SwingWorker} notifies any {@code PropertyChangeListeners} about the
  * {@code state} property change to {@code StateValue.STARTED}.  After the
- * {@code doInBackground} method is finished the {@code done} method is
- * executed.  Then {@code SwingWorker} notifies any {@code PropertyChangeListeners}
- * about the {@code state} property change to {@code StateValue.DONE}.
+ * {@code doInBackground} method is finished, {@code SwingWorker} notifies
+ * any {@code PropertyChangeListeners} about the {@code state} property
+ * change to {@code StateValue.DONE}. Finally, {@code done} method is executed.
  *
  * <p>
  * {@code SwingWorker} is only designed to be executed once.  Executing a

--- a/src/java.desktop/share/classes/javax/swing/SwingWorker.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingWorker.java
@@ -754,7 +754,7 @@ public abstract class SwingWorker<T, V> implements RunnableFuture<T> {
             if (state != StateValue.DONE) {
                 do {
                     try {
-                        Thread.sleep(500);
+                        Thread.sleep(100);
                     } catch (InterruptedException e) {}
                 } while (state != StateValue.DONE);
             }
@@ -763,7 +763,7 @@ public abstract class SwingWorker<T, V> implements RunnableFuture<T> {
             if (state != StateValue.DONE) {
                 do {
                     try {
-                        Thread.sleep(500);
+                        Thread.sleep(100);
                     } catch (InterruptedException e) {}
                 } while (state != StateValue.DONE);
             }

--- a/src/java.desktop/share/classes/javax/swing/SwingWorker.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingWorker.java
@@ -751,13 +751,6 @@ public abstract class SwingWorker<T, V> implements RunnableFuture<T> {
                 }
             };
         if (SwingUtilities.isEventDispatchThread()) {
-            if (state != StateValue.DONE) {
-                do {
-                    try {
-                        Thread.sleep(100);
-                    } catch (InterruptedException e) {}
-                } while (state != StateValue.DONE);
-            }
             doDone.run();
         } else {
             if (state != StateValue.DONE) {

--- a/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
+++ b/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
@@ -87,7 +87,7 @@ public class TestDoneBeforeDoInBackground {
                     // SwingWorker notifies PropertyChangeListeners about the
                     // property change to StateValue.STARTED
                     if (doInBackgroundFinished.get()
-                          && worker.getState() == SwingWorker.StateValue.STARTED) {
+                        && worker.getState() == SwingWorker.StateValue.STARTED) {
                         throw new RuntimeException(
                                "PropertyChangeListeners called with " +
                                "state STARTED after doInBackground is invoked");
@@ -96,7 +96,7 @@ public class TestDoneBeforeDoInBackground {
                     // Ensure the STARTED state is notified
                     // before doInBackground started running
                     if (doInBackgroundStarted.get()
-                          && worker.getState() == SwingWorker.StateValue.STARTED) {
+                        && worker.getState() == SwingWorker.StateValue.STARTED) {
                         throw new RuntimeException(
                               "PropertyChangeListeners called with " +
                                "state STARTED before doInBackground is finished");
@@ -106,7 +106,7 @@ public class TestDoneBeforeDoInBackground {
                     // SwingWorker notifies PropertyChangeListeners
                     // property change to StateValue.DONE
                     if (worker.getState() != SwingWorker.StateValue.DONE
-                          && doInBackgroundFinished.get()) {
+                        && doInBackgroundFinished.get()) {
                         throw new RuntimeException(
                             "PropertyChangeListeners called after " +
                             " doInBackground is finished but before State changed to DONE");
@@ -130,9 +130,9 @@ public class TestDoneBeforeDoInBackground {
         System.out.println("doInBackground " + doInBackgroundFinished.get() +
                            " getState " + worker.getState());
         if (worker.getState() != SwingWorker.StateValue.DONE
-              && doInBackgroundFinished.get()) {
+            && doInBackgroundFinished.get()) {
             throw new RuntimeException("doInBackground is finished " +
-                                         "but State is not DONE");
+                                       "but State is not DONE");
         }
     }
 }

--- a/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
+++ b/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
@@ -36,10 +36,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class TestDoneBeforeDoInBackground {
 
-    private static AtomicBoolean doInBackgroundStarted = new AtomicBoolean(false);
-    private static AtomicBoolean doInBackgroundFinished = new AtomicBoolean(false);
     private static final int WAIT_TIME = 200;
     private static final long CLEANUP_TIME = 1000;
+
+    private static final AtomicBoolean doInBackgroundStarted = new AtomicBoolean(false);
+    private static final AtomicBoolean doInBackgroundFinished = new AtomicBoolean(false);
     private static final CountDownLatch doneLatch = new CountDownLatch(1);
 
     public static void main(String[] args) throws InterruptedException {
@@ -54,6 +55,7 @@ public class TestDoneBeforeDoInBackground {
                 } catch (InterruptedException ex) {
                     System.out.println("Got interrupted!");
                 }
+
                 try {
                     doInBackgroundStarted.set(true);
                     System.out.println("Cleaning up");
@@ -63,6 +65,7 @@ public class TestDoneBeforeDoInBackground {
                 } catch (InterruptedException ex) {
                     System.out.println("Got interrupted second time!");
                 }
+
                 return null;
             }
 
@@ -70,7 +73,7 @@ public class TestDoneBeforeDoInBackground {
             protected void done() {
                 if (!doInBackgroundFinished.get()) {
                     throw new RuntimeException("done called before " +
-                                             " doInBackground is finished");
+                                               "doInBackground is finished");
                 }
                 System.out.println("Done");
                 doneLatch.countDown();
@@ -83,25 +86,27 @@ public class TestDoneBeforeDoInBackground {
                     // Before doInBackground method is invoked,
                     // SwingWorker notifies PropertyChangeListeners about the
                     // property change to StateValue.STARTED
-                    if (doInBackgroundFinished.get() &&
-                         worker.getState() == SwingWorker.StateValue.STARTED) {
+                    if (doInBackgroundFinished.get()
+                        && worker.getState() == SwingWorker.StateValue.STARTED) {
                         throw new RuntimeException(
                                "PropertyChangeListeners called with " +
                                "state STARTED after doInBackground is invoked");
                     }
+
                     // Ensure the STARTED state is notified
                     // before doInBackground started running
-                    if (doInBackgroundStarted.get() &&
-                         worker.getState() == SwingWorker.StateValue.STARTED) {
+                    if (doInBackgroundStarted.get()
+                        && worker.getState() == SwingWorker.StateValue.STARTED) {
                         throw new RuntimeException(
                                "PropertyChangeListeners called with " +
                                "state STARTED before doInBackground is finished");
                     }
+
                     // After the doInBackground method is finished
                     // SwingWorker notifies PropertyChangeListeners
                     // property change to StateValue.DONE
-                    if (doInBackgroundFinished.get() &&
-                            worker.getState() != SwingWorker.StateValue.DONE) {
+                    if (worker.getState() != SwingWorker.StateValue.DONE
+                          && doInBackgroundFinished.get()) {
                         throw new RuntimeException(
                             "PropertyChangeListeners called after " +
                             " doInBackground is finished but before State changed to DONE");
@@ -124,10 +129,10 @@ public class TestDoneBeforeDoInBackground {
         }
         System.out.println("doInBackground " + doInBackgroundFinished.get() +
                            " getState " + worker.getState());
-        if (doInBackgroundFinished.get() &&
-              worker.getState() != SwingWorker.StateValue.DONE) {
-            throw new RuntimeException("doInBackground is finished " +
-                                       " but State is not DONE");
+        if (worker.getState() != SwingWorker.StateValue.DONE
+            && doInBackgroundFinished.get()) {
+              throw new RuntimeException("doInBackground is finished " +
+                                         "but State is not DONE");
         }
     }
 }

--- a/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
+++ b/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
@@ -85,7 +85,7 @@ public class TestDoneBeforeDoInBackground {
         worker.addPropertyChangeListener(
             new PropertyChangeListener() {
                 public void propertyChange(PropertyChangeEvent evt) {
-                    System.out.println("doInBackground started: " +
+                    System.out.println("doInBackgroundStarted: " +
                                         doInBackgroundStarted.get() +
                                         " doInBackgroundFinished: " +
                                         doInBackgroundFinished.get() +

--- a/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
+++ b/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
@@ -31,7 +31,8 @@ import javax.swing.SwingWorker;
 
 public class TestDoneBeforeDoInBackground {
 
-    static boolean doInBackground =  false;
+    static boolean doInBackground = false;
+    static final int WAIT_TIME = 2000;
 
     public static void main(String[] args) throws InterruptedException {
         SwingWorker<String, String> worker =
@@ -41,14 +42,14 @@ public class TestDoneBeforeDoInBackground {
                 try {
                     while (!Thread.currentThread().isInterrupted()) {
                         System.out.println("Working...");
-                        Thread.sleep(1000);
+                        Thread.sleep(WAIT_TIME);
                     }
                 } catch (InterruptedException ex) {
                     System.out.println("Got interrupted!");
                 }
                 try {
                     System.out.println("Cleaning up");
-                    Thread.sleep(5000);
+                    Thread.sleep(WAIT_TIME);
                     System.out.println("Done cleaning");
                     doInBackground = true;
                 } catch (InterruptedException ex) {
@@ -67,9 +68,10 @@ public class TestDoneBeforeDoInBackground {
         };
 
         worker.execute();
-        Thread.sleep(5000);
+        Thread.sleep(WAIT_TIME);
 
         worker.cancel(true);
-        Thread.sleep(2000);
+        Thread.sleep(WAIT_TIME);
     }
 }
+

--- a/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
+++ b/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 
 public class TestDoneBeforeDoInBackground {
 
-    static boolean doInBackground = false;
+    private static boolean doInBackground = false;
     private static final int WAIT_TIME = 200;
     private static final long CLEANUP_TIME = 3000;
     private static final CountDownLatch doneLatch = new CountDownLatch(1);
@@ -86,7 +86,8 @@ public class TestDoneBeforeDoInBackground {
         if (!doneLatch.await(CLEANUP_TIME + 1000L, TimeUnit.MILLISECONDS)) {
             throw new RuntimeException("done didn't complete in time");
         }
-        System.out.println("doInBackground " + doInBackground);
+        System.out.println("doInBackground " + doInBackground +
+                           " getState " + worker.getState());
         if (doInBackground && worker.getState() != SwingWorker.StateValue.DONE) {
             throw new RuntimeException("doInBackground is finished " +
                                        " but State is not DONE");

--- a/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
+++ b/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
@@ -25,11 +25,11 @@
  * @bug 8081474
  * @summary  Verifies if SwingWorker calls 'done'
  *           before the 'doInBackground' is finished
- * @run main TestSwingWorker
+ * @run main TestDoneBeforeDoInBackground
  */
 import javax.swing.SwingWorker;
 
-public class TestSwingWorker {
+public class TestDoneBeforeDoInBackground {
 
     static boolean doInBackground =  false;
 
@@ -43,8 +43,7 @@ public class TestSwingWorker {
                         System.out.println("Working...");
                         Thread.sleep(1000);
                     }
-                }
-                catch (InterruptedException ex) {
+                } catch (InterruptedException ex) {
                     System.out.println("Got interrupted!");
                 }
                 try {
@@ -52,8 +51,7 @@ public class TestSwingWorker {
                     Thread.sleep(5000);
                     System.out.println("Done cleaning");
                     doInBackground = true;
-                }
-                catch (InterruptedException ex) {
+                } catch (InterruptedException ex) {
                     System.out.println("Got interrupted second time!");
                 }
                 return null;

--- a/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
+++ b/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
@@ -87,7 +87,7 @@ public class TestDoneBeforeDoInBackground {
                     // SwingWorker notifies PropertyChangeListeners about the
                     // property change to StateValue.STARTED
                     if (doInBackgroundFinished.get()
-                        && worker.getState() == SwingWorker.StateValue.STARTED) {
+                          && worker.getState() == SwingWorker.StateValue.STARTED) {
                         throw new RuntimeException(
                                "PropertyChangeListeners called with " +
                                "state STARTED after doInBackground is invoked");
@@ -96,9 +96,9 @@ public class TestDoneBeforeDoInBackground {
                     // Ensure the STARTED state is notified
                     // before doInBackground started running
                     if (doInBackgroundStarted.get()
-                        && worker.getState() == SwingWorker.StateValue.STARTED) {
+                          && worker.getState() == SwingWorker.StateValue.STARTED) {
                         throw new RuntimeException(
-                               "PropertyChangeListeners called with " +
+                              "PropertyChangeListeners called with " +
                                "state STARTED before doInBackground is finished");
                     }
 
@@ -130,8 +130,8 @@ public class TestDoneBeforeDoInBackground {
         System.out.println("doInBackground " + doInBackgroundFinished.get() +
                            " getState " + worker.getState());
         if (worker.getState() != SwingWorker.StateValue.DONE
-            && doInBackgroundFinished.get()) {
-              throw new RuntimeException("doInBackground is finished " +
+              && doInBackgroundFinished.get()) {
+            throw new RuntimeException("doInBackground is finished " +
                                          "but State is not DONE");
         }
     }

--- a/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
+++ b/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
@@ -95,8 +95,8 @@ public class TestDoneBeforeDoInBackground {
                             worker.getState() != SwingWorker.StateValue.DONE) {
                         throw new RuntimeException(
                             "listener called after doInBackground is finised" +
-			   " but before State changed to DONE");
-		    }
+                            " but before State changed to DONE");
+                    }
                 }
             });
         worker.execute();

--- a/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
+++ b/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
@@ -35,7 +35,7 @@ public class TestDoneBeforeDoInBackground {
 
     private static boolean doInBackground = false;
     private static final int WAIT_TIME = 200;
-    private static final long CLEANUP_TIME = 3000;
+    private static final long CLEANUP_TIME = 1000;
     private static final CountDownLatch doneLatch = new CountDownLatch(1);
 
     public static void main(String[] args) throws InterruptedException {

--- a/test/jdk/javax/swing/SwingWorker/TestSwingWorker.java
+++ b/test/jdk/javax/swing/SwingWorker/TestSwingWorker.java
@@ -58,12 +58,12 @@ public class TestSwingWorker {
                 }
                 return null;
             }
-            
+
             @Override
             protected void done() {
                 if (!doInBackground) {
                     throw new RuntimeException("done called before doInBackground");
-                }		    
+                }
                 System.out.println("Done");
             }
         };
@@ -74,4 +74,4 @@ public class TestSwingWorker {
         worker.cancel(true);
         Thread.sleep(2000);
     }
-} 
+}

--- a/test/jdk/javax/swing/SwingWorker/TestSwingWorker.java
+++ b/test/jdk/javax/swing/SwingWorker/TestSwingWorker.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8081474
+ * @summary  Verifies if SwingWorker calls 'done' 
+ *           before the 'doInBackground' is finished
+ * @run main TestSwingWorker
+ */
+import javax.swing.SwingWorker;
+
+public class TestSwingWorker {
+
+    static boolean doInBackground =  false;
+
+    public static void main(String[] args) throws InterruptedException {
+        SwingWorker<String, String> worker = 
+            new SwingWorker<String, String>() {
+            @Override
+            protected String doInBackground() throws Exception {
+                try {
+                    while (!Thread.currentThread().isInterrupted()) {
+                        System.out.println("Working...");
+                        Thread.sleep(1000);
+                        
+                    }
+                }
+                catch (InterruptedException ex) {
+                    System.out.println("Got interrupted!");
+                }
+                
+                try {
+                    System.out.println("Cleaning up");
+                    Thread.sleep(5000);
+                    System.out.println("Done cleaning");
+		    doInBackground = true;
+                }
+                catch (InterruptedException ex) {
+                    System.out.println("Got interrupted second time!");
+                }
+                
+                return null;
+            }
+            
+            @Override
+            protected void done() {
+                if (!doInBackground) {
+                    throw new RuntimeException("done called before doInBackground");
+		}		    
+                System.out.println("Done");
+            }
+        };
+        
+        worker.execute();
+        Thread.sleep(5000);
+        
+        worker.cancel(true);
+        Thread.sleep(2000);
+    }
+} 

--- a/test/jdk/javax/swing/SwingWorker/TestSwingWorker.java
+++ b/test/jdk/javax/swing/SwingWorker/TestSwingWorker.java
@@ -23,7 +23,7 @@
 /*
  * @test
  * @bug 8081474
- * @summary  Verifies if SwingWorker calls 'done' 
+ * @summary  Verifies if SwingWorker calls 'done'
  *           before the 'doInBackground' is finished
  * @run main TestSwingWorker
  */
@@ -34,7 +34,7 @@ public class TestSwingWorker {
     static boolean doInBackground =  false;
 
     public static void main(String[] args) throws InterruptedException {
-        SwingWorker<String, String> worker = 
+        SwingWorker<String, String> worker =
             new SwingWorker<String, String>() {
             @Override
             protected String doInBackground() throws Exception {
@@ -42,23 +42,20 @@ public class TestSwingWorker {
                     while (!Thread.currentThread().isInterrupted()) {
                         System.out.println("Working...");
                         Thread.sleep(1000);
-                        
                     }
                 }
                 catch (InterruptedException ex) {
                     System.out.println("Got interrupted!");
                 }
-                
                 try {
                     System.out.println("Cleaning up");
                     Thread.sleep(5000);
                     System.out.println("Done cleaning");
-		    doInBackground = true;
+                    doInBackground = true;
                 }
                 catch (InterruptedException ex) {
                     System.out.println("Got interrupted second time!");
                 }
-                
                 return null;
             }
             
@@ -66,14 +63,14 @@ public class TestSwingWorker {
             protected void done() {
                 if (!doInBackground) {
                     throw new RuntimeException("done called before doInBackground");
-		}		    
+                }		    
                 System.out.println("Done");
             }
         };
-        
+
         worker.execute();
         Thread.sleep(5000);
-        
+
         worker.cancel(true);
         Thread.sleep(2000);
     }


### PR DESCRIPTION
SwingWorker done() method [spec ](https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/javax/swing/SwingWorker.java#L452) says "Executed on the Event Dispatch Thread after the doInBackground method is finished"
but there's no mechanism in place to honor that claim.
The [spec](https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/javax/swing/SwingWorker.java#L289)
also says the state should be DONE after doInBackground() returns which is also not done.

Modified the code to honour the specification.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8081474](https://bugs.openjdk.org/browse/JDK-8081474): SwingWorker calls 'done' before the 'doInBackground' is finished
 * [JDK-8301940](https://bugs.openjdk.org/browse/JDK-8301940): SwingWorker calls 'done' before the 'doInBackground' is finished (**CSR**) (Withdrawn)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11940/head:pull/11940` \
`$ git checkout pull/11940`

Update a local copy of the PR: \
`$ git checkout pull/11940` \
`$ git pull https://git.openjdk.org/jdk pull/11940/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11940`

View PR using the GUI difftool: \
`$ git pr show -t 11940`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11940.diff">https://git.openjdk.org/jdk/pull/11940.diff</a>

</details>
