### PR TITLE
JDK-8300069: Left shift of negative value in share/adlc/dict2.cpp

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -468,6 +468,11 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_UNDEFINED_BEHAVIOR_SANITIZER],
         fi
       ],
       IF_ENABLED: [
+        # GCC reports lots of likely false positives for stringop-truncation and format-overflow.
+        # Silence them for now.
+        UBSAN_CHECKS="-fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize=shift-base"
+        UBSAN_CFLAGS="$UBSAN_CHECKS -Wno-stringop-truncation -Wno-format-overflow -fno-omit-frame-pointer -DUNDEFINED_BEHAVIOR_SANITIZER"
+        UBSAN_LDFLAGS="$UBSAN_CHECKS"
         JVM_CFLAGS="$JVM_CFLAGS $UBSAN_CFLAGS"
         JVM_LDFLAGS="$JVM_LDFLAGS $UBSAN_LDFLAGS"
         CFLAGS_JDKLIB="$CFLAGS_JDKLIB $UBSAN_CFLAGS"

--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -453,8 +453,9 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_UNDEFINED_BEHAVIOR_SANITIZER],
 [
   # GCC reports lots of likely false positives for stringop-truncation and format-overflow.
   # Silence them for now.
-  UBSAN_CFLAGS="-fsanitize=undefined -fsanitize=float-divide-by-zero -Wno-stringop-truncation -Wno-format-overflow -fno-omit-frame-pointer -DUNDEFINED_BEHAVIOR_SANITIZER"
-  UBSAN_LDFLAGS="-fsanitize=undefined -fsanitize=float-divide-by-zero"
+  UBSAN_CHECKS="-fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize=shift-base"
+  UBSAN_CFLAGS="$UBSAN_CHECKS -Wno-stringop-truncation -Wno-format-overflow -fno-omit-frame-pointer -DUNDEFINED_BEHAVIOR_SANITIZER"
+  UBSAN_LDFLAGS="$UBSAN_CHECKS"
   UTIL_ARG_ENABLE(NAME: ubsan, DEFAULT: false, RESULT: UBSAN_ENABLED,
       DESC: [enable UndefinedBehaviorSanitizer],
       CHECK_AVAILABLE: [
@@ -468,11 +469,6 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_UNDEFINED_BEHAVIOR_SANITIZER],
         fi
       ],
       IF_ENABLED: [
-        # GCC reports lots of likely false positives for stringop-truncation and format-overflow.
-        # Silence them for now.
-        UBSAN_CHECKS="-fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize=shift-base"
-        UBSAN_CFLAGS="$UBSAN_CHECKS -Wno-stringop-truncation -Wno-format-overflow -fno-omit-frame-pointer -DUNDEFINED_BEHAVIOR_SANITIZER"
-        UBSAN_LDFLAGS="$UBSAN_CHECKS"
         JVM_CFLAGS="$JVM_CFLAGS $UBSAN_CFLAGS"
         JVM_LDFLAGS="$JVM_LDFLAGS $UBSAN_LDFLAGS"
         CFLAGS_JDKLIB="$CFLAGS_JDKLIB $UBSAN_CFLAGS"

--- a/src/hotspot/share/adlc/dict2.cpp
+++ b/src/hotspot/share/adlc/dict2.cpp
@@ -283,12 +283,12 @@ void Dict::print(PrintKeyOrValue print_key, PrintKeyOrValue print_value) {
 // limited to MAXID characters in length.  Experimental evidence on 150K of
 // C text shows excellent spreading of values for any size hash table.
 int hashstr(const void *t) {
-  char c, k = 0;
-  int sum = 0;
-  const char *s = (const char *)t;
+  unsigned char c, k = 0;
+  unsigned int sum = 0;
+  const unsigned char *s = (const unsigned char *)t;
 
   while (((c = s[k]) != '\0') && (k < MAXID-1)) { // Get characters till nul
-    c = (char) ((c << 1) + 1);    // Characters are always odd!
+    c = (unsigned char) ((c << 1) + 1);    // Characters are always odd!
     sum += c + (c << shft[k++]);  // Universal hash function
   }
   assert(k < (MAXID), "Exceeded maximum name length");

--- a/src/hotspot/share/adlc/dict2.cpp
+++ b/src/hotspot/share/adlc/dict2.cpp
@@ -283,12 +283,12 @@ void Dict::print(PrintKeyOrValue print_key, PrintKeyOrValue print_value) {
 // limited to MAXID characters in length.  Experimental evidence on 150K of
 // C text shows excellent spreading of values for any size hash table.
 int hashstr(const void *t) {
-  unsigned char c, k = 0;
-  unsigned int sum = 0;
-  const unsigned char *s = (const unsigned char *)t;
+  char c, k = 0;
+  int sum = 0;
+  const char *s = (const char *)t;
 
   while (((c = s[k]) != '\0') && (k < MAXID-1)) { // Get characters till nul
-    c = (unsigned char) ((c << 1) + 1);    // Characters are always odd!
+    c = (char) ((c << 1) + 1);    // Characters are always odd!
     sum += c + (c << shft[k++]);  // Universal hash function
   }
   assert(k < (MAXID), "Exceeded maximum name length");


### PR DESCRIPTION
Refactor `hashstr` to use unsigned integrals to avoid undefined behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8300069](https://bugs.openjdk.org/browse/JDK-8300069): Left shift of negative value in share/adlc/dict2.cpp


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11977/head:pull/11977` \
`$ git checkout pull/11977`

Update a local copy of the PR: \
`$ git checkout pull/11977` \
`$ git pull https://git.openjdk.org/jdk pull/11977/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11977`

View PR using the GUI difftool: \
`$ git pr show -t 11977`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11977.diff">https://git.openjdk.org/jdk/pull/11977.diff</a>

</details>
