### PR TITLE
JDK-8300080: offset_of for GCC/Clang exhibits undefined behavior and is not always a compile-time constant

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -86,11 +86,10 @@ CFLAGS_VM_VERSION := \
 DISABLED_WARNINGS_gcc := array-bounds comment delete-non-virtual-dtor \
     empty-body ignored-qualifiers implicit-fallthrough int-in-bool-context \
     maybe-uninitialized missing-field-initializers parentheses \
-    shift-negative-value unknown-pragmas invalid-offsetof
+    shift-negative-value unknown-pragmas
 
 DISABLED_WARNINGS_clang := ignored-qualifiers sometimes-uninitialized \
-    missing-braces delete-non-abstract-non-virtual-dtor unknown-pragmas \
-    invalid-offsetof
+    missing-braces delete-non-abstract-non-virtual-dtor unknown-pragmas
 
 ifneq ($(DEBUG_LEVEL), release)
   # Assert macro gives warning

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -86,10 +86,11 @@ CFLAGS_VM_VERSION := \
 DISABLED_WARNINGS_gcc := array-bounds comment delete-non-virtual-dtor \
     empty-body ignored-qualifiers implicit-fallthrough int-in-bool-context \
     maybe-uninitialized missing-field-initializers parentheses \
-    shift-negative-value unknown-pragmas
+    shift-negative-value unknown-pragmas invalid-offsetof
 
 DISABLED_WARNINGS_clang := ignored-qualifiers sometimes-uninitialized \
-    missing-braces delete-non-abstract-non-virtual-dtor unknown-pragmas
+    missing-braces delete-non-abstract-non-virtual-dtor unknown-pragmas \
+    invalid-offsetof
 
 ifneq ($(DEBUG_LEVEL), release)
   # Assert macro gives warning

--- a/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
@@ -144,12 +144,12 @@ inline int g_isfinite(jdouble f)                 { return isfinite(f); }
 // chances we use our own implementation which both GCC/Clang ultimately produce a constant for but
 // is not a constant expression.
 #define offset_of(klass, field)                         \
-__attribute__((always_inline)) []() {                   \
+(__attribute__((always_inline)) []() {                  \
   alignas(klass) char space[sizeof(klass)];             \
   klass* dummyObj = (klass*)space;                      \
   char* c = (char*)(void*)&dummyObj->field;             \
   return (size_t)(c - space);                           \
-}()
+}())
 
 #if defined(_LP64) && defined(__APPLE__)
 #define JLONG_FORMAT          "%ld"

--- a/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
@@ -144,7 +144,7 @@ inline int g_isfinite(jdouble f)                 { return isfinite(f); }
 // chances we use our own implementation which both GCC/Clang ultimately produce a constant for but
 // is not a constant expression.
 #define offset_of(klass, field)                         \
-(__attribute__((always_inline)) []() {                  \
+([]() __attribute__((always_inline)) {                  \
   alignas(klass) char space[sizeof(klass)];             \
   klass* dummyObj = (klass*)space;                      \
   char* c = (char*)(void*)&dummyObj->field;             \

--- a/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
@@ -138,22 +138,7 @@ inline int g_isfinite(jdouble f)                 { return isfinite(f); }
 #define FORMAT64_MODIFIER "ll"
 #endif // _LP64
 
-// gcc warns about applying offsetof() to non-POD object or calculating
-// offset directly when base address is NULL. The -Wno-invalid-offsetof
-// option could be used to suppress this warning, but we instead just
-// avoid the use of offsetof().
-//
-// FIXME: This macro is complex and rather arcane. Perhaps we should
-// use offsetof() instead, with the invalid-offsetof warning
-// temporarily disabled.
-#define offset_of(klass,field)                          \
-[]() {                                                  \
-  char space[sizeof (klass)] ATTRIBUTE_ALIGNED(16);     \
-  klass* dummyObj = (klass*)space;                      \
-  char* c = (char*)(void*)&dummyObj->field;             \
-  return (size_t)(c - space);                           \
-}()
-
+#define offset_of(klass,field) offsetof(klass, field)
 
 #if defined(_LP64) && defined(__APPLE__)
 #define JLONG_FORMAT          "%ld"


### PR DESCRIPTION
The implementation of `offset_of` for GCC/Clang only deals with types are aligned to 16 bytes or less, if they are more, such as `zCollectedHeap` the behavior is undefined. UBSan also suggests that `offset_of` is not always a compile time constant, as the stack trace came from the dynamic loader during library loading. This patch changes `offset_of` to use `offsetof` and disables the warning `invalid-offsetof` for the JVM.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8300080](https://bugs.openjdk.org/browse/JDK-8300080): offset_of for GCC/Clang exhibits undefined behavior and is not always a compile-time constant


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/11978/head:pull/11978` \
`$ git checkout pull/11978`

Update a local copy of the PR: \
`$ git checkout pull/11978` \
`$ git pull https://git.openjdk.org/jdk.git pull/11978/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11978`

View PR using the GUI difftool: \
`$ git pr show -t 11978`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11978.diff">https://git.openjdk.org/jdk/pull/11978.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/11978#issuecomment-1380970396)