### PR TITLE
8291154: Create a non static nested class without enclosing class throws VerifyError 

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -3056,7 +3056,8 @@ public class Lower extends TreeTranslator {
             // is qualified, pass qualifier as first argument in front of
             // the explicit constructor arguments. If the call
             // is not qualified, pass the correct outer instance as
-            // first argument.
+            // first argument. If we are a static class, there is no
+            // such outer instance, so generate an error.
             if (c.hasOuterInstance()) {
                 JCExpression thisArg;
                 if (tree.meth.hasTag(SELECT)) {
@@ -3067,6 +3068,11 @@ public class Lower extends TreeTranslator {
                 } else if (c.isDirectlyOrIndirectlyLocal() || methName == names._this){
                     // local class or this() call
                     thisArg = makeThis(tree.meth.pos(), c.type.getEnclosingType().tsym);
+                } else if (currentClass.isStatic()) {
+                    // super() call from static nested class - invalid
+                    log.error(tree.pos(),
+                        Errors.NoEnclInstanceOfTypeInScope(c.type.getEnclosingType().tsym));
+                    thisArg = make.Literal(BOT, null).setType(syms.botType);
                 } else {
                     // super() call of nested class - never pick 'this'
                     thisArg = makeOwnerThisN(tree.meth.pos(), c, false);

--- a/test/langtools/tools/javac/nested/StaticNestedNonStaticSuper.java
+++ b/test/langtools/tools/javac/nested/StaticNestedNonStaticSuper.java
@@ -1,0 +1,19 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8291154
+ * @summary Disallow static nested subclasses of non-static nested classes
+ * @compile/fail/ref=StaticNestedNonStaticSuper.out -XDrawDiagnostics StaticNestedNonStaticSuper.java
+ */
+
+class StaticNestedNonStaticSuper{
+    public abstract class NonStaticNested {
+        public static class StaticNested extends NonStaticNested {
+        }
+        public static NonStaticNested create() {
+            return new StaticNested();
+        }
+    }
+    public static void main(String[] args) {
+        NonStaticNested.create();
+    }
+}

--- a/test/langtools/tools/javac/nested/StaticNestedNonStaticSuper.java
+++ b/test/langtools/tools/javac/nested/StaticNestedNonStaticSuper.java
@@ -9,11 +9,5 @@ class StaticNestedNonStaticSuper{
     public abstract class NonStaticNested {
         public static class StaticNested extends NonStaticNested {
         }
-        public static NonStaticNested create() {
-            return new StaticNested();
-        }
-    }
-    public static void main(String[] args) {
-        NonStaticNested.create();
     }
 }

--- a/test/langtools/tools/javac/nested/StaticNestedNonStaticSuper.out
+++ b/test/langtools/tools/javac/nested/StaticNestedNonStaticSuper.out
@@ -1,0 +1,2 @@
+StaticNestedNonStaticSuper.java:10:23: compiler.err.no.encl.instance.of.type.in.scope: StaticNestedNonStaticSuper
+1 error


### PR DESCRIPTION
The fix for [JDK-8254321](https://bugs.openjdk.org/browse/JDK-8254321) opened a loophole where a Java source file that defines a static nested class `B` that extends a non-static nested class `A` no longer generates an error if `B` is nested within `A`.

Here's an example:
```java
class StaticNestedNonStaticSuper {
    public abstract class NonStaticNested {
        public static class StaticNested extends NonStaticNested {
            public StaticNested() {
                // where is StaticNestedNonStaticSuper.this for super() going to come from??
            }
        }
    }
}
```

Of course this is illegal because the non-static nested superclass requires an outer 'this' instance to be passed as the first argument to all of its constructors, but the static nested subclass has no such outer 'this' to provide. The compiler was proceeding anyway, resulting in unverifiable bytecode.

This PR adds a check for this situation. The check is added at the point in `Lower.java` where superclass constructor invocations in subclasses of non-static nested classes add the outer 'this' instance as a first parameter to `super()`.

I'm not sure if this is the most appropriate location for this additional check, but at least it is in an optimal place to observe the problem when it happens.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291154](https://bugs.openjdk.org/browse/JDK-8291154): Create a non static nested class without enclosing class throws VerifyError


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/11954/head:pull/11954` \
`$ git checkout pull/11954`

Update a local copy of the PR: \
`$ git checkout pull/11954` \
`$ git pull https://git.openjdk.org/jdk.git pull/11954/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11954`

View PR using the GUI difftool: \
`$ git pr show -t 11954`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11954.diff">https://git.openjdk.org/jdk/pull/11954.diff</a>

</details>
