### PR TITLE
8146132: Excessive output from make test-image

### DIFF
--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -547,6 +547,7 @@ endef
 #   STRIPFLAGS Optionally change the flags given to the strip command
 #   PRECOMPILED_HEADER Header file to use as precompiled header
 #   PRECOMPILED_HEADER_EXCLUDE List of source files that should not use PCH
+#   BUILD_INFO_LOG_MACRO Overrides log level of the build info log message, default LogWarn
 #
 # After being called, some variables are exported from this macro, all prefixed
 # with parameter 1 followed by a '_':
@@ -931,12 +932,18 @@ define SetupNativeCompilationBody
 
   # Setup rule for printing progress info when compiling source files.
   # This is a rough heuristic and may not always print accurate information.
-  $$($1_BUILD_INFO): $$($1_SRCS) $$($1_COMPILE_VARDEPS_FILE)
+  # The $1_BUILD_INFO and $1_BUILD_INFO_DEPS variables are used in
+  # TestFilesCompilation.gmk.
+  $$(call SetIfEmpty, $1_BUILD_INFO_LOG_MACRO, LogWarn)
+  $1_BUILD_INFO_DEPS := $$($1_SRCS) $$($1_COMPILE_VARDEPS_FILE)
+  $$($1_BUILD_INFO): $$($1_BUILD_INFO_DEPS)
         ifeq ($$(wildcard $$($1_TARGET)), )
-	  $$(call LogWarn, Creating $$(subst $$(OUTPUTDIR)/,,$$($1_TARGET)) from $$(words \
+	  $$(call $$($1_BUILD_INFO_LOG_MACRO), \
+	      Creating $$(subst $$(OUTPUTDIR)/,,$$($1_TARGET)) from $$(words \
 	      $$(filter-out %.vardeps, $$?)) file(s))
         else
-	  $$(call LogWarn, $$(strip Updating $$(subst $$(OUTPUTDIR)/,,$$($1_TARGET)) \
+	  $$(call $$($1_BUILD_INFO_LOG_MACRO), \
+	      $$(strip Updating $$(subst $$(OUTPUTDIR)/,,$$($1_TARGET)) \
 	      $$(if $$(filter-out %.vardeps, $$?), \
 	        due to $$(words $$(filter-out %.vardeps, $$?)) file(s), \
 	      $$(if $$(filter %.vardeps, $$?), due to makefile changes))))

--- a/make/common/TestFilesCompilation.gmk
+++ b/make/common/TestFilesCompilation.gmk
@@ -111,7 +111,7 @@ define SetupTestFilesCompilationBody
     )) \
     $$(eval $1 += $$(BUILD_TEST_$$(name)) ) \
     $$(eval $1_BUILD_INFO_DEPS += $$(BUILD_TEST_$$(name)_BUILD_INFO_DEPS)) \
-    $$(eval $$(BUILD_TEST_$$(name)_BUILD_INFO) :| $$($1_BUILD_INFO)) \
+    $$(eval $$(BUILD_TEST_$$(name)_BUILD_INFO): | $$($1_BUILD_INFO)) \
   )
 
   # Setup rule for printing a summary of all the tests being compiled. On Warn

--- a/make/common/TestFilesCompilation.gmk
+++ b/make/common/TestFilesCompilation.gmk
@@ -64,6 +64,7 @@ define SetupTestFilesCompilationBody
     $1_BASE_CXXFLAGS := $(CXXFLAGS_JDKLIB)
     $1_LDFLAGS := $(LDFLAGS_JDKLIB) $$(call SET_SHARED_LIBRARY_ORIGIN)
     $1_COMPILATION_TYPE := LIBRARY
+    $1_LOG_TYPE := library
   else ifeq ($$($1_TYPE), PROGRAM)
     $1_PREFIX = exe
     $1_OUTPUT_SUBDIR := bin
@@ -71,6 +72,7 @@ define SetupTestFilesCompilationBody
     $1_BASE_CXXFLAGS := $(CXXFLAGS_JDKEXE)
     $1_LDFLAGS := $(LDFLAGS_JDKEXE) $(LDFLAGS_TESTEXE)
     $1_COMPILATION_TYPE := EXECUTABLE
+    $1_LOG_TYPE := executable
   else
     $$(error Unknown type: $$($1_TYPE))
   endif
@@ -81,6 +83,8 @@ define SetupTestFilesCompilationBody
 
   $1_EXCLUDE_PATTERN := $$(addprefix %/, $$($1_EXCLUDE))
   $1_FILTERED_FILE_LIST := $$(filter-out $$($1_EXCLUDE_PATTERN), $$($1_FILE_LIST))
+
+  $1_BUILD_INFO := $$($1_OUTPUT_DIR)/_$1-build-info.marker
 
   # Setup a compilation for each and every one of them
   $$(foreach file, $$($1_FILTERED_FILE_LIST),\
@@ -103,9 +107,20 @@ define SetupTestFilesCompilationBody
         OPTIMIZATION := $$(if $$($1_OPTIMIZATION_$$(name)),$$($1_OPTIMIZATION_$$(name)),LOW), \
         COPY_DEBUG_SYMBOLS := false, \
         STRIP_SYMBOLS := $$(if $$($1_STRIP_SYMBOLS_$$(name)),$$($1_STRIP_SYMBOLS_$$(name)),false), \
+        BUILD_INFO_LOG_MACRO := LogInfo, \
     )) \
