### PR TITLE
8300253: Introduce AArch64 nzcv accessors

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -581,6 +581,14 @@ public:
     mrs(0b011, 0b0000, 0b0000, 0b001, reg);
   }
 
+  inline void get_nzcv(Register reg) {
+    mrs(0b011, 0b0100, 0b0010, 0b000, reg);
+  }
+
+  inline void set_nzcv(Register reg) {
+    msr(0b011, 0b0100, 0b0010, 0b000, reg);
+  }
+
   // idiv variant which deals with MINLONG as dividend and -1 as divisor
   int corrected_idivl(Register result, Register ra, Register rb,
                       bool want_remainder, Register tmp = rscratch1);

--- a/test/hotspot/gtest/aarch64/aarch64-asmtest.py
+++ b/test/hotspot/gtest/aarch64/aarch64-asmtest.py
@@ -350,6 +350,67 @@ class OneRegOp(Instruction):
         return (super(OneRegOp, self).astr()
                 + '%s' % self.reg.astr(self.asmRegPrefix))
 
+class SystemRegOp(Instruction):
+    def __init__(self, args):
+        name, self.system_reg = args
+        Instruction.__init__(self, name)
+        if self.system_reg == 'fpsr':
+            self.op1 = 0b011
+            self.CRn = 0b0100
+            self.CRm = 0b0100
+            self.op2 = 0b001
+        elif self.system_reg == 'dczid_el0':
+            self.op1 = 0b011
+            self.CRn = 0b0000
+            self.CRm = 0b0000
+            self.op2 = 0b111
+        elif self.system_reg == 'ctr_el0':
+            self.op1 = 0b011
+            self.CRn = 0b0000
+            self.CRm = 0b0000
+            self.op2 = 0b001
+        elif self.system_reg == 'nzcv':
+            self.op1 = 0b011
+            self.CRn = 0b0100
+            self.CRm = 0b0010
+            self.op2 = 0b000
+
+    def generate(self):
+        self.reg = [GeneralRegister().generate()]
+        return self
+
+class SystemOneRegOp(SystemRegOp):
+
+    def cstr(self):
+        return (super(SystemOneRegOp, self).cstr()
+                + '%s' % self.op1
+                + ', %s' % self.CRn
+                + ', %s' % self.CRm
+                + ', %s' % self.op2
+                + ', %s);' % self.reg[0])
+
+    def astr(self):
+        prefix = self.asmRegPrefix
+        return (super(SystemOneRegOp, self).astr()
+                + '%s' % self.system_reg
+                + ', %s' % self.reg[0].astr(prefix))
+
+class OneRegSystemOp(SystemRegOp):
+
+    def cstr(self):
+        return (super(OneRegSystemOp, self).cstr()
+                + '%s' % self.op1
+                + ', %s' % self.CRn
+                + ', %s' % self.CRm
+                + ', %s' % self.op2
+                + ', %s);' % self.reg[0])
+
+    def astr(self):
+        prefix = self.asmRegPrefix
+        return (super(OneRegSystemOp, self).astr()
+                + '%s' % self.reg[0].astr(prefix)
+                + ', %s' % self.system_reg)
+
 class PostfixExceptionOneRegOp(OneRegOp):
 
     def __init__(self, op):
@@ -1395,6 +1456,10 @@ generate (OneRegOp, ["br", "blr",
                      "paciza", "pacizb", "pacdza", "pacdzb",
                      "autiza", "autizb", "autdza", "autdzb", "xpacd",
                      "braaz", "brabz", "blraaz", "blrabz"])
+
+for system_reg in ["fpsr", "dczid_el0", "ctr_el0", "nzcv"]:
+    generate (SystemOneRegOp, [ ["msr", system_reg] ])
+    generate (OneRegSystemOp, [ ["mrs", system_reg] ])
 
 # Ensure the "i" is not stripped off the end of the instruction
 generate (PostfixExceptionOneRegOp, ["xpaci"])

--- a/test/hotspot/gtest/aarch64/aarch64-asmtest.py
+++ b/test/hotspot/gtest/aarch64/aarch64-asmtest.py
@@ -1457,8 +1457,10 @@ generate (OneRegOp, ["br", "blr",
                      "autiza", "autizb", "autdza", "autdzb", "xpacd",
                      "braaz", "brabz", "blraaz", "blrabz"])
 
-for system_reg in ["fpsr", "dczid_el0", "ctr_el0", "nzcv"]:
+for system_reg in ["fpsr", "nzcv"]:
     generate (SystemOneRegOp, [ ["msr", system_reg] ])
+
+for system_reg in ["fpsr", "nzcv", "dczid_el0", "ctr_el0"]:
     generate (OneRegSystemOp, [ ["mrs", system_reg] ])
 
 # Ensure the "i" is not stripped off the end of the instruction

--- a/test/hotspot/gtest/aarch64/asmtest.out.h
+++ b/test/hotspot/gtest/aarch64/asmtest.out.h
@@ -213,561 +213,579 @@
     __ blraaz(r23);                                    //       blraaz  x23
     __ blrabz(r21);                                    //       blrabz  x21
 
+// SystemOneRegOp
+    __ msr(3, 4, 4, 1, r20);                           //       msr     fpsr, x20
+
+// SystemOneRegOp
+    __ msr(3, 4, 2, 0, r22);                           //       msr     nzcv, x22
+
+// OneRegSystemOp
+    __ mrs(3, 4, 4, 1, r27);                           //       mrs     x27, fpsr
+
+// OneRegSystemOp
+    __ mrs(3, 4, 2, 0, r19);                           //       mrs     x19, nzcv
+
+// OneRegSystemOp
+    __ mrs(3, 0, 0, 7, r11);                           //       mrs     x11, dczid_el0
+
+// OneRegSystemOp
+    __ mrs(3, 0, 0, 1, r16);                           //       mrs     x16, ctr_el0
+
 // PostfixExceptionOneRegOp
-    __ xpaci(r20);                                     //       xpaci   x20
+    __ xpaci(r6);                                      //       xpaci   x6
 
 // LoadStoreExclusiveOp
-    __ stxr(r22, r27, r19);                            //       stxr    w22, x27, [x19]
-    __ stlxr(r11, r16, r6);                            //       stlxr   w11, x16, [x6]
-    __ ldxr(r17, r0);                                  //       ldxr    x17, [x0]
-    __ ldaxr(r4, r10);                                 //       ldaxr   x4, [x10]
-    __ stlr(r24, r22);                                 //       stlr    x24, [x22]
-    __ ldar(r10, r19);                                 //       ldar    x10, [x19]
+    __ stxr(r17, r0, r4);                              //       stxr    w17, x0, [x4]
+    __ stlxr(r10, r24, r22);                           //       stlxr   w10, x24, [x22]
+    __ ldxr(r10, r19);                                 //       ldxr    x10, [x19]
+    __ ldaxr(r1, r5);                                  //       ldaxr   x1, [x5]
+    __ stlr(r30, r8);                                  //       stlr    x30, [x8]
+    __ ldar(r12, r17);                                 //       ldar    x12, [x17]
 
 // LoadStoreExclusiveOp
-    __ stxrw(r1, r5, r30);                             //       stxr    w1, w5, [x30]
-    __ stlxrw(r8, r12, r17);                           //       stlxr   w8, w12, [x17]
-    __ ldxrw(r9, r14);                                 //       ldxr    w9, [x14]
-    __ ldaxrw(r7, r1);                                 //       ldaxr   w7, [x1]
-    __ stlrw(r5, r16);                                 //       stlr    w5, [x16]
-    __ ldarw(r2, r12);                                 //       ldar    w2, [x12]
+    __ stxrw(r9, r14, r7);                             //       stxr    w9, w14, [x7]
+    __ stlxrw(r1, r5, r16);                            //       stlxr   w1, w5, [x16]
+    __ ldxrw(r2, r12);                                 //       ldxr    w2, [x12]
+    __ ldaxrw(r10, r12);                               //       ldaxr   w10, [x12]
+    __ stlrw(r3, r28);                                 //       stlr    w3, [x28]
+    __ ldarw(r14, r26);                                //       ldar    w14, [x26]
 
 // LoadStoreExclusiveOp
-    __ stxrh(r10, r12, r3);                            //       stxrh   w10, w12, [x3]
-    __ stlxrh(r28, r14, r26);                          //       stlxrh  w28, w14, [x26]
-    __ ldxrh(r30, r10);                                //       ldxrh   w30, [x10]
-    __ ldaxrh(r14, r21);                               //       ldaxrh  w14, [x21]
-    __ stlrh(r13, r9);                                 //       stlrh   w13, [x9]
-    __ ldarh(r22, r27);                                //       ldarh   w22, [x27]
+    __ stxrh(r30, r10, r14);                           //       stxrh   w30, w10, [x14]
+    __ stlxrh(r21, r13, r9);                           //       stlxrh  w21, w13, [x9]
+    __ ldxrh(r22, r27);                                //       ldxrh   w22, [x27]
+    __ ldaxrh(r28, r19);                               //       ldaxrh  w28, [x19]
+    __ stlrh(r11, r30);                                //       stlrh   w11, [x30]
+    __ ldarh(r19, r2);                                 //       ldarh   w19, [x2]
 
 // LoadStoreExclusiveOp
-    __ stxrb(r28, r19, r11);                           //       stxrb   w28, w19, [x11]
-    __ stlxrb(r30, r19, r2);                           //       stlxrb  w30, w19, [x2]
-    __ ldxrb(r2, r23);                                 //       ldxrb   w2, [x23]
-    __ ldaxrb(r1, r0);                                 //       ldaxrb  w1, [x0]
-    __ stlrb(r12, r16);                                //       stlrb   w12, [x16]
-    __ ldarb(r13, r15);                                //       ldarb   w13, [x15]
+    __ stxrb(r2, r23, r1);                             //       stxrb   w2, w23, [x1]
+    __ stlxrb(r0, r12, r16);                           //       stlxrb  w0, w12, [x16]
+    __ ldxrb(r13, r15);                                //       ldxrb   w13, [x15]
+    __ ldaxrb(r17, r21);                               //       ldaxrb  w17, [x21]
+    __ stlrb(r13, r11);                                //       stlrb   w13, [x11]
+    __ ldarb(r30, r8);                                 //       ldarb   w30, [x8]
 
 // LoadStoreExclusiveOp
-    __ ldxp(r17, r21, r13);                            //       ldxp    x17, x21, [x13]
-    __ ldaxp(r11, r30, r8);                            //       ldaxp   x11, x30, [x8]
-    __ stxp(r24, r13, r11, r1);                        //       stxp    w24, x13, x11, [x1]
-    __ stlxp(r26, r21, r27, r13);                      //       stlxp   w26, x21, x27, [x13]
+    __ ldxp(r24, r13, r11);                            //       ldxp    x24, x13, [x11]
+    __ ldaxp(r1, r26, r21);                            //       ldaxp   x1, x26, [x21]
+    __ stxp(r27, r13, r20, r3);                        //       stxp    w27, x13, x20, [x3]
+    __ stlxp(r12, r6, r1, r29);                        //       stlxp   w12, x6, x1, [x29]
 
 // LoadStoreExclusiveOp
-    __ ldxpw(r20, r3, r12);                            //       ldxp    w20, w3, [x12]
-    __ ldaxpw(r6, r1, r29);                            //       ldaxp   w6, w1, [x29]
-    __ stxpw(r6, r4, r11, r16);                        //       stxp    w6, w4, w11, [x16]
-    __ stlxpw(r4, r30, r12, r21);                      //       stlxp   w4, w30, w12, [x21]
+    __ ldxpw(r6, r4, r11);                             //       ldxp    w6, w4, [x11]
+    __ ldaxpw(r16, r4, r30);                           //       ldaxp   w16, w4, [x30]
+    __ stxpw(r30, r4, r12, r21);                       //       stxp    w30, w4, w12, [x21]
+    __ stlxpw(r27, r15, r28, r9);                      //       stlxp   w27, w15, w28, [x9]
 
 // base_plus_unscaled_offset
 // LoadStoreOp
-    __ str(r6, Address(r27, 97));                      //       str     x6, [x27, 97]
-    __ strw(r17, Address(r10, 45));                    //       str     w17, [x10, 45]
-    __ strb(r26, Address(r22, -29));                   //       strb    w26, [x22, -29]
-    __ strh(r21, Address(r10, -50));                   //       strh    w21, [x10, -50]
-    __ ldr(r14, Address(r24, 125));                    //       ldr     x14, [x24, 125]
-    __ ldrw(r7, Address(r24, -16));                    //       ldr     w7, [x24, -16]
-    __ ldrb(r8, Address(r2, 13));                      //       ldrb    w8, [x2, 13]
-    __ ldrh(r30, Address(r25, -61));                   //       ldrh    w30, [x25, -61]
-    __ ldrsb(r3, Address(r12, -14));                   //       ldrsb   x3, [x12, -14]
-    __ ldrsh(r10, Address(r17, -28));                  //       ldrsh   x10, [x17, -28]
-    __ ldrshw(r21, Address(r3, -5));                   //       ldrsh   w21, [x3, -5]
-    __ ldrsw(r2, Address(r25, 23));                    //       ldrsw   x2, [x25, 23]
-    __ ldrd(v25, Address(r1, -69));                    //       ldr     d25, [x1, -69]
-    __ ldrs(v29, Address(r27, 6));                     //       ldr     s29, [x27, 6]
-    __ strd(v29, Address(r12, 41));                    //       str     d29, [x12, 41]
-    __ strs(v2, Address(r22, -115));                   //       str     s2, [x22, -115]
+    __ str(r25, Address(r15, 1));                      //       str     x25, [x15, 1]
+    __ strw(r2, Address(r1, -79));                     //       str     w2, [x1, -79]
+    __ strb(r20, Address(r26, -22));                   //       strb    w20, [x26, -22]
+    __ strh(r23, Address(r30, 22));                    //       strh    w23, [x30, 22]
+    __ ldr(r26, Address(r28, -49));                    //       ldr     x26, [x28, -49]
+    __ ldrw(r9, Address(r24, -128));                   //       ldr     w9, [x24, -128]
+    __ ldrb(r12, Address(r12, -30));                   //       ldrb    w12, [x12, -30]
+    __ ldrh(r1, Address(r15, 5));                      //       ldrh    w1, [x15, 5]
+    __ ldrsb(r24, Address(r14, -31));                  //       ldrsb   x24, [x14, -31]
+    __ ldrsh(r24, Address(r15, -6));                   //       ldrsh   x24, [x15, -6]
+    __ ldrshw(r5, Address(r3, 12));                    //       ldrsh   w5, [x3, 12]
+    __ ldrsw(r27, Address(r24, 17));                   //       ldrsw   x27, [x24, 17]
+    __ ldrd(v13, Address(r29, -35));                   //       ldr     d13, [x29, -35]
+    __ ldrs(v22, Address(r9, -47));                    //       ldr     s22, [x9, -47]
+    __ strd(v11, Address(r0, 9));                      //       str     d11, [x0, 9]
+    __ strs(v20, Address(r0, -127));                   //       str     s20, [x0, -127]
 
 // pre
 // LoadStoreOp
-    __ str(r26, Address(__ pre(r5, 3)));               //       str     x26, [x5, 3]!
-    __ strw(r20, Address(__ pre(r5, -103)));           //       str     w20, [x5, -103]!
-    __ strb(r8, Address(__ pre(r12, -25)));            //       strb    w8, [x12, -25]!
-    __ strh(r20, Address(__ pre(r2, -57)));            //       strh    w20, [x2, -57]!
-    __ ldr(r14, Address(__ pre(r29, -234)));           //       ldr     x14, [x29, -234]!
-    __ ldrw(r13, Address(__ pre(r29, 4)));             //       ldr     w13, [x29, 4]!
-    __ ldrb(r24, Address(__ pre(r19, -9)));            //       ldrb    w24, [x19, -9]!
-    __ ldrh(r3, Address(__ pre(r27, -19)));            //       ldrh    w3, [x27, -19]!
-    __ ldrsb(r17, Address(__ pre(r1, -5)));            //       ldrsb   x17, [x1, -5]!
-    __ ldrsh(r17, Address(__ pre(r19, -13)));          //       ldrsh   x17, [x19, -13]!
-    __ ldrshw(r21, Address(__ pre(r11, -26)));         //       ldrsh   w21, [x11, -26]!
-    __ ldrsw(r1, Address(__ pre(r9, -60)));            //       ldrsw   x1, [x9, -60]!
-    __ ldrd(v26, Address(__ pre(r23, -247)));          //       ldr     d26, [x23, -247]!
-    __ ldrs(v22, Address(__ pre(r21, -127)));          //       ldr     s22, [x21, -127]!
-    __ strd(v13, Address(__ pre(r7, -216)));           //       str     d13, [x7, -216]!
-    __ strs(v12, Address(__ pre(r13, -104)));          //       str     s12, [x13, -104]!
+    __ str(r29, Address(__ pre(r3, -114)));            //       str     x29, [x3, -114]!
+    __ strw(r17, Address(__ pre(r4, -72)));            //       str     w17, [x4, -72]!
+    __ strb(r0, Address(__ pre(r2, -17)));             //       strb    w0, [x2, -17]!
+    __ strh(r29, Address(__ pre(r1, 7)));              //       strh    w29, [x1, 7]!
+    __ ldr(r16, Address(__ pre(r21, -133)));           //       ldr     x16, [x21, -133]!
+    __ ldrw(r20, Address(__ pre(r14, 19)));            //       ldr     w20, [x14, 19]!
+    __ ldrb(r22, Address(__ pre(r14, -3)));            //       ldrb    w22, [x14, -3]!
+    __ ldrh(r15, Address(__ pre(r17, 9)));             //       ldrh    w15, [x17, 9]!
+    __ ldrsb(r10, Address(__ pre(r15, -19)));          //       ldrsb   x10, [x15, -19]!
+    __ ldrsh(r20, Address(__ pre(r12, -25)));          //       ldrsh   x20, [x12, -25]!
+    __ ldrshw(r21, Address(__ pre(r10, -29)));         //       ldrsh   w21, [x10, -29]!
+    __ ldrsw(r19, Address(__ pre(r0, 5)));             //       ldrsw   x19, [x0, 5]!
+    __ ldrd(v0, Address(__ pre(r14, -54)));            //       ldr     d0, [x14, -54]!
+    __ ldrs(v3, Address(__ pre(r1, 40)));              //       ldr     s3, [x1, 40]!
+    __ strd(v4, Address(__ pre(r14, -94)));            //       str     d4, [x14, -94]!
+    __ strs(v17, Address(__ pre(r28, -54)));           //       str     s17, [x28, -54]!
 
 // post
 // LoadStoreOp
-    __ str(r20, Address(__ post(r5, -237)));           //       str     x20, [x5], -237
-    __ strw(r29, Address(__ post(r28, -74)));          //       str     w29, [x28], -74
-    __ strb(r4, Address(__ post(r24, -22)));           //       strb    w4, [x24], -22
-    __ strh(r13, Address(__ post(r9, -21)));           //       strh    w13, [x9], -21
-    __ ldr(r26, Address(__ post(r7, -55)));            //       ldr     x26, [x7], -55
-    __ ldrw(r13, Address(__ post(r3, -115)));          //       ldr     w13, [x3], -115
-    __ ldrb(r1, Address(__ post(r5, 12)));             //       ldrb    w1, [x5], 12
-    __ ldrh(r8, Address(__ post(r13, -34)));           //       ldrh    w8, [x13], -34
-    __ ldrsb(r23, Address(__ post(r20, -27)));         //       ldrsb   x23, [x20], -27
-    __ ldrsh(r20, Address(__ post(r6, -2)));           //       ldrsh   x20, [x6], -2
-    __ ldrshw(r9, Address(__ post(r17, -42)));         //       ldrsh   w9, [x17], -42
-    __ ldrsw(r21, Address(__ post(r6, -30)));          //       ldrsw   x21, [x6], -30
-    __ ldrd(v16, Address(__ post(r22, -29)));          //       ldr     d16, [x22], -29
-    __ ldrs(v9, Address(__ post(r11, -3)));            //       ldr     s9, [x11], -3
-    __ strd(v22, Address(__ post(r26, 60)));           //       str     d22, [x26], 60
-    __ strs(v16, Address(__ post(r29, -2)));           //       str     s16, [x29], -2
+    __ str(r22, Address(__ post(r15, -185)));          //       str     x22, [x15], -185
+    __ strw(r17, Address(__ post(r14, -7)));           //       str     w17, [x14], -7
+    __ strb(r30, Address(__ post(r11, -25)));          //       strb    w30, [x11], -25
+    __ strh(r1, Address(__ post(r11, 20)));            //       strh    w1, [x11], 20
+    __ ldr(r22, Address(__ post(r1, 2)));              //       ldr     x22, [x1], 2
+    __ ldrw(r2, Address(__ post(r23, -119)));          //       ldr     w2, [x23], -119
+    __ ldrb(r3, Address(__ post(r27, -12)));           //       ldrb    w3, [x27], -12
+    __ ldrh(r16, Address(__ post(r7, -37)));           //       ldrh    w16, [x7], -37
+    __ ldrsb(r15, Address(__ post(r26, 3)));           //       ldrsb   x15, [x26], 3
+    __ ldrsh(r7, Address(__ post(r15, -30)));          //       ldrsh   x7, [x15], -30
+    __ ldrshw(r3, Address(__ post(r11, -48)));         //       ldrsh   w3, [x11], -48
+    __ ldrsw(r25, Address(__ post(r23, 22)));          //       ldrsw   x25, [x23], 22
+    __ ldrd(v0, Address(__ post(r10, -215)));          //       ldr     d0, [x10], -215
+    __ ldrs(v17, Address(__ post(r6, 55)));            //       ldr     s17, [x6], 55
+    __ strd(v13, Address(__ post(r21, -234)));         //       str     d13, [x21], -234
+    __ strs(v0, Address(__ post(r22, -70)));           //       str     s0, [x22], -70
 
 // base_plus_reg
 // LoadStoreOp
-    __ str(r1, Address(r22, r4, Address::sxtw(0)));    //       str     x1, [x22, w4, sxtw #0]
-    __ strw(r23, Address(r30, r13, Address::lsl(2)));  //       str     w23, [x30, x13, lsl #2]
-    __ strb(r12, Address(r11, r12, Address::uxtw(0))); //       strb    w12, [x11, w12, uxtw #0]
-    __ strh(r25, Address(r12, r0, Address::lsl(1)));   //       strh    w25, [x12, x0, lsl #1]
-    __ ldr(r17, Address(r7, r0, Address::uxtw(3)));    //       ldr     x17, [x7, w0, uxtw #3]
-    __ ldrw(r1, Address(r19, r14, Address::uxtw(2)));  //       ldr     w1, [x19, w14, uxtw #2]
-    __ ldrb(r12, Address(r2, r9, Address::lsl(0)));    //       ldrb    w12, [x2, x9, lsl #0]
-    __ ldrh(r22, Address(r9, r27, Address::sxtw(0)));  //       ldrh    w22, [x9, w27, sxtw #0]
-    __ ldrsb(r21, Address(r12, r15, Address::sxtx(0))); //      ldrsb   x21, [x12, x15, sxtx #0]
-    __ ldrsh(r28, Address(r6, r16, Address::lsl(1)));  //       ldrsh   x28, [x6, x16, lsl #1]
-    __ ldrshw(r25, Address(r17, r22, Address::sxtw(0))); //     ldrsh   w25, [x17, w22, sxtw #0]
-    __ ldrsw(r4, Address(r17, r29, Address::sxtx(0))); //       ldrsw   x4, [x17, x29, sxtx #0]
-    __ ldrd(v5, Address(r1, r3, Address::sxtx(3)));    //       ldr     d5, [x1, x3, sxtx #3]
-    __ ldrs(v24, Address(r17, r13, Address::uxtw(2))); //       ldr     s24, [x17, w13, uxtw #2]
-    __ strd(v17, Address(r17, r23, Address::sxtx(3))); //       str     d17, [x17, x23, sxtx #3]
-    __ strs(v17, Address(r30, r5, Address::sxtw(2)));  //       str     s17, [x30, w5, sxtw #2]
+    __ str(r27, Address(r19, r0, Address::sxtx(0)));   //       str     x27, [x19, x0, sxtx #0]
+    __ strw(r8, Address(r6, r13, Address::lsl(0)));    //       str     w8, [x6, x13, lsl #0]
+    __ strb(r4, Address(r16, r22, Address::lsl(0)));   //       strb    w4, [x16, x22, lsl #0]
+    __ strh(r25, Address(r26, r15, Address::uxtw(0))); //       strh    w25, [x26, w15, uxtw #0]
+    __ ldr(r4, Address(r5, r24, Address::sxtw(0)));    //       ldr     x4, [x5, w24, sxtw #0]
+    __ ldrw(r4, Address(r17, r7, Address::uxtw(0)));   //       ldr     w4, [x17, w7, uxtw #0]
+    __ ldrb(r17, Address(r7, r11, Address::lsl(0)));   //       ldrb    w17, [x7, x11, lsl #0]
+    __ ldrh(r0, Address(r30, r23, Address::lsl(0)));   //       ldrh    w0, [x30, x23, lsl #0]
+    __ ldrsb(r10, Address(r22, r1, Address::uxtw(0))); //       ldrsb   x10, [x22, w1, uxtw #0]
+    __ ldrsh(r21, Address(r30, r30, Address::sxtw(1))); //      ldrsh   x21, [x30, w30, sxtw #1]
+    __ ldrshw(r11, Address(r10, r28, Address::sxtw(1))); //     ldrsh   w11, [x10, w28, sxtw #1]
+    __ ldrsw(r28, Address(r19, r10, Address::uxtw(0))); //      ldrsw   x28, [x19, w10, uxtw #0]
+    __ ldrd(v29, Address(r29, r14, Address::sxtw(0))); //       ldr     d29, [x29, w14, sxtw #0]
+    __ ldrs(v8, Address(r5, r5, Address::sxtw(2)));    //       ldr     s8, [x5, w5, sxtw #2]
+    __ strd(v24, Address(r8, r13, Address::sxtx(0)));  //       str     d24, [x8, x13, sxtx #0]
+    __ strs(v17, Address(r24, r26, Address::lsl(2)));  //       str     s17, [x24, x26, lsl #2]
 
 // base_plus_scaled_offset
 // LoadStoreOp
