### PR TITLE
JDK-8300205: Swing test bug8078268 make latch timeout configurable

### DIFF
--- a/test/jdk/javax/swing/text/html/parser/Parser/8078268/bug8078268.java
+++ b/test/jdk/javax/swing/text/html/parser/Parser/8078268/bug8078268.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -38,8 +38,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
    @run main bug8078268
 */
 public class bug8078268 {
-    private static final float timeoutFactor = Float.parseFloat(System.getProperty("test.timeout.factor", "1.0"));
-    private static final long TIMEOUT = 10_000 * (long)timeoutFactor;
+    private static final float tf = Float.parseFloat(System.getProperty("test.timeout.factor", "1.0"));
+    private static final long TIMEOUT = 10_000 * (long)tf;
 
     private static final String FILENAME = "slowparse.html";
 

--- a/test/jdk/javax/swing/text/html/parser/Parser/8078268/bug8078268.java
+++ b/test/jdk/javax/swing/text/html/parser/Parser/8078268/bug8078268.java
@@ -38,7 +38,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
    @run main bug8078268
 */
 public class bug8078268 {
-    private static final long TIMEOUT = 10_000;
+    private static final float timeoutFactor = Float.parseFloat(System.getProperty("test.timeout.factor", "1.0"));
+    private static final long TIMEOUT = 10_000 * (long)timeoutFactor;
 
     private static final String FILENAME = "slowparse.html";
 
@@ -61,7 +62,7 @@ public class bug8078268 {
         });
 
         if (!latch.await(TIMEOUT, MILLISECONDS)) {
-            throw new RuntimeException("Parsing takes too long.");
+            throw new RuntimeException("Parsing takes too long. Current timeout is " + TIMEOUT);
         }
         if (exception != null) {
             throw exception;


### PR DESCRIPTION
The test javax/swing/text/html/parser/Parser/8078268/bug8078268.java has a latch timeout that is currently fix but should better be configurable to better deal with slow test infrastructures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300205](https://bugs.openjdk.org/browse/JDK-8300205): Swing test bug8078268 make latch timeout configurable


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**) ⚠️ Review applies to [0c46dace](https://git.openjdk.org/jdk/pull/12011/files/0c46dacedc2992be45d04a627a5f27b649f66b99)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to [0c46dace](https://git.openjdk.org/jdk/pull/12011/files/0c46dacedc2992be45d04a627a5f27b649f66b99)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12011/head:pull/12011` \
`$ git checkout pull/12011`

Update a local copy of the PR: \
`$ git checkout pull/12011` \
`$ git pull https://git.openjdk.org/jdk pull/12011/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12011`

View PR using the GUI difftool: \
`$ git pr show -t 12011`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12011.diff">https://git.openjdk.org/jdk/pull/12011.diff</a>

</details>
