### PR TITLE
JDK-8300279: Use generalized see and link tags in core libs in client libs

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Shape.java
+++ b/src/java.desktop/share/classes/java/awt/Shape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,8 +91,8 @@ public interface Shape {
      *
      * <p>
      * Note that the
-     * <a href="{@docRoot}/java.desktop/java/awt/Shape.html#def_insideness">
-     * definition of insideness</a> can lead to situations where points
+     * {@linkplain Shape##def_insideness
+     * definition of insideness} can lead to situations where points
      * on the defining outline of the {@code shape} may not be considered
      * contained in the returned {@code bounds} object, but only in cases
      * where those points are also not considered contained in the original
@@ -137,8 +137,8 @@ public interface Shape {
      *
      * <p>
      * Note that the
-     * <a href="{@docRoot}/java.desktop/java/awt/Shape.html#def_insideness">
-     * definition of insideness</a> can lead to situations where points
+     * {@linkplain Shape##def_insideness
+     * definition of insideness} can lead to situations where points
      * on the defining outline of the {@code shape} may not be considered
      * contained in the returned {@code bounds} object, but only in cases
      * where those points are also not considered contained in the original
@@ -171,8 +171,7 @@ public interface Shape {
     /**
      * Tests if the specified coordinates are inside the boundary of the
      * {@code Shape}, as described by the
-     * <a href="{@docRoot}/java.desktop/java/awt/Shape.html#def_insideness">
-     * definition of insideness</a>.
+     * {@linkplain Shape##def_insideness definition of insideness}.
      * @param x the specified X coordinate to be tested
      * @param y the specified Y coordinate to be tested
      * @return {@code true} if the specified coordinates are inside


### PR DESCRIPTION
Use new javadoc capabilities courtesy JDK-8200337 to use more readable in javadoc source anchors AWT's Shape interface. Analogous change is out for review in core libs, JDK-8300133.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300279](https://bugs.openjdk.org/browse/JDK-8300279): Use generalized see and link tags in core libs in client libs


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12048/head:pull/12048` \
`$ git checkout pull/12048`

Update a local copy of the PR: \
`$ git checkout pull/12048` \
`$ git pull https://git.openjdk.org/jdk pull/12048/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12048`

View PR using the GUI difftool: \
`$ git pr show -t 12048`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12048.diff">https://git.openjdk.org/jdk/pull/12048.diff</a>

</details>
