### PR TITLE
8299865: Unnecessary NullPointerException catch in java.util.TimeZone#setDefaultZone

### DIFF
--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -675,14 +675,10 @@ public abstract class TimeZone implements Serializable, Cloneable {
         // platform to Java time zone ID mapping.
         if (zoneID == null || zoneID.isEmpty()) {
             String javaHome = StaticProperty.javaHome();
-            try {
                 zoneID = getSystemTimeZoneID(javaHome);
                 if (zoneID == null) {
                     zoneID = GMT_ID;
                 }
-            } catch (NullPointerException e) {
-                zoneID = GMT_ID;
-            }
         }
 
         // Get the time zone for zoneID. But not fall back to

--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -675,10 +675,10 @@ public abstract class TimeZone implements Serializable, Cloneable {
         // platform to Java time zone ID mapping.
         if (zoneID == null || zoneID.isEmpty()) {
             String javaHome = StaticProperty.javaHome();
-                zoneID = getSystemTimeZoneID(javaHome);
-                if (zoneID == null) {
-                    zoneID = GMT_ID;
-                }
+            zoneID = getSystemTimeZoneID(javaHome);
+            if (zoneID == null) {
+                zoneID = GMT_ID;
+            }
         }
 
         // Get the time zone for zoneID. But not fall back to

--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -674,8 +674,7 @@ public abstract class TimeZone implements Serializable, Cloneable {
         // if the time zone ID is not set (yet), perform the
         // platform to Java time zone ID mapping.
         if (zoneID == null || zoneID.isEmpty()) {
-            String javaHome = StaticProperty.javaHome();
-            zoneID = getSystemTimeZoneID(javaHome);
+            zoneID = getSystemTimeZoneID(StaticProperty.javaHome());
             if (zoneID == null) {
                 zoneID = GMT_ID;
             }


### PR DESCRIPTION
In [JDK-4368016](https://bugs.openjdk.org/browse/JDK-4368016) **TimeZone.setDefaultZone()** was updated so that 

_TimeZone.java [will] not cause an NPE. If getSystemTimeZoneID()
can't determine the time zone from java.home and user.region properties,
it returns GMT._ 

This change updates the code to get rid of the no longer needed Try Catch

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299865](https://bugs.openjdk.org/browse/JDK-8299865): Unnecessary NullPointerException catch in java.util.TimeZone#setDefaultZone


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Andrey Turbanov](https://openjdk.org/census#aturbanov) (@turbanoff - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11951/head:pull/11951` \
`$ git checkout pull/11951`

Update a local copy of the PR: \
`$ git checkout pull/11951` \
`$ git pull https://git.openjdk.org/jdk pull/11951/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11951`

View PR using the GUI difftool: \
`$ git pr show -t 11951`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11951.diff">https://git.openjdk.org/jdk/pull/11951.diff</a>

</details>
