### PR TITLE
8300208: Optimize Adler32 stub for AVX-512 targets.

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -4870,6 +4870,23 @@ void Assembler::evpmovzxbw(XMMRegister dst, KRegister mask, Address src, int vec
   emit_operand(dst, src, 0);
 }
 
+void Assembler::evpmovzxbd(XMMRegister dst, KRegister mask, Address src, int vector_len) {
+  assert(VM_Version::supports_avx512vl(), "");
+  assert(dst != xnoreg, "sanity");
+  InstructionMark im(this);
+  InstructionAttr attributes(vector_len, /* rex_w */ false, /* legacy_mode */ _legacy_mode_bw, /* no_mask_reg */ false, /* uses_vl */ true);
+  attributes.set_address_attributes(/* tuple_type */ EVEX_HVM, /* input_size_in_bits */ EVEX_NObit);
+  attributes.set_embedded_opmask_register_specifier(mask);
+  attributes.set_is_evex_instruction();
+  vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
+  emit_int8(0x31);
+  emit_operand(dst, src, 0);
+}
+
+void Assembler::evpmovzxbd(XMMRegister dst, Address src, int vector_len) {
+  evpmovzxbd(dst, k0, src, vector_len);
+}
+
 void Assembler::evpandd(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
   assert(VM_Version::supports_evex(), "");
   // Encoding: EVEX.NDS.XXX.66.0F.W0 DB /r

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -1873,6 +1873,8 @@ private:
   void pmovzxdq(XMMRegister dst, XMMRegister src);
   void vpmovzxdq(XMMRegister dst, XMMRegister src, int vector_len);
   void evpmovzxbw(XMMRegister dst, KRegister mask, Address src, int vector_len);
+  void evpmovzxbd(XMMRegister dst, KRegister mask, Address src, int vector_len);
+  void evpmovzxbd(XMMRegister dst, Address src, int vector_len);
 
   // Sign extend moves
   void pmovsxbd(XMMRegister dst, XMMRegister src);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_adler.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_adler.cpp
@@ -140,10 +140,8 @@ address StubGenerator::generate_updateBytesAdler32() {
 
   __ align32();
   if (VM_Version::supports_avx512vl()) {
-    __ cmpl(s, VM_Version::avx3_threshold());
-    __ jcc(Assembler::belowEqual, SPRELOOP1A_AVX2);
     // AVX2 performs better for smaller inputs because of leaner post loop reduction sequence..
-    __ cmpl(s, 128);
+    __ cmpl(s, MAX(128, VM_Version::avx3_threshold()));
     __ jcc(Assembler::belowEqual, SPRELOOP1A_AVX2);
     __ vpxor(yb, yb, yb, Assembler::AVX_512bit);
 

--- a/test/hotspot/jtreg/compiler/intrinsics/zip/TestAdler32.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/zip/TestAdler32.java
@@ -146,7 +146,7 @@ public class TestAdler32 {
         if (adler0.getValue() != adler1.getValue()) {
             System.err.printf("ERROR: adler0 = %08x, adler1 = %08x\n",
                               adler0.getValue(), adler1.getValue());
-            return false;
+            throw new AssertionError("TEST FAILED", null);
         }
         return true;
     }

--- a/test/micro/org/openjdk/bench/java/util/TestAdler32.java
+++ b/test/micro/org/openjdk/bench/java/util/TestAdler32.java
@@ -36,7 +36,7 @@ public class TestAdler32 {
     private Random random;
     private byte[] bytes;
 
-    @Param({"64", "128", "256", "512", "1024",  "2048", "5012", "8192", "16384", "32768", "65536"})
+    @Param({"64", "128", "256", "512", "1024", "2048", "5012", "8192", "16384", "32768", "65536"})
     private int count;
 
     public TestAdler32() {

--- a/test/micro/org/openjdk/bench/java/util/TestAdler32.java
+++ b/test/micro/org/openjdk/bench/java/util/TestAdler32.java
@@ -27,20 +27,16 @@ import java.util.concurrent.TimeUnit;
 import java.util.zip.Adler32;
 import org.openjdk.jmh.annotations.*;
 
-@BenchmarkMode(Mode.AverageTime)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
-@Fork(value = 2)
-@Warmup(iterations = 2, time = 30, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 3, time = 60, timeUnit = TimeUnit.SECONDS)
-
 public class TestAdler32 {
 
     private Adler32 adler32;
     private Random random;
     private byte[] bytes;
 
-    @Param({"64", "128", "256", "512", /* "1024", */ "2048", /* "4096", "8192", */ "16384", /* "32768", */ "65536"})
+    @Param({"64", "128", "256", "512", "1024",  "2048", "5012", "8192", "16384", "32768", "65536"})
     private int count;
 
     public TestAdler32() {


### PR DESCRIPTION
Patch optimizes Adler32 stub for AVX512 target.

Main computation loop now uses zero extended lane widening load vector operation.

New sequence also honors AVX3Thresholds so that implementation uses existing AVX2 instruction sequence on relevant targets
if input size is smaller than threshold limit (default 4096).

Following are the result of an [existing JMH micro ](https://github.com/openjdk/jdk/blob/master/test/micro/org/openjdk/bench/java/util/TestAdler32.java)on various targets.

**System Configurations : Turbo frequency scaling is disabled, all the data is collected at fixed frequency of 2.8 GHz.
SUT1   : Intel® Xeon® Platinum 8480+ Processor (Sapphire Rapids)  56C 2S
SUT2   : Intel(R) Xeon(R) Platinum 8380 CPU (Icelake Server) 40C 2S
SUT3   : Intel(R) Xeon(R) Platinum 8280 CPU (Cascadelake Server) 28C 2S**


![image](https://user-images.githubusercontent.com/59989778/212934730-68717a61-191f-4dba-8c83-2eddf6007a47.png)

![image](https://user-images.githubusercontent.com/59989778/212934945-cada95ad-c93c-487f-bacc-928a2e3b5c21.png)

![image](https://user-images.githubusercontent.com/59989778/212935059-511aca3b-c736-40a2-bff6-89caf0664828.png)


Please review and share your feedback.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300208](https://bugs.openjdk.org/browse/JDK-8300208): Optimize Adler32 stub for AVX-512 targets.


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12045/head:pull/12045` \
`$ git checkout pull/12045`

Update a local copy of the PR: \
`$ git checkout pull/12045` \
`$ git pull https://git.openjdk.org/jdk pull/12045/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12045`

View PR using the GUI difftool: \
`$ git pr show -t 12045`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12045.diff">https://git.openjdk.org/jdk/pull/12045.diff</a>

</details>
