### PR TITLE
JDK-8300254: ASan build does not correctly propagate ASAN_OPTIONS

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -410,7 +410,7 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_CODE_COVERAGE],
 #
 AC_DEFUN_ONCE([JDKOPT_SETUP_ADDRESS_SANITIZER],
 [
-  UTIL_ARG_ENABLE(NAME: asan, DEFAULT: false,
+  UTIL_ARG_ENABLE(NAME: asan, DEFAULT: false, RESULT: ASAN_ENABLED,
       DESC: [enable AddressSanitizer],
       CHECK_AVAILABLE: [
         AC_MSG_CHECKING([if AddressSanitizer (asan) is available])
@@ -426,7 +426,7 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_ADDRESS_SANITIZER],
         # ASan is simply incompatible with gcc -Wstringop-truncation. See
         # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85650
         # It's harmless to be suppressed in clang as well.
-        ASAN_CFLAGS="-fsanitize=address -Wno-stringop-truncation -fno-omit-frame-pointer"
+        ASAN_CFLAGS="-fsanitize=address -Wno-stringop-truncation -fno-omit-frame-pointer -DADDRESS_SANITIZER"
         ASAN_LDFLAGS="-fsanitize=address"
         JVM_CFLAGS="$JVM_CFLAGS $ASAN_CFLAGS"
         JVM_LDFLAGS="$JVM_LDFLAGS $ASAN_LDFLAGS"
@@ -436,10 +436,6 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_ADDRESS_SANITIZER],
         CXXFLAGS_JDKEXE="$CXXFLAGS_JDKEXE $ASAN_CFLAGS"
         LDFLAGS_JDKLIB="$LDFLAGS_JDKLIB $ASAN_LDFLAGS"
         LDFLAGS_JDKEXE="$LDFLAGS_JDKEXE $ASAN_LDFLAGS"
-        ASAN_ENABLED="yes"
-      ],
-      IF_DISABLED: [
-        ASAN_ENABLED="no"
       ])
 
   AC_SUBST(ASAN_ENABLED)

--- a/make/autoconf/spec.gmk.in
+++ b/make/autoconf/spec.gmk.in
@@ -446,14 +446,7 @@ JCOV_INPUT_JDK=@JCOV_INPUT_JDK@
 JCOV_FILTERS=@JCOV_FILTERS@
 
 # AddressSanitizer
-export ASAN_ENABLED:=@ASAN_ENABLED@
-export DEVKIT_LIB_DIR:=@DEVKIT_LIB_DIR@
-ifeq ($(ASAN_ENABLED), yes)
-  export ASAN_OPTIONS=handle_segv=0 detect_leaks=0
-  ifneq ($(DEVKIT_LIB_DIR),)
-    export LD_LIBRARY_PATH:=$(LD_LIBRARY_PATH):$(DEVKIT_LIB_DIR)
-  endif
-endif
+ASAN_ENABLED:=@ASAN_ENABLED@
 
 # UndefinedBehaviorSanitizer
 UBSAN_ENABLED:=@UBSAN_ENABLED@

--- a/make/common/modules/LauncherCommon.gmk
+++ b/make/common/modules/LauncherCommon.gmk
@@ -144,9 +144,15 @@ define SetupBuildLauncherBody
 
   $1_WINDOWS_JLI_LIB := $(call FindStaticLib, java.base, jli, /libjli)
 
+  $1_EXTRA_FILES := $(LAUNCHER_SRC)/main.c
+
+  ifeq ($(ASAN_ENABLED), true)
+    $1_EXTRA_FILES += $(TOPDIR)/make/data/asan/asan_default_options.c
+  endif
+
   $$(eval $$(call SetupJdkExecutable, BUILD_LAUNCHER_$1, \
       NAME := $1, \
-      EXTRA_FILES := $(LAUNCHER_SRC)/main.c, \
+      EXTRA_FILES := $$($1_EXTRA_FILES), \
       OPTIMIZATION := $$($1_OPTIMIZATION), \
       CFLAGS := $$(CFLAGS_JDKEXE) \
           $$(LAUNCHER_CFLAGS) \

--- a/make/data/asan/asan_default_options.c
+++ b/make/data/asan/asan_default_options.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifndef ADDRESS_SANITIZER
+#error "Build misconfigured, preprocessor macro ADDRESS_SANITIZER should be defined"
+#endif
+
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+
+#if (defined(__GNUC__) && !defined(__clang__)) || __has_attribute(visibility)
+#define ATTRIBUTE_DEFAULT_VISIBILITY __attribute__((visibility("default")))
+#else
+#define ATTRIBUTE_DEFAULT_VISIBILITY
+#endif
+
+#if (defined(__GNUC__) && !defined(__clang__)) || __has_attribute(used)
+#define ATTRIBUTE_USED __attribute__((used))
+#else
+#define ATTRIBUTE_USED
+#endif
+
+// Override weak symbol exposed by ASan to override default options. This is called by ASan
+// extremely early during library loading, before main is called. We need to override the default
+// options because LSan is enabled by default and Hotspot is not yet compatible with it.
+// Additionally we need to prevent ASan from handling SIGSEGV, so that Hotspot's crash handler is
+// used. You can override these options by setting the environment variable ASAN_OPTIONS.
+ATTRIBUTE_DEFAULT_VISIBILITY ATTRIBUTE_USED const char* __asan_default_options() {
+  return "detect_leaks=0,handle_segv=0";
+}

--- a/make/data/asan/asan_default_options.c
+++ b/make/data/asan/asan_default_options.c
@@ -49,5 +49,9 @@
 // Additionally we need to prevent ASan from handling SIGSEGV, so that Hotspot's crash handler is
 // used. You can override these options by setting the environment variable ASAN_OPTIONS.
 ATTRIBUTE_DEFAULT_VISIBILITY ATTRIBUTE_USED const char* __asan_default_options() {
-  return "detect_leaks=0,handle_segv=0";
+  return
+#ifndef LEAK_SANITIZER
+    "detect_leaks=0"
+#endif
+    ",handle_segv=0";
 }

--- a/make/data/asan/asan_default_options.c
+++ b/make/data/asan/asan_default_options.c
@@ -51,7 +51,7 @@
 ATTRIBUTE_DEFAULT_VISIBILITY ATTRIBUTE_USED const char* __asan_default_options() {
   return
 #ifndef LEAK_SANITIZER
-    "detect_leaks=0"
+    "detect_leaks=0,"
 #endif
-    ",handle_segv=0";
+    "handle_segv=0";
 }


### PR DESCRIPTION
Update ASan build to use the same approach as UBSan for setting default options. The main difference is that we only want to change the default ASan options for processes which launch the JVM. We do this by only compiling the default options in the common launcher build file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300254](https://bugs.openjdk.org/browse/JDK-8300254): ASan build does not correctly propagate ASAN_OPTIONS


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12039/head:pull/12039` \
`$ git checkout pull/12039`

Update a local copy of the PR: \
`$ git checkout pull/12039` \
`$ git pull https://git.openjdk.org/jdk pull/12039/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12039`

View PR using the GUI difftool: \
`$ git pr show -t 12039`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12039.diff">https://git.openjdk.org/jdk/pull/12039.diff</a>

</details>
