### PR TITLE
8299976: Initialize static fields in Net eagerly

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/Net.java
+++ b/src/java.base/share/classes/sun/nio/ch/Net.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/nio/ch/Net.java
+++ b/src/java.base/share/classes/sun/nio/ch/Net.java
@@ -73,21 +73,21 @@ public class Net {
 
     // -- Miscellaneous utilities --
 
-    private static final boolean IP_V6_AVAILABLE;
-    private static final boolean REUSE_PORT_AVAILABLE;
+    private static final boolean IPV6_AVAILABLE;
+    private static final boolean SO_REUSEPORT_AVAILABLE;
 
     /**
      * Tells whether dual-IPv4/IPv6 sockets should be used.
      */
     static boolean isIPv6Available() {
-        return IP_V6_AVAILABLE;
+        return IPV6_AVAILABLE;
     }
 
     /**
      * Tells whether SO_REUSEPORT is supported.
      */
     static boolean isReusePortAvailable() {
-        return REUSE_PORT_AVAILABLE;
+        return SO_REUSEPORT_AVAILABLE;
     }
 
     /**
@@ -190,6 +190,10 @@ public class Net {
             throw new Error("Untranslated exception", nx);
     }
 
+    private static SocketException newSocketException(String msg) {
+        return new SocketException(msg);
+    }
+
     static void translateException(Exception x,
                                    boolean unknownHostForUnresolved)
         throws IOException
@@ -244,40 +248,40 @@ public class Net {
         return new InetSocketAddress(InetAddress.getLoopbackAddress(), port);
     }
 
-    private static final InetAddress ANY_LOCAL_INET_4_ADDRESS;
-    private static final InetAddress ANY_LOCAL_INET_6_ADDRESS;
-    private static final InetAddress INET_4_LOOPBACK_ADDRESS;
-    private static final InetAddress INET_6_LOOPBACK_ADDRESS;
+    private static final InetAddress ANY_LOCAL_INET4ADDRESS;
+    private static final InetAddress ANY_LOCAL_INET6ADDRESS;
+    private static final InetAddress INET4_LOOPBACK_ADDRESS;
+    private static final InetAddress INET6_LOOPBACK_ADDRESS;
     static {
         try {
-            ANY_LOCAL_INET_4_ADDRESS = inet4FromInt(0);
-            assert ANY_LOCAL_INET_4_ADDRESS instanceof Inet4Address
-                    && ANY_LOCAL_INET_4_ADDRESS.isAnyLocalAddress();
+            ANY_LOCAL_INET4ADDRESS = inet4FromInt(0);
+            assert ANY_LOCAL_INET4ADDRESS instanceof Inet4Address
+                    && ANY_LOCAL_INET4ADDRESS.isAnyLocalAddress();
 
-            ANY_LOCAL_INET_6_ADDRESS = InetAddress.getByAddress(new byte[16]);
-            assert ANY_LOCAL_INET_6_ADDRESS instanceof Inet6Address
-                    && ANY_LOCAL_INET_6_ADDRESS.isAnyLocalAddress();
+            ANY_LOCAL_INET6ADDRESS = InetAddress.getByAddress(new byte[16]);
+            assert ANY_LOCAL_INET6ADDRESS instanceof Inet6Address
+                    && ANY_LOCAL_INET6ADDRESS.isAnyLocalAddress();
 
-            INET_4_LOOPBACK_ADDRESS = inet4FromInt(0x7f000001);
-            assert INET_4_LOOPBACK_ADDRESS instanceof Inet4Address
-                    && INET_4_LOOPBACK_ADDRESS.isLoopbackAddress();
+            INET4_LOOPBACK_ADDRESS = inet4FromInt(0x7f000001);
+            assert INET4_LOOPBACK_ADDRESS instanceof Inet4Address
+                    && INET4_LOOPBACK_ADDRESS.isLoopbackAddress();
 
             byte[] bytes = new byte[16];
             bytes[15] = 0x01;
-            INET_6_LOOPBACK_ADDRESS = InetAddress.getByAddress(bytes);
-            assert INET_6_LOOPBACK_ADDRESS instanceof Inet6Address
-                    && INET_6_LOOPBACK_ADDRESS.isLoopbackAddress();
+            INET6_LOOPBACK_ADDRESS = InetAddress.getByAddress(bytes);
+            assert INET6_LOOPBACK_ADDRESS instanceof Inet6Address
+                    && INET6_LOOPBACK_ADDRESS.isLoopbackAddress();
         } catch (Exception e) {
             throw new InternalError(e);
         }
     }
 
     static InetAddress inet4LoopbackAddress() {
-        return INET_4_LOOPBACK_ADDRESS;
+        return INET4_LOOPBACK_ADDRESS;
     }
 
     static InetAddress inet6LoopbackAddress() {
-        return INET_6_LOOPBACK_ADDRESS;
+        return INET6_LOOPBACK_ADDRESS;
     }
 
     /**
@@ -287,9 +291,9 @@ public class Net {
      */
     static InetAddress anyLocalAddress(ProtocolFamily family) {
         if (family == StandardProtocolFamily.INET) {
-            return ANY_LOCAL_INET_4_ADDRESS;
+            return ANY_LOCAL_INET4ADDRESS;
         } else if (family == StandardProtocolFamily.INET6) {
-            return ANY_LOCAL_INET_6_ADDRESS;
+            return ANY_LOCAL_INET6ADDRESS;
         } else {
             throw new IllegalArgumentException();
         }
@@ -812,7 +816,7 @@ public class Net {
             if (exclBindProp != null) {
                 EXCLUSIVE_BIND = exclBindProp.isEmpty() || Boolean.parseBoolean(exclBindProp);
             } else {
-                EXCLUSIVE_BIND = availLevel == 1;
+                EXCLUSIVE_BIND = (availLevel == 1);
             }
         } else {
             EXCLUSIVE_BIND = false;
@@ -820,16 +824,12 @@ public class Net {
 
         FAST_LOOPBACK = isFastTcpLoopbackRequested();
 
-        IP_V6_AVAILABLE = isIPv6Available0();
-        REUSE_PORT_AVAILABLE = isReusePortAvailable0();
+        IPV6_AVAILABLE = isIPv6Available0();
+        SO_REUSEPORT_AVAILABLE = isReusePortAvailable0();
     }
 
     private static AssertionError shouldNotReachHere() {
         return new AssertionError("Should not reach here");
-    }
-
-    private static SocketException newSocketException(String msg) {
-        return new SocketException(msg);
     }
 
 }

--- a/src/java.base/share/classes/sun/nio/ch/Net.java
+++ b/src/java.base/share/classes/sun/nio/ch/Net.java
@@ -168,19 +168,19 @@ public class Net {
             throw se;
         Exception nx = x;
         if (x instanceof ClosedChannelException)
-            nx = new SocketException("Socket is closed");
+            nx = newSocketException("Socket is closed");
         else if (x instanceof NotYetConnectedException)
-            nx = new SocketException("Socket is not connected");
+            nx = newSocketException("Socket is not connected");
         else if (x instanceof AlreadyBoundException)
-            nx = new SocketException("Already bound");
+            nx = newSocketException("Already bound");
         else if (x instanceof NotYetBoundException)
-            nx = new SocketException("Socket is not bound yet");
+            nx = newSocketException("Socket is not bound yet");
         else if (x instanceof UnsupportedAddressTypeException)
-            nx = new SocketException("Unsupported address type");
+            nx = newSocketException("Unsupported address type");
         else if (x instanceof UnresolvedAddressException)
-            nx = new SocketException("Unresolved address");
+            nx = newSocketException("Unresolved address");
         else if (x instanceof IOException) {
-            nx = new SocketException(x.getMessage());
+            nx = newSocketException(x.getMessage());
         }
         if (nx != x)
             nx.initCause(x);
@@ -323,12 +323,7 @@ public class Net {
      */
     static int inet4AsInt(InetAddress ia) {
         if (ia instanceof Inet4Address) {
-            byte[] addr = ia.getAddress();
-            int address  = addr[3] & 0xFF;
-            address |= ((addr[2] << 8) & 0xFF00);
-            address |= ((addr[1] << 16) & 0xFF0000);
-            address |= ((addr[0] << 24) & 0xFF000000);
-            return address;
+            return getInt(ia.getAddress());
         }
         throw shouldNotReachHere();
     }
@@ -339,10 +334,7 @@ public class Net {
      */
     static InetAddress inet4FromInt(int address) {
         byte[] addr = new byte[4];
-        addr[0] = (byte) ((address >>> 24) & 0xFF);
-        addr[1] = (byte) ((address >>> 16) & 0xFF);
-        addr[2] = (byte) ((address >>> 8) & 0xFF);
-        addr[3] = (byte) (address & 0xFF);
+        putInt(addr, address);
         try {
             return InetAddress.getByAddress(addr);
         } catch (UnknownHostException uhe) {
@@ -832,6 +824,10 @@ public class Net {
 
     private static AssertionError shouldNotReachHere() {
         return new AssertionError("Should not reach here");
+    }
+
+    private static SocketException newSocketException(String msg) {
+        return new SocketException(msg);
     }
 
     // Network-ordered accessors for int values in byte arrays


### PR DESCRIPTION
This PR proposes initializing some static fields eagerly using `final` fields. 

This will improve performance slightly and will allow us to remove two static fields.

The PR also contains "blessed" variable casing and deduplication of exception creation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299976](https://bugs.openjdk.org/browse/JDK-8299976): Initialize static fields in Net eagerly


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11948/head:pull/11948` \
`$ git checkout pull/11948`

Update a local copy of the PR: \
`$ git checkout pull/11948` \
`$ git pull https://git.openjdk.org/jdk pull/11948/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11948`

View PR using the GUI difftool: \
`$ git pr show -t 11948`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11948.diff">https://git.openjdk.org/jdk/pull/11948.diff</a>

</details>
