### PR TITLE
8299827: Add resolved IP address in connection exception for sockets

### DIFF
--- a/src/java.base/share/classes/sun/net/util/SocketExceptions.java
+++ b/src/java.base/share/classes/sun/net/util/SocketExceptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/net/util/SocketExceptions.java
+++ b/src/java.base/share/classes/sun/net/util/SocketExceptions.java
@@ -68,23 +68,10 @@ public final class SocketExceptions {
     }
 
     private static IOException ofInet(IOException e, InetSocketAddress addr) {
-        int port = addr.getPort();
-        String host = addr.getHostString();
-        InetAddress resolved = addr.getAddress();
         StringBuilder sb = new StringBuilder();
         sb.append(e.getMessage());
         sb.append(": ");
-        sb.append(host);
-        if (resolved != null) {
-            String resolvedAddr = resolved.getHostAddress();
-            if (resolvedAddr != null && !resolvedAddr.equals(host)) {
-                sb.append('(');
-                sb.append(resolvedAddr);
-                sb.append(')');
-            }
-        }
-        sb.append(':');
-        sb.append(Integer.toString(port));
+        sb.append(addr.toString());
         String enhancedMsg = sb.toString();
         return create(e, enhancedMsg);
     }

--- a/src/java.base/share/classes/sun/net/util/SocketExceptions.java
+++ b/src/java.base/share/classes/sun/net/util/SocketExceptions.java
@@ -27,6 +27,7 @@ package sun.net.util;
 
 import java.io.IOException;
 import java.lang.reflect.Constructor;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnixDomainSocketAddress;
 import java.net.SocketAddress;
