### PR TITLE
8299213: Bad cast in GrowableArrayWithAllocator<>::grow

### DIFF
--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -514,7 +514,7 @@ void GrowableArrayWithAllocator<E, Derived>::expand_to(int new_capacity) {
 template <typename E, typename Derived>
 void GrowableArrayWithAllocator<E, Derived>::grow(int j) {
   // grow the array by increasing _capacity to the first power of two larger than the size we need
-  expand_to(next_power_of_2((uint32_t)j));
+  expand_to(next_power_of_2(j));
 }
 
 template <typename E, typename Derived>


### PR DESCRIPTION
### Description 
The grow size was wrongfully casted from `int` to `uint32`.

### Patch
The casting is removed.

### Tests
Local: **gtest:GrowableArrays***
mach5 tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299213](https://bugs.openjdk.org/browse/JDK-8299213): Bad cast in GrowableArrayWithAllocator<>::grow


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - Committer)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12007/head:pull/12007` \
`$ git checkout pull/12007`

Update a local copy of the PR: \
`$ git checkout pull/12007` \
`$ git pull https://git.openjdk.org/jdk pull/12007/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12007`

View PR using the GUI difftool: \
`$ git pr show -t 12007`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12007.diff">https://git.openjdk.org/jdk/pull/12007.diff</a>

</details>
