### PR TITLE
8300356: Refactor code examples to use @snippet in java.text.CollationElementIterator

### DIFF
--- a/src/java.base/share/classes/java/text/CollationElementIterator.java
+++ b/src/java.base/share/classes/java/text/CollationElementIterator.java
@@ -79,8 +79,7 @@ import jdk.internal.icu.text.NormalizerBase;
  * {@snippet lang=java :
  * String testString = "This is a test";
  * Collator col = Collator.getInstance();
- * if (col instanceof RuleBasedCollator) {
- *     RuleBasedCollator ruleBasedCollator = (RuleBasedCollator)col;
+ * if (col instanceof RuleBasedCollator ruleBasedCollator) {
  *     CollationElementIterator collationElementIterator = ruleBasedCollator.getCollationElementIterator(testString);
  *     int primaryOrder = CollationElementIterator.primaryOrder(collationElementIterator.next());
  * }

--- a/src/java.base/share/classes/java/text/CollationElementIterator.java
+++ b/src/java.base/share/classes/java/text/CollationElementIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,8 +76,7 @@ import jdk.internal.icu.text.NormalizerBase;
  * <p>
  * Example of the iterator usage,
  * <blockquote>
- * <pre>
- *
+ * {@snippet lang=java :
  *  String testString = "This is a test";
  *  Collator col = Collator.getInstance();
  *  if (col instanceof RuleBasedCollator) {
@@ -86,7 +85,7 @@ import jdk.internal.icu.text.NormalizerBase;
  *      int primaryOrder = CollationElementIterator.primaryOrder(collationElementIterator.next());
  *          :
  *  }
- * </pre>
+ * }
  * </blockquote>
  *
  * <p>

--- a/src/java.base/share/classes/java/text/CollationElementIterator.java
+++ b/src/java.base/share/classes/java/text/CollationElementIterator.java
@@ -77,14 +77,13 @@ import jdk.internal.icu.text.NormalizerBase;
  * Example of the iterator usage,
  * <blockquote>
  * {@snippet lang=java :
- *  String testString = "This is a test";
- *  Collator col = Collator.getInstance();
- *  if (col instanceof RuleBasedCollator) {
- *      RuleBasedCollator ruleBasedCollator = (RuleBasedCollator)col;
- *      CollationElementIterator collationElementIterator = ruleBasedCollator.getCollationElementIterator(testString);
- *      int primaryOrder = CollationElementIterator.primaryOrder(collationElementIterator.next());
- *          :
- *  }
+ * String testString = "This is a test";
+ * Collator col = Collator.getInstance();
+ * if (col instanceof RuleBasedCollator) {
+ *     RuleBasedCollator ruleBasedCollator = (RuleBasedCollator)col;
+ *     CollationElementIterator collationElementIterator = ruleBasedCollator.getCollationElementIterator(testString);
+ *     int primaryOrder = CollationElementIterator.primaryOrder(collationElementIterator.next());
+ * }
  * }
  * </blockquote>
  *

--- a/src/java.base/share/classes/java/text/CollationElementIterator.java
+++ b/src/java.base/share/classes/java/text/CollationElementIterator.java
@@ -82,6 +82,7 @@ import jdk.internal.icu.text.NormalizerBase;
  * if (col instanceof RuleBasedCollator ruleBasedCollator) {
  *     CollationElementIterator collationElementIterator = ruleBasedCollator.getCollationElementIterator(testString);
  *     int primaryOrder = CollationElementIterator.primaryOrder(collationElementIterator.next());
+ *         \u22ee
  * }
  * }
  * </blockquote>


### PR DESCRIPTION
This PR implements _JEP 413: Code Snippets in Java API Documentation_ for [java.text.CollationElementIterator](https://docs.oracle.com/en/java/javase/19/docs/api/java.base/java/text/CollationElementIterator.html).

Code examples using \<pre> ... \</pre> blocks are replaced with the @ snippet syntax where applicable.


Additionally, removed a floating colon in the code example

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300356](https://bugs.openjdk.org/browse/JDK-8300356): Refactor code examples to use @snippet in java.text.CollationElementIterator


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12055/head:pull/12055` \
`$ git checkout pull/12055`

Update a local copy of the PR: \
`$ git checkout pull/12055` \
`$ git pull https://git.openjdk.org/jdk pull/12055/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12055`

View PR using the GUI difftool: \
`$ git pr show -t 12055`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12055.diff">https://git.openjdk.org/jdk/pull/12055.diff</a>

</details>
