### PR TITLE
8300405: Screen capture for test JFileChooserSetLocationTest.java, failure case

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/JFileChooserSetLocationTest.java
+++ b/test/jdk/javax/swing/JFileChooser/JFileChooserSetLocationTest.java
@@ -23,11 +23,12 @@
 
 import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsEnvironment;
 import java.awt.HeadlessException;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Robot;
-import java.awt.Toolkit;
 import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
@@ -186,9 +187,11 @@ public class JFileChooserSetLocationTest {
             (Math.abs(y1 - y2) < TOLERANCE_LEVEL)) {
             System.out.println("Test passed");
         } else {
-            Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+            GraphicsConfiguration gc = GraphicsEnvironment.
+                    getLocalGraphicsEnvironment().getDefaultScreenDevice().getDefaultConfiguration();
+            Rectangle gcBounds = gc.getBounds();
             BufferedImage bufferedImage = robot.createScreenCapture(
-                    new Rectangle(screenSize));
+                    new Rectangle(gcBounds));
             ImageIO.write(bufferedImage, "png",new File("FailureImage.png"));
             throw new RuntimeException(
                     "Test Failed, setLocation() is not working properly");

--- a/test/jdk/javax/swing/JFileChooser/JFileChooserSetLocationTest.java
+++ b/test/jdk/javax/swing/JFileChooser/JFileChooserSetLocationTest.java
@@ -25,15 +25,20 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.HeadlessException;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.Robot;
+import java.awt.Toolkit;
 import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import java.awt.image.BufferedImage;
+import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+import javax.imageio.ImageIO;
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JFileChooser;
@@ -175,12 +180,16 @@ public class JFileChooserSetLocationTest {
         return pt.get();
     }
 
-    public static void verify(int x1, int x2, int y1, int y2) {
+    public static void verify(int x1, int x2, int y1, int y2) throws Exception {
         System.out.println("verify " + x1 + "==" + x2 + "; " + y1 + "==" + y2);
         if ((Math.abs(x1 - x2) < TOLERANCE_LEVEL) &&
             (Math.abs(y1 - y2) < TOLERANCE_LEVEL)) {
             System.out.println("Test passed");
         } else {
+            Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+            BufferedImage bufferedImage = robot.createScreenCapture(
+                    new Rectangle(screenSize));
+            ImageIO.write(bufferedImage, "png",new File("FailureImage.png"));
             throw new RuntimeException(
                     "Test Failed, setLocation() is not working properly");
         }


### PR DESCRIPTION
This is a diagnostic update related to [JDK-8295804](https://bugs.openjdk.org/browse/JDK-8295804). The issue was not reproducible and was showing up in particular machines (Where the machines are down now). So adding a screen capture to `BufferedImage` in case of failure so that it will help in analysis when the issue comes up in future.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300405](https://bugs.openjdk.org/browse/JDK-8300405): Screen capture for test JFileChooserSetLocationTest.java, failure case


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12060/head:pull/12060` \
`$ git checkout pull/12060`

Update a local copy of the PR: \
`$ git checkout pull/12060` \
`$ git pull https://git.openjdk.org/jdk pull/12060/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12060`

View PR using the GUI difftool: \
`$ git pr show -t 12060`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12060.diff">https://git.openjdk.org/jdk/pull/12060.diff</a>

</details>
