### PR TITLE
8299074: nmethod marked for deoptimization is not deoptimized

### DIFF
--- a/src/hotspot/share/code/dependencyContext.cpp
+++ b/src/hotspot/share/code/dependencyContext.cpp
@@ -68,16 +68,22 @@ int DependencyContext::mark_dependent_nmethods(DepChange& changes) {
   int found = 0;
   for (nmethodBucket* b = dependencies_not_unloading(); b != NULL; b = b->next_not_unloading()) {
     nmethod* nm = b->get_nmethod();
-    if (b->count() > 0 && nm->check_dependency_on(changes)) {
-      if (TraceDependencies) {
-        ResourceMark rm;
-        tty->print_cr("Marked for deoptimization");
-        changes.print();
-        nm->print();
-        nm->print_dependencies();
+    if (b->count() > 0) {
+      if (nm->is_marked_for_deoptimization()) {
+        // Also count already (concurrently) marked nmethods to make sure
+        // deoptimization is triggered before execution in this thread continues.
+        found++;
+      } else if (nm->check_dependency_on(changes)) {
+        if (TraceDependencies) {
+          ResourceMark rm;
+          tty->print_cr("Marked for deoptimization");
+          changes.print();
+          nm->print();
+          nm->print_dependencies();
+        }
+        changes.mark_for_deoptimization(nm);
+        found++;
       }
-      changes.mark_for_deoptimization(nm);
-      found++;
     }
   }
   return found;
@@ -190,6 +196,8 @@ int DependencyContext::remove_and_mark_for_deoptimization_all_dependents() {
   while (b != NULL) {
     nmethod* nm = b->get_nmethod();
     if (b->count() > 0) {
+      // Also count already (concurrently) marked nmethods to make sure
+      // deoptimization is triggered before execution in this thread continues.
       nm->mark_for_deoptimization();
       marked++;
     }

--- a/src/hotspot/share/code/dependencyContext.cpp
+++ b/src/hotspot/share/code/dependencyContext.cpp
@@ -68,7 +68,7 @@ int DependencyContext::mark_dependent_nmethods(DepChange& changes) {
   int found = 0;
   for (nmethodBucket* b = dependencies_not_unloading(); b != NULL; b = b->next_not_unloading()) {
     nmethod* nm = b->get_nmethod();
-    if (b->count() > 0 && !nm->is_marked_for_deoptimization() && nm->check_dependency_on(changes)) {
+    if (b->count() > 0 && nm->check_dependency_on(changes)) {
       if (TraceDependencies) {
         ResourceMark rm;
         tty->print_cr("Marked for deoptimization");
@@ -189,7 +189,7 @@ int DependencyContext::remove_and_mark_for_deoptimization_all_dependents() {
   int marked = 0;
   while (b != NULL) {
     nmethod* nm = b->get_nmethod();
-    if (b->count() > 0 && !nm->is_marked_for_deoptimization()) {
+    if (b->count() > 0) {
       nm->mark_for_deoptimization();
       marked++;
     }


### PR DESCRIPTION
In the failing `UnexpectedDeoptimizationAllTest` there is a race condition between one thread repeatedly calling `WB_DeoptimizeAll()` and the main thread checking nmethod dependencies on class loading and also attempting marking/deoptimization of nmethods due to dependency violations. The problem is that already (concurrently) marked nmethods are not counted and if no new nmethods are marked, we then wrongly assume that there is no need to call `deoptimize_all_marked`:
https://github.com/openjdk/jdk/blob/08008139cc05a8271e7163eca47d2bc59db2049b/src/hotspot/share/code/codeCache.cpp#L1438-L1440

Details:

**Thread 1:** Method `useNativeAccessor(Executable member)` is compiled under the assumption that its argument type `java.lang.reflect.Executable` has only one implementer `java.lang.reflect.Method`. A corresponding dependency is registered in the nmethod and a virtual call to `member.getParameterCount()` is inlined to `java.lang.reflect.Method::getParameterCount()`.

**Thread 2:** Calls Whitebox API method `WB_DeoptimizeAll` -> `CodeCache::mark_all_nmethods_for_deoptimization()` that marks `useNativeAccessor` for deoptimization.

**Thread 1:** Triggers class loading of `java.lang.reflect.Constructor` and `CodeCache::flush_dependents_on` -> `CodeCache::mark_for_deoptimization` -> ... -> `DependencyContext::mark_dependent_nmethods` detects that `useNativeAccessor` needs to be deoptimized now that `java.lang.reflect.Executable` has more than one implementer. However, the nmethod is already marked for deoptimization (most nmethods are) and therefore ignored. The marked counter is 0 and therefore `Deoptimization::deoptimize_all_marked()` is not executed either. The thread continues execution and ends up crashing because a `java.lang.reflect.Constructor` object is passed to compiled `useNativeAccessor` which can not handle it (we call the wrong `getParameterCount` on it).

**Thread 2:** Is still in `WB_DeoptimizeAll`, marking nmethods for deoptimization but didn't get a chance to call `Deoptimization::deoptimize_all_marked()` yet.

Before [JDK-8221734](https://bugs.openjdk.org/browse/JDK-8221734) in JDK 13, `WB_DeoptimizeAll` acquired the `Compile_lock` but it got [removed](http://hg.openjdk.java.net/jdk/jdk/rev/9b70ebd131b4#l15.7). Instead of re-adding the lock, I modified the code to also count nmethods that were already marked for deoptimization, as suggested by @robehn in the bug comments.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299074](https://bugs.openjdk.org/browse/JDK-8299074): nmethod marked for deoptimization is not deoptimized


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to [5ac3fdde](https://git.openjdk.org/jdk/pull/12012/files/5ac3fddebfb8f18577cae8f94332c72de5089abf)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12012/head:pull/12012` \
`$ git checkout pull/12012`

Update a local copy of the PR: \
`$ git checkout pull/12012` \
`$ git pull https://git.openjdk.org/jdk pull/12012/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12012`

View PR using the GUI difftool: \
`$ git pr show -t 12012`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12012.diff">https://git.openjdk.org/jdk/pull/12012.diff</a>

</details>
