### PR TITLE
8041447: Test javax/swing/dnd/7171812/bug7171812.java fails with java.lang.RuntimeException: Test failed, scroll on drag doesn't work

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -126,7 +126,6 @@ java/awt/FileDialog/FileDialogIconTest/FileDialogIconTest.java 8160558 windows-a
 java/awt/event/MouseWheelEvent/InfiniteRecursion/InfiniteRecursion.java 8060176 windows-all,macosx-all
 java/awt/event/MouseWheelEvent/InfiniteRecursion/InfiniteRecursion_1.java 8060176 windows-all,macosx-all
 java/awt/dnd/URIListBetweenJVMsTest/URIListBetweenJVMsTest.java 8171510 macosx-all
-javax/swing/dnd/7171812/bug7171812.java 8041447 macosx-all
 java/awt/Focus/ChoiceFocus/ChoiceFocus.java 8169103 windows-all,macosx-all
 java/awt/Focus/ClearLwQueueBreakTest/ClearLwQueueBreakTest.java 8198618 macosx-all
 java/awt/Focus/ConsumeNextKeyTypedOnModalShowTest/ConsumeNextKeyTypedOnModalShowTest.java 6986252 macosx-all

--- a/test/jdk/javax/swing/dnd/7171812/bug7171812.java
+++ b/test/jdk/javax/swing/dnd/7171812/bug7171812.java
@@ -30,6 +30,7 @@
  */
 
 import java.awt.BorderLayout;
+import java.awt.Point;
 import java.awt.Robot;
 import java.awt.dnd.DnDConstants;
 import java.awt.dnd.DropTarget;
@@ -47,6 +48,8 @@ public class bug7171812 {
     static String listData[];
     static JListWithScroll<String> list;
     static JScrollPane scrollPane;
+    static volatile Point pt;
+    static volatile int height;
 
     /**
      * @param args the command line arguments
@@ -66,16 +69,17 @@ public class bug7171812 {
 
         robot.waitForIdle();
         robot.delay(1000);
-        robot.mouseMove(scrollPane.getLocationOnScreen().x + 5,
-                        scrollPane.getLocationOnScreen().y + 5);
+        SwingUtilities.invokeAndWait(() -> {
+            pt = scrollPane.getLocationOnScreen();
+            height = scrollPane.getHeight();
+        });
+        robot.mouseMove(pt.x + 5, pt.y + 5);
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-        for(int offset = 5; offset < scrollPane.getHeight()-20; offset++) {
-            robot.mouseMove(scrollPane.getLocationOnScreen().x+5,
-                            scrollPane.getLocationOnScreen().y+offset);
+        for(int offset = 5; offset < height - 20; offset++) {
+            robot.mouseMove(pt.x + 5, pt.y + offset);
         }
         for(int offset = 5; offset < 195; offset++) {
-            robot.mouseMove(scrollPane.getLocationOnScreen().x+offset,
-                            scrollPane.getLocationOnScreen().y+scrollPane.getHeight()-20);
+            robot.mouseMove(pt.x + offset, pt.y + height - 20);
         }
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         try {

--- a/test/jdk/javax/swing/dnd/7171812/bug7171812.java
+++ b/test/jdk/javax/swing/dnd/7171812/bug7171812.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,14 +26,21 @@
  * @key headful
  * @bug 7171812
  * @summary [macosx] Views keep scrolling back to the drag position after DnD
- * @author Alexander Zuev
  * @run main bug7171812
  */
 
-import java.awt.*;
-import java.awt.dnd.*;
+import java.awt.BorderLayout;
+import java.awt.Robot;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetDragEvent;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetEvent;
+import java.awt.dnd.DropTargetListener;
 import java.awt.event.InputEvent;
-import javax.swing.*;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
 
 public class bug7171812 {
     static JFrame mainFrame;
@@ -46,6 +53,10 @@ public class bug7171812 {
      */
     public static void main(String[] args) throws Exception{
 
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        robot.setAutoWaitForIdle(true);
+
         SwingUtilities.invokeAndWait(new Runnable() {
             @Override
             public void run() {
@@ -53,18 +64,20 @@ public class bug7171812 {
             }
         });
 
-        Robot robot = new Robot();
-        robot.setAutoDelay(10);
         robot.waitForIdle();
-        robot.mouseMove(scrollPane.getLocationOnScreen().x + 5, scrollPane.getLocationOnScreen().y + 5);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
+        robot.delay(1000);
+        robot.mouseMove(scrollPane.getLocationOnScreen().x + 5,
+                        scrollPane.getLocationOnScreen().y + 5);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         for(int offset = 5; offset < scrollPane.getHeight()-20; offset++) {
-            robot.mouseMove(scrollPane.getLocationOnScreen().x+5, scrollPane.getLocationOnScreen().y+offset);
+            robot.mouseMove(scrollPane.getLocationOnScreen().x+5,
+                            scrollPane.getLocationOnScreen().y+offset);
         }
         for(int offset = 5; offset < 195; offset++) {
-            robot.mouseMove(scrollPane.getLocationOnScreen().x+offset, scrollPane.getLocationOnScreen().y+scrollPane.getHeight()-20);
+            robot.mouseMove(scrollPane.getLocationOnScreen().x+offset,
+                            scrollPane.getLocationOnScreen().y+scrollPane.getHeight()-20);
         }
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         try {
             SwingUtilities.invokeAndWait(new Runnable() {
                 @Override


### PR DESCRIPTION
Test probably was failing few years back due to samevm mode.
It's not failing now but made some robot safeguards.
Several iterations are passing in all CI platforms. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8041447](https://bugs.openjdk.org/browse/JDK-8041447): Test javax/swing/dnd/7171812/bug7171812.java fails with java.lang.RuntimeException: Test failed, scroll on drag doesn't work


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11959/head:pull/11959` \
`$ git checkout pull/11959`

Update a local copy of the PR: \
`$ git checkout pull/11959` \
`$ git pull https://git.openjdk.org/jdk pull/11959/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11959`

View PR using the GUI difftool: \
`$ git pr show -t 11959`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11959.diff">https://git.openjdk.org/jdk/pull/11959.diff</a>

</details>
