### PR TITLE
8300002: Performance regression caused by non-inlined hot methods due to post call noop instructions

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1101,9 +1101,11 @@ void MacroAssembler::post_call_nop() {
   }
   InstructionMark im(this);
   relocate(post_call_nop_Relocation::spec());
+  PostCallNopCounter nopCounter(this);
   nop();
   movk(zr, 0);
   movk(zr, 0);
+  nopCounter.register_nop();
 }
 
 // these are no-ops overridden by InterpreterMacroAssembler

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1101,11 +1101,11 @@ void MacroAssembler::post_call_nop() {
   }
   InstructionMark im(this);
   relocate(post_call_nop_Relocation::spec());
-  PostCallNopCounter nopCounter(this);
+  InlineSkippedInstructionsCounter skipCounter(this);
   nop();
   movk(zr, 0);
   movk(zr, 0);
-  nopCounter.register_nop();
+  skipCounter.register_skipped();
 }
 
 // these are no-ops overridden by InterpreterMacroAssembler

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1105,7 +1105,6 @@ void MacroAssembler::post_call_nop() {
   nop();
   movk(zr, 0);
   movk(zr, 0);
-  skipCounter.register_skipped();
 }
 
 // these are no-ops overridden by InterpreterMacroAssembler

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -1185,9 +1185,9 @@ void MacroAssembler::post_call_nop() {
   if (!Continuations::enabled()) {
     return;
   }
-  PostCallNopCounter nopCounter(this);
+  InlineSkippedInstructionsCounter skipCounter(this);
   nop();
-  nopCounter.register_nop();
+  skipCounter.register_skipped();
 }
 
 void MacroAssembler::call_VM_base(Register oop_result,

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -1185,7 +1185,9 @@ void MacroAssembler::post_call_nop() {
   if (!Continuations::enabled()) {
     return;
   }
+  PostCallNopCounter nopCounter(this);
   nop();
+  nopCounter.register_nop();
 }
 
 void MacroAssembler::call_VM_base(Register oop_result,

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -1187,7 +1187,6 @@ void MacroAssembler::post_call_nop() {
   }
   InlineSkippedInstructionsCounter skipCounter(this);
   nop();
-  skipCounter.register_skipped();
 }
 
 void MacroAssembler::call_VM_base(Register oop_result,

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2035,11 +2035,13 @@ void MacroAssembler::post_call_nop() {
   }
   InstructionMark im(this);
   relocate(post_call_nop_Relocation::spec());
+  PostCallNopCounter nopCounter(this);
   emit_int8((int8_t)0x0f);
   emit_int8((int8_t)0x1f);
   emit_int8((int8_t)0x84);
   emit_int8((int8_t)0x00);
   emit_int32(0x00);
+  nopCounter.register_nop();
 }
 
 // A 5 byte nop that is safe for patching (see patch_verified_entry)

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2035,13 +2035,13 @@ void MacroAssembler::post_call_nop() {
   }
   InstructionMark im(this);
   relocate(post_call_nop_Relocation::spec());
-  PostCallNopCounter nopCounter(this);
+  InlineSkippedInstructionsCounter skipCounter(this);
   emit_int8((int8_t)0x0f);
   emit_int8((int8_t)0x1f);
   emit_int8((int8_t)0x84);
   emit_int8((int8_t)0x00);
   emit_int32(0x00);
-  nopCounter.register_nop();
+  skipCounter.register_skipped();
 }
 
 // A 5 byte nop that is safe for patching (see patch_verified_entry)

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2041,7 +2041,6 @@ void MacroAssembler::post_call_nop() {
   emit_int8((int8_t)0x84);
   emit_int8((int8_t)0x00);
   emit_int32(0x00);
-  skipCounter.register_skipped();
 }
 
 // A 5 byte nop that is safe for patching (see patch_verified_entry)

--- a/src/hotspot/share/asm/assembler.hpp
+++ b/src/hotspot/share/asm/assembler.hpp
@@ -248,10 +248,9 @@ class AbstractAssembler : public ResourceObj  {
     address _nop_start;
    public:
     PostCallNopCounter(AbstractAssembler* assm) : _assm(assm), _nop_start(assm->pc()) {
-      assert(assm->inst_mark() == NULL, "overlapping instructions");
     }
     void register_nop() {
-        _assm->count_post_call_nop(_assm->pc() - _nop_start);
+      _assm->count_post_call_nop(_assm->pc() - _nop_start);
     }
   };
   friend class PostCallNopCounter;

