### PR TITLE
JDK-8299896: Reduce enum values of HtmlLinkInfo.Kind

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
@@ -45,12 +45,11 @@ import jdk.javadoc.internal.doclets.formats.html.markup.TagName;
 import jdk.javadoc.internal.doclets.formats.html.markup.Text;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 
-import static jdk.javadoc.internal.doclets.formats.html.HtmlLinkInfo.Kind.EXECUTABLE_MEMBER_PARAM;
-import static jdk.javadoc.internal.doclets.formats.html.HtmlLinkInfo.Kind.MEMBER;
-import static jdk.javadoc.internal.doclets.formats.html.HtmlLinkInfo.Kind.MEMBER_DEPRECATED_PREVIEW;
-import static jdk.javadoc.internal.doclets.formats.html.HtmlLinkInfo.Kind.MEMBER_TYPE_PARAMS;
-import static jdk.javadoc.internal.doclets.formats.html.HtmlLinkInfo.Kind.RECEIVER_TYPE;
-import static jdk.javadoc.internal.doclets.formats.html.HtmlLinkInfo.Kind.THROWS_TYPE;
+import static jdk.javadoc.internal.doclets.formats.html.HtmlLinkInfo.Kind.LINK_TYPE_PARAMS;
+import static jdk.javadoc.internal.doclets.formats.html.HtmlLinkInfo.Kind.LINK_TYPE_PARAMS_AND_BOUNDS;
+import static jdk.javadoc.internal.doclets.formats.html.HtmlLinkInfo.Kind.PLAIN;
+import static jdk.javadoc.internal.doclets.formats.html.HtmlLinkInfo.Kind.SHOW_PREVIEW;
+import static jdk.javadoc.internal.doclets.formats.html.HtmlLinkInfo.Kind.SHOW_TYPE_PARAMS_AND_BOUNDS;
 
 /**
  * Print method and constructor info.
@@ -73,7 +72,9 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
      * @return the type parameters.
      */
     protected Content getTypeParameters(ExecutableElement member) {
-        HtmlLinkInfo linkInfo = new HtmlLinkInfo(configuration, MEMBER_TYPE_PARAMS, member);
+        HtmlLinkInfo linkInfo = new HtmlLinkInfo(configuration, LINK_TYPE_PARAMS_AND_BOUNDS, member);
+        linkInfo.addLineBreaksInTypeParameters = true;
+        linkInfo.showTypeParameterAnnotations = true;
         return writer.getTypeParameterLinks(linkInfo);
     }
 
@@ -91,7 +92,7 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
         }
         content.add(signature);
 
-        return writer.getDocLink(MEMBER_DEPRECATED_PREVIEW, utils.getEnclosingTypeElement(member),
+        return writer.getDocLink(SHOW_PREVIEW, utils.getEnclosingTypeElement(member),
                 member, content, null, false);
     }
 
@@ -107,7 +108,7 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
 
     @Override
     protected void addInheritedSummaryLink(TypeElement te, Element member, Content target) {
-        target.add(writer.getDocLink(MEMBER, te, member, name(member)));
+        target.add(writer.getDocLink(PLAIN, te, member, name(member)));
     }
 
     /**
@@ -120,8 +121,10 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
      */
     protected void addParam(VariableElement param, TypeMirror paramType, boolean isVarArg,
                             Content target) {
-        Content link = writer.getLink(new HtmlLinkInfo(configuration, EXECUTABLE_MEMBER_PARAM,
-                paramType).varargs(isVarArg));
+        HtmlLinkInfo linkInfo = new HtmlLinkInfo(configuration, LINK_TYPE_PARAMS,
+                paramType).varargs(isVarArg);
+        linkInfo.showTypeParameterAnnotations = true;
+        Content link = writer.getLink(linkInfo);
         target.add(link);
         if(name(param).length() > 0) {
             target.add(Entity.NO_BREAK_SPACE);
@@ -139,7 +142,7 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
      * @param target the content to which the information will be added.
      */
     protected void addReceiver(ExecutableElement member, TypeMirror rcvrType, Content target) {
-        var info = new HtmlLinkInfo(configuration, RECEIVER_TYPE, rcvrType);
+        var info = new HtmlLinkInfo(configuration, SHOW_TYPE_PARAMS_AND_BOUNDS, rcvrType);
         info.linkToSelf = false;
         target.add(writer.getLink(info));
         target.add(Entity.NO_BREAK_SPACE);
@@ -270,7 +273,7 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
                 result.add(",");
                 result.add(Text.NL);
             }
-            Content link = writer.getLink(new HtmlLinkInfo(configuration, THROWS_TYPE, t));
+            Content link = writer.getLink(new HtmlLinkInfo(configuration, PLAIN, t));
             result.add(link);
         }
         return result;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
@@ -142,7 +142,7 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter, Membe
      * @param content     the content to which the link will be added
      */
     protected void addSummaryLink(TypeElement typeElement, Element member, Content content) {
-        addSummaryLink(HtmlLinkInfo.Kind.MEMBER, typeElement, member, content);
+        addSummaryLink(HtmlLinkInfo.Kind.PLAIN, typeElement, member, content);
     }
 
     /**
@@ -212,7 +212,7 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter, Membe
             }
             code.add(
                     writer.getLink(new HtmlLinkInfo(configuration,
-                            HtmlLinkInfo.Kind.SUMMARY_RETURN_TYPE, type)));
+                            HtmlLinkInfo.Kind.LINK_TYPE_PARAMS, type)));
         }
         target.add(code);
     }
@@ -323,8 +323,8 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter, Membe
                 typeContent.add(name);
             }
             addSummaryLink(utils.isClass(element) || utils.isPlainInterface(element)
-                    ? HtmlLinkInfo.Kind.CLASS_USE
-                    : HtmlLinkInfo.Kind.MEMBER,
+                    ? HtmlLinkInfo.Kind.SHOW_TYPE_PARAMS_AND_BOUNDS
+                    : HtmlLinkInfo.Kind.PLAIN,
                     te, element, typeContent);
             Content desc = new ContentBuilder();
             writer.addSummaryLinkComment(element, desc);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractTreeWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractTreeWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractTreeWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractTreeWriter.java
@@ -142,7 +142,7 @@ public abstract class AbstractTreeWriter extends HtmlDocletWriter {
                         } else {
                             content.add(", ");
                         }
-                        addPreQualifiedClassLink(HtmlLinkInfo.Kind.TREE, intf, content);
+                        addPreQualifiedClassLink(HtmlLinkInfo.Kind.SHOW_TYPE_PARAMS, intf, content);
                     }
                 }
             }
@@ -159,6 +159,6 @@ public abstract class AbstractTreeWriter extends HtmlDocletWriter {
      * @param content the content to which the information will be added
      */
     protected void addPartialInfo(TypeElement typeElement, Content content) {
-        addPreQualifiedStrongClassLink(HtmlLinkInfo.Kind.TREE, typeElement, content);
+        addPreQualifiedStrongClassLink(HtmlLinkInfo.Kind.SHOW_TYPE_PARAMS, typeElement, content);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesIndexWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesIndexWriter.java
@@ -149,7 +149,7 @@ public class AllClassesIndexWriter extends HtmlDocletWriter {
     protected void addTableRow(Table<TypeElement> table, TypeElement klass) {
         List<Content> rowContents = new ArrayList<>();
         Content classLink = getLink(new HtmlLinkInfo(
-                configuration, HtmlLinkInfo.Kind.INDEX, klass));
+                configuration, HtmlLinkInfo.Kind.LINK_TYPE_PARAMS_AND_BOUNDS, klass));
         ContentBuilder description = new ContentBuilder();
         Set<ElementFlag> flags = utils.elementFlags(klass);
         if (flags.contains(ElementFlag.PREVIEW)) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeMemberWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeMemberWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeMemberWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeMemberWriterImpl.java
@@ -248,7 +248,7 @@ public class AnnotationTypeMemberWriterImpl extends AbstractMemberWriter
     @Override
     protected Content getSummaryLink(Element member) {
         String name = utils.getFullyQualifiedName(member) + "." + member.getSimpleName();
-        return writer.getDocLink(HtmlLinkInfo.Kind.MEMBER_DEPRECATED_PREVIEW, member, name);
+        return writer.getDocLink(HtmlLinkInfo.Kind.SHOW_PREVIEW, member, name);
     }
 
     protected Comment selectComment(Comment c1, Comment c2) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassUseWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassUseWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassUseWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassUseWriter.java
@@ -241,7 +241,7 @@ public class ClassUseWriter extends SubWriterHolderWriter {
         Content caption = contents.getContent(
                 "doclet.ClassUse_Packages.that.use.0",
                 getLink(new HtmlLinkInfo(configuration,
-                        HtmlLinkInfo.Kind.CLASS_USE_HEADER, typeElement)));
+                        HtmlLinkInfo.Kind.PLAIN, typeElement)));
         var table = new Table<Void>(HtmlStyle.summaryTable)
                 .setCaption(caption)
                 .setHeader(getPackageTableHeader())