-    __ str(r29, Address(r11, 14160));                  //       str     x29, [x11, 14160]
-    __ strw(r28, Address(r21, 7752));                  //       str     w28, [x21, 7752]
-    __ strb(r28, Address(r2, 1746));                   //       strb    w28, [x2, 1746]
-    __ strh(r0, Address(r28, 3296));                   //       strh    w0, [x28, 3296]
-    __ ldr(r25, Address(r7, 15408));                   //       ldr     x25, [x7, 15408]
-    __ ldrw(r0, Address(r3, 6312));                    //       ldr     w0, [x3, 6312]
-    __ ldrb(r30, Address(r5, 1992));                   //       ldrb    w30, [x5, 1992]
-    __ ldrh(r14, Address(r23, 3194));                  //       ldrh    w14, [x23, 3194]
-    __ ldrsb(r10, Address(r19, 1786));                 //       ldrsb   x10, [x19, 1786]
-    __ ldrsh(r29, Address(r17, 3482));                 //       ldrsh   x29, [x17, 3482]
-    __ ldrshw(r25, Address(r30, 3362));                //       ldrsh   w25, [x30, 3362]
-    __ ldrsw(r17, Address(r2, 7512));                  //       ldrsw   x17, [x2, 7512]
-    __ ldrd(v15, Address(r16, 15176));                 //       ldr     d15, [x16, 15176]
-    __ ldrs(v12, Address(r30, 6220));                  //       ldr     s12, [x30, 6220]
-    __ strd(v1, Address(r1, 15216));                   //       str     d1, [x1, 15216]
-    __ strs(v5, Address(r11, 7832));                   //       str     s5, [x11, 7832]
+    __ str(r19, Address(r12, 15904));                  //       str     x19, [x12, 15904]
+    __ strw(r23, Address(r15, 7892));                  //       str     w23, [x15, 7892]
+    __ strb(r29, Address(r13, 1970));                  //       strb    w29, [x13, 1970]
+    __ strh(r11, Address(r7, 3094));                   //       strh    w11, [x7, 3094]
+    __ ldr(r10, Address(r24, 14992));                  //       ldr     x10, [x24, 14992]
+    __ ldrw(r16, Address(r0, 6160));                   //       ldr     w16, [x0, 6160]
+    __ ldrb(r20, Address(r1, 2032));                   //       ldrb    w20, [x1, 2032]
+    __ ldrh(r1, Address(r17, 4056));                   //       ldrh    w1, [x17, 4056]
+    __ ldrsb(r17, Address(r25, 1889));                 //       ldrsb   x17, [x25, 1889]
+    __ ldrsh(r27, Address(r25, 3964));                 //       ldrsh   x27, [x25, 3964]
+    __ ldrshw(r14, Address(r17, 3724));                //       ldrsh   w14, [x17, 3724]
+    __ ldrsw(r10, Address(r7, 6372));                  //       ldrsw   x10, [x7, 6372]
+    __ ldrd(v3, Address(r25, 12392));                  //       ldr     d3, [x25, 12392]
+    __ ldrs(v12, Address(r9, 7840));                   //       ldr     s12, [x9, 7840]
+    __ strd(v23, Address(r1, 12728));                  //       str     d23, [x1, 12728]
+    __ strs(v3, Address(r20, 6924));                   //       str     s3, [x20, 6924]
 
 // pcrel
 // LoadStoreOp
-    __ ldr(r17, back);                                 //       ldr     x17, back
-    __ ldrw(r2, back);                                 //       ldr     w2, back
+    __ ldr(r2, back);                                  //       ldr     x2, back
+    __ ldrw(r29, __ pc());                             //       ldr     w29, .
 
 // LoadStoreOp
-    __ prfm(Address(r25, 111));                        //       prfm    PLDL1KEEP, [x25, 111]
+    __ prfm(Address(r14, 93));                         //       prfm    PLDL1KEEP, [x14, 93]
 
 // LoadStoreOp
     __ prfm(back);                                     //       prfm    PLDL1KEEP, back
 
 // LoadStoreOp
-    __ prfm(Address(r14, r27, Address::uxtw(0)));      //       prfm    PLDL1KEEP, [x14, w27, uxtw #0]
+    __ prfm(Address(r1, r7, Address::lsl(3)));         //       prfm    PLDL1KEEP, [x1, x7, lsl #3]
 
 // LoadStoreOp
-    __ prfm(Address(r14, 12328));                      //       prfm    PLDL1KEEP, [x14, 12328]
+    __ prfm(Address(r17, 12288));                      //       prfm    PLDL1KEEP, [x17, 12288]
 
 // AddSubCarryOp
-    __ adcw(r0, r25, r15);                             //       adc     w0, w25, w15
-    __ adcsw(r1, r24, r3);                             //       adcs    w1, w24, w3
-    __ sbcw(r17, r24, r20);                            //       sbc     w17, w24, w20
-    __ sbcsw(r11, r0, r13);                            //       sbcs    w11, w0, w13
-    __ adc(r28, r10, r7);                              //       adc     x28, x10, x7
-    __ adcs(r4, r15, r16);                             //       adcs    x4, x15, x16
-    __ sbc(r2, r12, r20);                              //       sbc     x2, x12, x20
-    __ sbcs(r29, r13, r13);                            //       sbcs    x29, x13, x13
+    __ adcw(r1, r24, r3);                              //       adc     w1, w24, w3
+    __ adcsw(r17, r24, r20);                           //       adcs    w17, w24, w20
+    __ sbcw(r11, r0, r13);                             //       sbc     w11, w0, w13
+    __ sbcsw(r28, r10, r7);                            //       sbcs    w28, w10, w7
+    __ adc(r4, r15, r16);                              //       adc     x4, x15, x16
+    __ adcs(r2, r12, r20);                             //       adcs    x2, x12, x20
+    __ sbc(r29, r13, r13);                             //       sbc     x29, x13, x13
+    __ sbcs(r14, r6, r12);                             //       sbcs    x14, x6, x12
 
 // AddSubExtendedOp
-    __ addw(r14, r6, r12, ext::uxtx, 3);               //       add     w14, w6, w12, uxtx #3
-    __ addsw(r17, r25, r30, ext::uxtw, 4);             //       adds    w17, w25, w30, uxtw #4
-    __ sub(r0, r17, r14, ext::uxtb, 1);                //       sub     x0, x17, x14, uxtb #1
-    __ subsw(r9, r24, r29, ext::sxtx, 1);              //       subs    w9, w24, w29, sxtx #1
-    __ add(r1, r22, r0, ext::sxtw, 2);                 //       add     x1, x22, x0, sxtw #2
-    __ adds(r12, r28, r22, ext::uxth, 3);              //       adds    x12, x28, x22, uxth #3
-    __ sub(r10, r12, r17, ext::uxtw, 4);               //       sub     x10, x12, x17, uxtw #4
-    __ subs(r15, r28, r10, ext::sxtw, 3);              //       subs    x15, x28, x10, sxtw #3
+    __ addw(r20, r12, r17, ext::sxtx, 4);              //       add     w20, w12, w17, sxtx #4
+    __ addsw(r27, r11, r0, ext::uxtx, 3);              //       adds    w27, w11, w0, uxtx #3
+    __ sub(r7, r1, r9, ext::sxtx, 4);                  //       sub     x7, x1, x9, sxtx #4
+    __ subsw(r3, r27, r1, ext::uxtb, 3);               //       subs    w3, w27, w1, uxtb #3
+    __ add(r13, r26, r12, ext::sxth, 4);               //       add     x13, x26, x12, sxth #4
+    __ adds(r17, r5, r10, ext::sxtb, 2);               //       adds    x17, x5, x10, sxtb #2
+    __ sub(r30, r8, r15, ext::uxtw, 4);                //       sub     x30, x8, x15, uxtw #4
+    __ subs(r19, r23, r19, ext::uxth, 4);              //       subs    x19, x23, x19, uxth #4
 
 // ConditionalCompareOp
-    __ ccmnw(r19, r23, 2u, Assembler::LE);             //       ccmn    w19, w23, #2, LE
-    __ ccmpw(r17, r9, 6u, Assembler::LO);              //       ccmp    w17, w9, #6, LO
-    __ ccmn(r21, r8, 2u, Assembler::CC);               //       ccmn    x21, x8, #2, CC
-    __ ccmp(r19, r5, 1u, Assembler::MI);               //       ccmp    x19, x5, #1, MI
+    __ ccmnw(r29, r5, 10u, Assembler::LO);             //       ccmn    w29, w5, #10, LO
+    __ ccmpw(r9, r13, 11u, Assembler::LO);             //       ccmp    w9, w13, #11, LO
+    __ ccmn(r10, r4, 6u, Assembler::HS);               //       ccmn    x10, x4, #6, HS
+    __ ccmp(r12, r2, 12u, Assembler::HI);              //       ccmp    x12, x2, #12, HI
 
 // ConditionalCompareImmedOp
-    __ ccmnw(r22, 17, 12, Assembler::HI);              //       ccmn    w22, #17, #12, HI
-    __ ccmpw(r17, 7, 3, Assembler::HS);                //       ccmp    w17, #7, #3, HS
-    __ ccmn(r16, 28, 5, Assembler::LT);                //       ccmn    x16, #28, #5, LT
-    __ ccmp(r22, 3, 5, Assembler::LS);                 //       ccmp    x22, #3, #5, LS
+    __ ccmnw(r16, 6, 2, Assembler::VS);                //       ccmn    w16, #6, #2, VS
+    __ ccmpw(r7, 11, 13, Assembler::VS);               //       ccmp    w7, #11, #13, VS
+    __ ccmn(r27, 10, 11, Assembler::LS);               //       ccmn    x27, #10, #11, LS
+    __ ccmp(r3, 13, 13, Assembler::LE);                //       ccmp    x3, #13, #13, LE
 
 // ConditionalSelectOp
-    __ cselw(r29, r26, r12, Assembler::LT);            //       csel    w29, w26, w12, LT
-    __ csincw(r27, r10, r15, Assembler::CC);           //       csinc   w27, w10, w15, CC
-    __ csinvw(r21, r28, r30, Assembler::LS);           //       csinv   w21, w28, w30, LS
-    __ csnegw(r9, r27, r30, Assembler::CC);            //       csneg   w9, w27, w30, CC
-    __ csel(r29, r15, r29, Assembler::LE);             //       csel    x29, x15, x29, LE
-    __ csinc(r25, r21, r4, Assembler::EQ);             //       csinc   x25, x21, x4, EQ
-    __ csinv(r17, r21, r29, Assembler::VS);            //       csinv   x17, x21, x29, VS
-    __ csneg(r21, r20, r6, Assembler::HI);             //       csneg   x21, x20, x6, HI
+    __ cselw(r26, r27, r10, Assembler::VS);            //       csel    w26, w27, w10, VS
+    __ csincw(r10, r21, r28, Assembler::LE);           //       csinc   w10, w21, w28, LE
+    __ csinvw(r23, r9, r27, Assembler::LE);            //       csinv   w23, w9, w27, LE
+    __ csnegw(r10, r29, r15, Assembler::LE);           //       csneg   w10, w29, w15, LE
+    __ csel(r30, r25, r21, Assembler::HS);             //       csel    x30, x25, x21, HS
+    __ csinc(r0, r17, r21, Assembler::GT);             //       csinc   x0, x17, x21, GT
+    __ csinv(r16, r21, r20, Assembler::CS);            //       csinv   x16, x21, x20, CS
+    __ csneg(r19, r30, r3, Assembler::LS);             //       csneg   x19, x30, x3, LS
 
 // TwoRegOp
-    __ rbitw(r30, r3);                                 //       rbit    w30, w3
-    __ rev16w(r21, r19);                               //       rev16   w21, w19
-    __ revw(r11, r24);                                 //       rev     w11, w24
-    __ clzw(r0, r27);                                  //       clz     w0, w27
-    __ clsw(r25, r14);                                 //       cls     w25, w14
-    __ rbit(r3, r14);                                  //       rbit    x3, x14
-    __ rev16(r17, r7);                                 //       rev16   x17, x7
-    __ rev32(r15, r24);                                //       rev32   x15, x24
-    __ rev(r28, r17);                                  //       rev     x28, x17
-    __ clz(r25, r2);                                   //       clz     x25, x2
-    __ cls(r26, r28);                                  //       cls     x26, x28
-    __ pacia(r5, r25);                                 //       pacia   x5, x25
-    __ pacib(r26, r27);                                //       pacib   x26, x27
-    __ pacda(r16, r17);                                //       pacda   x16, x17
-    __ pacdb(r6, r21);                                 //       pacdb   x6, x21
-    __ autia(r12, r0);                                 //       autia   x12, x0
-    __ autib(r4, r12);                                 //       autib   x4, x12
-    __ autda(r27, r17);                                //       autda   x27, x17
-    __ autdb(r28, r28);                                //       autdb   x28, x28
-    __ braa(r2, r17);                                  //       braa    x2, x17
-    __ brab(r10, r15);                                 //       brab    x10, x15
-    __ blraa(r14, r14);                                //       blraa   x14, x14
-    __ blrab(r3, r25);                                 //       blrab   x3, x25
+    __ rbitw(r19, r11);                                //       rbit    w19, w11
+    __ rev16w(r24, r0);                                //       rev16   w24, w0
+    __ revw(r27, r25);                                 //       rev     w27, w25
+    __ clzw(r14, r3);                                  //       clz     w14, w3
+    __ clsw(r14, r17);                                 //       cls     w14, w17
+    __ rbit(r7, r15);                                  //       rbit    x7, x15
+    __ rev16(r24, r28);                                //       rev16   x24, x28
+    __ rev32(r17, r25);                                //       rev32   x17, x25
+    __ rev(r2, r26);                                   //       rev     x2, x26
+    __ clz(r28, r5);                                   //       clz     x28, x5
+    __ cls(r25, r26);                                  //       cls     x25, x26
+    __ pacia(r27, r16);                                //       pacia   x27, x16
+    __ pacib(r17, r6);                                 //       pacib   x17, x6
+    __ pacda(r21, r12);                                //       pacda   x21, x12
+    __ pacdb(r0, r4);                                  //       pacdb   x0, x4
+    __ autia(r12, r27);                                //       autia   x12, x27
+    __ autib(r17, r28);                                //       autib   x17, x28
+    __ autda(r28, r2);                                 //       autda   x28, x2
+    __ autdb(r17, r10);                                //       autdb   x17, x10
+    __ braa(r15, r14);                                 //       braa    x15, x14
+    __ brab(r14, r3);                                  //       brab    x14, x3
+    __ blraa(r25, r15);                                //       blraa   x25, x15
+    __ blrab(r19, r14);                                //       blrab   x19, x14
 
 // ThreeRegOp
-    __ udivw(r15, r19, r14);                           //       udiv    w15, w19, w14
-    __ sdivw(r5, r16, r4);                             //       sdiv    w5, w16, w4
-    __ lslvw(r26, r25, r4);                            //       lslv    w26, w25, w4
-    __ lsrvw(r2, r2, r12);                             //       lsrv    w2, w2, w12
-    __ asrvw(r29, r17, r8);                            //       asrv    w29, w17, w8
-    __ rorvw(r7, r3, r4);                              //       rorv    w7, w3, w4
-    __ udiv(r25, r4, r26);                             //       udiv    x25, x4, x26
-    __ sdiv(r25, r4, r17);                             //       sdiv    x25, x4, x17
-    __ lslv(r0, r26, r17);                             //       lslv    x0, x26, x17
-    __ lsrv(r23, r15, r21);                            //       lsrv    x23, x15, x21
-    __ asrv(r28, r17, r27);                            //       asrv    x28, x17, x27
-    __ rorv(r10, r3, r0);                              //       rorv    x10, x3, x0
-    __ umulh(r7, r25, r9);                             //       umulh   x7, x25, x9
-    __ smulh(r6, r15, r29);                            //       smulh   x6, x15, x29
+    __ udivw(r5, r16, r4);                             //       udiv    w5, w16, w4
+    __ sdivw(r26, r25, r4);                            //       sdiv    w26, w25, w4
+    __ lslvw(r2, r2, r12);                             //       lslv    w2, w2, w12
+    __ lsrvw(r29, r17, r8);                            //       lsrv    w29, w17, w8
+    __ asrvw(r7, r3, r4);                              //       asrv    w7, w3, w4
+    __ rorvw(r25, r4, r26);                            //       rorv    w25, w4, w26
+    __ udiv(r25, r4, r17);                             //       udiv    x25, x4, x17
+    __ sdiv(r0, r26, r17);                             //       sdiv    x0, x26, x17
+    __ lslv(r23, r15, r21);                            //       lslv    x23, x15, x21
+    __ lsrv(r28, r17, r27);                            //       lsrv    x28, x17, x27
+    __ asrv(r10, r3, r0);                              //       asrv    x10, x3, x0
+    __ rorv(r7, r25, r9);                              //       rorv    x7, x25, x9
+    __ umulh(r6, r15, r29);                            //       umulh   x6, x15, x29
+    __ smulh(r15, r10, r2);                            //       smulh   x15, x10, x2
 
 // FourRegMulOp
-    __ maddw(r15, r10, r2, r17);                       //       madd    w15, w10, w2, w17
-    __ msubw(r7, r11, r11, r23);                       //       msub    w7, w11, w11, w23
-    __ madd(r7, r29, r23, r14);                        //       madd    x7, x29, x23, x14
-    __ msub(r27, r11, r11, r4);                        //       msub    x27, x11, x11, x4
-    __ smaddl(r24, r12, r15, r14);                     //       smaddl  x24, w12, w15, x14
-    __ smsubl(r20, r11, r28, r13);                     //       smsubl  x20, w11, w28, x13
-    __ umaddl(r11, r12, r23, r30);                     //       umaddl  x11, w12, w23, x30
-    __ umsubl(r26, r14, r9, r13);                      //       umsubl  x26, w14, w9, x13
+    __ maddw(r17, r7, r11, r11);                       //       madd    w17, w7, w11, w11
+    __ msubw(r23, r7, r29, r23);                       //       msub    w23, w7, w29, w23
+    __ madd(r14, r27, r11, r11);                       //       madd    x14, x27, x11, x11
+    __ msub(r4, r24, r12, r15);                        //       msub    x4, x24, x12, x15
+    __ smaddl(r14, r20, r11, r28);                     //       smaddl  x14, w20, w11, x28
+    __ smsubl(r13, r11, r12, r23);                     //       smsubl  x13, w11, w12, x23
+    __ umaddl(r30, r26, r14, r9);                      //       umaddl  x30, w26, w14, x9
+    __ umsubl(r13, r10, r7, r5);                       //       umsubl  x13, w10, w7, x5
 
 // ThreeRegFloatOp
-    __ fabds(v10, v7, v5);                             //       fabd    s10, s7, s5
-    __ fmuls(v29, v15, v3);                            //       fmul    s29, s15, s3
-    __ fdivs(v11, v12, v15);                           //       fdiv    s11, s12, s15
-    __ fadds(v30, v30, v17);                           //       fadd    s30, s30, s17
-    __ fsubs(v19, v20, v15);                           //       fsub    s19, s20, s15
-    __ fabdd(v15, v9, v21);                            //       fabd    d15, d9, d21
-    __ fmuld(v2, v9, v27);                             //       fmul    d2, d9, d27
-    __ fdivd(v7, v29, v30);                            //       fdiv    d7, d29, d30
-    __ faddd(v17, v1, v2);                             //       fadd    d17, d1, d2
-    __ fsubd(v6, v10, v3);                             //       fsub    d6, d10, d3
+    __ fabds(v29, v15, v3);                            //       fabd    s29, s15, s3
+    __ fmuls(v11, v12, v15);                           //       fmul    s11, s12, s15
+    __ fdivs(v30, v30, v17);                           //       fdiv    s30, s30, s17
+    __ fadds(v19, v20, v15);                           //       fadd    s19, s20, s15
+    __ fsubs(v15, v9, v21);                            //       fsub    s15, s9, s21
+    __ fabdd(v2, v9, v27);                             //       fabd    d2, d9, d27
+    __ fmuld(v7, v29, v30);                            //       fmul    d7, d29, d30
+    __ fdivd(v17, v1, v2);                             //       fdiv    d17, d1, d2
+    __ faddd(v6, v10, v3);                             //       fadd    d6, d10, d3
+    __ fsubd(v24, v11, v7);                            //       fsub    d24, d11, d7
 
 // FourRegFloatOp
-    __ fmadds(v24, v11, v7, v1);                       //       fmadd   s24, s11, s7, s1
-    __ fmsubs(v11, v0, v3, v17);                       //       fmsub   s11, s0, s3, s17
-    __ fnmadds(v28, v6, v22, v6);                      //       fnmadd  s28, s6, s22, s6
-    __ fnmadds(v0, v27, v26, v2);                      //       fnmadd  s0, s27, s26, s2
-    __ fmaddd(v5, v7, v28, v11);                       //       fmadd   d5, d7, d28, d11
-    __ fmsubd(v25, v13, v11, v23);                     //       fmsub   d25, d13, d11, d23
-    __ fnmaddd(v19, v8, v17, v21);                     //       fnmadd  d19, d8, d17, d21
-    __ fnmaddd(v25, v20, v19, v17);                    //       fnmadd  d25, d20, d19, d17
+    __ fmadds(v1, v11, v0, v3);                        //       fmadd   s1, s11, s0, s3
+    __ fmsubs(v17, v28, v6, v22);                      //       fmsub   s17, s28, s6, s22
+    __ fnmadds(v6, v0, v27, v26);                      //       fnmadd  s6, s0, s27, s26
+    __ fnmadds(v2, v5, v7, v28);                       //       fnmadd  s2, s5, s7, s28
+    __ fmaddd(v11, v25, v13, v11);                     //       fmadd   d11, d25, d13, d11
+    __ fmsubd(v23, v19, v8, v17);                      //       fmsub   d23, d19, d8, d17
+    __ fnmaddd(v21, v25, v20, v19);                    //       fnmadd  d21, d25, d20, d19
+    __ fnmaddd(v17, v2, v29, v22);                     //       fnmadd  d17, d2, d29, d22
 
 // TwoRegFloatOp
