### PR TITLE
Concurrent liveness estimation

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1965,6 +1965,13 @@ void G1CollectedHeap::collect(GCCause::Cause cause) {
   try_collect(cause, collection_counters(this));
 }
 
+bool G1CollectedHeap::is_concurrent_gc_active() {
+  if (_cm_thread == nullptr) {
+    return false;
+  }
+  return _cm_thread->in_progress();
+}
+
 // Return true if (x < y) with allowance for wraparound.
 static bool gc_counter_less_than(uint x, uint y) {
   return (x - y) > (UINT_MAX/2);

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -771,6 +771,8 @@ public:
   // Start a concurrent cycle.
   void start_concurrent_cycle(bool concurrent_operation_is_full_mark);
 
+  virtual bool is_concurrent_gc_active() override;
+
   void prepare_tlabs_for_mutator();
 
   void retire_tlabs();

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -391,6 +391,8 @@ class CollectedHeap : public CHeapObj<mtGC> {
   // collector -- dld).
   bool is_gc_active() const { return _is_gc_active; }
 
+  virtual bool is_concurrent_gc_active() { return false; }
+
   // Total number of GC collections (started)
   unsigned int total_collections() const { return _total_collections; }
   unsigned int total_full_collections() const { return _total_full_collections;}

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -53,6 +53,7 @@ class GCHeapSummary;
 class GCTimer;
 class GCTracer;
 class GCMemoryManager;
+class LivenessEstimatorThread;
 class MemoryPool;
 class MetaspaceSummary;
 class ReservedHeapSpace;
@@ -100,6 +101,8 @@ class CollectedHeap : public CHeapObj<mtGC> {
 
  private:
   GCHeapLog* _gc_heap_log;
+
+  LivenessEstimatorThread* _liveness_estimator_thread;
 
   // Historic gc information
   size_t _capacity_at_last_gc;
@@ -530,6 +533,8 @@ class CollectedHeap : public CHeapObj<mtGC> {
   void reset_promotion_should_fail(volatile size_t* count);
   void reset_promotion_should_fail();
 #endif  // #ifndef PRODUCT
+
+  void stop_liveness_estimator();
 };
 
 // Class to set and reset the GC cause for a CollectedHeap.

--- a/src/hotspot/share/gc/shared/concurrentGCBreakpoints.cpp
+++ b/src/hotspot/share/gc/shared/concurrentGCBreakpoints.cpp
@@ -45,6 +45,10 @@ bool ConcurrentGCBreakpoints::_is_stopped = false;
 // True if the collector is idle.
 bool ConcurrentGCBreakpoints::_is_idle = true;
 
+bool ConcurrentGCBreakpoints::is_idle() {
+  return _is_idle;
+}
+
 void ConcurrentGCBreakpoints::reset_request_state() {
   _run_to = NULL;
   _want_idle = false;

--- a/src/hotspot/share/gc/shared/concurrentGCBreakpoints.hpp
+++ b/src/hotspot/share/gc/shared/concurrentGCBreakpoints.hpp
@@ -131,6 +131,8 @@ public:
   // precondition: Must not be a concurrent notification.
   // precondition: Must be at a safepoint or have the monitor locked.
   static void notify_idle_to_active();
+
+  static bool is_idle();
 };
 
 #endif // SHARE_GC_SHARED_CONCURRENTGCBREAKPOINTS_HPP

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -704,7 +704,15 @@
   product(bool, ConcLivenessVerify, false, EXPERIMENTAL,                    \
           "Compare concurrent liveness estimation with liveness computed"   \
           " on a safepoint. Concurrent estimation does NOT use barriers,"   \
-          " so some inaccuracy is expected.")
+          " so some inaccuracy is expected.")                               \
+                                                                            \
+  product(bool, ConcLivenessHisto, false, EXPERIMENTAL,                     \
+          "Print heap histogram after a concurrent liveness check."         \
+          "Requires +UseConcLivenessEstimate.")                             \
+                                                                            \
+  product(intx, HeapHistoTopN, 20, EXPERIMENTAL,                            \
+          "Number of elements to print in a heap histogram, for example"    \
+          " when using +ConcLivenessHisto.")                              
 
   // end of GC_FLAGS
 

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -697,11 +697,11 @@
           " of live objects in the heap. This does not use a barrier "      \
           " so it is an estimate only.")                                    \
                                                                             \
-  product(intx, ConcLivenessEstimateSeconds, 10, EXPERIMENTAL,              \
+  product(uintx, ConcLivenessEstimateSeconds, 10, EXPERIMENTAL,             \
           "The number of seconds between the end of producing a liveness"   \
           " estimate and beginning the next.")                              \
                                                                             \
-  product(intx, ConcLivenessThreads, 1, EXPERIMENTAL,                       \
+  product(uintx, ConcLivenessThreads, 1, EXPERIMENTAL,                      \
           "The number of parallel marking threads.")                        \
                                                                             \
   product(bool, ConcLivenessVerify, false, EXPERIMENTAL,                    \

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -690,7 +690,17 @@
   product(uint, GCCardSizeInBytes, 512,                                     \
           "Card table entry size (in bytes) for card based collectors")     \
           range(128, NOT_LP64(512) LP64_ONLY(1024))                         \
-          constraint(GCCardSizeInBytesConstraintFunc,AtParse)
+          constraint(GCCardSizeInBytesConstraintFunc,AtParse)               \
+                                                                            \
+  product(bool, UseConcLivenessEstimate, false, EXPERIMENTAL,               \
+          "Run a thread to concurrently estimate the size and number"       \
+          " of live objects in the heap. This does not use a barrier "      \
+          " so it is an estimate only.")                                    \
+                                                                            \
+  product(intx, ConcLivenessEstimateSeconds, 10, EXPERIMENTAL,             \
+          "The number of seconds between the end of producing a liveness"   \
+          " estimate and beginning the next.")
+
   // end of GC_FLAGS
 
 DECLARE_FLAGS(GC_FLAGS)

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -697,9 +697,14 @@
           " of live objects in the heap. This does not use a barrier "      \
           " so it is an estimate only.")                                    \
                                                                             \
-  product(intx, ConcLivenessEstimateSeconds, 10, EXPERIMENTAL,             \
+  product(intx, ConcLivenessEstimateSeconds, 10, EXPERIMENTAL,              \
           "The number of seconds between the end of producing a liveness"   \
-          " estimate and beginning the next.")
+          " estimate and beginning the next.")                              \
+                                                                            \
+  product(bool, ConcLivenessVerify, false, EXPERIMENTAL,                    \
+          "Compare concurrent liveness estimation with liveness computed"   \
+          " on a safepoint. Concurrent estimation does NOT use barriers,"   \
+          " so some inaccuracy is expected.")
 
   // end of GC_FLAGS
 

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -701,6 +701,9 @@
           "The number of seconds between the end of producing a liveness"   \
           " estimate and beginning the next.")                              \
                                                                             \
+  product(intx, ConcLivenessThreads, 1, EXPERIMENTAL,                       \
+          "The number of parallel marking threads.")                        \
+                                                                            \
   product(bool, ConcLivenessVerify, false, EXPERIMENTAL,                    \
           "Compare concurrent liveness estimation with liveness computed"   \
           " on a safepoint. Concurrent estimation does NOT use barriers,"   \

--- a/src/hotspot/share/gc/shared/liveness.cpp
+++ b/src/hotspot/share/gc/shared/liveness.cpp
@@ -1,15 +1,80 @@
 #include "gc/shared/collectedHeap.hpp"
+#include "gc/shared/gcHeapSummary.hpp"
 #include "gc/shared/liveness.hpp"
+#include "gc/shared/oopStorageSet.inline.hpp"
 #include "gc/shared/suspendibleThreadSet.hpp"
 #include "jfr/jfrEvents.hpp"
 #include "logging/log.hpp"
+#include "memory/iterator.inline.hpp"
+#include "oops/oop.inline.hpp"
+#include "runtime/vmThread.hpp"
+#include "utilities/stack.inline.hpp"
+#include "services/memTracker.hpp"
+
+
+class VM_LivenessRootScan : public VM_Operation {
+ public:
+  VM_LivenessRootScan(LivenessEstimatorThread* estimator)
+    : _estimator(estimator) {}
+
+  virtual VMOp_Type type() const override {
+    return VMOp_LivenessRootScan;
+  }
+
+  virtual void doit() override {
+    _estimator->do_roots();
+  }
+
+ private:
+  LivenessEstimatorThread* _estimator;
+};
+
+class LivenessOopClosure : public BasicOopIterateClosure {
+ private:
+  LivenessEstimatorThread* _estimator;
+
+  template<typename OopT>
+  void do_oop_work(OopT* location) {
+    OopT o = RawAccess<>::oop_load(location);
+    if (!CompressedOops::is_null(o)) {
+      oop obj = CompressedOops::decode_not_null(o);
+      _estimator->do_oop(obj);
+    }
+  }
+ public:
+  explicit LivenessOopClosure(LivenessEstimatorThread* estimator)
+    : _estimator(estimator) {}
+
+  virtual void do_oop(oop* o) override       { do_oop_work(o); }
+  virtual void do_oop(narrowOop* o) override { do_oop_work(o); }
+};
 
 LivenessEstimatorThread::LivenessEstimatorThread()
   : ConcurrentGCThread()
   , _lock(Mutex::safepoint - 1, "LivenessEstimator_lock", true)
 {
+  // This initializes the bitmap and reserves the memory, but does not commit it
+  initialize_mark_bit_map();
+
   // create the os thread using default priority
   create_and_start();
+}
+
+void LivenessEstimatorThread::initialize_mark_bit_map() {
+  CollectedHeap* heap = Universe::heap();
+  VirtualSpaceSummary summary = heap->create_heap_space_summary();
+  size_t bitmap_page_size = UseLargePages ? (size_t)os::large_page_size() : (size_t)os::vm_page_size();
+  size_t bitmap_size = MarkBitMap::compute_size(summary.reserved_size());
+  bitmap_size = align_up(bitmap_size, bitmap_page_size);
+
+  log_info(gc)("LivenessEstimator: start: " PTR_FORMAT ", max_capacity: " SIZE_FORMAT ", reserved_size: " SIZE_FORMAT,
+               p2i(summary.start()), heap->max_capacity(), summary.reserved_size());
+
+  ReservedSpace bitmap(bitmap_size, bitmap_page_size);
+  MemTracker::record_virtual_memory_type(bitmap.base(), mtTracing);
+  _mark_bit_map_region = MemRegion((HeapWord *) bitmap.base(), bitmap.size() / HeapWordSize);
+  MemRegion heap_region = MemRegion((HeapWord *) summary.start(), summary.reserved_size() / HeapWordSize);
+  _mark_bit_map.initialize(heap_region, _mark_bit_map_region);
 }
 
 void LivenessEstimatorThread::run_service() {
@@ -17,13 +82,87 @@ void LivenessEstimatorThread::run_service() {
     // Start with a wait because there is nothing interesting in the heap yet.
     MonitorLocker locker(&_lock,Monitor::SafepointCheckFlag::_no_safepoint_check_flag);
     bool timeout = locker.wait(ConcLivenessEstimateSeconds * MILLIUNITS);
-    log_info(gc)("Wokeup, timeout: %s", BOOL_TO_STR(timeout));
+    log_info(gc)("Estimator: starting, scheduled: %s", BOOL_TO_STR(timeout));
 
-    if (!is_concurrent_gc_active()) {
+    if (!is_concurrent_gc_active() && estimation_begin()) {
       bool completed = estimate_liveness();
-      log_info(gc)("Estimation completed: %s", BOOL_TO_STR(completed));
+      log_info(gc)("Estimator: completed: %s", BOOL_TO_STR(completed));
+      estimation_end(completed);
     }
   }
+}
+
+bool LivenessEstimatorThread::estimation_begin() {
+  assert(_mark_stack.is_empty(), "Unexpected oops in mark stack");
+  return commit_bit_map_memory();
+}
+
+void LivenessEstimatorThread::estimation_end(bool completed) {
+  uncommit_bit_map_memory();
+  if (completed) {
+    assert(_mark_stack.is_empty(), "Should have empty mark stack if scan completed");
+    send_live_set_estimate(42);
+  } else {
+    _mark_stack.clear(true);
+  }
+}
+
+bool LivenessEstimatorThread::estimate_liveness() {
+  // Run root scan on a safepoint. Much of this could be done concurrently,
+  // but that would also take much longer to implement.
+  VM_LivenessRootScan root_scan(this);
+  VMThread::execute(&root_scan);
+
+  log_info(gc)("Estimator: mark stack size after root scan: " SIZE_FORMAT, _mark_stack.size());
+
+  size_t oops_visited = _mark_stack.size();
+  LivenessOopClosure cl(this);
+  SuspendibleThreadSetJoiner sst;
+  while (!_mark_stack.is_empty()) {
+    oop obj = _mark_stack.pop();
+    obj->oop_iterate(&cl);
+    ++oops_visited;
+    if (!check_yield_and_continue(&sst)) {
+      return false;
+    }
+  }
+
+  log_info(gc)("Estimator: visited " SIZE_FORMAT " oops", oops_visited);
+  return true;
+}
+
+void LivenessEstimatorThread::do_roots() {
+  assert(Thread::current()->is_VM_thread(), "Expected to be on safepoint here");
+  LivenessOopClosure cl(this);
+  OopStorageSet::strong_oops_do(&cl);
+}
+
+void LivenessEstimatorThread::do_oop(oop obj) {
+  if (!_mark_bit_map.is_marked(obj)) {
+    if (_mark_stack.is_full()) {
+      log_warning(gc)("Estimator: mark stack is full");
+    } else {
+      _mark_bit_map.mark(obj);
+      _mark_stack.push(obj);
+    }
+  }
+}
+
+bool LivenessEstimatorThread::check_yield_and_continue(SuspendibleThreadSetJoiner* sst) {
+  if (sst->should_yield()) {
+    // Shenandoah may not update this count, but other collectors seem to.
+    unsigned int collections = Universe::heap()->total_collections();
+
+    // This blocks the caller until the vm operation has executed.
+    SuspendibleThreadSet::yield();
+
+    if (collections != Universe::heap()->total_collections()) {
+      // Heap has been collected, pointer in the mark queues may be invalid.
+      return false;
+    }
+  }
+
+  return !should_terminate();
 }
 
 void LivenessEstimatorThread::stop_service() {
@@ -36,37 +175,10 @@ void LivenessEstimatorThread::stop_service() {
 void LivenessEstimatorThread::send_live_set_estimate(size_t live_set_bytes) {
   EventLiveSetEstimate evt;
   if (evt.should_commit()) {
+    // TODO: We could add object count here?
     evt.set_estimatedLiveSetSize(live_set_bytes);
     evt.commit();
   }
-}
-
-bool LivenessEstimatorThread::estimate_liveness() {
-  // Simulate waiting for our vm operation to scan the roots to complete
-  os::naked_sleep(10);
-
-  SuspendibleThreadSetJoiner sst;
-  // Simulate a concurrent heap walk with checks to see if we need to let
-  // another vm operation run. We may want to abandon or resume the estimation
-  // effort if we can determine whether a concurrent gc effort is underway.
-  for (int i = 0; i < 1000; ++i) {
-    if (sst.should_yield()) {
-
-      // Shenandoah may not update this, other collectors seem to.
-      unsigned int collections = Universe::heap()->total_collections();
-
-      // This blocks the caller until the vm operation has executed.
-      SuspendibleThreadSet::yield();
-
-      if (collections != Universe::heap()->total_collections()) {
-        // Heap has been collected, pointer in the mark queues may be invalid.
-        return false;
-      }
-    }
-    os::naked_sleep(10);
-  }
-
-  return true;
 }
 
 bool LivenessEstimatorThread::is_concurrent_gc_active() {
@@ -77,4 +189,20 @@ bool LivenessEstimatorThread::is_concurrent_gc_active() {
 
 const char* LivenessEstimatorThread::type_name() const {
   return "LivenessEstimator";
+}
+
+bool LivenessEstimatorThread::commit_bit_map_memory() {
+  if (!os::commit_memory((char*)_mark_bit_map_region.start(), _mark_bit_map_region.byte_size(), false)) {
+    log_warning(gc)("Estimator: could not commit native memory for marking bitmap, estimator failed");
+    return false;
+  }
+  return true;
+}
+
+bool LivenessEstimatorThread::uncommit_bit_map_memory() {
+  if (!os::uncommit_memory((char*)_mark_bit_map_region.start(), _mark_bit_map_region.byte_size())) {
+    log_warning(gc)("Estimator: could not uncommit native memory for marking bitmap");
+    return false;
+  }
+  return true;
 }

--- a/src/hotspot/share/gc/shared/liveness.cpp
+++ b/src/hotspot/share/gc/shared/liveness.cpp
@@ -243,7 +243,7 @@ void LivenessEstimatorThread::stop_service() {
 }
 
 void LivenessEstimatorThread::send_live_set_estimate(size_t count, size_t size_bytes) {
-  log_info(gc, estimator)("Summary: " SIZE_FORMAT " objects, total size " SIZE_FORMAT " bytes", count, size_bytes);
+  log_info(gc, estimator)("Summary: " SIZE_FORMAT " objects, total size " SIZE_FORMAT "MB", count, (long)size_bytes / M);
 
   EventLiveSetEstimate evt;
   if (evt.should_commit()) {

--- a/src/hotspot/share/gc/shared/liveness.cpp
+++ b/src/hotspot/share/gc/shared/liveness.cpp
@@ -195,11 +195,9 @@ bool LivenessEstimatorThread::estimate_liveness() {
 
   log_info(gc, estimator)("Mark stack size after root scan: " SIZE_FORMAT, _mark_stack.size());
 
-  Heap_lock->lock();
   LivenessOopClosure cl(this);
   while (!_mark_stack.is_empty()) {
     if (!check_yield_and_continue(&sst)) {
-      Heap_lock->unlock();
       return false;
     }
 
@@ -209,7 +207,6 @@ bool LivenessEstimatorThread::estimate_liveness() {
       cit.record_instance(obj);
     }
   }
-  Heap_lock->unlock();
   Ticks after_scan = Ticks::now();
 
   if (ConcLivenessHisto) {

--- a/src/hotspot/share/gc/shared/liveness.cpp
+++ b/src/hotspot/share/gc/shared/liveness.cpp
@@ -334,7 +334,7 @@ void LivenessEstimatorThread::verify_estimate() {
   long count_difference = long(_actual_object_count) - long(all_object_count);
   long size_difference = long(_actual_object_size_words) - long(all_object_size_words);
 
-  log_info(gc, estimator)("Verified - estimate: " INT64_FORMAT " objects, " INT64_FORMAT " bytes.",
+  log_info(gc, estimator)("Verified - estimate: %ld objects, %ld bytes.",
                       count_difference, size_difference * HeapWordSize);
 }
 

--- a/src/hotspot/share/gc/shared/liveness.cpp
+++ b/src/hotspot/share/gc/shared/liveness.cpp
@@ -112,6 +112,15 @@ void LivenessEstimatorThread::run_service() {
       estimation_end(completed);
     }
   }
+
+  if (ConcLivenessVerify) {
+    LogTarget(Info, gc, estimator) lt;
+    LogStream ls(lt);
+    ls.print("Object count accuracy: ");
+    _object_count_error.print_on(&ls);
+    ls.print("Object size accuracy: ");
+    _object_size_error.print_on(&ls);
+  }
 }
 
 bool LivenessEstimatorThread::estimation_begin() {
@@ -147,8 +156,8 @@ void LivenessEstimatorThread::estimation_end(bool completed) {
 }
 
 void LivenessEstimatorThread::verify_estimate() {
-  // _object_count_error.sample(_all_object_count, _verified_object_count);
-  // _object_size_error.sample(_all_object_size_words, _verified_object_size_words);
+  _object_count_error.sample(_all_object_count, _verified_object_count);
+  _object_size_error.sample(_all_object_size_words, _verified_object_size_words);
 
   long count_difference = long(_verified_object_count) - long(_all_object_count);
   long size_difference = long(_verified_object_size_words) - long(_all_object_size_words);
@@ -161,7 +170,7 @@ class HistoClosure : public KlassInfoClosure {
  private:
   KlassInfoHisto* _cih;
  public:
-  HistoClosure(KlassInfoHisto* cih) : _cih(cih) {}
+  explicit HistoClosure(KlassInfoHisto* cih) : _cih(cih) {}
 
   void do_cinfo(KlassInfoEntry* cie) {
     _cih->add(cie);

--- a/src/hotspot/share/gc/shared/liveness.cpp
+++ b/src/hotspot/share/gc/shared/liveness.cpp
@@ -1,5 +1,6 @@
 #include "gc/shared/liveness.hpp"
 #include "gc/shared/suspendibleThreadSet.hpp"
+#include "jfr/jfrEvents.hpp"
 #include "logging/log.hpp"
 
 LivenessEstimatorThread::LivenessEstimatorThread()
@@ -27,6 +28,14 @@ void LivenessEstimatorThread::stop_service() {
   MonitorLocker locker(&_lock);
   _lock.notify();
   log_info(gc)("Notified estimator thread to wakeup.");
+}
+
+void LivenessEstimatorThread::send_live_set_estimate(size_t live_set_bytes) {
+  EventLiveSetEstimate evt;
+  if (evt.should_commit()) {
+    evt.set_estimatedLiveSetSize(live_set_bytes);
+    evt.commit();
+  }
 }
 
 bool LivenessEstimatorThread::estimate_liveness() {

--- a/src/hotspot/share/gc/shared/liveness.cpp
+++ b/src/hotspot/share/gc/shared/liveness.cpp
@@ -1,0 +1,54 @@
+#include "gc/shared/liveness.hpp"
+#include "gc/shared/suspendibleThreadSet.hpp"
+#include "logging/log.hpp"
+
+LivenessEstimatorThread::LivenessEstimatorThread()
+  : ConcurrentGCThread()
+  , _lock(Mutex::safepoint - 1, "LivenessEstimator_lock", true)
+{
+  // create the os thread using default priority
+  create_and_start();
+}
+
+void LivenessEstimatorThread::run_service() {
+  while (!should_terminate()) {
+    // Start with a wait because there is nothing interesting in the heap yet.
+    MonitorLocker locker(&_lock);
+    bool timeout = _lock.wait(ConcLivenessEstimateSeconds * MILLIUNITS);
+    log_info(gc)("Wokeup, timeout: %s", BOOL_TO_STR(timeout));
+
+    bool completed = estimate_liveness();
+    log_info(gc)("Estimation completed: %s", BOOL_TO_STR(completed));
+  }
+}
+
+void LivenessEstimatorThread::stop_service() {
+  // We could have a long timeout on the wait before the estimator thread wakes up
+  MonitorLocker locker(&_lock);
+  _lock.notify();
+  log_info(gc)("Notified estimator thread to wakeup.");
+}
+
+bool LivenessEstimatorThread::estimate_liveness() {
+  // Simulate waiting for our vm operation to scan the roots to complete
+  os::naked_sleep(10);
+
+  // TODO: We _might_ able to use CollectedHeap::object_iterate here, but it's
+  // not clear if all implementations will let it run outside of a safepoint. At
+  // any rate, the implementations I inspected do not participate in any cancellation
+  // scheme.
+
+  SuspendibleThreadSetJoiner sst;
+  // Simulate a concurrent heap walk with checks to see if we need to let
+  // another vm operation run. We may want to abandon or resume the estimation
+  // effort if we can determine whether a concurrent gc effort is underway.
+  for (int i = 0; i < 1000; ++i) {
+    if (sst.should_yield()) {
+      SuspendibleThreadSet::yield();
+      return false;
+    }
+    os::naked_sleep(10);
+  }
+
+  return true;
+}

--- a/src/hotspot/share/gc/shared/liveness.cpp
+++ b/src/hotspot/share/gc/shared/liveness.cpp
@@ -6,16 +6,20 @@
 #include "gc/shared/strongRootsScope.hpp"
 #include "gc/shared/suspendibleThreadSet.hpp"
 #include "gc/shared/markBitMap.hpp"
+#include "gc/shared/taskqueue.inline.hpp"
 #include "jfr/jfrEvents.hpp"
 #include "logging/log.hpp"
 #include "logging/logStream.hpp"
 #include "memory/heapInspection.hpp"
 #include "memory/iterator.inline.hpp"
+#include "memory/allocation.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/vmThread.hpp"
 #include "utilities/stack.inline.hpp"
 #include "services/memTracker.hpp"
 #include "utilities/ticks.hpp"
+#include "gc/shared/weakProcessor.inline.hpp"
+#include "gc/shared/oopStorageSetParState.inline.hpp"
 
 size_t LivenessEstimatorThread::live_heap_usage = 0;
 size_t LivenessEstimatorThread::live_object_count = 0;
@@ -53,36 +57,145 @@ class VM_LivenessRootScan : public VM_Operation {
 class LivenessOopClosure : public BasicOopIterateClosure {
  private:
   LivenessEstimatorThread* _estimator;
+  uint _task_num;
 
   template<typename OopT>
   void do_oop_work(OopT* location) {
     OopT o = RawAccess<>::oop_load(location);
     if (!CompressedOops::is_null(o)) {
       oop obj = CompressedOops::decode_not_null(o);
-      _estimator->do_oop(obj);
+
+      // Add tasks to worker's queue. Otherwise add in round robin scheduling.
+      // Useful when marking roots with a single thread so all workers get a similar
+      // amount of roots instead of all roots going into a single worker's queue
+      Thread* current = Thread::current();
+      if (current->is_Worker_thread()) {
+        _task_num = WorkerThread::worker_id();
+      } else {
+        assert(current->is_VM_thread(), "Round robin should only be used on VM Thread");
+        _task_num = (_task_num + 1) % _estimator->get_num_workers();
+      }
+
+      _estimator->do_oop(obj, _task_num);
     }
   }
  public:
+
   explicit LivenessOopClosure(LivenessEstimatorThread* estimator)
-    : _estimator(estimator) {}
+    : _estimator(estimator), _task_num(0) {}
 
   virtual void do_oop(oop* o) override       { do_oop_work(o); }
   virtual void do_oop(narrowOop* o) override { do_oop_work(o); }
 };
 
+class LivenessConcurrentMarkTask : public WorkerTask {
+public:
+  LivenessConcurrentMarkTask(LivenessEstimatorThread* estimator, KlassInfoTable* cit) :
+    WorkerTask("Liveness Concurrent Mark"),
+    _estimator(estimator),
+    _cit(cit) {}
+
+  LivenessConcurrentMarkTask(LivenessEstimatorThread* estimator) :
+    LivenessConcurrentMarkTask(estimator, NULL) {}
+
+  void work(uint worker_id) {
+    unsigned int collections = Universe::heap()->total_collections();
+    
+    SuspendibleThreadSetJoiner sst;
+    
+    if (collections != Universe::heap()->total_collections()) {
+      // The gc has run while this thread was joining the collection set. The oops in the
+      // mark stack from the root scan cannot be used.
+      _estimator->_task_failed = true;
+      return;
+    }
+
+    log_debug(gc, estimator)("Worker %d started", worker_id);
+
+    MarkTaskQueue* queue = _estimator->_task_queues->queue(worker_id);
+
+    // Attempt to get oop from queue. If none are available steal from another queue
+    oop obj;
+    LivenessOopClosure cl(_estimator);
+    while (queue->pop_local(obj) || _estimator->_task_queues->steal(worker_id, obj)) {
+      if (!_estimator->check_yield_and_continue(&sst)) {
+        _estimator->_task_failed = true;
+        return;
+      }
+
+      obj->oop_iterate(&cl);
+      if (ConcLivenessHisto && _cit != NULL) {
+        _cit->record_instance(obj);
+      }
+    }
+    log_debug(gc, estimator)("Worker %d done", worker_id);
+  }
+
+private:
+  LivenessEstimatorThread* _estimator;
+  KlassInfoTable* _cit;
+};
+
+class ThreadRootsTaskClosure : public ThreadClosure {
+public:
+  ThreadRootsTaskClosure(LivenessEstimatorThread* estimator) :
+    _estimator(estimator) {}
+
+  virtual void do_thread(Thread* thread) {
+    LivenessOopClosure cl(_estimator);
+
+    thread->oops_do(&cl, NULL);
+  }
+
+private:
+  LivenessEstimatorThread* _estimator;
+};
+
+class LivenessConcurrentRootMarkTask : public WorkerTask {
+OopStorageSetStrongParState<false /* concurrent */, false /* is_const */> _oop_storage_strong_par_state;
+
+public:
+  LivenessConcurrentRootMarkTask(LivenessEstimatorThread* estimator) :
+    WorkerTask("Liveness Concurrent Mark"),
+    _estimator(estimator),
+    _strong_roots_scope(estimator->get_num_workers()) {}
+
+  void work(uint worker_id) {
+    ResourceMark rm;
+
+    log_debug(gc, estimator)("Worker %d started", worker_id);
+
+    // Threads
+    ThreadRootsTaskClosure thread_cl(_estimator);
+    Threads::possibly_parallel_threads_do(true /*parallel */, &thread_cl);
+
+    // Strong
+    LivenessOopClosure oop_cl(_estimator);
+    _oop_storage_strong_par_state.oops_do(&oop_cl);
+
+    log_debug(gc, estimator)("Worker %d done", worker_id);
+  }
+
+private:
+  LivenessEstimatorThread* _estimator;
+  StrongRootsScope _strong_roots_scope; // needed for Threads::possibly_parallel_threads_do
+};
+
 LivenessEstimatorThread::LivenessEstimatorThread()
   : ConcurrentGCThread()
   , _lock(Mutex::safepoint - 1, "LivenessEstimator_lock", true)
-  , _estimated_object_count(0)
-  , _estimated_object_size_words(0)
   , _actual_object_count(0)
   , _actual_object_size_words(0)
+  , _task_failed(false)
 {
   // Give this thread a name
   set_name("LivenessEstimator");
 
   // This initializes the bitmap and reserves the memory, but does not commit it
   initialize_mark_bit_map();
+
+  // This initializes the workers for parallel marking
+  initialize_workers();
 
   // create the os thread using default priority
   create_and_start();
@@ -103,6 +216,25 @@ void LivenessEstimatorThread::initialize_mark_bit_map() {
   _mark_bit_map_region = MemRegion((HeapWord *) bitmap.base(), bitmap.size() / HeapWordSize);
   MemRegion heap_region = MemRegion((HeapWord *) summary.start(), summary.reserved_size() / HeapWordSize);
   _mark_bit_map.initialize(heap_region, _mark_bit_map_region);
+}
+
+void LivenessEstimatorThread::initialize_workers() {
+  _workers = new WorkerThreads("Liveness Worker Thread", ConcLivenessThreads);
+  _workers->initialize_workers();
+  _workers->set_active_workers(ConcLivenessThreads);
+
+  _task_queues = new MarkTaskQueueSet(ConcLivenessThreads);
+
+  _estimated_object_count = NEW_C_HEAP_ARRAY(size_t, ConcLivenessThreads, mtTracing);
+  _estimated_object_size_words = NEW_C_HEAP_ARRAY(size_t, ConcLivenessThreads, mtTracing);
+
+  for (uint i = 0; i < ConcLivenessThreads; i++) {
+    MarkTaskQueue* q = new MarkTaskQueue();
+    _task_queues->register_queue(i, q);
+
+    _estimated_object_count[i] = 0;
+    _estimated_object_size_words[i] = 0;
+  }
 }
 
 void LivenessEstimatorThread::run_service() {
@@ -127,12 +259,21 @@ void LivenessEstimatorThread::run_service() {
     ls.print("Object size accuracy  : ");
     _object_size_error.print_on(&ls);
   }
+
+  FREE_C_HEAP_ARRAY(size_t, _estimated_object_count);
+  FREE_C_HEAP_ARRAY(size_t, _estimated_object_size_words);
 }
 
 bool LivenessEstimatorThread::estimation_begin() {
-  assert(_mark_stack.is_empty(), "Unexpected oops in mark stack");
-  _estimated_object_count = 0;
-  _estimated_object_size_words = 0;
+  for (uint i = 0; i < _task_queues->size(); i++) {
+    assert(_task_queues->queue(i)->is_empty(), "Unexpected oops in mark stack %d", i);
+  }
+
+  for (uint i = 0; i < ConcLivenessThreads; i++) {
+    _estimated_object_count[i] = 0;
+    _estimated_object_size_words[i] = 0;
+  }
+
   if (ConcLivenessVerify) {
     _actual_object_count = 0;
     _actual_object_size_words = 0;
@@ -145,15 +286,27 @@ void LivenessEstimatorThread::estimation_end(bool completed) {
   uncommit_bit_map_memory();
 
   if (!completed) {
-    _mark_stack.clear(true);
+    for (uint i = 0; i < _task_queues->size(); i++) {
+      _task_queues->queue(i)->set_empty();
+    }
   } else {
-    assert(_mark_stack.is_empty(), "Should have empty mark stack if scan completed");
+    for (uint i = 0; i < _task_queues->size(); i++) {
+      assert(_task_queues->queue(i)->is_empty(), "Should have empty mark stack (stack %d) if scan completed", i);
+    }
 
-    size_t all_object_size_bytes = _estimated_object_size_words * HeapWordSize;
+    // Loop over worker counts and sizes to find the total
+    size_t all_object_size_bytes = 0;
+    size_t all_object_count = 0;
+    for (uint i = 0; i < ConcLivenessThreads; i++) {
+      all_object_size_bytes += _estimated_object_size_words[i];
+      all_object_count += _estimated_object_count[i];
+    }
+    all_object_size_bytes *= HeapWordSize;
+
     log_info(gc, estimator)("Estimated: " SIZE_FORMAT " objects, total size " SIZE_FORMAT " (" SIZE_FORMAT "%s)",
-                            _estimated_object_count, all_object_size_bytes, byte_size_in_proper_unit(all_object_size_bytes), proper_unit_for_byte_size(all_object_size_bytes));
+                            all_object_count, all_object_size_bytes, byte_size_in_proper_unit(all_object_size_bytes), proper_unit_for_byte_size(all_object_size_bytes));
 
-    send_live_set_estimate<EventLiveSetEstimate>(_estimated_object_count, all_object_size_bytes);
+    send_live_set_estimate<EventLiveSetEstimate>(all_object_count, all_object_size_bytes);
 
     if (ConcLivenessVerify) {
       verify_estimate();
@@ -162,11 +315,19 @@ void LivenessEstimatorThread::estimation_end(bool completed) {
 }
 
 void LivenessEstimatorThread::verify_estimate() {
-  _object_count_error.sample(_estimated_object_count, _actual_object_count);
-  _object_size_error.sample(_estimated_object_size_words, _actual_object_size_words);
+  // Loop over worker counts and sizes to find the total
+  size_t all_object_size_words = 0;
+  size_t all_object_count = 0;
+  for (uint i = 0; i < ConcLivenessThreads; i++) {
+    all_object_size_words += _estimated_object_size_words[i];
+    all_object_count += _estimated_object_count[i];
+  }
+  
+  _object_count_error.sample(all_object_count, _actual_object_count);
+  _object_size_error.sample(all_object_size_words, _actual_object_size_words);
 
-  long count_difference = long(_actual_object_count) - long(_estimated_object_count);
-  long size_difference = long(_actual_object_size_words) - long(_estimated_object_size_words);
+  long count_difference = long(_actual_object_count) - long(all_object_count);
+  long size_difference = long(_actual_object_size_words) - long(all_object_size_words);
 
   log_info(gc, estimator)("Verified - estimate: " INT64_FORMAT " objects, " INT64_FORMAT " bytes.",
                       count_difference, size_difference * HeapWordSize);
@@ -210,21 +371,20 @@ bool LivenessEstimatorThread::estimate_liveness() {
   KlassInfoTable cit(false);
 
 
-
-  log_debug(gc, estimator)("Mark stack size after root scan: " SIZE_FORMAT, _mark_stack.size());
-
-  LivenessOopClosure cl(this);
-  while (!_mark_stack.is_empty()) {
-    if (!check_yield_and_continue(&sst)) {
-      return false;
-    }
-
-    oop obj = _mark_stack.pop();
-    obj->oop_iterate(&cl);
-    if (ConcLivenessHisto) {
-      cit.record_instance(obj);
-    }
+  for (uint i = 0; i < _task_queues->size(); i++) {
+    log_debug(gc, estimator)("Mark stack %d size after root scan: %d", i, _task_queues->queue(i)->size());
   }
+
+  _task_failed = false;
+
+  LivenessConcurrentMarkTask task(this, &cit);
+  _workers->run_task(&task);
+
+  // Check if task completed
+  if (_task_failed) {
+    return false;
+  }
+
   Ticks after_scan = Ticks::now();
 
   if (ConcLivenessHisto) {
@@ -251,20 +411,36 @@ bool LivenessEstimatorThread::estimate_liveness() {
   return true;
 }
 
+class IsAliveClosure: public BoolObjectClosure {
+public:
+  bool do_object_b(oop p) {
+    return !CompressedOops::is_null(p);
+  }
+};
+
 void LivenessEstimatorThread::do_roots() {
   assert(Thread::current()->is_VM_thread(), "Expected to be on safepoint here");
   Ticks start = Ticks::now();
 
-  StrongRootsScope roots_scope(0);
   LivenessOopClosure cl(this);
 
-  OopStorageSet::strong_oops_do(&cl);
+  // This adds support for parallel weak oop marking
+  // After initial testing this was noticibly worse than
+  // doing it with a single thread. Testing with an application
+  // with many weak oops may cause this to show improvements
+  // but for now it is disabled
+  // IsAliveClosure isAliveClosure;
+  // WeakProcessor::weak_oops_do(_workers, &isAliveClosure, &cl, 1);
+
   for (OopStorage* storage : OopStorageSet::Range<OopStorageSet::WeakId>()) {
     storage->oops_do(&cl);
   }
+
   Ticks a = Ticks::now();
 
-  Threads::oops_do(&cl, NULL);
+  LivenessConcurrentRootMarkTask task(this);
+  _workers->run_task(&task);
+
   Ticks b = Ticks::now();
 
   CLDToOopClosure cldt(&cl, ClassLoaderData::_claim_none);
@@ -281,29 +457,35 @@ void LivenessEstimatorThread::do_roots() {
 
   log_info(gc, estimator)("Root scan timings:");
   log_info(gc, estimator)("    Total scan          : %fms", total_time.seconds() * MILLIUNITS);
-  log_info(gc, estimator)("    OopStorageSet       : %fms", (a - start).seconds() * MILLIUNITS);
-  log_info(gc, estimator)("    Threads             : %fms", (b - a).seconds() * MILLIUNITS);
+  log_info(gc, estimator)("    WeakOopStorageSet   : %fms", (a - start).seconds() * MILLIUNITS);
+  log_info(gc, estimator)("    StrongOops/Threads  : %fms", (b - a).seconds() * MILLIUNITS);
   log_info(gc, estimator)("    ClassLoaderDataGraph: %fms", (c - b).seconds() * MILLIUNITS);
   log_info(gc, estimator)("    CodeCache           : %fms", (d - c).seconds() * MILLIUNITS);
 }
 
-void LivenessEstimatorThread::do_oop(oop obj) {
+void LivenessEstimatorThread::do_oop(oop obj, uint task_num) {
   oop is_marked_obj = obj;
 
   if (Universe::heap()->kind() == Universe::heap()->Name::Z) {
     is_marked_obj = ZOop::from_address(ZAddress::offset(ZOop::to_address(obj)));
   }
 
-  if (!_mark_bit_map.is_marked(is_marked_obj)) {
-    if (_mark_stack.is_full()) {
-      log_warning(gc, estimator)("Mark stack is full");
-    } else {
-      _mark_bit_map.mark(obj);
-      _mark_stack.push(obj);
-      _estimated_object_count++;
-      _estimated_object_size_words += obj->size();
+  if (!_mark_bit_map.par_is_marked(is_marked_obj)) {
+    if (_mark_bit_map.par_mark(obj)) {
+      MarkTaskQueue* queue = _task_queues->queue(task_num);
+      if (queue->push(obj)) {
+        _estimated_object_count[task_num]++;
+        _estimated_object_size_words[task_num] += obj->size();
+      }
+      else {
+        log_warning(gc, estimator)("Mark stack is full");
+      }
     }
   }
+}
+
+uint LivenessEstimatorThread::get_num_workers() {
+  return _workers->active_workers();
 }
 
 bool LivenessEstimatorThread::check_yield_and_continue(SuspendibleThreadSetJoiner* sst) {
@@ -387,13 +569,25 @@ void LivenessEstimatorThread::compute_liveness() {
   assert(ConcLivenessVerify, "Only for verification");
 
   LivenessOopClosure cl(this);
-  while (!_mark_stack.is_empty()) {
-    oop obj = _mark_stack.pop();
-    obj->oop_iterate(&cl);
+  for (uint i = 0; i < ConcLivenessThreads; i++) {
+    MarkTaskQueue* queue = _task_queues->queue(i);
+
+    oop obj;
+    while (queue->pop_local(obj)) {
+      obj->oop_iterate(&cl);
+    }
   }
 
-  _actual_object_count = _estimated_object_count;
-  _actual_object_size_words = _estimated_object_size_words;
+  // Loop over worker counts and sizes to find the total
+  size_t all_object_size_words = 0;
+  size_t all_object_count = 0;
+  for (uint i = 0; i < ConcLivenessThreads; i++) {
+    all_object_size_words += _estimated_object_size_words[i];
+    all_object_count += _estimated_object_count[i];
+  }
+
+  _actual_object_count = all_object_count;
+  _actual_object_size_words = all_object_size_words;
 
   size_t actual_object_size_bytes = _actual_object_size_words * HeapWordSize;
   send_live_set_estimate<EventLiveSetActual>(_actual_object_count, actual_object_size_bytes);
@@ -403,7 +597,10 @@ void LivenessEstimatorThread::compute_liveness() {
                           byte_size_in_proper_unit(actual_object_size_bytes),
                           proper_unit_for_byte_size(actual_object_size_bytes));
 
-  _estimated_object_count = 0;
-  _estimated_object_size_words = 0;
+  for (uint i = 0; i < ConcLivenessThreads; i++) {
+    _estimated_object_size_words[i] = 0;
+    _estimated_object_count[i] = 0;
+  }
+
   _mark_bit_map.clear();
 }

--- a/src/hotspot/share/gc/shared/liveness.cpp
+++ b/src/hotspot/share/gc/shared/liveness.cpp
@@ -119,7 +119,7 @@ bool LivenessEstimatorThread::estimate_liveness() {
 
   log_info(gc, estimator)("Mark stack size after root scan: " SIZE_FORMAT, _mark_stack.size());
 
-  size_t oops_visited = _mark_stack.size();
+  size_t oops_visited = _mark_stack.size(); // TODO: I think this is double-counting the roots, should start at zero.
   LivenessOopClosure cl(this);
   SuspendibleThreadSetJoiner sst;
   while (!_mark_stack.is_empty()) {

--- a/src/hotspot/share/gc/shared/liveness.cpp
+++ b/src/hotspot/share/gc/shared/liveness.cpp
@@ -16,6 +16,8 @@
 #include "services/memTracker.hpp"
 #include "utilities/ticks.hpp"
 
+size_t LivenessEstimatorThread::live_heap_usage = 0;
+size_t LivenessEstimatorThread::live_object_count = 0;
 
 class VM_LivenessRootScan : public VM_Operation {
  public:
@@ -329,6 +331,9 @@ void LivenessEstimatorThread::stop_service() {
 
 template<typename EventT>
 void LivenessEstimatorThread::send_live_set_estimate(size_t count, size_t size_bytes) {
+  LivenessEstimatorThread::set_live_heap_usage(size_bytes);
+  LivenessEstimatorThread::set_live_object_count(count);
+  
   EventT evt;
   if (evt.should_commit()) {
     log_info(gc, estimator)("Sending JFR event: %d", evt.id());

--- a/src/hotspot/share/gc/shared/liveness.cpp
+++ b/src/hotspot/share/gc/shared/liveness.cpp
@@ -116,9 +116,9 @@ void LivenessEstimatorThread::run_service() {
   if (ConcLivenessVerify) {
     LogTarget(Info, gc, estimator) lt;
     LogStream ls(lt);
-    ls.print("Object count accuracy: ");
+    ls.print("Object count accuracy : ");
     _object_count_error.print_on(&ls);
-    ls.print("Object size accuracy: ");
+    ls.print("Object size accuracy  : ");
     _object_size_error.print_on(&ls);
   }
 }
@@ -237,13 +237,18 @@ void LivenessEstimatorThread::do_roots() {
   LivenessOopClosure cl(this);
 
   OopStorageSet::strong_oops_do(&cl);
+  for (OopStorage* storage : OopStorageSet::Range<OopStorageSet::WeakId>()) {
+    storage->oops_do(&cl);
+  }
   Ticks a = Ticks::now();
 
   Threads::oops_do(&cl, NULL);
   Ticks b = Ticks::now();
 
   CLDToOopClosure cldt(&cl, ClassLoaderData::_claim_none);
+  // ClassLoaderDataGraph::cld_do(&cldt);
   ClassLoaderDataGraph::always_strong_cld_do(&cldt);
+
   Ticks c = Ticks::now();
 
   MarkingCodeBlobClosure code_blob_closure(&cl, false);

--- a/src/hotspot/share/gc/shared/liveness.cpp
+++ b/src/hotspot/share/gc/shared/liveness.cpp
@@ -123,19 +123,15 @@ bool LivenessEstimatorThread::estimate_liveness() {
 
   log_info(gc, estimator)("Mark stack size after root scan: " SIZE_FORMAT, _mark_stack.size());
 
-  size_t oops_visited = _mark_stack.size(); // TODO: I think this is double-counting the roots, should start at zero.
   LivenessOopClosure cl(this);
   SuspendibleThreadSetJoiner sst;
   while (!_mark_stack.is_empty()) {
     oop obj = _mark_stack.pop();
     obj->oop_iterate(&cl);
-    ++oops_visited;
     if (!check_yield_and_continue(&sst)) {
       return false;
     }
   }
-
-  log_info(gc, estimator)("Visited " SIZE_FORMAT " oops", oops_visited);
 
   Tickspan total_scan_time = Ticks::now() - start;
   Tickspan non_root_scan_time = total_scan_time - root_scan_time;

--- a/src/hotspot/share/gc/shared/liveness.hpp
+++ b/src/hotspot/share/gc/shared/liveness.hpp
@@ -42,12 +42,14 @@ class LivenessEstimatorThread : public  ConcurrentGCThread {
   bool estimate_liveness();
   void do_roots();
   void do_oop(oop obj);
-  void send_live_set_estimate(size_t live_set_bytes);
+  void send_live_set_estimate(size_t count, size_t size_bytes);
 
   Monitor _lock;
   MarkBitMap _mark_bit_map;
   MemRegion _mark_bit_map_region;
   EstimatorStack _mark_stack;
+  size_t _all_object_count;
+  size_t _all_object_size_words;
 };
 
 

--- a/src/hotspot/share/gc/shared/liveness.hpp
+++ b/src/hotspot/share/gc/shared/liveness.hpp
@@ -19,7 +19,7 @@ class LivenessMarkBitMap : public MarkBitMap {
     // ZGC uses pointers that hold metadata about the object
     // check_mark calls Heap::is_in which requires an unmasked pointer
     // set_bit requires a masked pointer
-    // Because of this we must override this method
+    // Because of this we must redefine this method and call it directly
     bool par_mark(oop obj) {
       HeapWord* addr = cast_from_oop<HeapWord*>(obj);
       check_mark(addr);
@@ -38,7 +38,7 @@ class LivenessMarkBitMap : public MarkBitMap {
       assert(_covered.contains(addr),
             "Address " PTR_FORMAT " is outside underlying space from " PTR_FORMAT " to " PTR_FORMAT,
             p2i(addr), p2i(_covered.start()), p2i(_covered.end()));
-      
+
       return _bm.par_at(addr_to_offset(addr));
     }
 };
@@ -75,7 +75,6 @@ class LivenessEstimatorThread : public  ConcurrentGCThread {
   friend class LivenessConcurrentMarkTask;
   friend class LivenessConcurrentRootMarkTask;
 
-
  public:
   LivenessEstimatorThread();
 
@@ -86,7 +85,7 @@ class LivenessEstimatorThread : public  ConcurrentGCThread {
 
   static size_t get_live_heap_usage() { return live_heap_usage; }
   static size_t get_live_object_count() { return live_object_count; }
-  
+
  private:
   bool estimation_begin();
   void estimation_end(bool completed);

--- a/src/hotspot/share/gc/shared/liveness.hpp
+++ b/src/hotspot/share/gc/shared/liveness.hpp
@@ -75,14 +75,15 @@ class LivenessEstimatorThread : public  ConcurrentGCThread {
   MarkBitMap _mark_bit_map;
   MemRegion _mark_bit_map_region;
   EstimatorStack _mark_stack;
-  size_t _all_object_count;
-  size_t _all_object_size_words;
+
+  size_t _estimated_object_count;
+  size_t _estimated_object_size_words;
 
   // For verification
   void compute_liveness();
   void verify_estimate();
-  size_t _verified_object_count;
-  size_t _verified_object_size_words;
+  size_t _actual_object_count;
+  size_t _actual_object_size_words;
   EstimationErrorTracker _object_count_error;
   EstimationErrorTracker _object_size_error;
 };

--- a/src/hotspot/share/gc/shared/liveness.hpp
+++ b/src/hotspot/share/gc/shared/liveness.hpp
@@ -23,6 +23,7 @@ class LivenessEstimatorThread : public  ConcurrentGCThread {
 
  private:
   bool estimate_liveness();
+  void send_live_set_estimate(size_t live_set_bytes);
 
   Monitor _lock;
 };

--- a/src/hotspot/share/gc/shared/liveness.hpp
+++ b/src/hotspot/share/gc/shared/liveness.hpp
@@ -43,6 +43,7 @@ class LivenessEstimatorThread : public  ConcurrentGCThread {
   bool estimate_liveness();
   void do_roots();
   void do_oop(oop obj);
+  template<typename EventT>
   void send_live_set_estimate(size_t count, size_t size_bytes);
 
   Monitor _lock;

--- a/src/hotspot/share/gc/shared/liveness.hpp
+++ b/src/hotspot/share/gc/shared/liveness.hpp
@@ -12,7 +12,6 @@ class SuspendibleThreadSetJoiner;
 
 class LivenessEstimatorThread : public  ConcurrentGCThread {
   friend class VM_LivenessRootScan;
-  friend class VM_LivenessVerifier;
   friend class LivenessOopClosure;
 
 
@@ -55,6 +54,7 @@ class LivenessEstimatorThread : public  ConcurrentGCThread {
 
   // For verification
   void compute_liveness();
+  void verify_estimate();
   size_t _verified_object_count;
   size_t _verified_object_size_words;
 };

--- a/src/hotspot/share/gc/shared/liveness.hpp
+++ b/src/hotspot/share/gc/shared/liveness.hpp
@@ -1,0 +1,32 @@
+#ifndef SHARE_GC_SHARED_LIVENESS_HPP
+#define SHARE_GC_SHARED_LIVENESS_HPP
+
+#include "gc/shared/concurrentGCThread.hpp"
+#include "gc/shared/gc_globals.hpp"
+#include "runtime/task.hpp"
+
+class LivenessEstimatorThread : public  ConcurrentGCThread {
+ public:
+  LivenessEstimatorThread();
+
+  // TODO: For simplicity, this should:
+  //  1. Take a safepoint and scan the roots
+  //  2. Finish heap walk concurrently computing liveness count
+  //  3. Expose results (log them, emit JFR event)
+  //
+  // TODO: Participate in the SuspendibleThreadSet scheme to
+  // avoid interfering with safepoint operations. Would be nice
+  // to also not interfere with other concurrent mark activity
+  // from GC, but this will require GC specific integrations.
+  void run_service() override;
+  void stop_service() override;
+
+ private:
+  bool estimate_liveness();
+
+  Monitor _lock;
+};
+
+
+
+#endif //SHARE_GC_SHARED_LIVENESS_HPP

--- a/src/hotspot/share/gc/shared/liveness.hpp
+++ b/src/hotspot/share/gc/shared/liveness.hpp
@@ -1,11 +1,20 @@
 #ifndef SHARE_GC_SHARED_LIVENESS_HPP
 #define SHARE_GC_SHARED_LIVENESS_HPP
 
+#include "utilities/stack.hpp"
 #include "gc/shared/concurrentGCThread.hpp"
 #include "gc/shared/gc_globals.hpp"
+#include "gc/shared/markBitMap.hpp"
 #include "runtime/task.hpp"
 
+typedef Stack<oop, mtTracing> EstimatorStack;
+class SuspendibleThreadSetJoiner;
+
 class LivenessEstimatorThread : public  ConcurrentGCThread {
+  friend class VM_LivenessRootScan;
+  friend class LivenessOopClosure;
+
+
  public:
   LivenessEstimatorThread();
 
@@ -14,9 +23,7 @@ class LivenessEstimatorThread : public  ConcurrentGCThread {
   //  2. Finish heap walk concurrently computing liveness count
   //  3. Expose results (log them, emit JFR event)
   //
-  // TODO: Participate in the SuspendibleThreadSet scheme to
-  // avoid interfering with safepoint operations. Would be nice
-  // to also not interfere with other concurrent mark activity
+  // TODO: Would be nice to also not interfere with other concurrent mark activity
   // from GC, but this will require GC specific integrations.
   virtual void run_service() override;
   virtual void stop_service() override;
@@ -24,11 +31,23 @@ class LivenessEstimatorThread : public  ConcurrentGCThread {
   virtual const char* type_name() const override;
 
  private:
+  bool estimation_begin();
+  void estimation_end(bool completed);
+  void initialize_mark_bit_map();
+  bool commit_bit_map_memory();
+  bool uncommit_bit_map_memory();
+
+  bool check_yield_and_continue(SuspendibleThreadSetJoiner* sst);
   bool is_concurrent_gc_active();
   bool estimate_liveness();
+  void do_roots();
+  void do_oop(oop obj);
   void send_live_set_estimate(size_t live_set_bytes);
 
   Monitor _lock;
+  MarkBitMap _mark_bit_map;
+  MemRegion _mark_bit_map_region;
+  EstimatorStack _mark_stack;
 };
 
 

--- a/src/hotspot/share/gc/shared/liveness.hpp
+++ b/src/hotspot/share/gc/shared/liveness.hpp
@@ -18,10 +18,13 @@ class LivenessEstimatorThread : public  ConcurrentGCThread {
   // avoid interfering with safepoint operations. Would be nice
   // to also not interfere with other concurrent mark activity
   // from GC, but this will require GC specific integrations.
-  void run_service() override;
-  void stop_service() override;
+  virtual void run_service() override;
+  virtual void stop_service() override;
+
+  virtual const char* type_name() const override;
 
  private:
+  bool is_concurrent_gc_active();
   bool estimate_liveness();
   void send_live_set_estimate(size_t live_set_bytes);
 

--- a/src/hotspot/share/gc/shared/liveness.hpp
+++ b/src/hotspot/share/gc/shared/liveness.hpp
@@ -12,6 +12,7 @@ class SuspendibleThreadSetJoiner;
 
 class LivenessEstimatorThread : public  ConcurrentGCThread {
   friend class VM_LivenessRootScan;
+  friend class VM_LivenessVerifier;
   friend class LivenessOopClosure;
 
 
@@ -50,6 +51,11 @@ class LivenessEstimatorThread : public  ConcurrentGCThread {
   EstimatorStack _mark_stack;
   size_t _all_object_count;
   size_t _all_object_size_words;
+
+  // For verification
+  void compute_liveness();
+  size_t _verified_object_count;
+  size_t _verified_object_size_words;
 };
 
 

--- a/src/hotspot/share/gc/shared/liveness.hpp
+++ b/src/hotspot/share/gc/shared/liveness.hpp
@@ -56,6 +56,9 @@ class LivenessEstimatorThread : public  ConcurrentGCThread {
 
   virtual const char* type_name() const override;
 
+  static size_t get_live_heap_usage() { return live_heap_usage; }
+  static size_t get_live_object_count() { return live_object_count; }
+  
  private:
   bool estimation_begin();
   void estimation_end(bool completed);
@@ -86,6 +89,12 @@ class LivenessEstimatorThread : public  ConcurrentGCThread {
   size_t _actual_object_size_words;
   EstimationErrorTracker _object_count_error;
   EstimationErrorTracker _object_size_error;
+
+  static void set_live_heap_usage(size_t usage) { live_heap_usage = usage; }
+  static void set_live_object_count(size_t count) { live_object_count = count; }
+
+  static size_t live_heap_usage;
+  static size_t live_object_count;
 };
 
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -544,6 +544,10 @@ void ShenandoahHeap::reset_mark_bitmap() {
   _workers->run_task(&task);
 }
 
+bool ShenandoahHeap::is_concurrent_gc_active() {
+  return !is_stable();
+}
+
 void ShenandoahHeap::print_on(outputStream* st) const {
   st->print_cr("Shenandoah Heap");
   st->print_cr(" " SIZE_FORMAT "%s max, " SIZE_FORMAT "%s soft max, " SIZE_FORMAT "%s committed, " SIZE_FORMAT "%s used",

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -304,6 +304,8 @@ public:
   void set_concurrent_strong_root_in_progress(bool cond);
   void set_concurrent_weak_root_in_progress(bool cond);
 
+  virtual bool is_concurrent_gc_active() override;
+
   inline bool is_stable() const;
   inline bool is_idle() const;
   inline bool is_concurrent_mark_in_progress() const;

--- a/src/hotspot/share/gc/z/zCollectedHeap.cpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.cpp
@@ -43,6 +43,7 @@
 #include "oops/stackChunkOop.hpp"
 #include "runtime/continuationJavaClasses.hpp"
 #include "utilities/align.hpp"
+#include "gc/shared/concurrentGCBreakpoints.hpp"
 
 ZCollectedHeap* ZCollectedHeap::heap() {
   return named_heap<ZCollectedHeap>(CollectedHeap::Z);
@@ -340,4 +341,8 @@ bool ZCollectedHeap::is_oop(oop object) const {
 
 bool ZCollectedHeap::supports_concurrent_gc_breakpoints() const {
   return true;
+}
+
+bool ZCollectedHeap::is_concurrent_gc_active() {
+  return !ConcurrentGCBreakpoints::is_idle();
 }

--- a/src/hotspot/share/gc/z/zCollectedHeap.hpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.hpp
@@ -123,6 +123,8 @@ public:
   virtual void verify(VerifyOption option /* ignored */);
   virtual bool is_oop(oop object) const;
   virtual bool supports_concurrent_gc_breakpoints() const;
+
+  virtual bool is_concurrent_gc_active() override;
 };
 
 #endif // SHARE_GC_Z_ZCOLLECTEDHEAP_HPP

--- a/src/hotspot/share/include/jmm.h
+++ b/src/hotspot/share/include/jmm.h
@@ -249,6 +249,8 @@ typedef struct jmmInterface_1_ {
                                                   jlongArray sizeArray);
 
   jobject      (JNICALL *GetMemoryUsage)         (JNIEnv* env, jboolean heap);
+  jobject      (JNICALL *GetLiveHeapUsage)       (JNIEnv* env);
+  jlong        (JNICALL *GetLiveObjectCount)       (JNIEnv* env);
 
   jlong        (JNICALL *GetLongAttribute)       (JNIEnv *env, jobject obj, jmmLongAttribute att);
   jboolean     (JNICALL *GetBoolAttribute)       (JNIEnv *env, jmmBoolAttribute att);

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -410,6 +410,11 @@
     <Field type="ulong" contentType="bytes" name="size" label="Estimated live-set size" />
   </Event>
 
+  <Event name="LiveSetActual" category="Java Virtual Machine, GC, Detailed" startTime="false" label="Live-set actual">
+    <Field type="ulong" name="objectCount" label="Actual live-set object count" />
+    <Field type="ulong" contentType="bytes" name="size" label="Actual live-set size" />
+  </Event>
+
   <Type name="G1EvacuationStatistics">
     <Field type="uint" name="gcId" label="GC Identifier" relation="GcId" />
     <Field type="ulong" contentType="bytes" name="allocated" label="Allocated" description="Total memory allocated by PLABs" />

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -405,6 +405,10 @@
     <Field type="ulong" contentType="bytes" name="totalSize" label="Total Size" />
   </Event>
 
+  <Event name="LiveSetEstimate" category="Java Virtual Machine, GC, Detailed" startTime="false" label="Live set estimate">
+    <Field type="ulong" contentType="bytes" name="estimatedLiveSetSize" label="Estimated live-set size" />
+  </Event>
+
   <Type name="G1EvacuationStatistics">
     <Field type="uint" name="gcId" label="GC Identifier" relation="GcId" />
     <Field type="ulong" contentType="bytes" name="allocated" label="Allocated" description="Total memory allocated by PLABs" />

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -405,8 +405,9 @@
     <Field type="ulong" contentType="bytes" name="totalSize" label="Total Size" />
   </Event>
 
-  <Event name="LiveSetEstimate" category="Java Virtual Machine, GC, Detailed" startTime="false" label="Live set estimate">
-    <Field type="ulong" contentType="bytes" name="estimatedLiveSetSize" label="Estimated live-set size" />
+  <Event name="LiveSetEstimate" category="Java Virtual Machine, GC, Detailed" startTime="false" label="Live-set estimate">
+    <Field type="ulong" name="objectCount" label="Estimated live-set object count" />
+    <Field type="ulong" contentType="bytes" name="size" label="Estimated live-set size" />
   </Event>
 
   <Type name="G1EvacuationStatistics">

--- a/src/hotspot/share/logging/logPrefix.hpp
+++ b/src/hotspot/share/logging/logPrefix.hpp
@@ -56,6 +56,7 @@ DEBUG_ONLY(size_t Test_log_prefix_prefixer(char* buf, size_t len);)
   LOG_PREFIX(GCId::print_prefix, LOG_TAGS(gc, ergo, cset)) \
   LOG_PREFIX(GCId::print_prefix, LOG_TAGS(gc, ergo, heap)) \
   LOG_PREFIX(GCId::print_prefix, LOG_TAGS(gc, ergo, ihop)) \
+  LOG_PREFIX(GCId::print_prefix, LOG_TAGS(gc, estimator)) \
   LOG_PREFIX(GCId::print_prefix, LOG_TAGS(gc, ergo, refine)) \
   LOG_PREFIX(GCId::print_prefix, LOG_TAGS(gc, heap)) \
   LOG_PREFIX(GCId::print_prefix, LOG_TAGS(gc, heap, numa)) \

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -73,6 +73,7 @@ class outputStream;
   LOG_TAG(dump) \
   LOG_TAG(dynamic) \
   LOG_TAG(ergo) \
+  LOG_TAG(estimator) \
   LOG_TAG(event) \
   LOG_TAG(exceptions) \
   LOG_TAG(exit) \

--- a/src/hotspot/share/memory/heapInspection.cpp
+++ b/src/hotspot/share/memory/heapInspection.cpp
@@ -298,7 +298,7 @@ void KlassInfoHisto::print_elements(outputStream* st) const {
   // simplify the formatting (ILP32 vs LP64) - store the sum in 64-bit
   int64_t total = 0;
   uint64_t totalw = 0;
-  for(int i=0; i < elements()->length(); i++) {
+  for(int i=0; i < elements()->length() && i < HeapHistoTopN; i++) {
     st->print("%4d: ", i+1);
     elements()->at(i)->print_on(st);
     total += elements()->at(i)->count();

--- a/src/hotspot/share/memory/heapInspection.cpp
+++ b/src/hotspot/share/memory/heapInspection.cpp
@@ -298,7 +298,7 @@ void KlassInfoHisto::print_elements(outputStream* st) const {
   // simplify the formatting (ILP32 vs LP64) - store the sum in 64-bit
   int64_t total = 0;
   uint64_t totalw = 0;
-  for(int i=0; i < elements()->length() && i < HeapHistoTopN; i++) {
+  for(int i = 0; i < elements()->length() && i < HeapHistoTopN; i++) {
     st->print("%4d: ", i+1);
     elements()->at(i)->print_on(st);
     total += elements()->at(i)->count();

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -452,6 +452,7 @@ void before_exit(JavaThread* thread, bool halt) {
 
   // Stop concurrent GC threads
   Universe::heap()->stop();
+  Universe::heap()->stop_liveness_estimator();
 
   // Print GC/heap related information.
   Log(gc, heap, exit) log;

--- a/src/hotspot/share/runtime/vmOperation.hpp
+++ b/src/hotspot/share/runtime/vmOperation.hpp
@@ -105,7 +105,8 @@
   template(GTestExecuteAtSafepoint)               \
   template(GTestStopSafepoint)                    \
   template(JFROldObject)                          \
-  template(JvmtiPostObjectFree)
+  template(JvmtiPostObjectFree)                   \
+  template(LivenessRootScan)
 
 class Thread;
 class outputStream;

--- a/src/hotspot/share/services/memoryManager.cpp
+++ b/src/hotspot/share/services/memoryManager.cpp
@@ -288,7 +288,11 @@ void GCMemoryManager::gc_end(bool recordPostGCUsage,
         heapMemoryAfterGCUse += pool->get_last_collection_usage().used();
       }
     }
-    log_info(gc, estimator)("HeapMemoryAfterGCUse total: " SIZE_FORMAT "MB", heapMemoryAfterGCUse/M);
+    if (allMemoryPoolsAffected) {
+      log_info(gc, estimator)("HeapMemoryAfterGCUse [allMemoryPoolsAffected] total: " SIZE_FORMAT "MB", heapMemoryAfterGCUse/M);
+    } else {
+      log_info(gc, estimator)("HeapMemoryAfterGCUse total: " SIZE_FORMAT "MB", heapMemoryAfterGCUse/M);
+    }
   }
 
   if (countCollection) {

--- a/src/hotspot/share/services/memoryManager.cpp
+++ b/src/hotspot/share/services/memoryManager.cpp
@@ -268,7 +268,6 @@ void GCMemoryManager::gc_end(bool recordPostGCUsage,
       _current_gc_stat->set_after_gc_usage(i, usage);
     }
 
-    size_t heapMemoryAfterGCUse = 0;
     // Set last collection usage of the memory pools managed by this collector
     for (i = 0; i < num_memory_pools(); i++) {
       MemoryPool* pool = get_memory_pool(i);
@@ -279,21 +278,6 @@ void GCMemoryManager::gc_end(bool recordPostGCUsage,
         pool->set_last_collection_usage(usage);
         LowMemoryDetector::detect_after_gc_memory(pool);
       }
-
-      // Mimics the Coral 'HeapMemoryAfterGCUse' metric which queries last_collection_usage.
-      // Note that for some pools (e.g. G1 old gen) this value is not updated for every gc, only full gc, hence
-      // we check last_collection_usage instead of the usage value for *this* gc.
-      if (pool->is_heap()) { // TODO: also exclude any 'Eden' pools
-        log_info(gc, estimator)("HeapMemoryAfterGCUse | %s : " SIZE_FORMAT "MB", pool->name(), pool->get_last_collection_usage().used()/M);
-        heapMemoryAfterGCUse += pool->get_last_collection_usage().used();
-      }
-    }
-    if (allMemoryPoolsAffected) {
-      log_info(gc, estimator)("HeapMemoryAfterGCUse [allMemoryPoolsAffected] total: " SIZE_FORMAT "MB", heapMemoryAfterGCUse/M);
-    } else {
-      log_info(gc, estimator)("HeapMemoryAfterGCUse total: " SIZE_FORMAT " (" SIZE_FORMAT "%s)",
-                              heapMemoryAfterGCUse, byte_size_in_proper_unit(heapMemoryAfterGCUse),
-                              proper_unit_for_byte_size(heapMemoryAfterGCUse));
     }
   }
 

--- a/src/hotspot/share/services/memoryManager.cpp
+++ b/src/hotspot/share/services/memoryManager.cpp
@@ -284,11 +284,11 @@ void GCMemoryManager::gc_end(bool recordPostGCUsage,
       // Note that for some pools (e.g. G1 old gen) this value is not updated for every gc, only full gc, hence
       // we check last_collection_usage instead of the usage value for *this* gc.
       if (pool->is_heap()) { // TODO: also exclude any 'Eden' pools
-        log_info(gc, estimator)("HeapMemoryAfterGCUse | %s : " SIZE_FORMAT " bytes", pool->name(), pool->get_last_collection_usage().used());
+        log_info(gc, estimator)("HeapMemoryAfterGCUse | %s : " SIZE_FORMAT "MB", pool->name(), pool->get_last_collection_usage().used()/M);
         heapMemoryAfterGCUse += pool->get_last_collection_usage().used();
       }
     }
-    log_info(gc, estimator)("HeapMemoryAfterGCUse total: " SIZE_FORMAT " bytes", heapMemoryAfterGCUse);
+    log_info(gc, estimator)("HeapMemoryAfterGCUse total: " SIZE_FORMAT "MB", heapMemoryAfterGCUse/M);
   }
 
   if (countCollection) {

--- a/src/hotspot/share/services/memoryManager.cpp
+++ b/src/hotspot/share/services/memoryManager.cpp
@@ -291,7 +291,9 @@ void GCMemoryManager::gc_end(bool recordPostGCUsage,
     if (allMemoryPoolsAffected) {
       log_info(gc, estimator)("HeapMemoryAfterGCUse [allMemoryPoolsAffected] total: " SIZE_FORMAT "MB", heapMemoryAfterGCUse/M);
     } else {
-      log_info(gc, estimator)("HeapMemoryAfterGCUse total: " SIZE_FORMAT "MB", heapMemoryAfterGCUse/M);
+      log_info(gc, estimator)("HeapMemoryAfterGCUse total: " SIZE_FORMAT " (" SIZE_FORMAT "%s)",
+                              heapMemoryAfterGCUse, byte_size_in_proper_unit(heapMemoryAfterGCUse),
+                              proper_unit_for_byte_size(heapMemoryAfterGCUse));
     }
   }
 

--- a/src/java.management/share/classes/sun/management/MemoryImpl.java
+++ b/src/java.management/share/classes/sun/management/MemoryImpl.java
@@ -43,7 +43,7 @@ import javax.management.openmbean.CompositeData;
  * ManagementFactory.getMemoryMXBean() returns an instance
  * of this class.
  */
-class MemoryImpl extends NotificationEmitterSupport
+public class MemoryImpl extends NotificationEmitterSupport
                  implements MemoryMXBean {
 
     private final VMManagement jvm;
@@ -54,7 +54,7 @@ class MemoryImpl extends NotificationEmitterSupport
     /**
      * Constructor of MemoryImpl class
      */
-    MemoryImpl(VMManagement vm) {
+    protected MemoryImpl(VMManagement vm) {
         this.jvm = vm;
     }
 
@@ -86,6 +86,14 @@ class MemoryImpl extends NotificationEmitterSupport
         setVerboseGC(value);
     }
 
+    public MemoryUsage getLiveHeapUsage() {
+        return getLiveHeapUsage0();
+    }
+
+    public long getLiveObjectCount() {
+        return getLiveObjectCount0();
+    }
+
     // The current Hotspot implementation does not support
     // dynamically add or remove memory pools & managers.
     static synchronized MemoryPoolMXBean[] getMemoryPools() {
@@ -104,6 +112,8 @@ class MemoryImpl extends NotificationEmitterSupport
     private static native MemoryManagerMXBean[] getMemoryManagers0();
     private native MemoryUsage getMemoryUsage0(boolean heap);
     private native void setVerboseGC(boolean value);
+    private native MemoryUsage getLiveHeapUsage0();
+    private native long getLiveObjectCount0();
 
     private static final String notifName =
         "javax.management.Notification";

--- a/src/java.management/share/native/libmanagement/MemoryImpl.c
+++ b/src/java.management/share/native/libmanagement/MemoryImpl.c
@@ -46,3 +46,13 @@ JNIEXPORT jobject JNICALL Java_sun_management_MemoryImpl_getMemoryUsage0
   (JNIEnv *env, jobject dummy, jboolean heap) {
     return jmm_interface->GetMemoryUsage(env, heap);
 }
+
+JNIEXPORT jobject JNICALL Java_sun_management_MemoryImpl_getLiveHeapUsage0
+(JNIEnv *env, jobject dummy) {
+    return jmm_interface->GetLiveHeapUsage(env);
+}
+
+JNIEXPORT jlong JNICALL Java_sun_management_MemoryImpl_getLiveObjectCount0
+(JNIEnv *env, jobject dummy) {
+    return jmm_interface->GetLiveObjectCount(env);
+}

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -862,6 +862,10 @@
       <setting name="enabled">true</setting>
     </event>
 
+    <event name="jdk.LiveSetActual">
+      <setting name="enabled">true</setting>
+    </event>
+
 
 
 

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -858,6 +858,10 @@
       <setting name="period">endChunk</setting>
     </event>
 
+    <event name="jdk.LiveSetEstimate">
+      <setting name="enabled">true</setting>
+    </event>
+
 
 
 

--- a/src/jdk.management/share/classes/com/sun/management/MemoryMXBean.java
+++ b/src/jdk.management/share/classes/com/sun/management/MemoryMXBean.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2021, Amazon.com Inc. or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.management;
+
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.CompositeDataView;
+import javax.management.openmbean.CompositeType;
+
+import java.lang.String;
+
+import java.lang.management.MemoryUsage;
+
+/**
+ * Platform-specific management interface for a garbage collector
+ * which performs collections in cycles.
+ * <p>
+ * GarbageCollectorMXBean is an interface used by the management system to
+ * access garbage collector properties and reset the values of associated
+ * counter and accumulator properties. 
+ *
+ * <p> This platform extension is only available to the garbage
+ * collection implementation that supports this extension.
+ *
+ * @author  Paul Hohensee
+ * @since   18
+ */
+public interface MemoryMXBean extends java.lang.management.MemoryMXBean {
+
+    /**
+     * Version of the MemoryMXBean application programming interface. 
+     * The format for the version is majorVersion.minorVersion.microVersion.
+     *
+     * @return the version of the MemoryMXBean application programming interface;
+     *         the null string if no version information is available.
+     */
+    public default String getVersion() {
+        return "";
+    }
+
+    /**
+     * Returns an approximation of the total amount of memory, in bytes,
+     * allocated in Java object heap memory since the start of JVM execution.
+     * The returned value is an approximation because some Java virtual machine
+     * implementations may use object allocation mechanisms that result in a
+     * delay between the time an object is allocated and the time its size is
+     * recorded.
+     *
+     * @return an approximation of the total memory allocated, in bytes, in
+     *         Java object heap memory since the start of JVM execution, if
+     *         memory allocation measurement is enabled; {@code -1} otherwise.
+     *
+     * @throws UnsupportedOperationException if the Java virtual
+     *         machine implementation does not support memory allocation
+     *         measurement.
+     */
+    public default long getAllocatedBytes() {
+        return -1;
+    }
+
+    /**
+     * Returns the current memory usage of the heap that
+     * is used for object allocation.  The heap consists
+     * of one or more memory pools.  The {@code used} size
+     * of the returned memory usage is an approximation of
+     * the live object memory usage. The returned value is an
+     * approximation as objects can be created or dereferenced
+     * while the estimator is running since it runs concurrently.
+     * The {@code committed} size of the returned memory usage
+     * is the sum of those values of all heap memory pools
+     * whereas the {@code init} and {@code max} size of the
+     * returned memory usage represents the setting of the
+     * heap memory which may not be the sum of those of all
+     * heap memory pools.
+     * <p>
+     * The amount of used memory in the returned memory usage
+     * is the amount of memory occupied by only live objects
+     *
+     * <p>
+     * <b>MBeanServer access</b>:<br>
+     * The mapped type of {@code MemoryUsage} is
+     * {@code CompositeData} with attributes as specified in
+     * {@link MemoryUsage#from MemoryUsage}.
+     *
+     * @return a {@link MemoryUsage} object representing
+     * the heap memory usage.
+     */
+    public MemoryUsage getLiveHeapUsage();
+
+
+    /**
+     * Returns an approximation of the total live object count.
+     * The returned value is an approximation as objects can be
+     * created or dereferenced while the estimator is running
+     * since it runs concurrently
+     *
+     * @return an approximation of the total live object count
+     */
+    public long getLiveObjectCount();
+}

--- a/src/jdk.management/share/classes/com/sun/management/internal/HotSpotMemoryImpl.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/HotSpotMemoryImpl.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.management.internal;
+
+import com.sun.management.MemoryMXBean;
+import sun.management.ManagementFactoryHelper;
+import sun.management.MemoryImpl;
+import sun.management.VMManagement;
+import java.lang.management.MemoryUsage;
+
+/**
+ *
+ */
+public class HotSpotMemoryImpl extends MemoryImpl implements MemoryMXBean {
+    public HotSpotMemoryImpl(VMManagement vm) {
+        super(ManagementFactoryHelper.getVMManagement());
+    }
+
+    @Override
+    public MemoryUsage getLiveHeapUsage() {
+        return super.getLiveHeapUsage();
+    }
+
+    @Override
+    public long getLiveObjectCount() {
+        return super.getLiveObjectCount();
+    }
+}

--- a/src/jdk.management/share/classes/com/sun/management/internal/PlatformMBeanProviderImpl.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/PlatformMBeanProviderImpl.java
@@ -26,6 +26,7 @@ package com.sun.management.internal;
 
 import com.sun.management.DiagnosticCommandMBean;
 import com.sun.management.HotSpotDiagnosticMXBean;
+import com.sun.management.MemoryMXBean;
 import com.sun.management.ThreadMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryManagerMXBean;
@@ -121,6 +122,45 @@ public final class PlatformMBeanProviderImpl extends PlatformMBeanProvider {
                 }
 
                 return map;
+            }
+        });
+
+        /**
+         * Memory system of the Java virtual machine.
+         */
+        initMBeanList.add(new PlatformComponent<java.lang.management.MemoryMXBean>() {
+            private final Set<String> memoryMXBeanInterfaceNames
+                    = Collections.unmodifiableSet(
+                            Stream.of("java.lang.management.MemoryMXBean",
+                                    "com.sun.management.MemoryMXBean")
+                            .collect(Collectors.toSet()));
+            private MemoryMXBean memoryMBean = null;
+
+            @Override
+            public Set<Class<? extends java.lang.management.MemoryMXBean>> mbeanInterfaces() {
+                return Stream.of(java.lang.management.MemoryMXBean.class,
+                        com.sun.management.MemoryMXBean.class)
+                        .collect(Collectors.toSet());
+            }
+
+            @Override
+            public Set<String> mbeanInterfaceNames() {
+                return memoryMXBeanInterfaceNames;
+            }
+
+            @Override
+            public String getObjectNamePattern() {
+                return ManagementFactory.MEMORY_MXBEAN_NAME;
+            }
+
+            @Override
+            public synchronized Map<String, java.lang.management.MemoryMXBean> nameToMBeanMap() {
+                if (memoryMBean == null) {
+                    memoryMBean = new HotSpotMemoryImpl(ManagementFactoryHelper.getVMManagement());
+                }
+                return Collections.singletonMap(
+                        ManagementFactory.MEMORY_MXBEAN_NAME,
+                        memoryMBean);
             }
         });
 

--- a/test/hotspot/jtreg/gc/liveness/TestConcurrentLivenessWhenGCAlwaysRuns.java
+++ b/test/hotspot/jtreg/gc/liveness/TestConcurrentLivenessWhenGCAlwaysRuns.java
@@ -17,7 +17,7 @@ public class TestConcurrentLivenessWhenGCAlwaysRuns {
 
         Runnable runnable = () -> {
             while (true) {
-                System.gc(); 
+                System.gc();
             }
         };
 
@@ -33,7 +33,7 @@ public class TestConcurrentLivenessWhenGCAlwaysRuns {
             if (heap.getUsed() != 0) {
                 throw new RuntimeException("Concurrent liveness ran during concurrent GC. Estimate should be zero but is " + heap.getUsed());
             }
-            
+
             Thread.sleep(100);
         }
     }

--- a/test/hotspot/jtreg/gc/liveness/TestConcurrentLivenessWhenGCAlwaysRuns.java
+++ b/test/hotspot/jtreg/gc/liveness/TestConcurrentLivenessWhenGCAlwaysRuns.java
@@ -1,0 +1,40 @@
+import java.lang.management.ManagementFactory;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.MemoryUsage;
+import java.util.concurrent.TimeUnit;
+import java.util.List;
+import com.sun.management.MemoryMXBean;
+
+/*
+ * @test
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseConcLivenessEstimate -XX:ConcLivenessEstimateSeconds=1 -XX:+UseG1GC -XX:InitiatingHeapOccupancyPercent=0 -XX:+ExplicitGCInvokesConcurrent TestConcurrentLivenessWhenGCAlwaysRuns
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseConcLivenessEstimate -XX:ConcLivenessEstimateSeconds=1 -XX:+UseShenandoahGC -XX:+ExplicitGCInvokesConcurrent TestConcurrentLivenessWhenGCAlwaysRuns
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseConcLivenessEstimate -XX:ConcLivenessEstimateSeconds=1 -XX:+UseZGC -XX:+ExplicitGCInvokesConcurrent TestConcurrentLivenessWhenGCAlwaysRuns
+ */
+public class TestConcurrentLivenessWhenGCAlwaysRuns {
+
+    public static void main(String[] args) throws Exception {
+
+        Runnable runnable = () -> {
+            while (true) {
+                System.gc(); 
+            }
+        };
+
+        Thread thread = new Thread(runnable);
+        thread.setDaemon(true);
+        thread.start();
+
+        long start = System.currentTimeMillis();
+        while(System.currentTimeMillis() < start + 3000) {
+            MemoryMXBean memBean = (MemoryMXBean) ManagementFactory.getMemoryMXBean();
+            MemoryUsage heap = memBean.getLiveHeapUsage();
+
+            if (heap.getUsed() != 0) {
+                throw new RuntimeException("Concurrent liveness ran during concurrent GC. Estimate should be zero but is " + heap.getUsed());
+            }
+            
+            Thread.sleep(100);
+        }
+    }
+}

--- a/test/hotspot/jtreg/gc/liveness/TestConcurrentLivenessWhenGCAlwaysRunsMultipleWorkers.java
+++ b/test/hotspot/jtreg/gc/liveness/TestConcurrentLivenessWhenGCAlwaysRunsMultipleWorkers.java
@@ -7,11 +7,11 @@ import com.sun.management.MemoryMXBean;
 
 /*
  * @test
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseConcLivenessEstimate -XX:ConcLivenessEstimateSeconds=7 -XX:+UseG1GC -XX:InitiatingHeapOccupancyPercent=0 -XX:+ExplicitGCInvokesConcurrent TestConcurrentLivenessWhenGCAlwaysRuns
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseConcLivenessEstimate -XX:ConcLivenessEstimateSeconds=7 -XX:+UseShenandoahGC -XX:+ExplicitGCInvokesConcurrent TestConcurrentLivenessWhenGCAlwaysRuns
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseConcLivenessEstimate -XX:ConcLivenessEstimateSeconds=7 -XX:+UseZGC -XX:+ExplicitGCInvokesConcurrent TestConcurrentLivenessWhenGCAlwaysRuns
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseConcLivenessEstimate -XX:ConcLivenessEstimateSeconds=7 -XX:+UseG1GC -XX:InitiatingHeapOccupancyPercent=0 -XX:+ExplicitGCInvokesConcurrent -XX:ConcLivenessThreads=5 TestConcurrentLivenessWhenGCAlwaysRunsMultipleWorkers
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseConcLivenessEstimate -XX:ConcLivenessEstimateSeconds=7 -XX:+UseShenandoahGC -XX:+ExplicitGCInvokesConcurrent -XX:ConcLivenessThreads=5 TestConcurrentLivenessWhenGCAlwaysRunsMultipleWorkers
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseConcLivenessEstimate -XX:ConcLivenessEstimateSeconds=7 -XX:+UseZGC -XX:+ExplicitGCInvokesConcurrent -XX:ConcLivenessThreads=5 TestConcurrentLivenessWhenGCAlwaysRunsMultipleWorkers
  */
-public class TestConcurrentLivenessWhenGCAlwaysRuns {
+public class TestConcurrentLivenessWhenGCAlwaysRunsMultipleWorkers {
 
     public static void main(String[] args) throws Exception {
 

--- a/test/hotspot/jtreg/gc/liveness/TestConcurrentLivenessWhenMemoryUsageChanges.java
+++ b/test/hotspot/jtreg/gc/liveness/TestConcurrentLivenessWhenMemoryUsageChanges.java
@@ -9,8 +9,11 @@ import java.lang.Math;
 /*
  * @test
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseConcLivenessEstimate -XX:ConcLivenessEstimateSeconds=3 -XX:+UseG1GC -XX:InitiatingHeapOccupancyPercent=100 TestConcurrentLivenessWhenMemoryUsageChanges
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseConcLivenessEstimate -XX:ConcLivenessEstimateSeconds=3 -XX:+UseG1GC -XX:InitiatingHeapOccupancyPercent=100 -XX:ConcLivenessThreads=5 TestConcurrentLivenessWhenMemoryUsageChanges
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseConcLivenessEstimate -XX:ConcLivenessEstimateSeconds=3 -XX:+UseShenandoahGC -XX:ShenandoahGuaranteedGCInterval=100000 TestConcurrentLivenessWhenMemoryUsageChanges
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseConcLivenessEstimate -XX:ConcLivenessEstimateSeconds=3 -XX:+UseShenandoahGC -XX:ShenandoahGuaranteedGCInterval=100000 -XX:ConcLivenessThreads=5 TestConcurrentLivenessWhenMemoryUsageChanges
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseConcLivenessEstimate -XX:ConcLivenessEstimateSeconds=3 -XX:+UseZGC -XX:ZCollectionInterval=100 TestConcurrentLivenessWhenMemoryUsageChanges
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseConcLivenessEstimate -XX:ConcLivenessEstimateSeconds=3 -XX:+UseZGC -XX:ZCollectionInterval=100 -XX:ConcLivenessThreads=5 TestConcurrentLivenessWhenMemoryUsageChanges
  */
 public class TestConcurrentLivenessWhenMemoryUsageChanges {
     
@@ -56,7 +59,7 @@ public class TestConcurrentLivenessWhenMemoryUsageChanges {
         if (getError(decHeap.getUsed(), incHeap.getUsed() - allocationSize) > epsilon) {
             throw new RuntimeException(
                 "Expected ConcLivenessEstimate to decrease but error of " + 
-                getError(incHeap.getUsed(), initHeap.getUsed() + allocationSize) +
+                getError(decHeap.getUsed(), incHeap.getUsed() - allocationSize) +
                 " is not within allowed error of " + epsilon
             );
         }

--- a/test/hotspot/jtreg/gc/liveness/TestConcurrentLivenessWhenMemoryUsageChanges.java
+++ b/test/hotspot/jtreg/gc/liveness/TestConcurrentLivenessWhenMemoryUsageChanges.java
@@ -19,7 +19,7 @@ public class TestConcurrentLivenessWhenMemoryUsageChanges {
     
     // 100 MB
     private static final int allocationSize = 1024 * 1024 * 100;
-    
+
     // Error we give to estimator
     private static final double epsilon = 0.05;
 
@@ -44,7 +44,7 @@ public class TestConcurrentLivenessWhenMemoryUsageChanges {
 
         if (getError(incHeap.getUsed(), initHeap.getUsed() + allocationSize) > epsilon) {
             throw new RuntimeException(
-                "Expected ConcLivenessEstimate to increase but error of " + 
+                "Expected ConcLivenessEstimate to increase but error of " +
                 getError(incHeap.getUsed(), initHeap.getUsed() + allocationSize) +
                 " is not within allowed error of " + epsilon
             );
@@ -58,7 +58,7 @@ public class TestConcurrentLivenessWhenMemoryUsageChanges {
 
         if (getError(decHeap.getUsed(), incHeap.getUsed() - allocationSize) > epsilon) {
             throw new RuntimeException(
-                "Expected ConcLivenessEstimate to decrease but error of " + 
+                "Expected ConcLivenessEstimate to decrease but error of " +
                 getError(decHeap.getUsed(), incHeap.getUsed() - allocationSize) +
                 " is not within allowed error of " + epsilon
             );
@@ -69,3 +69,4 @@ public class TestConcurrentLivenessWhenMemoryUsageChanges {
         return Math.abs(num1 - num2) / ((num1 + num2) / 2.0);
     }
 }
+

--- a/test/hotspot/jtreg/gc/liveness/TestConcurrentLivenessWhenMemoryUsageChanges.java
+++ b/test/hotspot/jtreg/gc/liveness/TestConcurrentLivenessWhenMemoryUsageChanges.java
@@ -1,0 +1,68 @@
+import java.lang.management.ManagementFactory;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.MemoryUsage;
+import java.util.concurrent.TimeUnit;
+import java.util.List;
+import com.sun.management.MemoryMXBean;
+import java.lang.Math;
+
+/*
+ * @test
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseConcLivenessEstimate -XX:ConcLivenessEstimateSeconds=3 -XX:+UseG1GC -XX:InitiatingHeapOccupancyPercent=100 TestConcurrentLivenessWhenMemoryUsageChanges
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseConcLivenessEstimate -XX:ConcLivenessEstimateSeconds=3 -XX:+UseShenandoahGC -XX:ShenandoahGuaranteedGCInterval=100000 TestConcurrentLivenessWhenMemoryUsageChanges
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseConcLivenessEstimate -XX:ConcLivenessEstimateSeconds=3 -XX:+UseZGC -XX:ZCollectionInterval=100 TestConcurrentLivenessWhenMemoryUsageChanges
+ */
+public class TestConcurrentLivenessWhenMemoryUsageChanges {
+    
+    // 100 MB
+    private static final int allocationSize = 1024 * 1024 * 100;
+    
+    // Error we give to estimator
+    private static final double epsilon = 0.05;
+
+    // MemoryMXBean contains the liveness estimation
+    private static final MemoryMXBean memBean = (MemoryMXBean) ManagementFactory.getMemoryMXBean();
+
+    public static void main(String[] args) throws Exception {
+
+        TimeUnit.SECONDS.sleep(10);
+
+        MemoryUsage initHeap = memBean.getLiveHeapUsage();
+
+        if (initHeap.getUsed() == 0) {
+            throw new RuntimeException("Expected ConcLivenessEstimate to produce a liveHeapUsage metric, but instead it is 0");
+        }
+
+        byte[] tempArr = new byte[allocationSize];
+
+        TimeUnit.SECONDS.sleep(10);
+
+        MemoryUsage incHeap = memBean.getLiveHeapUsage();
+
+        if (getError(incHeap.getUsed(), initHeap.getUsed() + allocationSize) > epsilon) {
+            throw new RuntimeException(
+                "Expected ConcLivenessEstimate to increase but error of " + 
+                getError(incHeap.getUsed(), initHeap.getUsed() + allocationSize) +
+                " is not within allowed error of " + epsilon
+            );
+        }
+
+        tempArr = null;
+
+        TimeUnit.SECONDS.sleep(10);
+
+        MemoryUsage decHeap = memBean.getLiveHeapUsage();
+
+        if (getError(decHeap.getUsed(), incHeap.getUsed() - allocationSize) > epsilon) {
+            throw new RuntimeException(
+                "Expected ConcLivenessEstimate to decrease but error of " + 
+                getError(incHeap.getUsed(), initHeap.getUsed() + allocationSize) +
+                " is not within allowed error of " + epsilon
+            );
+        }
+    }
+
+    private static double getError(long num1, long num2) {
+        return Math.abs(num1 - num2) / ((num1 + num2) / 2.0);
+    }
+}


### PR DESCRIPTION
These changes introduce a component that provides an estimation of the number, size and distribution of objects in the heap. It does this independently of any collector implementation or operation. It walks the heap _concurrently, without any barriers_. For this reason, it provides only an estimation (our testing has shown the estimation is generally accurate).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12002/head:pull/12002` \
`$ git checkout pull/12002`

Update a local copy of the PR: \
`$ git checkout pull/12002` \
`$ git pull https://git.openjdk.org/jdk pull/12002/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12002`

View PR using the GUI difftool: \
`$ git pr show -t 12002`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12002.diff">https://git.openjdk.org/jdk/pull/12002.diff</a>

</details>
