### PR TITLE
8298596: vmTestbase/nsk/sysdict/vm/stress/chain/chain008/chain008.java fails with "NoClassDefFoundError: Could not initialize class java.util.concurrent.ThreadLocalRandom"

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -42,4 +42,3 @@ serviceability/sa/ClhsdbPstack.java#core                      8248912   generic-
 vmTestbase/gc/gctests/MemoryEaterMT/MemoryEaterMT.java        8289582   windows-x64
 
 vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded002/TestDescription.java 8298302 generic-all
-vmTestbase/nsk/sysdict/vm/stress/chain/chain008/chain008.java 8298596 linux-x64

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/gp/GarbageUtils.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/gp/GarbageUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -234,11 +234,21 @@ public final class GarbageUtils {
                      long.class,
                      OOM_TYPE.class);
 
+         private static MethodHandle eat;
+
+         static {
+             try {
+                 eat = MethodHandles.lookup().findStatic(GarbageUtils.class, "eatMemoryImpl", mt);
+             } catch (Exception nsme) {
+                 // Can't run the test for some unexpected reason
+                 throw new RuntimeException(nsme);
+             }
+         }
+
+
          public static int eatMemory(ExecutionController stresser, GarbageProducer gp, long initialFactor, long minMemoryChunk, long factor, OOM_TYPE type) {
             try {
                // Using a methodhandle invoke of eatMemoryImpl to prevent inlining of it
-               MethodHandles.Lookup lookup = MethodHandles.lookup();
-               MethodHandle eat = lookup.findStatic(GarbageUtils.class, "eatMemoryImpl", mt);
                return (int) eat.invoke(stresser, gp, initialFactor, minMemoryChunk, factor, type);
             } catch (OutOfMemoryError e) {
                return numberOfOOMEs++;


### PR DESCRIPTION
Moved the MethodHandle initialization out of the eatMemory function into the static initializer, so the eatMemory function doesn't get an unexpected OOM while loading the ThreadLocal class.
Tested 100x with ZGC with and without debug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298596](https://bugs.openjdk.org/browse/JDK-8298596): vmTestbase/nsk/sysdict/vm/stress/chain/chain008/chain008.java fails with "NoClassDefFoundError: Could not initialize class java.util.concurrent.ThreadLocalRandom"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12043/head:pull/12043` \
`$ git checkout pull/12043`

Update a local copy of the PR: \
`$ git checkout pull/12043` \
`$ git pull https://git.openjdk.org/jdk pull/12043/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12043`

View PR using the GUI difftool: \
`$ git pr show -t 12043`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12043.diff">https://git.openjdk.org/jdk/pull/12043.diff</a>

</details>
