### PR TITLE
8300259: Add test coverage for processing of pending block files in signed JARs

### DIFF
--- a/test/jdk/java/util/jar/JarFile/PendingBlocksJar.java
+++ b/test/jdk/java/util/jar/JarFile/PendingBlocksJar.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @modules java.base/sun.security.tools.keytool
+ * @summary JARs with pending signature files (where .RSA comes before .SF) should verify correctly
+ */
+
+import jdk.security.jarsigner.JarSigner;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.cert.CertPath;
+import java.security.cert.CertificateFactory;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.jar.*;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+public class PendingBlocksJar {
+
+    public static void main(String[] args) throws Exception {
+        File jar = createJarFile();
+        File signed = signJarFile(jar);
+        File pendingBlocks = moveBlockFirst(signed);
+        File invalid = invalidate(pendingBlocks);
+
+        // 1: Regular signed JAR with no pending blocks should verify
+        checkSigned(signed);
+
+        // 2: Signed jar with pending blocks should verify
+        checkSigned(pendingBlocks);
+
+        // 3: Invalid signed jar with pending blocks should throw SecurityException
+        try {
+            checkSigned(invalid);
+            throw new Exception("Expected invalid digest to be detected");
+        } catch (SecurityException se) {
+            // Ignore
+        }
+    }
+
+    private static void checkSigned(File b) throws Exception {
+        try(JarFile jf = new JarFile(b, true)) {
+
+            JarEntry je = jf.getJarEntry("a.txt");
+            try(InputStream in = jf.getInputStream(je)) {
+                in.transferTo(OutputStream.nullOutputStream());
+            }
+        }
+    }
+
+    /**
+     * Invalidate signed file by modifying the contents of "a.txt"
+     */
+    private static File invalidate(File s) throws Exception{
+        File invalid = File.createTempFile("pending-block-file-invalidated-", ".jar");
+
+        try(ZipFile zip = new ZipFile(s);
+            ZipOutputStream out = new ZipOutputStream(new FileOutputStream(invalid))) {
+
+            for(ZipEntry ze : Collections.list(zip.entries())) {
+                String name = ze.getName();
+                out.putNextEntry(new ZipEntry(name));
+
+                if (name.equals("a.txt")) {
+                    // Change the contents of a.txt to trigger SignatureException
+                    out.write("b".getBytes(StandardCharsets.UTF_8));
+                } else {
+                    try (InputStream in = zip.getInputStream(ze)) {
+                        in.transferTo(out);
+                    }
+                }
+            }
+        }
+        return invalid;
+    }
+
+    private static File moveBlockFirst(File s) throws Exception {
+        File b = File.createTempFile("pending-block-file-blockfirst-", ".jar");
+        try(ZipFile in = new ZipFile(s);
+            ZipOutputStream out = new ZipOutputStream(new FileOutputStream(b))) {
+
+            copy("META-INF/MANIFEST.MF", in, out);
+
+            // Switch the order of the RSA and SF files
+            copy("META-INF/SIGNER.RSA", in, out);
+            copy("META-INF/SIGNER.SF", in, out);
+
+            copy("a.txt", in, out);
+        }
+        return b;
+    }
+
+    /**
+     * Copy an entry from a ZipFile to a ZipOutputStream
+     */
+    private static void copy(String name, ZipFile in, ZipOutputStream out) throws Exception {
+        out.putNextEntry(new ZipEntry(name));
+        try(InputStream is = in.getInputStream(in.getEntry(name))) {
+            is.transferTo(out);
+        }
+    }
+
+    private static File signJarFile(File f) throws Exception {
+        File s = File.createTempFile("pending-block-file-signed-", ".jar");
+
+        new File("ks").delete();
+
+        sun.security.tools.keytool.Main.main(
+                ("-keystore ks -storepass changeit -keypass changeit -dname" +
+                        " CN=SIGNER" +" -alias r -genkeypair -keyalg rsa").split(" "));
+
+        char[] pass = "changeit".toCharArray();
+
+        KeyStore ks = KeyStore.getInstance(
+                new File("ks"), pass);
+        PrivateKey pkr = (PrivateKey)ks.getKey("r", pass);
+
+        CertPath cp = CertificateFactory.getInstance("X.509")
+                .generateCertPath(Arrays.asList(ks.getCertificateChain("r")));
+
+        JarSigner signer = new JarSigner.Builder(pkr, cp)
+                .digestAlgorithm("SHA-256")
+                .signatureAlgorithm("SHA256withRSA")
+                .signerName("SIGNER")
+                .build();
+
+        try(ZipFile in = new ZipFile(f);
+            OutputStream out = new FileOutputStream(s)) {
+            signer.sign(in, out);
+        }
+
+        return s;
+    }
+
+    /**
+     * Create a jar file with single entry "a.txt" containing "a"
+     */
+    private static File createJarFile() throws Exception {
+        File f = File.createTempFile("pending-block-file-", ".jar");
+        Manifest manifest = new Manifest();
+        manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        try(JarOutputStream out = new JarOutputStream(new FileOutputStream(f), manifest)) {
+            out.putNextEntry(new JarEntry("a.txt"));
+            out.write("a".getBytes(StandardCharsets.UTF_8));
+        }
+        return f;
+    }
+}

