### PR TITLE
8296999: AArch64: scalar intrinsics for reverse method in Integer and Long

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -14056,6 +14056,31 @@ instruct maxI_immM1_reg(iRegINoSp dst, immI_M1 imm, iRegIorL2I src)
   %}
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
+instruct bits_reverse_I(iRegINoSp dst, iRegIorL2I src)
+%{
+  match(Set dst (ReverseI src));
+  ins_cost(INSN_COST);
+  format %{ "rbitw  $dst, $src" %}
+  ins_encode %{
+    __ rbitw($dst$$Register, $src$$Register);
+  %}
+  ins_pipe(ialu_reg);
+%}
+
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
+instruct bits_reverse_L(iRegLNoSp dst, iRegL src)
+%{
+  match(Set dst (ReverseL src));
+  ins_cost(INSN_COST);
+  format %{ "rbit  $dst, $src" %}
+  ins_encode %{
+    __ rbit($dst$$Register, $src$$Register);
+  %}
+  ins_pipe(ialu_reg);
+%}
 
 
 // END This section of the file is automatically generated. Do not edit --------------

--- a/src/hotspot/cpu/aarch64/aarch64_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_ad.m4
@@ -615,4 +615,19 @@ MINMAX_DRAW_INSN(Max, I, _, 1, gt)
 MINMAX_DRAW_INSN(Max, I, _, 1, gt, rev)
 MINMAX_DRAW_INSN(Max, I, _, M1, ge)
 MINMAX_DRAW_INSN(Max, I, _, M1, ge, rev)
