### PR TITLE
8300024: Replace use of JNI_COMMIT mode with mode 0

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.cpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2021, NTT DATA.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -600,7 +600,7 @@ JNIEXPORT jlongArray JNICALL Java_sun_jvm_hotspot_debugger_linux_LinuxDebuggerLo
 
 #endif
 
-  env->ReleaseLongArrayElements(array, regs, JNI_COMMIT);
+  env->ReleaseLongArrayElements(array, regs, 0);
   return array;
 }
 #endif

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -621,7 +621,7 @@ jlongArray getThreadIntegerRegisterSetFromCore(JNIEnv *env, jobject this_obj, lo
 #error UNSUPPORTED_ARCH
 #endif
 
-  (*env)->ReleaseLongArrayElements(env, array, regs, JNI_COMMIT);
+  (*env)->ReleaseLongArrayElements(env, array, regs, 0);
   return array;
 }
 

--- a/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
+++ b/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -625,7 +625,7 @@ static bool addThreads(JNIEnv* env, jobject obj) {
     ptrRegs[REG_INDEX(RIP)] = context.Rip;
 #endif
 
-    env->ReleaseLongArrayElements(regs, ptrRegs, JNI_COMMIT);
+    env->ReleaseLongArrayElements(regs, ptrRegs, 0);
     CHECK_EXCEPTION_(false);
 
     env->CallVoidMethod(obj, setThreadIntegerRegisterSet_ID, (jlong)ptrThreadIds[t], regs);

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/libRedefineRetransform.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/libRedefineRetransform.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -166,7 +166,7 @@ public:
                 result = nullptr;
             } else {
                 memcpy(arrayPtr, savedClassBytes, savedClassBytesLen);
-                env->ReleaseByteArrayElements(result, arrayPtr, JNI_COMMIT);
+                env->ReleaseByteArrayElements(result, arrayPtr, 0);
             }
         }
         return result;


### PR DESCRIPTION
Please review this patch that fixes a few memory leaks in JNI code.

[The latest documentation](https://docs.oracle.com/en/java/javase/17/docs/specs/jni/functions.html#releaseprimitivetypearrayelements-routines) of JNI functions makes an explicit note about the use of JNI_COMMIT:

> If `JNI_COMMIT` is passed as the `mode` argument when `elems` is a copy of the elements in `array`, then a final call to *Release\<PrimitiveType\>ArrayElements* passing a `mode` argument of "0" or `JNI_ABORT`, should be made to free the `elems` buffer

No new regression test. I manually verified the Linux fix using ClhdsbPstack test in root mode. Also, tier1-2 tests on mach5 continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300024](https://bugs.openjdk.org/browse/JDK-8300024): Replace use of JNI_COMMIT mode with mode 0


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**) ⚠️ Review applies to [cecacd13](https://git.openjdk.org/jdk/pull/11963/files/cecacd13fcdf58c39e53290408c203e63901fe5e)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11963/head:pull/11963` \
`$ git checkout pull/11963`

Update a local copy of the PR: \
`$ git checkout pull/11963` \
`$ git pull https://git.openjdk.org/jdk pull/11963/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11963`

View PR using the GUI difftool: \
`$ git pr show -t 11963`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11963.diff">https://git.openjdk.org/jdk/pull/11963.diff</a>

</details>
