### PR TITLE
8300011: Refactor code examples to use @snippet in java.util.TimeZone

### DIFF
--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -63,9 +63,11 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * along with a time zone ID. For instance, the time zone ID for the
  * U.S. Pacific Time zone is "America/Los_Angeles". So, you can get a
  * U.S. Pacific Time {@code TimeZone} object with:
+ * <blockquote>
  * {@snippet lang=java :
  * TimeZone tz = TimeZone.getTimeZone("America/Los_Angeles");
  * }
+ * </blockquote>
  * You can use the {@code getAvailableIDs} method to iterate through
  * all the supported time zone IDs. You can then choose a
  * supported ID to get a {@code TimeZone}.
@@ -309,12 +311,14 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * presentation to the user in the default locale.
      *
      * <p>This method is equivalent to:
+     * <blockquote>
      * {@snippet lang=java :
      * // @link substring="LONG" target="#LONG" :
      * getDisplayName(false, LONG,
      *                // @link substring="Locale.Category.DISPLAY" target="Locale.Category#DISPLAY" :
      *                Locale.getDefault(Locale.Category.DISPLAY))
      * }
+     * </blockquote>
      *
      * @return the human-readable name of this time zone in the default locale.
      * @since 1.2
@@ -332,10 +336,12 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * presentation to the user in the specified {@code locale}.
      *
      * <p>This method is equivalent to:
+     * <blockquote>
      * {@snippet lang=java :
      * // @link substring="LONG" target="#LONG" :
      * getDisplayName(false, LONG, locale)
      * }
+     * </blockquote>
      *
      * @param locale the locale in which to supply the display name.
      * @return the human-readable name of this time zone in the given locale.
@@ -355,11 +361,13 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * Time). Otherwise, a Standard Time name is returned.
      *
      * <p>This method is equivalent to:
+     * <blockquote>
      * {@snippet lang=java :
      * getDisplayName(daylight, style,
      *                // @link substring="Locale.Category.DISPLAY" target="Locale.Category#DISPLAY" :
      *                Locale.getDefault(Locale.Category.DISPLAY))
      * }
+     * </blockquote>
      *
      * @param daylight {@code true} specifying a Daylight Saving Time name, or
      *                 {@code false} specifying a Standard Time name

--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,9 +63,9 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * along with a time zone ID. For instance, the time zone ID for the
  * U.S. Pacific Time zone is "America/Los_Angeles". So, you can get a
  * U.S. Pacific Time {@code TimeZone} object with:
- * <blockquote><pre>
+ * {@snippet lang=java :
  * TimeZone tz = TimeZone.getTimeZone("America/Los_Angeles");
- * </pre></blockquote>
+ * }
  * You can use the {@code getAvailableIDs} method to iterate through
  * all the supported time zone IDs. You can then choose a
  * supported ID to get a {@code TimeZone}.
@@ -309,10 +309,10 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * presentation to the user in the default locale.
      *
      * <p>This method is equivalent to:
