### PR TITLE
8300125: Serial: Remove unused Generation::reset_saved_marks

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -772,13 +772,6 @@ void DefNewGeneration::save_marks() {
 }
 
 
-void DefNewGeneration::reset_saved_marks() {
-  eden()->reset_saved_mark();
-  to()->reset_saved_mark();
-  from()->reset_saved_mark();
-}
-
-
 bool DefNewGeneration::no_allocs_since_save_marks() {
   assert(eden()->saved_mark_at_top(), "Violated spec - alloc in eden");
   assert(from()->saved_mark_at_top(), "Violated spec - alloc in from");

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -278,7 +278,7 @@ protected:
 
   // Accessing marks
   void save_marks();
-  void reset_saved_marks();
+
   bool no_allocs_since_save_marks();
 
   // Need to declare the full complement of closures, whether we'll

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -500,10 +500,6 @@ void TenuredGeneration::save_marks() {
   _the_space->set_saved_mark();
 }
 
-void TenuredGeneration::reset_saved_marks() {
-  _the_space->reset_saved_mark();
-}
-
 bool TenuredGeneration::no_allocs_since_save_marks() {
   return _the_space->saved_mark_at_top();
 }

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -132,7 +132,7 @@ class TenuredGeneration: public Generation {
   void oop_since_save_marks_iterate(OopClosureType* cl);
 
   void save_marks();
-  void reset_saved_marks();
+
   bool no_allocs_since_save_marks();
 
   inline size_t block_size(const HeapWord* addr) const;

--- a/src/hotspot/share/gc/shared/generation.hpp
+++ b/src/hotspot/share/gc/shared/generation.hpp
@@ -333,10 +333,6 @@ class Generation: public CHeapObj<mtGC> {
   // operations to be optimized.
   virtual void save_marks() {}
 
-  // This function allows generations to initialize any "saved marks".  That
-  // is, should only be called when the generation is empty.
-  virtual void reset_saved_marks() {}
-
   // This function is "true" iff any no allocations have occurred in the
   // generation since the last call to "save_marks".
   virtual bool no_allocs_since_save_marks() = 0;


### PR DESCRIPTION
Trivial change of removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300125](https://bugs.openjdk.org/browse/JDK-8300125): Serial: Remove unused Generation::reset_saved_marks


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Leo Korinth](https://openjdk.org/census#lkorinth) (@lkorinth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11994/head:pull/11994` \
`$ git checkout pull/11994`

Update a local copy of the PR: \
`$ git checkout pull/11994` \
`$ git pull https://git.openjdk.org/jdk pull/11994/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11994`

View PR using the GUI difftool: \
`$ git pr show -t 11994`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11994.diff">https://git.openjdk.org/jdk/pull/11994.diff</a>

</details>
