### PR TITLE
8286907: keytool should warn about weak PBE algorithms

### DIFF
--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -1837,14 +1837,10 @@ public final class Main {
                 useDefaultPBEAlgorithm = false;
             }
 
-            String[] weakAlgs = new String[] {"DES", "DESEDE", "MD5", "SHA1", "RC2", "RC4"};
-            boolean isWeak = Arrays.stream(weakAlgs).anyMatch(
-                    keyAlgName.toUpperCase(Locale.ENGLISH)::contains);
-            if (isWeak) {
-                weakWarnings.add(String.format(
-                        rb.getString("key.algorithm.weak"),
-                        rb.getString("the.generated.secretkey"), keyAlgName));
-            }
+            SecretKeyConstraintsParameters skcp =
+                    new SecretKeyConstraintsParameters(secKey);
+            checkWeakConstraint(rb.getString("the.generated.secretkey"),
+                    keyAlgName, skcp);
 
             if (verbose) {
                 MessageFormat form = new MessageFormat(rb.getString(
@@ -5074,6 +5070,16 @@ public final class Main {
             CertPathConstraintsParameters cpcp) throws Exception {
         if (crl instanceof X509CRLImpl impl) {
             checkWeakConstraint(label, impl.getSigAlgName(), key, cpcp);
+        }
+    }
+
+    private void checkWeakConstraint(String label, String keyAlg,
+            SecretKeyConstraintsParameters skcp) {
+        try {
+            LEGACY_CHECK.permits(keyAlg, skcp, false);
+        } catch (CertPathValidatorException e) {
+            weakWarnings.add(String.format(
+                    rb.getString("key.algorithm.weak"), label, keyAlg));
         }
     }
 

--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1835,6 +1835,15 @@ public final class Main {
             // Check whether a specific PBE algorithm was specified
             if (!"PBE".equalsIgnoreCase(keyAlgName)) {
                 useDefaultPBEAlgorithm = false;
+            }
+
+            String[] weakAlgs = new String[] {"DES", "DESEDE", "MD5", "SHA1", "RC2", "RC4"};
+            boolean isWeak = Arrays.stream(weakAlgs).anyMatch(
+                    keyAlgName.toUpperCase(Locale.ENGLISH)::contains);
+            if (isWeak) {
+                weakWarnings.add(String.format(
+                        rb.getString("key.algorithm.weak"),
+                        rb.getString("the.generated.secretkey"), keyAlgName));
             }
 
             if (verbose) {

--- a/test/jdk/sun/security/tools/keytool/WeakSecretKeyTest.java
+++ b/test/jdk/sun/security/tools/keytool/WeakSecretKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8255552 8286090
+ * @bug 8255552 8286090 8286907
  * @summary Test keytool commands associated with secret key entries which use weak algorithms
  * @library /test/lib
  */
@@ -107,6 +107,25 @@ public class WeakSecretKeyTest {
                 JAVA_SECURITY_FILE)
                 .shouldContain("Warning")
                 .shouldMatch("The generated secret key uses a 128-bit AES key.*considered a security risk")
+                .shouldHaveExitValue(0);
+
+        SecurityTools.keytool("-keystore ks.p12 -storepass changeit " +
+                "-genseckey -keyalg PBEWithMD5AndDES -alias pbekey1")
+                .shouldContain("Warning")
+                .shouldMatch("The generated secret key uses the PBEWithMD5AndDES algorithm.*considered a security risk")
+                .shouldHaveExitValue(0);
+
+        SecurityTools.keytool("-keystore ks.p12 -storepass changeit " +
+                "-genseckey -keyalg PBEWithSHA1AndDESede -alias pbekey2")
+                .shouldContain("Warning")
+                .shouldMatch("The generated secret key uses the PBEWithSHA1AndDESede algorithm.*considered a security risk")
+                .shouldHaveExitValue(0);
+
+        SecurityTools.setResponse("changeit", "changeit");
+        SecurityTools.keytool("-keystore ks.p12 -storepass changeit " +
+                "-importpass -keyalg PBEWithMD5AndDES -alias newentry")
+                .shouldContain("Warning")
+                .shouldMatch("The generated secret key uses the PBEWithMD5AndDES algorithm.*considered a security risk")
                 .shouldHaveExitValue(0);
     }
 }


### PR DESCRIPTION
Please review the fix to address the problem in keytool -genseckey and -importpass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286907](https://bugs.openjdk.org/browse/JDK-8286907): keytool should warn about weak PBE algorithms


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12056/head:pull/12056` \
`$ git checkout pull/12056`

Update a local copy of the PR: \
`$ git checkout pull/12056` \
`$ git pull https://git.openjdk.org/jdk pull/12056/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12056`

View PR using the GUI difftool: \
`$ git pr show -t 12056`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12056.diff">https://git.openjdk.org/jdk/pull/12056.diff</a>

</details>
