### PR TITLE
7169951: SwingSet2 throws NullPointerException with Nimbus L&F

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTabbedPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTabbedPaneUI.java
@@ -837,6 +837,9 @@ public class SynthTabbedPaneUI extends BasicTabbedPaneUI
     }
 
     private FontMetrics getFontMetrics(Font font) {
+        if (font == null) {
+            font = tabPane.getFont();
+        }
         return tabPane.getFontMetrics(font);
     }
 


### PR DESCRIPTION
It is observed that if SwingSet2 is run in Nimbus L&F and
we drag the icon tool bar (which is floatable) out of the GUI Window
and  Once the tool bar is detached, click on "Look & Feel" menu option to change to any L&F (say Java L&F)
it causes NPE due to font being null when getFontMetrics() is called

In other L&F, it uses the tabPane's [font ](https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTabbedPaneUI.java#L2177) whereas in Nimbus font is obtained from getStyle().getFont() which returns null when toolbar is detached from the main window.
The proposed fix is to get tabPane's font if the font passed is null alike other L&Fs. 

No regression test is made as it can be verified with SwingSet2..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-7169951](https://bugs.openjdk.org/browse/JDK-7169951): SwingSet2 throws NullPointerException with Nimbus L&amp;F


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11984/head:pull/11984` \
`$ git checkout pull/11984`

Update a local copy of the PR: \
`$ git checkout pull/11984` \
`$ git pull https://git.openjdk.org/jdk pull/11984/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11984`

View PR using the GUI difftool: \
`$ git pr show -t 11984`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11984.diff">https://git.openjdk.org/jdk/pull/11984.diff</a>

</details>
