### PR TITLE
8293862: javax/swing/JFileChooser/8046391/bug8046391.java failed with 'Cannot invoke "java.awt.Image.getWidth(java.awt.image.ImageObserver)" because "retVal" is null'

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
@@ -1131,6 +1131,14 @@ final class Win32ShellFolder2 extends ShellFolder {
     }
 
     /**
+     * The data is not available yet.
+     * @see
+     * <a href="https://learn.microsoft.com/en-us/windows/win32/com/com-error-codes-1">COM
+     * Error Codes</a>.
+     */
+    private static final long E_PENDING = 0x8000000AL;
+
+    /**
      * @return The icon image of specified size used to display this shell folder
      */
     public Image getIcon(int width, int height) {
@@ -1155,10 +1163,10 @@ final class Win32ShellFolder2 extends ShellFolder {
                             getRelativePIDL(), s, false);
 
                     // E_PENDING: loading can take time so get the default
-                    if (hIcon <= 0) {
+                    if (hIcon == E_PENDING || hIcon == 0) {
                         hIcon = extractIcon(getParentIShellFolder(),
                                 getRelativePIDL(), s, true);
-                        if (hIcon <= 0) {
+                        if (hIcon == 0) {
                             if (isDirectory()) {
                                 newIcon = getShell32Icon(FOLDER_ICON_ID, size);
                             } else {
@@ -1395,11 +1403,14 @@ final class Win32ShellFolder2 extends ShellFolder {
         final Map<Integer, Image> resolutionVariants = new HashMap<>();
 
         public MultiResolutionIconImage(int baseSize, Map<Integer, Image> resolutionVariants) {
+            assert !resolutionVariants.containsValue(null)
+                   : "There are null icons in the MRI variants map";
             this.baseSize = baseSize;
             this.resolutionVariants.putAll(resolutionVariants);
         }
 
         public MultiResolutionIconImage(int baseSize, Image image) {
+            assert image != null : "Null icon passed as the base image for MRI";
             this.baseSize = baseSize;
             this.resolutionVariants.put(baseSize, image);
         }

--- a/src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -974,7 +974,7 @@ JNIEXPORT jlong JNICALL Java_sun_awt_shell_Win32ShellFolder2_extractIcon
         return 0;
     }
 
-    HICON hIcon = NULL;
+    HICON hIcon;
 
     HRESULT hres;
     IExtractIconW* pIcon;
@@ -995,15 +995,21 @@ JNIEXPORT jlong JNICALL Java_sun_awt_shell_Win32ShellFolder2_extractIcon
                 iconSize = (16 << 16) + size;
             }
             hres = pIcon->Extract(szBuf, index, &hIcon, &hIconSmall, iconSize);
-            if (size < 24) {
-                fn_DestroyIcon((HICON)hIcon);
-                hIcon = hIconSmall;
+            if (SUCCEEDED(hres)) {
+                if (size < 24) {
+                    fn_DestroyIcon((HICON)hIcon);
+                    hIcon = hIconSmall;
+                } else {
+                    fn_DestroyIcon((HICON)hIconSmall);
+                }
             } else {
-                fn_DestroyIcon((HICON)hIconSmall);
+                hIcon = NULL;
             }
         } else if (hres == E_PENDING) {
             pIcon->Release();
-            return E_PENDING;
+            return (unsigned) E_PENDING;
+        } else {
+            hIcon = NULL;
         }
         pIcon->Release();
     }

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -672,8 +672,6 @@ java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 m
 javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8274106 macosx-aarch64
 
 java/awt/Mouse/EnterExitEvents/DragWindowTest.java 8298823 macosx-all
-javax/swing/JFileChooser/8046391/bug8046391.java 8293862 windows-x64
-javax/swing/JFileChooser/4847375/bug4847375.java 8293862 windows-x64
 java/awt/Focus/NonFocusableWindowTest/NonfocusableOwnerTest.java 8280392 windows-x64
 java/awt/Mixing/AWT_Mixing/OpaqueOverlapping.java 8294264 windows-x64
 java/awt/Mixing/AWT_Mixing/ViewportOverlapping.java 8253184,8295813 windows-x64

--- a/test/jdk/javax/swing/JFileChooser/8046391/bug8046391.java
+++ b/test/jdk/javax/swing/JFileChooser/8046391/bug8046391.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8046391
+ * @bug 8046391 8293862
  * @requires (os.family == "windows")
  * @summary JFileChooser hangs if displayed in Windows L&F
  * @author Alexey Ivanov


### PR DESCRIPTION
This is somewhat a continuation of #11104 where the issue was discussed and where I found [the root cause](https://github.com/openjdk/jdk/pull/11104#issuecomment-1382435784).

**Root Cause**

The icon extraction code compares the returned handle to zero: 
https://github.com/openjdk/jdk/blob/8cb25d3de494c6d9357a1c199e1a9dbff9be9948/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java#L1157-L1158

On 64-bit systems, a valid handle can be negative. For example:

```text
getIcon : Desktop 16(16)
GetIconLocation(uFlags=0x22, flags=0x4, index=-110) SUCCESS - szBuf=C:\Windows\system32\imageres.dll
Extract - hres: 0, hIcon=0000000019B200F9, hIconSmall=FFFFFFFFF98C00EB, size=16(0x100020)
SUCCEEDED
!!! hIcon(0xfffffffff98c00eb) <= 0 : Desktop 16(16)
```

Here in `size=16(0x100020)`, 16 is the requested icon size, the value in parenthesis is value of `iconSize` passed to the [`Extract`](https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-iextracticonw-extract) method that contains the size for small icon in high word and that for large icon in low word. `Desktop 16(16)` means the icon of size 16×16 is requested, and we're extracting 16×16 icon.

The icon was extracted _successfully_ but its handle was interpreted as an error.

The same problem exists in the fallback code:
https://github.com/openjdk/jdk/blob/8cb25d3de494c6d9357a1c199e1a9dbff9be9948/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java#L1161

Then when the fallback code is executed, another problem occurs:

```text
GetIconLocation(uFlags=0x40, flags=0x1a3, index=-675088752) SUCCESS - szBuf=
Extract - hres: 80004005, hIcon=0000000000000000, hIconSmall=000001A3D7C2F83A, size=16(100020)
NOT SUCCEEDED
hIcon = 0x1a3d7c2f83a : Desktop 16(16)
```

The error code 0x80004005 is `E_FAIL`. Yet the return value is not verified in the code:
https://github.com/openjdk/jdk/blob/8cb25d3de494c6d9357a1c199e1a9dbff9be9948/src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp#L997-L1003

Since the icon handle is *seemingly* valid, it continues to extracting the icon bits:

```text
native getIconBits - fn_GetIconInfo returned false
Error code: 0x57a - Invalid cursor handle.
makeIcon: iconBits = null
```

It's not a surprise. After all, the `Extract` method returned an error, which means neither icon handle is valid.

In the end, the `MultiResolutionIcon` contains `null`:
```text
    16 -> null
    32 -> [BufferedImage@59e735d](mailto:BufferedImage@59e735d)
    24 -> [BufferedImage@60b2faf0](mailto:BufferedImage@60b2faf0)
```

This problem has existed for since [JDK-8182043](https://bugs.openjdk.org/browse/JDK-8182043), yet it went unnoticed because `getResolutionVariant` just returned a null. However, after [JDK-8282526](https://bugs.openjdk.org/browse/JDK-8282526) was integrated, the result is used, which leads to `NullPointerException`.


**The Fix**

Handle the errors as `hIcon == E_PENDING || hIcon == 0` and `hIcon == 0`. In the fallback code where a default icon is requested, [`E_PENDING` cannot be returned](https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-iextracticonw-geticonlocation#remarks), it's valid only if `GIL_ASYNC` flag is used.

Add `assert` statements to `MultiResolutionIconImage` for null-checks which will help us to catch a similar situation if it occurs.

**Testing**

The two errors combined lead to random failures. No particular host reproduced the problem more often.

While I was testing with the additional traces, sometimes 5 of 10 tests failed, other times only 1 of 10. There were a couple of test runs where no failures occurred.

With the fix applied, no failures occurred.