-    __ fmovs(v2, v29);                                 //       fmov    s2, s29
-    __ fabss(v22, v8);                                 //       fabs    s22, s8
-    __ fnegs(v21, v19);                                //       fneg    s21, s19
-    __ fsqrts(v20, v11);                               //       fsqrt   s20, s11
-    __ fcvts(v17, v20);                                //       fcvt    d17, s20
-    __ fcvtsh(v6, v15);                                //       fcvt    h6, s15
-    __ fcvths(v3, v3);                                 //       fcvt    s3, h3
-    __ fmovd(v28, v3);                                 //       fmov    d28, d3
-    __ fabsd(v27, v14);                                //       fabs    d27, d14
-    __ fnegd(v14, v10);                                //       fneg    d14, d10
-    __ fsqrtd(v12, v11);                               //       fsqrt   d12, d11
-    __ fcvtd(v17, v10);                                //       fcvt    s17, d10
+    __ fmovs(v8, v21);                                 //       fmov    s8, s21
+    __ fabss(v19, v20);                                //       fabs    s19, s20
+    __ fnegs(v11, v17);                                //       fneg    s11, s17
+    __ fsqrts(v20, v6);                                //       fsqrt   s20, s6
+    __ fcvts(v15, v3);                                 //       fcvt    d15, s3
+    __ fcvtsh(v3, v28);                                //       fcvt    h3, s28
+    __ fcvths(v3, v27);                                //       fcvt    s3, h27
+    __ fmovd(v14, v14);                                //       fmov    d14, d14
+    __ fabsd(v10, v12);                                //       fabs    d10, d12
+    __ fnegd(v11, v17);                                //       fneg    d11, d17
+    __ fsqrtd(v10, v25);                               //       fsqrt   d10, d25
+    __ fcvtd(v7, v7);                                  //       fcvt    s7, d7
 
 // FloatConvertOp
-    __ fcvtzsw(r25, v7);                               //       fcvtzs  w25, s7
-    __ fcvtzs(r7, v14);                                //       fcvtzs  x7, s14
-    __ fcvtzdw(r28, v0);                               //       fcvtzs  w28, d0
-    __ fcvtzd(r22, v0);                                //       fcvtzs  x22, d0
-    __ scvtfws(v12, r23);                              //       scvtf   s12, w23
-    __ scvtfs(v13, r13);                               //       scvtf   s13, x13
-    __ scvtfwd(v7, r14);                               //       scvtf   d7, w14
-    __ scvtfd(v7, r8);                                 //       scvtf   d7, x8
-    __ fcvtassw(r20, v17);                             //       fcvtas  w20, s17
-    __ fcvtasd(r28, v30);                              //       fcvtas  x28, d30
-    __ fcvtmssw(r16, v2);                              //       fcvtms  w16, s2
-    __ fcvtmsd(r9, v16);                               //       fcvtms  x9, d16
-    __ fmovs(r20, v29);                                //       fmov    w20, s29
-    __ fmovd(r4, v1);                                  //       fmov    x4, d1
-    __ fmovs(v26, r24);                                //       fmov    s26, w24
-    __ fmovd(v23, r14);                                //       fmov    d23, x14
+    __ fcvtzsw(r14, v28);                              //       fcvtzs  w14, s28
+    __ fcvtzs(r0, v22);                                //       fcvtzs  x0, s22
+    __ fcvtzdw(r0, v12);                               //       fcvtzs  w0, d12
+    __ fcvtzd(r23, v13);                               //       fcvtzs  x23, d13
+    __ scvtfws(v13, r7);                               //       scvtf   s13, w7
+    __ scvtfs(v14, r7);                                //       scvtf   s14, x7
+    __ scvtfwd(v8, r20);                               //       scvtf   d8, w20
+    __ scvtfd(v17, r28);                               //       scvtf   d17, x28
+    __ fcvtassw(r30, v16);                             //       fcvtas  w30, s16
+    __ fcvtasd(r2, v9);                                //       fcvtas  x2, d9
+    __ fcvtmssw(r16, v20);                             //       fcvtms  w16, s20
+    __ fcvtmsd(r29, v4);                               //       fcvtms  x29, d4
+    __ fmovs(r1, v26);                                 //       fmov    w1, s26
+    __ fmovd(r24, v23);                                //       fmov    x24, d23
+    __ fmovs(v14, r21);                                //       fmov    s14, w21
+    __ fmovd(v12, r5);                                 //       fmov    d12, x5
 
 // TwoRegFloatOp
-    __ fcmps(v21, v12);                                //       fcmp    s21, s12
-    __ fcmpd(v5, v12);                                 //       fcmp    d5, d12
-    __ fcmps(v24, 0.0);                                //       fcmp    s24, #0.0
-    __ fcmpd(v24, 0.0);                                //       fcmp    d24, #0.0
+    __ fcmps(v12, v24);                                //       fcmp    s12, s24
+    __ fcmpd(v24, v29);                                //       fcmp    d24, d29
+    __ fcmps(v27, 0.0);                                //       fcmp    s27, #0.0
+    __ fcmpd(v21, 0.0);                                //       fcmp    d21, #0.0
 
 // LoadStorePairOp
-    __ stpw(r27, r21, Address(r16, 128));              //       stp     w27, w21, [x16, #128]
-    __ ldpw(r17, r13, Address(r22, 32));               //       ldp     w17, w13, [x22, #32]
-    __ ldpsw(r6, r13, Address(r17, -16));              //       ldpsw   x6, x13, [x17, #-16]
-    __ stp(r28, r26, Address(r17, -160));              //       stp     x28, x26, [x17, #-160]
-    __ ldp(r21, r6, Address(r13, -192));               //       ldp     x21, x6, [x13, #-192]
+    __ stpw(r22, r5, Address(r28, -48));               //       stp     w22, w5, [x28, #-48]
+    __ ldpw(r19, r27, Address(r19, 16));               //       ldp     w19, w27, [x19, #16]
+    __ ldpsw(r28, r26, Address(r7, -32));              //       ldpsw   x28, x26, [x7, #-32]
+    __ stp(r6, r1, Address(r4, -48));                  //       stp     x6, x1, [x4, #-48]
+    __ ldp(r26, r23, Address(r21, -80));               //       ldp     x26, x23, [x21, #-80]
 
 // LoadStorePairOp
-    __ stpw(r26, r23, Address(__ pre(r19, 16)));       //       stp     w26, w23, [x19, #16]!
-    __ ldpw(r4, r16, Address(__ pre(r10, 128)));       //       ldp     w4, w16, [x10, #128]!
-    __ ldpsw(r14, r4, Address(__ pre(r23, -96)));      //       ldpsw   x14, x4, [x23, #-96]!
-    __ stp(r29, r12, Address(__ pre(r16, 32)));        //       stp     x29, x12, [x16, #32]!
-    __ ldp(r26, r17, Address(__ pre(r27, 96)));        //       ldp     x26, x17, [x27, #96]!
+    __ stpw(r20, r30, Address(__ pre(r9, -96)));       //       stp     w20, w30, [x9, #-96]!
+    __ ldpw(r13, r20, Address(__ pre(r26, 16)));       //       ldp     w13, w20, [x26, #16]!
+    __ ldpsw(r29, r11, Address(__ pre(r13, -80)));     //       ldpsw   x29, x11, [x13, #-80]!
+    __ stp(r27, r21, Address(__ pre(r5, -48)));        //       stp     x27, x21, [x5, #-48]!
+    __ ldp(r6, r0, Address(__ pre(r30, 80)));          //       ldp     x6, x0, [x30, #80]!
 
 // LoadStorePairOp
-    __ stpw(r6, r0, Address(__ post(r4, -96)));        //       stp     w6, w0, [x4], #-96
-    __ ldpw(r2, r30, Address(__ post(r14, 0)));        //       ldp     w2, w30, [x14], #0
-    __ ldpsw(r23, r24, Address(__ post(r7, -256)));    //       ldpsw   x23, x24, [x7], #-256
-    __ stp(r0, r26, Address(__ post(r5, 128)));        //       stp     x0, x26, [x5], #128
-    __ ldp(r6, r11, Address(__ post(r15, -160)));      //       ldp     x6, x11, [x15], #-160
+    __ stpw(r19, r15, Address(__ post(r16, -208)));    //       stp     w19, w15, [x16], #-208
+    __ ldpw(r12, r23, Address(__ post(r9, -240)));     //       ldp     w12, w23, [x9], #-240
+    __ ldpsw(r0, r26, Address(__ post(r15, 32)));      //       ldpsw   x0, x26, [x15], #32
+    __ stp(r8, r17, Address(__ post(r26, -208)));      //       stp     x8, x17, [x26], #-208
+    __ ldp(r25, r7, Address(__ post(r2, -176)));       //       ldp     x25, x7, [x2], #-176
 
 // LoadStorePairOp
-    __ stnpw(r25, r8, Address(r2, -128));              //       stnp    w25, w8, [x2, #-128]
-    __ ldnpw(r30, r14, Address(r1, -208));             //       ldnp    w30, w14, [x1, #-208]
-    __ stnp(r22, r0, Address(r13, -144));              //       stnp    x22, x0, [x13, #-144]
-    __ ldnp(r3, r12, Address(r27, 0));                 //       ldnp    x3, x12, [x27, #0]
+    __ stnpw(r19, r17, Address(r1, -208));             //       stnp    w19, w17, [x1, #-208]
+    __ ldnpw(r0, r13, Address(r22, 128));              //       ldnp    w0, w13, [x22, #128]
+    __ stnp(r29, r23, Address(r27, 0));                //       stnp    x29, x23, [x27, #0]
+    __ ldnp(r11, r10, Address(r8, -224));              //       ldnp    x11, x10, [x8, #-224]
 
 // LdStNEONOp
-    __ ld1(v10, __ T8B, Address(r0));                  //       ld1     {v10.8B}, [x0]
-    __ ld1(v12, v13, __ T16B, Address(__ post(r17, 32))); //    ld1     {v12.16B, v13.16B}, [x17], 32
-    __ ld1(v10, v11, v12, __ T1D, Address(__ post(r24, r2))); //        ld1     {v10.1D, v11.1D, v12.1D}, [x24], x2
-    __ ld1(v8, v9, v10, v11, __ T8H, Address(__ post(r17, 64))); //     ld1     {v8.8H, v9.8H, v10.8H, v11.8H}, [x17], 64
-    __ ld1r(v23, __ T8B, Address(r30));                //       ld1r    {v23.8B}, [x30]
-    __ ld1r(v22, __ T4S, Address(__ post(r2, 4)));     //       ld1r    {v22.4S}, [x2], 4
-    __ ld1r(v30, __ T1D, Address(__ post(r30, r15)));  //       ld1r    {v30.1D}, [x30], x15
-    __ ld2(v20, v21, __ T2D, Address(r5));             //       ld2     {v20.2D, v21.2D}, [x5]
-    __ ld2(v24, v25, __ T4H, Address(__ post(r9, 16))); //      ld2     {v24.4H, v25.4H}, [x9], 16
-    __ ld2r(v16, v17, __ T16B, Address(r12));          //       ld2r    {v16.16B, v17.16B}, [x12]
-    __ ld2r(v23, v24, __ T2S, Address(__ post(r7, 8))); //      ld2r    {v23.2S, v24.2S}, [x7], 8
-    __ ld2r(v26, v27, __ T2D, Address(__ post(r16, r3))); //    ld2r    {v26.2D, v27.2D}, [x16], x3
-    __ ld3(v25, v26, v27, __ T4S, Address(__ post(r11, r7))); //        ld3     {v25.4S, v26.4S, v27.4S}, [x11], x7
-    __ ld3(v30, v31, v0, __ T2S, Address(r12));        //       ld3     {v30.2S, v31.2S, v0.2S}, [x12]
-    __ ld3r(v15, v16, v17, __ T8H, Address(r9));       //       ld3r    {v15.8H, v16.8H, v17.8H}, [x9]
-    __ ld3r(v30, v31, v0, __ T4S, Address(__ post(r6, 12))); // ld3r    {v30.4S, v31.4S, v0.4S}, [x6], 12
-    __ ld3r(v7, v8, v9, __ T1D, Address(__ post(r23, r13))); // ld3r    {v7.1D, v8.1D, v9.1D}, [x23], x13
-    __ ld4(v4, v5, v6, v7, __ T8H, Address(__ post(r6, 64))); //        ld4     {v4.8H, v5.8H, v6.8H, v7.8H}, [x6], 64
-    __ ld4(v4, v5, v6, v7, __ T8B, Address(__ post(r19, r15))); //      ld4     {v4.8B, v5.8B, v6.8B, v7.8B}, [x19], x15
-    __ ld4r(v25, v26, v27, v28, __ T8B, Address(r14)); //       ld4r    {v25.8B, v26.8B, v27.8B, v28.8B}, [x14]
-    __ ld4r(v26, v27, v28, v29, __ T4H, Address(__ post(r28, 8))); //   ld4r    {v26.4H, v27.4H, v28.4H, v29.4H}, [x28], 8
-    __ ld4r(v25, v26, v27, v28, __ T2S, Address(__ post(r5, r6))); //   ld4r    {v25.2S, v26.2S, v27.2S, v28.2S}, [x5], x6
+    __ ld1(v0, __ T8B, Address(r11));                  //       ld1     {v0.8B}, [x11]
+    __ ld1(v16, v17, __ T16B, Address(__ post(r26, 32))); //    ld1     {v16.16B, v17.16B}, [x26], 32
+    __ ld1(v21, v22, v23, __ T1D, Address(__ post(r26, r17))); //       ld1     {v21.1D, v22.1D, v23.1D}, [x26], x17
+    __ ld1(v26, v27, v28, v29, __ T8H, Address(__ post(r29, 64))); //   ld1     {v26.8H, v27.8H, v28.8H, v29.8H}, [x29], 64
+    __ ld1r(v21, __ T8B, Address(r6));                 //       ld1r    {v21.8B}, [x6]
+    __ ld1r(v13, __ T4S, Address(__ post(r29, 4)));    //       ld1r    {v13.4S}, [x29], 4
+    __ ld1r(v21, __ T1D, Address(__ post(r12, r16)));  //       ld1r    {v21.1D}, [x12], x16
+    __ ld2(v1, v2, __ T2D, Address(r0));               //       ld2     {v1.2D, v2.2D}, [x0]
+    __ ld2(v9, v10, __ T4H, Address(__ post(r21, 16))); //      ld2     {v9.4H, v10.4H}, [x21], 16
+    __ ld2r(v7, v8, __ T16B, Address(r25));            //       ld2r    {v7.16B, v8.16B}, [x25]
+    __ ld2r(v8, v9, __ T2S, Address(__ post(r9, 8)));  //       ld2r    {v8.2S, v9.2S}, [x9], 8
+    __ ld2r(v9, v10, __ T2D, Address(__ post(r12, r14))); //    ld2r    {v9.2D, v10.2D}, [x12], x14
+    __ ld3(v7, v8, v9, __ T4S, Address(__ post(r4, r17))); //   ld3     {v7.4S, v8.4S, v9.4S}, [x4], x17
+    __ ld3(v23, v24, v25, __ T2S, Address(r17));       //       ld3     {v23.2S, v24.2S, v25.2S}, [x17]
+    __ ld3r(v3, v4, v5, __ T8H, Address(r22));         //       ld3r    {v3.8H, v4.8H, v5.8H}, [x22]
+    __ ld3r(v12, v13, v14, __ T4S, Address(__ post(r2, 12))); //        ld3r    {v12.4S, v13.4S, v14.4S}, [x2], 12
+    __ ld3r(v15, v16, v17, __ T1D, Address(__ post(r10, r12))); //      ld3r    {v15.1D, v16.1D, v17.1D}, [x10], x12
+    __ ld4(v4, v5, v6, v7, __ T8H, Address(__ post(r2, 64))); //        ld4     {v4.8H, v5.8H, v6.8H, v7.8H}, [x2], 64
+    __ ld4(v6, v7, v8, v9, __ T8B, Address(__ post(r20, r11))); //      ld4     {v6.8B, v7.8B, v8.8B, v9.8B}, [x20], x11
+    __ ld4r(v11, v12, v13, v14, __ T8B, Address(r12)); //       ld4r    {v11.8B, v12.8B, v13.8B, v14.8B}, [x12]
+    __ ld4r(v15, v16, v17, v18, __ T4H, Address(__ post(r17, 8))); //   ld4r    {v15.4H, v16.4H, v17.4H, v18.4H}, [x17], 8
+    __ ld4r(v14, v15, v16, v17, __ T2S, Address(__ post(r25, r16))); // ld4r    {v14.2S, v15.2S, v16.2S, v17.2S}, [x25], x16
 
 // NEONReduceInstruction
-    __ addv(v14, __ T8B, v15);                         //       addv    b14, v15.8B
-    __ addv(v10, __ T16B, v11);                        //       addv    b10, v11.16B
-    __ addv(v13, __ T4H, v14);                         //       addv    h13, v14.4H
-    __ addv(v14, __ T8H, v15);                         //       addv    h14, v15.8H
-    __ addv(v20, __ T4S, v21);                         //       addv    s20, v21.4S
-    __ smaxv(v1, __ T8B, v2);                          //       smaxv   b1, v2.8B
-    __ smaxv(v22, __ T16B, v23);                       //       smaxv   b22, v23.16B
-    __ smaxv(v30, __ T4H, v31);                        //       smaxv   h30, v31.4H
-    __ smaxv(v14, __ T8H, v15);                        //       smaxv   h14, v15.8H
-    __ smaxv(v2, __ T4S, v3);                          //       smaxv   s2, v3.4S
-    __ fmaxv(v6, __ T4S, v7);                          //       fmaxv   s6, v7.4S
-    __ sminv(v3, __ T8B, v4);                          //       sminv   b3, v4.8B
-    __ uminv(v7, __ T8B, v8);                          //       uminv   b7, v8.8B
-    __ sminv(v24, __ T16B, v25);                       //       sminv   b24, v25.16B
-    __ uminv(v0, __ T16B, v1);                         //       uminv   b0, v1.16B
-    __ sminv(v27, __ T4H, v28);                        //       sminv   h27, v28.4H
-    __ uminv(v29, __ T4H, v30);                        //       uminv   h29, v30.4H
-    __ sminv(v5, __ T8H, v6);                          //       sminv   h5, v6.8H
-    __ uminv(v5, __ T8H, v6);                          //       uminv   h5, v6.8H
-    __ sminv(v29, __ T4S, v30);                        //       sminv   s29, v30.4S
-    __ uminv(v11, __ T4S, v12);                        //       uminv   s11, v12.4S
-    __ fminv(v25, __ T4S, v26);                        //       fminv   s25, v26.4S
-    __ fmaxp(v0, v1, __ S);                            //       fmaxp   s0, v1.2S
-    __ fmaxp(v30, v31, __ D);                          //       fmaxp   d30, v31.2D
-    __ fminp(v0, v1, __ S);                            //       fminp   s0, v1.2S
-    __ fminp(v17, v18, __ D);                          //       fminp   d17, v18.2D
+    __ addv(v20, __ T8B, v21);                         //       addv    b20, v21.8B
+    __ addv(v1, __ T16B, v2);                          //       addv    b1, v2.16B
+    __ addv(v22, __ T4H, v23);                         //       addv    h22, v23.4H
+    __ addv(v30, __ T8H, v31);                         //       addv    h30, v31.8H
+    __ addv(v14, __ T4S, v15);                         //       addv    s14, v15.4S
+    __ smaxv(v2, __ T8B, v3);                          //       smaxv   b2, v3.8B
+    __ smaxv(v6, __ T16B, v7);                         //       smaxv   b6, v7.16B
+    __ smaxv(v3, __ T4H, v4);                          //       smaxv   h3, v4.4H
+    __ smaxv(v7, __ T8H, v8);                          //       smaxv   h7, v8.8H
+    __ smaxv(v24, __ T4S, v25);                        //       smaxv   s24, v25.4S
+    __ fmaxv(v0, __ T4S, v1);                          //       fmaxv   s0, v1.4S
+    __ sminv(v27, __ T8B, v28);                        //       sminv   b27, v28.8B
+    __ uminv(v29, __ T8B, v30);                        //       uminv   b29, v30.8B
+    __ sminv(v5, __ T16B, v6);                         //       sminv   b5, v6.16B
+    __ uminv(v5, __ T16B, v6);                         //       uminv   b5, v6.16B
+    __ sminv(v29, __ T4H, v30);                        //       sminv   h29, v30.4H
+    __ uminv(v11, __ T4H, v12);                        //       uminv   h11, v12.4H
+    __ sminv(v25, __ T8H, v26);                        //       sminv   h25, v26.8H
+    __ uminv(v0, __ T8H, v1);                          //       uminv   h0, v1.8H
+    __ sminv(v30, __ T4S, v31);                        //       sminv   s30, v31.4S
+    __ uminv(v0, __ T4S, v1);                          //       uminv   s0, v1.4S
+    __ fminv(v17, __ T4S, v18);                        //       fminv   s17, v18.4S
+    __ fmaxp(v28, v29, __ S);                          //       fmaxp   s28, v29.2S
+    __ fmaxp(v25, v26, __ D);                          //       fmaxp   d25, v26.2D
+    __ fminp(v9, v10, __ S);                           //       fminp   s9, v10.2S
+    __ fminp(v25, v26, __ D);                          //       fminp   d25, v26.2D
 
 // TwoRegNEONOp
-    __ absr(v28, __ T8B, v29);                         //       abs     v28.8B, v29.8B
-    __ absr(v25, __ T16B, v26);                        //       abs     v25.16B, v26.16B
-    __ absr(v9, __ T4H, v10);                          //       abs     v9.4H, v10.4H
-    __ absr(v25, __ T8H, v26);                         //       abs     v25.8H, v26.8H
-    __ absr(v12, __ T2S, v13);                         //       abs     v12.2S, v13.2S
-    __ absr(v15, __ T4S, v16);                         //       abs     v15.4S, v16.4S
-    __ absr(v11, __ T2D, v12);                         //       abs     v11.2D, v12.2D
-    __ fabs(v10, __ T2S, v11);                         //       fabs    v10.2S, v11.2S
-    __ fabs(v17, __ T4S, v18);                         //       fabs    v17.4S, v18.4S
-    __ fabs(v24, __ T2D, v25);                         //       fabs    v24.2D, v25.2D
-    __ fneg(v21, __ T2S, v22);                         //       fneg    v21.2S, v22.2S
-    __ fneg(v23, __ T4S, v24);                         //       fneg    v23.4S, v24.4S
-    __ fneg(v0, __ T2D, v1);                           //       fneg    v0.2D, v1.2D
-    __ fsqrt(v16, __ T2S, v17);                        //       fsqrt   v16.2S, v17.2S
-    __ fsqrt(v10, __ T4S, v11);                        //       fsqrt   v10.4S, v11.4S
-    __ fsqrt(v6, __ T2D, v7);                          //       fsqrt   v6.2D, v7.2D
-    __ notr(v28, __ T8B, v29);                         //       not     v28.8B, v29.8B
-    __ notr(v6, __ T16B, v7);                          //       not     v6.16B, v7.16B
+    __ absr(v12, __ T8B, v13);                         //       abs     v12.8B, v13.8B
+    __ absr(v15, __ T16B, v16);                        //       abs     v15.16B, v16.16B
+    __ absr(v11, __ T4H, v12);                         //       abs     v11.4H, v12.4H
+    __ absr(v10, __ T8H, v11);                         //       abs     v10.8H, v11.8H
+    __ absr(v17, __ T2S, v18);                         //       abs     v17.2S, v18.2S
+    __ absr(v24, __ T4S, v25);                         //       abs     v24.4S, v25.4S
+    __ absr(v21, __ T2D, v22);                         //       abs     v21.2D, v22.2D
+    __ fabs(v23, __ T2S, v24);                         //       fabs    v23.2S, v24.2S
+    __ fabs(v0, __ T4S, v1);                           //       fabs    v0.4S, v1.4S
+    __ fabs(v16, __ T2D, v17);                         //       fabs    v16.2D, v17.2D
+    __ fneg(v10, __ T2S, v11);                         //       fneg    v10.2S, v11.2S
+    __ fneg(v6, __ T4S, v7);                           //       fneg    v6.4S, v7.4S
+    __ fneg(v28, __ T2D, v29);                         //       fneg    v28.2D, v29.2D
+    __ fsqrt(v6, __ T2S, v7);                          //       fsqrt   v6.2S, v7.2S
+    __ fsqrt(v5, __ T4S, v6);                          //       fsqrt   v5.4S, v6.4S
+    __ fsqrt(v5, __ T2D, v6);                          //       fsqrt   v5.2D, v6.2D
+    __ notr(v20, __ T8B, v21);                         //       not     v20.8B, v21.8B
+    __ notr(v17, __ T16B, v18);                        //       not     v17.16B, v18.16B
 
 // ThreeRegNEONOp
