### PR TITLE
8299962: Speed up compiler/intrinsics/unsafe/DirectByteBufferTest.java and HeapByteBufferTest.java

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/unsafe/DirectByteBufferTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/unsafe/DirectByteBufferTest.java
@@ -41,7 +41,7 @@ public class DirectByteBufferTest extends ByteBufferTest {
     public static void main(String[] args) {
         // The number of iterations is high to ensure that tiered
         // compilation kicks in all the way up to C2.
-        long iterations = 100000;
+        long iterations = 5000;
         if (args.length > 0)
             iterations = Long.parseLong(args[0]);
 

--- a/test/hotspot/jtreg/compiler/intrinsics/unsafe/HeapByteBufferTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/unsafe/HeapByteBufferTest.java
@@ -59,7 +59,7 @@ public class HeapByteBufferTest extends ByteBufferTest {
     public static void main(String[] args) {
         // The number of iterations is high to ensure that tiered
         // compilation kicks in all the way up to C2.
-        long iterations = 100000;
+        long iterations = 5000;
         if (args.length > 0)
             iterations = Long.parseLong(args[0]);
 


### PR DESCRIPTION
The test used a blanket `100_000` iterations to ensure C2 triggers for the relevant intrinsics of `jdk.internal.misc.Unsafe`.

I experimented lowering the number of iterations, and got the following results:
`100_000` (overkill, 8.5 sec) `5000`(very safe, 3 sec), `2000`(decent, 2.6 sec) and even `200` (ok, 2.5 sec).
I measured the time per `@run` statement (there are 6 over the two test files).

For `5000` I got the same count of intrinsifications per intrinsic.
For `2000` it dropped slightly, rarely an intrinsic was not intrinsified.
For `200` it dropped a bit more, and sometimes multiple intrinsics are not intrinsified.

If one uses `-Xbatch -X:-TieredCompilation`, then the cound does not change at all, even for `200`.

Since the marginal speedup from `5000` to `200` is very small, I decided to be on the **safe side**.
This is still a **speedup of 2.7x**.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299962](https://bugs.openjdk.org/browse/JDK-8299962): Speed up compiler/intrinsics/unsafe/DirectByteBufferTest.java and HeapByteBufferTest.java


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11944/head:pull/11944` \
`$ git checkout pull/11944`

Update a local copy of the PR: \
`$ git checkout pull/11944` \
`$ git pull https://git.openjdk.org/jdk pull/11944/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11944`

View PR using the GUI difftool: \
`$ git pr show -t 11944`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11944.diff">https://git.openjdk.org/jdk/pull/11944.diff</a>

</details>
