### PR TITLE
8300001: ProblemList test java/security/Policy/Root/Root.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -620,6 +620,8 @@ sun/security/pkcs11/rsa/TestKeyPairGenerator.java               8295343 linux-al
 sun/security/pkcs11/rsa/TestKeyFactory.java                     8295343 linux-all
 sun/security/pkcs11/KeyStore/Basic.java                         8295343 linux-all
 
+java/security/Policy/Root/Root.java                            8299994 generic-all
+
 ############################################################################
 
 # jdk_sound

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -620,7 +620,7 @@ sun/security/pkcs11/rsa/TestKeyPairGenerator.java               8295343 linux-al
 sun/security/pkcs11/rsa/TestKeyFactory.java                     8295343 linux-all
 sun/security/pkcs11/KeyStore/Basic.java                         8295343 linux-all
 
-java/security/Policy/Root/Root.java                            8299994 generic-all
+java/security/Policy/Root/Root.java                             8299994 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Test needs to be updated to better run without rewriting files in user.home directory. Although it fails only on macOS, this fix will ProblemList it on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300001](https://bugs.openjdk.org/browse/JDK-8300001): ProblemList test java/security/Policy/Root/Root.java


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11953/head:pull/11953` \
`$ git checkout pull/11953`

Update a local copy of the PR: \
`$ git checkout pull/11953` \
`$ git pull https://git.openjdk.org/jdk pull/11953/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11953`

View PR using the GUI difftool: \
`$ git pr show -t 11953`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11953.diff">https://git.openjdk.org/jdk/pull/11953.diff</a>

</details>