--- a/test/jdk/java/util/jar/JarFile/PendingBlocksJar.java
+++ b/test/jdk/java/util/jar/JarFile/PendingBlocksJar.java
@@ -141,14 +141,12 @@ public class PendingBlocksJar {
 
         char[] pass = "changeit".toCharArray();
 
-        KeyStore ks = KeyStore.getInstance(
-                new File("ks"), pass);
-        PrivateKey pkr = (PrivateKey)ks.getKey("r", pass);
+        KeyStore ks = KeyStore.getInstance(new File("ks"), pass);
 
-        CertPath cp = CertificateFactory.getInstance("X.509")
-                .generateCertPath(Arrays.asList(ks.getCertificateChain("r")));
+        KeyStore.PrivateKeyEntry pke = (KeyStore.PrivateKeyEntry)
+                ks.getEntry("r", new KeyStore.PasswordProtection(pass));
 
-        JarSigner signer = new JarSigner.Builder(pkr, cp)
+        JarSigner signer = new JarSigner.Builder(pke)
                 .digestAlgorithm("SHA-256")
                 .signatureAlgorithm("SHA256withRSA")
                 .signerName("SIGNER")

--- a/test/jdk/java/util/jar/JarFile/PendingBlocksJar.java
+++ b/test/jdk/java/util/jar/JarFile/PendingBlocksJar.java
@@ -69,10 +69,10 @@ public class PendingBlocksJar {
     }
 
     private static void checkSigned(File b) throws Exception {
-        try(JarFile jf = new JarFile(b, true)) {
+        try (JarFile jf = new JarFile(b, true)) {
 
             JarEntry je = jf.getJarEntry("a.txt");
-            try(InputStream in = jf.getInputStream(je)) {
+            try (InputStream in = jf.getInputStream(je)) {
                 in.transferTo(OutputStream.nullOutputStream());
             }
         }
@@ -84,10 +84,10 @@ public class PendingBlocksJar {
     private static File invalidate(File s) throws Exception{
         File invalid = File.createTempFile("pending-block-file-invalidated-", ".jar");
 
-        try(ZipFile zip = new ZipFile(s);
+        try (ZipFile zip = new ZipFile(s);
             ZipOutputStream out = new ZipOutputStream(new FileOutputStream(invalid))) {
 
-            for(ZipEntry ze : Collections.list(zip.entries())) {
+            for (ZipEntry ze : Collections.list(zip.entries())) {
                 String name = ze.getName();
                 out.putNextEntry(new ZipEntry(name));
 
@@ -106,7 +106,7 @@ public class PendingBlocksJar {
 
     private static File moveBlockFirst(File s) throws Exception {
         File b = File.createTempFile("pending-block-file-blockfirst-", ".jar");
-        try(ZipFile in = new ZipFile(s);
+        try (ZipFile in = new ZipFile(s);
             ZipOutputStream out = new ZipOutputStream(new FileOutputStream(b))) {
 
             copy("META-INF/MANIFEST.MF", in, out);
@@ -125,7 +125,7 @@ public class PendingBlocksJar {
      */
     private static void copy(String name, ZipFile in, ZipOutputStream out) throws Exception {
         out.putNextEntry(new ZipEntry(name));
-        try(InputStream is = in.getInputStream(in.getEntry(name))) {
+        try (InputStream is = in.getInputStream(in.getEntry(name))) {
             is.transferTo(out);
         }
     }
@@ -152,7 +152,7 @@ public class PendingBlocksJar {
                 .signerName("SIGNER")
                 .build();
 
-        try(ZipFile in = new ZipFile(f);
+        try (ZipFile in = new ZipFile(f);
             OutputStream out = new FileOutputStream(s)) {
             signer.sign(in, out);
         }
@@ -167,7 +167,7 @@ public class PendingBlocksJar {
         File f = File.createTempFile("pending-block-file-", ".jar");
         Manifest manifest = new Manifest();
         manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
-        try(JarOutputStream out = new JarOutputStream(new FileOutputStream(f), manifest)) {
+        try (JarOutputStream out = new JarOutputStream(new FileOutputStream(f), manifest)) {
             out.putNextEntry(new JarEntry("a.txt"));
             out.write("a".getBytes(StandardCharsets.UTF_8));
         }

--- a/test/jdk/java/util/jar/JarFile/SignedJarPendingBlock.java
+++ b/test/jdk/java/util/jar/JarFile/SignedJarPendingBlock.java
@@ -42,7 +42,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
-public class PendingBlocksJar {
+public class SignedJarPendingBlock {
 
     public static void main(String[] args) throws Exception {
         Path jar = createJarFile();

--- a/test/jdk/java/util/jar/JarFile/SignedJarPendingBlock.java
+++ b/test/jdk/java/util/jar/JarFile/SignedJarPendingBlock.java
@@ -24,7 +24,7 @@
 /**
  * @test
  * @modules java.base/sun.security.tools.keytool
- * @summary JARs with pending signature files (where .RSA comes before .SF) should verify correctly
+ * @summary JARs with pending block files (where .RSA comes before .SF) should verify correctly
  */
 
 import jdk.security.jarsigner.JarSigner;


### PR DESCRIPTION
This PR adds test coverage for pending block files in signed JAR files

A signed JAR has pending block files if the block file [RSA, DSA, EC] comes before the corresponding signature file [SF] in the JAR. 

JarVerifier.processEntry supports processing of such pending block files, but this code path does not seem to be exercised by current test.

The new test PendingBlocksJar checks that signed JARs  with pending blocks are processed correctly, both for the valid and invalid cases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300259](https://bugs.openjdk.org/browse/JDK-8300259): Add test coverage for processing of pending block files in signed JARs


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12009/head:pull/12009` \
`$ git checkout pull/12009`

Update a local copy of the PR: \
`$ git checkout pull/12009` \
`$ git pull https://git.openjdk.org/jdk pull/12009/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12009`

View PR using the GUI difftool: \
`$ git pr show -t 12009`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12009.diff">https://git.openjdk.org/jdk/pull/12009.diff</a>

</details>