-    __ andr(v5, __ T8B, v6, v7);                       //       and     v5.8B, v6.8B, v7.8B
-    __ andr(v5, __ T16B, v6, v7);                      //       and     v5.16B, v6.16B, v7.16B
-    __ orr(v20, __ T8B, v21, v22);                     //       orr     v20.8B, v21.8B, v22.8B
-    __ orr(v17, __ T16B, v18, v19);                    //       orr     v17.16B, v18.16B, v19.16B
-    __ eor(v15, __ T8B, v16, v17);                     //       eor     v15.8B, v16.8B, v17.8B
-    __ eor(v17, __ T16B, v18, v19);                    //       eor     v17.16B, v18.16B, v19.16B
-    __ addv(v29, __ T8B, v30, v31);                    //       add     v29.8B, v30.8B, v31.8B
-    __ addv(v26, __ T16B, v27, v28);                   //       add     v26.16B, v27.16B, v28.16B
-    __ addv(v28, __ T4H, v29, v30);                    //       add     v28.4H, v29.4H, v30.4H
-    __ addv(v1, __ T8H, v2, v3);                       //       add     v1.8H, v2.8H, v3.8H
-    __ addv(v27, __ T2S, v28, v29);                    //       add     v27.2S, v28.2S, v29.2S
-    __ addv(v0, __ T4S, v1, v2);                       //       add     v0.4S, v1.4S, v2.4S
-    __ addv(v20, __ T2D, v21, v22);                    //       add     v20.2D, v21.2D, v22.2D
+    __ andr(v15, __ T8B, v16, v17);                    //       and     v15.8B, v16.8B, v17.8B
+    __ andr(v17, __ T16B, v18, v19);                   //       and     v17.16B, v18.16B, v19.16B
+    __ orr(v29, __ T8B, v30, v31);                     //       orr     v29.8B, v30.8B, v31.8B
+    __ orr(v26, __ T16B, v27, v28);                    //       orr     v26.16B, v27.16B, v28.16B
+    __ eor(v28, __ T8B, v29, v30);                     //       eor     v28.8B, v29.8B, v30.8B
+    __ eor(v1, __ T16B, v2, v3);                       //       eor     v1.16B, v2.16B, v3.16B
+    __ addv(v27, __ T8B, v28, v29);                    //       add     v27.8B, v28.8B, v29.8B
+    __ addv(v0, __ T16B, v1, v2);                      //       add     v0.16B, v1.16B, v2.16B
+    __ addv(v20, __ T4H, v21, v22);                    //       add     v20.4H, v21.4H, v22.4H
+    __ addv(v28, __ T8H, v29, v30);                    //       add     v28.8H, v29.8H, v30.8H
+    __ addv(v15, __ T2S, v16, v17);                    //       add     v15.2S, v16.2S, v17.2S
+    __ addv(v12, __ T4S, v13, v14);                    //       add     v12.4S, v13.4S, v14.4S
+    __ addv(v10, __ T2D, v11, v12);                    //       add     v10.2D, v11.2D, v12.2D
     __ fadd(v28, __ T2S, v29, v30);                    //       fadd    v28.2S, v29.2S, v30.2S
-    __ fadd(v15, __ T4S, v16, v17);                    //       fadd    v15.4S, v16.4S, v17.4S
-    __ fadd(v12, __ T2D, v13, v14);                    //       fadd    v12.2D, v13.2D, v14.2D
-    __ subv(v10, __ T8B, v11, v12);                    //       sub     v10.8B, v11.8B, v12.8B
-    __ subv(v28, __ T16B, v29, v30);                   //       sub     v28.16B, v29.16B, v30.16B
-    __ subv(v28, __ T4H, v29, v30);                    //       sub     v28.4H, v29.4H, v30.4H
-    __ subv(v19, __ T8H, v20, v21);                    //       sub     v19.8H, v20.8H, v21.8H
-    __ subv(v22, __ T2S, v23, v24);                    //       sub     v22.2S, v23.2S, v24.2S
-    __ subv(v10, __ T4S, v11, v12);                    //       sub     v10.4S, v11.4S, v12.4S
-    __ subv(v4, __ T2D, v5, v6);                       //       sub     v4.2D, v5.2D, v6.2D
-    __ fsub(v30, __ T2S, v31, v0);                     //       fsub    v30.2S, v31.2S, v0.2S
-    __ fsub(v20, __ T4S, v21, v22);                    //       fsub    v20.4S, v21.4S, v22.4S
-    __ fsub(v8, __ T2D, v9, v10);                      //       fsub    v8.2D, v9.2D, v10.2D
-    __ mulv(v30, __ T8B, v31, v0);                     //       mul     v30.8B, v31.8B, v0.8B
-    __ mulv(v17, __ T16B, v18, v19);                   //       mul     v17.16B, v18.16B, v19.16B
-    __ mulv(v10, __ T4H, v11, v12);                    //       mul     v10.4H, v11.4H, v12.4H
-    __ mulv(v27, __ T8H, v28, v29);                    //       mul     v27.8H, v28.8H, v29.8H
-    __ mulv(v2, __ T2S, v3, v4);                       //       mul     v2.2S, v3.2S, v4.2S
-    __ mulv(v24, __ T4S, v25, v26);                    //       mul     v24.4S, v25.4S, v26.4S
-    __ fabd(v4, __ T2S, v5, v6);                       //       fabd    v4.2S, v5.2S, v6.2S
-    __ fabd(v3, __ T4S, v4, v5);                       //       fabd    v3.4S, v4.4S, v5.4S
-    __ fabd(v8, __ T2D, v9, v10);                      //       fabd    v8.2D, v9.2D, v10.2D
-    __ faddp(v22, __ T2S, v23, v24);                   //       faddp   v22.2S, v23.2S, v24.2S
-    __ faddp(v17, __ T4S, v18, v19);                   //       faddp   v17.4S, v18.4S, v19.4S
-    __ faddp(v13, __ T2D, v14, v15);                   //       faddp   v13.2D, v14.2D, v15.2D
-    __ fmul(v4, __ T2S, v5, v6);                       //       fmul    v4.2S, v5.2S, v6.2S
-    __ fmul(v28, __ T4S, v29, v30);                    //       fmul    v28.4S, v29.4S, v30.4S
-    __ fmul(v23, __ T2D, v24, v25);                    //       fmul    v23.2D, v24.2D, v25.2D
-    __ mlav(v21, __ T4H, v22, v23);                    //       mla     v21.4H, v22.4H, v23.4H
-    __ mlav(v25, __ T8H, v26, v27);                    //       mla     v25.8H, v26.8H, v27.8H
-    __ mlav(v24, __ T2S, v25, v26);                    //       mla     v24.2S, v25.2S, v26.2S
-    __ mlav(v3, __ T4S, v4, v5);                       //       mla     v3.4S, v4.4S, v5.4S
-    __ fmla(v23, __ T2S, v24, v25);                    //       fmla    v23.2S, v24.2S, v25.2S
-    __ fmla(v26, __ T4S, v27, v28);                    //       fmla    v26.4S, v27.4S, v28.4S
+    __ fadd(v28, __ T4S, v29, v30);                    //       fadd    v28.4S, v29.4S, v30.4S
+    __ fadd(v19, __ T2D, v20, v21);                    //       fadd    v19.2D, v20.2D, v21.2D
+    __ subv(v22, __ T8B, v23, v24);                    //       sub     v22.8B, v23.8B, v24.8B
+    __ subv(v10, __ T16B, v11, v12);                   //       sub     v10.16B, v11.16B, v12.16B
+    __ subv(v4, __ T4H, v5, v6);                       //       sub     v4.4H, v5.4H, v6.4H
+    __ subv(v30, __ T8H, v31, v0);                     //       sub     v30.8H, v31.8H, v0.8H
+    __ subv(v20, __ T2S, v21, v22);                    //       sub     v20.2S, v21.2S, v22.2S
+    __ subv(v8, __ T4S, v9, v10);                      //       sub     v8.4S, v9.4S, v10.4S
+    __ subv(v30, __ T2D, v31, v0);                     //       sub     v30.2D, v31.2D, v0.2D
+    __ fsub(v17, __ T2S, v18, v19);                    //       fsub    v17.2S, v18.2S, v19.2S
+    __ fsub(v10, __ T4S, v11, v12);                    //       fsub    v10.4S, v11.4S, v12.4S
+    __ fsub(v27, __ T2D, v28, v29);                    //       fsub    v27.2D, v28.2D, v29.2D
+    __ mulv(v2, __ T8B, v3, v4);                       //       mul     v2.8B, v3.8B, v4.8B
+    __ mulv(v24, __ T16B, v25, v26);                   //       mul     v24.16B, v25.16B, v26.16B
+    __ mulv(v4, __ T4H, v5, v6);                       //       mul     v4.4H, v5.4H, v6.4H
+    __ mulv(v3, __ T8H, v4, v5);                       //       mul     v3.8H, v4.8H, v5.8H
+    __ mulv(v8, __ T2S, v9, v10);                      //       mul     v8.2S, v9.2S, v10.2S
+    __ mulv(v22, __ T4S, v23, v24);                    //       mul     v22.4S, v23.4S, v24.4S
+    __ fabd(v17, __ T2S, v18, v19);                    //       fabd    v17.2S, v18.2S, v19.2S
+    __ fabd(v13, __ T4S, v14, v15);                    //       fabd    v13.4S, v14.4S, v15.4S
+    __ fabd(v4, __ T2D, v5, v6);                       //       fabd    v4.2D, v5.2D, v6.2D
+    __ faddp(v28, __ T2S, v29, v30);                   //       faddp   v28.2S, v29.2S, v30.2S
+    __ faddp(v23, __ T4S, v24, v25);                   //       faddp   v23.4S, v24.4S, v25.4S
+    __ faddp(v21, __ T2D, v22, v23);                   //       faddp   v21.2D, v22.2D, v23.2D
+    __ fmul(v25, __ T2S, v26, v27);                    //       fmul    v25.2S, v26.2S, v27.2S
+    __ fmul(v24, __ T4S, v25, v26);                    //       fmul    v24.4S, v25.4S, v26.4S
+    __ fmul(v3, __ T2D, v4, v5);                       //       fmul    v3.2D, v4.2D, v5.2D
+    __ mlav(v23, __ T4H, v24, v25);                    //       mla     v23.4H, v24.4H, v25.4H
+    __ mlav(v26, __ T8H, v27, v28);                    //       mla     v26.8H, v27.8H, v28.8H
+    __ mlav(v23, __ T2S, v24, v25);                    //       mla     v23.2S, v24.2S, v25.2S
+    __ mlav(v14, __ T4S, v15, v16);                    //       mla     v14.4S, v15.4S, v16.4S
+    __ fmla(v21, __ T2S, v22, v23);                    //       fmla    v21.2S, v22.2S, v23.2S
+    __ fmla(v3, __ T4S, v4, v5);                       //       fmla    v3.4S, v4.4S, v5.4S
     __ fmla(v23, __ T2D, v24, v25);                    //       fmla    v23.2D, v24.2D, v25.2D
-    __ mlsv(v14, __ T4H, v15, v16);                    //       mls     v14.4H, v15.4H, v16.4H
-    __ mlsv(v21, __ T8H, v22, v23);                    //       mls     v21.8H, v22.8H, v23.8H
-    __ mlsv(v3, __ T2S, v4, v5);                       //       mls     v3.2S, v4.2S, v5.2S
-    __ mlsv(v23, __ T4S, v24, v25);                    //       mls     v23.4S, v24.4S, v25.4S
-    __ fmls(v8, __ T2S, v9, v10);                      //       fmls    v8.2S, v9.2S, v10.2S
-    __ fmls(v24, __ T4S, v25, v26);                    //       fmls    v24.4S, v25.4S, v26.4S
-    __ fmls(v19, __ T2D, v20, v21);                    //       fmls    v19.2D, v20.2D, v21.2D
-    __ fdiv(v15, __ T2S, v16, v17);                    //       fdiv    v15.2S, v16.2S, v17.2S
-    __ fdiv(v16, __ T4S, v17, v18);                    //       fdiv    v16.4S, v17.4S, v18.4S
-    __ fdiv(v2, __ T2D, v3, v4);                       //       fdiv    v2.2D, v3.2D, v4.2D
-    __ maxv(v1, __ T8B, v2, v3);                       //       smax    v1.8B, v2.8B, v3.8B
-    __ maxv(v0, __ T16B, v1, v2);                      //       smax    v0.16B, v1.16B, v2.16B
-    __ maxv(v24, __ T4H, v25, v26);                    //       smax    v24.4H, v25.4H, v26.4H
-    __ maxv(v4, __ T8H, v5, v6);                       //       smax    v4.8H, v5.8H, v6.8H
-    __ maxv(v3, __ T2S, v4, v5);                       //       smax    v3.2S, v4.2S, v5.2S
-    __ maxv(v11, __ T4S, v12, v13);                    //       smax    v11.4S, v12.4S, v13.4S
-    __ smaxp(v30, __ T8B, v31, v0);                    //       smaxp   v30.8B, v31.8B, v0.8B
-    __ smaxp(v27, __ T16B, v28, v29);                  //       smaxp   v27.16B, v28.16B, v29.16B
-    __ smaxp(v9, __ T4H, v10, v11);                    //       smaxp   v9.4H, v10.4H, v11.4H
-    __ smaxp(v25, __ T8H, v26, v27);                   //       smaxp   v25.8H, v26.8H, v27.8H
-    __ smaxp(v2, __ T2S, v3, v4);                      //       smaxp   v2.2S, v3.2S, v4.2S
+    __ mlsv(v8, __ T4H, v9, v10);                      //       mls     v8.4H, v9.4H, v10.4H
+    __ mlsv(v24, __ T8H, v25, v26);                    //       mls     v24.8H, v25.8H, v26.8H
+    __ mlsv(v19, __ T2S, v20, v21);                    //       mls     v19.2S, v20.2S, v21.2S
+    __ mlsv(v15, __ T4S, v16, v17);                    //       mls     v15.4S, v16.4S, v17.4S
+    __ fmls(v16, __ T2S, v17, v18);                    //       fmls    v16.2S, v17.2S, v18.2S
+    __ fmls(v2, __ T4S, v3, v4);                       //       fmls    v2.4S, v3.4S, v4.4S
+    __ fmls(v1, __ T2D, v2, v3);                       //       fmls    v1.2D, v2.2D, v3.2D
+    __ fdiv(v0, __ T2S, v1, v2);                       //       fdiv    v0.2S, v1.2S, v2.2S
+    __ fdiv(v24, __ T4S, v25, v26);                    //       fdiv    v24.4S, v25.4S, v26.4S
+    __ fdiv(v4, __ T2D, v5, v6);                       //       fdiv    v4.2D, v5.2D, v6.2D
+    __ maxv(v3, __ T8B, v4, v5);                       //       smax    v3.8B, v4.8B, v5.8B
+    __ maxv(v11, __ T16B, v12, v13);                   //       smax    v11.16B, v12.16B, v13.16B
+    __ maxv(v30, __ T4H, v31, v0);                     //       smax    v30.4H, v31.4H, v0.4H
+    __ maxv(v27, __ T8H, v28, v29);                    //       smax    v27.8H, v28.8H, v29.8H
+    __ maxv(v9, __ T2S, v10, v11);                     //       smax    v9.2S, v10.2S, v11.2S
+    __ maxv(v25, __ T4S, v26, v27);                    //       smax    v25.4S, v26.4S, v27.4S
+    __ smaxp(v2, __ T8B, v3, v4);                      //       smaxp   v2.8B, v3.8B, v4.8B
+    __ smaxp(v12, __ T16B, v13, v14);                  //       smaxp   v12.16B, v13.16B, v14.16B
+    __ smaxp(v17, __ T4H, v18, v19);                   //       smaxp   v17.4H, v18.4H, v19.4H
+    __ smaxp(v30, __ T8H, v31, v0);                    //       smaxp   v30.8H, v31.8H, v0.8H
+    __ smaxp(v1, __ T2S, v2, v3);                      //       smaxp   v1.2S, v2.2S, v3.2S
     __ smaxp(v12, __ T4S, v13, v14);                   //       smaxp   v12.4S, v13.4S, v14.4S
-    __ fmax(v17, __ T2S, v18, v19);                    //       fmax    v17.2S, v18.2S, v19.2S
-    __ fmax(v30, __ T4S, v31, v0);                     //       fmax    v30.4S, v31.4S, v0.4S
-    __ fmax(v1, __ T2D, v2, v3);                       //       fmax    v1.2D, v2.2D, v3.2D
+    __ fmax(v28, __ T2S, v29, v30);                    //       fmax    v28.2S, v29.2S, v30.2S
+    __ fmax(v0, __ T4S, v1, v2);                       //       fmax    v0.4S, v1.4S, v2.4S
+    __ fmax(v17, __ T2D, v18, v19);                    //       fmax    v17.2D, v18.2D, v19.2D
     __ minv(v12, __ T8B, v13, v14);                    //       smin    v12.8B, v13.8B, v14.8B
-    __ minv(v28, __ T16B, v29, v30);                   //       smin    v28.16B, v29.16B, v30.16B
-    __ minv(v0, __ T4H, v1, v2);                       //       smin    v0.4H, v1.4H, v2.4H
-    __ minv(v17, __ T8H, v18, v19);                    //       smin    v17.8H, v18.8H, v19.8H
-    __ minv(v12, __ T2S, v13, v14);                    //       smin    v12.2S, v13.2S, v14.2S
-    __ minv(v17, __ T4S, v18, v19);                    //       smin    v17.4S, v18.4S, v19.4S
-    __ sminp(v21, __ T8B, v22, v23);                   //       sminp   v21.8B, v22.8B, v23.8B
-    __ sminp(v12, __ T16B, v13, v14);                  //       sminp   v12.16B, v13.16B, v14.16B
-    __ sminp(v27, __ T4H, v28, v29);                   //       sminp   v27.4H, v28.4H, v29.4H
-    __ sminp(v29, __ T8H, v30, v31);                   //       sminp   v29.8H, v30.8H, v31.8H
-    __ sminp(v30, __ T2S, v31, v0);                    //       sminp   v30.2S, v31.2S, v0.2S
-    __ sminp(v1, __ T4S, v2, v3);                      //       sminp   v1.4S, v2.4S, v3.4S
-    __ fmin(v25, __ T2S, v26, v27);                    //       fmin    v25.2S, v26.2S, v27.2S
-    __ fmin(v27, __ T4S, v28, v29);                    //       fmin    v27.4S, v28.4S, v29.4S
-    __ fmin(v4, __ T2D, v5, v6);                       //       fmin    v4.2D, v5.2D, v6.2D
-    __ cmeq(v29, __ T8B, v30, v31);                    //       cmeq    v29.8B, v30.8B, v31.8B
-    __ cmeq(v3, __ T16B, v4, v5);                      //       cmeq    v3.16B, v4.16B, v5.16B
-    __ cmeq(v6, __ T4H, v7, v8);                       //       cmeq    v6.4H, v7.4H, v8.4H
-    __ cmeq(v29, __ T8H, v30, v31);                    //       cmeq    v29.8H, v30.8H, v31.8H
-    __ cmeq(v25, __ T2S, v26, v27);                    //       cmeq    v25.2S, v26.2S, v27.2S
-    __ cmeq(v17, __ T4S, v18, v19);                    //       cmeq    v17.4S, v18.4S, v19.4S
-    __ cmeq(v8, __ T2D, v9, v10);                      //       cmeq    v8.2D, v9.2D, v10.2D
-    __ fcmeq(v7, __ T2S, v8, v9);                      //       fcmeq   v7.2S, v8.2S, v9.2S
-    __ fcmeq(v12, __ T4S, v13, v14);                   //       fcmeq   v12.4S, v13.4S, v14.4S
-    __ fcmeq(v0, __ T2D, v1, v2);                      //       fcmeq   v0.2D, v1.2D, v2.2D
-    __ cmgt(v19, __ T8B, v20, v21);                    //       cmgt    v19.8B, v20.8B, v21.8B
-    __ cmgt(v1, __ T16B, v2, v3);                      //       cmgt    v1.16B, v2.16B, v3.16B
+    __ minv(v17, __ T16B, v18, v19);                   //       smin    v17.16B, v18.16B, v19.16B
+    __ minv(v21, __ T4H, v22, v23);                    //       smin    v21.4H, v22.4H, v23.4H
+    __ minv(v12, __ T8H, v13, v14);                    //       smin    v12.8H, v13.8H, v14.8H
+    __ minv(v27, __ T2S, v28, v29);                    //       smin    v27.2S, v28.2S, v29.2S
+    __ minv(v29, __ T4S, v30, v31);                    //       smin    v29.4S, v30.4S, v31.4S
+    __ sminp(v30, __ T8B, v31, v0);                    //       sminp   v30.8B, v31.8B, v0.8B
+    __ sminp(v1, __ T16B, v2, v3);                     //       sminp   v1.16B, v2.16B, v3.16B
+    __ sminp(v25, __ T4H, v26, v27);                   //       sminp   v25.4H, v26.4H, v27.4H
+    __ sminp(v27, __ T8H, v28, v29);                   //       sminp   v27.8H, v28.8H, v29.8H
+    __ sminp(v4, __ T2S, v5, v6);                      //       sminp   v4.2S, v5.2S, v6.2S
+    __ sminp(v29, __ T4S, v30, v31);                   //       sminp   v29.4S, v30.4S, v31.4S
+    __ fmin(v3, __ T2S, v4, v5);                       //       fmin    v3.2S, v4.2S, v5.2S
+    __ fmin(v6, __ T4S, v7, v8);                       //       fmin    v6.4S, v7.4S, v8.4S
+    __ fmin(v29, __ T2D, v30, v31);                    //       fmin    v29.2D, v30.2D, v31.2D
+    __ cmeq(v25, __ T8B, v26, v27);                    //       cmeq    v25.8B, v26.8B, v27.8B
+    __ cmeq(v17, __ T16B, v18, v19);                   //       cmeq    v17.16B, v18.16B, v19.16B
+    __ cmeq(v8, __ T4H, v9, v10);                      //       cmeq    v8.4H, v9.4H, v10.4H
+    __ cmeq(v7, __ T8H, v8, v9);                       //       cmeq    v7.8H, v8.8H, v9.8H
+    __ cmeq(v12, __ T2S, v13, v14);                    //       cmeq    v12.2S, v13.2S, v14.2S
+    __ cmeq(v0, __ T4S, v1, v2);                       //       cmeq    v0.4S, v1.4S, v2.4S
+    __ cmeq(v19, __ T2D, v20, v21);                    //       cmeq    v19.2D, v20.2D, v21.2D
+    __ fcmeq(v1, __ T2S, v2, v3);                      //       fcmeq   v1.2S, v2.2S, v3.2S
+    __ fcmeq(v23, __ T4S, v24, v25);                   //       fcmeq   v23.4S, v24.4S, v25.4S
+    __ fcmeq(v2, __ T2D, v3, v4);                      //       fcmeq   v2.2D, v3.2D, v4.2D
+    __ cmgt(v0, __ T8B, v1, v2);                       //       cmgt    v0.8B, v1.8B, v2.8B
+    __ cmgt(v8, __ T16B, v9, v10);                     //       cmgt    v8.16B, v9.16B, v10.16B
     __ cmgt(v23, __ T4H, v24, v25);                    //       cmgt    v23.4H, v24.4H, v25.4H
