### PR TITLE
8299956: [BACKOUT] 8297487: G1 Remark: no need to keep alive oop constants of nmethods on stack

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1779,17 +1779,30 @@ public:
 
 class G1RemarkThreadsClosure : public ThreadClosure {
   G1SATBMarkQueueSet& _qset;
+  G1CMOopClosure _cm_cl;
+  MarkingCodeBlobClosure _code_cl;
   uintx _claim_token;
 
  public:
   G1RemarkThreadsClosure(G1CollectedHeap* g1h, G1CMTask* task) :
     _qset(G1BarrierSet::satb_mark_queue_set()),
+    _cm_cl(g1h, task),
+    _code_cl(&_cm_cl, !CodeBlobToOopClosure::FixRelocations, true /* keepalive nmethods */),
     _claim_token(Threads::thread_claim_token()) {}
 
   void do_thread(Thread* thread) {
     if (thread->claim_threads_do(true, _claim_token)) {
       // Transfer any partial buffer to the qset for completed buffer processing.
       _qset.flush_queue(G1ThreadLocalData::satb_mark_queue(thread));
+      if (thread->is_Java_thread()) {
+        // In theory it should not be necessary to explicitly walk the nmethods to find roots for concurrent marking
+        // however the liveness of oops reachable from nmethods have very complex lifecycles:
+        // * Alive if on the stack of an executing method
+        // * Weakly reachable otherwise
+        // Some objects reachable from nmethods, such as the class loader (or klass_holder) of the receiver should be
+        // live by the SATB invariant but other oops recorded in nmethods may behave differently.
+        JavaThread::cast(thread)->nmethods_do(&_code_cl);
+      }
     }
   }
 };

--- a/src/hotspot/share/gc/shared/barrierSet.cpp
+++ b/src/hotspot/share/gc/shared/barrierSet.cpp
@@ -57,9 +57,8 @@ static BarrierSetNMethod* select_barrier_set_nmethod(BarrierSetNMethod* barrier_
     // The GC needs nmethod entry barriers to do concurrent GC
     return barrier_set_nmethod;
   } else {
-    // The GC needs nmethod entry barriers for code cache unloading (recently
-    // used heuristics) and, if it's a SATB GC, to keep alive constant objects
-    // of nmethods because they are weakly referenced.
+    // The GC needs nmethod entry barriers to deal with continuations
+    // and code cache unloading
     return new BarrierSetNMethod();
   }
 }


### PR DESCRIPTION
Clean backout after we observed various crashes with different tests after the integration of [JDK-8297487](https://bugs.openjdk.org/browse/JDK-8297487).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299956](https://bugs.openjdk.org/browse/JDK-8299956): [BACKOUT] 8297487: G1 Remark: no need to keep alive oop constants of nmethods on stack


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11941/head:pull/11941` \
`$ git checkout pull/11941`

Update a local copy of the PR: \
`$ git checkout pull/11941` \
`$ git pull https://git.openjdk.org/jdk pull/11941/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11941`

View PR using the GUI difftool: \
`$ git pr show -t 11941`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11941.diff">https://git.openjdk.org/jdk/pull/11941.diff</a>

</details>