@@ -266,7 +266,7 @@ public class ClassUseWriter extends SubWriterHolderWriter {
         Content caption = contents.getContent(
                 "doclet.ClassUse_PackageAnnotation",
                 getLink(new HtmlLinkInfo(configuration,
-                        HtmlLinkInfo.Kind.CLASS_USE_HEADER, typeElement)));
+                        HtmlLinkInfo.Kind.PLAIN, typeElement)));
 
         var table = new Table<Void>(HtmlStyle.summaryTable)
                 .setCaption(caption)
@@ -291,7 +291,7 @@ public class ClassUseWriter extends SubWriterHolderWriter {
             var section = HtmlTree.SECTION(HtmlStyle.detail)
                     .setId(htmlIds.forPackage(pkg));
             Content link = contents.getContent("doclet.ClassUse_Uses.of.0.in.1",
-                    getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.CLASS_USE_HEADER,
+                    getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.PLAIN,
                             typeElement)),
                     getPackageLink(pkg, getLocalizedPackageName(pkg)));
             var heading = HtmlTree.HEADING(Headings.TypeUse.SUMMARY_HEADING, link);
@@ -325,7 +325,7 @@ public class ClassUseWriter extends SubWriterHolderWriter {
      */
     protected void addClassUse(PackageElement pkg, Content content) {
         Content classLink = getLink(new HtmlLinkInfo(configuration,
-            HtmlLinkInfo.Kind.CLASS_USE_HEADER, typeElement));
+            HtmlLinkInfo.Kind.PLAIN, typeElement));
         Content pkgLink = getPackageLink(pkg, getLocalizedPackageName(pkg));
         classSubWriter.addUseInfo(pkgToClassAnnotations.get(pkg),
                 contents.getContent("doclet.ClassUse_Annotation", classLink,
@@ -425,7 +425,7 @@ public class ClassUseWriter extends SubWriterHolderWriter {
         Content mdleLinkContent = getModuleLink(utils.elementUtils.getModuleOf(typeElement),
                 contents.moduleLabel);
         Content classLinkContent = getLink(new HtmlLinkInfo(
-                configuration, HtmlLinkInfo.Kind.CLASS_USE_HEADER, typeElement)
+                configuration, HtmlLinkInfo.Kind.PLAIN, typeElement)
                 .label(resources.getText("doclet.Class"))
                 .skipPreview(true));
         return super.getNavBar(pageMode, element)

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriterImpl.java
@@ -115,7 +115,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
             div.add(pkgNameDiv);
         }
         HtmlLinkInfo linkInfo = new HtmlLinkInfo(configuration,
-                HtmlLinkInfo.Kind.CLASS_HEADER, typeElement);
+                HtmlLinkInfo.Kind.SHOW_TYPE_PARAMS_AND_BOUNDS, typeElement);
         //Let's not link to ourselves in the header.
         linkInfo.linkToSelf = false;
         var heading = HtmlTree.HEADING_TITLE(Headings.PAGE_TITLE_HEADING,
@@ -240,7 +240,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
         Content result = new ContentBuilder();
         if (utils.typeUtils.isSameType(type, typeElement.asType())) {
             Content typeParameters = getTypeParameterLinks(
-                    new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.TREE,
+                    new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.SHOW_TYPE_PARAMS,
                     typeElement));
             if (configuration.shouldExcludeQualifier(utils.containingPackage(typeElement).toString())) {
                 result.add(utils.asTypeElement(type).getSimpleName());
@@ -251,7 +251,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
             }
         } else {
             Content link = getLink(new HtmlLinkInfo(configuration,
-                    HtmlLinkInfo.Kind.CLASS_TREE_PARENT, type)
+                    HtmlLinkInfo.Kind.SHOW_TYPE_PARAMS, type)
                     .label(configuration.getClassName(utils.asTypeElement(type))));
             result.add(link);
         }
@@ -289,7 +289,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
             if (!subclasses.isEmpty()) {
                 var dl = HtmlTree.DL(HtmlStyle.notes);
                 dl.add(HtmlTree.DT(contents.subclassesLabel));
-                dl.add(HtmlTree.DD(getClassLinks(HtmlLinkInfo.Kind.SUBCLASSES, subclasses)));
+                dl.add(HtmlTree.DD(getClassLinks(HtmlLinkInfo.Kind.PLAIN, subclasses)));
                 target.add(dl);
             }
         }
@@ -302,7 +302,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
             if (!subInterfaces.isEmpty()) {
                 var dl = HtmlTree.DL(HtmlStyle.notes);
                 dl.add(HtmlTree.DT(contents.subinterfacesLabel));
-                dl.add(HtmlTree.DD(getClassLinks(HtmlLinkInfo.Kind.SUBINTERFACES, subInterfaces)));
+                dl.add(HtmlTree.DD(getClassLinks(HtmlLinkInfo.Kind.SHOW_TYPE_PARAMS, subInterfaces)));
                 target.add(dl);
             }
         }
@@ -322,7 +322,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
         if (!implcl.isEmpty()) {
             var dl = HtmlTree.DL(HtmlStyle.notes);
             dl.add(HtmlTree.DT(contents.implementingClassesLabel));
-            dl.add(HtmlTree.DD(getClassLinks(HtmlLinkInfo.Kind.IMPLEMENTED_CLASSES, implcl)));
+            dl.add(HtmlTree.DD(getClassLinks(HtmlLinkInfo.Kind.PLAIN, implcl)));
             target.add(dl);
         }
     }
@@ -334,7 +334,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
         if (utils.isClass(typeElement) && !interfaces.isEmpty()) {
             var dl = HtmlTree.DL(HtmlStyle.notes);
             dl.add(HtmlTree.DT(contents.allImplementedInterfacesLabel));
-            dl.add(HtmlTree.DD(getClassLinks(HtmlLinkInfo.Kind.IMPLEMENTED_INTERFACES, interfaces)));
+            dl.add(HtmlTree.DD(getClassLinks(HtmlLinkInfo.Kind.SHOW_TYPE_PARAMS, interfaces)));
             target.add(dl);
         }
     }
@@ -348,7 +348,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
         if (utils.isPlainInterface(typeElement) && !interfaces.isEmpty()) {
             var dl = HtmlTree.DL(HtmlStyle.notes);
             dl.add(HtmlTree.DT(contents.allSuperinterfacesLabel));
-            dl.add(HtmlTree.DD(getClassLinks(HtmlLinkInfo.Kind.SUPER_INTERFACES, interfaces)));
+            dl.add(HtmlTree.DD(getClassLinks(HtmlLinkInfo.Kind.SHOW_TYPE_PARAMS, interfaces)));
             target.add(dl);
         }
     }
@@ -365,7 +365,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
                 dl.add(HtmlTree.DT(utils.isPlainInterface(e)
                         ? contents.enclosingInterfaceLabel
                         : contents.enclosingClassLabel));
-                dl.add(HtmlTree.DD(getClassLinks(HtmlLinkInfo.Kind.CLASS, List.of(e))));
+                dl.add(HtmlTree.DD(getClassLinks(HtmlLinkInfo.Kind.LINK_TYPE_PARAMS_AND_BOUNDS, List.of(e))));
                 target.add(dl);
                 return null;
             }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriterImpl.java
@@ -171,7 +171,7 @@ public class ConstantsSummaryWriterImpl extends HtmlDocletWriter implements Cons
         //generate links backward only to public classes.
         Content classLink = (utils.isPublic(typeElement) || utils.isProtected(typeElement)) ?
             getLink(new HtmlLinkInfo(configuration,
-                    HtmlLinkInfo.Kind.CONSTANT_SUMMARY, typeElement)) :
+                    HtmlLinkInfo.Kind.LINK_TYPE_PARAMS_AND_BOUNDS, typeElement)) :
             Text.of(utils.getFullyQualifiedName(typeElement));
 
         PackageElement enclosingPackage  = utils.containingPackage(typeElement);
@@ -208,7 +208,7 @@ public class ConstantsSummaryWriterImpl extends HtmlDocletWriter implements Cons
                     .add(Entity.NO_BREAK_SPACE);
         }
         Content type = getLink(new HtmlLinkInfo(configuration,
-                HtmlLinkInfo.Kind.CONSTANT_SUMMARY, member.asType()));
+                HtmlLinkInfo.Kind.LINK_TYPE_PARAMS_AND_BOUNDS, member.asType()));
         code.add(type);
         typeContent.add(code);
         return typeContent;
