### PR TITLE
8300117: Replace use of JNI_COMMIT mode with mode 0

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CClipboard.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CClipboard.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -227,7 +227,7 @@ JNI_COCOA_ENTER(env);
         }
     }
 
-    (*env)->ReleaseLongArrayElements(env, returnValue, saveFormats, JNI_COMMIT);
+    (*env)->ReleaseLongArrayElements(env, returnValue, saveFormats, 0);
 JNI_COCOA_EXIT(env);
     return returnValue;
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDropTarget.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDropTarget.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -267,7 +267,7 @@ extern jclass jc_CDropTargetContextPeer;
             jformats[i] = registerFormatWithPasteboard(pbType);
     }
 
-    (*env)->ReleaseLongArrayElements(env, sDraggingFormats, jformats, JNI_COMMIT);
+    (*env)->ReleaseLongArrayElements(env, sDraggingFormats, jformats, 0);
 
     return TRUE;
 }
@@ -368,7 +368,7 @@ extern jclass jc_CDropTargetContextPeer;
 
     // Copy data to byte array and release elements:
     memcpy(jbytes, dataBytes, dataLength);
-    (*env)->ReleaseByteArrayElements(env, gbyteArray, jbytes, JNI_COMMIT);
+    (*env)->ReleaseByteArrayElements(env, gbyteArray, jbytes, 0);
 
     // In case of an error make sure to return nil:
     if ((*env)->ExceptionOccurred(env)) {


### PR DESCRIPTION
Please review this patch that fixes memory leaks in native code.

The call to `ReleaseXXArrayElements` with `JNI_COMMIT` parameter does not release the native buffer allocated by the previous `GetXXArrayElements` call. The buffer pointers were only stored in local variables and were lost on function exit.

No new regression test; existing tests under `java/awt/dnd` and `java/awt/datatransfer` cover all 3 modified functions.

Mach5 clientlibs tests continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300117](https://bugs.openjdk.org/browse/JDK-8300117): Replace use of JNI_COMMIT mode with mode 0


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12023/head:pull/12023` \
`$ git checkout pull/12023`

Update a local copy of the PR: \
`$ git checkout pull/12023` \
`$ git pull https://git.openjdk.org/jdk pull/12023/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12023`

View PR using the GUI difftool: \
`$ git pr show -t 12023`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12023.diff">https://git.openjdk.org/jdk/pull/12023.diff</a>

</details>
