### PR TITLE
8300140: ZipFile.isSignatureRelated returns true for files in META-INF subdirectories

### DIFF
--- a/src/java.base/share/classes/java/util/jar/JarVerifier.java
+++ b/src/java.base/share/classes/java/util/jar/JarVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -136,8 +136,7 @@ class JarVerifier {
 
         if (parsingMeta) {
             String uname = name.toUpperCase(Locale.ENGLISH);
-            if ((uname.startsWith("META-INF/") ||
-                 uname.startsWith("/META-INF/"))) {
+            if (isInMetaInf(uname)) {
 
                 if (je.isDirectory()) {
                     mev.setEntry(null, je);
@@ -194,6 +193,14 @@ class JarVerifier {
 
         // don't compute the digest for this entry
         mev.setEntry(null, je);
+    }
+
+    /**
+     * Returns true iff the entry resides directly in the META-INF/ directory
+     */
+    private boolean isInMetaInf(String uname) {
+        return (uname.startsWith("META-INF/") || uname.startsWith("/META-INF/") )
+                && uname.lastIndexOf('/') < "META-INF/".length();
     }
 
     /**

--- a/src/java.base/share/classes/java/util/jar/JarVerifier.java
+++ b/src/java.base/share/classes/java/util/jar/JarVerifier.java
@@ -39,6 +39,8 @@ import sun.security.util.ManifestEntryVerifier;
 import sun.security.util.SignatureFileVerifier;
 import sun.security.util.Debug;
 
+import static sun.security.util.SignatureFileVerifier.isInMetaInf;
+
 /**
  *
  * @author      Roland Schemers
@@ -135,14 +137,14 @@ class JarVerifier {
          */
 
         if (parsingMeta) {
-            String uname = name.toUpperCase(Locale.ENGLISH);
-            if (isInMetaInf(uname)) {
+
+            if (isInMetaInf(name)) {
 
                 if (je.isDirectory()) {
                     mev.setEntry(null, je);
                     return;
                 }
-
+                String uname = name.toUpperCase(Locale.ENGLISH);
                 if (uname.equals(JarFile.MANIFEST_NAME) ||
                         uname.equals(JarIndex.INDEX_NAME)) {
                     return;
@@ -193,14 +195,6 @@ class JarVerifier {
 
         // don't compute the digest for this entry
         mev.setEntry(null, je);
-    }
-
-    /**
-     * Returns true iff the entry resides directly in the META-INF/ directory
-     */
-    private boolean isInMetaInf(String uname) {
-        return (uname.startsWith("META-INF/") || uname.startsWith("/META-INF/") )
-                && uname.lastIndexOf('/') < "META-INF/".length();
     }
 
     /**

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -1747,7 +1747,7 @@ public class ZipFile implements ZipConstants, Closeable {
                     .toUpperCase(Locale.ENGLISH)));
 
             // Signature related files must reside directly in META-INF/
-            if(signatureRelated && hasSlash(name, off + META_INF_LEN, off + len)) {
+            if (signatureRelated && hasSlash(name, off + META_INF_LEN, off + len)) {
                 signatureRelated = false;
             }
             return signatureRelated;
@@ -1758,9 +1758,9 @@ public class ZipFile implements ZipConstants, Closeable {
          * it is already assumed in isMetaName
          */
         private boolean hasSlash(byte[] name, int start, int end) {
-            for(int i = start; i < end; i++) {
+            for (int i = start; i < end; i++) {
                 int c = name[i];
-                if(c == '/') {
+                if (c == '/') {
                     return true;
                 }
             }

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1745,7 +1745,26 @@ public class ZipFile implements ZipConstants, Closeable {
             assert(signatureRelated == SignatureFileVerifier
                 .isBlockOrSF(new String(name, off, len, UTF_8.INSTANCE)
                     .toUpperCase(Locale.ENGLISH)));
+
+            // Signature related files must reside directly in META-INF/
+            if(signatureRelated && hasSlash(name, off + META_INF_LEN, off + len)) {
+                signatureRelated = false;
+            }
             return signatureRelated;
+        }
+        /*
+         * Return true if the encoded name contains a '/' within the byte given range
+         * This assumes an ASCII-compatible encoding, which is ok here since
+         * it is already assumed in isMetaName
+         */
+        private boolean hasSlash(byte[] name, int start, int end) {
+            for(int i = start; i < end; i++) {
+                int c = name[i];
+                if(c == '/') {
+                    return true;
+                }
+            }
+            return false;
         }
 
         /*

--- a/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
@@ -153,7 +153,7 @@ public class SignatureFileVerifier {
      */
     public static boolean isBlockOrSF(String s) {
         // Note: keep this in sync with j.u.z.ZipFile.Source#isSignatureRelated
-        // we currently only support DSA and RSA PKCS7 blocks
+        // we currently only support DSA, RSA or EC PKCS7 blocks
         return s.endsWith(".SF")
             || s.endsWith(".DSA")
             || s.endsWith(".RSA")

--- a/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
@@ -81,6 +81,8 @@ public class SignatureFileVerifier {
     /** ConstraintsParameters for checking disabled algorithms */
     private JarConstraintsParameters params;
 
+    private static final String META_INF = "META-INF/";
+
     /**
      * Create the named SignatureFileVerifier.
      *
@@ -143,6 +145,18 @@ public class SignatureFileVerifier {
 
     /**
      * Utility method used by JarVerifier and JarSigner
+     * to determine if a path is located directly in the
+     * META-INF/ directory
+     *
+     * @param name the path name to check
+     * @return true if the path resides in META-INF directly, ignoring case
+     */
+    public static boolean isInMetaInf(String name) {
+        return name.regionMatches(true, 0, META_INF, 0, META_INF.length())
+                && name.lastIndexOf('/') < META_INF.length();
+    }
+    /**
+     * Utility method used by JarVerifier and JarSigner
      * to determine the signature file names and PKCS7 block
      * files names that are supported
      *
@@ -191,14 +205,10 @@ public class SignatureFileVerifier {
      * @return true if the input file name is signature related
      */
     public static boolean isSigningRelated(String name) {
+        if (!isInMetaInf(name)) {
+            return false;
+        }
         name = name.toUpperCase(Locale.ENGLISH);
-        if (!name.startsWith("META-INF/")) {
-            return false;
-        }
-        name = name.substring(9);
-        if (name.indexOf('/') != -1) {
-            return false;
-        }
         if (isBlockOrSF(name) || name.equals("MANIFEST.MF")) {
             return true;
         } else if (name.startsWith("SIG-")) {

--- a/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
@@ -213,7 +213,7 @@ public class SignatureFileVerifier {
             return true;
         } else if (name.startsWith("SIG-", META_INF.length())) {
             // check filename extension
-            // see http://docs.oracle.com/javase/7/docs/technotes/guides/jar/jar.html#Digital_Signatures
+            // see https://docs.oracle.com/en/java/javase/19/docs/specs/jar/jar.html#digital-signatures
             // for what filename extensions are legal
             int extIndex = name.lastIndexOf('.');
             if (extIndex != -1) {

--- a/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
@@ -209,9 +209,9 @@ public class SignatureFileVerifier {
             return false;
         }
         name = name.toUpperCase(Locale.ENGLISH);
-        if (isBlockOrSF(name) || name.equals("MANIFEST.MF")) {
+        if (isBlockOrSF(name) || name.equals("META-INF/MANIFEST.MF")) {
             return true;
-        } else if (name.startsWith("SIG-")) {
+        } else if (name.startsWith("SIG-", META_INF.length())) {
             // check filename extension
             // see http://docs.oracle.com/javase/7/docs/technotes/guides/jar/jar.html#Digital_Signatures
             // for what filename extensions are legal

--- a/src/jdk.jartool/share/classes/jdk/security/jarsigner/JarSigner.java
+++ b/src/jdk.jartool/share/classes/jdk/security/jarsigner/JarSigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -731,7 +731,7 @@ public final class JarSigner {
              enum_.hasMoreElements(); ) {
             ZipEntry ze = enum_.nextElement();
 
-            if (ze.getName().startsWith(META_INF)) {
+            if (isInMetaInf(ze)) {
                 // Store META-INF files in vector, so they can be written
                 // out first
                 mfFiles.addElement(ze);
@@ -959,7 +959,7 @@ public final class JarSigner {
              enum_.hasMoreElements(); ) {
             ZipEntry ze = enum_.nextElement();
 
-            if (!ze.getName().startsWith(META_INF)) {
+            if (!isInMetaInf(ze)) {
                 if (handler != null) {
                     if (manifest.getAttributes(ze.getName()) != null) {
                         handler.accept("signing", ze.getName());
@@ -972,6 +972,13 @@ public final class JarSigner {
         }
         zipFile.close();
         zos.close();
+    }
+
+    /**
+     * Returns true iff the entry resides directly in the META-INF/ directory
+     */
+    private boolean isInMetaInf(ZipEntry ze) {
+        return ze.getName().startsWith(META_INF) && ze.getName().lastIndexOf('/') < META_INF.length();
     }
 
     private void writeEntry(ZipFile zf, ZipOutputStream os, ZipEntry ze)

--- a/src/jdk.jartool/share/classes/jdk/security/jarsigner/JarSigner.java
+++ b/src/jdk.jartool/share/classes/jdk/security/jarsigner/JarSigner.java
@@ -63,6 +63,8 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
+import static sun.security.util.SignatureFileVerifier.isInMetaInf;
+
 /**
  * An immutable utility class to sign a jar file.
  * <p>
@@ -475,8 +477,6 @@ public final class JarSigner {
         }
     }
 
-    private static final String META_INF = "META-INF/";
-
     // All fields in Builder are duplicated here as final. Those not
     // provided but has a default value will be filled with default value.
 
@@ -731,7 +731,7 @@ public final class JarSigner {
              enum_.hasMoreElements(); ) {
             ZipEntry ze = enum_.nextElement();
 
-            if (isInMetaInf(ze)) {
+            if (isInMetaInf(ze.getName())) {
                 // Store META-INF files in vector, so they can be written
                 // out first
                 mfFiles.addElement(ze);
@@ -959,7 +959,7 @@ public final class JarSigner {
              enum_.hasMoreElements(); ) {
             ZipEntry ze = enum_.nextElement();
 
-            if (!isInMetaInf(ze)) {
+            if (!isInMetaInf(ze.getName())) {
                 if (handler != null) {
                     if (manifest.getAttributes(ze.getName()) != null) {
                         handler.accept("signing", ze.getName());
@@ -974,12 +974,6 @@ public final class JarSigner {
         zos.close();
     }
 
-    /**
-     * Returns true iff the entry resides directly in the META-INF/ directory
-     */
-    private boolean isInMetaInf(ZipEntry ze) {
-        return ze.getName().startsWith(META_INF) && ze.getName().lastIndexOf('/') < META_INF.length();
-    }
 
     private void writeEntry(ZipFile zf, ZipOutputStream os, ZipEntry ze)
             throws IOException {

--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
@@ -835,8 +835,7 @@ public class Main {
                     if (!extraAttrsDetected && JUZFA.getExtraAttributes(je) != -1) {
                         extraAttrsDetected = true;
                     }
-                    hasSignature = hasSignature
-                            || SignatureFileVerifier.isBlockOrSF(name);
+                    hasSignature |= signatureRelated(name) && SignatureFileVerifier.isBlockOrSF(name);
 
                     CodeSigner[] signers = je.getCodeSigners();
                     boolean isSigned = (signers != null);

--- a/test/jdk/java/util/jar/JarFile/IgnoreUnrelatedSignatureFiles.java
+++ b/test/jdk/java/util/jar/JarFile/IgnoreUnrelatedSignatureFiles.java
@@ -59,7 +59,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
-public class VerifyUnrelatedSignatureFiles {
+public class IgnoreUnrelatedSignatureFiles {
 
     private static final JavaUtilZipFileAccess JUZA = SharedSecrets.getJavaUtilZipFileAccess();
 

--- a/test/jdk/java/util/jar/JarFile/IgnoreUnrelatedSignatureFiles.java
+++ b/test/jdk/java/util/jar/JarFile/IgnoreUnrelatedSignatureFiles.java
@@ -87,7 +87,7 @@ public class IgnoreUnrelatedSignatureFiles {
         // 0: Sanity check that the basic signed JAR verifies
         try (JarFile jf = new JarFile(s.toFile(), true)) {
             Map<String, Attributes> entries = jf.getManifest().getEntries();
-            if(entries.size() != 1) {
+            if (entries.size() != 1) {
                 throw new Exception("Expected a single manifest entry for the digest of a.txt, instead found entries: " + entries.keySet());
             }
             JarEntry entry = jf.getJarEntry("a.txt");
@@ -181,7 +181,7 @@ public class IgnoreUnrelatedSignatureFiles {
 
             Set<String> actualSigned = jf.getManifest().getEntries().keySet();
 
-            if(!expectedSigned.equals(actualSigned)) {
+            if (!expectedSigned.equals(actualSigned)) {
                 throw new Exception("Unexpected MANIFEST entries. Expected %s, got %s"
                         .formatted(expectedSigned, actualSigned));
             }

--- a/test/jdk/java/util/jar/JarFile/IgnoreUnrelatedSignatureFiles.java
+++ b/test/jdk/java/util/jar/JarFile/IgnoreUnrelatedSignatureFiles.java
@@ -175,9 +175,13 @@ public class IgnoreUnrelatedSignatureFiles {
 
             // These files are not signature-related and should be signed
             Set<String> expectedSigned = Set.of("a.txt",
+                    "META-INF/unrelated.txt",
                     "META-INF/SIG-CUSTOM2.C-1",
+                    "META-INF/SIG-CUSTOM2.",
+                    "META-INF/SIG-CUSTOM2.ABCD",
                     "META-INF/subdirectory/SIG-CUSTOM2.SF",
-                    "META-INF/subdirectory/SIG-CUSTOM2.CS1");
+                    "META-INF/subdirectory/SIG-CUSTOM2.CS1"
+            );
 
             Set<String> actualSigned = jf.getManifest().getEntries().keySet();
 
@@ -258,15 +262,21 @@ public class IgnoreUnrelatedSignatureFiles {
         try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(jar), manifest)) {
             // Regular file
             write(out, "a.txt", "a");
-            // Custom SIG files with valid extension
+            // Regular file in META-INF
+            write(out, "META-INF/unrelated.txt", "a");
+
+            // Custom SIG files with valid extension (no extension is also OK)
             write(out, "META-INF/SIG-CUSTOM.SF", "");
             write(out, "META-INF/SIG-CUSTOM.CS1", "");
+            write(out, "META-INF/SIG-CUSTOM", "");
 
-            // Custom SIG files with invalid extension
+            // Custom SIG files with invalid extensions
             write(out, "META-INF/SIG-CUSTOM2.SF", "");
             write(out, "META-INF/SIG-CUSTOM2.C-1", "");
+            write(out, "META-INF/SIG-CUSTOM2.", "");
+            write(out, "META-INF/SIG-CUSTOM2.ABCD", "");
 
-            // Custom SIG files with valid extension, invalid directory
+            // Custom SIG files with valid extensions in subdirectories
             write(out, "META-INF/subdirectory/SIG-CUSTOM2.SF", "");
             write(out, "META-INF/subdirectory/SIG-CUSTOM2.CS1", "");
 

--- a/test/jdk/java/util/jar/JarFile/VerifyUnrelatedSignatureFiles.java
+++ b/test/jdk/java/util/jar/JarFile/VerifyUnrelatedSignatureFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/jar/JarFile/VerifyUnrelatedSignatureFiles.java
+++ b/test/jdk/java/util/jar/JarFile/VerifyUnrelatedSignatureFiles.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Make sure signature related files in subdirectories of META-INF are not considered for verification
+ * @compile --add-exports java.base/jdk.internal.access=ALL-UNNAMED --add-exports java.base/sun.security.util=ALL-UNNAMED --add-exports java.base/sun.security.tools.keytool=ALL-UNNAMED VerifyUnrelatedSignatureFiles.java
+ * @run main/othervm --add-exports java.base/jdk.internal.access=ALL-UNNAMED  --add-exports java.base/sun.security.util=ALL-UNNAMED --add-exports java.base/sun.security.tools.keytool=ALL-UNNAMED VerifyUnrelatedSignatureFiles
+ */
+
+import jdk.internal.access.JavaUtilZipFileAccess;
+import jdk.internal.access.SharedSecrets;
+import jdk.security.jarsigner.JarSigner;
+import sun.security.util.SignatureFileVerifier;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.cert.CertPath;
+import java.security.cert.CertificateFactory;
+import java.util.Arrays;
+import java.util.List;
+import java.util.jar.*;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
+
+public class VerifyUnrelatedSignatureFiles {
+
+    private static final JavaUtilZipFileAccess JUZA = SharedSecrets.getJavaUtilZipFileAccess();
+
+    // These paths do not reside directly in META-INF/ and should not be considered signature related
+    public static final String SUBDIR_SF_PATH = "META-INF/subdirectory/META-INF/SIGNER.SF";
+
+
+    public static void main(String[] args) throws Exception {
+
+        File j = createJarFile();
+        File s = signJarFile(j, "signed");
+        File m = moveSignatureRelated(s);
+
+        // 1: Check ZipFile.Source.isSignatureRelated
+        try(JarFile jarFile = new JarFile(m)) {
+            final List<String> manifestAndSignatureRelatedFiles = JUZA.getManifestAndSignatureRelatedFiles(jarFile);
+            for (String signatureRelatedFile : manifestAndSignatureRelatedFiles) {
+                String dir = signatureRelatedFile.substring(0, signatureRelatedFile.lastIndexOf("/"));
+                if(!"META-INF".equals(dir)) {
+                    throw new Exception("Signature related file does not reside directly in META-INF/ : " + signatureRelatedFile);
+                }
+            }
+        }
+
+        // 2: Check SignatureFileVerifier.isSigningRelated
+        if(SignatureFileVerifier.isSigningRelated(SUBDIR_SF_PATH)) {
+            throw new Exception("Signature related file does not reside directly in META-INF/ : " + SUBDIR_SF_PATH);
+        }
+
+        // 3: Check JarInputStream with doVerify = true
+        try(JarInputStream in = new JarInputStream(new FileInputStream(m), true)) {
+            while( in.getNextEntry() != null) {
+                in.transferTo(OutputStream.nullOutputStream());
+            }
+        }
+
+        // 4: Check that jar with unrelated .SF, .RSA files are signed as-if they are unsigned
+
+        File sm = signJarFile(m, "modified-signed");
+
+        try(ZipFile zf = new ZipFile(sm)) {
+            final ZipEntry mf = zf.getEntry("META-INF/MANIFEST.MF");
+            try(InputStream stream = zf.getInputStream(mf)) {
+                final String manifest = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+                // When JarSigner considers a jar to not be already signed,
+                // the 'Manifest-Version' attributed name will be case-normalized
+                // Assert that manifest-version is not in lowercase
+                if(manifest.startsWith("manifest-version")) {
+                    throw new Exception("JarSigner unexpectedly treated unsigned jar as signed");
+                }
+            }
+        }
+    }
+
+    /**
+     * Create a jar file with a '*.SF' file residing in META-INF/subdirectory/
+     */
+    private static File createJarFile() throws Exception {
+
+        File f = File.createTempFile("unrelated-signature-file-", ".jar");
+
+
+        Manifest manifest = new Manifest();
+        manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        try(JarOutputStream out = new JarOutputStream(new FileOutputStream(f), manifest)) {
+            out.putNextEntry(new JarEntry("a.txt"));
+            out.write("a".getBytes(StandardCharsets.UTF_8));
+        }
+
+        return f;
+    }
+    /**
+     * Create a signed version of the given jar file
+     */
+    private static File signJarFile(File f, String classifier) throws Exception {
+        File s = File.createTempFile("unrelated-signature-files-" + classifier +"-", ".jar");
+
+        new File("ks").delete();
+
+        sun.security.tools.keytool.Main.main(
+                ("-keystore ks -storepass changeit -keypass changeit -dname" +
+                        " CN=RSA -alias r -genkeypair -keyalg rsa").split(" "));
+
+        char[] pass = "changeit".toCharArray();
+
+        KeyStore ks = KeyStore.getInstance(
+                new File("ks"), pass);
+        PrivateKey pkr = (PrivateKey)ks.getKey("r", pass);
+
+        CertPath cp = CertificateFactory.getInstance("X.509")
+                .generateCertPath(Arrays.asList(ks.getCertificateChain("r")));
+
+        JarSigner signer = new JarSigner.Builder(pkr, cp)
+                .digestAlgorithm("SHA-256")
+                .signatureAlgorithm("SHA256withRSA")
+                .build();
+
+        try(ZipFile in = new ZipFile(f);
+            OutputStream out = new FileOutputStream(s)) {
+            signer.sign(in, out);
+        }
+
+        return s;
+    }
+
+    /**
+     * Create a modified version of a signed jar file where signature-related files
+     * are moved into a subdirectory of META-INF/ and the manifest is changed to trigger
+     * a digest mismatch.
+     *
+     * Since the signature related files are moved out of META-INF/, the returned jar file should
+     * not be considered signed
+     */
+    private static File moveSignatureRelated(File s) throws IOException {
+        File m = File.createTempFile("unrelated-signature-files-modified-", ".jar");
+
+
+        try(ZipInputStream in = new JarInputStream(new FileInputStream(s));
+            JarOutputStream out = new JarOutputStream(new FileOutputStream(m))) {
+
+            out.putNextEntry(new ZipEntry("META-INF/MANIFEST.MF"));
+            out.write("manifest-version: 1.0\n\n".getBytes(StandardCharsets.UTF_8));
+
+            ZipEntry entry;
+            while((entry = in.getNextEntry()) != null) {
+                String name = entry.getName();
+
+                // Skip the existing manifest
+                if("META-INF/MANIFEST.MF".equals(name)) {
+                    continue;
+                }
+
+                // Move signature related files into subdirectory of META-INF
+                if(name.endsWith(".SF") || name.endsWith(".RSA")) {
+                    name = "META-INF/subdirectory/" + name;
+                }
+
+                out.putNextEntry(new ZipEntry(name));
+                in.transferTo(out);
+            }
+        }
+        return m;
+    }
+}

--- a/test/jdk/java/util/jar/JarFile/VerifyUnrelatedSignatureFiles.java
+++ b/test/jdk/java/util/jar/JarFile/VerifyUnrelatedSignatureFiles.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @bug 8300140
  * @summary Make sure signature related files in subdirectories of META-INF are not considered for verification
  * @modules java.base/jdk.internal.access
  * @modules java.base/sun.security.util

--- a/test/jdk/java/util/jar/JarFile/VerifyUnrelatedSignatureFiles.java
+++ b/test/jdk/java/util/jar/JarFile/VerifyUnrelatedSignatureFiles.java
@@ -24,8 +24,11 @@
 /**
  * @test
  * @summary Make sure signature related files in subdirectories of META-INF are not considered for verification
- * @compile --add-exports java.base/jdk.internal.access=ALL-UNNAMED --add-exports java.base/sun.security.util=ALL-UNNAMED --add-exports java.base/sun.security.tools.keytool=ALL-UNNAMED VerifyUnrelatedSignatureFiles.java
- * @run main/othervm --add-exports java.base/jdk.internal.access=ALL-UNNAMED  --add-exports java.base/sun.security.util=ALL-UNNAMED --add-exports java.base/sun.security.tools.keytool=ALL-UNNAMED VerifyUnrelatedSignatureFiles
+ * @modules java.base/jdk.internal.access
+ * @modules java.base/sun.security.util
+ * @modules java.base/sun.security.tools.keytool
+ * @compile VerifyUnrelatedSignatureFiles.java
+ * @run main/othervm VerifyUnrelatedSignatureFiles
  */
 
 import jdk.internal.access.JavaUtilZipFileAccess;

--- a/test/jdk/java/util/jar/JarFile/VerifyUnrelatedSignatureFiles.java
+++ b/test/jdk/java/util/jar/JarFile/VerifyUnrelatedSignatureFiles.java
@@ -53,7 +53,7 @@ public class VerifyUnrelatedSignatureFiles {
 
     private static final JavaUtilZipFileAccess JUZA = SharedSecrets.getJavaUtilZipFileAccess();
 
-    // These paths do not reside directly in META-INF/ and should not be considered signature related
+    // This path resides in a subdirectory of META-INF, so it should not be considered signature related
     public static final String SUBDIR_SF_PATH = "META-INF/subdirectory/META-INF/SIGNER.SF";
 
 

--- a/test/jdk/java/util/jar/JarFile/VerifyUnrelatedSignatureFiles.java
+++ b/test/jdk/java/util/jar/JarFile/VerifyUnrelatedSignatureFiles.java
@@ -118,9 +118,11 @@ public class VerifyUnrelatedSignatureFiles {
                     "META-INF/MANIFEST.MF",
                     "META-INF/SIGNER2.SF",
                     "META-INF/SIGNER2.RSA",
-                    "a.txt",
                     "META-INF/subdirectory/META-INF/SIGNER1.SF",
-                    "META-INF/subdirectory/META-INF/SIGNER1.RSA"
+                    "META-INF/subdirectory/META-INF/SIGNER1.RSA",
+                    "a.txt",
+                    "META-INF/subdirectory2/META-INF/SIGNER1.SF",
+                    "META-INF/subdirectory2/META-INF/SIGNER1.RSA"
             );
 
             if(!expectedOrder.equals(actualOrder)) {
@@ -235,13 +237,16 @@ public class VerifyUnrelatedSignatureFiles {
             out.putNextEntry(new ZipEntry("META-INF/MANIFEST.MF"));
             out.write("manifest-version: 1.0\n\n".getBytes(StandardCharsets.UTF_8));
 
+            copy("META-INF/SIGNER1.SF", "META-INF/subdirectory/META-INF/SIGNER1.SF", in, out);
+            copy("META-INF/SIGNER1.RSA", "META-INF/subdirectory/META-INF/SIGNER1.RSA", in, out);
+
             // Copy over the regular a.txt file
             copy("a.txt", "a.txt", in, out);
 
             // These are also just regular files in their new location, but putting them at end
             // allows us to verify that JarSigner does not move them to the beginning of the signed JAR
-            copy("META-INF/SIGNER1.SF", "META-INF/subdirectory/META-INF/SIGNER1.SF", in, out);
-            copy("META-INF/SIGNER1.RSA", "META-INF/subdirectory/META-INF/SIGNER1.RSA", in, out);
+            copy("META-INF/SIGNER1.SF", "META-INF/subdirectory2/META-INF/SIGNER1.SF", in, out);
+            copy("META-INF/SIGNER1.RSA", "META-INF/subdirectory2/META-INF/SIGNER1.RSA", in, out);
         }
         return m;
     }


### PR DESCRIPTION
Some call sites of SignatureFileVerifier.isBlockOrSF fails to check that files reside in META-INF directly, and not in a subdirectory of META-INF.

The mentioned call sites needs updates to check and ignore such files.

A new test IgnoreUnrelatedSignatureFiles is added which verifies that [*.SF, *.RSA] files in META-INF/ subdirectories are indeed ignored.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300140](https://bugs.openjdk.org/browse/JDK-8300140): ZipFile.isSignatureRelated returns true for files in META-INF subdirectories


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11976/head:pull/11976` \
`$ git checkout pull/11976`

Update a local copy of the PR: \
`$ git checkout pull/11976` \
`$ git pull https://git.openjdk.org/jdk pull/11976/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11976`

View PR using the GUI difftool: \
`$ git pr show -t 11976`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11976.diff">https://git.openjdk.org/jdk/pull/11976.diff</a>

</details>