-    __ cmgt(v2, __ T8H, v3, v4);                       //       cmgt    v2.8H, v3.8H, v4.8H
-    __ cmgt(v0, __ T2S, v1, v2);                       //       cmgt    v0.2S, v1.2S, v2.2S
-    __ cmgt(v8, __ T4S, v9, v10);                      //       cmgt    v8.4S, v9.4S, v10.4S
-    __ cmgt(v23, __ T2D, v24, v25);                    //       cmgt    v23.2D, v24.2D, v25.2D
-    __ cmhi(v25, __ T8B, v26, v27);                    //       cmhi    v25.8B, v26.8B, v27.8B
-    __ cmhi(v15, __ T16B, v16, v17);                   //       cmhi    v15.16B, v16.16B, v17.16B
-    __ cmhi(v29, __ T4H, v30, v31);                    //       cmhi    v29.4H, v30.4H, v31.4H
-    __ cmhi(v3, __ T8H, v4, v5);                       //       cmhi    v3.8H, v4.8H, v5.8H
-    __ cmhi(v10, __ T2S, v11, v12);                    //       cmhi    v10.2S, v11.2S, v12.2S
-    __ cmhi(v22, __ T4S, v23, v24);                    //       cmhi    v22.4S, v23.4S, v24.4S
-    __ cmhi(v10, __ T2D, v11, v12);                    //       cmhi    v10.2D, v11.2D, v12.2D
-    __ cmhs(v4, __ T8B, v5, v6);                       //       cmhs    v4.8B, v5.8B, v6.8B
-    __ cmhs(v17, __ T16B, v18, v19);                   //       cmhs    v17.16B, v18.16B, v19.16B
-    __ cmhs(v1, __ T4H, v2, v3);                       //       cmhs    v1.4H, v2.4H, v3.4H
-    __ cmhs(v11, __ T8H, v12, v13);                    //       cmhs    v11.8H, v12.8H, v13.8H
-    __ cmhs(v7, __ T2S, v8, v9);                       //       cmhs    v7.2S, v8.2S, v9.2S
-    __ cmhs(v10, __ T4S, v11, v12);                    //       cmhs    v10.4S, v11.4S, v12.4S
-    __ cmhs(v15, __ T2D, v16, v17);                    //       cmhs    v15.2D, v16.2D, v17.2D
-    __ fcmgt(v16, __ T2S, v17, v18);                   //       fcmgt   v16.2S, v17.2S, v18.2S
-    __ fcmgt(v2, __ T4S, v3, v4);                      //       fcmgt   v2.4S, v3.4S, v4.4S
-    __ fcmgt(v9, __ T2D, v10, v11);                    //       fcmgt   v9.2D, v10.2D, v11.2D
-    __ cmge(v11, __ T8B, v12, v13);                    //       cmge    v11.8B, v12.8B, v13.8B
-    __ cmge(v12, __ T16B, v13, v14);                   //       cmge    v12.16B, v13.16B, v14.16B
-    __ cmge(v14, __ T4H, v15, v16);                    //       cmge    v14.4H, v15.4H, v16.4H
-    __ cmge(v13, __ T8H, v14, v15);                    //       cmge    v13.8H, v14.8H, v15.8H
-    __ cmge(v2, __ T2S, v3, v4);                       //       cmge    v2.2S, v3.2S, v4.2S
-    __ cmge(v6, __ T4S, v7, v8);                       //       cmge    v6.4S, v7.4S, v8.4S
-    __ cmge(v19, __ T2D, v20, v21);                    //       cmge    v19.2D, v20.2D, v21.2D
-    __ fcmge(v25, __ T2S, v26, v27);                   //       fcmge   v25.2S, v26.2S, v27.2S
-    __ fcmge(v15, __ T4S, v16, v17);                   //       fcmge   v15.4S, v16.4S, v17.4S
-    __ fcmge(v4, __ T2D, v5, v6);                      //       fcmge   v4.2D, v5.2D, v6.2D
-    __ facgt(v2, __ T2S, v3, v4);                      //       facgt   v2.2S, v3.2S, v4.2S
-    __ facgt(v4, __ T4S, v5, v6);                      //       facgt   v4.4S, v5.4S, v6.4S
-    __ facgt(v11, __ T2D, v12, v13);                   //       facgt   v11.2D, v12.2D, v13.2D
+    __ cmgt(v25, __ T8H, v26, v27);                    //       cmgt    v25.8H, v26.8H, v27.8H
+    __ cmgt(v15, __ T2S, v16, v17);                    //       cmgt    v15.2S, v16.2S, v17.2S
+    __ cmgt(v29, __ T4S, v30, v31);                    //       cmgt    v29.4S, v30.4S, v31.4S
+    __ cmgt(v3, __ T2D, v4, v5);                       //       cmgt    v3.2D, v4.2D, v5.2D
+    __ cmhi(v10, __ T8B, v11, v12);                    //       cmhi    v10.8B, v11.8B, v12.8B
+    __ cmhi(v22, __ T16B, v23, v24);                   //       cmhi    v22.16B, v23.16B, v24.16B
+    __ cmhi(v10, __ T4H, v11, v12);                    //       cmhi    v10.4H, v11.4H, v12.4H
+    __ cmhi(v4, __ T8H, v5, v6);                       //       cmhi    v4.8H, v5.8H, v6.8H
+    __ cmhi(v17, __ T2S, v18, v19);                    //       cmhi    v17.2S, v18.2S, v19.2S
+    __ cmhi(v1, __ T4S, v2, v3);                       //       cmhi    v1.4S, v2.4S, v3.4S
+    __ cmhi(v11, __ T2D, v12, v13);                    //       cmhi    v11.2D, v12.2D, v13.2D
+    __ cmhs(v7, __ T8B, v8, v9);                       //       cmhs    v7.8B, v8.8B, v9.8B
+    __ cmhs(v10, __ T16B, v11, v12);                   //       cmhs    v10.16B, v11.16B, v12.16B
+    __ cmhs(v15, __ T4H, v16, v17);                    //       cmhs    v15.4H, v16.4H, v17.4H
+    __ cmhs(v16, __ T8H, v17, v18);                    //       cmhs    v16.8H, v17.8H, v18.8H
+    __ cmhs(v2, __ T2S, v3, v4);                       //       cmhs    v2.2S, v3.2S, v4.2S
+    __ cmhs(v9, __ T4S, v10, v11);                     //       cmhs    v9.4S, v10.4S, v11.4S
+    __ cmhs(v11, __ T2D, v12, v13);                    //       cmhs    v11.2D, v12.2D, v13.2D
+    __ fcmgt(v12, __ T2S, v13, v14);                   //       fcmgt   v12.2S, v13.2S, v14.2S
+    __ fcmgt(v14, __ T4S, v15, v16);                   //       fcmgt   v14.4S, v15.4S, v16.4S
+    __ fcmgt(v13, __ T2D, v14, v15);                   //       fcmgt   v13.2D, v14.2D, v15.2D
+    __ cmge(v2, __ T8B, v3, v4);                       //       cmge    v2.8B, v3.8B, v4.8B
+    __ cmge(v6, __ T16B, v7, v8);                      //       cmge    v6.16B, v7.16B, v8.16B
+    __ cmge(v19, __ T4H, v20, v21);                    //       cmge    v19.4H, v20.4H, v21.4H
+    __ cmge(v25, __ T8H, v26, v27);                    //       cmge    v25.8H, v26.8H, v27.8H
+    __ cmge(v15, __ T2S, v16, v17);                    //       cmge    v15.2S, v16.2S, v17.2S
+    __ cmge(v4, __ T4S, v5, v6);                       //       cmge    v4.4S, v5.4S, v6.4S
+    __ cmge(v2, __ T2D, v3, v4);                       //       cmge    v2.2D, v3.2D, v4.2D
+    __ fcmge(v4, __ T2S, v5, v6);                      //       fcmge   v4.2S, v5.2S, v6.2S
+    __ fcmge(v11, __ T4S, v12, v13);                   //       fcmge   v11.4S, v12.4S, v13.4S
+    __ fcmge(v17, __ T2D, v18, v19);                   //       fcmge   v17.2D, v18.2D, v19.2D
+    __ facgt(v20, __ T2S, v21, v22);                   //       facgt   v20.2S, v21.2S, v22.2S
+    __ facgt(v16, __ T4S, v17, v18);                   //       facgt   v16.4S, v17.4S, v18.4S
+    __ facgt(v17, __ T2D, v18, v19);                   //       facgt   v17.2D, v18.2D, v19.2D
 
 // SVEComparisonWithZero
-    __ sve_fcm(Assembler::EQ, p9, __ D, p4, z20, 0.0); //       fcmeq   p9.d, p4/z, z20.d, #0.0
-    __ sve_fcm(Assembler::GT, p5, __ D, p3, z20, 0.0); //       fcmgt   p5.d, p3/z, z20.d, #0.0
-    __ sve_fcm(Assembler::GE, p13, __ D, p3, z23, 0.0); //      fcmge   p13.d, p3/z, z23.d, #0.0
-    __ sve_fcm(Assembler::LT, p5, __ S, p3, z24, 0.0); //       fcmlt   p5.s, p3/z, z24.s, #0.0
-    __ sve_fcm(Assembler::LE, p15, __ D, p1, z10, 0.0); //      fcmle   p15.d, p1/z, z10.d, #0.0
-    __ sve_fcm(Assembler::NE, p1, __ S, p4, z3, 0.0);  //       fcmne   p1.s, p4/z, z3.s, #0.0
+    __ sve_fcm(Assembler::EQ, p5, __ D, p3, z20, 0.0); //       fcmeq   p5.d, p3/z, z20.d, #0.0
+    __ sve_fcm(Assembler::GT, p13, __ D, p3, z23, 0.0); //      fcmgt   p13.d, p3/z, z23.d, #0.0
+    __ sve_fcm(Assembler::GE, p5, __ S, p3, z24, 0.0); //       fcmge   p5.s, p3/z, z24.s, #0.0
+    __ sve_fcm(Assembler::LT, p15, __ D, p1, z10, 0.0); //      fcmlt   p15.d, p1/z, z10.d, #0.0
+    __ sve_fcm(Assembler::LE, p1, __ S, p4, z3, 0.0);  //       fcmle   p1.s, p4/z, z3.s, #0.0
+    __ sve_fcm(Assembler::NE, p8, __ S, p0, z16, 0.0); //       fcmne   p8.s, p0/z, z16.s, #0.0
 
 // SpecialCases
     __ ccmn(zr, zr, 3u, Assembler::LE);                //       ccmn    xzr, xzr, #3, LE
@@ -1022,215 +1040,215 @@
     __ fmovd(v0, -1.0625);                             //       fmov d0, #-1.0625
 
 // LSEOp
-    __ swp(Assembler::xword, r17, r16, r3);            //       swp     x17, x16, [x3]
-    __ ldadd(Assembler::xword, r1, r11, r30);          //       ldadd   x1, x11, [x30]
-    __ ldbic(Assembler::xword, r5, r8, r15);           //       ldclr   x5, x8, [x15]
-    __ ldeor(Assembler::xword, r29, r30, r0);          //       ldeor   x29, x30, [x0]
-    __ ldorr(Assembler::xword, r20, r7, r20);          //       ldset   x20, x7, [x20]
-    __ ldsmin(Assembler::xword, r23, r28, r21);        //       ldsmin  x23, x28, [x21]
-    __ ldsmax(Assembler::xword, r27, r25, r5);         //       ldsmax  x27, x25, [x5]
-    __ ldumin(Assembler::xword, r1, r23, r16);         //       ldumin  x1, x23, [x16]
-    __ ldumax(Assembler::xword, zr, r5, r12);          //       ldumax  xzr, x5, [x12]
+    __ swp(Assembler::xword, r11, r30, r5);            //       swp     x11, x30, [x5]
+    __ ldadd(Assembler::xword, r8, r15, r29);          //       ldadd   x8, x15, [x29]
+    __ ldbic(Assembler::xword, r30, r0, r20);          //       ldclr   x30, x0, [x20]
+    __ ldeor(Assembler::xword, r7, r20, r23);          //       ldeor   x7, x20, [x23]
+    __ ldorr(Assembler::xword, r28, r21, r27);         //       ldset   x28, x21, [x27]
+    __ ldsmin(Assembler::xword, r25, r5, r1);          //       ldsmin  x25, x5, [x1]
+    __ ldsmax(Assembler::xword, r23, r16, sp);         //       ldsmax  x23, x16, [sp]
+    __ ldumin(Assembler::xword, r5, r12, r9);          //       ldumin  x5, x12, [x9]
+    __ ldumax(Assembler::xword, r28, r15, r29);        //       ldumax  x28, x15, [x29]
 
 // LSEOp
-    __ swpa(Assembler::xword, r9, r28, r15);           //       swpa    x9, x28, [x15]
-    __ ldadda(Assembler::xword, r29, r22, sp);         //       ldadda  x29, x22, [sp]
-    __ ldbica(Assembler::xword, r19, zr, r5);          //       ldclra  x19, xzr, [x5]
-    __ ldeora(Assembler::xword, r14, r16, sp);         //       ldeora  x14, x16, [sp]
-    __ ldorra(Assembler::xword, r16, r27, r20);        //       ldseta  x16, x27, [x20]
-    __ ldsmina(Assembler::xword, r16, r12, r11);       //       ldsmina x16, x12, [x11]
-    __ ldsmaxa(Assembler::xword, r9, r6, r30);         //       ldsmaxa x9, x6, [x30]
-    __ ldumina(Assembler::xword, r17, r27, r28);       //       ldumina x17, x27, [x28]
-    __ ldumaxa(Assembler::xword, r30, r7, r10);        //       ldumaxa x30, x7, [x10]
+    __ swpa(Assembler::xword, r22, zr, r19);           //       swpa    x22, xzr, [x19]
+    __ ldadda(Assembler::xword, zr, r5, r14);          //       ldadda  xzr, x5, [x14]
+    __ ldbica(Assembler::xword, r16, zr, r15);         //       ldclra  x16, xzr, [x15]
+    __ ldeora(Assembler::xword, r27, r20, r16);        //       ldeora  x27, x20, [x16]
+    __ ldorra(Assembler::xword, r12, r11, r9);         //       ldseta  x12, x11, [x9]
+    __ ldsmina(Assembler::xword, r6, r30, r17);        //       ldsmina x6, x30, [x17]
+    __ ldsmaxa(Assembler::xword, r27, r28, r30);       //       ldsmaxa x27, x28, [x30]
+    __ ldumina(Assembler::xword, r7, r10, r20);        //       ldumina x7, x10, [x20]
+    __ ldumaxa(Assembler::xword, r10, r4, r24);        //       ldumaxa x10, x4, [x24]
 
 // LSEOp
-    __ swpal(Assembler::xword, r20, r10, r4);          //       swpal   x20, x10, [x4]
-    __ ldaddal(Assembler::xword, r24, r17, r17);       //       ldaddal x24, x17, [x17]
-    __ ldbical(Assembler::xword, r22, r3, r29);        //       ldclral x22, x3, [x29]
-    __ ldeoral(Assembler::xword, r15, r22, r19);       //       ldeoral x15, x22, [x19]
-    __ ldorral(Assembler::xword, r19, r22, r2);        //       ldsetal x19, x22, [x2]
-    __ ldsminal(Assembler::xword, r15, r6, r12);       //       ldsminal        x15, x6, [x12]
-    __ ldsmaxal(Assembler::xword, r16, r11, r13);      //       ldsmaxal        x16, x11, [x13]
-    __ lduminal(Assembler::xword, r23, r1, r30);       //       lduminal        x23, x1, [x30]
-    __ ldumaxal(Assembler::xword, r19, r5, r17);       //       ldumaxal        x19, x5, [x17]
+    __ swpal(Assembler::xword, r17, r17, r22);         //       swpal   x17, x17, [x22]
+    __ ldaddal(Assembler::xword, r3, r29, r15);        //       ldaddal x3, x29, [x15]
+    __ ldbical(Assembler::xword, r22, r19, r19);       //       ldclral x22, x19, [x19]
+    __ ldeoral(Assembler::xword, r22, r2, r15);        //       ldeoral x22, x2, [x15]
+    __ ldorral(Assembler::xword, r6, r12, r16);        //       ldsetal x6, x12, [x16]
+    __ ldsminal(Assembler::xword, r11, r13, r23);      //       ldsminal        x11, x13, [x23]
+    __ ldsmaxal(Assembler::xword, r1, r30, r19);       //       ldsmaxal        x1, x30, [x19]
+    __ lduminal(Assembler::xword, r5, r17, r2);        //       lduminal        x5, x17, [x2]
+    __ ldumaxal(Assembler::xword, r16, r22, r13);      //       ldumaxal        x16, x22, [x13]
 
 // LSEOp
-    __ swpl(Assembler::xword, r2, r16, r22);           //       swpl    x2, x16, [x22]
-    __ ldaddl(Assembler::xword, r13, r10, r21);        //       ldaddl  x13, x10, [x21]
-    __ ldbicl(Assembler::xword, r29, r27, r12);        //       ldclrl  x29, x27, [x12]
-    __ ldeorl(Assembler::xword, r27, r3, r1);          //       ldeorl  x27, x3, [x1]
-    __ ldorrl(Assembler::xword, zr, r24, r19);         //       ldsetl  xzr, x24, [x19]
-    __ ldsminl(Assembler::xword, r17, r9, r28);        //       ldsminl x17, x9, [x28]
-    __ ldsmaxl(Assembler::xword, r27, r15, r7);        //       ldsmaxl x27, x15, [x7]
-    __ lduminl(Assembler::xword, r21, r23, sp);        //       lduminl x21, x23, [sp]
-    __ ldumaxl(Assembler::xword, r25, r2, sp);         //       ldumaxl x25, x2, [sp]
+    __ swpl(Assembler::xword, r10, r21, r29);          //       swpl    x10, x21, [x29]
+    __ ldaddl(Assembler::xword, r27, r12, r27);        //       ldaddl  x27, x12, [x27]
+    __ ldbicl(Assembler::xword, r3, r1, sp);           //       ldclrl  x3, x1, [sp]
+    __ ldeorl(Assembler::xword, r24, r19, r17);        //       ldeorl  x24, x19, [x17]
+    __ ldorrl(Assembler::xword, r9, r28, r27);         //       ldsetl  x9, x28, [x27]
+    __ ldsminl(Assembler::xword, r15, r7, r21);        //       ldsminl x15, x7, [x21]
+    __ ldsmaxl(Assembler::xword, r23, zr, r25);        //       ldsmaxl x23, xzr, [x25]
+    __ lduminl(Assembler::xword, r2, zr, r27);         //       lduminl x2, xzr, [x27]
+    __ ldumaxl(Assembler::xword, r16, r10, r23);       //       ldumaxl x16, x10, [x23]
 
 // LSEOp
-    __ swp(Assembler::word, r27, r16, r10);            //       swp     w27, w16, [x10]
-    __ ldadd(Assembler::word, r23, r19, r3);           //       ldadd   w23, w19, [x3]
-    __ ldbic(Assembler::word, r16, r0, r25);           //       ldclr   w16, w0, [x25]
-    __ ldeor(Assembler::word, r26, r23, r2);           //       ldeor   w26, w23, [x2]
-    __ ldorr(Assembler::word, r16, r12, r4);           //       ldset   w16, w12, [x4]
-    __ ldsmin(Assembler::word, r28, r30, r29);         //       ldsmin  w28, w30, [x29]
-    __ ldsmax(Assembler::word, r16, r27, r6);          //       ldsmax  w16, w27, [x6]
-    __ ldumin(Assembler::word, r9, r29, r15);          //       ldumin  w9, w29, [x15]
-    __ ldumax(Assembler::word, r7, r4, r7);            //       ldumax  w7, w4, [x7]
+    __ swp(Assembler::word, r19, r3, r15);             //       swp     w19, w3, [x15]
+    __ ldadd(Assembler::word, r0, r25, r26);           //       ldadd   w0, w25, [x26]
+    __ ldbic(Assembler::word, r23, r2, r15);           //       ldclr   w23, w2, [x15]
+    __ ldeor(Assembler::word, r12, r4, r28);           //       ldeor   w12, w4, [x28]
+    __ ldorr(Assembler::word, r30, r29, r16);          //       ldset   w30, w29, [x16]
+    __ ldsmin(Assembler::word, r27, r6, r9);           //       ldsmin  w27, w6, [x9]
+    __ ldsmax(Assembler::word, r29, r16, r7);          //       ldsmax  w29, w16, [x7]
+    __ ldumin(Assembler::word, r4, r7, r15);           //       ldumin  w4, w7, [x15]
+    __ ldumax(Assembler::word, r9, r23, r8);           //       ldumax  w9, w23, [x8]
 
 // LSEOp
-    __ swpa(Assembler::word, r15, r9, r23);            //       swpa    w15, w9, [x23]
-    __ ldadda(Assembler::word, r8, r2, r28);           //       ldadda  w8, w2, [x28]
-    __ ldbica(Assembler::word, r21, zr, r5);           //       ldclra  w21, wzr, [x5]
-    __ ldeora(Assembler::word, r27, r0, r17);          //       ldeora  w27, w0, [x17]
-    __ ldorra(Assembler::word, r15, r4, r26);          //       ldseta  w15, w4, [x26]
-    __ ldsmina(Assembler::word, r8, r28, r22);         //       ldsmina w8, w28, [x22]
-    __ ldsmaxa(Assembler::word, r27, r27, r25);        //       ldsmaxa w27, w27, [x25]
-    __ ldumina(Assembler::word, r23, r0, r4);          //       ldumina w23, w0, [x4]
-    __ ldumaxa(Assembler::word, r6, r16, r0);          //       ldumaxa w6, w16, [x0]
+    __ swpa(Assembler::word, r2, r28, r21);            //       swpa    w2, w28, [x21]
+    __ ldadda(Assembler::word, zr, r5, r27);           //       ldadda  wzr, w5, [x27]
+    __ ldbica(Assembler::word, r0, r17, r15);          //       ldclra  w0, w17, [x15]
+    __ ldeora(Assembler::word, r4, r26, r8);           //       ldeora  w4, w26, [x8]
+    __ ldorra(Assembler::word, r28, r22, r27);         //       ldseta  w28, w22, [x27]
+    __ ldsmina(Assembler::word, r27, r25, r23);        //       ldsmina w27, w25, [x23]
+    __ ldsmaxa(Assembler::word, r0, r4, r6);           //       ldsmaxa w0, w4, [x6]
+    __ ldumina(Assembler::word, r16, r0, r4);          //       ldumina w16, w0, [x4]
+    __ ldumaxa(Assembler::word, r15, r1, r10);         //       ldumaxa w15, w1, [x10]
 
 // LSEOp
-    __ swpal(Assembler::word, r4, r15, r1);            //       swpal   w4, w15, [x1]
-    __ ldaddal(Assembler::word, r10, r7, r5);          //       ldaddal w10, w7, [x5]
-    __ ldbical(Assembler::word, r10, r28, r7);         //       ldclral w10, w28, [x7]
-    __ ldeoral(Assembler::word, r20, r23, r21);        //       ldeoral w20, w23, [x21]
-    __ ldorral(Assembler::word, r6, r11, r8);          //       ldsetal w6, w11, [x8]
-    __ ldsminal(Assembler::word, r17, zr, r6);         //       ldsminal        w17, wzr, [x6]
-    __ ldsmaxal(Assembler::word, r17, r2, r12);        //       ldsmaxal        w17, w2, [x12]
-    __ lduminal(Assembler::word, r30, r29, r3);        //       lduminal        w30, w29, [x3]
-    __ ldumaxal(Assembler::word, r27, r22, r29);       //       ldumaxal        w27, w22, [x29]
+    __ swpal(Assembler::word, r7, r5, r10);            //       swpal   w7, w5, [x10]
+    __ ldaddal(Assembler::word, r28, r7, r20);         //       ldaddal w28, w7, [x20]
+    __ ldbical(Assembler::word, r23, r21, r6);         //       ldclral w23, w21, [x6]
+    __ ldeoral(Assembler::word, r11, r8, r17);         //       ldeoral w11, w8, [x17]
+    __ ldorral(Assembler::word, zr, r6, r17);          //       ldsetal wzr, w6, [x17]
+    __ ldsminal(Assembler::word, r2, r12, r30);        //       ldsminal        w2, w12, [x30]
+    __ ldsmaxal(Assembler::word, r29, r3, r27);        //       ldsmaxal        w29, w3, [x27]
+    __ lduminal(Assembler::word, r22, r29, r14);       //       lduminal        w22, w29, [x14]
+    __ ldumaxal(Assembler::word, r13, r28, r17);       //       ldumaxal        w13, w28, [x17]
 
 // LSEOp
