### PR TITLE
8301822: BasicLookAndFeel does not need to check for null after checking for type

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLookAndFeel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2234,23 +2234,20 @@ public abstract class BasicLookAndFeel extends LookAndFeel implements Serializab
                     }
                 }
             }
-            /* Activate a JInternalFrame if necessary. */
-            if (eventID == MouseEvent.MOUSE_PRESSED) {
-                Object object = ev.getSource();
-                if (!(object instanceof Component)) {
-                    return;
-                }
-                Component component = (Component)object;
-                if (component != null) {
-                    Component parent = component;
-                    while (parent != null && !(parent instanceof Window)) {
-                        if (parent instanceof JInternalFrame) {
+
+            // Activate a JInternalFrame if necessary.
+            if (eventID == MouseEvent.MOUSE_PRESSED
+                    && ev.getSource() instanceof Component parent) {
+                while (parent != null && !(parent instanceof Window)) {
+                    if (parent instanceof JInternalFrame internalFrame) {
+                        try {
                             // Activate the frame.
-                            try { ((JInternalFrame)parent).setSelected(true); }
-                            catch (PropertyVetoException e1) { }
+                            internalFrame.setSelected(true);
+                        } catch (PropertyVetoException ignored) {
                         }
-                        parent = parent.getParent();
                     }
+
+                    parent = parent.getParent();
                 }
             }
         }


### PR DESCRIPTION
BasicLookAndFeel checks an instanceof in its `AWTEventHelper` listener class, but the result of that will always be non-null. The check should be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301822](https://bugs.openjdk.org/browse/JDK-8301822): BasicLookAndFeel does not need to check for null after checking for type


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12019/head:pull/12019` \
`$ git checkout pull/12019`

Update a local copy of the PR: \
`$ git checkout pull/12019` \
`$ git pull https://git.openjdk.org/jdk pull/12019/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12019`

View PR using the GUI difftool: \
`$ git pr show -t 12019`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12019.diff">https://git.openjdk.org/jdk/pull/12019.diff</a>

</details>
