### PR TITLE
8300184: Optimize ResourceHashtableBase::iterate_all using _number_of_entries

### DIFF
--- a/src/hotspot/share/utilities/resourceHash.hpp
+++ b/src/hotspot/share/utilities/resourceHash.hpp
@@ -25,9 +25,7 @@
 #ifndef SHARE_UTILITIES_RESOURCEHASH_HPP
 #define SHARE_UTILITIES_RESOURCEHASH_HPP
 
-#include "logging/log.hpp"
 #include "memory/allocation.hpp"
-#include "runtime/thread.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/numberSeq.hpp"
 #include "utilities/tableStatistics.hpp"
@@ -241,12 +239,6 @@ class ResourceHashtableBase : public STORAGE {
         --cnt;
       }
       ++bucket;
-    }
-
-    Thread* current = Thread::current_or_null();
-    // AsyncLog itself uses ResourceHashtable. We need to avoid recursion here.
-    if (current == nullptr || strcmp(current->name(), "AsyncLog Thread")) {
-      log_debug(hashtables)("ResourceHashtableBase table_size = %d, break at " INTX_FORMAT, sz, (bucket - table()));
     }
   }
 

--- a/src/hotspot/share/utilities/resourceHash.hpp
+++ b/src/hotspot/share/utilities/resourceHash.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -246,7 +246,7 @@ class ResourceHashtableBase : public STORAGE {
     Thread* current = Thread::current_or_null();
     // AsyncLog itself uses ResourceHashtable. We need to avoid recursion here.
     if (current == nullptr || strcmp(current->name(), "AsyncLog Thread")) {
-      log_debug(hashtables)("table_size = %d, break at %ld", sz, (bucket - table()));
+      log_debug(hashtables)("ResourceHashtableBase table_size = %d, break at " INTX_FORMAT, sz, (bucket - table()));
     }
   }
 


### PR DESCRIPTION
Current implementation needs to visit all buckets. In extreme case, an empty hashtable with 1k buckets. iterate_all() loads 1k buckets for nothing. `_number_of_entries` is the number of nodes in the hashtable. This patch leverages that to quit iteration earlier. The real effect is up to the distribution of nodes among buckets.

I also included a debug log in the original patch. It was used for the observation in the following section, but I deleted it because it introduces circular dependency. 
```cpp
log_debug(hashtables)("ResourceHashtableBase table_size = %d, break at " INTX_FORMAT, sz, (bucket - table()));
```
**Evaluation** 
In release build, the patch is very marginal. class loading do use ResourceHashtable but they are saturated. 

I use it to run `Renaissance/finagle-http`. hahstable iterate_all quits a little bit earlier and save some loads. eg. in line 2, there are 109 buckets in the hashable. the iteration quit at 68th bucket, we save 42 loads. 

```
$java -Xlog:hashtables=debug  -jar renaissance-gpl-0.14.1.jar finagle-http
...
[12.824s][debug][hashtables] table_size = 109, break at 109
[12.824s][debug][hashtables] table_size = 109, break at 68
[12.824s][debug][hashtables] table_size = 109, break at 107
[12.825s][debug][hashtables] table_size = 109, break at 108
[12.825s][debug][hashtables] table_size = 109, break at 99
[12.825s][debug][hashtables] table_size = 109, break at 108
[12.825s][debug][hashtables] table_size = 109, break at 98
[12.825s][debug][hashtables] table_size = 109, break at 109
[12.825s][debug][hashtables] table_size = 109, break at 102
...
```

Another application is in AsyncLog Thread. We have a hashtable with 17 buckets. Each Log Output creates one node in the hashtable. In common cases, there are only 2~3 nodes in the hashtable. Each time AsyncLog Thread flushes the buffer, it has to scan the hashtable twice. Saving loads means saving the memory bandwidth for the application. 

In fastdebug build, extra verification is deployed. It's common to observe that JVM scan an empty hashtable. It's in destroy_VM. 
 
```
./build/linux-x86_64-server-fastdebug/images/jdk/bin/java -Xlog:hashtables=debug --version
openjdk 21-internal 2023-09-19
OpenJDK Runtime Environment (fastdebug build 21-internal-adhoc.xxinliu.jdk)
OpenJDK 64-Bit Server VM (fastdebug build 21-internal-adhoc.xxinliu.jdk, mixed mode, sharing)
[0.130s][debug][hashtables] table_size = 139, break at 0
[0.136s][debug][hashtables] table_size = 107, break at 0
[0.136s][debug][hashtables] table_size = 1009, break at 0
[0.136s][debug][hashtables] table_size = 109, break at 107
[0.136s][debug][hashtables] table_size = 109, break at 109
[0.137s][debug][hashtables] table_size = 109, break at 101
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300184](https://bugs.openjdk.org/browse/JDK-8300184): Optimize ResourceHashtableBase::iterate_all using _number_of_entries


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12016/head:pull/12016` \
`$ git checkout pull/12016`

Update a local copy of the PR: \
`$ git checkout pull/12016` \
`$ git pull https://git.openjdk.org/jdk pull/12016/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12016`

View PR using the GUI difftool: \
`$ git pr show -t 12016`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12016.diff">https://git.openjdk.org/jdk/pull/12016.diff</a>

</details>
