### PR TITLE
8300127: Serial: Remove unnecessary from-space iteration in DefNewGeneration::oop_since_save_marks_iterate

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.inline.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.inline.hpp
@@ -91,7 +91,7 @@ inline void DefNewGeneration::FastKeepAliveClosure::do_oop_work(T* p) {
 
 template <typename OopClosureType>
 void DefNewGeneration::oop_since_save_marks_iterate(OopClosureType* cl) {
-  // no allocation in from-space (eden/from)
+  // No allocation in eden and from spaces, so no iteration required.
   assert(eden()->saved_mark_at_top(), "inv");
   assert(from()->saved_mark_at_top(), "inv");
 

--- a/src/hotspot/share/gc/serial/defNewGeneration.inline.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.inline.hpp
@@ -91,11 +91,12 @@ inline void DefNewGeneration::FastKeepAliveClosure::do_oop_work(T* p) {
 
 template <typename OopClosureType>
 void DefNewGeneration::oop_since_save_marks_iterate(OopClosureType* cl) {
-  eden()->oop_since_save_marks_iterate(cl);
-  to()->oop_since_save_marks_iterate(cl);
-  from()->oop_since_save_marks_iterate(cl);
+  // no allocation in from-space (eden/from)
+  assert(eden()->saved_mark_at_top(), "inv");
+  assert(from()->saved_mark_at_top(), "inv");
 
-  save_marks();
+  to()->oop_since_save_marks_iterate(cl);
+  to()->set_saved_mark();
 }
 
 #endif // SHARE_GC_SERIAL_DEFNEWGENERATION_INLINE_HPP


### PR DESCRIPTION
Converting no-ops to assertions in young-gen obj iteration.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300127](https://bugs.openjdk.org/browse/JDK-8300127): Serial: Remove unnecessary from-space iteration in DefNewGeneration::oop_since_save_marks_iterate


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11995/head:pull/11995` \
`$ git checkout pull/11995`

Update a local copy of the PR: \
`$ git checkout pull/11995` \
`$ git pull https://git.openjdk.org/jdk pull/11995/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11995`

View PR using the GUI difftool: \
`$ git pr show -t 11995`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11995.diff">https://git.openjdk.org/jdk/pull/11995.diff</a>

</details>
