### PR TITLE
JDK-8300222: Replace NULL with nullptr in share/logging

### DIFF
--- a/src/hotspot/share/logging/log.hpp
+++ b/src/hotspot/share/logging/log.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -164,7 +164,7 @@ class LogImpl {
     return is_level(LogLevel::level); \
   } \
   static LogTargetImpl<LogLevel::level, T0, T1, T2, T3, T4, GuardTag>* name() { \
-    return (LogTargetImpl<LogLevel::level, T0, T1, T2, T3, T4, GuardTag>*)NULL; \
+    return (LogTargetImpl<LogLevel::level, T0, T1, T2, T3, T4, GuardTag>*)nullptr; \
   }
   LOG_LEVEL_LIST
 #undef LOG_LEVEL

--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -192,10 +192,10 @@ void AsyncLogWriter::initialize() {
   AsyncLogWriter* self = new AsyncLogWriter();
   if (self->_initialized) {
     Atomic::release_store_fence(&AsyncLogWriter::_instance, self);
-    // All readers of _instance after the fence see non-NULL.
+    // All readers of _instance after the fence see non-nullptr.
     // We use LogOutputList's RCU counters to ensure all synchronous logsites have completed.
     // After that, we start AsyncLog Thread and it exclusively takes over all logging I/O.
-    for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+    for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
       ts->wait_until_no_readers();
     }
     os::start_thread(self);

--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,10 +40,10 @@
 #include "runtime/semaphore.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-LogOutput** LogConfiguration::_outputs = NULL;
+LogOutput** LogConfiguration::_outputs = nullptr;
 size_t      LogConfiguration::_n_outputs = 0;
 
-LogConfiguration::UpdateListenerFunction* LogConfiguration::_listener_callbacks = NULL;
+LogConfiguration::UpdateListenerFunction* LogConfiguration::_listener_callbacks = nullptr;
 size_t      LogConfiguration::_n_listener_callbacks = 0;
 
 // LogFileOutput is the default type of output, its type prefix should be used if no type was specified
@@ -105,7 +105,7 @@ void LogConfiguration::initialize(jlong vm_start_time) {
   StdoutLog = new LogStdoutOutput();
   StderrLog = new LogStderrOutput();
   LogFileOutput::set_file_name_parameters(vm_start_time);
-  assert(_outputs == NULL, "Should not initialize _outputs before this function, initialize called twice?");
+  assert(_outputs == nullptr, "Should not initialize _outputs before this function, initialize called twice?");
   _outputs = NEW_C_HEAP_ARRAY(LogOutput*, 2, mtLogging);
   _outputs[0] = StdoutLog;
   _outputs[1] = StderrLog;
@@ -114,7 +114,7 @@ void LogConfiguration::initialize(jlong vm_start_time) {
   _outputs[1]->set_config_string("all=off");
 
   // Set the default output to warning and error level for all new tagsets.
-  for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+  for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
     ts->set_output_level(StdoutLog, LogLevel::Default);
   }
 }
@@ -129,18 +129,18 @@ void LogConfiguration::finalize() {
 static bool normalize_output_name(const char* full_name, char* buffer, size_t len, outputStream* errstream) {
   const char* start_quote = strchr(full_name, '"');
   const char* equals = strchr(full_name, '=');
-  const bool quoted = start_quote != NULL;
+  const bool quoted = start_quote != nullptr;
   const bool is_stdout_or_stderr = (strcmp(full_name, "stdout") == 0 || strcmp(full_name, "stderr") == 0);
 
   // ignore equals sign within quotes
   if (quoted && equals > start_quote) {
-    equals = NULL;
+    equals = nullptr;
   }
 
   const char* prefix = "";
   size_t prefix_len = 0;
   const char* name = full_name;
-  if (equals != NULL) {
+  if (equals != nullptr) {
     // split on equals sign
     name = equals + 1;
     prefix = full_name;
@@ -153,7 +153,7 @@ static bool normalize_output_name(const char* full_name, char* buffer, size_t le
 
   if (quoted) {
     const char* end_quote = strchr(start_quote + 1, '"');
-    if (end_quote == NULL) {
+    if (end_quote == nullptr) {
       errstream->print_cr("Output name has opening quote but is missing a terminating quote.");
       return false;
     }
@@ -190,14 +190,14 @@ LogOutput* LogConfiguration::new_output(const char* name,
     output = new LogFileOutput(name);
   } else {
     errstream->print_cr("Unsupported log output type: %s", name);
-    return NULL;
+    return nullptr;
   }
 
   bool success = output->initialize(options, errstream);
   if (!success) {
     errstream->print_cr("Initialization of output '%s' using options '%s' failed.", name, options);
     delete output;
-    return NULL;
+    return nullptr;
   }
   return output;
 }
@@ -245,7 +245,7 @@ void LogConfiguration::configure_output(size_t idx, const LogSelectionList& sele
   size_t on_level[LogLevel::Count] = {0};
 
   bool enabled = false;
-  for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+  for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
     LogLevelType level = selections.level_for(*ts);
 
     // Ignore tagsets that do not, and will not log on the output
@@ -285,7 +285,7 @@ void LogConfiguration::configure_output(size_t idx, const LogSelectionList& sele
   output->set_decorators(decorators);
 
   // Update the decorators on all tagsets to get rid of unused decorators
-  for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+  for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
     ts->update_decorators();
   }
 
@@ -303,7 +303,7 @@ void LogConfiguration::disable_outputs() {
   size_t idx = _n_outputs;
 
   // Remove all outputs from all tagsets.
-  for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+  for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
     ts->disable_outputs();
   }
 
@@ -328,7 +328,7 @@ void LogConfiguration::disable_logging() {
   ConfigurationLock cl;
   disable_outputs();
   // Update the decorators on all tagsets to get rid of unused decorators
-  for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+  for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
     ts->update_decorators();
   }
   notify_update_listeners();
@@ -376,15 +376,15 @@ bool LogConfiguration::parse_command_line_arguments(const char* opts) {
 #ifdef _WINDOWS
     // Skip over Windows paths such as "C:\..." and "C:/...".
     // Handles both "C:\..." and "file=C:\...".
-    if (next != NULL && next[0] == ':' && (next[1] == '\\' || next[1] == '/')) {
+    if (next != nullptr && next[0] == ':' && (next[1] == '\\' || next[1] == '/')) {
       if (next == str + 1 || (strncmp(str, "file=", 5) == 0)) {
         next = strpbrk(next + 1, ":\"");
       }
     }
 #endif
-    while (next != NULL && *next == '"') {
+    while (next != nullptr && *next == '"') {
       char* end_quote = strchr(next + 1, '"');
-      if (end_quote == NULL) {
+      if (end_quote == nullptr) {
         log_error(logging)("Missing terminating quote in -Xlog option '%s'", str);
         os::free(copy);
         return false;
@@ -393,16 +393,16 @@ bool LogConfiguration::parse_command_line_arguments(const char* opts) {
       next = strpbrk(end_quote + 1, ":\"");
     }
 
-    if (next != NULL) {
+    if (next != nullptr) {
       *next = '\0';
       str = next + 1;
     } else {
-      str = NULL;
+      str = nullptr;
       break;
     }
   }
 
-  if (str != NULL) {
+  if (str != nullptr) {
     log_warning(logging)("Ignoring excess -Xlog options: \"%s\"", str);
   }
 
@@ -423,13 +423,13 @@ bool LogConfiguration::parse_command_line_arguments(const char* opts) {
   // (parse_log_arguments() will report an error), but we make an exception for
   // both StdoutLog and StderrLog as they're initialized automatically
   // very early in the boot process.
-  if (output == NULL || strlen(output) == 0 ||
+  if (output == nullptr || strlen(output) == 0 ||
       strcmp("stdout", output) == 0 || strcmp("#0", output) == 0) {
     if (!stdout_configured) {
       success = StdoutLog->parse_options(output_options, &ss);
       stdout_configured = true;
       // We no longer need to pass output options to parse_log_arguments().
-      output_options = NULL;
+      output_options = nullptr;
     }
     // else - fall-through to normal option processing which will be rejected
     // with a warning
@@ -438,7 +438,7 @@ bool LogConfiguration::parse_command_line_arguments(const char* opts) {
       success = StderrLog->parse_options(output_options, &ss);
       stderr_configured = true;
       // We no longer need to pass output options to parse_log_arguments().
-      output_options = NULL;
+      output_options = nullptr;
     }
     // else - fall-through to normal option processing which will be rejected
     // with a warning
@@ -456,7 +456,7 @@ bool LogConfiguration::parse_command_line_arguments(const char* opts) {
     Log(logging) log;
     char* start = errbuf;
     char* end = strchr(start, '\n');
-    assert(end != NULL, "line must end with newline '%s'", start);
+    assert(end != nullptr, "line must end with newline '%s'", start);
     do {
       assert(start < errbuf + sizeof(errbuf) &&
              end < errbuf + sizeof(errbuf),
@@ -465,8 +465,8 @@ bool LogConfiguration::parse_command_line_arguments(const char* opts) {
       log.write(level, "%s", start);
       start = end + 1;
       end = strchr(start, '\n');
-      assert(end != NULL || *start == '\0', "line must end with newline '%s'", start);
-    } while (end != NULL);
+      assert(end != nullptr || *start == '\0', "line must end with newline '%s'", start);
+    } while (end != nullptr);
   }
 
   os::free(copy);
@@ -478,8 +478,8 @@ bool LogConfiguration::parse_log_arguments(const char* outputstr,
                                            const char* decoratorstr,
                                            const char* output_options,
                                            outputStream* errstream) {
-  assert(errstream != NULL, "errstream can not be NULL");
-  if (outputstr == NULL || strlen(outputstr) == 0) {
+  assert(errstream != nullptr, "errstream can not be nullptr");
+  if (outputstr == nullptr || strlen(outputstr) == 0) {
     outputstr = "stdout";
   }
 
@@ -514,7 +514,7 @@ bool LogConfiguration::parse_log_arguments(const char* outputstr,
     if (idx == SIZE_MAX) {
       // Attempt to create and add the output
       LogOutput* output = new_output(normalized, output_options, errstream);
-      if (output != NULL) {
+      if (output != nullptr) {
         idx = add_output(output);
         added = true;
       }
@@ -525,7 +525,7 @@ bool LogConfiguration::parse_log_arguments(const char* outputstr,
       return false;
     }
   }
-  if (!added && output_options != NULL && strlen(output_options) > 0) {
+  if (!added && output_options != nullptr && strlen(output_options) > 0) {
     errstream->print_cr("Output options for existing outputs are ignored.");
   }
   configure_output(idx, selections, decorators);
@@ -690,7 +690,7 @@ void LogConfiguration::rotate_all_outputs() {
 }
 
 void LogConfiguration::register_update_listener(UpdateListenerFunction cb) {
-  assert(cb != NULL, "Should not register NULL as listener");
+  assert(cb != nullptr, "Should not register nullptr as listener");
   ConfigurationLock cl;
   size_t idx = _n_listener_callbacks++;
   _listener_callbacks = REALLOC_C_HEAP_ARRAY(UpdateListenerFunction,

--- a/src/hotspot/share/logging/logConfiguration.hpp
+++ b/src/hotspot/share/logging/logConfiguration.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ class LogConfiguration : public AllStatic {
   static size_t                     _n_listener_callbacks;
   static bool                       _async_mode;
 
-  // Create a new output. Returns NULL if failed.
+  // Create a new output. Returns nullptr if failed.
   static LogOutput* new_output(const char* name, const char* options, outputStream* errstream);
 
   // Add an output to the list of configured outputs. Returns the assigned index.

--- a/src/hotspot/share/logging/logDecorations.cpp
+++ b/src/hotspot/share/logging/logDecorations.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,17 +30,17 @@
 #include "runtime/os.hpp"
 #include "services/management.hpp"
 
-const char* volatile LogDecorations::_host_name = NULL;
+const char* volatile LogDecorations::_host_name = nullptr;
 const int LogDecorations::_pid = os::current_process_id(); // This is safe to call during dynamic initialization.
 
 const char* LogDecorations::host_name() {
   const char* host_name = Atomic::load_acquire(&_host_name);
-  if (host_name == NULL) {
+  if (host_name == nullptr) {
     char buffer[1024];
     if (os::get_host_name(buffer, sizeof(buffer))) {
       host_name = os::strdup_check_oom(buffer);
-      const char* old_value = Atomic::cmpxchg(&_host_name, (const char*)NULL, host_name);
-      if (old_value != NULL) {
+      const char* old_value = Atomic::cmpxchg(&_host_name, (const char*)nullptr, host_name);
+      if (old_value != nullptr) {
         os::free((void *) host_name);
         host_name = old_value;
       }

--- a/src/hotspot/share/logging/logDecorators.cpp
+++ b/src/hotspot/share/logging/logDecorators.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ LogDecorators::Decorator LogDecorators::from_string(const char* str) {
 }
 
 bool LogDecorators::parse(const char* decorator_args, outputStream* errstream) {
-  if (decorator_args == NULL || strlen(decorator_args) == 0) {
+  if (decorator_args == nullptr || strlen(decorator_args) == 0) {
     _decorators = DefaultDecoratorsMask;
     return true;
   }
@@ -73,12 +73,12 @@ bool LogDecorators::parse(const char* decorator_args, outputStream* errstream) {
   char* comma_pos;
   do {
     comma_pos = strchr(token, ',');
-    if (comma_pos != NULL) {
+    if (comma_pos != nullptr) {
       *comma_pos = '\0';
     }
     Decorator d = from_string(token);
     if (d == Invalid) {
-      if (errstream != NULL) {
+      if (errstream != nullptr) {
         errstream->print_cr("Invalid decorator '%s'.", token);
       }
       result = false;
@@ -86,7 +86,7 @@ bool LogDecorators::parse(const char* decorator_args, outputStream* errstream) {
     }
     tmp_decorators |= mask(d);
     token = comma_pos + 1;
-  } while (comma_pos != NULL);
+  } while (comma_pos != nullptr);
   os::free(args_copy);
   if (result) {
     _decorators = tmp_decorators;

--- a/src/hotspot/share/logging/logDecorators.hpp
+++ b/src/hotspot/share/logging/logDecorators.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,7 +113,7 @@ class LogDecorators {
     return (_decorators & mask(decorator)) != 0;
   }
 
-  bool parse(const char* decorator_args, outputStream* errstream = NULL);
+  bool parse(const char* decorator_args, outputStream* errstream = nullptr);
 };
 
 #endif // SHARE_LOGGING_LOGDECORATORS_HPP

--- a/src/hotspot/share/logging/logDiagnosticCommand.cpp
+++ b/src/hotspot/share/logging/logDiagnosticCommand.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,8 +47,8 @@ LogDiagnosticCommand::LogDiagnosticCommand(outputStream* output, bool heap_alloc
 
 int LogDiagnosticCommand::num_arguments() {
   ResourceMark rm;
-  LogDiagnosticCommand* dcmd = new LogDiagnosticCommand(NULL, false);
-  if (dcmd != NULL) {
+  LogDiagnosticCommand* dcmd = new LogDiagnosticCommand(nullptr, false);
+  if (dcmd != nullptr) {
     DCmdMark mark(dcmd);
     return dcmd->_dcmdparser.num_arguments();
   } else {

--- a/src/hotspot/share/logging/logDiagnosticCommand.hpp
+++ b/src/hotspot/share/logging/logDiagnosticCommand.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ class LogDiagnosticCommand : public DCmdWithParser {
 
   // Used by SecurityManager. This DCMD requires ManagementPermission = control.
   static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission", "control", NULL};
+    JavaPermission p = {"java.lang.management.ManagementPermission", "control", nullptr};
     return p;
   }
 };

--- a/src/hotspot/share/logging/logFileOutput.cpp
+++ b/src/hotspot/share/logging/logFileOutput.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,8 +44,8 @@ char        LogFileOutput::_pid_str[PidBufferSize];
 char        LogFileOutput::_vm_start_time_str[StartTimeBufferSize];
 
 LogFileOutput::LogFileOutput(const char* name)
-    : LogFileStreamOutput(NULL), _name(os::strdup_check_oom(name, mtLogging)),
-      _file_name(NULL), _archive_name(NULL), _current_file(0),
+    : LogFileStreamOutput(nullptr), _name(os::strdup_check_oom(name, mtLogging)),
+      _file_name(nullptr), _archive_name(nullptr), _current_file(0),
       _file_count(DefaultFileCount), _is_default_file_count(true), _archive_name_len(0),
       _rotate_size(DefaultFileSize), _current_size(0), _rotation_semaphore(1) {
   assert(strstr(name, Prefix) == name, "invalid output name '%s': missing prefix: %s", name, Prefix);
@@ -72,7 +72,7 @@ void LogFileOutput::set_file_name_parameters(jlong vm_start_time) {
 }
 
 LogFileOutput::~LogFileOutput() {
-  if (_stream != NULL) {
+  if (_stream != nullptr) {
     if (fclose(_stream) != 0) {
       jio_fprintf(defaultStream::error_stream(), "Could not close log file '%s' (%s).\n",
                   _file_name, os::strerror(errno));
@@ -238,7 +238,7 @@ bool LogFileOutput::initialize(const char* options, outputStream* errstream) {
   }
 
   _stream = os::fopen(_file_name, FileOpenMode);
-  if (_stream == NULL) {
+  if (_stream == nullptr) {
     errstream->print_cr("Error opening log file '%s': %s",
                         _file_name, os::strerror(errno));
     return false;
@@ -267,7 +267,7 @@ class RotationLocker : public StackObj {
 
 int LogFileOutput::write_blocking(const LogDecorations& decorations, const char* msg) {
   RotationLocker lock(_rotation_semaphore);
-  if (_stream == NULL) {
+  if (_stream == nullptr) {
     // An error has occurred with this output, avoid writing to it.
     return 0;
   }
@@ -287,7 +287,7 @@ int LogFileOutput::write_blocking(const LogDecorations& decorations, const char*
 }
 
 int LogFileOutput::write(const LogDecorations& decorations, const char* msg) {
-  if (_stream == NULL) {
+  if (_stream == nullptr) {
     // An error has occurred with this output, avoid writing to it.
     return 0;
   }
@@ -302,7 +302,7 @@ int LogFileOutput::write(const LogDecorations& decorations, const char* msg) {
 }
 
 int LogFileOutput::write(LogMessageBuffer::Iterator msg_iterator) {
-  if (_stream == NULL) {
+  if (_stream == nullptr) {
     // An error has occurred with this output, avoid writing to it.
     return 0;
   }
@@ -327,7 +327,7 @@ int LogFileOutput::write(LogMessageBuffer::Iterator msg_iterator) {
 }
 
 void LogFileOutput::archive() {
-  assert(_archive_name != NULL && _archive_name_len > 0, "Rotation must be configured before using this function.");
+  assert(_archive_name != nullptr && _archive_name_len > 0, "Rotation must be configured before using this function.");
   int ret = jio_snprintf(_archive_name, _archive_name_len, "%s.%0*u",
                          _file_name, _file_count_max_digits, _current_file);
   assert(ret >= 0, "Buffer should always be large enough");
@@ -364,7 +364,7 @@ void LogFileOutput::rotate() {
 
   // Open the active log file using the same stream as before
   _stream = os::fopen(_file_name, FileOpenMode);
-  if (_stream == NULL) {
+  if (_stream == nullptr) {
     jio_fprintf(defaultStream::error_stream(), "Could not reopen file '%s' during log rotation (%s).\n",
                 _file_name, os::strerror(errno));
     return;
@@ -378,14 +378,14 @@ void LogFileOutput::rotate() {
 char* LogFileOutput::make_file_name(const char* file_name,
                                     const char* pid_string,
                                     const char* timestamp_string) {
-  char* result = NULL;
+  char* result = nullptr;
 
   // Lets start finding out if we have any %d and/or %t in the name.
   // We will only replace the first occurrence of any placeholder
   const char* pid = strstr(file_name, PidFilenamePlaceholder);
   const char* timestamp = strstr(file_name, TimestampFilenamePlaceholder);
 
-  if (pid == NULL && timestamp == NULL) {
+  if (pid == nullptr && timestamp == nullptr) {
     // We found no place-holders, return the simple filename
     return os::strdup_check_oom(file_name, mtLogging);
   }
@@ -400,8 +400,8 @@ char* LogFileOutput::make_file_name(const char* file_name,
   size_t second_replace_len = 0;
 
   // If we found a %p, then setup our variables accordingly
-  if (pid != NULL) {
-    if (timestamp == NULL || pid < timestamp) {
+  if (pid != nullptr) {
+    if (timestamp == nullptr || pid < timestamp) {
       first = pid_string;
       first_pos = pid - file_name;
       first_replace_len = strlen(PidFilenamePlaceholder);
@@ -412,8 +412,8 @@ char* LogFileOutput::make_file_name(const char* file_name,
     }
   }
 
-  if (timestamp != NULL) {
-    if (pid == NULL || timestamp < pid) {
+  if (timestamp != nullptr) {
+    if (pid == nullptr || timestamp < pid) {
       first = timestamp_string;
       first_pos = timestamp - file_name;
       first_replace_len = strlen(TimestampFilenamePlaceholder);

--- a/src/hotspot/share/logging/logFileStreamOutput.cpp
+++ b/src/hotspot/share/logging/logFileStreamOutput.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -134,7 +134,7 @@ int LogFileStreamOutput::write_internal(const LogDecorations& decorations, const
     char *next;
     do {
       next = strpbrk(cur, "\n\\");
-      if (next == NULL) {
+      if (next == nullptr) {
         WRITE_LOG_WITH_RESULT_CHECK(jio_fprintf(_stream, "%s\n", cur), written);
       } else {
         const char *found = (*next == '\n') ? "\\n" : "\\\\";
@@ -142,7 +142,7 @@ int LogFileStreamOutput::write_internal(const LogDecorations& decorations, const
         WRITE_LOG_WITH_RESULT_CHECK(jio_fprintf(_stream, "%s%s", cur, found), written);
         cur = next + 1;
       }
-    } while (next != NULL);
+    } while (next != nullptr);
     os::free(dupstr);
   }
   return written;

--- a/src/hotspot/share/logging/logMessageBuffer.cpp
+++ b/src/hotspot/share/logging/logMessageBuffer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,13 +38,13 @@ static void grow(T*& buffer, size_t& capacity, size_t minimum_length = 0) {
 
 LogMessageBuffer::LogMessageBuffer() : _message_buffer_size(0),
                                        _message_buffer_capacity(0),
-                                       _message_buffer(NULL),
+                                       _message_buffer(nullptr),
                                        _line_count(0),
                                        _line_capacity(0),
-                                       _lines(NULL),
+                                       _lines(nullptr),
                                        _allocated(false),
                                        _least_detailed_level(LogLevel::Off),
-                                       _prefix_fn(NULL) {
+                                       _prefix_fn(nullptr) {
 }
 
 LogMessageBuffer::~LogMessageBuffer() {
@@ -98,7 +98,7 @@ void LogMessageBuffer::vwrite(LogLevelType level, const char* fmt, va_list args)
     size_t remaining_buffer_length = _message_buffer_capacity - _message_buffer_size;
     char* current_buffer_position = _message_buffer + _message_buffer_size;
 
-    if (_prefix_fn != NULL) {
+    if (_prefix_fn != nullptr) {
       written += _prefix_fn(current_buffer_position, remaining_buffer_length);
       current_buffer_position += written;
       if (remaining_buffer_length < written) {

--- a/src/hotspot/share/logging/logMessageBuffer.hpp
+++ b/src/hotspot/share/logging/logMessageBuffer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,7 +109,7 @@ class LogMessageBuffer : public StackObj {
   // It is, however, possible to specify a prefix per LogMessageBuffer,
   // using set_prefix(). Lines added to the LogMessageBuffer after a prefix
   // function has been set will be prefixed automatically.
-  // Setting this to NULL will disable prefixing.
+  // Setting this to nullptr will disable prefixing.
   void set_prefix(size_t (*prefix_fn)(char*, size_t)) {
     _prefix_fn = prefix_fn;
   }

--- a/src/hotspot/share/logging/logOutput.cpp
+++ b/src/hotspot/share/logging/logOutput.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,13 +85,13 @@ static const size_t MaxSubsets = 1 << LogTag::MaxTags;
 static void generate_all_subsets_of(LogTagType result[MaxSubsets][LogTag::MaxTags],
                                     size_t* result_size,
                                     const LogTagType tags[LogTag::MaxTags],
-                                    LogTagType subset[LogTag::MaxTags] = NULL,
+                                    LogTagType subset[LogTag::MaxTags] = nullptr,
                                     const size_t subset_size = 0,
                                     const size_t depth = 0) {
   assert(subset_size <= LogTag::MaxTags, "subset must never have more than MaxTags tags");
   assert(depth <= LogTag::MaxTags, "recursion depth overflow");
 
-  if (subset == NULL) {
+  if (subset == nullptr) {
     assert(*result_size == 0, "outer (non-recursive) call expects result_size to be 0");
     // Make subset the first element in the result array initially
     subset = result[0];
@@ -161,7 +161,7 @@ static void add_selections(LogSelection** selections,
     // Check if the two selections match any tag sets
     bool wildcard_match = false;
     bool exact_match = false;
-    for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+    for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
       if (!wildcard_selection.selects(*ts)) {
         continue;
       }
@@ -227,7 +227,7 @@ void LogOutput::update_config_string(const size_t on_level[LogLevel::Count]) {
   const LogTagSet** deviates = NEW_C_HEAP_ARRAY(const LogTagSet*, deviating_tagsets, mtLogging);
 
   // Generate all possible selections involving the deviating tag sets
-  for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+  for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
     LogLevelType level = ts->level_for(this);
     if (level == mcl) {
       continue;
@@ -259,7 +259,7 @@ void LogOutput::update_config_string(const size_t on_level[LogLevel::Count]) {
       }
 
       // Subtract from the score the number of tag sets it selects with an incorrect level
-      for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+      for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
         if (selections[i].selects(*ts) && ts->level_for(this) != selections[i].level()) {
           score--;
         }
@@ -285,7 +285,7 @@ void LogOutput::update_config_string(const size_t on_level[LogLevel::Count]) {
     }
 
     // Add back any new deviates that this selection added (no array growth since removed > added)
-    for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+    for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
       if (ts->level_for(this) == best_selection->level() || !best_selection->selects(*ts)) {
         continue;
       }
@@ -323,7 +323,7 @@ void LogOutput::update_config_string(const size_t on_level[LogLevel::Count]) {
 }
 
 bool LogOutput::parse_options(const char* options, outputStream* errstream) {
-  if (options == NULL || strlen(options) == 0) {
+  if (options == nullptr || strlen(options) == 0) {
     return true;
   }
   bool success = true;
@@ -333,11 +333,11 @@ bool LogOutput::parse_options(const char* options, outputStream* errstream) {
   char* pos = opts;
   do {
     comma_pos = strchr(pos, ',');
-    if (comma_pos != NULL) {
+    if (comma_pos != nullptr) {
       *comma_pos = '\0';
     }
     char* equals_pos = strchr(pos, '=');
-    if (equals_pos == NULL) {
+    if (equals_pos == nullptr) {
       errstream->print_cr("Invalid option '%s' for log output (%s).", pos, name());
       success = false;
       break;
@@ -355,7 +355,7 @@ bool LogOutput::parse_options(const char* options, outputStream* errstream) {
       break;
     }
     pos = comma_pos + 1;
-  } while (comma_pos != NULL);
+  } while (comma_pos != nullptr);
 
   os::free(opts);
   return success;

--- a/src/hotspot/share/logging/logOutputList.cpp
+++ b/src/hotspot/share/logging/logOutputList.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,22 +53,22 @@ void LogOutputList::wait_until_no_readers() const {
 
 void LogOutputList::set_output_level(LogOutput* output, LogLevelType level) {
   LogOutputNode* node = find(output);
-  if (level == LogLevel::Off && node != NULL) {
+  if (level == LogLevel::Off && node != nullptr) {
     remove_output(node);
-  } else if (level != LogLevel::Off && node == NULL) {
+  } else if (level != LogLevel::Off && node == nullptr) {
     add_output(output, level);
-  } else if (node != NULL) {
+  } else if (node != nullptr) {
     update_output_level(node, level);
   }
 }
 
 LogOutputList::LogOutputNode* LogOutputList::find(const LogOutput* output) const {
-  for (LogOutputNode* node = _level_start[LogLevel::Last]; node != NULL; node = node->_next) {
+  for (LogOutputNode* node = _level_start[LogLevel::Last]; node != nullptr; node = node->_next) {
     if (output == node->_value) {
       return node;
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 void LogOutputList::clear() {
@@ -78,12 +78,12 @@ void LogOutputList::clear() {
 
   // Clear _level_start
   for (uint level = LogLevel::First; level < LogLevel::Count; level++) {
-    _level_start[level] = NULL;
+    _level_start[level] = nullptr;
   }
 
   // Delete all nodes from the linked list
   wait_until_no_readers();
-  while (cur != NULL) {
+  while (cur != nullptr) {
     LogOutputNode* next = cur->_next;
     delete cur;
     cur = next;
@@ -91,7 +91,7 @@ void LogOutputList::clear() {
 }
 
 void LogOutputList::remove_output(LogOutputList::LogOutputNode* node) {
-  assert(node != NULL, "Node must be non-null");
+  assert(node != nullptr, "Node must be non-null");
 
   // Remove node from _level_start first
   bool found = false;
@@ -103,7 +103,7 @@ void LogOutputList::remove_output(LogOutputList::LogOutputNode* node) {
   }
 
   // Now remove it from the linked list
-  for (LogOutputNode* cur = _level_start[LogLevel::Last]; cur != NULL; cur = cur->_next) {
+  for (LogOutputNode* cur = _level_start[LogLevel::Last]; cur != nullptr; cur = cur->_next) {
     if (cur->_next == node) {
       found = true;
       cur->_next = node->_next;
@@ -123,19 +123,19 @@ void LogOutputList::add_output(LogOutput* output, LogLevelType level) {
 
   // Set the next pointer to the first node of a lower level
   for (node->_next = _level_start[level];
-       node->_next != NULL && node->_next->_level == level;
+       node->_next != nullptr && node->_next->_level == level;
        node->_next = node->_next->_next) {
   }
 
   // Update the _level_start index
   for (int l = LogLevel::Last; l >= level; l--) {
-    if (_level_start[l] == NULL || _level_start[l]->_level < level) {
+    if (_level_start[l] == nullptr || _level_start[l]->_level < level) {
       _level_start[l] = node;
     }
   }
 
   // Add the node the list
-  for (LogOutputNode* cur = _level_start[LogLevel::Last]; cur != NULL; cur = cur->_next) {
+  for (LogOutputNode* cur = _level_start[LogLevel::Last]; cur != nullptr; cur = cur->_next) {
     if (cur != node && cur->_next == node->_next) {
       cur->_next = node;
       break;

--- a/src/hotspot/share/logging/logOutputList.hpp
+++ b/src/hotspot/share/logging/logOutputList.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,18 +67,18 @@ class LogOutputList {
  public:
   LogOutputList() : _active_readers(0) {
     for (size_t i = 0; i < LogLevel::Count; i++) {
-      _level_start[i] = NULL;
+      _level_start[i] = nullptr;
     }
   }
 
   // Test if the outputlist has an output for the given level.
   bool is_level(LogLevelType level) const {
-    return _level_start[level] != NULL;
+    return _level_start[level] != nullptr;
   }
 
   LogLevelType level_for(const LogOutput* output) const {
     LogOutputNode* node = this->find(output);
-    if (node == NULL) {
+    if (node == nullptr) {
       return LogLevel::Off;
     }
     return node->_level;
@@ -142,7 +142,7 @@ class LogOutputList {
   }
 
   LogOutputNode* end() const {
-    return NULL;
+    return nullptr;
   }
 };
 

--- a/src/hotspot/share/logging/logSelection.cpp
+++ b/src/hotspot/share/logging/logSelection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ LogSelection::LogSelection(const LogTagType tags[LogTag::MaxTags], bool wildcard
     _ntags++;
   }
 
-  for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+  for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
     if (selects(*ts)) {
       _tag_sets_selected++;
     }
@@ -73,11 +73,11 @@ static LogSelection parse_internal(char *str, outputStream* errstream) {
   // Parse the level, if specified
   LogLevelType level = LogLevel::Unspecified;
   char* equals = strchr(str, '=');
-  if (equals != NULL) {
+  if (equals != nullptr) {
     const char* levelstr = equals + 1;
     level = LogLevel::from_string(levelstr);
     if (level == LogLevel::Invalid) {
-      if (errstream != NULL) {
+      if (errstream != nullptr) {
         errstream->print("Invalid level '%s' in log selection.", levelstr);
         LogLevelType match = LogLevel::fuzzy_match(levelstr);
         if (match != LogLevel::Invalid) {
@@ -101,7 +101,7 @@ static LogSelection parse_internal(char *str, outputStream* errstream) {
   // Check for '*' suffix
   bool wildcard = false;
   char* asterisk_pos = strchr(str, '*');
-  if (asterisk_pos != NULL && asterisk_pos[1] == '\0') {
+  if (asterisk_pos != nullptr && asterisk_pos[1] == '\0') {
     wildcard = true;
     *asterisk_pos = '\0';
   }
@@ -111,12 +111,12 @@ static LogSelection parse_internal(char *str, outputStream* errstream) {
   char* cur_tag = str;
   do {
     plus_pos = strchr(cur_tag, '+');
-    if (plus_pos != NULL) {
+    if (plus_pos != nullptr) {
       *plus_pos = '\0';
     }
     LogTagType tag = LogTag::from_string(cur_tag);
     if (tag == LogTag::__NO_TAG) {
-      if (errstream != NULL) {
+      if (errstream != nullptr) {
         errstream->print("Invalid tag '%s' in log selection.", cur_tag);
         LogTagType match =  LogTag::fuzzy_match(cur_tag);
         if (match != LogTag::__NO_TAG) {
@@ -127,7 +127,7 @@ static LogSelection parse_internal(char *str, outputStream* errstream) {
       return LogSelection::Invalid;
     }
     if (ntags == LogTag::MaxTags) {
-      if (errstream != NULL) {
+      if (errstream != nullptr) {
         errstream->print_cr("Too many tags in log selection '%s' (can only have up to " SIZE_FORMAT " tags).",
                                str, LogTag::MaxTags);
       }
@@ -135,12 +135,12 @@ static LogSelection parse_internal(char *str, outputStream* errstream) {
     }
     tags[ntags++] = tag;
     cur_tag = plus_pos + 1;
-  } while (plus_pos != NULL);
+  } while (plus_pos != nullptr);
 
   for (size_t i = 0; i < ntags; i++) {
     for (size_t j = 0; j < ntags; j++) {
       if (i != j && tags[i] == tags[j]) {
-        if (errstream != NULL) {
+        if (errstream != nullptr) {
           errstream->print_cr("Log selection contains duplicates of tag %s.", LogTag::name(tags[i]));
         }
         return LogSelection::Invalid;
@@ -275,7 +275,7 @@ void LogSelection::suggest_similar_matching(outputStream* out) const {
   }
 
   // Check for matching tag sets with a single tag mismatching (a tag too many or short a tag)
-  for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+  for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
     LogTagType tags[LogTag::MaxTags] = { LogTag::__NO_TAG };
     for (size_t i = 0; i < ts->ntags(); i++) {
       tags[i] = ts->tag(i);

--- a/src/hotspot/share/logging/logSelection.hpp
+++ b/src/hotspot/share/logging/logSelection.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ class LogSelection : public StackObj {
  public:
   static const LogSelection Invalid;
 
-  static LogSelection parse(const char* str, outputStream* error_stream = NULL);
+  static LogSelection parse(const char* str, outputStream* error_stream = nullptr);
 
   LogSelection(const LogTagType tags[LogTag::MaxTags], bool wildcard, LogLevelType level);
 

--- a/src/hotspot/share/logging/logSelectionList.cpp
+++ b/src/hotspot/share/logging/logSelectionList.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ bool LogSelectionList::verify_selections(outputStream* out) const {
   for (size_t i = 0; i < _nselections; i++) {
     if (_selections[i].tag_sets_selected() == 0) {
       // Return immediately unless all invalid selections should be listed
-      if (out == NULL) {
+      if (out == nullptr) {
         return false;
       }
 
@@ -56,14 +56,14 @@ bool LogSelectionList::verify_selections(outputStream* out) const {
 
 bool LogSelectionList::parse(const char* str, outputStream* errstream) {
   bool success = true;
-  if (str == NULL || strcmp(str, "") == 0) {
+  if (str == nullptr || strcmp(str, "") == 0) {
     str = DefaultExpressionString;
   }
   char* copy = os::strdup_check_oom(str, mtLogging);
   // Split string on commas
-  for (char *comma_pos = copy, *cur = copy; success && comma_pos != NULL; cur = comma_pos + 1) {
+  for (char *comma_pos = copy, *cur = copy; success && comma_pos != nullptr; cur = comma_pos + 1) {
     if (_nselections == MaxSelections) {
-      if (errstream != NULL) {
+      if (errstream != nullptr) {
         errstream->print_cr("Can not have more than " SIZE_FORMAT " log selections in a single configuration.",
                             MaxSelections);
       }
@@ -72,7 +72,7 @@ bool LogSelectionList::parse(const char* str, outputStream* errstream) {
     }
 
     comma_pos = strchr(cur, ',');
-    if (comma_pos != NULL) {
+    if (comma_pos != nullptr) {
       *comma_pos = '\0';
     }
 

--- a/src/hotspot/share/logging/logSelectionList.hpp
+++ b/src/hotspot/share/logging/logSelectionList.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,13 +53,13 @@ class LogSelectionList : public StackObj {
     _selections[0] = selection;
   }
 
-  bool parse(const char* str, outputStream* errstream = NULL);
+  bool parse(const char* str, outputStream* errstream = nullptr);
   LogLevelType level_for(const LogTagSet& ts) const;
 
   // Verify that each selection actually selects something.
   // Returns false if some invalid selection was found. If given an outputstream,
   // this function will list all the invalid selections on the stream.
-  bool verify_selections(outputStream* out = NULL) const;
+  bool verify_selections(outputStream* out = nullptr) const;
 };
 
 #endif // SHARE_LOGGING_LOGSELECTIONLIST_HPP

--- a/src/hotspot/share/logging/logStream.cpp
+++ b/src/hotspot/share/logging/logStream.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ bool LogStreamImplBase::LineBuffer::try_ensure_cap(size_t atleast) {
   }
 
   char* const newbuf = (char*)os::malloc(newcap, mtLogging);
-  if (newbuf == NULL) { // OOM. Leave object unchanged.
+  if (newbuf == nullptr) { // OOM. Leave object unchanged.
     return false;
   }
   if (_pos > 0) { // preserve old content

--- a/src/hotspot/share/logging/logStream.hpp
+++ b/src/hotspot/share/logging/logStream.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,11 +100,11 @@ public:
   LogStream(const LogTargetImpl<level, T0, T1, T2, T3, T4, GuardTag>& type_carrier)
     : LogStreamImpl(LogTargetHandle(level, LogTagSetMapping<T0, T1, T2, T3, T4>::tagset())) {}
 
-  // Constructor to support creation from typed (likely NULL) pointer. Mostly used by the logging framework.
+  // Constructor to support creation from typed (likely nullptr) pointer. Mostly used by the logging framework.
   //
   // LogStream stream(log.debug());
   //  or
-  // LogStream stream((LogTargetImpl<level, T0, T1, T2, T3, T4, GuardTag>*)NULL);
+  // LogStream stream((LogTargetImpl<level, T0, T1, T2, T3, T4, GuardTag>*)nullptr);
   template <LogLevelType level, LogTagType T0, LogTagType T1, LogTagType T2, LogTagType T3, LogTagType T4, LogTagType GuardTag>
   LogStream(const LogTargetImpl<level, T0, T1, T2, T3, T4, GuardTag>* type_carrier)
     : LogStreamImpl(LogTargetHandle(level, LogTagSetMapping<T0, T1, T2, T3, T4>::tagset())) {}
@@ -133,7 +133,7 @@ template <LogLevelType level, LogTagType T0, LogTagType T1, LogTagType T2, LogTa
 class LogStreamTemplate : public LogStream {
 public:
   LogStreamTemplate()
-    : LogStream((LogTargetImpl<level, T0, T1, T2, T3, T4, GuardTag>*)NULL) {}
+    : LogStream((LogTargetImpl<level, T0, T1, T2, T3, T4, GuardTag>*)nullptr) {}
 };
 
 class LogMessageHandle {

--- a/src/hotspot/share/logging/logTagSet.cpp
+++ b/src/hotspot/share/logging/logTagSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/ostream.hpp"
 
-LogTagSet*  LogTagSet::_list      = NULL;
+LogTagSet*  LogTagSet::_list      = nullptr;
 size_t      LogTagSet::_ntagsets  = 0;
 
 // This constructor is called only during static initialization.
@@ -181,7 +181,7 @@ static const size_t TagSetBufferSize = 128;
 
 void LogTagSet::describe_tagsets(outputStream* out) {
   out->print_cr("Described tag sets:");
-  for (const LogTagSetDescription* d = tagset_descriptions; d->tagset != NULL; d++) {
+  for (const LogTagSetDescription* d = tagset_descriptions; d->tagset != nullptr; d++) {
     out->sp();
     d->tagset->label(out, "+");
     out->print_cr(": %s", d->descr);
@@ -197,7 +197,7 @@ void LogTagSet::list_all_tagsets(outputStream* out) {
 
   // Generate the list of tagset labels
   size_t idx = 0;
-  for (LogTagSet* ts = first(); ts != NULL; ts = ts->next()) {
+  for (LogTagSet* ts = first(); ts != nullptr; ts = ts->next()) {
     char buf[TagSetBufferSize];
     ts->label(buf, sizeof(buf), "+");
     tagset_labels[idx++] = os::strdup_check_oom(buf, mtLogging);

--- a/src/hotspot/share/logging/logTagSetDescriptions.cpp
+++ b/src/hotspot/share/logging/logTagSetDescriptions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,5 +38,5 @@
 
 struct LogTagSetDescription tagset_descriptions[] = {
   LOG_TAG_SET_DESCRIPTION_LIST
-  { NULL, NULL }
+  { nullptr, nullptr }
 };


### PR DESCRIPTION
Do the conversion in the share/logging sub-directory and all of its files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300222](https://bugs.openjdk.org/browse/JDK-8300222): Replace NULL with nullptr in share/logging


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12014/head:pull/12014` \
`$ git checkout pull/12014`

Update a local copy of the PR: \
`$ git checkout pull/12014` \
`$ git pull https://git.openjdk.org/jdk pull/12014/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12014`

View PR using the GUI difftool: \
`$ git pr show -t 12014`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12014.diff">https://git.openjdk.org/jdk/pull/12014.diff</a>

</details>