--- a/src/hotspot/share/asm/assembler.hpp
+++ b/src/hotspot/share/asm/assembler.hpp
@@ -353,7 +353,7 @@ class AbstractAssembler : public ResourceObj  {
   void      set_inst_mark()       {        code_section()->set_mark();   }
   void    clear_inst_mark()       {        code_section()->clear_mark(); }
 
-  
+
   // Constants in code
   void relocate(RelocationHolder const& rspec, int format = 0) {
     assert(!pd_check_instruction_mark()

--- a/src/hotspot/share/asm/assembler.hpp
+++ b/src/hotspot/share/asm/assembler.hpp
@@ -250,11 +250,10 @@ class AbstractAssembler : public ResourceObj  {
    public:
     InlineSkippedInstructionsCounter(AbstractAssembler* assm) : _assm(assm), _start(assm->pc()) {
     }
-    void register_skipped() {
+    ~InlineSkippedInstructionsCounter() {
       _assm->register_skipped(_assm->pc() - _start);
     }
   };
-  friend class InlineSkippedInstructionsCounter;
 #ifdef ASSERT
   // Make it return true on platforms which need to verify
   // instruction boundaries for some operations.

--- a/src/hotspot/share/asm/assembler.hpp
+++ b/src/hotspot/share/asm/assembler.hpp
@@ -242,18 +242,19 @@ class AbstractAssembler : public ResourceObj  {
   };
   friend class InstructionMark;
 
-  class PostCallNopCounter: public StackObj {
+  // count size of instructions which are skipped from inline heuristics
+  class InlineSkippedInstructionsCounter: public StackObj {
    private:
     AbstractAssembler* _assm;
-    address _nop_start;
+    address _start;
    public:
-    PostCallNopCounter(AbstractAssembler* assm) : _assm(assm), _nop_start(assm->pc()) {
+    InlineSkippedInstructionsCounter(AbstractAssembler* assm) : _assm(assm), _start(assm->pc()) {
     }
-    void register_nop() {
-      _assm->count_post_call_nop(_assm->pc() - _nop_start);
+    void register_skipped() {
+      _assm->register_skipped(_assm->pc() - _start);
     }
   };
-  friend class PostCallNopCounter;
+  friend class InlineSkippedInstructionsCounter;
 #ifdef ASSERT
   // Make it return true on platforms which need to verify
   // instruction boundaries for some operations.
@@ -346,7 +347,7 @@ class AbstractAssembler : public ResourceObj  {
   OopRecorder*  oop_recorder() const   { return _oop_recorder; }
   void      set_oop_recorder(OopRecorder* r) { _oop_recorder = r; }
 
-  void   count_post_call_nop(int size) { code_section()->count_post_call_nop(size); }
+  void   register_skipped(int size) { code_section()->register_skipped(size); }
 
   address       inst_mark() const { return code_section()->mark();       }
   void      set_inst_mark()       {        code_section()->set_mark();   }

--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -596,6 +596,17 @@ csize_t CodeBuffer::total_offset_of(const CodeSection* cs) const {
   return -1;
 }
 
+int CodeBuffer::total_post_call_nop_size() const {
+  int total_nop_size = 0;
+  for (int n = (int) SECT_FIRST; n < (int) SECT_LIMIT; n++) {
+    const CodeSection* cur_cs = code_section(n);
+    if (!cur_cs->is_empty()) {
+      total_nop_size += cur_cs->_post_call_nop_size;
+    }
+  }
+  return total_nop_size;
+}
+
 csize_t CodeBuffer::total_relocation_size() const {
   csize_t total = copy_relocations_to(NULL);  // dry run only
   return (csize_t) align_up(total, HeapWordSize);

--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -597,14 +597,14 @@ csize_t CodeBuffer::total_offset_of(const CodeSection* cs) const {
 }
 
 int CodeBuffer::total_skipped_instructions_size() const {
-  int total_nop_size = 0;
+  int total_skipped_size = 0;
   for (int n = (int) SECT_FIRST; n < (int) SECT_LIMIT; n++) {
     const CodeSection* cur_cs = code_section(n);
     if (!cur_cs->is_empty()) {
-      total_nop_size += cur_cs->_skipped_instructions_size;
+      total_skipped_size += cur_cs->_skipped_instructions_size;
     }
   }
-  return total_nop_size;
+  return total_skipped_size;
 }
 
 csize_t CodeBuffer::total_relocation_size() const {

--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -596,12 +596,12 @@ csize_t CodeBuffer::total_offset_of(const CodeSection* cs) const {
   return -1;
 }
 
-int CodeBuffer::total_post_call_nop_size() const {
+int CodeBuffer::total_skipped_instructions_size() const {
   int total_nop_size = 0;
   for (int n = (int) SECT_FIRST; n < (int) SECT_LIMIT; n++) {
     const CodeSection* cur_cs = code_section(n);
     if (!cur_cs->is_empty()) {
-      total_nop_size += cur_cs->_post_call_nop_size;
+      total_nop_size += cur_cs->_skipped_instructions_size;
     }
   }
   return total_nop_size;

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -208,7 +208,7 @@ class CodeSection {
   }
 
   void count_post_call_nop(int size) {
-      _post_call_nop_size += size;
+    _post_call_nop_size += size;
   }
 
   // Code emission

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -98,7 +98,7 @@ class CodeSection {
   address     _locs_point;      // last relocated position (grows upward)
   bool        _locs_own;        // did I allocate the locs myself?
   bool        _scratch_emit;    // Buffer is used for scratch emit, don't relocate.
-  int         _post_call_nop_size;
+  int         _skipped_instructions_size;
   char        _index;           // my section number (SECT_INST, etc.)
   CodeBuffer* _outer;           // enclosing CodeBuffer
 
@@ -115,7 +115,7 @@ class CodeSection {
     _locs_point    = NULL;
     _locs_own      = false;
     _scratch_emit  = false;
-    _post_call_nop_size = 0;
+    _skipped_instructions_size = 0;
     debug_only(_index = (char)-1);
     debug_only(_outer = (CodeBuffer*)badAddress);
   }
@@ -146,7 +146,7 @@ class CodeSection {
     _end        = cs->_end;
     _limit      = cs->_limit;
     _locs_point = cs->_locs_point;
-    _post_call_nop_size = cs->_post_call_nop_size;
+    _skipped_instructions_size = cs->_skipped_instructions_size;
   }
 
  public:
@@ -207,8 +207,8 @@ class CodeSection {
     _locs_point = pc;
   }
 
-  void count_post_call_nop(int size) {
-    _post_call_nop_size += size;
+  void register_skipped(int size) {
+    _skipped_instructions_size += size;
   }
 
   // Code emission
@@ -645,7 +645,7 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
   // allocated size of all relocation data, including index, rounded up
   csize_t total_relocation_size() const;
 
-  int total_post_call_nop_size() const;
+  int total_skipped_instructions_size() const;
 
   csize_t copy_relocations_to(address buf, csize_t buf_limit, bool only_inst) const;
 

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -98,6 +98,7 @@ class CodeSection {
   address     _locs_point;      // last relocated position (grows upward)
   bool        _locs_own;        // did I allocate the locs myself?
   bool        _scratch_emit;    // Buffer is used for scratch emit, don't relocate.
+  int         _post_call_nop_size;
   char        _index;           // my section number (SECT_INST, etc.)
   CodeBuffer* _outer;           // enclosing CodeBuffer
 
@@ -114,6 +115,7 @@ class CodeSection {
     _locs_point    = NULL;
     _locs_own      = false;
     _scratch_emit  = false;
+    _post_call_nop_size = 0;
     debug_only(_index = (char)-1);
     debug_only(_outer = (CodeBuffer*)badAddress);
   }
@@ -144,6 +146,7 @@ class CodeSection {
     _end        = cs->_end;
     _limit      = cs->_limit;
     _locs_point = cs->_locs_point;
+    _post_call_nop_size = cs->_post_call_nop_size;
   }
 
  public:
@@ -202,6 +205,10 @@ class CodeSection {
     assert(pc >= locs_point(), "relocation addr may not decrease");
     assert(allocates2(pc),     "relocation addr must be in this section");
     _locs_point = pc;
+  }
+
+  void count_post_call_nop(int size) {
+      _post_call_nop_size += size;
   }
 
   // Code emission
@@ -637,6 +644,8 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
 
   // allocated size of all relocation data, including index, rounded up
   csize_t total_relocation_size() const;
+
+  int total_post_call_nop_size() const;
 
   csize_t copy_relocations_to(address buf, csize_t buf_limit, bool only_inst) const;
 

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -1089,7 +1089,7 @@ bool ciMethod::can_be_compiled() {
 // ------------------------------------------------------------------
 // ciMethod::has_compiled_code
 bool ciMethod::has_compiled_code() {
-  return inline_instructions_size() > 0; 
+  return inline_instructions_size() > 0;
 }
 
 int ciMethod::highest_osr_comp_level() {
@@ -1119,7 +1119,7 @@ int ciMethod::code_size_for_inlining() {
 // junk like exception handler, stubs, and constant table, which are
 // not highly relevant to an inlined method.  So we use the more
 // specific accessor nmethod::insts_size.
-// Also some instructions inside the code are excluded from inline 
+// Also some instructions inside the code are excluded from inline
 // heuristic (e.g. post call nop instructions; see InlineSkippedInstructionsCounter)
 int ciMethod::inline_instructions_size() {
   if (_inline_instructions_size == -1) {

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -1122,13 +1122,13 @@ int ciMethod::code_size_for_inlining() {
 int ciMethod::instructions_size() {
   if (_instructions_size == -1) {
     GUARDED_VM_ENTRY(
-                     CompiledMethod* code = get_Method()->code();
-                     if (code != NULL && (code->comp_level() == CompLevel_full_optimization)) {
-                       _instructions_size = code->insts_end() - code->verified_entry_point();
-                     } else {
-                       _instructions_size = 0;
-                     }
-                     );
+      CompiledMethod* code = get_Method()->code();
+      if (code != NULL && (code->comp_level() == CompLevel_full_optimization)) {
+        _instructions_size = code->insts_end() - code->verified_entry_point();
+      } else {
+        _instructions_size = 0;
+      }
+    );
   }
   return _instructions_size;
 }
@@ -1136,14 +1136,14 @@ int ciMethod::instructions_size() {
 int ciMethod::inline_instructions_size() {
   if (_inline_instructions_size == -1) {
     GUARDED_VM_ENTRY(
-                     CompiledMethod* code = get_Method()->code();
-                     if (code != NULL && (code->comp_level() == CompLevel_full_optimization)) {
-                       int isize = code->insts_end() - code->verified_entry_point() - code->post_call_nop_size();
-                       _inline_instructions_size = isize > 0 ? isize : 0;
-                     } else {
-                       _inline_instructions_size = 0;
-                     }
-                     );
+      CompiledMethod* code = get_Method()->code();
+      if (code != NULL && (code->comp_level() == CompLevel_full_optimization)) {
+        int isize = code->insts_end() - code->verified_entry_point() - code->post_call_nop_size();
+        _inline_instructions_size = isize > 0 ? isize : 0;
+      } else {
+        _inline_instructions_size = 0;
+      }
+    );
   }
   return _inline_instructions_size;
 }

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -1089,7 +1089,7 @@ bool ciMethod::can_be_compiled() {
 // ------------------------------------------------------------------
 // ciMethod::has_compiled_code
 bool ciMethod::has_compiled_code() {
-  return instructions_size() > 0;
+  return inline_instructions_size() > 0; 
 }
 
 int ciMethod::highest_osr_comp_level() {
@@ -1119,26 +1119,14 @@ int ciMethod::code_size_for_inlining() {
 // junk like exception handler, stubs, and constant table, which are
 // not highly relevant to an inlined method.  So we use the more
 // specific accessor nmethod::insts_size.
-int ciMethod::instructions_size() {
-  if (_instructions_size == -1) {
-    GUARDED_VM_ENTRY(
-      CompiledMethod* code = get_Method()->code();
-      if (code != NULL && (code->comp_level() == CompLevel_full_optimization)) {
-        _instructions_size = code->insts_end() - code->verified_entry_point();
-      } else {
-        _instructions_size = 0;
-      }
-    );
-  }
-  return _instructions_size;
-}
-
+// Also some instructions inside the code are excluded from inline 
+// heuristic (e.g. post call nop instructions; see InlineSkippedInstructionsCounter)
 int ciMethod::inline_instructions_size() {
   if (_inline_instructions_size == -1) {
     GUARDED_VM_ENTRY(
       CompiledMethod* code = get_Method()->code();
       if (code != NULL && (code->comp_level() == CompLevel_full_optimization)) {
-        int isize = code->insts_end() - code->verified_entry_point() - code->post_call_nop_size();
+        int isize = code->insts_end() - code->verified_entry_point() - code->skipped_instructions_size();
         _inline_instructions_size = isize > 0 ? isize : 0;
       } else {
         _inline_instructions_size = 0;

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -151,7 +151,6 @@ ciMethod::ciMethod(const methodHandle& h_m, ciInstanceKlass* holder) :
   }
   if (_interpreter_invocation_count == 0)
     _interpreter_invocation_count = 1;
-  _instructions_size = -1;
   _inline_instructions_size = -1;
   if (ReplayCompiles) {
     ciReplay::initialize(this);
@@ -173,7 +172,6 @@ ciMethod::ciMethod(ciInstanceKlass* holder,
   _method_data(            NULL),
   _method_blocks(          NULL),
   _intrinsic_id(           vmIntrinsics::_none),
-  _instructions_size(-1),
   _inline_instructions_size(-1),
   _can_be_statically_bound(false),
   _can_omit_stack_trace(true),
@@ -1112,7 +1110,7 @@ int ciMethod::code_size_for_inlining() {
 }
 
 // ------------------------------------------------------------------
-// ciMethod::instructions_size
+// ciMethod::inline_instructions_size
 //
 // This is a rough metric for "fat" methods, compared before inlining
 // with InlineSmallCode.  The CodeBlob::code_size accessor includes
@@ -1320,7 +1318,7 @@ void ciMethod::dump_replay_data(outputStream* st) {
                mcs == NULL ? 0 : mcs->backedge_counter()->raw_counter(),
                interpreter_invocation_count(),
                interpreter_throwout_count(),
-               _instructions_size);
+               _inline_instructions_size);
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/ci/ciMethod.hpp
+++ b/src/hotspot/share/ci/ciMethod.hpp
@@ -83,6 +83,7 @@ class ciMethod : public ciMetadata {
   int _interpreter_invocation_count;
   int _interpreter_throwout_count;
   int _instructions_size;
+  int _inline_instructions_size;
   int _size_of_parameters;
 
   bool _uses_monitors;
@@ -316,6 +317,7 @@ class ciMethod : public ciMetadata {
   bool ensure_method_data();  // make sure it exists in the VM also
   MethodCounters* ensure_method_counters();
   int instructions_size();
+  int inline_instructions_size();
   int scale_count(int count, float prof_factor = 1.);  // make MDO count commensurate with IIC
 
   // Stack walking support

--- a/src/hotspot/share/ci/ciMethod.hpp
+++ b/src/hotspot/share/ci/ciMethod.hpp
@@ -82,7 +82,6 @@ class ciMethod : public ciMetadata {
   int _handler_count;
   int _interpreter_invocation_count;
   int _interpreter_throwout_count;
-  int _instructions_size;
   int _inline_instructions_size;
   int _size_of_parameters;
 
@@ -316,7 +315,7 @@ class ciMethod : public ciMetadata {
   bool check_call(int refinfo_index, bool is_static) const;
   bool ensure_method_data();  // make sure it exists in the VM also
   MethodCounters* ensure_method_counters();
-  int instructions_size();
+
   int inline_instructions_size();
   int scale_count(int count, float prof_factor = 1.);  // make MDO count commensurate with IIC
 

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -1529,7 +1529,6 @@ void ciReplay::initialize(ciMethod* m) {
   } else {
     EXCEPTION_CONTEXT;
     // m->_instructions_size = rec->_instructions_size;
-    m->_instructions_size = -1;
     m->_inline_instructions_size = -1;
     m->_interpreter_invocation_count = rec->_interpreter_invocation_count;
     m->_interpreter_throwout_count = rec->_interpreter_throwout_count;

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -1530,6 +1530,7 @@ void ciReplay::initialize(ciMethod* m) {
     EXCEPTION_CONTEXT;
     // m->_instructions_size = rec->_instructions_size;
     m->_instructions_size = -1;
+    m->_inline_instructions_size = -1;
     m->_interpreter_invocation_count = rec->_interpreter_invocation_count;
     m->_interpreter_throwout_count = rec->_interpreter_throwout_count;
     MethodCounters* mcs = method->get_method_counters(CHECK_AND_CLEAR);

--- a/src/hotspot/share/code/compiledMethod.hpp
+++ b/src/hotspot/share/code/compiledMethod.hpp
@@ -281,6 +281,8 @@ public:
   bool consts_contains(address addr) const { return consts_begin() <= addr && addr < consts_end(); }
   int consts_size() const { return consts_end() - consts_begin(); }
 
+  virtual int post_call_nop_size() const = 0;
+
   virtual address stub_begin() const = 0;
   virtual address stub_end() const = 0;
   bool stub_contains(address addr) const { return stub_begin() <= addr && addr < stub_end(); }

--- a/src/hotspot/share/code/compiledMethod.hpp
+++ b/src/hotspot/share/code/compiledMethod.hpp
@@ -281,7 +281,7 @@ public:
   bool consts_contains(address addr) const { return consts_begin() <= addr && addr < consts_end(); }
   int consts_size() const { return consts_end() - consts_begin(); }
 
-  virtual int post_call_nop_size() const = 0;
+  virtual int skipped_instructions_size() const = 0;
 
   virtual address stub_begin() const = 0;
   virtual address stub_end() const = 0;

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -677,7 +677,7 @@ nmethod::nmethod(
     _dependencies_offset     = _scopes_pcs_offset;
     _handler_table_offset    = _dependencies_offset;
     _nul_chk_table_offset    = _handler_table_offset;
-    _post_call_nop_size      = code_buffer->total_post_call_nop_size();
+    _skipped_instructions_size = code_buffer->total_skipped_instructions_size();
 #if INCLUDE_JVMCI
     _speculations_offset     = _nul_chk_table_offset;
     _jvmci_data_offset       = _speculations_offset;
@@ -814,7 +814,7 @@ nmethod::nmethod(
     _consts_offset           = content_offset()      + code_buffer->total_offset_of(code_buffer->consts());
     _stub_offset             = content_offset()      + code_buffer->total_offset_of(code_buffer->stubs());
     set_ctable_begin(header_begin() + _consts_offset);
-    _post_call_nop_size      = code_buffer->total_post_call_nop_size();
+    _skipped_instructions_size      = code_buffer->total_skipped_instructions_size();
 
 #if INCLUDE_JVMCI
     if (compiler->is_jvmci()) {

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -677,6 +677,7 @@ nmethod::nmethod(
     _dependencies_offset     = _scopes_pcs_offset;
     _handler_table_offset    = _dependencies_offset;
     _nul_chk_table_offset    = _handler_table_offset;
+    _post_call_nop_size      = code_buffer->total_post_call_nop_size();
 #if INCLUDE_JVMCI
     _speculations_offset     = _nul_chk_table_offset;
     _jvmci_data_offset       = _speculations_offset;
@@ -813,6 +814,7 @@ nmethod::nmethod(
     _consts_offset           = content_offset()      + code_buffer->total_offset_of(code_buffer->consts());
     _stub_offset             = content_offset()      + code_buffer->total_offset_of(code_buffer->stubs());
     set_ctable_begin(header_begin() + _consts_offset);
+    _post_call_nop_size      = code_buffer->total_post_call_nop_size();
 
 #if INCLUDE_JVMCI
     if (compiler->is_jvmci()) {

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -260,7 +260,7 @@ class nmethod : public CompiledMethod {
   // Protected by CompiledMethod_lock
   volatile signed char _state;         // {not_installed, in_use, not_used, not_entrant}
 
-  int _post_call_nop_size;
+  int _skipped_instructions_size;
 
   // For native wrappers
   nmethod(Method* method,
@@ -395,7 +395,8 @@ class nmethod : public CompiledMethod {
   address handler_table_begin   () const          { return           header_begin() + _handler_table_offset ; }
   address handler_table_end     () const          { return           header_begin() + _nul_chk_table_offset ; }
   address nul_chk_table_begin   () const          { return           header_begin() + _nul_chk_table_offset ; }
-  int     post_call_nop_size    () const          { return           _post_call_nop_size                    ; }
+
+  int skipped_instructions_size () const          { return           _skipped_instructions_size             ; }
 
 #if INCLUDE_JVMCI
   address nul_chk_table_end     () const          { return           header_begin() + _speculations_offset  ; }

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -260,6 +260,8 @@ class nmethod : public CompiledMethod {
   // Protected by CompiledMethod_lock
   volatile signed char _state;         // {not_installed, in_use, not_used, not_entrant}
 
+  int _post_call_nop_size;
+
   // For native wrappers
   nmethod(Method* method,
           CompilerType type,
@@ -393,6 +395,8 @@ class nmethod : public CompiledMethod {
   address handler_table_begin   () const          { return           header_begin() + _handler_table_offset ; }
   address handler_table_end     () const          { return           header_begin() + _nul_chk_table_offset ; }
   address nul_chk_table_begin   () const          { return           header_begin() + _nul_chk_table_offset ; }
+  int     post_call_nop_size    () const          { return           _post_call_nop_size                    ; }
+
 #if INCLUDE_JVMCI
   address nul_chk_table_end     () const          { return           header_begin() + _speculations_offset  ; }
   address speculations_begin    () const          { return           header_begin() + _speculations_offset  ; }

--- a/src/hotspot/share/opto/bytecodeInfo.cpp
+++ b/src/hotspot/share/opto/bytecodeInfo.cpp
@@ -180,7 +180,7 @@ bool InlineTree::should_inline(ciMethod* callee_method, ciMethod* caller_method,
   } else {
     // Not hot.  Check for medium-sized pre-existing nmethod at cold sites.
     if (callee_method->has_compiled_code() &&
-        callee_method->instructions_size() > inline_small_code_size) {
+        callee_method->inline_instructions_size() > inline_small_code_size) {
       set_msg("already compiled into a medium method");
       return false;
     }
@@ -278,7 +278,7 @@ bool InlineTree::should_not_inline(ciMethod* callee_method, ciMethod* caller_met
   }
 
   if (callee_method->has_compiled_code() &&
-      callee_method->instructions_size() > InlineSmallCode) {
+      callee_method->inline_instructions_size() > InlineSmallCode) {
     set_msg("already compiled into a big method");
     return true;
   }

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -814,7 +814,7 @@
                                                                                                                                      \
   nonstatic_field(ciMethod,                    _interpreter_invocation_count,                 int)                                   \
   nonstatic_field(ciMethod,                    _interpreter_throwout_count,                   int)                                   \
-  nonstatic_field(ciMethod,                    _instructions_size,                            int)                                   \
+  nonstatic_field(ciMethod,                    _inline_instructions_size,                     int)                                   \
                                                                                                                                      \
   nonstatic_field(ciMethodData,                _data_size,                                    int)                                   \
   nonstatic_field(ciMethodData,                _state,                                        u_char)                                \


### PR DESCRIPTION
Post call nop instructions increase the size of methods, which leads to different inline decisions and performance regression.
Restore inline behavior by excluding post call nop instructions sizes from inline heuristics.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300002](https://bugs.openjdk.org/browse/JDK-8300002): Performance regression caused by non-inlined hot methods due to post call noop instructions


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11958/head:pull/11958` \
`$ git checkout pull/11958`

Update a local copy of the PR: \
`$ git checkout pull/11958` \
`$ git pull https://git.openjdk.org/jdk pull/11958/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11958`

View PR using the GUI difftool: \
`$ git pr show -t 11958`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11958.diff">https://git.openjdk.org/jdk/pull/11958.diff</a>

</details>
