### PR TITLE
8300113: C2: Single-bit fields with signed type in TypePtr after JDK-8297933

### DIFF
--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -883,9 +883,9 @@ protected:
     void raw_add(ciKlass* interface);
     void add(ciKlass* interface);
     void verify() const;
-    int _hash_computed:1;
-    int _exact_klass_computed:1;
-    int _is_loaded_computed:1;
+    uint _hash_computed:1;
+    uint _exact_klass_computed:1;
+    uint _is_loaded_computed:1;
     int _hash;
     ciKlass* _exact_klass;
     bool _is_loaded;


### PR DESCRIPTION
See the description in the bug. Attention @rwestrel.
The solution is to use `uint` like the rest of C2 and other `:1` fields there.

Additional testing:
 - [x] Linux x86_64 fastdebug hotspot:tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300113](https://bugs.openjdk.org/browse/JDK-8300113): C2: Single-bit fields with signed type in TypePtr after JDK-8297933


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11989/head:pull/11989` \
`$ git checkout pull/11989`

Update a local copy of the PR: \
`$ git checkout pull/11989` \
`$ git pull https://git.openjdk.org/jdk pull/11989/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11989`

View PR using the GUI difftool: \
`$ git pr show -t 11989`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11989.diff">https://git.openjdk.org/jdk/pull/11989.diff</a>

</details>