-    __ swpl(Assembler::word, r14, r13, r28);           //       swpl    w14, w13, [x28]
-    __ ldaddl(Assembler::word, r17, r24, r5);          //       ldaddl  w17, w24, [x5]
-    __ ldbicl(Assembler::word, r2, r14, r10);          //       ldclrl  w2, w14, [x10]
-    __ ldeorl(Assembler::word, r16, r11, r27);         //       ldeorl  w16, w11, [x27]
-    __ ldorrl(Assembler::word, r23, r12, r4);          //       ldsetl  w23, w12, [x4]
-    __ ldsminl(Assembler::word, r22, r17, r4);         //       ldsminl w22, w17, [x4]
-    __ ldsmaxl(Assembler::word, r1, r19, r16);         //       ldsmaxl w1, w19, [x16]
-    __ lduminl(Assembler::word, r16, r13, r14);        //       lduminl w16, w13, [x14]
-    __ ldumaxl(Assembler::word, r12, r2, r17);         //       ldumaxl w12, w2, [x17]
+    __ swpl(Assembler::word, r24, r5, r2);             //       swpl    w24, w5, [x2]
+    __ ldaddl(Assembler::word, r14, r10, r16);         //       ldaddl  w14, w10, [x16]
+    __ ldbicl(Assembler::word, r11, r27, r23);         //       ldclrl  w11, w27, [x23]
+    __ ldeorl(Assembler::word, r12, r4, r22);          //       ldeorl  w12, w4, [x22]
+    __ ldorrl(Assembler::word, r17, r4, r1);           //       ldsetl  w17, w4, [x1]
+    __ ldsminl(Assembler::word, r19, r16, r15);        //       ldsminl w19, w16, [x15]
+    __ ldsmaxl(Assembler::word, r13, r14, r12);        //       ldsmaxl w13, w14, [x12]
+    __ lduminl(Assembler::word, r2, r17, r3);          //       lduminl w2, w17, [x3]
+    __ ldumaxl(Assembler::word, r21, r23, r5);         //       ldumaxl w21, w23, [x5]
 
 // SHA3SIMDOp
-    __ bcax(v3, __ T16B, v20, v23, v5);                //       bcax            v3.16B, v20.16B, v23.16B, v5.16B
-    __ eor3(v6, __ T16B, v7, v17, v12);                //       eor3            v6.16B, v7.16B, v17.16B, v12.16B
-    __ rax1(v27, __ T2D, v16, v16);                    //       rax1            v27.2D, v16.2D, v16.2D
-    __ xar(v6, __ T2D, v2, v28, 6);                    //       xar             v6.2D, v2.2D, v28.2D, #6
+    __ bcax(v6, __ T16B, v7, v17, v12);                //       bcax            v6.16B, v7.16B, v17.16B, v12.16B
+    __ eor3(v27, __ T16B, v16, v16, v6);               //       eor3            v27.16B, v16.16B, v16.16B, v6.16B
+    __ rax1(v2, __ T2D, v28, v3);                      //       rax1            v2.2D, v28.2D, v3.2D
+    __ xar(v4, __ T2D, v6, v17, 40);                   //       xar             v4.2D, v6.2D, v17.2D, #40
 
 // SHA512SIMDOp
-    __ sha512h(v4, __ T2D, v6, v17);                   //       sha512h         q4, q6, v17.2D
-    __ sha512h2(v19, __ T2D, v13, v12);                //       sha512h2                q19, q13, v12.2D
-    __ sha512su0(v19, __ T2D, v8);                     //       sha512su0               v19.2D, v8.2D
-    __ sha512su1(v24, __ T2D, v19, v17);               //       sha512su1               v24.2D, v19.2D, v17.2D
+    __ sha512h(v13, __ T2D, v12, v19);                 //       sha512h         q13, q12, v19.2D
+    __ sha512h2(v8, __ T2D, v24, v19);                 //       sha512h2                q8, q24, v19.2D
+    __ sha512su0(v17, __ T2D, v0);                     //       sha512su0               v17.2D, v0.2D
+    __ sha512su1(v10, __ T2D, v23, v6);                //       sha512su1               v10.2D, v23.2D, v6.2D
 
 // SVEBinaryImmOp
-    __ sve_add(z0, __ H, 196u);                        //       add     z0.h, z0.h, #0xc4
-    __ sve_sub(z6, __ S, 249u);                        //       sub     z6.s, z6.s, #0xf9
-    __ sve_and(z13, __ S, 1u);                         //       and     z13.s, z13.s, #0x1
-    __ sve_eor(z7, __ H, 63489u);                      //       eor     z7.h, z7.h, #0xf801
-    __ sve_orr(z8, __ H, 51199u);                      //       orr     z8.h, z8.h, #0xc7ff
+    __ sve_add(z19, __ D, 112u);                       //       add     z19.d, z19.d, #0x70
+    __ sve_sub(z16, __ B, 1u);                         //       sub     z16.b, z16.b, #0x1
+    __ sve_and(z7, __ H, 63489u);                      //       and     z7.h, z7.h, #0xf801
+    __ sve_eor(z8, __ H, 51199u);                      //       eor     z8.h, z8.h, #0xc7ff
+    __ sve_orr(z22, __ D, 17179852800u);               //       orr     z22.d, z22.d, #0x3ffffc000
 
 // SVEBinaryImmOp
-    __ sve_add(z22, __ D, 22u);                        //       add     z22.d, z22.d, #0x16
-    __ sve_sub(z3, __ H, 156u);                        //       sub     z3.h, z3.h, #0x9c
-    __ sve_and(z20, __ B, 254u);                       //       and     z20.b, z20.b, #0xfe
-    __ sve_eor(z7, __ B, 131u);                        //       eor     z7.b, z7.b, #0x83
-    __ sve_orr(z19, __ S, 2147484159u);                //       orr     z19.s, z19.s, #0x800001ff
+    __ sve_add(z15, __ S, 167u);                       //       add     z15.s, z15.s, #0xa7
+    __ sve_sub(z7, __ B, 235u);                        //       sub     z7.b, z7.b, #0xeb
+    __ sve_and(z7, __ B, 131u);                        //       and     z7.b, z7.b, #0x83
+    __ sve_eor(z19, __ S, 2147484159u);                //       eor     z19.s, z19.s, #0x800001ff
+    __ sve_orr(z9, __ S, 4292870159u);                 //       orr     z9.s, z9.s, #0xffe0000f
 
 // SVEBinaryImmOp
-    __ sve_add(z9, __ S, 92u);                         //       add     z9.s, z9.s, #0x5c
-    __ sve_sub(z25, __ B, 254u);                       //       sub     z25.b, z25.b, #0xfe
-    __ sve_and(z16, __ H, 16368u);                     //       and     z16.h, z16.h, #0x3ff0
-    __ sve_eor(z1, __ H, 51199u);                      //       eor     z1.h, z1.h, #0xc7ff
-    __ sve_orr(z16, __ D, 274877904896u);              //       orr     z16.d, z16.d, #0x3ffffff800
+    __ sve_add(z5, __ D, 133u);                        //       add     z5.d, z5.d, #0x85
+    __ sve_sub(z13, __ S, 96u);                        //       sub     z13.s, z13.s, #0x60
+    __ sve_and(z1, __ H, 51199u);                      //       and     z1.h, z1.h, #0xc7ff
+    __ sve_eor(z16, __ D, 274877904896u);              //       eor     z16.d, z16.d, #0x3ffffff800
+    __ sve_orr(z4, __ S, 4186112u);                    //       orr     z4.s, z4.s, #0x3fe000
 
 // SVEBinaryImmOp
-    __ sve_add(z4, __ S, 67u);                         //       add     z4.s, z4.s, #0x43
-    __ sve_sub(z6, __ D, 35u);                         //       sub     z6.d, z6.d, #0x23
-    __ sve_and(z28, __ S, 4294049777u);                //       and     z28.s, z28.s, #0xfff1fff1
-    __ sve_eor(z9, __ H, 8064u);                       //       eor     z9.h, z9.h, #0x1f80
-    __ sve_orr(z28, __ B, 1u);                         //       orr     z28.b, z28.b, #0x1
+    __ sve_add(z29, __ B, 234u);                       //       add     z29.b, z29.b, #0xea
+    __ sve_sub(z16, __ D, 214u);                       //       sub     z16.d, z16.d, #0xd6
+    __ sve_and(z9, __ H, 8064u);                       //       and     z9.h, z9.h, #0x1f80
+    __ sve_eor(z28, __ B, 1u);                         //       eor     z28.b, z28.b, #0x1
+    __ sve_orr(z26, __ S, 1610637312u);                //       orr     z26.s, z26.s, #0x60006000
 
 // SVEBinaryImmOp
-    __ sve_add(z26, __ S, 150u);                       //       add     z26.s, z26.s, #0x96
-    __ sve_sub(z14, __ H, 149u);                       //       sub     z14.h, z14.h, #0x95
-    __ sve_and(z21, __ D, 18302628885642084351u);      //       and     z21.d, z21.d, #0xfe000000007fffff
-    __ sve_eor(z21, __ S, 2151677951u);                //       eor     z21.s, z21.s, #0x803fffff
-    __ sve_orr(z29, __ S, 1u);                         //       orr     z29.s, z29.s, #0x1
+    __ sve_add(z8, __ S, 179u);                        //       add     z8.s, z8.s, #0xb3
+    __ sve_sub(z24, __ B, 160u);                       //       sub     z24.b, z24.b, #0xa0
+    __ sve_and(z21, __ S, 2151677951u);                //       and     z21.s, z21.s, #0x803fffff
+    __ sve_eor(z29, __ S, 1u);                         //       eor     z29.s, z29.s, #0x1
+    __ sve_orr(z4, __ S, 491520u);                     //       orr     z4.s, z4.s, #0x78000
 
 // SVEBinaryImmOp
-    __ sve_add(z4, __ S, 196u);                        //       add     z4.s, z4.s, #0xc4
-    __ sve_sub(z4, __ S, 39u);                         //       sub     z4.s, z4.s, #0x27
-    __ sve_and(z23, __ D, 66977792u);                  //       and     z23.d, z23.d, #0x3fe0000
-    __ sve_eor(z8, __ H, 57855u);                      //       eor     z8.h, z8.h, #0xe1ff
-    __ sve_orr(z17, __ D, 274877904896u);              //       orr     z17.d, z17.d, #0x3ffffff800
+    __ sve_add(z19, __ B, 195u);                       //       add     z19.b, z19.b, #0xc3
+    __ sve_sub(z25, __ S, 17u);                        //       sub     z25.s, z25.s, #0x11
+    __ sve_and(z8, __ H, 57855u);                      //       and     z8.h, z8.h, #0xe1ff
+    __ sve_eor(z17, __ D, 274877904896u);              //       eor     z17.d, z17.d, #0x3ffffff800
+    __ sve_orr(z30, __ B, 225u);                       //       orr     z30.b, z30.b, #0xe1
 
 // SVEVectorOp
-    __ sve_add(z30, __ S, z1, z10);                    //       add     z30.s, z1.s, z10.s
-    __ sve_sub(z12, __ B, z0, z9);                     //       sub     z12.b, z0.b, z9.b
-    __ sve_fadd(z24, __ D, z17, z4);                   //       fadd    z24.d, z17.d, z4.d
-    __ sve_fmul(z6, __ D, z9, z27);                    //       fmul    z6.d, z9.d, z27.d
-    __ sve_fsub(z13, __ D, z16, z30);                  //       fsub    z13.d, z16.d, z30.d
-    __ sve_abs(z22, __ D, p5, z30);                    //       abs     z22.d, p5/m, z30.d
-    __ sve_add(z9, __ B, p3, z19);                     //       add     z9.b, p3/m, z9.b, z19.b
-    __ sve_and(z20, __ H, p7, z9);                     //       and     z20.h, p7/m, z20.h, z9.h
-    __ sve_asr(z13, __ B, p3, z19);                    //       asr     z13.b, p3/m, z13.b, z19.b
-    __ sve_bic(z24, __ H, p2, z19);                    //       bic     z24.h, p2/m, z24.h, z19.h
-    __ sve_clz(z17, __ B, p4, z16);                    //       clz     z17.b, p4/m, z16.b
-    __ sve_cnt(z0, __ H, p0, z11);                     //       cnt     z0.h, p0/m, z11.h
-    __ sve_eor(z15, __ B, p3, z15);                    //       eor     z15.b, p3/m, z15.b, z15.b
-    __ sve_lsl(z15, __ B, p7, z5);                     //       lsl     z15.b, p7/m, z15.b, z5.b
-    __ sve_lsr(z10, __ B, p5, z26);                    //       lsr     z10.b, p5/m, z10.b, z26.b
-    __ sve_mul(z0, __ D, p2, z19);                     //       mul     z0.d, p2/m, z0.d, z19.d
-    __ sve_neg(z10, __ S, p6, z3);                     //       neg     z10.s, p6/m, z3.s
-    __ sve_not(z7, __ H, p6, z28);                     //       not     z7.h, p6/m, z28.h
-    __ sve_orr(z21, __ H, p2, z26);                    //       orr     z21.h, p2/m, z21.h, z26.h
-    __ sve_rbit(z17, __ H, p7, z17);                   //       rbit    z17.h, p7/m, z17.h
-    __ sve_revb(z2, __ D, p7, z16);                    //       revb    z2.d, p7/m, z16.d
-    __ sve_smax(z20, __ B, p1, z19);                   //       smax    z20.b, p1/m, z20.b, z19.b
-    __ sve_smin(z1, __ H, p6, z17);                    //       smin    z1.h, p6/m, z1.h, z17.h
-    __ sve_sub(z16, __ B, p4, z21);                    //       sub     z16.b, p4/m, z16.b, z21.b
-    __ sve_fabs(z4, __ S, p0, z23);                    //       fabs    z4.s, p0/m, z23.s
-    __ sve_fadd(z6, __ S, p2, z20);                    //       fadd    z6.s, p2/m, z6.s, z20.s
-    __ sve_fdiv(z16, __ S, p7, z12);                   //       fdiv    z16.s, p7/m, z16.s, z12.s
-    __ sve_fmax(z3, __ S, p5, z9);                     //       fmax    z3.s, p5/m, z3.s, z9.s
-    __ sve_fmin(z24, __ D, p7, z3);                    //       fmin    z24.d, p7/m, z24.d, z3.d
-    __ sve_fmul(z22, __ D, p1, z25);                   //       fmul    z22.d, p1/m, z22.d, z25.d
-    __ sve_fneg(z13, __ D, p1, z7);                    //       fneg    z13.d, p1/m, z7.d
-    __ sve_frintm(z5, __ D, p5, z17);                  //       frintm  z5.d, p5/m, z17.d
-    __ sve_frintn(z0, __ D, p0, z9);                   //       frintn  z0.d, p0/m, z9.d
-    __ sve_frintp(z11, __ S, p2, z11);                 //       frintp  z11.s, p2/m, z11.s
-    __ sve_fsqrt(z17, __ S, p4, z11);                  //       fsqrt   z17.s, p4/m, z11.s
-    __ sve_fsub(z24, __ D, p4, z30);                   //       fsub    z24.d, p4/m, z24.d, z30.d
-    __ sve_fmad(z8, __ D, p4, z14, z26);               //       fmad    z8.d, p4/m, z14.d, z26.d
-    __ sve_fmla(z27, __ S, p5, z7, z8);                //       fmla    z27.s, p5/m, z7.s, z8.s
-    __ sve_fmls(z27, __ S, p7, z10, z0);               //       fmls    z27.s, p7/m, z10.s, z0.s
-    __ sve_fmsb(z24, __ S, p5, z20, z0);               //       fmsb    z24.s, p5/m, z20.s, z0.s
-    __ sve_fnmad(z22, __ D, p6, z5, z25);              //       fnmad   z22.d, p6/m, z5.d, z25.d
-    __ sve_fnmsb(z17, __ S, p4, z1, z12);              //       fnmsb   z17.s, p4/m, z1.s, z12.s
-    __ sve_fnmla(z29, __ S, p3, z0, z17);              //       fnmla   z29.s, p3/m, z0.s, z17.s
-    __ sve_fnmls(z30, __ D, p5, z22, z21);             //       fnmls   z30.d, p5/m, z22.d, z21.d
-    __ sve_mla(z12, __ H, p2, z2, z0);                 //       mla     z12.h, p2/m, z2.h, z0.h
-    __ sve_mls(z23, __ D, p5, z0, z19);                //       mls     z23.d, p5/m, z0.d, z19.d
-    __ sve_and(z26, z23, z12);                         //       and     z26.d, z23.d, z12.d
-    __ sve_eor(z21, z1, z1);                           //       eor     z21.d, z1.d, z1.d
-    __ sve_orr(z19, z11, z19);                         //       orr     z19.d, z11.d, z19.d
-    __ sve_bic(z23, z8, z30);                          //       bic     z23.d, z8.d, z30.d
-    __ sve_uzp1(z19, __ B, z19, z20);                  //       uzp1    z19.b, z19.b, z20.b
-    __ sve_uzp2(z20, __ S, z13, z30);                  //       uzp2    z20.s, z13.s, z30.s
-    __ sve_fabd(z30, __ D, p7, z25);                   //       fabd    z30.d, p7/m, z30.d, z25.d
-    __ sve_bext(z17, __ H, z14, z11);                  //       bext    z17.h, z14.h, z11.h
-    __ sve_bdep(z28, __ B, z20, z5);                   //       bdep    z28.b, z20.b, z5.b
-    __ sve_eor3(z13, z13, z2);                         //       eor3    z13.d, z13.d, z13.d, z2.d
+    __ sve_add(z12, __ B, z0, z9);                     //       add     z12.b, z0.b, z9.b
+    __ sve_sub(z24, __ D, z17, z4);                    //       sub     z24.d, z17.d, z4.d
+    __ sve_fadd(z6, __ D, z9, z27);                    //       fadd    z6.d, z9.d, z27.d
+    __ sve_fmul(z13, __ D, z16, z30);                  //       fmul    z13.d, z16.d, z30.d
+    __ sve_fsub(z22, __ D, z20, z30);                  //       fsub    z22.d, z20.d, z30.d
+    __ sve_abs(z9, __ B, p3, z19);                     //       abs     z9.b, p3/m, z19.b
+    __ sve_add(z20, __ H, p7, z9);                     //       add     z20.h, p7/m, z20.h, z9.h
+    __ sve_and(z13, __ B, p3, z19);                    //       and     z13.b, p3/m, z13.b, z19.b
+    __ sve_asr(z24, __ H, p2, z19);                    //       asr     z24.h, p2/m, z24.h, z19.h
+    __ sve_bic(z17, __ B, p4, z16);                    //       bic     z17.b, p4/m, z17.b, z16.b
+    __ sve_clz(z0, __ H, p0, z11);                     //       clz     z0.h, p0/m, z11.h
+    __ sve_cnt(z15, __ B, p3, z15);                    //       cnt     z15.b, p3/m, z15.b
+    __ sve_eor(z15, __ B, p7, z5);                     //       eor     z15.b, p7/m, z15.b, z5.b
+    __ sve_lsl(z10, __ B, p5, z26);                    //       lsl     z10.b, p5/m, z10.b, z26.b
+    __ sve_lsr(z0, __ D, p2, z19);                     //       lsr     z0.d, p2/m, z0.d, z19.d
+    __ sve_mul(z10, __ S, p6, z3);                     //       mul     z10.s, p6/m, z10.s, z3.s
+    __ sve_neg(z7, __ H, p6, z28);                     //       neg     z7.h, p6/m, z28.h
+    __ sve_not(z21, __ H, p2, z26);                    //       not     z21.h, p2/m, z26.h
+    __ sve_orr(z17, __ H, p7, z17);                    //       orr     z17.h, p7/m, z17.h, z17.h
+    __ sve_rbit(z2, __ S, p7, z16);                    //       rbit    z2.s, p7/m, z16.s
+    __ sve_revb(z20, __ H, p1, z19);                   //       revb    z20.h, p1/m, z19.h
+    __ sve_smax(z1, __ H, p6, z17);                    //       smax    z1.h, p6/m, z1.h, z17.h
+    __ sve_smin(z16, __ B, p4, z21);                   //       smin    z16.b, p4/m, z16.b, z21.b
+    __ sve_sub(z4, __ H, p0, z23);                     //       sub     z4.h, p0/m, z4.h, z23.h
+    __ sve_fabs(z6, __ S, p2, z20);                    //       fabs    z6.s, p2/m, z20.s
+    __ sve_fadd(z16, __ S, p7, z12);                   //       fadd    z16.s, p7/m, z16.s, z12.s
+    __ sve_fdiv(z3, __ S, p5, z9);                     //       fdiv    z3.s, p5/m, z3.s, z9.s
+    __ sve_fmax(z24, __ D, p7, z3);                    //       fmax    z24.d, p7/m, z24.d, z3.d
+    __ sve_fmin(z22, __ D, p1, z25);                   //       fmin    z22.d, p1/m, z22.d, z25.d
+    __ sve_fmul(z13, __ D, p1, z7);                    //       fmul    z13.d, p1/m, z13.d, z7.d
+    __ sve_fneg(z5, __ D, p5, z17);                    //       fneg    z5.d, p5/m, z17.d
+    __ sve_frintm(z0, __ D, p0, z9);                   //       frintm  z0.d, p0/m, z9.d
+    __ sve_frintn(z11, __ S, p2, z11);                 //       frintn  z11.s, p2/m, z11.s
+    __ sve_frintp(z17, __ S, p4, z11);                 //       frintp  z17.s, p4/m, z11.s
+    __ sve_fsqrt(z24, __ D, p4, z30);                  //       fsqrt   z24.d, p4/m, z30.d
+    __ sve_fsub(z8, __ D, p4, z14);                    //       fsub    z8.d, p4/m, z8.d, z14.d
+    __ sve_fmad(z22, __ S, p7, z22, z7);               //       fmad    z22.s, p7/m, z22.s, z7.s
+    __ sve_fmla(z5, __ S, p7, z27, z10);               //       fmla    z5.s, p7/m, z27.s, z10.s
+    __ sve_fmls(z14, __ S, p6, z21, z20);              //       fmls    z14.s, p6/m, z21.s, z20.s
+    __ sve_fmsb(z3, __ D, p5, z25, z5);                //       fmsb    z3.d, p5/m, z25.d, z5.d
+    __ sve_fnmad(z29, __ S, p4, z17, z1);              //       fnmad   z29.s, p4/m, z17.s, z1.s
+    __ sve_fnmsb(z14, __ D, p7, z13, z0);              //       fnmsb   z14.d, p7/m, z13.d, z0.d
+    __ sve_fnmla(z2, __ D, p7, z20, z22);              //       fnmla   z2.d, p7/m, z20.d, z22.d
+    __ sve_fnmls(z29, __ S, p3, z8, z2);               //       fnmls   z29.s, p3/m, z8.s, z2.s
+    __ sve_mla(z14, __ S, p5, z22, z0);                //       mla     z14.s, p5/m, z22.s, z0.s
+    __ sve_mls(z25, __ S, p6, z23, z12);               //       mls     z25.s, p6/m, z23.s, z12.s
+    __ sve_and(z21, z1, z1);                           //       and     z21.d, z1.d, z1.d
+    __ sve_eor(z19, z11, z19);                         //       eor     z19.d, z11.d, z19.d
+    __ sve_orr(z23, z8, z30);                          //       orr     z23.d, z8.d, z30.d
+    __ sve_bic(z19, z19, z20);                         //       bic     z19.d, z19.d, z20.d
+    __ sve_uzp1(z20, __ S, z13, z30);                  //       uzp1    z20.s, z13.s, z30.s
+    __ sve_uzp2(z30, __ S, z30, z25);                  //       uzp2    z30.s, z30.s, z25.s
+    __ sve_fabd(z17, __ S, p3, z11);                   //       fabd    z17.s, p3/m, z17.s, z11.s
+    __ sve_bext(z28, __ B, z20, z5);                   //       bext    z28.b, z20.b, z5.b
+    __ sve_bdep(z13, __ B, z13, z2);                   //       bdep    z13.b, z13.b, z2.b
+    __ sve_eor3(z10, z11, z19);                        //       eor3    z10.d, z10.d, z11.d, z19.d
 
 // SVEReductionOp
-    __ sve_andv(v10, __ B, p3, z19);                   //       andv b10, p3, z19.b
-    __ sve_orv(v25, __ B, p3, z2);                     //       orv b25, p3, z2.b
-    __ sve_eorv(v29, __ B, p0, z20);                   //       eorv b29, p0, z20.b
-    __ sve_smaxv(v20, __ H, p7, z28);                  //       smaxv h20, p7, z28.h
-    __ sve_sminv(v13, __ D, p2, z13);                  //       sminv d13, p2, z13.d
-    __ sve_fminv(v1, __ S, p3, z27);                   //       fminv s1, p3, z27.s
-    __ sve_fmaxv(v3, __ D, p6, z8);                    //       fmaxv d3, p6, z8.d
-    __ sve_fadda(v9, __ S, p0, z25);                   //       fadda s9, p0, s9, z25.s
-    __ sve_uaddv(v14, __ D, p0, z20);                  //       uaddv d14, p0, z20.d
+    __ sve_andv(v25, __ B, p3, z2);                    //       andv b25, p3, z2.b
+    __ sve_orv(v29, __ B, p0, z20);                    //       orv b29, p0, z20.b
+    __ sve_eorv(v20, __ H, p7, z28);                   //       eorv h20, p7, z28.h
+    __ sve_smaxv(v13, __ D, p2, z13);                  //       smaxv d13, p2, z13.d
+    __ sve_sminv(v1, __ B, p3, z27);                   //       sminv b1, p3, z27.b
+    __ sve_fminv(v3, __ D, p6, z8);                    //       fminv d3, p6, z8.d
+    __ sve_fmaxv(v9, __ S, p0, z25);                   //       fmaxv s9, p0, z25.s
+    __ sve_fadda(v14, __ D, p0, z20);                  //       fadda d14, p0, d14, z20.d
+    __ sve_uaddv(v6, __ S, p7, z19);                   //       uaddv d6, p7, z19.s
 
     __ bind(forth);
 
