### PR TITLE
8300099: Configuration fails to auto-detect build user through $USER in dockers

### DIFF
--- a/make/autoconf/basic_tools.m4
+++ b/make/autoconf/basic_tools.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -88,6 +88,7 @@ AC_DEFUN_ONCE([BASIC_SETUP_FUNDAMENTAL_TOOLS],
   UTIL_LOOKUP_PROGS(GIT, git)
   UTIL_LOOKUP_PROGS(NICE, nice)
   UTIL_LOOKUP_PROGS(READLINK, greadlink readlink)
+  UTIL_LOOKUP_PROGS(WHOAMI, whoami)
 
   # These are only needed on some platforms
   UTIL_LOOKUP_PROGS(PATHTOOL, cygpath wslpath)

--- a/make/autoconf/jdk-version.m4
+++ b/make/autoconf/jdk-version.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -73,6 +73,11 @@ AC_DEFUN_ONCE([JDKVER_SETUP_JDK_VERSION_NUMBERS],
 
   # Outer [ ] to quote m4.
   [ USERNAME=`$ECHO "$USER" | $TR -d -c '[a-z][A-Z][0-9]'` ]
+
+  # $USER may be not defined in dockers, so try to check with $WHOAMI
+  if test "x$USERNAME" = x && test "x$WHOAMI" != x; then
+    [ USERNAME=`$WHOAMI | $TR -d -c '[a-z][A-Z][0-9]'` ]
+  fi
 
   # Setup username (for use in adhoc version strings etc)
   UTIL_ARG_WITH(NAME: build-user, TYPE: string,


### PR DESCRIPTION
Hi all,

Configuration is broken in dockers after JDK-8296478.
This is because `$USER` is not defined in dockers [1].

The fix will check `whoami` if we get an empty `$USERNAME`.

Thanks.
Best regards,
Jie

[1] https://stackoverflow.com/questions/54411218/docker-why-isnt-user-environment-variable-set

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300099](https://bugs.openjdk.org/browse/JDK-8300099): Configuration fails to auto-detect build user through $USER in dockers


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11983/head:pull/11983` \
`$ git checkout pull/11983`

Update a local copy of the PR: \
`$ git checkout pull/11983` \
`$ git pull https://git.openjdk.org/jdk pull/11983/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11983`

View PR using the GUI difftool: \
`$ git pr show -t 11983`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11983.diff">https://git.openjdk.org/jdk/pull/11983.diff</a>

</details>
