### PR TITLE
8300040: TypeOopPtr::make_from_klass_common calls itself with args in wrong order

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -3578,7 +3578,7 @@ const TypeOopPtr* TypeOopPtr::make_from_klass_common(ciKlass* klass, bool klass_
   } else if (klass->is_obj_array_klass()) {
     // Element is an object array. Recursively call ourself.
     ciKlass* eklass = klass->as_obj_array_klass()->element_klass();
-    const TypeOopPtr *etype = TypeOopPtr::make_from_klass_common(eklass, try_for_exact, false, interface_handling);
+    const TypeOopPtr *etype = TypeOopPtr::make_from_klass_common(eklass, false, try_for_exact, interface_handling);
     bool xk = etype->klass_is_exact();
     const TypeAry* arr0 = TypeAry::make(etype, TypeInt::POS);
     // We used to pass NotNull in here, asserting that the sub-arrays


### PR DESCRIPTION
[JDK-8297933](https://bugs.openjdk.org/browse/JDK-8297933) added an `InterfaceHandling interface_handling` parameter to `TypeOopPtr::make_from_klass_common` and updated all callers. Accidentally, the order of the `klass_change` and `try_for_exact` arguments were swapped.

Thanks to @MrSimms for reporting!

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300040](https://bugs.openjdk.org/browse/JDK-8300040): TypeOopPtr::make_from_klass_common calls itself with args in wrong order


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Contributors
 * David Simms `<dsimms@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11966/head:pull/11966` \
`$ git checkout pull/11966`

Update a local copy of the PR: \
`$ git checkout pull/11966` \
`$ git pull https://git.openjdk.org/jdk pull/11966/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11966`

View PR using the GUI difftool: \
`$ git pr show -t 11966`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11966.diff">https://git.openjdk.org/jdk/pull/11966.diff</a>

</details>