@@ -1249,30 +1267,30 @@
     0x9101a1a0,     0xb10a5cc8,     0xd10810aa,     0xf10fd061,
     0x120cb166,     0x321764bc,     0x52174681,     0x720c0227,
     0x9241018e,     0xb25a2969,     0xd278b411,     0xf26aad01,
-    0x14000000,     0x17ffffd7,     0x14000409,     0x94000000,
-    0x97ffffd4,     0x94000406,     0x3400000a,     0x34fffa2a,
-    0x3400806a,     0x35000008,     0x35fff9c8,     0x35008008,
-    0xb400000b,     0xb4fff96b,     0xb4007fab,     0xb500001d,
-    0xb5fff91d,     0xb5007f5d,     0x10000013,     0x10fff8b3,
-    0x10007ef3,     0x90000013,     0x36300016,     0x3637f836,
-    0x36307e76,     0x3758000c,     0x375ff7cc,     0x37587e0c,
+    0x14000000,     0x17ffffd7,     0x1400040f,     0x94000000,
+    0x97ffffd4,     0x9400040c,     0x3400000a,     0x34fffa2a,
+    0x3400812a,     0x35000008,     0x35fff9c8,     0x350080c8,
+    0xb400000b,     0xb4fff96b,     0xb400806b,     0xb500001d,
+    0xb5fff91d,     0xb500801d,     0x10000013,     0x10fff8b3,
+    0x10007fb3,     0x90000013,     0x36300016,     0x3637f836,
+    0x36307f36,     0x3758000c,     0x375ff7cc,     0x37587ecc,
     0x128313a0,     0x528a32c7,     0x7289173b,     0x92ab3acc,
     0xd2a0bf94,     0xf2c285e8,     0x9358722f,     0x330e652f,
     0x53067f3b,     0x93577c53,     0xb34a1aac,     0xd35a4016,
     0x13946c63,     0x93c3dbc8,     0x54000000,     0x54fff5a0,
-    0x54007be0,     0x54000001,     0x54fff541,     0x54007b81,
-    0x54000002,     0x54fff4e2,     0x54007b22,     0x54000002,
-    0x54fff482,     0x54007ac2,     0x54000003,     0x54fff423,
-    0x54007a63,     0x54000003,     0x54fff3c3,     0x54007a03,
-    0x54000004,     0x54fff364,     0x540079a4,     0x54000005,
-    0x54fff305,     0x54007945,     0x54000006,     0x54fff2a6,
-    0x540078e6,     0x54000007,     0x54fff247,     0x54007887,
-    0x54000008,     0x54fff1e8,     0x54007828,     0x54000009,
-    0x54fff189,     0x540077c9,     0x5400000a,     0x54fff12a,
-    0x5400776a,     0x5400000b,     0x54fff0cb,     0x5400770b,
-    0x5400000c,     0x54fff06c,     0x540076ac,     0x5400000d,
-    0x54fff00d,     0x5400764d,     0x5400000e,     0x54ffefae,
-    0x540075ee,     0x5400000f,     0x54ffef4f,     0x5400758f,
+    0x54007ca0,     0x54000001,     0x54fff541,     0x54007c41,
+    0x54000002,     0x54fff4e2,     0x54007be2,     0x54000002,
+    0x54fff482,     0x54007b82,     0x54000003,     0x54fff423,
+    0x54007b23,     0x54000003,     0x54fff3c3,     0x54007ac3,
+    0x54000004,     0x54fff364,     0x54007a64,     0x54000005,
+    0x54fff305,     0x54007a05,     0x54000006,     0x54fff2a6,
+    0x540079a6,     0x54000007,     0x54fff247,     0x54007947,
+    0x54000008,     0x54fff1e8,     0x540078e8,     0x54000009,
+    0x54fff189,     0x54007889,     0x5400000a,     0x54fff12a,
+    0x5400782a,     0x5400000b,     0x54fff0cb,     0x540077cb,
+    0x5400000c,     0x54fff06c,     0x5400776c,     0x5400000d,
+    0x54fff00d,     0x5400770d,     0x5400000e,     0x54ffefae,
+    0x540076ae,     0x5400000f,     0x54ffef4f,     0x5400764f,
     0xd40658e1,     0xd4014d22,     0xd4046543,     0xd4273f60,
     0xd44cad80,     0xd503201f,     0xd503203f,     0xd503205f,
     0xd503209f,     0xd50320bf,     0xd503219f,     0xd50323bf,
@@ -1284,229 +1302,231 @@
     0xdac127fb,     0xdac12be8,     0xdac12fe0,     0xdac133e1,
     0xdac137f5,     0xdac13bf1,     0xdac13ffd,     0xdac147fd,
     0xd61f0b9f,     0xd61f0c3f,     0xd63f0aff,     0xd63f0ebf,
