### PR TITLE
8283203: Fix typo in SystemTray.getTrayIconSize javadoc

### DIFF
--- a/src/java.desktop/share/classes/java/awt/SystemTray.java
+++ b/src/java.desktop/share/classes/java/awt/SystemTray.java
@@ -344,9 +344,9 @@ public class SystemTray {
 
     /**
      * Returns the size, in pixels, of the space that a tray icon will
-     * occupy in the system tray.  Developers may use this methods to
+     * occupy in the system tray. Developers may use this method to
      * acquire the preferred size for the image property of a tray icon
-     * before it is created.  For convenience, there is a similar
+     * before it is created. For convenience, there is a similar
      * method {@link TrayIcon#getSize} in the {@code TrayIcon} class.
      *
      * @return the default size of a tray icon, in pixels

--- a/src/java.desktop/share/classes/java/awt/SystemTray.java
+++ b/src/java.desktop/share/classes/java/awt/SystemTray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -345,9 +345,9 @@ public class SystemTray {
     /**
      * Returns the size, in pixels, of the space that a tray icon will
      * occupy in the system tray. Developers may use this method to
-     * acquire the preferred size for the image property of a tray icon
-     * before it is created. For convenience, there is a similar
-     * method {@link TrayIcon#getSize} in the {@code TrayIcon} class.
+     * acquire the preferred size for the tray icon before it is created.
+     * For convenience, there is a similar method {@link TrayIcon#getSize}
+     * in the {@code TrayIcon} class.
      *
      * @return the default size of a tray icon, in pixels
      * @see TrayIcon#setImageAutoSize(boolean)


### PR DESCRIPTION
Please review this itty-bitty typo fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283203](https://bugs.openjdk.org/browse/JDK-8283203): Fix typo in SystemTray.getTrayIconSize javadoc


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12020/head:pull/12020` \
`$ git checkout pull/12020`

Update a local copy of the PR: \
`$ git checkout pull/12020` \
`$ git pull https://git.openjdk.org/jdk pull/12020/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12020`

View PR using the GUI difftool: \
`$ git pr show -t 12020`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12020.diff">https://git.openjdk.org/jdk/pull/12020.diff</a>

</details>
