### PR TITLE
8300053: Shenandoah: Handle more GCCauses in ShenandoahControlThread::request_gc

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -482,10 +482,11 @@ void ShenandoahControlThread::request_gc(GCCause::Cause cause) {
          cause == GCCause::_codecache_GC_aggressive ||
          cause == GCCause::_codecache_GC_threshold ||
          cause == GCCause::_full_gc_alot ||
+         cause == GCCause::_wb_young_gc ||
          cause == GCCause::_wb_full_gc ||
          cause == GCCause::_wb_breakpoint ||
          cause == GCCause::_scavenge_alot,
-         "only requested GCs here");
+         "only requested GCs here: %s", GCCause::to_string(cause));
 
   if (is_explicit_gc(cause)) {
     if (!DisableExplicitGC) {


### PR DESCRIPTION
```
$ CONF=linux-x86_64-server-fastdebug make test TEST=jdk/internal/vm/Continuation/BasicExt.java TEST_VM_OPTS="-XX:+UseShenandoahGC"

# Internal Error (/home/shade/trunks/jdk/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp:479), pid=406430, tid=406562
# assert(GCCause::is_user_requested_gc(cause) || GCCause::is_serviceability_requested_gc(cause) || cause == GCCause::_metadata_GC_clear_soft_refs || cause == GCCause::_codecache_GC_aggressive || cause == GCCause::_codecache_GC_threshold || cause == GCCause::_full_gc_alot || cause == GCCause::_wb_full_gc || cause == GCCause::_wb_breakpoint || cause == GCCause::_scavenge_alot) failed: only requested GCs here: WhiteBox Initiated Young GC
#
``` 

Added a missing cause into the assert. The test starts to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300053](https://bugs.openjdk.org/browse/JDK-8300053): Shenandoah: Handle more GCCauses in ShenandoahControlThread::request_gc


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - no project role)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11970/head:pull/11970` \
`$ git checkout pull/11970`

Update a local copy of the PR: \
`$ git checkout pull/11970` \
`$ git pull https://git.openjdk.org/jdk pull/11970/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11970`

View PR using the GUI difftool: \
`$ git pr show -t 11970`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11970.diff">https://git.openjdk.org/jdk/pull/11970.diff</a>

</details>
