### PR TITLE
8300227: [macos_aarch64] assert(cpu_has("hw.optional.arm.FEAT_AES")) failed after JDK-8297092

### DIFF
--- a/src/hotspot/os_cpu/bsd_aarch64/vm_version_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/vm_version_bsd_aarch64.cpp
@@ -72,10 +72,10 @@ void VM_Version::get_os_cpu_info() {
 
   // All Apple-darwin Arm processors have AES, PMULL, SHA1 and SHA2.
   // See https://github.com/apple-oss-distributions/xnu/blob/main/osfmk/arm/commpage/commpage.c#L412
-  assert(cpu_has("hw.optional.arm.FEAT_AES"), "should be");
-  assert(cpu_has("hw.optional.arm.FEAT_PMULL"), "should be");
-  assert(cpu_has("hw.optional.arm.FEAT_SHA1"), "should be");
-  assert(cpu_has("hw.optional.arm.FEAT_SHA256"), "should be");
+  // Note that we ought to add assertions to check sysctlbyname parameters for
+  // these four CPU features, e.g., "hw.optional.arm.FEAT_AES", but the
+  // corresponding string names are not available before xnu-8019 version.
+  // Hence, assertions are omitted considering backward compatibility.
   _features |= CPU_AES | CPU_PMULL | CPU_SHA1 | CPU_SHA2;
 
   if (cpu_has("hw.optional.armv8_crc32")) {


### PR DESCRIPTION
This failure occurs on macOS before xnu-8019 version, mainly because the sysctlbyname string names were not introduced before xnu-8019. Take the source code of xnu-7195 [1] as an example.

In this patch, we remove the assertions for the sake of backward compatibility.

Test:
In my local test environment, one Macmini with xnu-8020.140.41 and another Macmini with xnu-7195.141.6, fastdebug build can pass now and the CPU features can be detected as expected.

```
$ ./jdk/bin/java -XX:+PrintFlagsFinal --version | grep SHA
     bool UseSHA                = true       {product} {default}
     bool UseSHA1Intrinsics     = true    {diagnostic} {default}
     bool UseSHA256Intrinsics   = true    {diagnostic} {default}
     bool UseSHA3Intrinsics     = true    {diagnostic} {default}
     bool UseSHA512Intrinsics   = true    {diagnostic} {default}
```

[1] https://github.com/apple-oss-distributions/xnu/blob/rel/xnu-7195/bsd/kern/kern_mib.c#L855

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300227](https://bugs.openjdk.org/browse/JDK-8300227): [macos_aarch64] assert(cpu_has("hw.optional.arm.FEAT_AES")) failed after JDK-8297092


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12022/head:pull/12022` \
`$ git checkout pull/12022`

Update a local copy of the PR: \
`$ git checkout pull/12022` \
`$ git pull https://git.openjdk.org/jdk pull/12022/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12022`

View PR using the GUI difftool: \
`$ git pr show -t 12022`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12022.diff">https://git.openjdk.org/jdk/pull/12022.diff</a>

</details>
