### PR TITLE
8299960: Speed up test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeURShiftSubword.java

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeURShiftSubword.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeURShiftSubword.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeURShiftSubword.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeURShiftSubword.java
@@ -68,6 +68,7 @@ public class TestVectorizeURShiftSubword {
     }
 
     @Test
+    @Warmup(1)
     @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.RSHIFT_VB, ">0", IRNode.STORE_VECTOR, ">0"})
     public void testByte0() {
         for(int i = 0; i < NUM; i++) {
@@ -76,6 +77,7 @@ public class TestVectorizeURShiftSubword {
     }
 
     @Test
+    @Warmup(1)
     @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.RSHIFT_VB, ">0", IRNode.STORE_VECTOR, ">0"})
     public void testByte1() {
         for(int i = 0; i < NUM; i++) {
@@ -84,6 +86,7 @@ public class TestVectorizeURShiftSubword {
     }
 
     @Test
+    @Warmup(1)
     @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.RSHIFT_VB, IRNode.STORE_VECTOR})
     public void testByte2() {
         for(int i = 0; i < NUM; i++) {
@@ -92,6 +95,7 @@ public class TestVectorizeURShiftSubword {
     }
 
     @Test
+    @Warmup(1)
     @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.RSHIFT_VS, ">0", IRNode.STORE_VECTOR, ">0"})
     public void testShort0() {
         for(int i = 0; i < NUM; i++) {
@@ -100,6 +104,7 @@ public class TestVectorizeURShiftSubword {
     }
 
     @Test
+    @Warmup(1)
     @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.RSHIFT_VS, ">0", IRNode.STORE_VECTOR, ">0"})
     public void testShort1() {
         for(int i = 0; i < NUM; i++) {
@@ -108,6 +113,7 @@ public class TestVectorizeURShiftSubword {
     }
 
     @Test
+    @Warmup(1)
     @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.RSHIFT_VS, IRNode.STORE_VECTOR})
     public void testShort2() {
         for(int i = 0; i < NUM; i++) {
@@ -145,6 +151,7 @@ public class TestVectorizeURShiftSubword {
     }
 
     @Run(test = "checkTest")
+    @Warmup(1)
     public void checkTest_runner() {
         for (int i = 0; i < SPECIALS.length; i++) {
             for (int j = 0; j < shorta.length; j++) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeURShiftSubword.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeURShiftSubword.java
@@ -64,11 +64,11 @@ public class TestVectorizeURShiftSubword {
     }
 
     public static void main(String[] args) {
-        TestFramework.runWithFlags("-XX:CompileCommand=exclude,*.urshift");
+        TestFramework framework = new TestFramework(TestVectorizeURShiftSubword.class);
+        framework.setDefaultWarmup(1).addFlags("-XX:CompileCommand=exclude,*.urshift").start();
     }
 
     @Test
-    @Warmup(1)
     @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.RSHIFT_VB, ">0", IRNode.STORE_VECTOR, ">0"})
     public void testByte0() {
         for(int i = 0; i < NUM; i++) {
@@ -77,7 +77,6 @@ public class TestVectorizeURShiftSubword {
     }
 
     @Test
-    @Warmup(1)
     @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.RSHIFT_VB, ">0", IRNode.STORE_VECTOR, ">0"})
     public void testByte1() {
         for(int i = 0; i < NUM; i++) {
@@ -86,7 +85,6 @@ public class TestVectorizeURShiftSubword {
     }
 
     @Test
-    @Warmup(1)
     @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.RSHIFT_VB, IRNode.STORE_VECTOR})
     public void testByte2() {
         for(int i = 0; i < NUM; i++) {
@@ -95,7 +93,6 @@ public class TestVectorizeURShiftSubword {
     }
 
     @Test
-    @Warmup(1)
     @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.RSHIFT_VS, ">0", IRNode.STORE_VECTOR, ">0"})
     public void testShort0() {
         for(int i = 0; i < NUM; i++) {
@@ -104,7 +101,6 @@ public class TestVectorizeURShiftSubword {
     }
 
     @Test
-    @Warmup(1)
     @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.RSHIFT_VS, ">0", IRNode.STORE_VECTOR, ">0"})
     public void testShort1() {
         for(int i = 0; i < NUM; i++) {
@@ -113,7 +109,6 @@ public class TestVectorizeURShiftSubword {
     }
 
     @Test
-    @Warmup(1)
     @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.RSHIFT_VS, IRNode.STORE_VECTOR})
     public void testShort2() {
         for(int i = 0; i < NUM; i++) {
@@ -151,7 +146,6 @@ public class TestVectorizeURShiftSubword {
     }
 
     @Run(test = "checkTest")
-    @Warmup(1)
     public void checkTest_runner() {
         for (int i = 0; i < SPECIALS.length; i++) {
             for (int j = 0; j < shorta.length; j++) {


### PR DESCRIPTION
This is one of the most time-consuming compiler tests.
On my machine, I was able to reduce it from `20 sec` to `3 sec`.

This is an irTest, so we basically only want to see if certain IR-nodes are present.
By default we do `2000` warmup iterations, this is not required in these examples, so I `setDefaultWarmup(1)`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299960](https://bugs.openjdk.org/browse/JDK-8299960): Speed up test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeURShiftSubword.java


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [7c44121b](https://git.openjdk.org/jdk/pull/11942/files/7c44121be60a218531db00b45c9268f5c3aa6d3b)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [7c44121b](https://git.openjdk.org/jdk/pull/11942/files/7c44121be60a218531db00b45c9268f5c3aa6d3b)
 * [Fei Gao](https://openjdk.org/census#fgao) (@fg1417 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11942/head:pull/11942` \
`$ git checkout pull/11942`

Update a local copy of the PR: \
`$ git checkout pull/11942` \
`$ git pull https://git.openjdk.org/jdk pull/11942/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11942`

View PR using the GUI difftool: \
`$ git pr show -t 11942`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11942.diff">https://git.openjdk.org/jdk/pull/11942.diff</a>

</details>
