### PR TITLE
8286581: Make Java process DPI Aware if sun.java2d.dpiaware property is set

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
@@ -31,6 +31,7 @@
 #include "Devices.h"
 #include "WindowsFlags.h"
 #include "DllUtil.h"
+#include <windef.h>
 
 BOOL DWMIsCompositionEnabled();
 
@@ -44,16 +45,14 @@ void initScreens(JNIEnv *env) {
 
 /**
  * This function attempts to make a Win32 API call to
- *   BOOL SetProcessDPIAware(VOID);
- * which is only present on Windows Vista, and which instructs the
- * Vista Windows Display Manager that this application is High DPI Aware
- * and does not need to be scaled by the WDM and lied about the
- * actual system dpi.
+ *   BOOL SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT);
+ * to set Process DPI Awareness to DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
+ * to match what we have in the manifest file.
  */
 static void
 SetProcessDPIAwareProperty()
 {
-    typedef BOOL (WINAPI SetProcessDPIAwareFunc)(void);
+    typedef BOOL (WINAPI SetProcessDpiAwarenessContextFunc)(DPI_AWARENESS_CONTEXT);
     static BOOL bAlreadySet = FALSE;
 
     // setHighDPIAware is set in WindowsFlags.cpp
@@ -66,12 +65,14 @@ SetProcessDPIAwareProperty()
     HMODULE hLibUser32Dll = JDK_LoadSystemLibrary("user32.dll");
 
     if (hLibUser32Dll != NULL) {
-        SetProcessDPIAwareFunc *lpSetProcessDPIAware =
-            (SetProcessDPIAwareFunc*)GetProcAddress(hLibUser32Dll,
-                                                    "SetProcessDPIAware");
-        if (lpSetProcessDPIAware != NULL) {
-            lpSetProcessDPIAware();
+        SetProcessDpiAwarenessContextFunc *lpSetProcessDpiAwarenessContext =
+                    (SetProcessDpiAwarenessContextFunc*)GetProcAddress(hLibUser32Dll,
+                                                            "SetProcessDpiAwarenessContext");
+
+        if (lpSetProcessDpiAwarenessContext != NULL) {
+            lpSetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
         }
+
         ::FreeLibrary(hLibUser32Dll);
     }
 }


### PR DESCRIPTION
I tested by removing dpi-awareness settings from the manifest file, and then running my app with -Dsun.java2d.dpiaware=false. This showed java.exe as "Unaware" in task-manager, and with it set to true I saw "Per-Monitor (v2)" dpi awareness for java.exe.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286581](https://bugs.openjdk.org/browse/JDK-8286581): Make Java process DPI Aware if sun.java2d.dpiaware property is set


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/11998/head:pull/11998` \
`$ git checkout pull/11998`

Update a local copy of the PR: \
`$ git checkout pull/11998` \
`$ git pull https://git.openjdk.org/jdk pull/11998/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11998`

View PR using the GUI difftool: \
`$ git pr show -t 11998`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/11998.diff">https://git.openjdk.org/jdk/pull/11998.diff</a>

</details>