-    0xdac143f4,     0xc8167e7b,     0xc80bfcd0,     0xc85f7c11,
-    0xc85ffd44,     0xc89ffed8,     0xc8dffe6a,     0x88017fc5,
-    0x8808fe2c,     0x885f7dc9,     0x885ffc27,     0x889ffe05,
-    0x88dffd82,     0x480a7c6c,     0x481cff4e,     0x485f7d5e,
-    0x485ffeae,     0x489ffd2d,     0x48dfff76,     0x081c7d73,
-    0x081efc53,     0x085f7ee2,     0x085ffc01,     0x089ffe0c,
-    0x08dffded,     0xc87f55b1,     0xc87ff90b,     0xc8382c2d,
-    0xc83aedb5,     0x887f0d94,     0x887f87a6,     0x88262e04,
-    0x8824b2be,     0xf8061366,     0xb802d151,     0x381e32da,
-    0x781ce155,     0xf847d30e,     0xb85f0307,     0x39403448,
-    0x785c333e,     0x389f2183,     0x789e422a,     0x78dfb075,
-    0xb8817322,     0xfc5bb039,     0xbc40637d,     0xfc02919d,
-    0xbc18d2c2,     0xf8003cba,     0xb8199cb4,     0x381e7d88,
-    0x781c7c54,     0xf8516fae,     0xb8404fad,     0x385f7e78,
-    0x785edf63,     0x389fbc31,     0x789f3e71,     0x78de6d75,
-    0xb89c4d21,     0xfc509efa,     0xbc581eb6,     0xfc128ced,
-    0xbc198dac,     0xf81134b4,     0xb81b679d,     0x381ea704,
-    0x781eb52d,     0xf85c94fa,     0xb858d46d,     0x3840c4a1,
-    0x785de5a8,     0x389e5697,     0x789fe4d4,     0x78dd6629,
-    0xb89e24d5,     0xfc5e36d0,     0xbc5fd569,     0xfc03c756,
-    0xbc1fe7b0,     0xf824cac1,     0xb82d7bd7,     0x382c596c,
-    0x78207999,     0xf86058f1,     0xb86e5a61,     0x3869784c,
-    0x787bc936,     0x38aff995,     0x78b078dc,     0x78f6ca39,
-    0xb8bdea24,     0xfc63f825,     0xbc6d5a38,     0xfc37fa31,
-    0xbc25dbd1,     0xf91ba97d,     0xb91e4abc,     0x391b485c,
-    0x7919c380,     0xf95e18f9,     0xb958a860,     0x395f20be,
-    0x7958f6ee,     0x399bea6a,     0x799b363d,     0x79da47d9,
-    0xb99d5851,     0xfd5da60f,     0xbd584fcc,     0xfd1db821,
-    0xbd1e9965,     0x58ffdb71,     0x18ffdb42,     0xf886f320,
-    0xd8ffdb00,     0xf8bb49c0,     0xf99815c0,     0x1a0f0320,
-    0x3a030301,     0x5a140311,     0x7a0d000b,     0x9a07015c,
-    0xba1001e4,     0xda140182,     0xfa0d01bd,     0x0b2c6cce,
-    0x2b3e5331,     0xcb2e0620,     0x6b3de709,     0x8b20cac1,
-    0xab362f8c,     0xcb31518a,     0xeb2acf8f,     0x3a57d262,
-    0x7a493226,     0xba4832a2,     0xfa454261,     0x3a518acc,
-    0x7a472a23,     0xba5cba05,     0xfa439ac5,     0x1a8cb35d,
-    0x1a8f355b,     0x5a9e9395,     0x5a9e3769,     0x9a9dd1fd,
-    0x9a8406b9,     0xda9d62b1,     0xda868695,     0x5ac0007e,
-    0x5ac00675,     0x5ac00b0b,     0x5ac01360,     0x5ac015d9,
-    0xdac001c3,     0xdac004f1,     0xdac00b0f,     0xdac00e3c,
-    0xdac01059,     0xdac0179a,     0xdac10325,     0xdac1077a,
-    0xdac10a30,     0xdac10ea6,     0xdac1100c,     0xdac11584,
-    0xdac11a3b,     0xdac11f9c,     0xd71f0851,     0xd71f0d4f,
-    0xd73f09ce,     0xd73f0c79,     0x1ace0a6f,     0x1ac40e05,
-    0x1ac4233a,     0x1acc2442,     0x1ac82a3d,     0x1ac42c67,
-    0x9ada0899,     0x9ad10c99,     0x9ad12340,     0x9ad525f7,
-    0x9adb2a3c,     0x9ac02c6a,     0x9bc97f27,     0x9b5d7de6,
-    0x1b02454f,     0x1b0bdd67,     0x9b173ba7,     0x9b0b917b,
-    0x9b2f3998,     0x9b3cb574,     0x9bb7798b,     0x9ba9b5da,
-    0x7ea5d4ea,     0x1e2309fd,     0x1e2f198b,     0x1e312bde,
-    0x1e2f3a93,     0x7ef5d52f,     0x1e7b0922,     0x1e7e1ba7,
-    0x1e622831,     0x1e633946,     0x1f070578,     0x1f03c40b,
-    0x1f3618dc,     0x1f3a0b60,     0x1f5c2ce5,     0x1f4bddb9,
-    0x1f715513,     0x1f734699,     0x1e2043a2,     0x1e20c116,
-    0x1e214275,     0x1e21c174,     0x1e22c291,     0x1e23c1e6,
-    0x1ee24063,     0x1e60407c,     0x1e60c1db,     0x1e61414e,
-    0x1e61c16c,     0x1e624151,     0x1e3800f9,     0x9e3801c7,
-    0x1e78001c,     0x9e780016,     0x1e2202ec,     0x9e2201ad,
-    0x1e6201c7,     0x9e620107,     0x1e240234,     0x9e6403dc,
-    0x1e300050,     0x9e700209,     0x1e2603b4,     0x9e660024,
-    0x1e27031a,     0x9e6701d7,     0x1e2c22a0,     0x1e6c20a0,
-    0x1e202308,     0x1e602308,     0x2910561b,     0x294436d1,
-    0x697e3626,     0xa9366a3c,     0xa97419b5,     0x29825e7a,
-    0x29d04144,     0x69f412ee,     0xa982321d,     0xa9c6477a,
-    0x28b40086,     0x28c079c2,     0x68e060f7,     0xa88868a0,
-    0xa8f62de6,     0x28302059,     0x2866383e,     0xa83701b6,
-    0xa8403363,     0x0c40700a,     0x4cdfa22c,     0x0cc26f0a,
-    0x4cdf2628,     0x0d40c3d7,     0x4ddfc856,     0x0dcfcfde,
-    0x4c408cb4,     0x0cdf8538,     0x4d60c190,     0x0dffc8f7,
-    0x4de3ce1a,     0x4cc74979,     0x0c40499e,     0x4d40e52f,
-    0x4ddfe8de,     0x0dcdeee7,     0x4cdf04c4,     0x0ccf0264,
-    0x0d60e1d9,     0x0dffe79a,     0x0de6e8b9,     0x0e31b9ee,
-    0x4e31b96a,     0x0e71b9cd,     0x4e71b9ee,     0x4eb1bab4,
-    0x0e30a841,     0x4e30aaf6,     0x0e70abfe,     0x4e70a9ee,
-    0x4eb0a862,     0x6e30f8e6,     0x0e31a883,     0x2e31a907,
-    0x4e31ab38,     0x6e31a820,     0x0e71ab9b,     0x2e71abdd,
-    0x4e71a8c5,     0x6e71a8c5,     0x4eb1abdd,     0x6eb1a98b,
-    0x6eb0fb59,     0x7e30f820,     0x7e70fbfe,     0x7eb0f820,
-    0x7ef0fa51,     0x0e20bbbc,     0x4e20bb59,     0x0e60b949,
-    0x4e60bb59,     0x0ea0b9ac,     0x4ea0ba0f,     0x4ee0b98b,
-    0x0ea0f96a,     0x4ea0fa51,     0x4ee0fb38,     0x2ea0fad5,
-    0x6ea0fb17,     0x6ee0f820,     0x2ea1fa30,     0x6ea1f96a,
-    0x6ee1f8e6,     0x2e205bbc,     0x6e2058e6,     0x0e271cc5,
-    0x4e271cc5,     0x0eb61eb4,     0x4eb31e51,     0x2e311e0f,
-    0x6e331e51,     0x0e3f87dd,     0x4e3c877a,     0x0e7e87bc,
-    0x4e638441,     0x0ebd879b,     0x4ea28420,     0x4ef686b4,
-    0x0e3ed7bc,     0x4e31d60f,     0x4e6ed5ac,     0x2e2c856a,
-    0x6e3e87bc,     0x2e7e87bc,     0x6e758693,     0x2eb886f6,
-    0x6eac856a,     0x6ee684a4,     0x0ea0d7fe,     0x4eb6d6b4,
-    0x4eead528,     0x0e209ffe,     0x4e339e51,     0x0e6c9d6a,
-    0x4e7d9f9b,     0x0ea49c62,     0x4eba9f38,     0x2ea6d4a4,
-    0x6ea5d483,     0x6eead528,     0x2e38d6f6,     0x6e33d651,
-    0x6e6fd5cd,     0x2e26dca4,     0x6e3edfbc,     0x6e79df17,
-    0x0e7796d5,     0x4e7b9759,     0x0eba9738,     0x4ea59483,
-    0x0e39cf17,     0x4e3ccf7a,     0x4e79cf17,     0x2e7095ee,
-    0x6e7796d5,     0x2ea59483,     0x6eb99717,     0x0eaacd28,
-    0x4ebacf38,     0x4ef5ce93,     0x2e31fe0f,     0x6e32fe30,
-    0x6e64fc62,     0x0e236441,     0x4e226420,     0x0e7a6738,
-    0x4e6664a4,     0x0ea56483,     0x4ead658b,     0x0e20a7fe,
-    0x4e3da79b,     0x0e6ba549,     0x4e7ba759,     0x0ea4a462,
-    0x4eaea5ac,     0x0e33f651,     0x4e20f7fe,     0x4e63f441,
-    0x0e2e6dac,     0x4e3e6fbc,     0x0e626c20,     0x4e736e51,
-    0x0eae6dac,     0x4eb36e51,     0x0e37aed5,     0x4e2eadac,
-    0x0e7daf9b,     0x4e7fafdd,     0x0ea0affe,     0x4ea3ac41,
-    0x0ebbf759,     0x4ebdf79b,     0x4ee6f4a4,     0x2e3f8fdd,
-    0x6e258c83,     0x2e688ce6,     0x6e7f8fdd,     0x2ebb8f59,
-    0x6eb38e51,     0x6eea8d28,     0x0e29e507,     0x4e2ee5ac,
-    0x4e62e420,     0x0e353693,     0x4e233441,     0x0e793717,
-    0x4e643462,     0x0ea23420,     0x4eaa3528,     0x4ef93717,
-    0x2e3b3759,     0x6e31360f,     0x2e7f37dd,     0x6e653483,
-    0x2eac356a,     0x6eb836f6,     0x6eec356a,     0x2e263ca4,
-    0x6e333e51,     0x2e633c41,     0x6e6d3d8b,     0x2ea93d07,
-    0x6eac3d6a,     0x6ef13e0f,     0x2eb2e630,     0x6ea4e462,
-    0x6eebe549,     0x0e2d3d8b,     0x4e2e3dac,     0x0e703dee,
-    0x4e6f3dcd,     0x0ea43c62,     0x4ea83ce6,     0x4ef53e93,
-    0x2e3be759,     0x6e31e60f,     0x6e66e4a4,     0x2ea4ec62,
-    0x6ea6eca4,     0x6eeded8b,     0x65d23289,     0x65d02e95,
-    0x65d02eed,     0x65912f05,     0x65d1255f,     0x65933061,
-    0xba5fd3e3,     0x3a5f03e5,     0xfa411be4,     0x7a42cbe2,
-    0x93df03ff,     0xc820ffff,     0x8822fc7f,     0xc8247cbf,
-    0x88267fff,     0x4e010fe0,     0x5e040420,     0x4e081fe1,
-    0x4e0c1fe1,     0x4e0a1fe1,     0x4e071fe1,     0x4e042c20,
-    0x4e062c20,     0x4e052c20,     0x4e083c20,     0x0e0c3c20,
-    0x0e0a3c20,     0x0e073c20,     0x9eae0020,     0x0f03f409,
-    0x6f03f40e,     0x4cc0ac3f,     0x0ea1b820,     0x4e21c862,
-    0x4e61b8a4,     0x05a08020,     0x05104fe0,     0x05505001,
-    0x05906fe2,     0x05d03005,     0x05101fea,     0x05901feb,
-    0x04b0e3e0,     0x0470e7e1,     0x042f9c20,     0x043f9c35,
-    0x047f9c20,     0x04ff9c20,     0x04299420,     0x04319160,
-    0x0461943e,     0x04a19020,     0x04038100,     0x040381a0,
-    0x040387e1,     0x04438be2,     0x04c38fe3,     0x040181e0,
-    0x04018100,     0x04018621,     0x04418b22,     0x04418822,
-    0x04818c23,     0x040081e0,     0x04008120,     0x04008761,
-    0x04008621,     0x04408822,     0x04808c23,     0x042053ff,
-    0x047f5401,     0x25208028,     0x2538cfe0,     0x2578d001,
-    0x25b8efe2,     0x25f8f007,     0x2538dfea,     0x25b8dfeb,
-    0xa400a3e0,     0xa420a7e0,     0xa4484be0,     0xa467afe0,
-    0xa4a8a7ea,     0xa547a814,     0xa4084ffe,     0xa55c53e0,
-    0xa5e1540b,     0xe400fbf6,     0xe408ffff,     0xe420e7e0,
-    0xe4484be0,     0xe460efe0,     0xe547e400,     0xe4014be0,
-    0xe4a84fe0,     0xe5f15000,     0x858043e0,     0x85a043ff,
-    0xe59f5d08,     0x0420e3e9,     0x0460e3ea,     0x04a0e3eb,
-    0x04e0e3ec,     0x25104042,     0x25104871,     0x25904861,
-    0x25904c92,     0x05344020,     0x05744041,     0x05b44062,
-    0x05f44083,     0x252c8840,     0x253c1420,     0x25681572,
-    0x25a21ce3,     0x25ea1e34,     0x253c0421,     0x25680572,
-    0x25a20ce3,     0x25ea0e34,     0x0522c020,     0x05e6c0a4,
-    0x2401a001,     0x2443a051,     0x24858881,     0x24c78cd1,
-    0x24850891,     0x24c70cc1,     0x250f9001,     0x25508051,
-    0x25802491,     0x25df28c1,     0x25850c81,     0x251e10d1,
-    0x65816001,     0x65c36051,     0x65854891,     0x65c74cc1,
-    0x05733820,     0x05b238a4,     0x05f138e6,     0x0570396a,
-    0x65d0a001,     0x65d6a443,     0x65d4a826,     0x6594ac26,
-    0x6554ac26,     0x6556ac26,     0x6552ac26,     0x65cbac85,
-    0x65caac01,     0x6589ac85,     0x6588ac01,     0x65c9ac85,
-    0x65c8ac01,     0x65dea833,     0x659ca509,     0x65d8a801,
-    0x65dcac01,     0x655cb241,     0x0520a1e0,     0x0521a601,
-    0x052281e0,     0x05238601,     0x04a14026,     0x042244a6,
-    0x046344a6,     0x04a444a6,     0x04e544a7,     0x0568aca7,
-    0x05b23230,     0x853040af,     0xc5b040af,     0xe57080af,
-    0xe5b080af,     0x25034440,     0x254054c4,     0x25034640,
-    0x25415a05,     0x25834440,     0x25c54489,     0x250b5d3a,
-    0x2550dc20,     0x2518e3e1,     0x2518e021,     0x2518e0a1,
-    0x2518e121,     0x2518e1a1,     0x2558e3e2,     0x2558e042,
-    0x2558e0c2,     0x2558e142,     0x2598e3e3,     0x2598e063,
-    0x2598e0e3,     0x2598e163,     0x25d8e3e4,     0x25d8e084,
-    0x25d8e104,     0x25d8e184,     0x2518e407,     0x05214800,
-    0x05614800,     0x05a14800,     0x05e14800,     0x05214c00,
-    0x05614c00,     0x05a14c00,     0x05e14c00,     0x05304001,
-    0x05314001,     0x05a18610,     0x05e18610,     0x05271e11,
-    0x6545e891,     0x6585e891,     0x65c5e891,     0x6545c891,
-    0x6585c891,     0x65c5c891,     0x45b0c210,     0x45f1c231,
-    0x1e601000,     0x1e603000,     0x1e621000,     0x1e623000,
-    0x1e641000,     0x1e643000,     0x1e661000,     0x1e663000,
-    0x1e681000,     0x1e683000,     0x1e6a1000,     0x1e6a3000,
-    0x1e6c1000,     0x1e6c3000,     0x1e6e1000,     0x1e6e3000,
-    0x1e701000,     0x1e703000,     0x1e721000,     0x1e723000,
-    0x1e741000,     0x1e743000,     0x1e761000,     0x1e763000,
-    0x1e781000,     0x1e783000,     0x1e7a1000,     0x1e7a3000,
-    0x1e7c1000,     0x1e7c3000,     0x1e7e1000,     0x1e7e3000,
-    0xf8318070,     0xf82103cb,     0xf82511e8,     0xf83d201e,
-    0xf8343287,     0xf83752bc,     0xf83b40b9,     0xf8217217,
-    0xf83f6185,     0xf8a981fc,     0xf8bd03f6,     0xf8b310bf,
-    0xf8ae23f0,     0xf8b0329b,     0xf8b0516c,     0xf8a943c6,
-    0xf8b1739b,     0xf8be6147,     0xf8f4808a,     0xf8f80231,
-    0xf8f613a3,     0xf8ef2276,     0xf8f33056,     0xf8ef5186,
-    0xf8f041ab,     0xf8f773c1,     0xf8f36225,     0xf86282d0,
-    0xf86d02aa,     0xf87d119b,     0xf87b2023,     0xf87f3278,
-    0xf8715389,     0xf87b40ef,     0xf87573f7,     0xf87963e2,
-    0xb83b8150,     0xb8370073,     0xb8301320,     0xb83a2057,
-    0xb830308c,     0xb83c53be,     0xb83040db,     0xb82971fd,
-    0xb82760e4,     0xb8af82e9,     0xb8a80382,     0xb8b510bf,
-    0xb8bb2220,     0xb8af3344,     0xb8a852dc,     0xb8bb433b,
-    0xb8b77080,     0xb8a66010,     0xb8e4802f,     0xb8ea00a7,
-    0xb8ea10fc,     0xb8f422b7,     0xb8e6310b,     0xb8f150df,
-    0xb8f14182,     0xb8fe707d,     0xb8fb63b6,     0xb86e838d,
-    0xb87100b8,     0xb862114e,     0xb870236b,     0xb877308c,
-    0xb8765091,     0xb8614213,     0xb87071cd,     0xb86c6222,
-    0xce371683,     0xce1130e6,     0xce708e1b,     0xce9c1846,
-    0xce7180c4,     0xce6c85b3,     0xcec08113,     0xce718a78,
-    0x2560d880,     0x25a1df26,     0x0580000d,     0x05402ca7,
-    0x05001588,     0x25e0c2d6,     0x2561d383,     0x05803ed4,
-    0x05400e47,     0x05000933,     0x25a0cb89,     0x2521dfd9,
-    0x05806530,     0x05401581,     0x0503ab50,     0x25a0c864,
-    0x25e1c466,     0x0580659c,     0x05404ca9,     0x0500061c,
-    0x25a0d2da,     0x2561d2ae,     0x05823bb5,     0x05400ad5,
-    0x0500001d,     0x25a0d884,     0x25a1c4e4,     0x05837917,
-    0x05401d68,     0x0503ab51,     0x04aa003e,     0x0429040c,
-    0x65c40238,     0x65db0926,     0x65de060d,     0x04d6b7d6,
-    0x04000e69,     0x045a1d34,     0x04108e6d,     0x045b0a78,
-    0x0419b211,     0x045aa160,     0x04190def,     0x04139caf,
-    0x0411974a,     0x04d00a60,     0x0497b86a,     0x045ebb87,
-    0x04580b55,     0x05679e31,     0x05e49e02,     0x04080674,
-    0x044a1a21,     0x040112b0,     0x049ca2e4,     0x65808a86,
-    0x658d9d90,     0x65869523,     0x65c79c78,     0x65c28736,
-    0x04dda4ed,     0x65c2b625,     0x65c0a120,     0x6581a96b,
-    0x658db171,     0x65c193d8,     0x65fa91c8,     0x65a814fb,
-    0x65a03d5b,     0x65a0b698,     0x65f9d8b6,     0x65acf031,
-    0x65b14c1d,     0x65f576de,     0x0440484c,     0x04d37417,
-    0x042c32fa,     0x04a13035,     0x04733173,     0x04fe3117,
-    0x05346a73,     0x05be6db4,     0x65c89f3e,     0x454bb1d1,
-    0x4505b69c,     0x042d384d,     0x041a2e6a,     0x04182c59,
-    0x0419229d,     0x04483f94,     0x04ca29ad,     0x65872f61,
-    0x65c63903,     0x65982329,     0x04c1228e,
+    0xd51b4434,     0xd51b4216,     0xd53b443b,     0xd53b4213,
+    0xd53b00eb,     0xd53b0030,     0xdac143e6,     0xc8117c80,
+    0xc80afed8,     0xc85f7e6a,     0xc85ffca1,     0xc89ffd1e,
+    0xc8dffe2c,     0x88097cee,     0x8801fe05,     0x885f7d82,
+    0x885ffd8a,     0x889fff83,     0x88dfff4e,     0x481e7dca,
+    0x4815fd2d,     0x485f7f76,     0x485ffe7c,     0x489fffcb,
+    0x48dffc53,     0x08027c37,     0x0800fe0c,     0x085f7ded,
+    0x085ffeb1,     0x089ffd6d,     0x08dffd1e,     0xc87f3578,
+    0xc87feaa1,     0xc83b506d,     0xc82c87a6,     0x887f1166,
+    0x887f93d0,     0x883e32a4,     0x883bf12f,     0xf80011f9,
+    0xb81b1022,     0x381ea354,     0x79002fd7,     0xf85cf39a,
+    0xb8580309,     0x385e218c,     0x784051e1,     0x389e11d8,
+    0x789fa1f8,     0x79c01865,     0xb881131b,     0xfc5dd3ad,
+    0xbc5d1136,     0xfc00900b,     0xbc181014,     0xf818ec7d,
+    0xb81b8c91,     0x381efc40,     0x78007c3d,     0xf857beb0,
+    0xb8413dd4,     0x385fddd6,     0x78409e2f,     0x389eddea,
+    0x789e7d94,     0x78de3d55,     0xb8805c13,     0xfc5cadc0,
+    0xbc428c23,     0xfc1a2dc4,     0xbc1caf91,     0xf81475f6,
+    0xb81f95d1,     0x381e757e,     0x78014561,     0xf8402436,
+    0xb85896e2,     0x385f4763,     0x785db4f0,     0x3880374f,
+    0x789e25e7,     0x78dd0563,     0xb88166f9,     0xfc529540,
+    0xbc4374d1,     0xfc1166ad,     0xbc1ba6c0,     0xf820ea7b,
+    0xb82d68c8,     0x38367a04,     0x782f4b59,     0xf878c8a4,
+    0xb8674a24,     0x386b78f1,     0x78776bc0,     0x38a15aca,
+    0x78bedbd5,     0x78fcd94b,     0xb8aa4a7c,     0xfc6ecbbd,
+    0xbc65d8a8,     0xfc2de918,     0xbc3a7b11,     0xf91f1193,
+    0xb91ed5f7,     0x391ec9bd,     0x79182ceb,     0xf95d4b0a,
+    0xb9581010,     0x395fc034,     0x795fb221,     0x399d8731,
+    0x799efb3b,     0x79dd1a2e,     0xb998e4ea,     0xfd583723,
+    0xbd5ea12c,     0xfd18dc37,     0xbd1b0e83,     0x58ffdaa2,
+    0x1800001d,     0xf885d1c0,     0xd8ffda40,     0xf8a77820,
+    0xf9980220,     0x1a030301,     0x3a140311,     0x5a0d000b,
+    0x7a07015c,     0x9a1001e4,     0xba140182,     0xda0d01bd,
+    0xfa0c00ce,     0x0b31f194,     0x2b206d7b,     0xcb29f027,
+    0x6b210f63,     0x8b2cb34d,     0xab2a88b1,     0xcb2f511e,
+    0xeb3332f3,     0x3a4533aa,     0x7a4d312b,     0xba442146,
+    0xfa42818c,     0x3a466a02,     0x7a4b68ed,     0xba4a9b6b,
+    0xfa4dd86d,     0x1a8a637a,     0x1a9cd6aa,     0x5a9bd137,
+    0x5a8fd7aa,     0x9a95233e,     0x9a95c620,     0xda9422b0,
+    0xda8397d3,     0x5ac00173,     0x5ac00418,     0x5ac00b3b,
+    0x5ac0106e,     0x5ac0162e,     0xdac001e7,     0xdac00798,
+    0xdac00b31,     0xdac00f42,     0xdac010bc,     0xdac01759,
+    0xdac1021b,     0xdac104d1,     0xdac10995,     0xdac10c80,
+    0xdac1136c,     0xdac11791,     0xdac1185c,     0xdac11d51,
+    0xd71f09ee,     0xd71f0dc3,     0xd73f0b2f,     0xd73f0e6e,
+    0x1ac40a05,     0x1ac40f3a,     0x1acc2042,     0x1ac8263d,
+    0x1ac42867,     0x1ada2c99,     0x9ad10899,     0x9ad10f40,
+    0x9ad521f7,     0x9adb263c,     0x9ac0286a,     0x9ac92f27,
+    0x9bdd7de6,     0x9b427d4f,     0x1b0b2cf1,     0x1b1ddcf7,
+    0x9b0b2f6e,     0x9b0cbf04,     0x9b2b728e,     0x9b2cdd6d,
+    0x9bae275e,     0x9ba7954d,     0x7ea3d5fd,     0x1e2f098b,
+    0x1e311bde,     0x1e2f2a93,     0x1e35392f,     0x7efbd522,
+    0x1e7e0ba7,     0x1e621831,     0x1e632946,     0x1e673978,
+    0x1f000d61,     0x1f06db91,     0x1f3b6806,     0x1f2770a2,
+    0x1f4d2f2b,     0x1f48c677,     0x1f744f35,     0x1f7d5851,
+    0x1e2042a8,     0x1e20c293,     0x1e21422b,     0x1e21c0d4,
+    0x1e22c06f,     0x1e23c383,     0x1ee24363,     0x1e6041ce,
+    0x1e60c18a,     0x1e61422b,     0x1e61c32a,     0x1e6240e7,
+    0x1e38038e,     0x9e3802c0,     0x1e780180,     0x9e7801b7,
+    0x1e2200ed,     0x9e2200ee,     0x1e620288,     0x9e620391,
+    0x1e24021e,     0x9e640122,     0x1e300290,     0x9e70009d,
+    0x1e260341,     0x9e6602f8,     0x1e2702ae,     0x9e6700ac,
+    0x1e382180,     0x1e7d2300,     0x1e202368,     0x1e6022a8,
+    0x293a1796,     0x29426e73,     0x697c68fc,     0xa93d0486,
+    0xa97b5eba,     0x29b47934,     0x29c2534d,     0x69f62dbd,
+    0xa9bd54bb,     0xa9c503c6,     0x28a63e13,     0x28e25d2c,
+    0x68c469e0,     0xa8b34748,     0xa8f51c59,     0x28264433,
+    0x285036c0,     0xa8005f7d,     0xa872290b,     0x0c407160,
+    0x4cdfa350,     0x0cd16f55,     0x4cdf27ba,     0x0d40c0d5,
+    0x4ddfcbad,     0x0dd0cd95,     0x4c408c01,     0x0cdf86a9,
+    0x4d60c327,     0x0dffc928,     0x4deecd89,     0x4cd14887,
+    0x0c404a37,     0x4d40e6c3,     0x4ddfe84c,     0x0dcced4f,
+    0x4cdf0444,     0x0ccb0286,     0x0d60e18b,     0x0dffe62f,
+    0x0df0eb2e,     0x0e31bab4,     0x4e31b841,     0x0e71baf6,
+    0x4e71bbfe,     0x4eb1b9ee,     0x0e30a862,     0x4e30a8e6,
+    0x0e70a883,     0x4e70a907,     0x4eb0ab38,     0x6e30f820,
+    0x0e31ab9b,     0x2e31abdd,     0x4e31a8c5,     0x6e31a8c5,
+    0x0e71abdd,     0x2e71a98b,     0x4e71ab59,     0x6e71a820,
+    0x4eb1abfe,     0x6eb1a820,     0x6eb0fa51,     0x7e30fbbc,
+    0x7e70fb59,     0x7eb0f949,     0x7ef0fb59,     0x0e20b9ac,
+    0x4e20ba0f,     0x0e60b98b,     0x4e60b96a,     0x0ea0ba51,
+    0x4ea0bb38,     0x4ee0bad5,     0x0ea0fb17,     0x4ea0f820,
+    0x4ee0fa30,     0x2ea0f96a,     0x6ea0f8e6,     0x6ee0fbbc,
+    0x2ea1f8e6,     0x6ea1f8c5,     0x6ee1f8c5,     0x2e205ab4,
+    0x6e205a51,     0x0e311e0f,     0x4e331e51,     0x0ebf1fdd,
+    0x4ebc1f7a,     0x2e3e1fbc,     0x6e231c41,     0x0e3d879b,
+    0x4e228420,     0x0e7686b4,     0x4e7e87bc,     0x0eb1860f,
+    0x4eae85ac,     0x4eec856a,     0x0e3ed7bc,     0x4e3ed7bc,
+    0x4e75d693,     0x2e3886f6,     0x6e2c856a,     0x2e6684a4,
+    0x6e6087fe,     0x2eb686b4,     0x6eaa8528,     0x6ee087fe,
+    0x0eb3d651,     0x4eacd56a,     0x4efdd79b,     0x0e249c62,
+    0x4e3a9f38,     0x0e669ca4,     0x4e659c83,     0x0eaa9d28,
+    0x4eb89ef6,     0x2eb3d651,     0x6eafd5cd,     0x6ee6d4a4,
+    0x2e3ed7bc,     0x6e39d717,     0x6e77d6d5,     0x2e3bdf59,
+    0x6e3adf38,     0x6e65dc83,     0x0e799717,     0x4e7c977a,
+    0x0eb99717,     0x4eb095ee,     0x0e37ced5,     0x4e25cc83,
+    0x4e79cf17,     0x2e6a9528,     0x6e7a9738,     0x2eb59693,
+    0x6eb1960f,     0x0eb2ce30,     0x4ea4cc62,     0x4ee3cc41,
+    0x2e22fc20,     0x6e3aff38,     0x6e66fca4,     0x0e256483,
+    0x4e2d658b,     0x0e6067fe,     0x4e7d679b,     0x0eab6549,
+    0x4ebb6759,     0x0e24a462,     0x4e2ea5ac,     0x0e73a651,
+    0x4e60a7fe,     0x0ea3a441,     0x4eaea5ac,     0x0e3ef7bc,
+    0x4e22f420,     0x4e73f651,     0x0e2e6dac,     0x4e336e51,
+    0x0e776ed5,     0x4e6e6dac,     0x0ebd6f9b,     0x4ebf6fdd,
+    0x0e20affe,     0x4e23ac41,     0x0e7baf59,     0x4e7daf9b,
+    0x0ea6aca4,     0x4ebfafdd,     0x0ea5f483,     0x4ea8f4e6,
+    0x4efff7dd,     0x2e3b8f59,     0x6e338e51,     0x2e6a8d28,
+    0x6e698d07,     0x2eae8dac,     0x6ea28c20,     0x6ef58e93,
+    0x0e23e441,     0x4e39e717,     0x4e64e462,     0x0e223420,
+    0x4e2a3528,     0x0e793717,     0x4e7b3759,     0x0eb1360f,
+    0x4ebf37dd,     0x4ee53483,     0x2e2c356a,     0x6e3836f6,
+    0x2e6c356a,     0x6e6634a4,     0x2eb33651,     0x6ea33441,
+    0x6eed358b,     0x2e293d07,     0x6e2c3d6a,     0x2e713e0f,
+    0x6e723e30,     0x2ea43c62,     0x6eab3d49,     0x6eed3d8b,
+    0x2eaee5ac,     0x6eb0e5ee,     0x6eefe5cd,     0x0e243c62,
+    0x4e283ce6,     0x0e753e93,     0x4e7b3f59,     0x0eb13e0f,
+    0x4ea63ca4,     0x4ee43c62,     0x2e26e4a4,     0x6e2de58b,
+    0x6e73e651,     0x2eb6eeb4,     0x6eb2ee30,     0x6ef3ee51,
+    0x65d22e85,     0x65d02efd,     0x65902f05,     0x65d1254f,
+    0x65913071,     0x65932208,     0xba5fd3e3,     0x3a5f03e5,
+    0xfa411be4,     0x7a42cbe2,     0x93df03ff,     0xc820ffff,
+    0x8822fc7f,     0xc8247cbf,     0x88267fff,     0x4e010fe0,
+    0x5e040420,     0x4e081fe1,     0x4e0c1fe1,     0x4e0a1fe1,
+    0x4e071fe1,     0x4e042c20,     0x4e062c20,     0x4e052c20,
+    0x4e083c20,     0x0e0c3c20,     0x0e0a3c20,     0x0e073c20,
+    0x9eae0020,     0x0f03f409,     0x6f03f40e,     0x4cc0ac3f,
+    0x0ea1b820,     0x4e21c862,     0x4e61b8a4,     0x05a08020,
+    0x05104fe0,     0x05505001,     0x05906fe2,     0x05d03005,
+    0x05101fea,     0x05901feb,     0x04b0e3e0,     0x0470e7e1,
+    0x042f9c20,     0x043f9c35,     0x047f9c20,     0x04ff9c20,
+    0x04299420,     0x04319160,     0x0461943e,     0x04a19020,
+    0x04038100,     0x040381a0,     0x040387e1,     0x04438be2,
+    0x04c38fe3,     0x040181e0,     0x04018100,     0x04018621,
+    0x04418b22,     0x04418822,     0x04818c23,     0x040081e0,
+    0x04008120,     0x04008761,     0x04008621,     0x04408822,
+    0x04808c23,     0x042053ff,     0x047f5401,     0x25208028,
+    0x2538cfe0,     0x2578d001,     0x25b8efe2,     0x25f8f007,
+    0x2538dfea,     0x25b8dfeb,     0xa400a3e0,     0xa420a7e0,
+    0xa4484be0,     0xa467afe0,     0xa4a8a7ea,     0xa547a814,
+    0xa4084ffe,     0xa55c53e0,     0xa5e1540b,     0xe400fbf6,
+    0xe408ffff,     0xe420e7e0,     0xe4484be0,     0xe460efe0,
+    0xe547e400,     0xe4014be0,     0xe4a84fe0,     0xe5f15000,
+    0x858043e0,     0x85a043ff,     0xe59f5d08,     0x0420e3e9,
+    0x0460e3ea,     0x04a0e3eb,     0x04e0e3ec,     0x25104042,
+    0x25104871,     0x25904861,     0x25904c92,     0x05344020,
+    0x05744041,     0x05b44062,     0x05f44083,     0x252c8840,
+    0x253c1420,     0x25681572,     0x25a21ce3,     0x25ea1e34,
+    0x253c0421,     0x25680572,     0x25a20ce3,     0x25ea0e34,
+    0x0522c020,     0x05e6c0a4,     0x2401a001,     0x2443a051,
+    0x24858881,     0x24c78cd1,     0x24850891,     0x24c70cc1,
+    0x250f9001,     0x25508051,     0x25802491,     0x25df28c1,
+    0x25850c81,     0x251e10d1,     0x65816001,     0x65c36051,
+    0x65854891,     0x65c74cc1,     0x05733820,     0x05b238a4,
+    0x05f138e6,     0x0570396a,     0x65d0a001,     0x65d6a443,
+    0x65d4a826,     0x6594ac26,     0x6554ac26,     0x6556ac26,
+    0x6552ac26,     0x65cbac85,     0x65caac01,     0x6589ac85,
+    0x6588ac01,     0x65c9ac85,     0x65c8ac01,     0x65dea833,
+    0x659ca509,     0x65d8a801,     0x65dcac01,     0x655cb241,
+    0x0520a1e0,     0x0521a601,     0x052281e0,     0x05238601,
+    0x04a14026,     0x042244a6,     0x046344a6,     0x04a444a6,
+    0x04e544a7,     0x0568aca7,     0x05b23230,     0x853040af,
+    0xc5b040af,     0xe57080af,     0xe5b080af,     0x25034440,
+    0x254054c4,     0x25034640,     0x25415a05,     0x25834440,
+    0x25c54489,     0x250b5d3a,     0x2550dc20,     0x2518e3e1,
+    0x2518e021,     0x2518e0a1,     0x2518e121,     0x2518e1a1,
+    0x2558e3e2,     0x2558e042,     0x2558e0c2,     0x2558e142,
+    0x2598e3e3,     0x2598e063,     0x2598e0e3,     0x2598e163,
+    0x25d8e3e4,     0x25d8e084,     0x25d8e104,     0x25d8e184,
+    0x2518e407,     0x05214800,     0x05614800,     0x05a14800,
+    0x05e14800,     0x05214c00,     0x05614c00,     0x05a14c00,
+    0x05e14c00,     0x05304001,     0x05314001,     0x05a18610,
+    0x05e18610,     0x05271e11,     0x6545e891,     0x6585e891,
+    0x65c5e891,     0x6545c891,     0x6585c891,     0x65c5c891,
+    0x45b0c210,     0x45f1c231,     0x1e601000,     0x1e603000,
+    0x1e621000,     0x1e623000,     0x1e641000,     0x1e643000,
+    0x1e661000,     0x1e663000,     0x1e681000,     0x1e683000,
+    0x1e6a1000,     0x1e6a3000,     0x1e6c1000,     0x1e6c3000,
+    0x1e6e1000,     0x1e6e3000,     0x1e701000,     0x1e703000,
+    0x1e721000,     0x1e723000,     0x1e741000,     0x1e743000,
+    0x1e761000,     0x1e763000,     0x1e781000,     0x1e783000,
+    0x1e7a1000,     0x1e7a3000,     0x1e7c1000,     0x1e7c3000,
+    0x1e7e1000,     0x1e7e3000,     0xf82b80be,     0xf82803af,
+    0xf83e1280,     0xf82722f4,     0xf83c3375,     0xf8395025,
+    0xf83743f0,     0xf825712c,     0xf83c63af,     0xf8b6827f,
+    0xf8bf01c5,     0xf8b011ff,     0xf8bb2214,     0xf8ac312b,
+    0xf8a6523e,     0xf8bb43dc,     0xf8a7728a,     0xf8aa6304,
+    0xf8f182d1,     0xf8e301fd,     0xf8f61273,     0xf8f621e2,
+    0xf8e6320c,     0xf8eb52ed,     0xf8e1427e,     0xf8e57051,
+    0xf8f061b6,     0xf86a83b5,     0xf87b036c,     0xf86313e1,
+    0xf8782233,     0xf869337c,     0xf86f52a7,     0xf877433f,
+    0xf862737f,     0xf87062ea,     0xb83381e3,     0xb8200359,
+    0xb83711e2,     0xb82c2384,     0xb83e321d,     0xb83b5126,
+    0xb83d40f0,     0xb82471e7,     0xb8296117,     0xb8a282bc,
+    0xb8bf0365,     0xb8a011f1,     0xb8a4211a,     0xb8bc3376,
+    0xb8bb52f9,     0xb8a040c4,     0xb8b07080,     0xb8af6141,
+    0xb8e78145,     0xb8fc0287,     0xb8f710d5,     0xb8eb2228,
+    0xb8ff3226,     0xb8e253cc,     0xb8fd4363,     0xb8f671dd,
+    0xb8ed623c,     0xb8788045,     0xb86e020a,     0xb86b12fb,
+    0xb86c22c4,     0xb8713024,     0xb87351f0,     0xb86d418e,
+    0xb8627071,     0xb87560b7,     0xce3130e6,     0xce101a1b,
+    0xce638f82,     0xce91a0c4,     0xce73818d,     0xce738708,
+    0xcec08011,     0xce668aea,     0x25e0ce13,     0x2521c030,
+    0x05802ca7,     0x05401588,     0x05039276,     0x25a0d4ef,
+    0x2521dd67,     0x05800e47,     0x05400933,     0x050059c9,
+    0x25e0d0a5,     0x25a1cc0d,     0x05801581,     0x0543ab50,
+    0x05009904,     0x2520dd5d,     0x25e1dad0,     0x05804ca9,
+    0x0540061c,     0x05001c3a,     0x25a0d668,     0x2521d418,
+    0x05800ad5,     0x0540001d,     0x05008864,     0x2520d873,
+    0x25a1c239,     0x05801d68,     0x0543ab51,     0x05001e7e,
+    0x0429000c,     0x04e40638,     0x65db0126,     0x65de0a0d,
+    0x65de0696,     0x0416ae69,     0x04401d34,     0x041a0e6d,
+    0x04508a78,     0x041b1211,     0x0459a160,     0x041aadef,
+    0x04191caf,     0x0413974a,     0x04d18a60,     0x0490186a,
+    0x0457bb87,     0x045eab55,     0x04581e31,     0x05a79e02,
+    0x05648674,     0x04481a21,     0x040a12b0,     0x044102e4,
+    0x049caa86,     0x65809d90,     0x658d9523,     0x65c69c78,
+    0x65c78736,     0x65c284ed,     0x04ddb625,     0x65c2a120,
+    0x6580a96b,     0x6581b171,     0x65cdb3d8,     0x65c191c8,
+    0x65a79ed6,     0x65aa1f65,     0x65b43aae,     0x65e5b723,
+    0x65a1d23d,     0x65e0fdae,     0x65f65e82,     0x65a26d1d,
+    0x048056ce,     0x048c7af9,     0x04213035,     0x04b33173,
+    0x047e3117,     0x04f43273,     0x05be69b4,     0x05b96fde,
+    0x65888d71,     0x4505b29c,     0x4502b5ad,     0x042b3a6a,
+    0x041a2c59,     0x0418229d,     0x04593f94,     0x04c829ad,
+    0x040a2f61,     0x65c73903,     0x65862329,     0x65d8228e,
+    0x04813e66,
   };
 // END  Generated code -- do not edit


### PR DESCRIPTION
Some code, such as verification code, might want to run without changing the state of the system. To do that, it's useful to be able to get and set the nzcv flags. This enhancement aims at adding accessors for that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300253](https://bugs.openjdk.org/browse/JDK-8300253): Introduce AArch64 nzcv accessors


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Stuart Monteith](https://openjdk.org/census#smonteith) - Author ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12038/head:pull/12038` \
`$ git checkout pull/12038`

Update a local copy of the PR: \
`$ git checkout pull/12038` \
`$ git pull https://git.openjdk.org/jdk pull/12038/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12038`

View PR using the GUI difftool: \
`$ git pr show -t 12038`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12038.diff">https://git.openjdk.org/jdk/pull/12038.diff</a>

</details>
