### PR TITLE
8303213: Avoid AtomicReference in TextComponentPrintable

### DIFF
--- a/src/java.desktop/share/classes/sun/swing/text/TextComponentPrintable.java
+++ b/src/java.desktop/share/classes/sun/swing/text/TextComponentPrintable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
-import java.util.concurrent.atomic.AtomicReference;
 
 import javax.swing.*;
 import javax.swing.border.Border;
@@ -324,6 +323,7 @@ public class TextComponentPrintable implements CountingPrintable {
             }
         }
     }
+
     @SuppressWarnings("serial") // anonymous class inside
     private JTextComponent createPrintShellOnEDT(final JTextComponent textComponent) {
         assert SwingUtilities.isEventDispatchThread();
@@ -339,6 +339,7 @@ public class TextComponentPrintable implements CountingPrintable {
                     }
                     @Override
                     public FontMetrics getFontMetrics(Font font) {
+                        FontRenderContext frc = TextComponentPrintable.this.frc;
                         return (frc == null)
                             ? super.getFontMetrics(font)
                             : FontDesignMetrics.getMetrics(font, frc);
@@ -353,6 +354,7 @@ public class TextComponentPrintable implements CountingPrintable {
                     }
                     @Override
                     public FontMetrics getFontMetrics(Font font) {
+                        FontRenderContext frc = TextComponentPrintable.this.frc;
                         return (frc == null)
                             ? super.getFontMetrics(font)
                             : FontDesignMetrics.getMetrics(font, frc);
@@ -369,6 +371,7 @@ public class TextComponentPrintable implements CountingPrintable {
                     }
                     @Override
                     public FontMetrics getFontMetrics(Font font) {
+                        FontRenderContext frc = TextComponentPrintable.this.frc;
                         return (frc == null)
                             ? super.getFontMetrics(font)
                             : FontDesignMetrics.getMetrics(font, frc);
@@ -379,6 +382,7 @@ public class TextComponentPrintable implements CountingPrintable {
                 new JTextPane() {
                     @Override
                     public FontMetrics getFontMetrics(Font font) {
+                        FontRenderContext frc = TextComponentPrintable.this.frc;
                         return (frc == null)
                             ? super.getFontMetrics(font)
                             : FontDesignMetrics.getMetrics(font, frc);
@@ -397,6 +401,7 @@ public class TextComponentPrintable implements CountingPrintable {
                 new JEditorPane() {
                     @Override
                     public FontMetrics getFontMetrics(Font font) {
+                        FontRenderContext frc = TextComponentPrintable.this.frc;
                         return (frc == null)
                             ? super.getFontMetrics(font)
                             : FontDesignMetrics.getMetrics(font, frc);

--- a/src/java.desktop/share/classes/sun/swing/text/TextComponentPrintable.java
+++ b/src/java.desktop/share/classes/sun/swing/text/TextComponentPrintable.java
@@ -47,7 +47,15 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 
-import javax.swing.*;
+import javax.swing.BorderFactory;
+import javax.swing.CellRendererPane;
+import javax.swing.JEditorPane;
+import javax.swing.JPasswordField;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import javax.swing.JTextPane;
+import javax.swing.JViewport;
+import javax.swing.SwingUtilities;
 import javax.swing.border.Border;
 import javax.swing.border.TitledBorder;
 import javax.swing.text.BadLocationException;

--- a/src/java.desktop/share/classes/sun/swing/text/TextComponentPrintable.java
+++ b/src/java.desktop/share/classes/sun/swing/text/TextComponentPrintable.java
@@ -103,8 +103,7 @@ public class TextComponentPrintable implements CountingPrintable {
     /*
      * The FontRenderContext to layout and print with
      */
-    private final AtomicReference<FontRenderContext> frc =
-        new AtomicReference<FontRenderContext>(null);
+    private volatile FontRenderContext frc;
 
     /**
      * Special text component used to print to the printer.
@@ -340,9 +339,9 @@ public class TextComponentPrintable implements CountingPrintable {
                     }
                     @Override
                     public FontMetrics getFontMetrics(Font font) {
-                        return (frc.get() == null)
+                        return (frc == null)
                             ? super.getFontMetrics(font)
-                            : FontDesignMetrics.getMetrics(font, frc.get());
+                            : FontDesignMetrics.getMetrics(font, frc);
                     }
                 };
         } else if (textComponent instanceof JTextField) {
@@ -354,9 +353,9 @@ public class TextComponentPrintable implements CountingPrintable {
                     }
                     @Override
                     public FontMetrics getFontMetrics(Font font) {
-                        return (frc.get() == null)
+                        return (frc == null)
                             ? super.getFontMetrics(font)
-                            : FontDesignMetrics.getMetrics(font, frc.get());
+                            : FontDesignMetrics.getMetrics(font, frc);
                     }
                 };
         } else if (textComponent instanceof JTextArea) {
@@ -370,9 +369,9 @@ public class TextComponentPrintable implements CountingPrintable {
                     }
                     @Override
                     public FontMetrics getFontMetrics(Font font) {
-                        return (frc.get() == null)
+                        return (frc == null)
                             ? super.getFontMetrics(font)
-                            : FontDesignMetrics.getMetrics(font, frc.get());
+                            : FontDesignMetrics.getMetrics(font, frc);
                     }
                 };
         } else if (textComponent instanceof JTextPane) {
@@ -380,9 +379,9 @@ public class TextComponentPrintable implements CountingPrintable {
                 new JTextPane() {
                     @Override
                     public FontMetrics getFontMetrics(Font font) {
-                        return (frc.get() == null)
+                        return (frc == null)
                             ? super.getFontMetrics(font)
-                            : FontDesignMetrics.getMetrics(font, frc.get());
+                            : FontDesignMetrics.getMetrics(font, frc);
                     }
                     @Override
                     public EditorKit getEditorKit() {
@@ -398,9 +397,9 @@ public class TextComponentPrintable implements CountingPrintable {
                 new JEditorPane() {
                     @Override
                     public FontMetrics getFontMetrics(Font font) {
-                        return (frc.get() == null)
+                        return (frc == null)
                             ? super.getFontMetrics(font)
-                            : FontDesignMetrics.getMetrics(font, frc.get());
+                            : FontDesignMetrics.getMetrics(font, frc);
                     }
                     @Override
                     public EditorKit getEditorKit() {
@@ -466,7 +465,7 @@ public class TextComponentPrintable implements CountingPrintable {
             final int pageIndex) throws PrinterException {
         if (!isLayouted) {
             if (graphics instanceof Graphics2D) {
-                frc.set(((Graphics2D)graphics).getFontRenderContext());
+                frc = ((Graphics2D)graphics).getFontRenderContext();
             }
             layout((int)Math.floor(pf.getImageableWidth()));
             calculateRowsMetrics();


### PR DESCRIPTION
If CompareAndSwap is not used, then AtomicReference could be replaced with volatile. It simplified code a bit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303213](https://bugs.openjdk.org/browse/JDK-8303213): Avoid AtomicReference in TextComponentPrintable


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**) ⚠️ Review applies to [b9e7bd7a](https://git.openjdk.org/jdk/pull/12018/files/b9e7bd7a46573214359eb64e52bb510668940777)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12018/head:pull/12018` \
`$ git checkout pull/12018`

Update a local copy of the PR: \
`$ git checkout pull/12018` \
`$ git pull https://git.openjdk.org/jdk pull/12018/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12018`

View PR using the GUI difftool: \
`$ git pr show -t 12018`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12018.diff">https://git.openjdk.org/jdk/pull/12018.diff</a>

</details>
