### PR TITLE
8300168: Typo in AccessibleJTableHeaderEntry javadoc

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
+++ b/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
@@ -935,7 +935,7 @@ public class JTableHeader extends JComponent implements TableColumnModelListener
             private JTable table;
 
             /**
-             *  Constructs an AccessibleJTableHeaderEntry
+             * Constructs an AccessibleJTableHeaderEntry
              * @since 1.4
              *
              * @param c  the column index

--- a/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
+++ b/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
@@ -935,7 +935,7 @@ public class JTableHeader extends JComponent implements TableColumnModelListener
             private JTable table;
 
             /**
-             *  Constructs an AccessiblJTableHeaaderEntry
+             *  Constructs an AccessibleJTableHeaderEntry
              * @since 1.4
              *
              * @param c  the column index


### PR DESCRIPTION
There was a typo error in method description of `public AccessibleJTableHeaderEntry(int c, JTableHeader p, JTable t)`. Replaced the text `AccessiblJTableHeaaderEntry` with `AccessibleJTableHeaderEntry`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300168](https://bugs.openjdk.org/browse/JDK-8300168): Typo in AccessibleJTableHeaderEntry javadoc


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12024/head:pull/12024` \
`$ git checkout pull/12024`

Update a local copy of the PR: \
`$ git checkout pull/12024` \
`$ git pull https://git.openjdk.org/jdk pull/12024/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12024`

View PR using the GUI difftool: \
`$ git pr show -t 12024`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12024.diff">https://git.openjdk.org/jdk/pull/12024.diff</a>

</details>
