### PR TITLE
8300169: Build failure with clang-15

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -166,8 +166,10 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_clang_g1ParScanThreadState.cpp := delete-abstract-non-virtual-dtor, \
     DISABLED_WARNINGS_clang_g1YoungGCPostEvacuateTasks.cpp := delete-abstract-non-virtual-dtor, \
     DISABLED_WARNINGS_clang_management.cpp := missing-field-initializers, \
+    DISABLED_WARNINGS_clang_notificationThread.cpp := bitwise-instead-of-logical, \
     DISABLED_WARNINGS_clang_os_posix.cpp := mismatched-tags missing-field-initializers, \
     DISABLED_WARNINGS_clang_postaloc.cpp := tautological-undefined-compare, \
+    DISABLED_WARNINGS_clang_serviceThread.cpp := bitwise-instead-of-logical, \
     DISABLED_WARNINGS_clang_vm_version_x86.cpp := missing-field-initializers, \
     DISABLED_WARNINGS_clang_zTracer.cpp := undefined-var-template, \
     DISABLED_WARNINGS_xlc := $(DISABLED_WARNINGS_xlc), \

--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -140,6 +140,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBZIP, \
         $(LIBZ_CFLAGS), \
     CFLAGS_unix := $(BUILD_LIBZIP_MMAP) -UDEBUG, \
     DISABLED_WARNINGS_gcc_zip_util.c := unused-function, \
+    DISABLED_WARNINGS_clang := deprecated-non-prototype, \
     DISABLED_WARNINGS_clang_gzwrite.c := format-nonliteral, \
     LDFLAGS := $(LDFLAGS_JDKLIB) \
         $(call SET_SHARED_LIBRARY_ORIGIN), \
@@ -211,7 +212,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJLI, \
     OPTIMIZATION := HIGH, \
     CFLAGS := $(CFLAGS_JDKLIB) $(LIBJLI_CFLAGS), \
     DISABLED_WARNINGS_gcc := unused-function, \
-    DISABLED_WARNINGS_clang := format-nonliteral, \
+    DISABLED_WARNINGS_clang := format-nonliteral deprecated-non-prototype, \
     LDFLAGS := $(LDFLAGS_JDKLIB) \
         $(call SET_SHARED_LIBRARY_ORIGIN), \
     LIBS_unix := $(LIBZ_LIBS), \

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -147,7 +147,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBAWT, \
     DISABLED_WARNINGS_gcc_Region.c := maybe-uninitialized, \
     DISABLED_WARNINGS_gcc_SurfaceData.c := unused-value, \
     DISABLED_WARNINGS_gcc_TransformHelper.c := sign-compare, \
-    DISABLED_WARNINGS_clang_awt_ImagingLib.c := sign-compare, \
+    DISABLED_WARNINGS_clang_awt_ImagingLib.c := sign-compare deprecated-non-prototype, \
     DISABLED_WARNINGS_clang_awt_parseImage.c := sign-compare, \
     DISABLED_WARNINGS_clang_debug_mem.c := extern-initializer format-nonliteral, \
     DISABLED_WARNINGS_clang_debug_trace.c := format-nonliteral, \
@@ -757,6 +757,7 @@ ifeq ($(ENABLE_HEADLESS_ONLY), false)
       DISABLED_WARNINGS_gcc_splashscreen_gfx_impl.c := implicit-fallthrough maybe-uninitialized, \
       DISABLED_WARNINGS_gcc_splashscreen_impl.c := implicit-fallthrough sign-compare unused-function, \
       DISABLED_WARNINGS_gcc_splashscreen_sys.c := type-limits unused-result, \
+      DISABLED_WARNINGS_clang := deprecated-non-prototype, \
       DISABLED_WARNINGS_clang_dgif_lib.c := sign-compare, \
       DISABLED_WARNINGS_clang_gzwrite.c := format-nonliteral, \
       DISABLED_WARNINGS_clang_splashscreen_impl.c := sign-compare, \
@@ -829,6 +830,7 @@ ifeq ($(call isTargetOs, macosx), true)
       DISABLED_WARNINGS_clang_ImageSurfaceData.m := enum-conversion parentheses-equality, \
       DISABLED_WARNINGS_clang_MTLBlitLoops.m := pointer-arith, \
       DISABLED_WARNINGS_clang_MTLPipelineStatesStorage.m := semicolon-before-method-body, \
