### PR TITLE
8300077: Refactor code examples to use @snippet in java.text.ChoiceFormat

### DIFF
--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -85,7 +85,7 @@ import java.util.Arrays;
  * <p>
  * Here is a simple example that shows formatting and parsing:
  * <blockquote>
- * <pre>{@code
+ * {@snippet lang=java :
  * double[] limits = {1,2,3,4,5,6,7};
  * String[] dayOfWeekNames = {"Sun","Mon","Tue","Wed","Thur","Fri","Sat"};
  * ChoiceFormat form = new ChoiceFormat(limits, dayOfWeekNames);
@@ -95,11 +95,11 @@ import java.util.Arrays;
  *     System.out.println(i + " -> " + form.format(i) + " -> "
  *                              + form.parse(form.format(i),status));
  * }
- * }</pre>
+ * }
  * </blockquote>
  * Here is a more complex example, with a pattern format:
  * <blockquote>
- * <pre>{@code
+ * {@snippet lang=java :
  * double[] filelimits = {0,1,2};
  * String[] filepart = {"are no files","is one file","are {2} files"};
  * ChoiceFormat fileform = new ChoiceFormat(filelimits, filepart);
@@ -112,13 +112,13 @@ import java.util.Arrays;
  *     testArgs[2] = testArgs[0];
  *     System.out.println(pattform.format(testArgs));
  * }
- * }</pre>
+ * }
  * </blockquote>
  * <p>
  * Specifying a pattern for ChoiceFormat objects is fairly straightforward.
  * For example:
  * <blockquote>
- * <pre>{@code
+ * {@snippet lang=java :
  * ChoiceFormat fmt = new ChoiceFormat(
  *      "-1#is negative| 0#is zero or fraction | 1#is one |1.0<is 1+ |2#is two |2<is more than 2.");
  * System.out.println("Formatter Pattern : " + fmt.toPattern());
@@ -133,7 +133,7 @@ import java.util.Arrays;
  * System.out.println("Format with 2.1 : " + fmt.format(2.1));
  * System.out.println("Format with NaN : " + fmt.format(Double.NaN));
  * System.out.println("Format with +INF : " + fmt.format(Double.POSITIVE_INFINITY));
- * }</pre>
+ * }
  * </blockquote>
  * And the output result would be like the following:
  * <blockquote>


### PR DESCRIPTION
This PR implements _JEP 413: Code Snippets in Java API Documentation_ for [java.text.ChoiceFormat](https://docs.oracle.com/en/java/javase/19/docs/api/java.base/java/text/ChoiceFormat.html).

Code examples using \<pre> ... \</pre> blocks are replaced with the @ snippet syntax where applicable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300077](https://bugs.openjdk.org/browse/JDK-8300077): Refactor code examples to use @snippet in java.text.ChoiceFormat


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11981/head:pull/11981` \
`$ git checkout pull/11981`

Update a local copy of the PR: \
`$ git checkout pull/11981` \
`$ git pull https://git.openjdk.org/jdk pull/11981/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11981`

View PR using the GUI difftool: \
`$ git pr show -t 11981`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11981.diff">https://git.openjdk.org/jdk/pull/11981.diff</a>

</details>
