### PR TITLE
8300093: Refactor code examples to use @snippet in java.text.MessageFormat

### DIFF
--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -230,14 +230,16 @@ import java.util.Locale;
  * <p>
  * The first example uses the static method {@code MessageFormat.format},
  * which internally creates a {@code MessageFormat} for one-time use:
- * <blockquote><pre>
+ * <blockquote>
+ * {@snippet lang=java :
  * int planet = 7;
  * String event = "a disturbance in the Force";
  *
  * String result = MessageFormat.format(
  *     "At {1,time} on {1,date}, there was {2} on planet {0,number,integer}.",
  *     planet, new Date(), event);
- * </pre></blockquote>
+ * }
+ * </blockquote>
  * The output is:
  * <blockquote><pre>
  * At 12:30 PM on Jul 3, 2053, there was a disturbance in the Force on planet 7.
@@ -246,7 +248,8 @@ import java.util.Locale;
  * <p>
  * The following example creates a {@code MessageFormat} instance that
  * can be used repeatedly:
- * <blockquote><pre>
+ * <blockquote>
+ * {@snippet lang=java :
  * int fileCount = 1273;
  * String diskName = "MyDisk";
  * Object[] testArgs = {Long.valueOf(fileCount), diskName};
@@ -255,7 +258,8 @@ import java.util.Locale;
  *     "The disk \"{1}\" contains {0} file(s).");
  *
  * System.out.println(form.format(testArgs));
- * </pre></blockquote>
+ * }
+ * </blockquote>
  * The output with different values for {@code fileCount}:
  * <blockquote><pre>
  * The disk "MyDisk" contains 0 file(s).
@@ -266,7 +270,8 @@ import java.util.Locale;
  * <p>
  * For more sophisticated patterns, you can use a {@code ChoiceFormat}
  * to produce correct forms for singular and plural:
- * <blockquote><pre>
+ * <blockquote>
+ * {@snippet lang=java :
  * MessageFormat form = new MessageFormat("The disk \"{1}\" contains {0}.");
  * double[] filelimits = {0,1,2};
  * String[] filepart = {"no files","one file","{0,number} files"};
@@ -278,7 +283,8 @@ import java.util.Locale;
  * Object[] testArgs = {Long.valueOf(fileCount), diskName};
  *
  * System.out.println(form.format(testArgs));
- * </pre></blockquote>
+ * }
+ * </blockquote>
  * The output with different values for {@code fileCount}:
  * <blockquote><pre>
  * The disk "MyDisk" contains no files.
@@ -290,10 +296,12 @@ import java.util.Locale;
  * You can create the {@code ChoiceFormat} programmatically, as in the
  * above example, or by using a pattern. See {@link ChoiceFormat}
  * for more information.
- * <blockquote><pre>{@code
+ * <blockquote>
+ * {@snippet lang=java :
  * form.applyPattern(
  *    "There {0,choice,0#are no files|1#is one file|1<are {0,number,integer} files}.");
- * }</pre></blockquote>
+ * }
+ * </blockquote>
  *
  * <p>
  * <strong>Note:</strong> As we see above, the string produced
@@ -305,25 +313,29 @@ import java.util.Locale;
  * <p>
  * When a single argument is parsed more than once in the string, the last match
  * will be the final result of the parsing.  For example,
- * <blockquote><pre>
+ * <blockquote>
+ * {@snippet lang=java :
  * MessageFormat mf = new MessageFormat("{0,number,#.##}, {0,number,#.#}");
  * Object[] objs = {Double.valueOf(3.1415)};
  * String result = mf.format( objs );
  * // result now equals "3.14, 3.1"
  * objs = mf.parse(result, new ParsePosition(0));
  * // objs now equals {Double.valueOf(3.1)}
- * </pre></blockquote>
+ * }
+ * </blockquote>
  *
  * <p>
  * Likewise, parsing with a {@code MessageFormat} object using patterns containing
  * multiple occurrences of the same argument would return the last match.  For
  * example,
- * <blockquote><pre>
+ * <blockquote>
+ * {@snippet lang=java :
  * MessageFormat mf = new MessageFormat("{0}, {0}, {0}");
  * String forParsing = "x, y, z";
  * Object[] objs = mf.parse(forParsing, new ParsePosition(0));
  * // result now equals {new String("z")}
- * </pre></blockquote>
+ * }
+ * </blockquote>
  *
  * <h3><a id="synchronization">Synchronization</a></h3>
  *


### PR DESCRIPTION
This PR implements _JEP 413: Code Snippets in Java API Documentation_ for [java.text.MessageFormat](https://docs.oracle.com/en/java/javase/19/docs/api/java.base/java/text/class-use/MessageFormat.html).

Code examples using \<pre> ... \</pre> blocks are replaced with the @ snippet syntax where applicable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300093](https://bugs.openjdk.org/browse/JDK-8300093): Refactor code examples to use @snippet in java.text.MessageFormat


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12001/head:pull/12001` \
`$ git checkout pull/12001`

Update a local copy of the PR: \
`$ git checkout pull/12001` \
`$ git pull https://git.openjdk.org/jdk pull/12001/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12001`

View PR using the GUI difftool: \
`$ git pr show -t 12001`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12001.diff">https://git.openjdk.org/jdk/pull/12001.diff</a>

</details>
