### PR TITLE
8300052: PdhDll::PdhCollectQueryData and PdhLookupPerfNameByIndex will never be NULL

### DIFF
--- a/src/hotspot/os/windows/pdh_interface.cpp
+++ b/src/hotspot/os/windows/pdh_interface.cpp
@@ -166,7 +166,7 @@ PDH_STATUS PdhDll::PdhMakeCounterPath(PDH_COUNTER_PATH_ELEMENTS* pCounterPathEle
 }
 
 PDH_STATUS PdhDll::PdhExpandWildCardPath(LPCSTR szDataSource, LPCSTR szWildCardPath, PZZSTR mszExpandedPathList, LPDWORD pcchPathListLength, DWORD dwFlags) {
-  assert(_initialized && PdhExpandWildCardPath != NULL, "PdhAvailable() not yet called");
+  assert(_initialized && _PdhExpandWildCardPath != NULL, "PdhAvailable() not yet called");
   return _PdhExpandWildCardPath(szDataSource, szWildCardPath, mszExpandedPathList, pcchPathListLength, dwFlags);
 }
 

--- a/src/hotspot/os/windows/pdh_interface.cpp
+++ b/src/hotspot/os/windows/pdh_interface.cpp
@@ -113,8 +113,8 @@ bool PdhDll::PdhAttach(void) {
   return (_PdhAddCounter != NULL && _PdhOpenQuery != NULL
          && _PdhCloseQuery != NULL && _PdhCollectQueryData != NULL
          && _PdhGetFormattedCounterValue != NULL && _PdhEnumObjectItems != NULL
-         && _PdhRemoveCounter != NULL && _PdhMakeCounterPath != NULL
-         && _PdhExpandWildCardPath != NULL);
+         && _PdhRemoveCounter != NULL && _PdhLookupPerfNameByIndex != NULL
+         && _PdhMakeCounterPath != NULL && _PdhExpandWildCardPath != NULL);
 }
 
 PDH_STATUS PdhDll::PdhAddCounter(HQUERY hQuery, LPCSTR szFullCounterPath, DWORD dwUserData, HCOUNTER* phCounter) {

--- a/src/hotspot/os/windows/pdh_interface.cpp
+++ b/src/hotspot/os/windows/pdh_interface.cpp
@@ -111,10 +111,10 @@ bool PdhDll::PdhAttach(void) {
   }
   while (InterlockedCompareExchange(&_critical_section, 0, 1) == 0);
   return (_PdhAddCounter != NULL && _PdhOpenQuery != NULL
-         && _PdhCloseQuery != NULL && PdhCollectQueryData != NULL
+         && _PdhCloseQuery != NULL && _PdhCollectQueryData != NULL
          && _PdhGetFormattedCounterValue != NULL && _PdhEnumObjectItems != NULL
-         && _PdhRemoveCounter != NULL && PdhLookupPerfNameByIndex != NULL
-         && _PdhMakeCounterPath != NULL && _PdhExpandWildCardPath != NULL);
+         && _PdhRemoveCounter != NULL && _PdhMakeCounterPath != NULL
+         && _PdhExpandWildCardPath != NULL);
 }
 
 PDH_STATUS PdhDll::PdhAddCounter(HQUERY hQuery, LPCSTR szFullCounterPath, DWORD dwUserData, HCOUNTER* phCounter) {


### PR DESCRIPTION
Both PdhDll::PdhCollectQueryData and PdhLookupPerfNameByIndex are concrete definitions and not pointers to executable code (Former is defined by us and the latter is a macro that expands into a concrete declaration), so it makes no sense to check if they will be NULL. The code fails to compile on Windows before this commit when gcc has warnings as errors enabled (-Waddress in this case)

In the case of PdhCollectQueryData I'm assuming the check actually intended to check for _PdhCollectQueryData with the leading underscore, which is actually a pointer and can be NULL. Do correct me if I'm wrong and point me to what the appropriate check would be otherwise

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300052](https://bugs.openjdk.org/browse/JDK-8300052): PdhDll::PdhCollectQueryData and PdhLookupPerfNameByIndex will never be NULL


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11968/head:pull/11968` \
`$ git checkout pull/11968`

Update a local copy of the PR: \
`$ git checkout pull/11968` \
`$ git pull https://git.openjdk.org/jdk pull/11968/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11968`

View PR using the GUI difftool: \
`$ git pr show -t 11968`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11968.diff">https://git.openjdk.org/jdk/pull/11968.diff</a>

</details>