+      DISABLED_WARNINGS_clang_MTLRenderer.m := gnu-folding-constant, \
       DISABLED_WARNINGS_clang_MTLVertexCache.m := pointer-arith, \
       DISABLED_WARNINGS_clang_OGLBufImgOps.c := format-nonliteral, \
       DISABLED_WARNINGS_clang_OGLPaints.c := format-nonliteral, \

--- a/src/hotspot/share/oops/generateOopMap.cpp
+++ b/src/hotspot/share/oops/generateOopMap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1732,7 +1732,7 @@ void GenerateOopMap::ppop(CellTypeState *out) {
 }
 
 void GenerateOopMap::ppush1(CellTypeState in) {
-  assert(in.is_reference() | in.is_value(), "sanity check");
+  assert(in.is_reference() || in.is_value(), "sanity check");
   push(in);
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ static jmethodID sjm_printerJob = NULL;
    GET_CPRINTERDIALOG_CLASS_RETURN(ret); \
    GET_FIELD_RETURN(sjm_printerJob, sjc_CPrinterDialog, "fPrinterJob", "Lsun/lwawt/macosx/CPrinterJob;", ret);
 
-static NSPrintInfo* createDefaultNSPrintInfo();
+static NSPrintInfo* createDefaultNSPrintInfo(JNIEnv* env, jstring printer);
 
 static void makeBestFit(NSPrintInfo* src);
 

--- a/src/java.desktop/share/native/libharfbuzz/hb-meta.hh
+++ b/src/java.desktop/share/native/libharfbuzz/hb-meta.hh
@@ -188,7 +188,7 @@ template <> struct hb_int_max<signed long long>         : hb_integral_constant<s
 template <> struct hb_int_max<unsigned long long>       : hb_integral_constant<unsigned long long,      ULLONG_MAX>     {};
 #define hb_int_max(T) hb_int_max<T>::value
 
-#if defined(__GNUC__) && __GNUC__ < 5
+#if defined(__GNUC__) && __GNUC__ < 5 && !defined(__clang__)
 #define hb_is_trivially_copyable(T) __has_trivial_copy(T)
 #define hb_is_trivially_copy_assignable(T) __has_trivial_assign(T)
 #define hb_is_trivially_constructible(T) __has_trivial_constructor(T)


### PR DESCRIPTION
Hi all,

Please review the fix for the build failure with clang-15.

1. -Wbitwise-instead-of-logical
```
   1) src/hotspot/share/oops/generateOopMap.cpp          <--- fixed the warning
   2) src/hotspot/share/runtime/notificationThread.cpp   <--- keep the code and disable warnings
   3) src/hotspot/share/runtime/serviceThread.cpp        <--- keep the code and disable warnings
```

2. -Wdeprecated-non-prototype (all the warnings are disabled)
```
   1) Mainly caused by files under `src/java.base/share/native/libzip/zlib/`  <--- keep the code and disable warnings
      It occurred while building LIBJLI, LIBZIP and LIBSPLASHSCREEN.

   2) While compiling src/java.desktop/share/native/libawt/awt/medialib/awt_ImagingLib.c  <--- keep the code and disable warnings

   3) Caused by src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m  <--- fixed the warnings
```

3. -Wdeprecated-builtins
```
   Caused by files under src/java.desktop/share/native/libharfbuzz/  <--- fixed the warnings
```
   Ref: https://github.com/harfbuzz/harfbuzz/blob/main/src/hb-meta.hh#L202

4. -Wgnu-folding-constant
```
   Caused by src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderer.m  <--- keep the code and disable warnings
```

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300169](https://bugs.openjdk.org/browse/JDK-8300169): Build failure with clang-15


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12005/head:pull/12005` \
`$ git checkout pull/12005`

Update a local copy of the PR: \
`$ git checkout pull/12005` \
`$ git pull https://git.openjdk.org/jdk pull/12005/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12005`

View PR using the GUI difftool: \
`$ git pr show -t 12005`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12005.diff">https://git.openjdk.org/jdk/pull/12005.diff</a>

</details>