-
+dnl
+define(`BITS_REVERSE', `// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
+instruct bits_reverse_$1(iReg$1NoSp dst, iReg$1`'ORL2I($1) src)
+%{
+  match(Set dst (Reverse$1 src));
+  ins_cost(INSN_COST);
+  format %{ "$2  $dst, $src" %}
+  ins_encode %{
+    __ $2($dst$$Register, $src$$Register);
+  %}
+  ins_pipe(ialu_reg);
+%}
+')dnl
+BITS_REVERSE(I, rbitw)
+BITS_REVERSE(L, rbit)

--- a/test/hotspot/jtreg/compiler/vectorization/TestReverseBitsVector.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestReverseBitsVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @bug 8290034
  * @summary Auto-vectorization of Reverse bit operation.
  * @requires vm.compiler2.enabled
- * @requires os.arch=="amd64" | os.arch=="x86_64"
+ * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") | os.arch == "aarch64"
  * @library /test/lib /
  * @run driver compiler.vectorization.TestReverseBitsVector
  */
@@ -73,7 +73,7 @@ public class TestReverseBitsVector {
   }
 
   @Test
-  @IR(applyIfCPUFeature={"avx2", "true"}, counts = {IRNode.REVERSE_V , " > 0 "})
+  @IR(counts = {IRNode.REVERSE_V, "> 0"})
   public void test_reverse_long1(long[] lout, long[] linp) {
       for (int i = 0; i < lout.length; i+=1) {
           lout[i] = Long.reverse(linp[i]);
@@ -89,7 +89,7 @@ public class TestReverseBitsVector {
   }
 
   @Test
-  @IR(applyIfCPUFeature={"avx2", "true"}, failOn = {IRNode.REVERSE_V , IRNode.REVERSE_L})
+  @IR(failOn = {IRNode.REVERSE_V, IRNode.REVERSE_L})
   public void test_reverse_long2(long[] lout, long[] linp) {
       for (int i = 0; i < lout.length; i+=1) {
           lout[i] = Long.reverse(Long.reverse(linp[i]));
@@ -105,7 +105,7 @@ public class TestReverseBitsVector {
   }
 
   @Test
-  @IR(applyIfCPUFeature={"avx2", "true"}, failOn = {IRNode.REVERSE_V , IRNode.REVERSE_L})
+  @IR(failOn = {IRNode.REVERSE_V, IRNode.REVERSE_L})
   public void test_reverse_long3(long[] lout, long[] linp) {
       for (int i = 0; i < lout.length; i+=1) {
           lout[i] = Long.reverse(linp[i] ^ linp[i]);
@@ -121,7 +121,7 @@ public class TestReverseBitsVector {
   }
 
   @Test
-  @IR(applyIfCPUFeature={"avx2", "true"}, counts = {IRNode.REVERSE_V, "> 0"})
+  @IR(counts = {IRNode.REVERSE_V, "> 0"})
   public void test_reverse_int1(int[] iout, int[] iinp) {
       for (int i = 0; i < iout.length; i+=1) {
           iout[i] = Integer.reverse(iinp[i]);
@@ -137,7 +137,7 @@ public class TestReverseBitsVector {
   }
 
   @Test
-  @IR(applyIfCPUFeature={"avx2", "true"}, failOn = {IRNode.REVERSE_V, IRNode.REVERSE_I})
+  @IR(failOn = {IRNode.REVERSE_V, IRNode.REVERSE_I})
   public void test_reverse_int2(int[] iout, int[] iinp) {
       for (int i = 0; i < iout.length; i+=1) {
           iout[i] = Integer.reverse(Integer.reverse(iinp[i]));
@@ -153,7 +153,7 @@ public class TestReverseBitsVector {
   }
 
   @Test
-  @IR(applyIfCPUFeature={"avx2", "true"}, failOn = {IRNode.REVERSE_V, IRNode.REVERSE_I})
+  @IR(failOn = {IRNode.REVERSE_V, IRNode.REVERSE_I})
   public void test_reverse_int3(int[] iout, int[] iinp) {
       for (int i = 0; i < iout.length; i+=1) {
           iout[i] = Integer.reverse(iinp[i] ^ iinp[i]);


### PR DESCRIPTION
x86 implemented the scalar intrinsics for reverse() method in
 java.lang.Integer and java.lang.Long. See JDK-8290034 [1].

In this patch, we implement the AArch64 backend part
 using `rbit` intruction [2].

TestReverseBitsVector.java was introduced in [1] to verify the
 IR test results of auto-vectorization and mid-end optimizations.
In this patch, we update it to test AArch64 as well.

Tests:
1: These scalar intrinsics can be covered by existing Jtreg cases,
 e.g. [3][4]. Hence, we don't add new one in this patch.
2: tier1~3 pass on Linux/AArch64 and Linux/x86. There are no new failures.
3: All the vector test cases under the following directories pass on
 128-bit and 256-bit SVE machines.

```
  test/hotspot/jtreg/compiler/vectorapi/
  test/jdk/jdk/incubator/vector/
  test/hotspot/jtreg/compiler/vectorization/
```

4: JMH case
We initially use the JMH case from [1] (i.e.Integers.reverse
 and Longs.reverse) to evaluate the performance uplifts after
enabling these scalar intrinsics. From the data shown below,
 about 5x and 6x performance uplifts can be perceived respectively.

```
Benchmark              (size) Mode  Before      After       Units
Integers.reverse        500   avgt  0.456±0.002 0.080±0.001 us/op
Longs.reverse           500   avgt  0.898±0.009 0.142±0.001 us/op
```

With an in-depth analysis, we notice that the benefit comes from
 auto-vectorization (SLP) improvement. Note that the loops in the
 two benchmarks can be vectorized by SLP. Without the scalar intrinsics,
 the vector version of the Java implementation [5][6] would be generated,
 below is a code snippet of it.

```
and   v17.16b, v16.16b, v18.16b
ushr  v16.4s, v16.4s, #1
and   v16.16b, v16.16b, v18.16b
shl   v17.4s, v17.4s, #1
orr   v16.16b, v17.16b, v16.16b
```

With the introduction of scalar intrinsics, ReverseI and ReverseL
 IR nodes can be created at mid-end. As a result, SLP could generate
 ReverseV node, i.e. generating "rbitv" instruction, which is much
 more efficient than previous instruction sequence. Hence, we can say
 that the introduction of these two scalar intrinsics can improve SLP
 to generate better code. It's an indirect effect of this patch.

Furthermore, in order to evaluate the direct effect of the scalar
 intrinsics, we
(1) evaluate a small test case which is not auto-vectorization friendly.
(2）evaluate Integers.reverse and Longs.reverse in [1] with JVM option
 "-XX:-UseSuperWord" to disable SLP.

In both cases, we observe about 5x performance uplifts after enabling
 the scalar instrinics.

```
Benchmark              (size) Mode  Before      After       Units
Integers.reverse        500   avgt  1.072±0.002 0.212±0.001 us/op
(disable SLP)
Longs.reverse           500   avgt  1.073±0.002 0.212±0.001 us/op
(disable SLP)
```

[1] https://bugs.openjdk.org/browse/JDK-8290034
[2] https://developer.arm.com/documentation/ddi0602/2022-12/Base-Instructions/RBIT--Reverse-Bits-?lang=en
[3] https://github.com/openjdk/jdk/blob/master/test/jdk/jdk/incubator/vector/IntMaxVectorTests.java#L1228
[4] https://github.com/openjdk/jdk/blob/master/test/jdk/jdk/incubator/vector/LongMaxVectorTests.java#L1250
[5] https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/lang/Integer.java#L1766
[6] https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/lang/Long.java#L1905

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296999](https://bugs.openjdk.org/browse/JDK-8296999): AArch64: scalar intrinsics for reverse method in Integer and Long


### Reviewers
 * [Eric Liu](https://openjdk.org/census#eliu) (@theRealELiu - Committer)
 * [Nick Gasson](https://openjdk.org/census#ngasson) (@nick-arm - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11962/head:pull/11962` \
`$ git checkout pull/11962`

Update a local copy of the PR: \
`$ git checkout pull/11962` \
`$ git pull https://git.openjdk.org/jdk pull/11962/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11962`

View PR using the GUI difftool: \
`$ git pr show -t 11962`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11962.diff">https://git.openjdk.org/jdk/pull/11962.diff</a>

</details>
