### PR TITLE
8300295: [AIX] TestDaemonDestroy fails due to !is_primordial_thread assertion

### DIFF
--- a/test/hotspot/jtreg/runtime/jni/daemonDestroy/exedaemonDestroy.c
+++ b/test/hotspot/jtreg/runtime/jni/daemonDestroy/exedaemonDestroy.c
@@ -128,8 +128,8 @@ int main(int argc, char *argv[]) {
    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
    pthread_attr_setguardsize(&attr, 0);
    pthread_attr_setstacksize(&attr, adjusted_stack_size);
-   pthread_create (&id,&attr,run,(void *)&args);
-   pthread_join(id,NULL);
+   pthread_create(&id, &attr, run, (void *)&args);
+   pthread_join(id, NULL);
 #else
    run(&args);
 #endif //AIX

--- a/test/hotspot/jtreg/runtime/jni/daemonDestroy/exedaemonDestroy.c
+++ b/test/hotspot/jtreg/runtime/jni/daemonDestroy/exedaemonDestroy.c
@@ -127,7 +127,7 @@ int main(int argc, char *argv[]) {
    pthread_attr_t attr;
    pthread_attr_init(&attr);
    pthread_attr_setstacksize(&attr, adjusted_stack_size);
-   pthread_create(&id, &attr, run, (void *)&args);
+   result = pthread_create(&id, &attr, run, (void *)&args);
    if (result != 0) {
      fprintf(stderr, "Error: pthread_create failed with error code %d \n", result);
      return -1;

--- a/test/hotspot/jtreg/runtime/jni/daemonDestroy/exedaemonDestroy.c
+++ b/test/hotspot/jtreg/runtime/jni/daemonDestroy/exedaemonDestroy.c
@@ -127,6 +127,10 @@ int main(int argc, char *argv[]) {
    pthread_attr_init(&attr);
    pthread_attr_setstacksize(&attr, adjusted_stack_size);
    pthread_create(&id, &attr, run, (void *)&args);
+   if (result != 0) {
+     fprintf(stderr, "Error: pthread_create failed with error code %d \n", result);
+     return -1;
+   }      
    pthread_join(id, NULL);
 #else
    run(&args);

--- a/test/hotspot/jtreg/runtime/jni/daemonDestroy/exedaemonDestroy.c
+++ b/test/hotspot/jtreg/runtime/jni/daemonDestroy/exedaemonDestroy.c
@@ -123,6 +123,7 @@ int main(int argc, char *argv[]) {
 #ifdef AIX
    size_t adjusted_stack_size = 1024*1024;
    pthread_t id;
+   int result;
    pthread_attr_t attr;
    pthread_attr_init(&attr);
    pthread_attr_setstacksize(&attr, adjusted_stack_size);
@@ -130,7 +131,7 @@ int main(int argc, char *argv[]) {
    if (result != 0) {
      fprintf(stderr, "Error: pthread_create failed with error code %d \n", result);
      return -1;
-   }      
+   }
    pthread_join(id, NULL);
 #else
    run(&args);

--- a/test/hotspot/jtreg/runtime/jni/daemonDestroy/exedaemonDestroy.c
+++ b/test/hotspot/jtreg/runtime/jni/daemonDestroy/exedaemonDestroy.c
@@ -125,8 +125,6 @@ int main(int argc, char *argv[]) {
    pthread_t id;
    pthread_attr_t attr;
    pthread_attr_init(&attr);
-   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-   pthread_attr_setguardsize(&attr, 0);
    pthread_attr_setstacksize(&attr, adjusted_stack_size);
    pthread_create(&id, &attr, run, (void *)&args);
    pthread_join(id, NULL);


### PR DESCRIPTION
The assertion failure with exit value 134 for the test TestDaemonDestroy.java is because when the JNI_CreateJavaVM is being called by main thread on AIX it prevents the jvm creation on the primordial thread on AIX. This is solved in such a way that when JNI_CreateJavaVM is called it runs in pthread thus enabling the creation of jvm. 

JBS issue for this test : [JDK-8300295](https://bugs.openjdk.org/browse/JDK-8300295)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300295](https://bugs.openjdk.org/browse/JDK-8300295): [AIX] TestDaemonDestroy fails due to !is_primordial_thread assertion


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12006/head:pull/12006` \
`$ git checkout pull/12006`

Update a local copy of the PR: \
`$ git checkout pull/12006` \
`$ git pull https://git.openjdk.org/jdk pull/12006/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12006`

View PR using the GUI difftool: \
`$ git pr show -t 12006`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12006.diff">https://git.openjdk.org/jdk/pull/12006.diff</a>

</details>
