### PR TITLE
8300409: Create an automated regression test for JComboBox titled border issues(JDK-8300269)

### DIFF
--- a/test/jdk/javax/swing/JComboBox/JComboBoxWithTitledBorderTest.java
+++ b/test/jdk/javax/swing/JComboBox/JComboBoxWithTitledBorderTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import javax.imageio.ImageIO;
+import javax.swing.BorderFactory;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UIManager.LookAndFeelInfo;
+import javax.swing.UnsupportedLookAndFeelException;
+
+
+import static javax.swing.UIManager.getInstalledLookAndFeels;
+
+/*
+ * @test
+ * @key headful
+ * @bug 8300269
+ * @summary This test verifies the issue: Can't see the selected JComboBox
+ *          item if it has a titled border.
+ * @run main JComboBoxWithTitledBorderTest
+ */
+public class JComboBoxWithTitledBorderTest {
+    private static final String[] comboStrings =
+            {"First", "Second", "Third", "Fourth"};
+    private static JFrame frame;
+    private static JComboBox<String> combo;
+    private static Robot robot;
+
+    public static void main(String[] argv) throws Exception {
+        robot = new Robot();
+        robot.setAutoWaitForIdle(true);
+        robot.setAutoDelay(200);
+        List<String> lafs = Arrays.stream(getInstalledLookAndFeels())
+                                  .map(LookAndFeelInfo::getClassName)
+                                  .collect(Collectors.toList());
+        for (final String laf : lafs) {
+            try {
+                AtomicBoolean lafSetSuccess = new AtomicBoolean(false);
+                System.out.println("Setting LAF: " + laf);
+                SwingUtilities.invokeAndWait(() -> {
+                    lafSetSuccess.set(setLookAndFeel(laf));
+                    if (lafSetSuccess.get()) {
+                        createAndShowGUI(laf);
+                    }
+                });
+                if (!lafSetSuccess.get()) {
+                    continue;
+                }
+                robot.waitForIdle();
+
+                mouseClick(combo);
+
+                hitKeys(KeyEvent.VK_RIGHT, KeyEvent.VK_BACK_SPACE,
+                        KeyEvent.VK_ENTER);
+                String item = (String) combo.getSelectedItem();
+                System.out.println("Current item: " + item);
+                // Deletes the last character of the combo item and check
+                // whether its getting reflected in item. Bug JDK-8300269: It's
+                // not getting reflected in case of AquaLookAndFeel.
+                if ("Firs".equals(item)) {
+                    System.out.println("Test Passed for " + laf);
+                } else {
+                    captureScreen();
+                    throw new RuntimeException("Test Failed for " + laf);
+                }
+            } finally {
+                SwingUtilities.invokeAndWait(
+                        JComboBoxWithTitledBorderTest::disposeFrame);
+            }
+        }
+    }
+
+    private static void hitKeys(int... keys) {
+        for (int key : keys) {
+            robot.keyPress(key);
+        }
+        for (int i = keys.length - 1; i >= 0; i--) {
+            robot.keyRelease(keys[i]);
+        }
+    }
+
+    private static void mouseClick(JComponent jComponent) throws Exception {
+        final AtomicReference<Point> loc = new AtomicReference<>();
+        SwingUtilities
+                .invokeAndWait(() -> loc.set(jComponent.getLocationOnScreen()));
+        final Point location = loc.get();
+        robot.mouseMove(location.x + 25, location.y + 5);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+    }
+
+    private static void createAndShowGUI(final String laf) {
+        frame = new JFrame("JComboBox with Titled Border test");
+        frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+
+        JPanel panel = new JPanel();
+        combo = new JComboBox<>(comboStrings);
+        combo.setEditable(true);
+
+        // Create a titled border for the ComboBox with the LAF name as title.
+        String[] lafStrings = laf.split("[.]");
+        combo.setBorder(BorderFactory.createTitledBorder(
+                lafStrings[lafStrings.length - 1]));
+        panel.add(combo);
+        frame.getContentPane().add(panel);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    private static boolean setLookAndFeel(String lafName) {
+        try {
+            UIManager.setLookAndFeel(lafName);
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.out.println("Ignoring Unsupported LAF: " + lafName);
+            return false;
+        } catch (ClassNotFoundException | InstantiationException
+                | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+        return true;
+    }
+
+    private static void disposeFrame() {
+        if (frame != null) {
+            frame.dispose();
+            frame = null;
+        }
+    }
+
+    private static void captureScreen() {
+        try {
+            final Rectangle screenBounds = new Rectangle(0, 0,
+                                                         1280, 720);
+            ImageIO.write(robot.createScreenCapture(screenBounds),
+                          "png", new File("screen.png"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+}


### PR DESCRIPTION
Create a automated regression test for JComboBox titled border issues([JDK-8300269](https://bugs.openjdk.org/browse/JDK-8300269)).

This test passes in JDK-20-ea+15 and fails in JDK-20-ea+16 and above.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300409](https://bugs.openjdk.org/browse/JDK-8300409): Create an automated regression test for JComboBox titled border issues(JDK-8300269)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12061/head:pull/12061` \
`$ git checkout pull/12061`

Update a local copy of the PR: \
`$ git checkout pull/12061` \
`$ git pull https://git.openjdk.org/jdk pull/12061/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12061`

View PR using the GUI difftool: \
`$ git pr show -t 12061`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12061.diff">https://git.openjdk.org/jdk/pull/12061.diff</a>

</details>
