### PR TITLE
8299959: C2: CmpU::Value must filter overflow computation against local sub computation

### DIFF
--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -779,6 +779,9 @@ const Type* CmpUNode::Value(PhaseGVN* phase) const {
   if (t2 == TypeInt::INT) { // Compare to bottom?
     return bottom_type();
   }
+
+  const Type* t_sub = sub(t1, t2); // compare based on immediate inputs
+
   uint in1_op = in1->Opcode();
   if (in1_op == Op_AddI || in1_op == Op_SubI) {
     // The problem rise when result of AddI(SubI) may overflow
@@ -831,13 +834,15 @@ const Type* CmpUNode::Value(PhaseGVN* phase) const {
         const TypeInt* tr2 = TypeInt::make(lo_tr2, hi_tr2, w);
         const TypeInt* cmp1 = sub(tr1, t2)->is_int();
         const TypeInt* cmp2 = sub(tr2, t2)->is_int();
-        // compute union, so that cmp handles all possible results from the two cases
-        return cmp1->meet(cmp2);
+        // Compute union, so that cmp handles all possible results from the two cases
+        const Type* t_cmp = cmp1->meet(cmp2);
+        // Pick narrowest type, based on overflow computation and on immediate inputs
+        return t_sub->filter(t_cmp);
       }
     }
   }
 
-  return sub(t1, t2);            // Local flavor of type subtraction
+  return t_sub;
 }
 
 bool CmpUNode::is_index_range_check() const {

--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckCmpUOverflowVsSub.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckCmpUOverflowVsSub.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8299959
+ * @summary In CmpU::Value, the sub computation may be narrower than the overflow computation.
+ *
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+StressCCP -Xcomp -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,compiler.rangechecks.TestRangeCheckCmpUOverflowVsSub::test
+ *                   -XX:RepeatCompilation=50
+ *                   compiler.rangechecks.TestRangeCheckCmpUOverflowVsSub
+*/
+
+package compiler.rangechecks;
+
+public class TestRangeCheckCmpUOverflowVsSub {
+    static int arr[] = new int[400];
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 10; i++) {
+            test(); // repeat for multiple compilations
+        }
+    }
+
+    static void test() {
+        for(int i = 0; i < 50_000; i++) {} //empty loop - trigger OSR faster
+        int val;
+        int zero = arr[5];
+        int i = 1;
+        do {
+            for (int j = 1; j < 3; j++) {
+                for (int k = 2; k > i; k -= 3) {
+                    try {
+                        val = arr[i + 1] % k;
+                        val = arr[i - 1] % zero;
+                        val = arr[k - 1];
+                    } catch (ArithmeticException e) {} // catch div by zero
+                }
+            }
+        } while (++i < 3);
+    }
+}
+


### PR DESCRIPTION
During CCP, the overflow computation can be wider than the `sub` computation, thus we must filter them together.

**Example**
```
CmpI(AddI(in11 ,in12), in2)
in1 = AddI

type(int1):  int:-17..-5:www
type(int11): int:<=-4:www
type(int12): int:-1
type(int2):  int:>=0
```
If we call `CmpU::Value` now, we go into the overflow computation.
Addin `-1` to the range `int:<=-4:www` we get two ranges: `int:<=-5:www` and `int:max`.
Unsigned-comparing these to `int:>=0`, we get `GT` for `int:<=-5:www` (negative numbers become very large unsigned numbers), and `GE` for `int:max`. Together that is `GE == bool == 0..1`

During CCP, we now have a type-update (widening) for `int11` to `int`. The logic in `CmpU::Value` does not go into the overflow computation, since `type(in11) == t11 == TypeInt::INT`. Instead, we now just do the `sub` computation based on `in1` and `in2`. 
There we have t1 > t2 (unsigned comparison, so negative values become very large positive values), so we get a `GT == int:1`, which is narrower than `GE == 0..1`

CCP detects that the type narrowed instead of widened, we get an assert: `failed: Not monotonic`.

**Discussion of Solution**

We cannot assume that the types of `in1` and those of `in11` and `in12` are in sync when we are in `CmpU::Value`. During IGVN generally the inputs of inputs are narrower (narrower type may not have propagated to AddI yet), during CCP they are wider (widening may not yet have propagated to AddI yet).

We can assume that the overflow computation and the `sub` computation are individually `monotonic`. Currently, the combination is not monotonic, as the example shows. We can ensure that the combination is monotonic by `filtering` them against each other (taking the intersection / narrowest type possible).
We only need to do this filtering if we actually do the overflow computation - else we have already checked that `in11` or `in12` do not have types that would lead to a narrower result than `sub`, and so taking the result of `sub` is sufficient.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299959](https://bugs.openjdk.org/browse/JDK-8299959): C2: CmpU::Value must filter overflow computation against local sub computation


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12036/head:pull/12036` \
`$ git checkout pull/12036`

Update a local copy of the PR: \
`$ git checkout pull/12036` \
`$ git pull https://git.openjdk.org/jdk pull/12036/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12036`

View PR using the GUI difftool: \
`$ git pr show -t 12036`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12036.diff">https://git.openjdk.org/jdk/pull/12036.diff</a>

</details>
