### PR TITLE
8278349: JarSigner javadoc example uses SHA-1

### DIFF
--- a/src/jdk.jartool/share/classes/jdk/security/jarsigner/JarSigner.java
+++ b/src/jdk.jartool/share/classes/jdk/security/jarsigner/JarSigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,16 +76,16 @@ import java.util.zip.ZipOutputStream;
  * a {@link NullPointerException}.
  * <p>
  * Example:
- * <pre>
+ * {@snippet lang="java" :
  * JarSigner signer = new JarSigner.Builder(key, certPath)
- *         .digestAlgorithm("SHA-1")
- *         .signatureAlgorithm("SHA1withDSA")
+ *         .digestAlgorithm("SHA-256")
+ *         .signatureAlgorithm("SHA256withRSA")
  *         .build();
  * try (ZipFile in = new ZipFile(inputFile);
  *         FileOutputStream out = new FileOutputStream(outputFile)) {
  *     signer.sign(in, out);
  * }
- * </pre>
+ * }
  *
  * @since 9
  */

--- a/src/jdk.jartool/share/classes/jdk/security/jarsigner/JarSigner.java
+++ b/src/jdk.jartool/share/classes/jdk/security/jarsigner/JarSigner.java
@@ -77,14 +77,14 @@ import java.util.zip.ZipOutputStream;
  * <p>
  * Example:
  * {@snippet lang="java" :
- * JarSigner signer = new JarSigner.Builder(key, certPath)
- *         .digestAlgorithm("SHA-256")
- *         .signatureAlgorithm("SHA256withRSA")
- *         .build();
- * try (ZipFile in = new ZipFile(inputFile);
- *         FileOutputStream out = new FileOutputStream(outputFile)) {
- *     signer.sign(in, out);
- * }
+ *     JarSigner signer = new JarSigner.Builder(key, certPath)
+ *             .digestAlgorithm("SHA-256")
+ *             .signatureAlgorithm("SHA256withRSA")
+ *             .build();
+ *     try (ZipFile  in = new ZipFile(inputFile);
+ *             FileOutputStream out = new FileOutputStream(outputFile)) {
+ *         signer.sign(in, out);
+ *     }
  * }
  *
  * @since 9


### PR DESCRIPTION
Please review this trivial PR which updates javadoc sample code in jdk.security.jarsigner.JarSigner to use SHA-256, SHA256withRSA instead of the now considered weak algorithms SHA-1, SHA1withDSA.

The sample code is also updated to use the new snippet syntax.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278349](https://bugs.openjdk.org/browse/JDK-8278349): JarSigner javadoc example uses SHA-1


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11992/head:pull/11992` \
`$ git checkout pull/11992`

Update a local copy of the PR: \
`$ git checkout pull/11992` \
`$ git pull https://git.openjdk.org/jdk pull/11992/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11992`

View PR using the GUI difftool: \
`$ git pr show -t 11992`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11992.diff">https://git.openjdk.org/jdk/pull/11992.diff</a>

</details>
