### PR TITLE
8300237: Minor improvements in MethodHandles

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -6776,10 +6776,10 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
                     loopReturnType + ")");
         }
 
-        if (pred.stream().anyMatch(Objects::isNull)) {
+        if (pred.stream().noneMatch(Objects::nonNull)) {
             throw newIllegalArgumentException("no predicate found", pred);
         }
-        if (pred.stream().map(MethodHandle::type).map(MethodType::returnType).
+        if (pred.stream().filter(Objects::nonNull).map(MethodHandle::type).map(MethodType::returnType).
                 anyMatch(t -> t != boolean.class)) {
             throw newIllegalArgumentException("predicates must have boolean return type", pred);
         }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -91,8 +91,6 @@ import static java.lang.invoke.MethodType.methodType;
  */
 public class MethodHandles {
 
-    private static final Class<?>[] EMPTY = new Class<?>[0];
-
     private MethodHandles() { }  // do not instantiate
 
     static final MemberName.Factory IMPL_NAMES = MemberName.getFactory();
@@ -6746,13 +6744,14 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
     }
 
     private static List<Class<?>> longestParameterList(Stream<MethodHandle> mhs, int skipSize) {
-        final Class<?>[] longest = mhs.filter(Objects::nonNull).
+        return mhs.filter(Objects::nonNull).
                 // take only those that can contribute to a common suffix because they are longer than the prefix
                         map(MethodHandle::type).
                         filter(t -> t.parameterCount() > skipSize).
                         map(MethodType::ptypes).
-                        reduce((p, q) -> p.length >= q.length ? p : q).orElse(EMPTY);
-        return longest.length == 0 ? List.of() : List.of(longest).subList(skipSize, longest.length);
+                        reduce((p, q) -> p.length >= q.length ? p : q).
+                        map(longest -> List.of(Arrays.copyOfRange(longest, skipSize, longest.length))).
+                        orElse(List.of());
     }
 
     private static List<Class<?>> buildCommonSuffix(List<MethodHandle> init, List<MethodHandle> step, List<MethodHandle> pred, List<MethodHandle> fini, int cpSize) {

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -56,7 +56,14 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.nio.ByteOrder;
 import java.security.ProtectionDomain;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
@@ -6743,8 +6750,7 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
                 .map(MethodHandle::type)
                 .filter(t -> t.parameterCount() > skipSize)
                 .max(Comparator.comparing(MethodType::parameterCount))
-                .map(MethodType::ptypes)
-                .map(longest -> List.of(Arrays.copyOfRange(longest, skipSize, longest.length)))
+                .map(methodType -> List.of(Arrays.copyOfRange(methodType.ptypes(), skipSize, methodType.parameterCount())))
                 .orElse(List.of());
     }
 

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -56,13 +56,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.nio.ByteOrder;
 import java.security.ProtectionDomain;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.BitSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
@@ -6744,14 +6738,14 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
     }
 
     private static List<Class<?>> longestParameterList(Stream<MethodHandle> mhs, int skipSize) {
-        return mhs.filter(Objects::nonNull).
+        return mhs.filter(Objects::nonNull)
                 // take only those that can contribute to a common suffix because they are longer than the prefix
-                        map(MethodHandle::type).
-                        filter(t -> t.parameterCount() > skipSize).
-                        map(MethodType::ptypes).
-                        reduce((p, q) -> p.length >= q.length ? p : q).
-                        map(longest -> List.of(Arrays.copyOfRange(longest, skipSize, longest.length))).
-                        orElse(List.of());
+                .map(MethodHandle::type)
+                .filter(t -> t.parameterCount() > skipSize)
+                .max(Comparator.comparing(MethodType::parameterCount))
+                .map(MethodType::ptypes)
+                .map(longest -> List.of(Arrays.copyOfRange(longest, skipSize, longest.length)))
+                .orElse(List.of());
     }
 
     private static List<Class<?>> buildCommonSuffix(List<MethodHandle> init, List<MethodHandle> step, List<MethodHandle> pred, List<MethodHandle> fini, int cpSize) {

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -6749,7 +6749,7 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
                 // take only those that can contribute to a common suffix because they are longer than the prefix
                 .map(MethodHandle::type)
                 .filter(t -> t.parameterCount() > skipSize)
-                .max(Comparator.comparing(MethodType::parameterCount))
+                .max(Comparator.comparingInt(MethodType::parameterCount))
                 .map(methodType -> List.of(Arrays.copyOfRange(methodType.ptypes(), skipSize, methodType.parameterCount())))
                 .orElse(List.of());
     }


### PR DESCRIPTION
- `MethodType.ptypes()` can be used instead of `MethodType.parameterList()` when we don't need a copy
- comparison of two lists can be done without `Stream.reduce()`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300237](https://bugs.openjdk.org/browse/JDK-8300237): Minor improvements in MethodHandles


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12025/head:pull/12025` \
`$ git checkout pull/12025`

Update a local copy of the PR: \
`$ git checkout pull/12025` \
`$ git pull https://git.openjdk.org/jdk pull/12025/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12025`

View PR using the GUI difftool: \
`$ git pr show -t 12025`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12025.diff">https://git.openjdk.org/jdk/pull/12025.diff</a>

</details>
