### PR TITLE
JDK-8300357: Use generalized see and link tags in java.management

### DIFF
--- a/src/java.management/share/classes/java/lang/management/ThreadMXBean.java
+++ b/src/java.management/share/classes/java/lang/management/ThreadMXBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,12 +31,11 @@ import java.util.Map;
  * The management interface for the thread system of the Java virtual machine.
  *
  * <p> {@code ThreadMXBean} supports monitoring and management of
- * <a href="{@docRoot}/java.base/java/lang/Thread.html#platform-threads">
- * platform threads</a> in the Java virtual machine. Platform threads are
+ * {@linkplain Thread##platform-threads
+ * platform threads} in the Java virtual machine. Platform threads are
  * typically mapped to kernel threads scheduled by the operating system.
  * {@code ThreadMXBean} does not support monitoring or management of
- * <a href="{@docRoot}/java.base/java/lang/Thread.html#virtual-threads">
- * virtual threads</a>.
+ * {@linkplain Thread##virtual-threads virtual threads}.
  *
  * <p> A Java virtual machine has a single instance of the implementation
  * class of this interface.  This instance implementing this interface is

--- a/src/java.management/share/classes/java/lang/management/ThreadMXBean.java
+++ b/src/java.management/share/classes/java/lang/management/ThreadMXBean.java
@@ -31,11 +31,11 @@ import java.util.Map;
  * The management interface for the thread system of the Java virtual machine.
  *
  * <p> {@code ThreadMXBean} supports monitoring and management of
- * {@linkplain Thread##platform-threads
- * platform threads} in the Java virtual machine. Platform threads are
- * typically mapped to kernel threads scheduled by the operating system.
- * {@code ThreadMXBean} does not support monitoring or management of
- * {@linkplain Thread##virtual-threads virtual threads}.
+ * {@linkplain Thread##platform-threads platform threads} in the Java
+ * virtual machine. Platform threads are typically mapped to kernel
+ * threads scheduled by the operating system.  {@code ThreadMXBean}
+ * does not support monitoring or management of {@linkplain
+ * Thread##virtual-threads virtual threads}.
  *
  * <p> A Java virtual machine has a single instance of the implementation
  * class of this interface.  This instance implementing this interface is

--- a/src/java.management/share/classes/javax/management/remote/JMXConnectorFactory.java
+++ b/src/java.management/share/classes/javax/management/remote/JMXConnectorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -136,8 +136,8 @@ import sun.reflect.misc.ReflectUtil;
  * <code><em>protocol</em></code>, or it will throw a
  * <code>MalformedURLException</code> if there is none.  An
  * implementation may choose to find providers by other means.  For
- * example, it may support <a
- * href="{@docRoot}/java.base/java/util/ServiceLoader.html#developing-service-providers">service providers</a>,
+ * example, it may support {@linkplain
+ * java.base/java.util.ServiceLoader##developing-service-providers service providers},
  * where the service interface is <code>JMXConnectorProvider</code>.</p>
  *
  * <p>Every implementation must support the RMI connector protocol with

--- a/src/java.management/share/classes/javax/management/remote/JMXConnectorFactory.java
+++ b/src/java.management/share/classes/javax/management/remote/JMXConnectorFactory.java
@@ -137,7 +137,7 @@ import sun.reflect.misc.ReflectUtil;
  * <code>MalformedURLException</code> if there is none.  An
  * implementation may choose to find providers by other means.  For
  * example, it may support {@linkplain
- * java.base/java.util.ServiceLoader##developing-service-providers service providers},
+ * ServiceLoader##developing-service-providers service providers},
  * where the service interface is <code>JMXConnectorProvider</code>.</p>
  *
  * <p>Every implementation must support the RMI connector protocol with

--- a/src/java.management/share/classes/javax/management/remote/JMXConnectorServerFactory.java
+++ b/src/java.management/share/classes/javax/management/remote/JMXConnectorServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,8 +126,8 @@ import javax.management.remote.JMXConnectorFactory.ConnectorFactory;
  * <code><em>protocol</em></code>, or it will throw a
  * <code>MalformedURLException</code> if there is none.  An
  * implementation may choose to find providers by other means.  For
- * example, it may support <a
- * href="{@docRoot}/java.base/java/util/ServiceLoader.html#developing-service-providers">service providers</a>,
+ * example, it may support {@linkplain
+ * java.base/java.util.ServiceLoader##developing-service-providers service providers},
  * where the service interface is <code>JMXConnectorServerProvider</code>.</p>
  *
  * <p>Every implementation must support the RMI connector protocol with

--- a/src/java.management/share/classes/javax/management/remote/JMXConnectorServerFactory.java
+++ b/src/java.management/share/classes/javax/management/remote/JMXConnectorServerFactory.java
@@ -127,7 +127,7 @@ import javax.management.remote.JMXConnectorFactory.ConnectorFactory;
  * <code>MalformedURLException</code> if there is none.  An
  * implementation may choose to find providers by other means.  For
  * example, it may support {@linkplain
- * java.base/java.util.ServiceLoader##developing-service-providers service providers},
+ * java.util.ServiceLoader##developing-service-providers service providers},
  * where the service interface is <code>JMXConnectorServerProvider</code>.</p>
  *
  * <p>Every implementation must support the RMI connector protocol with


### PR DESCRIPTION
Use new javadoc capabilities courtesy JDK-8200337 to have more-readable-in-javadoc-source links to anchors in several management types. Analogous change is out for review in core libs, JDK-8300133.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300357](https://bugs.openjdk.org/browse/JDK-8300357): Use generalized see and link tags in java.management


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [01ac3743](https://git.openjdk.org/jdk/pull/12058/files/01ac374390ebf7c5caeec493420f9860142ba1a4)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12058/head:pull/12058` \
`$ git checkout pull/12058`

Update a local copy of the PR: \
`$ git checkout pull/12058` \
`$ git pull https://git.openjdk.org/jdk pull/12058/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12058`

View PR using the GUI difftool: \
`$ git pr show -t 12058`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12058.diff">https://git.openjdk.org/jdk/pull/12058.diff</a>

</details>