-    $$(eval $1 += $$(BUILD_TEST_$$(name)) )  \
+    $$(eval $1 += $$(BUILD_TEST_$$(name)) ) \
+    $$(eval $1_BUILD_INFO_DEPS += $$(BUILD_TEST_$$(name)_BUILD_INFO_DEPS)) \
+    $$(eval $$(BUILD_TEST_$$(name)_BUILD_INFO) :| $$($1_BUILD_INFO)) \
   )
+
+  # Setup rule for printing a summary of all the tests being compiled. On Warn
+  # log level, this replaces the individual build info logging done by
+  # SetupNativeCompilation.
+  $$($1_BUILD_INFO): $$($1_BUILD_INFO_DEPS)
+	$$(call LogWarn, $$(strip Creating $$(words $$(filter-out %.vardeps, $$?)) \
+	    test $$($1_LOG_TYPE) file(s) for $1))
+	$(TOUCH) $$@
 
 endef
 


### PR DESCRIPTION
Here is my attempt at solving Coleen's logging issue. This patch changes the log level for the "build info" log messages for all native test libs and executables to `LogInfo`. It also adds a new meta log message for each call to SetupTestFilesCompilation, which is kept on LogWarn level, which prints a single line with the number of test files being compiled in this call. For `make test-image`, we have 5 such calls so the output will look like this, which I think is quite reasonable:

```
Creating 1 test executable file(s) for BUILD_LIBTEST_JTREG_EXECUTABLES
Creating 45 test library file(s) for BUILD_JDK_JTREG_LIBRARIES
Creating 6 test executable file(s) for BUILD_JDK_JTREG_EXECUTABLES
Creating 853 test library file(s) for BUILD_HOTSPOT_JTREG_LIBRARIES
Creating 16 test executable file(s) for BUILD_HOTSPOT_JTREG_EXECUTABLES
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8146132](https://bugs.openjdk.org/browse/JDK-8146132): Excessive output from make test-image


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [f388ecc9](https://git.openjdk.org/jdk/pull/12052/files/f388ecc9718a29e09fdf387d5d14eb66dd73bb61)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12052/head:pull/12052` \
`$ git checkout pull/12052`

Update a local copy of the PR: \
`$ git checkout pull/12052` \
`$ git pull https://git.openjdk.org/jdk pull/12052/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12052`

View PR using the GUI difftool: \
`$ git pr show -t 12052`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12052.diff">https://git.openjdk.org/jdk/pull/12052.diff</a>

</details>
