### PR TITLE
JDK-8299957: Enhance error logging in instrument coding with additional jplis_assert_msg

### DIFF
--- a/src/java.instrument/share/native/libinstrument/InvocationAdapter.c
+++ b/src/java.instrument/share/native/libinstrument/InvocationAdapter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -420,14 +420,14 @@ DEF_Agent_OnAttach(JavaVM* vm, char *args, void * reserved) {
          * Create the java.lang.instrument.Instrumentation instance
          */
         success = createInstrumentationImpl(jni_env, agent);
-        jplis_assert(success);
+        jplis_assert_msg(success, "createInstrumentationImpl failed");
 
         /*
          * Setup ClassFileLoadHook handler.
          */
         if (success) {
             success = setLivePhaseEventHandlers(agent);
-            jplis_assert(success);
+            jplis_assert_msg(success, "setLivePhaseEventHandlers failed");
         }
 
         /*
@@ -439,6 +439,7 @@ DEF_Agent_OnAttach(JavaVM* vm, char *args, void * reserved) {
                                      agentClass,
                                      options,
                                      agent->mAgentmainCaller);
+            jplis_assert_msg(success, "startJavaAgent failed");
         }
 
         if (!success) {

--- a/src/java.instrument/share/native/libinstrument/JPLISAgent.c
+++ b/src/java.instrument/share/native/libinstrument/JPLISAgent.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -448,6 +448,7 @@ startJavaAgent( JPLISAgent *    agent,
                                                optionsString,
                                                &classNameObject,
                                                &optionsStringObject);
+    jplis_assert_msg(success, "commandStringIntoJavaStrings failed");
 
     if (success) {
         success = invokeJavaAgentMainMethod(   jnienv,
@@ -455,6 +456,7 @@ startJavaAgent( JPLISAgent *    agent,
                                                agentMainMethod,
                                                classNameObject,
                                                optionsStringObject);
+        jplis_assert_msg(success, "invokeJavaAgentMainMethod failed");
     }
 
     return success;
@@ -614,6 +616,7 @@ invokeJavaAgentMainMethod( JNIEnv *    jnienv,
         errorOutstanding = checkForThrowable(jnienv);
         if ( errorOutstanding ) {
             logThrowable(jnienv);
+            jplis_assert_msg(!errorOutstanding, "Outstanding error when calling method in invokeJavaAgentMainMethod");
         }
         checkForAndClearThrowable(jnienv);
     }


### PR DESCRIPTION
There are a few places in the instrument coding where errors occur in our jtreg test, but the already existing error logging method jplis_assert_msg / jplis_assert is unfortunately missing so not much details are shown. This could be enhanced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299957](https://bugs.openjdk.org/browse/JDK-8299957): Enhance error logging in instrument coding with additional jplis_assert_msg


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11960/head:pull/11960` \
`$ git checkout pull/11960`

Update a local copy of the PR: \
`$ git checkout pull/11960` \
`$ git pull https://git.openjdk.org/jdk pull/11960/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11960`

View PR using the GUI difftool: \
`$ git pr show -t 11960`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11960.diff">https://git.openjdk.org/jdk/pull/11960.diff</a>

</details>
