### PR TITLE
8300447: Parallel: Refactor PSPromotionManager::drain_stacks_depth

### DIFF
--- a/src/hotspot/share/gc/parallel/psPromotionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.cpp
@@ -227,7 +227,8 @@ void PSPromotionManager::restore_preserved_marks() {
 }
 
 void PSPromotionManager::drain_stacks_depth(bool totally_drain) {
-  totally_drain = totally_drain || (_target_stack_size == 0);
+  const uint threshold = totally_drain ? 0
+                                       : _target_stack_size;
 
   PSScannerTasksQueue* const tq = claimed_stack_depth();
   do {
@@ -239,16 +240,10 @@ void PSPromotionManager::drain_stacks_depth(bool totally_drain) {
       process_popped_location_depth(task);
     }
 
-    if (totally_drain) {
-      while (tq->pop_local(task)) {
-        process_popped_location_depth(task);
-      }
-    } else {
-      while (tq->size() > _target_stack_size && tq->pop_local(task)) {
-        process_popped_location_depth(task);
-      }
+    while (tq->pop_local(task, threshold)) {
+      process_popped_location_depth(task);
     }
-  } while ((totally_drain && !tq->taskqueue_empty()) || !tq->overflow_empty());
+  } while (!tq->overflow_empty());
 
   assert(!totally_drain || tq->taskqueue_empty(), "Sanity");
   assert(totally_drain || tq->size() <= _target_stack_size, "Sanity");

--- a/src/hotspot/share/gc/parallel/psPromotionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.cpp
@@ -237,7 +237,9 @@ void PSPromotionManager::drain_stacks_depth(bool totally_drain) {
     // Drain overflow stack first, so other threads can steal from
     // claimed stack while we work.
     while (tq->pop_overflow(task)) {
-      process_popped_location_depth(task);
+      if (!tq->try_push_to_taskqueue(task)) {
+        process_popped_location_depth(task);
+      }
     }
 
     while (tq->pop_local(task, threshold)) {


### PR DESCRIPTION
Simple refactoring based on the counterpart in G1.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300447](https://bugs.openjdk.org/browse/JDK-8300447): Parallel: Refactor PSPromotionManager::drain_stacks_depth


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12063/head:pull/12063` \
`$ git checkout pull/12063`

Update a local copy of the PR: \
`$ git checkout pull/12063` \
`$ git pull https://git.openjdk.org/jdk pull/12063/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12063`

View PR using the GUI difftool: \
`$ git pr show -t 12063`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12063.diff">https://git.openjdk.org/jdk/pull/12063.diff</a>

</details>