@@ -69,10 +70,19 @@ public final class SocketExceptions {
     private static IOException ofInet(IOException e, InetSocketAddress addr) {
         int port = addr.getPort();
         String host = addr.getHostString();
+        InetAddress resolved = addr.getAddress();
         StringBuilder sb = new StringBuilder();
         sb.append(e.getMessage());
         sb.append(": ");
         sb.append(host);
+        if (resolved != null) {
+            String resolvedAddr = resolved.getHostAddress();
+            if (resolvedAddr != null && !resolvedAddr.equals(host)) {
+                sb.append('(');
+                sb.append(resolvedAddr);
+                sb.append(')');
+            }
+        }
         sb.append(':');
         sb.append(Integer.toString(port));
         String enhancedMsg = sb.toString();

--- a/src/java.base/share/classes/sun/net/util/SocketExceptions.java
+++ b/src/java.base/share/classes/sun/net/util/SocketExceptions.java
@@ -77,13 +77,7 @@ public final class SocketExceptions {
     }
 
     private static IOException ofUnixDomain(IOException e, UnixDomainSocketAddress addr) {
-        String path = addr.getPath().toString();
-        StringBuilder sb = new StringBuilder();
-        sb.append(e.getMessage());
-        sb.append(": ");
-        sb.append(path);
-        String enhancedMsg = sb.toString();
-        return create(e, enhancedMsg);
+        return create(e, String.join(": ", e.getMessage(), addr.toString()));
     }
 
     // return a new instance of the same type with the given detail

--- a/src/java.base/share/classes/sun/net/util/SocketExceptions.java
+++ b/src/java.base/share/classes/sun/net/util/SocketExceptions.java
@@ -27,7 +27,6 @@ package sun.net.util;
 
 import java.io.IOException;
 import java.lang.reflect.Constructor;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnixDomainSocketAddress;
 import java.net.SocketAddress;
@@ -68,16 +67,17 @@ public final class SocketExceptions {
     }
 
     private static IOException ofInet(IOException e, InetSocketAddress addr) {
-        StringBuilder sb = new StringBuilder();
-        sb.append(e.getMessage());
-        sb.append(": ");
-        sb.append(addr.toString());
-        String enhancedMsg = sb.toString();
-        return create(e, enhancedMsg);
+        return create(e, String.join(": ", e.getMessage(), addr.toString()));
     }
 
     private static IOException ofUnixDomain(IOException e, UnixDomainSocketAddress addr) {
-        return create(e, String.join(": ", e.getMessage(), addr.toString()));
+        String path = addr.getPath().toString();
+        StringBuilder sb = new StringBuilder();
+        sb.append(e.getMessage());
+        sb.append(": ");
+        sb.append(path);
+        String enhancedMsg = sb.toString();
+        return create(e, enhancedMsg);
     }
 
     // return a new instance of the same type with the given detail

--- a/test/jdk/java/net/Socket/ExceptionText.java
+++ b/test/jdk/java/net/Socket/ExceptionText.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/Socket/ExceptionText.java
+++ b/test/jdk/java/net/Socket/ExceptionText.java
@@ -106,8 +106,8 @@ public class ExceptionText {
                 throw new RuntimeException("Test failed: exception contains address info");
             }
         } else {
-            if (!msg.contains(HOST) || !msg.contains(PORT)  ||
-                (!msg.contains(ADDRESS.getHostAddress()))) {
+            if (!msg.contains(HOST) || !msg.contains(PORT) ||
+                !msg.contains(ADDRESS.getHostAddress())) {
                 if (e instanceof ClosedChannelException)
                     return; // has no detail msg
                 System.err.println("msg = " + msg);

--- a/test/jdk/java/net/Socket/ExceptionText.java
+++ b/test/jdk/java/net/Socket/ExceptionText.java
@@ -110,8 +110,7 @@ public class ExceptionText {
                 !msg.contains(ADDRESS.getHostAddress())) {
                 if (e instanceof ClosedChannelException)
                     return; // has no detail msg
-                System.err.println("msg = " + msg);
-                throw new RuntimeException("Test failed: exception does not contain address info: " + msg);
+                throw new RuntimeException("Test failed: message '" + msg + "' is missing address info " + dest);
             }
         }
     }

--- a/test/jdk/java/net/Socket/ExceptionText.java
+++ b/test/jdk/java/net/Socket/ExceptionText.java
@@ -106,7 +106,7 @@ public class ExceptionText {
                 throw new RuntimeException("Test failed: exception contains address info");
             }
         } else {
-            if (!msg.contains(HOST) || !msg.contains(PORT)  || 
+            if (!msg.contains(HOST) || !msg.contains(PORT)  ||
                 (!msg.contains(ADDRESS.getHostAddress()))) {
                 if (e instanceof ClosedChannelException)
                     return; // has no detail msg

--- a/test/jdk/java/net/Socket/ExceptionText.java
+++ b/test/jdk/java/net/Socket/ExceptionText.java
@@ -57,6 +57,7 @@
  */
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.channels.AsynchronousSocketChannel;
@@ -83,6 +84,7 @@ public class ExceptionText {
     static final InetSocketAddress dest  = Utils.refusingEndpoint();
     static final String PORT = ":" + Integer.toString(dest.getPort());
     static final String HOST = dest.getHostString();
+    static final InetAddress ADDRESS = dest.getAddress();
 
     static void test(boolean withProperty) {
         // Socket
@@ -104,11 +106,12 @@ public class ExceptionText {
                 throw new RuntimeException("Test failed: exception contains address info");
             }
         } else {
-            if (!msg.contains(HOST) || !msg.contains(PORT)) {
+            if (!msg.contains(HOST) || !msg.contains(PORT)  || 
+                (!msg.contains(ADDRESS.getHostAddress()))) {
                 if (e instanceof ClosedChannelException)
                     return; // has no detail msg
                 System.err.println("msg = " + msg);
-                throw new RuntimeException("Test failed: exception does not contain address info");
+                throw new RuntimeException("Test failed: exception does not contain address info: " + msg);
             }
         }
     }


### PR DESCRIPTION
This change adds the resolved IP address to the exception text of a failed socket connection. This helps if the connection failed because of stale DNS entries.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299827](https://bugs.openjdk.org/browse/JDK-8299827): Add resolved IP address in connection exception for sockets


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [074f212f](https://git.openjdk.org/jdk/pull/11961/files/074f212f8a53593ff57fd851f027305cdadfd9c0)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer) ⚠️ Review applies to [074f212f](https://git.openjdk.org/jdk/pull/11961/files/074f212f8a53593ff57fd851f027305cdadfd9c0)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11961/head:pull/11961` \
`$ git checkout pull/11961`

Update a local copy of the PR: \
`$ git checkout pull/11961` \
`$ git pull https://git.openjdk.org/jdk pull/11961/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11961`

View PR using the GUI difftool: \
`$ git pr show -t 11961`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11961.diff">https://git.openjdk.org/jdk/pull/11961.diff</a>

</details>
