### PR TITLE
8300010: UnsatisfiedLinkError on calling System.console().readPassword() on Windows

### DIFF
--- a/src/java.base/windows/native/libjava/JdkConsoleImpl_md.c
+++ b/src/java.base/windows/native/libjava/JdkConsoleImpl_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,40 +26,30 @@
 #include "jni.h"
 #include "jni_util.h"
 #include "jvm.h"
-#include "java_io_Console.h"
+#include "jdk_internal_io_JdkConsoleImpl.h"
 
 #include <stdlib.h>
 #include <Wincon.h>
 
-static HANDLE hStdOut = INVALID_HANDLE_VALUE;
-HANDLE java_io_Console_hStdIn = INVALID_HANDLE_VALUE;
-JNIEXPORT jboolean JNICALL
-Java_java_io_Console_istty(JNIEnv *env, jclass cls)
-{
-    if (java_io_Console_hStdIn == INVALID_HANDLE_VALUE &&
-        (java_io_Console_hStdIn = GetStdHandle(STD_INPUT_HANDLE)) == INVALID_HANDLE_VALUE) {
-        return JNI_FALSE;
-    }
-    if (hStdOut == INVALID_HANDLE_VALUE &&
-        (hStdOut = GetStdHandle(STD_OUTPUT_HANDLE)) == INVALID_HANDLE_VALUE) {
-        return JNI_FALSE;
-    }
-    if (GetFileType(java_io_Console_hStdIn) != FILE_TYPE_CHAR ||
-        GetFileType(hStdOut) != FILE_TYPE_CHAR)
-        return JNI_FALSE;
-    return JNI_TRUE;
-}
+extern HANDLE java_io_Console_hStdIn;
 
-JNIEXPORT jstring JNICALL
-Java_java_io_Console_encoding(JNIEnv *env, jclass cls)
+JNIEXPORT jboolean JNICALL
+Java_jdk_internal_io_JdkConsoleImpl_echo(JNIEnv *env, jclass cls, jboolean on)
 {
-    char buf[64];
-    int cp = GetConsoleCP();
-    if (cp >= 874 && cp <= 950)
-        sprintf(buf, "ms%d", cp);
-    else if (cp == 65001)
-        sprintf(buf, "UTF-8");
-    else
-        sprintf(buf, "cp%d", cp);
-    return JNU_NewStringPlatform(env, buf);
+    DWORD fdwMode;
+    jboolean old;
+    if (! GetConsoleMode(java_io_Console_hStdIn, &fdwMode)) {
+        JNU_ThrowIOExceptionWithLastError(env, "GetConsoleMode failed");
+        return !on;
+    }
+    old = (fdwMode & ENABLE_ECHO_INPUT) != 0;
+    if (on) {
+        fdwMode |= ENABLE_ECHO_INPUT;
+    } else {
+        fdwMode &= ~ENABLE_ECHO_INPUT;
+    }
+    if (! SetConsoleMode(java_io_Console_hStdIn, fdwMode)) {
+        JNU_ThrowIOExceptionWithLastError(env, "SetConsoleMode failed");
+    }
+    return old;
 }


### PR DESCRIPTION
Fixing a regression caused by the fix to [JDK-8298971](https://bugs.openjdk.org/browse/JDK-8298971). The previous fix lacked the native part change on Windows.