### PR TITLE
8300054: Use static_assert in basic_types_init

### DIFF
--- a/src/hotspot/share/utilities/globalDefinitions.cpp
+++ b/src/hotspot/share/utilities/globalDefinitions.cpp
@@ -78,35 +78,35 @@ extern bool signature_constants_sane();
 void basic_types_init() {
 #ifdef ASSERT
 #ifdef _LP64
-  assert(min_intx ==  (intx)CONST64(0x8000000000000000), "correct constant");
-  assert(max_intx ==  CONST64(0x7FFFFFFFFFFFFFFF), "correct constant");
-  assert(max_uintx == CONST64(0xFFFFFFFFFFFFFFFF), "correct constant");
-  assert( 8 == sizeof( intx),      "wrong size for basic type");
-  assert( 8 == sizeof( jobject),   "wrong size for basic type");
+  static_assert(min_intx ==  (intx)CONST64(0x8000000000000000), "correct constant");
+  static_assert(max_intx ==  CONST64(0x7FFFFFFFFFFFFFFF), "correct constant");
+  static_assert(max_uintx == CONST64(0xFFFFFFFFFFFFFFFF), "correct constant");
+  static_assert( 8 == sizeof( intx),      "wrong size for basic type");
+  static_assert( 8 == sizeof( jobject),   "wrong size for basic type");
 #else
-  assert(min_intx ==  (intx)0x80000000,  "correct constant");
-  assert(max_intx ==  0x7FFFFFFF,  "correct constant");
-  assert(max_uintx == 0xFFFFFFFF,  "correct constant");
-  assert( 4 == sizeof( intx),      "wrong size for basic type");
-  assert( 4 == sizeof( jobject),   "wrong size for basic type");
+  static_assert(min_intx ==  (intx)0x80000000,  "correct constant");
+  static_assert(max_intx ==  0x7FFFFFFF,  "correct constant");
+  static_assert(max_uintx == 0xFFFFFFFF,  "correct constant");
+  static_assert( 4 == sizeof( intx),      "wrong size for basic type");
+  static_assert( 4 == sizeof( jobject),   "wrong size for basic type");
 #endif
-  assert( (~max_juint) == 0,  "max_juint has all its bits");
-  assert( (~max_uintx) == 0,  "max_uintx has all its bits");
-  assert( (~max_julong) == 0, "max_julong has all its bits");
-  assert( 1 == sizeof( jbyte),     "wrong size for basic type");
-  assert( 2 == sizeof( jchar),     "wrong size for basic type");
-  assert( 2 == sizeof( jshort),    "wrong size for basic type");
-  assert( 4 == sizeof( juint),     "wrong size for basic type");
-  assert( 4 == sizeof( jint),      "wrong size for basic type");
-  assert( 1 == sizeof( jboolean),  "wrong size for basic type");
-  assert( 8 == sizeof( jlong),     "wrong size for basic type");
-  assert( 4 == sizeof( jfloat),    "wrong size for basic type");
-  assert( 8 == sizeof( jdouble),   "wrong size for basic type");
-  assert( 1 == sizeof( u1),        "wrong size for basic type");
-  assert( 2 == sizeof( u2),        "wrong size for basic type");
-  assert( 4 == sizeof( u4),        "wrong size for basic type");
-  assert(wordSize == BytesPerWord, "should be the same since they're used interchangeably");
-  assert(wordSize == HeapWordSize, "should be the same since they're also used interchangeably");
+  static_assert( (~max_juint) == 0,  "max_juint has all its bits");
+  static_assert( (~max_uintx) == 0,  "max_uintx has all its bits");
+  static_assert( (~max_julong) == 0, "max_julong has all its bits");
+  static_assert( 1 == sizeof( jbyte),     "wrong size for basic type");
+  static_assert( 2 == sizeof( jchar),     "wrong size for basic type");
+  static_assert( 2 == sizeof( jshort),    "wrong size for basic type");
+  static_assert( 4 == sizeof( juint),     "wrong size for basic type");
+  static_assert( 4 == sizeof( jint),      "wrong size for basic type");
+  static_assert( 1 == sizeof( jboolean),  "wrong size for basic type");
+  static_assert( 8 == sizeof( jlong),     "wrong size for basic type");
+  static_assert( 4 == sizeof( jfloat),    "wrong size for basic type");
+  static_assert( 8 == sizeof( jdouble),   "wrong size for basic type");
+  static_assert( 1 == sizeof( u1),        "wrong size for basic type");
+  static_assert( 2 == sizeof( u2),        "wrong size for basic type");
+  static_assert( 4 == sizeof( u4),        "wrong size for basic type");
+  static_assert(wordSize == BytesPerWord, "should be the same since they're used interchangeably");
+  static_assert(wordSize == HeapWordSize, "should be the same since they're also used interchangeably");
 
   assert(signature_constants_sane(), "");
 
@@ -155,11 +155,11 @@ void basic_types_init() {
     }
   }
   // These are assumed, e.g., when filling HeapWords with juints.
-  assert(is_power_of_2(sizeof(juint)), "juint must be power of 2");
-  assert(is_power_of_2(HeapWordSize), "HeapWordSize must be power of 2");
-  assert((size_t)HeapWordSize >= sizeof(juint),
+  static_assert(is_power_of_2(sizeof(juint)), "juint must be power of 2");
+  static_assert(is_power_of_2(HeapWordSize), "HeapWordSize must be power of 2");
+  static_assert((size_t)HeapWordSize >= sizeof(juint),
          "HeapWord should be at least as large as juint");
-  assert(sizeof(NULL) == sizeof(char*), "NULL must be same size as pointer");
+  static_assert(sizeof(NULL) == sizeof(char*), "NULL must be same size as pointer");
 #endif
 
   if( JavaPriority1_To_OSPriority != -1 )

--- a/src/hotspot/share/utilities/globalDefinitions.cpp
+++ b/src/hotspot/share/utilities/globalDefinitions.cpp
@@ -158,7 +158,7 @@ void basic_types_init() {
   static_assert(is_power_of_2(sizeof(juint)), "juint must be power of 2");
   static_assert(is_power_of_2(HeapWordSize), "HeapWordSize must be power of 2");
   static_assert((size_t)HeapWordSize >= sizeof(juint),
-         "HeapWord should be at least as large as juint");
+                "HeapWord should be at least as large as juint");
   static_assert(sizeof(NULL) == sizeof(char*), "NULL must be same size as pointer");
 #endif
 


### PR DESCRIPTION
Simple change to use `static_assert` when applicable inside a function.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300054](https://bugs.openjdk.org/browse/JDK-8300054): Use static_assert in basic_types_init


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11971/head:pull/11971` \
`$ git checkout pull/11971`

Update a local copy of the PR: \
`$ git checkout pull/11971` \
`$ git pull https://git.openjdk.org/jdk pull/11971/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11971`

View PR using the GUI difftool: \
`$ git pr show -t 11971`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11971.diff">https://git.openjdk.org/jdk/pull/11971.diff</a>

</details>