-     * <blockquote><pre>
-     * getDisplayName(false, {@link #LONG},
-     *                Locale.getDefault({@link Locale.Category#DISPLAY}))
-     * </pre></blockquote>
+     * {@snippet lang=java :
+     * getDisplayName(false, LONG, // @link substring="LONG" target="#LONG"
+     *                Locale.getDefault(Locale.Category.DISPLAY)) // @link substring="Locale.Category.DISPLAY" target="Locale.Category#DISPLAY"
+     * }
      *
      * @return the human-readable name of this time zone in the default locale.
      * @since 1.2
@@ -330,9 +330,9 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * presentation to the user in the specified {@code locale}.
      *
      * <p>This method is equivalent to:
-     * <blockquote><pre>
-     * getDisplayName(false, {@link #LONG}, locale)
-     * </pre></blockquote>
+     * {@snippet lang=java :
+     * getDisplayName(false, LONG, locale) // @link substring="LONG" target="#LONG"
+     * }
      *
      * @param locale the locale in which to supply the display name.
      * @return the human-readable name of this time zone in the given locale.
@@ -352,10 +352,10 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * Time). Otherwise, a Standard Time name is returned.
      *
      * <p>This method is equivalent to:
-     * <blockquote><pre>
+     * {@snippet lang=java :
      * getDisplayName(daylight, style,
-     *                Locale.getDefault({@link Locale.Category#DISPLAY}))
-     * </pre></blockquote>
+     *                Locale.getDefault(Locale.Category.DISPLAY)) // @link substring="Locale.Category.DISPLAY" target="Locale.Category#DISPLAY"
+     * }
      *
      * @param daylight {@code true} specifying a Daylight Saving Time name, or
      *                 {@code false} specifying a Standard Time name

--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -310,8 +310,10 @@ public abstract class TimeZone implements Serializable, Cloneable {
      *
      * <p>This method is equivalent to:
      * {@snippet lang=java :
-     * getDisplayName(false, LONG, // @link substring="LONG" target="#LONG"
-     *                Locale.getDefault(Locale.Category.DISPLAY)) // @link substring="Locale.Category.DISPLAY" target="Locale.Category#DISPLAY"
+     * // @link substring="LONG" target="#LONG" :
+     * getDisplayName(false, LONG,
+     *                // @link substring="Locale.Category.DISPLAY" target="Locale.Category#DISPLAY" :
+     *                Locale.getDefault(Locale.Category.DISPLAY))
      * }
      *
      * @return the human-readable name of this time zone in the default locale.
@@ -331,7 +333,8 @@ public abstract class TimeZone implements Serializable, Cloneable {
      *
      * <p>This method is equivalent to:
      * {@snippet lang=java :
-     * getDisplayName(false, LONG, locale) // @link substring="LONG" target="#LONG"
+     * // @link substring="LONG" target="#LONG" :
+     * getDisplayName(false, LONG, locale)
      * }
      *
      * @param locale the locale in which to supply the display name.
@@ -354,7 +357,8 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * <p>This method is equivalent to:
      * {@snippet lang=java :
      * getDisplayName(daylight, style,
-     *                Locale.getDefault(Locale.Category.DISPLAY)) // @link substring="Locale.Category.DISPLAY" target="Locale.Category#DISPLAY"
+     *                // @link substring="Locale.Category.DISPLAY" target="Locale.Category#DISPLAY" :
+     *                Locale.getDefault(Locale.Category.DISPLAY))
      * }
      *
      * @param daylight {@code true} specifying a Daylight Saving Time name, or

--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -316,7 +316,7 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * // @link substring="LONG" target="#LONG" :
      * getDisplayName(false, LONG,
      *                // @link substring="Locale.Category.DISPLAY" target="Locale.Category#DISPLAY" :
-     *                Locale.getDefault(Locale.Category.DISPLAY))
+     *                Locale.getDefault(Locale.Category.DISPLAY));
      * }
      * </blockquote>
      *
@@ -339,7 +339,7 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * <blockquote>
      * {@snippet lang=java :
      * // @link substring="LONG" target="#LONG" :
-     * getDisplayName(false, LONG, locale)
+     * getDisplayName(false, LONG, locale);
      * }
      * </blockquote>
      *
@@ -365,7 +365,7 @@ public abstract class TimeZone implements Serializable, Cloneable {
      * {@snippet lang=java :
      * getDisplayName(daylight, style,
      *                // @link substring="Locale.Category.DISPLAY" target="Locale.Category#DISPLAY" :
-     *                Locale.getDefault(Locale.Category.DISPLAY))
+     *                Locale.getDefault(Locale.Category.DISPLAY));
      * }
      * </blockquote>
      *


### PR DESCRIPTION
This PR implements JEP 413: Code Snippets in Java API Documentation for _[java.util.TimeZone](https://docs.oracle.com/en/java/javase/19/docs/api/java.base/java/util/TimeZone.html)_.

Code examples using \<pre> ...  \</pre> blocks are replaced with the @ snippet syntax where applicable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300011](https://bugs.openjdk.org/browse/JDK-8300011): Refactor code examples to use @snippet in java.util.TimeZone


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11955/head:pull/11955` \
`$ git checkout pull/11955`

Update a local copy of the PR: \
`$ git checkout pull/11955` \
`$ git pull https://git.openjdk.org/jdk pull/11955/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11955`

View PR using the GUI difftool: \
`$ git pr show -t 11955`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11955.diff">https://git.openjdk.org/jdk/pull/11955.diff</a>

</details>
