### PR TITLE
JDK-8300068: UBSan CFLAGS/LDFLAGS not passed when building ADLC

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -451,6 +451,10 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_ADDRESS_SANITIZER],
 #
 AC_DEFUN_ONCE([JDKOPT_SETUP_UNDEFINED_BEHAVIOR_SANITIZER],
 [
+  # GCC reports lots of likely false positives for stringop-truncation and format-overflow.
+  # Silence them for now.
+  UBSAN_CFLAGS="-fsanitize=undefined -fsanitize=float-divide-by-zero -Wno-stringop-truncation -Wno-format-overflow -fno-omit-frame-pointer -DUNDEFINED_BEHAVIOR_SANITIZER"
+  UBSAN_LDFLAGS="-fsanitize=undefined -fsanitize=float-divide-by-zero"
   UTIL_ARG_ENABLE(NAME: ubsan, DEFAULT: false, RESULT: UBSAN_ENABLED,
       DESC: [enable UndefinedBehaviorSanitizer],
       CHECK_AVAILABLE: [
@@ -464,10 +468,6 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_UNDEFINED_BEHAVIOR_SANITIZER],
         fi
       ],
       IF_ENABLED: [
-        # GCC reports lots of likely false positives for stringop-truncation and format-overflow.
-        # Silence them for now.
-        UBSAN_CFLAGS="-fsanitize=undefined -fsanitize=float-divide-by-zero -Wno-stringop-truncation -Wno-format-overflow -fno-omit-frame-pointer -DUNDEFINED_BEHAVIOR_SANITIZER"
-        UBSAN_LDFLAGS="-fsanitize=undefined -fsanitize=float-divide-by-zero"
         JVM_CFLAGS="$JVM_CFLAGS $UBSAN_CFLAGS"
         JVM_LDFLAGS="$JVM_LDFLAGS $UBSAN_LDFLAGS"
         CFLAGS_JDKLIB="$CFLAGS_JDKLIB $UBSAN_CFLAGS"
@@ -477,6 +477,12 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_UNDEFINED_BEHAVIOR_SANITIZER],
         LDFLAGS_JDKLIB="$LDFLAGS_JDKLIB $UBSAN_LDFLAGS"
         LDFLAGS_JDKEXE="$LDFLAGS_JDKEXE $UBSAN_LDFLAGS"
       ])
+  if test "x$UBSAN_ENABLED" = xfalse; then
+    UBSAN_CFLAGS=""
+    UBSAN_LDFLAGS=""
+  fi
+  AC_SUBST(UBSAN_CFLAGS)
+  AC_SUBST(UBSAN_LDFLAGS)
   AC_SUBST(UBSAN_ENABLED)
 ])
 

--- a/make/autoconf/spec.gmk.in
+++ b/make/autoconf/spec.gmk.in
@@ -457,6 +457,8 @@ endif
 
 # UndefinedBehaviorSanitizer
 UBSAN_ENABLED:=@UBSAN_ENABLED@
+UBSAN_CFLAGS:=@UBSAN_CFLAGS@
+UBSAN_LDFLAGS:=@UBSAN_LDFLAGS@
 
 # Necessary additional compiler flags to compile X11
 X_CFLAGS:=@X_CFLAGS@

--- a/make/hotspot/gensrc/GensrcAdlc.gmk
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -59,6 +59,11 @@ ifeq ($(call check-jvm-feature, compiler2), true)
   # Add file macro mappings
   ADLC_CFLAGS += $(FILE_MACRO_CFLAGS)
 
+  ifeq ($(UBSAN_ENABLED), true)
+    ADLC_CFLAGS += $(UBSAN_CFLAGS)
+    ADLC_LDFLAGS += $(UBSAN_LDFLAGS)
+  endif
+
   $(eval $(call SetupNativeCompilation, BUILD_ADLC, \
       NAME := adlc, \
       TYPE := EXECUTABLE, \


### PR DESCRIPTION
Fix misconfigured UBSan build by funneling `UBSAN_CFLAGS` and `UBSAN_LDFLAGS` to ADLC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300068](https://bugs.openjdk.org/browse/JDK-8300068): UBSan CFLAGS/LDFLAGS not passed when building ADLC


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11975/head:pull/11975` \
`$ git checkout pull/11975`

Update a local copy of the PR: \
`$ git checkout pull/11975` \
`$ git pull https://git.openjdk.org/jdk pull/11975/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11975`

View PR using the GUI difftool: \
`$ git pr show -t 11975`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11975.diff">https://git.openjdk.org/jdk/pull/11975.diff</a>

</details>
