### PR TITLE
8300012: Remove unused JDI VirtualMachineImpl.removeObjectMirror(ObjectReferenceImpl object) method

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/VirtualMachineImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/VirtualMachineImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1443,23 +1443,6 @@ class VirtualMachineImpl extends MirrorImpl
         }
 
         return object;
-    }
-
-    synchronized void removeObjectMirror(ObjectReferenceImpl object) {
-        // Handle any queue elements that are not strongly reachable
-        processQueue();
-
-        SoftObjectReference ref = objectsByID.remove(object.ref());
-        if (ref != null) {
-            batchForDispose(ref);
-        } else {
-            /*
-             * If there's a live ObjectReference about, it better be part
-             * of the cache.
-             */
-            throw new InternalException("ObjectReference " + object.ref() +
-                                        " not found in object cache");
-        }
     }
 
     synchronized void removeObjectMirror(SoftObjectReference ref) {

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/VirtualMachineImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/VirtualMachineImpl.java
@@ -1445,7 +1445,7 @@ class VirtualMachineImpl extends MirrorImpl
         return object;
     }
 
-    synchronized void removeObjectMirror(SoftObjectReference ref) {
+    private synchronized void removeObjectMirror(SoftObjectReference ref) {
         /*
          * This will remove the soft reference if it has not been
          * replaced in the cache.


### PR DESCRIPTION
`VirtualMachineImpl.removeObjectMirror(ObjectReferenceImpl object)` is not used. Furthermore it confuses the reader that runs across `removeObjectMirror()` calls, because what is actually being called is `removeObjectMirror(SoftObjectReference ref)`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300012](https://bugs.openjdk.org/browse/JDK-8300012): Remove unused JDI VirtualMachineImpl.removeObjectMirror(ObjectReferenceImpl object) method


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11957/head:pull/11957` \
`$ git checkout pull/11957`

Update a local copy of the PR: \
`$ git checkout pull/11957` \
`$ git pull https://git.openjdk.org/jdk pull/11957/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11957`

View PR using the GUI difftool: \
`$ git pr show -t 11957`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11957.diff">https://git.openjdk.org/jdk/pull/11957.diff</a>

</details>
