### PR TITLE
8300167: Add validation of the raster's layout before using in native

### DIFF
--- a/src/java.desktop/share/classes/sun/java2d/cmm/lcms/LCMSImageLayout.java
+++ b/src/java.desktop/share/classes/sun/java2d/cmm/lcms/LCMSImageLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -334,7 +334,8 @@ final class LCMSImageLayout {
 
             ComponentSampleModel csm = (ComponentSampleModel)r.getSampleModel();
 
-            l.pixelType = CHANNELS_SH(br.getNumBands()) | BYTES_SH(1);
+            int numBands = br.getNumBands();
+            l.pixelType = CHANNELS_SH(numBands) | BYTES_SH(1);
 
             int[] bandOffsets = csm.getBandOffsets();
             BandOrder order = BandOrder.getBandOrder(bandOffsets);
@@ -343,7 +344,7 @@ final class LCMSImageLayout {
             switch (order) {
                 case INVERTED:
                     l.pixelType |= DOSWAP;
-                    firstBand  = csm.getNumBands() - 1;
+                    firstBand  = numBands - 1;
                     break;
                 case DIRECT:
                     // do nothing
@@ -357,11 +358,14 @@ final class LCMSImageLayout {
             l.nextPixelOffset = br.getPixelStride();
 
             l.offset = br.getDataOffset(firstBand);
-            l.dataArray = br.getDataStorage();
             l.dataType = DT_BYTE;
+            byte[] data = br.getDataStorage();
+            l.dataArray = data;
+            l.dataArrayLength = data.length;
 
             l.width = br.getWidth();
             l.height = br.getHeight();
+            l.verify();
             return l;
         }
         return null;


### PR DESCRIPTION
Currently, we always validate image layouts passed from java to native, except for some types of rasters. One of the reasons why the rasters are skipped is that they are not public and have their own validation during construction. But it is unclear how it works in the multithreaded case. All these objects are not thread-safe - could it be possible that we can get the raster that is not completely constructed/validated?

FYI I have started to look into this method because when I did an accidental typo in pixel format in this method I got the same symptoms/crash as described [here](https://bugs.openjdk.org/browse/JDK-8278101). It might be unrelated but it is safer to fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300167](https://bugs.openjdk.org/browse/JDK-8300167): Add validation of the raster's layout before using in native


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12004/head:pull/12004` \
`$ git checkout pull/12004`

Update a local copy of the PR: \
`$ git checkout pull/12004` \
`$ git pull https://git.openjdk.org/jdk pull/12004/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12004`

View PR using the GUI difftool: \
`$ git pr show -t 12004`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12004.diff">https://git.openjdk.org/jdk/pull/12004.diff</a>

</details>