@@ -221,7 +221,7 @@ public class ConstantsSummaryWriterImpl extends HtmlDocletWriter implements Cons
      * @return the name column of the constant table row
      */
     private Content getNameColumn(VariableElement member) {
-        Content nameContent = getDocLink(HtmlLinkInfo.Kind.CONSTANT_SUMMARY,
+        Content nameContent = getDocLink(HtmlLinkInfo.Kind.PLAIN,
                 member, member.getSimpleName());
         return HtmlTree.CODE(nameContent);
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/EnumConstantWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/EnumConstantWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/EnumConstantWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/EnumConstantWriterImpl.java
@@ -172,7 +172,7 @@ public class EnumConstantWriterImpl extends AbstractMemberWriter
     @Override
     protected Content getSummaryLink(Element member) {
         String name = utils.getFullyQualifiedName(member) + "." + member.getSimpleName();
-        return writer.getDocLink(HtmlLinkInfo.Kind.MEMBER_DEPRECATED_PREVIEW, member, name);
+        return writer.getDocLink(HtmlLinkInfo.Kind.SHOW_PREVIEW, member, name);
     }
 
     @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FieldWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FieldWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FieldWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FieldWriterImpl.java
@@ -156,7 +156,7 @@ public class FieldWriterImpl extends AbstractMemberWriter
     @Override
     public void addInheritedSummaryLabel(TypeElement typeElement, Content content) {
         Content classLink = writer.getPreQualifiedClassLink(
-                HtmlLinkInfo.Kind.MEMBER, typeElement);
+                HtmlLinkInfo.Kind.PLAIN, typeElement);
         Content label;
         if (options.summarizeOverriddenMethods()) {
             label = Text.of(utils.isClass(typeElement)
@@ -187,7 +187,7 @@ public class FieldWriterImpl extends AbstractMemberWriter
     @Override
     protected void addInheritedSummaryLink(TypeElement typeElement, Element member, Content target) {
         target.add(
-                writer.getDocLink(HtmlLinkInfo.Kind.MEMBER, typeElement, member, name(member)));
+                writer.getDocLink(HtmlLinkInfo.Kind.PLAIN, typeElement, member, name(member)));
     }
 
     @Override
@@ -198,7 +198,7 @@ public class FieldWriterImpl extends AbstractMemberWriter
     @Override
     protected Content getSummaryLink(Element member) {
         String name = utils.getFullyQualifiedName(member) + "." + member.getSimpleName();
-        return writer.getDocLink(HtmlLinkInfo.Kind.MEMBER_DEPRECATED_PREVIEW, member, name);
+        return writer.getDocLink(HtmlLinkInfo.Kind.SHOW_PREVIEW, member, name);
     }
 
     @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -44,7 +43,6 @@ import java.util.regex.Pattern;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.ModuleElement;
 import javax.lang.model.element.Name;
@@ -72,7 +70,6 @@ import com.sun.source.doctree.IndexTree;
 import com.sun.source.doctree.InheritDocTree;
 import com.sun.source.doctree.LinkTree;
 import com.sun.source.doctree.LiteralTree;
-import com.sun.source.doctree.SeeTree;
 import com.sun.source.doctree.StartElementTree;
 import com.sun.source.doctree.SummaryTree;
 import com.sun.source.doctree.SystemPropertyTree;
@@ -980,7 +977,7 @@ public class HtmlDocletWriter {
             HtmlId id = isProperty ? htmlIds.forProperty(ee) : htmlIds.forMember(ee);
             return getLink(new HtmlLinkInfo(configuration, context, typeElement)
                 .label(label)
-                .where(id.name())
+                .fragment(id.name())
                 .style(style)
                 .targetMember(element));
         }
@@ -988,7 +985,7 @@ public class HtmlDocletWriter {
         if (utils.isVariableElement(element) || utils.isTypeElement(element)) {
             return getLink(new HtmlLinkInfo(configuration, context, typeElement)
                 .label(label)
-                .where(element.getSimpleName().toString())
+                .fragment(element.getSimpleName().toString())
                 .style(style)
                 .targetMember(element));
         }
@@ -1695,7 +1692,7 @@ public class HtmlDocletWriter {
             annotation = new ContentBuilder();
             isAnnotationDocumented = false;
             HtmlLinkInfo linkInfo = new HtmlLinkInfo(configuration,
-                                                     HtmlLinkInfo.Kind.ANNOTATION, annotationElement);
+                                                     HtmlLinkInfo.Kind.PLAIN, annotationElement);
             Map<? extends ExecutableElement, ? extends AnnotationValue> pairs = aDesc.getElementValues();
             // If the annotation is mandated, do not print the container.
             if (utils.configuration.workArounds.isMandated(aDesc)) {
@@ -1796,7 +1793,7 @@ public class HtmlDocletWriter {
                 }
                 String simpleName = element.getSimpleName().toString();
                 if (multipleValues || !"value".equals(simpleName)) { // Omit "value=" where unnecessary
-                    annotation.add(getDocLink(HtmlLinkInfo.Kind.ANNOTATION, element, simpleName));
+                    annotation.add(getDocLink(HtmlLinkInfo.Kind.PLAIN, element, simpleName));
                     annotation.add("=");
                 }
                 AnnotationValue annotationValue = map.get(element);
@@ -1886,7 +1883,7 @@ public class HtmlDocletWriter {
                     @Override
                     public Content visitDeclared(DeclaredType t, Void p) {
                         HtmlLinkInfo linkInfo = new HtmlLinkInfo(configuration,
-                                HtmlLinkInfo.Kind.ANNOTATION, t);
+                                HtmlLinkInfo.Kind.PLAIN, t);
                         String name = utils.isIncluded(t.asElement())
                                 ? t.asElement().getSimpleName().toString()
                                 : utils.getFullyQualifiedName(t.asElement());
@@ -1912,7 +1909,7 @@ public class HtmlDocletWriter {
 
             @Override
             public Content visitEnumConstant(VariableElement c, Void p) {
-                return getDocLink(HtmlLinkInfo.Kind.ANNOTATION, c, c.getSimpleName());
+                return getDocLink(HtmlLinkInfo.Kind.PLAIN, c, c.getSimpleName());
             }
 
             @Override
@@ -2189,7 +2186,7 @@ public class HtmlDocletWriter {
         elements.stream()
                 .sorted(Comparator.comparing(te -> te.getSimpleName().toString()))
                 .distinct()
-                .map(te -> getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.CLASS, te)
+                .map(te -> getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.LINK_TYPE_PARAMS_AND_BOUNDS, te)
                         .label(HtmlTree.CODE(Text.of(te.getSimpleName()))).skipPreview(true)))
                 .forEach(c -> {
                     links.add(sep[0]);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkFactory.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkFactory.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkFactory.java
@@ -76,7 +76,7 @@ public class HtmlLinkFactory extends LinkFactory {
         // Create a tool tip if we are linking to a class or interface.  Don't
         // create one if we are linking to a member.
         String title = "";
-        boolean hasWhere = classLinkInfo.where != null && classLinkInfo.where.length() != 0;
+        boolean hasWhere = classLinkInfo.fragment != null && classLinkInfo.fragment.length() != 0;
         if (!hasWhere) {
             boolean isTypeLink = classLinkInfo.type != null &&
                      utils.isTypeVariable(utils.getComponentType(classLinkInfo.type));
@@ -89,8 +89,8 @@ public class HtmlLinkFactory extends LinkFactory {
         if (!hasWhere && showPreview) {
             flags = utils.elementFlags(typeElement);
             previewTarget = typeElement;
-        } else if ((classLinkInfo.context == HtmlLinkInfo.Kind.SEE_TAG || classLinkInfo.context == HtmlLinkInfo.Kind.MEMBER_DEPRECATED_PREVIEW) &&
-                   classLinkInfo.targetMember != null && showPreview) {
+        } else if (classLinkInfo.context == HtmlLinkInfo.Kind.SHOW_PREVIEW
+                && classLinkInfo.targetMember != null && showPreview) {
             flags = utils.elementFlags(classLinkInfo.targetMember);
             TypeElement enclosing = utils.getEnclosingTypeElement(classLinkInfo.targetMember);
             Set<ElementFlag> enclosingFlags = utils.elementFlags(enclosing);
@@ -115,7 +115,7 @@ public class HtmlLinkFactory extends LinkFactory {
                 DocPath filename = getPath(classLinkInfo);
                 if (linkInfo.linkToSelf || typeElement != m_writer.getCurrentPageElement()) {
                         link.add(m_writer.links.createLink(
-                                filename.fragment(classLinkInfo.where),
+                                filename.fragment(classLinkInfo.fragment),
                                 label,
                                 classLinkInfo.style,
                                 title));
@@ -129,7 +129,7 @@ public class HtmlLinkFactory extends LinkFactory {
             }
         } else {
             Content crossLink = m_writer.getCrossClassLink(
-                typeElement, classLinkInfo.where,
+                typeElement, classLinkInfo.fragment,
                 label, classLinkInfo.style, true);
             if (crossLink != null) {
                 link.add(crossLink);
@@ -177,7 +177,7 @@ public class HtmlLinkFactory extends LinkFactory {
                 if (many) {
                     links.add(",");
                     links.add(new HtmlTree(TagName.WBR));
-                    if (((HtmlLinkInfo) linkInfo).getContext() == HtmlLinkInfo.Kind.MEMBER_TYPE_PARAMS) {
+                    if (linkInfo.addLineBreaksInTypeParameters) {
                         links.add(Text.NL);
                     }
                 }
@@ -199,9 +199,11 @@ public class HtmlLinkFactory extends LinkFactory {
     protected Content getTypeParameterLink(LinkInfo linkInfo, TypeMirror typeParam) {
         HtmlLinkInfo typeLinkInfo = new HtmlLinkInfo(m_writer.configuration,
                 ((HtmlLinkInfo) linkInfo).getContext(), typeParam);
-        typeLinkInfo.excludeTypeBounds = linkInfo.excludeTypeBounds;
-        typeLinkInfo.excludeTypeParameterLinks = linkInfo.excludeTypeParameterLinks;
+        typeLinkInfo.showTypeBounds = linkInfo.showTypeBounds;
+        typeLinkInfo.linkTypeParameters = linkInfo.linkTypeParameters;
         typeLinkInfo.linkToSelf = linkInfo.linkToSelf;
+        typeLinkInfo.addLineBreaksInTypeParameters = linkInfo.addLineBreaksInTypeParameters;
+        typeLinkInfo.showTypeParameterAnnotations = linkInfo.showTypeParameterAnnotations;
         return getLink(typeLinkInfo);
     }
 
@@ -211,21 +213,9 @@ public class HtmlLinkFactory extends LinkFactory {
         List<? extends AnnotationMirror> annotations;
         if (utils.isAnnotated(linkInfo.type)) {
             annotations = linkInfo.type.getAnnotationMirrors();
-        } else if (utils.isTypeVariable(linkInfo.type)) {
-            // TODO: use the context for now, and special case for Receiver_Types,
-            // which takes the default case.
-            switch (((HtmlLinkInfo)linkInfo).context) {
-                case MEMBER_TYPE_PARAMS:
-                case EXECUTABLE_MEMBER_PARAM:
-                case CLASS_SIGNATURE:
-                    Element element = utils.typeUtils.asElement(linkInfo.type);
-                    annotations = element.getAnnotationMirrors();
-                    break;
-                default:
-                    annotations = linkInfo.type.getAnnotationMirrors();
-                    break;
-            }
-
+        } else if (utils.isTypeVariable(linkInfo.type) && linkInfo.showTypeParameterAnnotations) {
+            Element element = utils.typeUtils.asElement(linkInfo.type);
+            annotations = element.getAnnotationMirrors();
         } else {
             return links;
         }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkInfo.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkInfo.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkInfo.java
@@ -39,199 +39,48 @@ import jdk.javadoc.internal.doclets.toolkit.util.links.LinkInfo;
 
 
 /**
+ * HTML-specific information about a link.
  */
 public class HtmlLinkInfo extends LinkInfo {
 
     public enum Kind {
-        DEFAULT,
-
         /**
-         * Indicate that the link appears in a class documentation.
+         * Link with just the element name as label.
          */
-        CLASS,
-
+        PLAIN,
         /**
-         * Indicate that the link appears in member documentation.
+         * Link with additional preview flag if appropriate.
          */
-        MEMBER,
-
+        SHOW_PREVIEW,
         /**
-         * Indicate that the link appears in member documentation on the Deprecated or Preview page.
+         * Link with additional type parameters as plain text if appropriate.
          */
-        MEMBER_DEPRECATED_PREVIEW,
-
+        SHOW_TYPE_PARAMS,
         /**
-         * Indicate that the link appears in class use documentation.
+         * Link with additional type parameters and bounds as plain text if appropriate.
          */
-        CLASS_USE,
-
+        SHOW_TYPE_PARAMS_AND_BOUNDS,
         /**
-         * Indicate that the link appears in index documentation.
+         * Link with additional type parameters as separate link if appropriate.
          */
-        INDEX,
-
+        LINK_TYPE_PARAMS,
         /**
-         * Indicate that the link appears in constant value summary.
+         * Link with additional type parameters and bounds as separate links if approprate.
          */
-        CONSTANT_SUMMARY,
-
-        /**
-         * Indicate that the link appears in serialized form documentation.
-         */
-        SERIALIZED_FORM,
-
-        /**
-         * Indicate that the link appears in serial member documentation.
-         */
-        SERIAL_MEMBER,
-
-        /**
-         * Indicate that the link appears in package documentation.
-         */
-        PACKAGE,
-
-        /**
-         * Indicate that the link appears in see tag documentation.
-         */
-        SEE_TAG,
-
-        /**
-         * Indicate that the link appears in value tag documentation.
-         */
-        VALUE_TAG,
-
-        /**
-         * Indicate that the link appears in tree documentation.
-         */
-        TREE,
-
-        /**
-         * The header in the class documentation.
-         */
-        CLASS_HEADER,
-
-        /**
-         * The signature in the class documentation.
-         */
-        CLASS_SIGNATURE,
-
-        /**
-         * The return type of a method.
-         */
-        RETURN_TYPE,
-
-        /**
-         * The return type of a method in a member summary.
-         */
-        SUMMARY_RETURN_TYPE,
-
-        /**
-         * The type of a method/constructor parameter.
-         */
-        EXECUTABLE_MEMBER_PARAM,
-
-        /**
-         * Superinterface links.
-         */
-        SUPER_INTERFACES,
-
-        /**
-         * Implemented interface links.
-         */
-        IMPLEMENTED_INTERFACES,
-
-        /**
-         * Implemented class links.
-         */
-        IMPLEMENTED_CLASSES,
-
-        /**
-         * Subinterface links.
-         */
-        SUBINTERFACES,
-
-        /**
-         * Subclasses links.
-         */
-        SUBCLASSES,
-
-        /**
-         * The signature in the class documentation (implements/extends portion).
-         */
-        CLASS_SIGNATURE_PARENT_NAME,
-
-        /**
-         * Permitted subclasses of a sealed type.
-         */
-        PERMITTED_SUBCLASSES,
-
-        /**
-         * The header for method documentation copied from parent.
-         */
-        EXECUTABLE_ELEMENT_COPY,
-
-        /**
-         * Method "specified by" link.
-         */
-        METHOD_SPECIFIED_BY,
-
-        /**
-         * Method "overrides" link.
-         */
-        METHOD_OVERRIDES,
-
-        /**
-         * Annotation link.
-         */
-        ANNOTATION,
-
-        /**
-         * The parent nodes in the class tree.
-         */
-        CLASS_TREE_PARENT,
-
-        /**
-         * The type parameters of a method or constructor.
-         */
-        MEMBER_TYPE_PARAMS,
-
-        /**
-         * Indicate that the link appears in class use documentation.
-         */
-        CLASS_USE_HEADER,
-
-        /**
-         * The header for property documentation copied from parent.
-         */
-        PROPERTY_COPY,
-
-        /**
-         * A receiver type.
-         */
-        RECEIVER_TYPE,
-
-        /**
-         * A record component within a class signature.
-         */
-        RECORD_COMPONENT,
-
-        /**
-         * A type thrown from a method.
-         */
-        THROWS_TYPE
+        LINK_TYPE_PARAMS_AND_BOUNDS;
     }
 
     public final HtmlConfiguration configuration;
 
     /**
-     * The location of the link.
+     * The context of the link.
      */
-    public Kind context = Kind.DEFAULT;
+    public Kind context = Kind.PLAIN;
 
     /**
-     * The value of the marker #.
+     * The fragment of the link.
      */
-    public String where = "";
+    public String fragment = "";
 
     /**
      * The member this link points to (if any).
@@ -328,8 +177,8 @@ public class HtmlLinkInfo extends LinkInfo {
     /**
      * Set the fragment specifier for the link.
      */
-    public HtmlLinkInfo where(String where) {
-        this.where = where;
+    public HtmlLinkInfo fragment(String fragment) {
+        this.fragment = fragment;
         return this;
     }
 
@@ -360,34 +209,8 @@ public class HtmlLinkInfo extends LinkInfo {
      * @param c the context id to set.
      */
     public final void setContext(Kind c) {
-        switch (c) {
-            case ANNOTATION:
-            case IMPLEMENTED_INTERFACES:
-            case SUPER_INTERFACES:
-            case SUBINTERFACES:
-            case CLASS_TREE_PARENT:
-            case TREE:
-            case CLASS_SIGNATURE_PARENT_NAME:
-            case PERMITTED_SUBCLASSES:
-                excludeTypeParameterLinks = true;
-                excludeTypeBounds = true;
-                break;
-
-            case PACKAGE:
-            case CLASS_USE:
-            case CLASS_HEADER:
-            case CLASS_SIGNATURE:
-            case RECEIVER_TYPE:
-                excludeTypeParameterLinks = true;
-                break;
-
-            case RETURN_TYPE:
-            case SUMMARY_RETURN_TYPE:
-            case EXECUTABLE_MEMBER_PARAM:
-            case THROWS_TYPE:
-                excludeTypeBounds = true;
-                break;
-        }
+        linkTypeParameters = c == Kind.LINK_TYPE_PARAMS || c == Kind.LINK_TYPE_PARAMS_AND_BOUNDS;
+        showTypeBounds = c == Kind.SHOW_TYPE_PARAMS_AND_BOUNDS || c == Kind.LINK_TYPE_PARAMS_AND_BOUNDS;
         context = c;
     }
 
@@ -404,37 +227,15 @@ public class HtmlLinkInfo extends LinkInfo {
     }
 
     @Override
-    public boolean includeTypeParameterLinks() {
-        return switch (context) {
-            case IMPLEMENTED_INTERFACES,
-                 SUPER_INTERFACES,
-                 SUBINTERFACES,
-                 CLASS_TREE_PARENT,
-                 TREE,
-                 CLASS_SIGNATURE_PARENT_NAME,
-                 PERMITTED_SUBCLASSES,
-                 PACKAGE,
-                 CLASS_USE,
-                 CLASS_HEADER,
-                 CLASS_SIGNATURE,
-                 RECEIVER_TYPE,
-                 MEMBER_TYPE_PARAMS -> true;
-
-            case IMPLEMENTED_CLASSES,
-                 SUBCLASSES,
-                 EXECUTABLE_ELEMENT_COPY,
-                 PROPERTY_COPY,
-                 CLASS_USE_HEADER -> false;
-
-            default -> label == null || label.isEmpty();
-        };
+    public boolean showTypeParameters() {
+        return context != Kind.PLAIN && context != Kind.SHOW_PREVIEW;
     }
 
     @Override
     public String toString() {
         return "HtmlLinkInfo{" +
                 "context=" + context +
-                ", where=" + where +
+                ", fragment=" + fragment +
                 ", style=" + style +
                 super.toString() + '}';
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialFieldWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialFieldWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialFieldWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialFieldWriter.java
@@ -41,7 +41,6 @@ import jdk.javadoc.internal.doclets.formats.html.markup.HtmlTree;
 import jdk.javadoc.internal.doclets.formats.html.markup.Text;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 import jdk.javadoc.internal.doclets.toolkit.SerializedFormWriter;
-import jdk.javadoc.internal.doclets.toolkit.util.CommentHelper;
 
 /**
  * Generate serialized form for serializable fields.
@@ -88,7 +87,7 @@ public class HtmlSerialFieldWriter extends FieldWriterImpl
         content.add(heading);
         var pre = new HtmlTree(TagName.PRE);
         Content fieldContent = writer.getLink(new HtmlLinkInfo(
-                configuration, HtmlLinkInfo.Kind.SERIAL_MEMBER, fieldType));
+                configuration, HtmlLinkInfo.Kind.LINK_TYPE_PARAMS_AND_BOUNDS, fieldType));
         pre.add(fieldContent);
         pre.add(" ");
         pre.add(fieldName);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
@@ -28,7 +28,6 @@ package jdk.javadoc.internal.doclets.formats.html;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.SortedSet;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.lang.model.element.Element;
@@ -210,7 +209,7 @@ public class IndexWriter extends HtmlDocletWriter {
             case ANNOTATION_TYPE:
             case INTERFACE:
                 dt = HtmlTree.DT(getLink(new HtmlLinkInfo(configuration,
-                        HtmlLinkInfo.Kind.INDEX, (TypeElement) element).style(HtmlStyle.typeNameLink)));
+                        HtmlLinkInfo.Kind.LINK_TYPE_PARAMS_AND_BOUNDS, (TypeElement) element).style(HtmlStyle.typeNameLink)));
                 dt.add(" - ");
                 addClassInfo((TypeElement) element, dt);
                 break;
@@ -220,7 +219,7 @@ public class IndexWriter extends HtmlDocletWriter {
             case FIELD:
             case ENUM_CONSTANT:
                 TypeElement containingType = item.getContainingTypeElement();
-                dt = HtmlTree.DT(getDocLink(HtmlLinkInfo.Kind.INDEX, containingType, element,
+                dt = HtmlTree.DT(getDocLink(HtmlLinkInfo.Kind.PLAIN, containingType, element,
                                 label, HtmlStyle.memberNameLink));
                 dt.add(" - ");
                 addMemberDesc(element, containingType, dt);
@@ -332,7 +331,7 @@ public class IndexWriter extends HtmlDocletWriter {
             default -> throw new IllegalArgumentException(member.getKind().toString());
         };
         content.add(contents.getContent(resource, kindName)).add(" ");
-        addPreQualifiedClassLink(HtmlLinkInfo.Kind.INDEX, enclosing,
+        addPreQualifiedClassLink(HtmlLinkInfo.Kind.PLAIN, enclosing,
                 null, content);
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriterImpl.java
@@ -140,7 +140,7 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
             } else {
                 if (!utils.hasHiddenTag(holder) && !utils.hasHiddenTag(method)) {
                     Content link =
-                            writer.getDocLink(HtmlLinkInfo.Kind.EXECUTABLE_ELEMENT_COPY,
+                            writer.getDocLink(HtmlLinkInfo.Kind.PLAIN,
                                     holder, method,
                                     utils.isIncluded(holder)
                                             ? utils.getSimpleName(holder)
@@ -204,7 +204,7 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
     @Override
     public void addInheritedSummaryLabel(TypeElement typeElement, Content content) {
         Content classLink = writer.getPreQualifiedClassLink(
-                HtmlLinkInfo.Kind.MEMBER, typeElement);
+                HtmlLinkInfo.Kind.PLAIN, typeElement);
         Content label;
         if (options.summarizeOverriddenMethods()) {
             label = Text.of(utils.isClass(typeElement)
@@ -267,18 +267,18 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
             //Abstract method is implemented from abstract class,
             //not overridden
             label = contents.specifiedByLabel;
-            context = HtmlLinkInfo.Kind.METHOD_SPECIFIED_BY;
+            context = HtmlLinkInfo.Kind.LINK_TYPE_PARAMS_AND_BOUNDS;
         } else {
             label = contents.overridesLabel;
-            context = HtmlLinkInfo.Kind.METHOD_OVERRIDES;
+            context = HtmlLinkInfo.Kind.LINK_TYPE_PARAMS_AND_BOUNDS;
         }
         dl.add(HtmlTree.DT(label));
         Content overriddenTypeLink =
                 writer.getLink(new HtmlLinkInfo(writer.configuration, context, overriddenType));
         var codeOverriddenTypeLink = HtmlTree.CODE(overriddenTypeLink);
         Content methlink = writer.getLink(
-                new HtmlLinkInfo(writer.configuration, HtmlLinkInfo.Kind.MEMBER, holder)
-                        .where(writer.htmlIds.forMember(method).name())
+                new HtmlLinkInfo(writer.configuration, HtmlLinkInfo.Kind.PLAIN, holder)
+                        .fragment(writer.htmlIds.forMember(method).name())
                         .label(method.getSimpleName()));
         var codeMethLink = HtmlTree.CODE(methlink);
         var dd = HtmlTree.DD(codeMethLink);
@@ -314,11 +314,11 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
             TypeMirror intfac = vmt.getImplementedMethodHolder(method, implementedMeth);
             intfac = utils.getDeclaredType(utils.getEnclosingTypeElement(method), intfac);
             Content intfaclink = writer.getLink(new HtmlLinkInfo(
-                    writer.configuration, HtmlLinkInfo.Kind.METHOD_SPECIFIED_BY, intfac));
+                    writer.configuration, HtmlLinkInfo.Kind.LINK_TYPE_PARAMS_AND_BOUNDS, intfac));
             var codeIntfacLink = HtmlTree.CODE(intfaclink);
             dl.add(HtmlTree.DT(contents.specifiedByLabel));
             Content methlink = writer.getDocLink(
-                    HtmlLinkInfo.Kind.MEMBER, implementedMeth,
+                    HtmlLinkInfo.Kind.PLAIN, implementedMeth,
                     implementedMeth.getSimpleName());
             var codeMethLink = HtmlTree.CODE(methlink);
             var dd = HtmlTree.DD(codeMethLink);
@@ -339,7 +339,7 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
     protected Content getReturnType(ExecutableElement method) {
         TypeMirror type = utils.getReturnType(typeElement, method);
         if (type != null) {
-            return writer.getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.RETURN_TYPE, type));
+            return writer.getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.LINK_TYPE_PARAMS, type));
         }
         return new ContentBuilder();
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriterImpl.java
@@ -703,7 +703,7 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
             if (!displayServiceDirective(t, usesTrees)) {
                 continue;
             }
-            typeLinkContent = getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.PACKAGE, t));
+            typeLinkContent = getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.SHOW_TYPE_PARAMS_AND_BOUNDS, t));
             Content summary = new ContentBuilder();
             if (display(usesTrees)) {
                 description = usesTrees.get(t);
@@ -733,7 +733,7 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
                 continue;
             }
             implSet = entry.getValue();
-            Content srvLinkContent = getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.PACKAGE, srv));
+            Content srvLinkContent = getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.SHOW_TYPE_PARAMS_AND_BOUNDS, srv));
             Content desc = new ContentBuilder();
             if (display(providesTrees)) {
                 description = providesTrees.get(srv);
@@ -755,7 +755,7 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
                 String sep = "";
                 for (TypeElement impl : implSet) {
                     desc.add(sep);
-                    desc.add(getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.PACKAGE, impl)));
+                    desc.add(getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.SHOW_TYPE_PARAMS_AND_BOUNDS, impl)));
                     sep = ", ";
                 }
                 desc.add(")");

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/NestedClassWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/NestedClassWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/NestedClassWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/NestedClassWriterImpl.java
@@ -96,7 +96,7 @@ public class NestedClassWriterImpl extends AbstractMemberWriter
 
     @Override
     public void addInheritedSummaryLabel(TypeElement typeElement, Content content) {
-        Content classLink = writer.getPreQualifiedClassLink(HtmlLinkInfo.Kind.MEMBER, typeElement);
+        Content classLink = writer.getPreQualifiedClassLink(HtmlLinkInfo.Kind.PLAIN, typeElement);
         Content label;
         if (options.summarizeOverriddenMethods()) {
             label = Text.of(utils.isPlainInterface(typeElement)
@@ -126,7 +126,7 @@ public class NestedClassWriterImpl extends AbstractMemberWriter
     @Override
     protected void addInheritedSummaryLink(TypeElement typeElement, Element member, Content target) {
         target.add(
-                writer.getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.MEMBER,
+                writer.getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.LINK_TYPE_PARAMS_AND_BOUNDS,
                         (TypeElement)member)));
     }
 
@@ -136,7 +136,12 @@ public class NestedClassWriterImpl extends AbstractMemberWriter
     }
 
     @Override
+    protected void addSummaryLink(TypeElement typeElement, Element member, Content content) {
+        addSummaryLink(HtmlLinkInfo.Kind.LINK_TYPE_PARAMS_AND_BOUNDS, typeElement, member, content);
+    }
+
+    @Override
     protected Content getSummaryLink(Element member) {
-        return writer.getQualifiedClassLink(HtmlLinkInfo.Kind.MEMBER_DEPRECATED_PREVIEW, member);
+        return writer.getQualifiedClassLink(HtmlLinkInfo.Kind.SHOW_PREVIEW, member);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
@@ -255,7 +255,7 @@ public class PackageWriterImpl extends HtmlDocletWriter
         for (TypeElement typeElement : allClasses) {
             if (typeElement != null && utils.isCoreClass(typeElement)) {
                 Content classLink = getLink(new HtmlLinkInfo(
-                        configuration, HtmlLinkInfo.Kind.PACKAGE, typeElement));
+                        configuration, HtmlLinkInfo.Kind.SHOW_TYPE_PARAMS_AND_BOUNDS, typeElement));
                 ContentBuilder description = new ContentBuilder();
                 addPreviewSummary(typeElement, description);
                 if (utils.isDeprecated(typeElement)) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriterImpl.java
@@ -108,7 +108,7 @@ public class PropertyWriterImpl extends AbstractMemberWriter
             } else {
                 if (!utils.hasHiddenTag(holder) && !utils.hasHiddenTag(property)) {
                     Content link =
-                            writer.getDocLink(HtmlLinkInfo.Kind.PROPERTY_COPY,
+                            writer.getDocLink(HtmlLinkInfo.Kind.PLAIN,
                                     holder, property,
                                     utils.isIncluded(holder)
                                             ? holder.getSimpleName() : holder.getQualifiedName());
@@ -164,7 +164,7 @@ public class PropertyWriterImpl extends AbstractMemberWriter
     @Override
     public void addInheritedSummaryLabel(TypeElement typeElement, Content content) {
         Content classLink = writer.getPreQualifiedClassLink(
-                HtmlLinkInfo.Kind.MEMBER, typeElement);
+                HtmlLinkInfo.Kind.PLAIN, typeElement);
         Content label;
         if (options.summarizeOverriddenMethods()) {
             label = Text.of(utils.isClass(typeElement)
@@ -199,7 +199,7 @@ public class PropertyWriterImpl extends AbstractMemberWriter
     @Override
     protected void addInheritedSummaryLink(TypeElement typeElement, Element member, Content target) {
         String mname = name(member);
-        Content content = writer.getDocLink(HtmlLinkInfo.Kind.MEMBER, typeElement, member,
+        Content content = writer.getDocLink(HtmlLinkInfo.Kind.PLAIN, typeElement, member,
                 utils.isProperty(mname) ? utils.getPropertyName(mname) : mname, true);
         target.add(content);
     }
@@ -211,7 +211,7 @@ public class PropertyWriterImpl extends AbstractMemberWriter
 
     @Override
     protected Content getSummaryLink(Element member) {
-        return writer.getDocLink(HtmlLinkInfo.Kind.MEMBER_DEPRECATED_PREVIEW, member,
+        return writer.getDocLink(HtmlLinkInfo.Kind.SHOW_PREVIEW, member,
                 utils.getFullyQualifiedName(member));
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SerializedFormWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SerializedFormWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SerializedFormWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SerializedFormWriterImpl.java
@@ -125,16 +125,16 @@ public class SerializedFormWriterImpl extends SubWriterHolderWriter
     @Override
     public Content getClassHeader(TypeElement typeElement) {
         Content classLink = (isVisibleClass(typeElement))
-                ? getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.DEFAULT, typeElement)
+                ? getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.PLAIN, typeElement)
                         .label(configuration.getClassName(typeElement)))
                 : Text.of(utils.getFullyQualifiedName(typeElement));
         var section = HtmlTree.SECTION(HtmlStyle.serializedClassDetails)
                 .setId(htmlIds.forClass(typeElement));
         Content superClassLink = typeElement.getSuperclass() != null
-                ? getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.SERIALIZED_FORM,
+                ? getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.LINK_TYPE_PARAMS_AND_BOUNDS,
                         typeElement.getSuperclass()))
                 : null;
-        Content interfaceLink = getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.SERIALIZED_FORM,
+        Content interfaceLink = getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.LINK_TYPE_PARAMS_AND_BOUNDS,
                 utils.isExternalizable(typeElement)
                         ? utils.getExternalizableType()
                         : utils.getSerializableType()));

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Signatures.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Signatures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Signatures.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Signatures.java
@@ -135,7 +135,8 @@ public class Signatures {
                 nameSpan.addStyle(HtmlStyle.typeNameLabel).add(className);
             }
             HtmlLinkInfo linkInfo = new HtmlLinkInfo(configuration,
-                    HtmlLinkInfo.Kind.CLASS_SIGNATURE, typeElement);
+                    HtmlLinkInfo.Kind.SHOW_TYPE_PARAMS_AND_BOUNDS, typeElement);
+            linkInfo.showTypeParameterAnnotations = true;
             //Let's not link to ourselves in the signature.
             linkInfo.linkToSelf = false;
             nameSpan.add(writer.getTypeParameterLinks(linkInfo));
@@ -152,7 +153,7 @@ public class Signatures {
                         content.add(Text.NL);
                         extendsImplements.add("extends ");
                         Content link = writer.getLink(new HtmlLinkInfo(configuration,
-                                HtmlLinkInfo.Kind.CLASS_SIGNATURE_PARENT_NAME,
+                                HtmlLinkInfo.Kind.SHOW_TYPE_PARAMS,
                                 superclass));
                         extendsImplements.add(link);
                     }
@@ -173,7 +174,7 @@ public class Signatures {
                             extendsImplements.add(", ");
                         }
                         Content link = writer.getLink(new HtmlLinkInfo(configuration,
-                                HtmlLinkInfo.Kind.CLASS_SIGNATURE_PARENT_NAME,
+                                HtmlLinkInfo.Kind.SHOW_TYPE_PARAMS,
                                 type));
                         extendsImplements.add(link);
                     }
@@ -199,7 +200,7 @@ public class Signatures {
                         permitsSpan.add(", ");
                     }
                     Content link = writer.getLink(new HtmlLinkInfo(configuration,
-                            HtmlLinkInfo.Kind.PERMITTED_SUBCLASSES,
+                            HtmlLinkInfo.Kind.SHOW_TYPE_PARAMS,
                             type));
                     permitsSpan.add(link);
                 }
@@ -221,7 +222,7 @@ public class Signatures {
                 content.add(sep);
                 writer.getAnnotations(e.getAnnotationMirrors(), false)
                         .forEach(a -> content.add(a).add(" "));
-                Content link = writer.getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.RECORD_COMPONENT,
+                Content link = writer.getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.LINK_TYPE_PARAMS_AND_BOUNDS,
                         e.asType()));
                 content.add(link);
                 content.add(Entity.NO_BREAK_SPACE);
@@ -402,7 +403,7 @@ public class Signatures {
          * @return this instance
          */
         MemberSignature setType(TypeMirror type) {
-            this.returnType = memberWriter.writer.getLink(new HtmlLinkInfo(memberWriter.configuration, HtmlLinkInfo.Kind.MEMBER, type));
+            this.returnType = memberWriter.writer.getLink(new HtmlLinkInfo(memberWriter.configuration, HtmlLinkInfo.Kind.LINK_TYPE_PARAMS_AND_BOUNDS, type));
             return this;
         }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
@@ -549,17 +549,17 @@ public class TagletWriterImpl extends TagletWriter {
                 if (utils.isGenericType(referencedType)) {
                     // This is a generic type link, use the TypeMirror representation.
                     return plainOrCode(isLinkPlain, htmlWriter.getLink(
-                            new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.DEFAULT, referencedType)));
+                            new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.LINK_TYPE_PARAMS_AND_BOUNDS, referencedType)));
                 }
                 labelContent = plainOrCode(isLinkPlain, Text.of(utils.getSimpleName(refClass)));
             }
-            return htmlWriter.getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.DEFAULT, refClass)
+            return htmlWriter.getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.PLAIN, refClass)
                     .label(labelContent));
         } else if (refMem == null) {
             // This is a fragment reference since refClass and refFragment are not null but refMem is null.
-            return htmlWriter.getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.SEE_TAG, refClass)
+            return htmlWriter.getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.PLAIN, refClass)
                     .label(labelContent)
-                    .where(refFragment)
+                    .fragment(refFragment)
                     .style(null));
         } else {
             // Must be a member reference since refClass is not null and refMemName is not null.
@@ -610,7 +610,7 @@ public class TagletWriterImpl extends TagletWriter {
                 }
             }
 
-            return htmlWriter.getDocLink(HtmlLinkInfo.Kind.SEE_TAG, containing,
+            return htmlWriter.getDocLink(HtmlLinkInfo.Kind.SHOW_PREVIEW, containing,
                     refMem, (labelContent.isEmpty()
                             ? plainOrCode(isLinkPlain, Text.of(refMemName))
                             : labelContent), null, false);
@@ -816,16 +816,15 @@ public class TagletWriterImpl extends TagletWriter {
         Element exception = ch.getException(throwsTag);
         Content excName;
         if (substituteType != null) {
-            excName = htmlWriter.getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.MEMBER,
+            excName = htmlWriter.getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.PLAIN,
                    substituteType));
         } else if (exception == null) {
             excName = Text.of(throwsTag.getExceptionName().toString());
         } else if (exception.asType() == null) {
             excName = Text.of(utils.getFullyQualifiedName(exception));
         } else {
-            HtmlLinkInfo link = new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.MEMBER,
+            HtmlLinkInfo link = new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.PLAIN,
                                                  exception.asType());
-            link.excludeTypeBounds = true;
             excName = htmlWriter.getLink(link);
         }
         body.add(HtmlTree.CODE(excName));
@@ -840,8 +839,7 @@ public class TagletWriterImpl extends TagletWriter {
 
     @Override
     public Content throwsTagOutput(TypeMirror throwsType, Optional<Content> content) {
-        var linkInfo = new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.MEMBER, throwsType);
-        linkInfo.excludeTypeBounds = true;
+        var linkInfo = new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.PLAIN, throwsType);
         var link = htmlWriter.getLink(linkInfo);
         var concat = new ContentBuilder(HtmlTree.CODE(link));
         if (content.isPresent()) {
@@ -854,7 +852,7 @@ public class TagletWriterImpl extends TagletWriter {
     @Override
     public Content valueTagOutput(VariableElement field, String constantVal, boolean includeLink) {
         return includeLink
-                ? htmlWriter.getDocLink(HtmlLinkInfo.Kind.VALUE_TAG, field, constantVal)
+                ? htmlWriter.getDocLink(HtmlLinkInfo.Kind.LINK_TYPE_PARAMS_AND_BOUNDS, field, constantVal)
                 : Text.of(constantVal);
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/links/LinkFactory.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/links/LinkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/links/LinkFactory.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/links/LinkFactory.java
@@ -123,7 +123,7 @@ public abstract class LinkFactory {
                             ? (TypeVariable) utils.getComponentType(type)
                             : type;
                     Element owner = typevariable.asElement().getEnclosingElement();
-                    if (!linkInfo.excludeTypeParameterLinks && utils.isTypeElement(owner)) {
+                    if (linkInfo.linkTypeParameters && utils.isTypeElement(owner)) {
                         linkInfo.typeElement = (TypeElement) owner;
                         Content label = newContent();
                         label.add(utils.getTypeName(type, false));
@@ -135,8 +135,8 @@ public abstract class LinkFactory {
                         link.add(utils.getTypeName(typevariable, false));
                     }
 
-                    if (!linkInfo.excludeTypeBounds) {
-                        linkInfo.excludeTypeBounds = true;
+                    if (linkInfo.showTypeBounds) {
+                        linkInfo.showTypeBounds = false;
                         TypeParameterElement tpe = ((TypeParameterElement) typevariable.asElement());
                         boolean more = false;
                         List<? extends TypeMirror> bounds = utils.getBounds(tpe);
@@ -172,7 +172,7 @@ public abstract class LinkFactory {
                     link.add(getTypeAnnotationLinks(linkInfo));
                     linkInfo.typeElement = utils.asTypeElement(type);
                     link.add(getClassLink(linkInfo));
-                    if (linkInfo.includeTypeParameterLinks()) {
+                    if (linkInfo.showTypeParameters()) {
                         link.add(getTypeParameterLinks(linkInfo));
                     }
                     return link;
@@ -182,7 +182,7 @@ public abstract class LinkFactory {
         } else if (linkInfo.typeElement != null) {
             Content link = newContent();
             link.add(getClassLink(linkInfo));
-            if (linkInfo.includeTypeParameterLinks()) {
+            if (linkInfo.showTypeParameters()) {
                 link.add(getTypeParameterLinks(linkInfo));
             }
             return link;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/links/LinkInfo.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/links/LinkInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/links/LinkInfo.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/links/LinkInfo.java
@@ -67,14 +67,14 @@ public abstract class LinkInfo {
     public Content label;
 
     /**
-     * True if we should exclude the type bounds for the type parameter.
+     * True if we should print the type bounds for the type parameter.
      */
-    public boolean excludeTypeBounds = false;
+    public boolean showTypeBounds = true;
 
     /**
-     * True if we should print the type parameters, but not link them.
+     * True if type parameters should be rendered as links.
      */
-    public boolean excludeTypeParameterLinks = false;
+    public boolean linkTypeParameters = true;
 
     /**
      * By default, the link can be to the page it's already on.  However,
@@ -86,6 +86,16 @@ public abstract class LinkInfo {
      * True iff the preview flags should be skipped for this link.
      */
     public boolean skipPreview;
+
+    /**
+     * True if type parameters should be separated by line breaks.
+     */
+    public boolean addLineBreaksInTypeParameters = false;
+
+    /**
+     * True if annotations on type parameters should be shown.
+     */
+    public boolean showTypeParameterAnnotations = false;
 
     /**
      * {@return a new instance of a content object}
@@ -102,12 +112,11 @@ public abstract class LinkInfo {
     public abstract boolean isLinkable();
 
     /**
-     * Returns true if links to declared types should include links to the
-     * type parameters.
+     * Returns true if links to declared types should include type parameters.
      *
      * @return true if type parameter links should be included
      */
-    public abstract boolean includeTypeParameterLinks();
+    public abstract boolean showTypeParameters();
 
     /**
      * Return the label for this class link.
@@ -140,8 +149,10 @@ public abstract class LinkInfo {
                 ", type=" + type +
                 ", isVarArg=" + isVarArg +
                 ", label=" + label +
-                ", excludeTypeBounds=" + excludeTypeBounds +
-                ", excludeTypeParameterLinks=" + excludeTypeParameterLinks +
-                ", linkToSelf=" + linkToSelf + '}';
+                ", showTypeBounds=" + showTypeBounds +
+                ", linkTypeParameters=" + linkTypeParameters +
+                ", linkToSelf=" + linkToSelf +
+                ", addLineBreaksInTypeParameters=" + addLineBreaksInTypeParameters +
+                ", showTypeParameterAnnotations=" + showTypeParameterAnnotations + '}';
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testInterface/TestInterface.java
+++ b/test/langtools/jdk/javadoc/doclet/testInterface/TestInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -208,5 +208,97 @@ public class TestInterface extends JavadocTester {
                 a href="Spliterator.OfPrimitive.html" title="type parameter in Spliterator.OfPri\
                 mitive">T_CONS</a>,<wbr><a href="Spliterator.OfPrimitive.html" title="type param\
                 eter in Spliterator.OfPrimitive">T_SPLITR</a>&gt;&gt;</code>""");
+        checkOutput("pkg2/Spliterator.html", true,
+            """
+                <div class="caption"><span>Nested Classes</span></div>
+                <div class="summary-table three-column-summary">
+                <div class="table-header col-first">Modifier and Type</div>
+                <div class="table-header col-second">Interface</div>
+                <div class="table-header col-last">Description</div>
+                <div class="col-first even-row-color"><code>static interface&nbsp;</code></div>
+                <div class="col-second even-row-color"><code><a href="Spliterator.OfDouble.html"\
+                 class="type-name-link" title="interface in pkg2">Spliterator.OfDouble</a></code></div>
+                <div class="col-last even-row-color">&nbsp;</div>
+                <div class="col-first odd-row-color"><code>static interface&nbsp;</code></div>
+                <div class="col-second odd-row-color"><code><a href="Spliterator.OfInt.html" cla\
+                ss="type-name-link" title="interface in pkg2">Spliterator.OfInt</a>&lt;<a href="\
+                Spliterator.OfInt.html" title="type parameter in Spliterator.OfInt">Integer</a>&\
+                gt;</code></div>
+                <div class="col-last odd-row-color">&nbsp;</div>
+                <div class="col-first even-row-color"><code>static interface&nbsp;</code></div>
+                <div class="col-second even-row-color"><code><a href="Spliterator.OfPrimitive.ht\
+                ml" class="type-name-link" title="interface in pkg2">Spliterator.OfPrimitive</a>\
+                &lt;<a href="Spliterator.OfPrimitive.html" title="type parameter in Spliterator.\
+                OfPrimitive">T</a>,<wbr><a href="Spliterator.OfPrimitive.html" title="type param\
+                eter in Spliterator.OfPrimitive">T_CONS</a>,<wbr><a href="Spliterator.OfPrimitiv\
+                e.html" title="type parameter in Spliterator.OfPrimitive">T_SPLITR</a> extends <\
+                a href="Spliterator.OfPrimitive.html" title="interface in pkg2">Spliterator.OfPr\
+                imitive</a>&lt;<a href="Spliterator.OfPrimitive.html" title="type parameter in S\
+                pliterator.OfPrimitive">T</a>,<wbr><a href="Spliterator.OfPrimitive.html" title=\
+                "type parameter in Spliterator.OfPrimitive">T_CONS</a>,<wbr><a href="Spliterator\
+                .OfPrimitive.html" title="type parameter in Spliterator.OfPrimitive">T_SPLITR</a\
+                >&gt;&gt;</code></div>
+                <div class="col-last even-row-color">&nbsp;</div>
+                </div>""");
+        checkOutput("allclasses-index.html", true,
+                """
+                <div class="col-first even-row-color all-classes-table all-classes-table-tab2"><\
+                a href="pkg2/Abstract.html" title="class in pkg2">Abstract</a></div>
+                <div class="col-last even-row-color all-classes-table all-classes-table-tab2">&n\
+                bsp;</div>
+                <div class="col-first odd-row-color all-classes-table all-classes-table-tab1"><a\
+                 href="pkg2/Spliterator.html" title="interface in pkg2">Spliterator</a>&lt;<a hr\
+                ef="pkg2/Spliterator.html" title="type parameter in Spliterator">T</a>&gt;</div>
+                <div class="col-last odd-row-color all-classes-table all-classes-table-tab1">&nbsp;</div>
+                <div class="col-first even-row-color all-classes-table all-classes-table-tab1"><\
+                a href="pkg2/Spliterator.OfDouble.html" title="interface in pkg2">Spliterator.Of\
+                Double</a></div>
+                <div class="col-last even-row-color all-classes-table all-classes-table-tab1">&nbsp;</div>
+                <div class="col-first odd-row-color all-classes-table all-classes-table-tab1"><a\
+                 href="pkg2/Spliterator.OfInt.html" title="interface in pkg2">Spliterator.OfInt<\
+                /a>&lt;<a href="pkg2/Spliterator.OfInt.html" title="type parameter in Spliterato\
+                r.OfInt">Integer</a>&gt;</div>
+                <div class="col-last odd-row-color all-classes-table all-classes-table-tab1">&nbsp;</div>
+                <div class="col-first even-row-color all-classes-table all-classes-table-tab1"><\
+                a href="pkg2/Spliterator.OfPrimitive.html" title="interface in pkg2">Spliterator\
+                .OfPrimitive</a>&lt;<a href="pkg2/Spliterator.OfPrimitive.html" title="type para\
+                meter in Spliterator.OfPrimitive">T</a>,<wbr><a href="pkg2/Spliterator.OfPrimiti\
+                ve.html" title="type parameter in Spliterator.OfPrimitive">T_CONS</a>,<wbr><a hr\
+                ef="pkg2/Spliterator.OfPrimitive.html" title="type parameter in Spliterator.OfPr\
+                imitive">T_SPLITR</a> extends <a href="pkg2/Spliterator.OfPrimitive.html" title=\
+                "interface in pkg2">Spliterator.OfPrimitive</a>&lt;<a href="pkg2/Spliterator.OfP\
+                rimitive.html" title="type parameter in Spliterator.OfPrimitive">T</a>,<wbr><a h\
+                ref="pkg2/Spliterator.OfPrimitive.html" title="type parameter in Spliterator.OfP\
+                rimitive">T_CONS</a>,<wbr><a href="pkg2/Spliterator.OfPrimitive.html" title="typ\
+                e parameter in Spliterator.OfPrimitive">T_SPLITR</a>&gt;&gt;</div>
+                <div class="col-last even-row-color all-classes-table all-classes-table-tab1">&nbsp;</div>""");
+        checkOutput("index-all.html", true,
+                """
+                <dt><a href="pkg2/Spliterator.html" class="type-name-link" title="interface in p\
+                kg2">Spliterator</a>&lt;<a href="pkg2/Spliterator.html" title="type parameter in\
+                 Spliterator">T</a>&gt; - Interface in <a href="pkg2/package-summary.html">pkg2</a></dt>
+                <dd>&nbsp;</dd>
+                <dt><a href="pkg2/Spliterator.OfDouble.html" class="type-name-link" title="inter\
+                face in pkg2">Spliterator.OfDouble</a> - Interface in <a href="pkg2/package-summ\
+                ary.html">pkg2</a></dt>
+                <dd>&nbsp;</dd>
+                <dt><a href="pkg2/Spliterator.OfInt.html" class="type-name-link" title="interfac\
+                e in pkg2">Spliterator.OfInt</a>&lt;<a href="pkg2/Spliterator.OfInt.html" title=\
+                "type parameter in Spliterator.OfInt">Integer</a>&gt; - Interface in <a href="pk\
+                g2/package-summary.html">pkg2</a></dt>
+                <dd>&nbsp;</dd>
+                <dt><a href="pkg2/Spliterator.OfPrimitive.html" class="type-name-link" title="in\
+                terface in pkg2">Spliterator.OfPrimitive</a>&lt;<a href="pkg2/Spliterator.OfPrim\
+                itive.html" title="type parameter in Spliterator.OfPrimitive">T</a>,<wbr><a href\
+                ="pkg2/Spliterator.OfPrimitive.html" title="type parameter in Spliterator.OfPrim\
+                itive">T_CONS</a>,<wbr><a href="pkg2/Spliterator.OfPrimitive.html" title="type p\
+                arameter in Spliterator.OfPrimitive">T_SPLITR</a> extends <a href="pkg2/Splitera\
+                tor.OfPrimitive.html" title="interface in pkg2">Spliterator.OfPrimitive</a>&lt;<\
+                a href="pkg2/Spliterator.OfPrimitive.html" title="type parameter in Spliterator.\
+                OfPrimitive">T</a>,<wbr><a href="pkg2/Spliterator.OfPrimitive.html" title="type \
+                parameter in Spliterator.OfPrimitive">T_CONS</a>,<wbr><a href="pkg2/Spliterator.\
+                OfPrimitive.html" title="type parameter in Spliterator.OfPrimitive">T_SPLITR</a>\
+                &gt;&gt; - Interface in <a href="pkg2/package-summary.html">pkg2</a></dt>
+                <dd>&nbsp;</dd>""");
     }
 }


### PR DESCRIPTION
Please review this change to drastically reduce the number of enum values in `HtmlLinkInfo.Kind` used to describe the format of a JavaDoc link. Previously the enum values were specific to the context in which a link was used. The new values describe the link format, such as whether to include preview information or type parameters or bounds. Other link properties that previously depended on this enum were moved into separate boolean flags as they are orthogonal to the link format and would have needlessly inflated the enum class. In some other cases the calling code had to be adapted slightly to generate the desired output. 

Apart from passing the tests, I made sure the new code generates the exact same output for the JDK documentation as the old code. Doing so I noticed that some generated links were not previously covered by tests. I added tests for these in the existing `TestInterface.java`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299896](https://bugs.openjdk.org/browse/JDK-8299896): Reduce enum values of HtmlLinkInfo.Kind


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11972/head:pull/11972` \
`$ git checkout pull/11972`

Update a local copy of the PR: \
`$ git checkout pull/11972` \
`$ git pull https://git.openjdk.org/jdk pull/11972/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11972`

View PR using the GUI difftool: \
`$ git pr show -t 11972`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11972.diff">https://git.openjdk.org/jdk/pull/11972.diff</a>

</details>
