### PR TITLE
8293198: [vectorapi] Improve the implementation of VectorMask.indexInRange()

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_vector.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_vector.ad
@@ -5689,6 +5689,18 @@ instruct vmask_gen_imm(pReg pd, immL con, rFlagsReg cr) %{
   ins_pipe(pipe_slow);
 %}
 
+instruct vmask_gen_sub(pReg pd, iRegL src1, iRegL src2, rFlagsReg cr) %{
+  predicate(UseSVE > 0);
+  match(Set pd (VectorMaskGen (SubL src1 src2)));
+  effect(KILL cr);
+  format %{ "vmask_gen_sub $pd, $src2, $src1\t# KILL cr" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ sve_whilelo($pd$$PRegister, __ elemType_to_regVariant(bt), $src2$$Register, $src1$$Register);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 // ------------------------------ Popcount vector ------------------------------
 
 // vector popcount - INT

--- a/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
@@ -4072,6 +4072,18 @@ instruct vmask_gen_imm(pReg pd, immL con, rFlagsReg cr) %{
   ins_pipe(pipe_slow);
 %}
 
+instruct vmask_gen_sub(pReg pd, iRegL src1, iRegL src2, rFlagsReg cr) %{
+  predicate(UseSVE > 0);
+  match(Set pd (VectorMaskGen (SubL src1 src2)));
+  effect(KILL cr);
+  format %{ "vmask_gen_sub $pd, $src2, $src1\t# KILL cr" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ sve_whilelo($pd$$PRegister, __ elemType_to_regVariant(bt), $src2$$Register, $src1$$Register);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 // ------------------------------ Popcount vector ------------------------------
 
 // vector popcount - INT

--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -1196,16 +1196,6 @@ class methodHandle;
                                       "Ljdk/internal/vm/vector/VectorSupport$VectorPayload;")                                                  \
    do_name(vector_compress_expand_op_name,     "compressExpandOp")                                                                             \
                                                                                                                                                \
-  do_intrinsic(_VectorIndexInRange, jdk_internal_vm_vector_VectorSupport, vector_index_in_range_name, vector_index_in_range_sig, F_S)          \
-    do_signature(vector_index_in_range_sig, "(Ljava/lang/Class;"                                                                               \
-                                            "Ljava/lang/Class;"                                                                                \
-                                            "I"                                                                                                \
-                                            "J"                                                                                                \
-                                            "J"                                                                                                \
-                                            "Ljdk/internal/vm/vector/VectorSupport$IndexInRangeOperation;)"                                    \
-                                            "Ljdk/internal/vm/vector/VectorSupport$VectorMask;")                                               \
-    do_name(vector_index_in_range_name, "indexInRange")                                                                                        \
-                                                                                                                                               \
   do_intrinsic(_IndexVector, jdk_internal_vm_vector_VectorSupport, index_vector_op_name, index_vector_op_sig, F_S)                             \
     do_signature(index_vector_op_sig, "(Ljava/lang/Class;"                                                                                     \
                                        "Ljava/lang/Class;"                                                                                     \
@@ -1217,6 +1207,16 @@ class methodHandle;
                                        "Ljdk/internal/vm/vector/VectorSupport$Vector;")                                                        \
     do_name(index_vector_op_name, "indexVector")                                                                                               \
                                                                                                                                                \
+  do_intrinsic(_IndexPartiallyInUpperRange, jdk_internal_vm_vector_VectorSupport, index_partially_in_upper_range_name, index_partially_in_upper_range_sig, F_S)\
+    do_signature(index_partially_in_upper_range_sig, "(Ljava/lang/Class;"                                                                                      \
+                                                     "Ljava/lang/Class;"                                                                                       \
+                                                     "I"                                                                                                       \
+                                                     "J"                                                                                                       \
+                                                     "J"                                                                                                       \
+                                                     "Ljdk/internal/vm/vector/VectorSupport$IndexPartiallyInUpperRangeOperation;)"                             \
+                                                     "Ljdk/internal/vm/vector/VectorSupport$VectorMask;")                                                      \
+    do_name(index_partially_in_upper_range_name, "indexPartiallyInUpperRange")                                                                                 \
+                                                                                                                               \
    /* (2) Bytecode intrinsics                                                                        */                        \
                                                                                                                                \
   do_intrinsic(_park,                     jdk_internal_misc_Unsafe,     park_name, park_signature,                     F_RN)   \
@@ -1325,7 +1325,7 @@ enum class vmIntrinsicID : int {
                    __IGNORE_CLASS, __IGNORE_NAME, __IGNORE_SIGNATURE, __IGNORE_ALIAS)
 
   ID_LIMIT,
-  LAST_COMPILER_INLINE = _IndexVector,
+  LAST_COMPILER_INLINE = _IndexPartiallyInUpperRange,
   FIRST_MH_SIG_POLY    = _invokeGeneric,
   FIRST_MH_STATIC      = _linkToVirtual,
   LAST_MH_SIG_POLY     = _linkToNative,

--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1195,6 +1195,16 @@ class methodHandle;
                                       "Ljdk/internal/vm/vector/VectorSupport$CompressExpandOperation;)"                                        \
                                       "Ljdk/internal/vm/vector/VectorSupport$VectorPayload;")                                                  \
    do_name(vector_compress_expand_op_name,     "compressExpandOp")                                                                             \
+                                                                                                                                               \
+  do_intrinsic(_VectorIndexInRange, jdk_internal_vm_vector_VectorSupport, vector_index_in_range_name, vector_index_in_range_sig, F_S)          \
+    do_signature(vector_index_in_range_sig, "(Ljava/lang/Class;"                                                                               \
+                                            "Ljava/lang/Class;"                                                                                \
+                                            "I"                                                                                                \
+                                            "J"                                                                                                \
+                                            "J"                                                                                                \
+                                            "Ljdk/internal/vm/vector/VectorSupport$IndexInRangeOperation;)"                                    \
+                                            "Ljdk/internal/vm/vector/VectorSupport$VectorMask;")                                               \
+    do_name(vector_index_in_range_name, "indexInRange")                                                                                        \
                                                                                                                                                \
   do_intrinsic(_IndexVector, jdk_internal_vm_vector_VectorSupport, index_vector_op_name, index_vector_op_sig, F_S)                             \
     do_signature(index_vector_op_sig, "(Ljava/lang/Class;"                                                                                     \

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -778,8 +778,8 @@ bool C2Compiler::is_intrinsic_supported(const methodHandle& method, bool is_virt
   case vmIntrinsics::_VectorInsert:
   case vmIntrinsics::_VectorExtract:
   case vmIntrinsics::_VectorMaskOp:
-  case vmIntrinsics::_VectorIndexInRange:
   case vmIntrinsics::_IndexVector:
+  case vmIntrinsics::_IndexPartiallyInUpperRange:
     return EnableVectorSupport;
   case vmIntrinsics::_blackhole:
     break;

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -778,6 +778,7 @@ bool C2Compiler::is_intrinsic_supported(const methodHandle& method, bool is_virt
   case vmIntrinsics::_VectorInsert:
   case vmIntrinsics::_VectorExtract:
   case vmIntrinsics::_VectorMaskOp:
+  case vmIntrinsics::_VectorIndexInRange:
   case vmIntrinsics::_IndexVector:
     return EnableVectorSupport;
   case vmIntrinsics::_blackhole:

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -720,10 +720,10 @@ bool LibraryCallKit::try_to_inline(int predicate) {
     return inline_vector_extract();
   case vmIntrinsics::_VectorCompressExpand:
     return inline_vector_compress_expand();
-  case vmIntrinsics::_VectorIndexInRange:
-    return inline_vector_index_in_range();
   case vmIntrinsics::_IndexVector:
     return inline_index_vector();
+  case vmIntrinsics::_IndexPartiallyInUpperRange:
+    return inline_index_partially_in_upper_range();
 
   case vmIntrinsics::_getObjectSize:
     return inline_getObjectSize();

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -720,6 +720,8 @@ bool LibraryCallKit::try_to_inline(int predicate) {
     return inline_vector_extract();
   case vmIntrinsics::_VectorCompressExpand:
     return inline_vector_compress_expand();
+  case vmIntrinsics::_VectorIndexInRange:
+    return inline_vector_index_in_range();
   case vmIntrinsics::_IndexVector:
     return inline_index_vector();
 

--- a/src/hotspot/share/opto/library_call.hpp
+++ b/src/hotspot/share/opto/library_call.hpp
@@ -350,8 +350,8 @@ class LibraryCallKit : public GraphKit {
   bool inline_vector_extract();
   bool inline_vector_insert();
   bool inline_vector_compress_expand();
-  bool inline_vector_index_in_range();
   bool inline_index_vector();
+  bool inline_index_partially_in_upper_range();
 
   Node* gen_call_to_svml(int vector_api_op_id, BasicType bt, int num_elem, Node* opd1, Node* opd2);
 

--- a/src/hotspot/share/opto/library_call.hpp
+++ b/src/hotspot/share/opto/library_call.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -350,6 +350,7 @@ class LibraryCallKit : public GraphKit {
   bool inline_vector_extract();
   bool inline_vector_insert();
   bool inline_vector_compress_expand();
+  bool inline_vector_index_in_range();
   bool inline_index_vector();
 
   Node* gen_call_to_svml(int vector_api_op_id, BasicType bt, int num_elem, Node* opd1, Node* opd2);

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -3009,10 +3009,10 @@ bool LibraryCallKit::inline_index_vector() {
 // public static
 // <E,
 //  M extends VectorMask<E>>
-// M indexInRange(Class<? extends M> mClass, Class<E> eClass, int length,
-//                long offset, long limit,
-//                IndexInRangeOperation<E, M> defaultImpl)
-bool LibraryCallKit::inline_vector_index_in_range() {
+// M indexPartiallyInUpperRange(Class<? extends M> mClass, Class<E> eClass, int length,
+//                              long offset, long limit,
+//                              IndexPartiallyInUpperRangeOperation<E, M> defaultImpl)
+bool LibraryCallKit::inline_index_partially_in_upper_range() {
   const TypeInstPtr* mask_klass   = gvn().type(argument(0))->isa_instptr();
   const TypeInstPtr* elem_klass   = gvn().type(argument(1))->isa_instptr();
   const TypeInt*     vlen         = gvn().type(argument(2))->isa_int();

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -3005,3 +3005,131 @@ bool LibraryCallKit::inline_index_vector() {
   C->set_max_vector_size(MAX2(C->max_vector_size(), (uint)(num_elem * type2aelembytes(elem_bt))));
   return true;
 }
+
+// public static
+// <E,
+//  M extends VectorMask<E>>
+// M indexInRange(Class<? extends M> mClass, Class<E> eClass, int length,
+//                long offset, long limit,
+//                IndexInRangeOperation<E, M> defaultImpl)
+bool LibraryCallKit::inline_vector_index_in_range() {
+  const TypeInstPtr* mask_klass   = gvn().type(argument(0))->isa_instptr();
+  const TypeInstPtr* elem_klass   = gvn().type(argument(1))->isa_instptr();
+  const TypeInt*     vlen         = gvn().type(argument(2))->isa_int();
+
+  if (mask_klass == NULL || elem_klass == NULL || vlen == NULL ||
+      mask_klass->const_oop() == NULL || elem_klass->const_oop() == NULL || !vlen->is_con()) {
+    if (C->print_intrinsics()) {
+      tty->print_cr("  ** missing constant: mclass=%s etype=%s vlen=%s",
+                    NodeClassNames[argument(0)->Opcode()],
+                    NodeClassNames[argument(1)->Opcode()],
+                    NodeClassNames[argument(2)->Opcode()]);
+    }
+    return false; // not enough info for intrinsification
+  }
+
+  if (!is_klass_initialized(mask_klass)) {
+    if (C->print_intrinsics()) {
+      tty->print_cr("  ** klass argument not initialized");
+    }
+    return false;
+  }
+
+  ciType* elem_type = elem_klass->const_oop()->as_instance()->java_mirror_type();
+  if (!elem_type->is_primitive_type()) {
+    if (C->print_intrinsics()) {
+      tty->print_cr("  ** not a primitive bt=%d", elem_type->basic_type());
+    }
+    return false; // should be primitive type
+  }
+
+  int num_elem = vlen->get_con();
+  BasicType elem_bt = elem_type->basic_type();
+
+  // Check whether the necessary ops are supported by current hardware.
+  bool supports_mask_gen = arch_supports_vector(Op_VectorMaskGen, num_elem, elem_bt, VecMaskUseStore);
+  if (!supports_mask_gen) {
+    if (!arch_supports_vector(Op_VectorLoadConst, num_elem, elem_bt, VecMaskNotUsed) ||
+        !arch_supports_vector(VectorNode::replicate_opcode(elem_bt), num_elem, elem_bt, VecMaskNotUsed) ||
+        !arch_supports_vector(Op_VectorMaskCmp, num_elem, elem_bt, VecMaskUseStore)) {
+      if (C->print_intrinsics()) {
+        tty->print_cr("  ** not supported: vlen=%d etype=%s", num_elem, type2name(elem_bt));
+      }
+      return false; // not supported
+    }
+
+    // Check whether the scalar cast operation is supported by current hardware.
+    if (elem_bt != T_LONG) {
+      int cast_op = is_integral_type(elem_bt) ? Op_ConvL2I
+                                              : (elem_bt == T_FLOAT ? Op_ConvL2F : Op_ConvL2D);
+      if (!Matcher::match_rule_supported(cast_op)) {
+        if (C->print_intrinsics()) {
+          tty->print_cr("  ** Rejected op (%s) because architecture does not support it",
+                        NodeClassNames[cast_op]);
+        }
+        return false; // not supported
+      }
+    }
+  }
+
+  Node* offset = argument(3);
+  Node* limit = argument(5);
+  if (offset == NULL || limit == NULL) {
+    if (C->print_intrinsics()) {
+      tty->print_cr("  ** offset or limit argument is NULL");
+    }
+    return false; // not supported
+  }
+
+  ciKlass* box_klass = mask_klass->const_oop()->as_instance()->java_lang_Class_klass();
+  assert(is_vector_mask(box_klass), "argument(0) should be a mask class");
+  const TypeInstPtr* box_type = TypeInstPtr::make_exact(TypePtr::NotNull, box_klass);
+
+  // We assume "offset > 0 && limit >= offset && limit - offset < num_elem".
+  // So directly get indexLimit with "indexLimit = limit - offset".
+  Node* indexLimit = gvn().transform(new SubLNode(limit, offset));
+  Node* mask = NULL;
+  if (supports_mask_gen) {
+    mask = gvn().transform(VectorMaskGenNode::make(indexLimit, elem_bt, num_elem));
+  } else {
+    // Generate the vector mask based on "mask = iota < indexLimit".
+    // Broadcast "indexLimit" to a vector.
+    switch (elem_bt) {
+      case T_BOOLEAN: // fall-through
+      case T_BYTE:    // fall-through
+      case T_SHORT:   // fall-through
+      case T_CHAR:    // fall-through
+      case T_INT: {
+        indexLimit = gvn().transform(new ConvL2INode(indexLimit));
+        break;
+      }
+      case T_DOUBLE: {
+        indexLimit = gvn().transform(new ConvL2DNode(indexLimit));
+        break;
+      }
+      case T_FLOAT: {
+        indexLimit = gvn().transform(new ConvL2FNode(indexLimit));
+        break;
+      }
+      case T_LONG: {
+        // no conversion needed
+        break;
+      }
+      default: fatal("%s", type2name(elem_bt));
+    }
+    indexLimit = gvn().transform(VectorNode::scalar2vector(indexLimit, num_elem, Type::get_const_basic_type(elem_bt)));
+
+    // Load the "iota" vector.
+    const TypeVect* vt = TypeVect::make(elem_bt, num_elem);
+    Node* iota = gvn().transform(new VectorLoadConstNode(gvn().makecon(TypeInt::ZERO), vt));
+
+    // Compute the vector mask with "mask = iota < indexLimit".
+    ConINode* pred_node = (ConINode*)gvn().makecon(TypeInt::make(BoolTest::lt));
+    const TypeVect* vmask_type = TypeVect::makemask(elem_bt, num_elem);
+    mask = gvn().transform(new VectorMaskCmpNode(BoolTest::lt, iota, indexLimit, pred_node, vmask_type));
+  }
+  Node* vbox = box_vector(mask, box_type, elem_bt, num_elem);
+  set_result(vbox);
+  C->set_max_vector_size(MAX2(C->max_vector_size(), (uint)(num_elem * type2aelembytes(elem_bt))));
+  return true;
+}

--- a/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
+++ b/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
@@ -211,8 +211,8 @@ public class VectorSupport {
     }
 
     /* ============================================================================ */
-    public interface IndexInRangeOperation<E,
-                                           M extends VectorMask<E>> {
+    public interface IndexPartiallyInUpperRangeOperation<E,
+                                                         M extends VectorMask<E>> {
         M apply(long offset, long limit);
     }
 
@@ -220,9 +220,9 @@ public class VectorSupport {
     public static
     <E,
      M extends VectorMask<E>>
-    M indexInRange(Class<? extends M> mClass, Class<E> eClass, int length,
-                   long offset, long limit,
-                   IndexInRangeOperation<E, M> defaultImpl) {
+    M indexPartiallyInUpperRange(Class<? extends M> mClass, Class<E> eClass,
+                                 int length, long offset, long limit,
+                                 IndexPartiallyInUpperRangeOperation<E, M> defaultImpl) {
         assert isNonCapturingLambda(defaultImpl) : defaultImpl;
         return defaultImpl.apply(offset, limit);
     }

--- a/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
+++ b/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -208,6 +208,23 @@ public class VectorSupport {
                        FromBitsCoercedOperation<VM, S> defaultImpl) {
         assert isNonCapturingLambda(defaultImpl) : defaultImpl;
         return defaultImpl.fromBits(bits, s);
+    }
+
+    /* ============================================================================ */
+    public interface IndexInRangeOperation<E,
+                                           M extends VectorMask<E>> {
+        M apply(long offset, long limit);
+    }
+
+    @IntrinsicCandidate
+    public static
+    <E,
+     M extends VectorMask<E>>
+    M indexInRange(Class<? extends M> mClass, Class<E> eClass, int length,
+                   long offset, long limit,
+                   IndexInRangeOperation<E, M> defaultImpl) {
+        assert isNonCapturingLambda(defaultImpl) : defaultImpl;
+        return defaultImpl.apply(offset, limit);
     }
 
     /* ============================================================================ */

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
@@ -197,7 +197,7 @@ abstract class AbstractMask<E> extends VectorMask<E> {
 
     /*package-private*/
     @ForceInline
-    VectorMask<E> indexInRange0Helper(int offset, int limit) {
+    VectorMask<E> indexPartiallyInRange(int offset, int limit) {
         int vlength = length();
         Vector<E> iota = vectorSpecies().zero().addIndex(1);
         VectorMask<E> badMask = checkIndex0(offset, limit, iota, vlength);
@@ -206,7 +206,7 @@ abstract class AbstractMask<E> extends VectorMask<E> {
 
     /*package-private*/
     @ForceInline
-    VectorMask<E> indexInRange0Helper(long offset, long limit) {
+    VectorMask<E> indexPartiallyInRange(long offset, long limit) {
         int vlength = length();
         Vector<E> iota = vectorSpecies().zero().addIndex(1);
         VectorMask<E> badMask = checkIndex0(offset, limit, iota, vlength);
@@ -217,29 +217,28 @@ abstract class AbstractMask<E> extends VectorMask<E> {
     @ForceInline
     public VectorMask<E> indexInRange(int offset, int limit) {
         if (offset < 0) {
-            return this.and(indexInRange0Helper(offset, limit));
+            return this.and(indexPartiallyInRange(offset, limit));
         } else if (offset >= limit) {
             return vectorSpecies().maskAll(false);
         } else if (limit - offset >= length()) {
             return this;
         }
-        return this.and(indexInRange0(offset, limit));
+        return this.and(indexPartiallyInUpperRange(offset, limit));
     }
 
-    @Override
     @ForceInline
     public VectorMask<E> indexInRange(long offset, long limit) {
         if (offset < 0) {
-            return this.and(indexInRange0Helper(offset, limit));
+            return this.and(indexPartiallyInRange(offset, limit));
         } else if (offset >= limit) {
             return vectorSpecies().maskAll(false);
         } else if (limit - offset >= length()) {
             return this;
         }
-        return this.and(indexInRange0(offset, limit));
+        return this.and(indexPartiallyInUpperRange(offset, limit));
     }
 
-    abstract VectorMask<E> indexInRange0(long offset, long limit);
+    abstract VectorMask<E> indexPartiallyInUpperRange(long offset, long limit);
 
     /*package-private*/
     @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
@@ -688,10 +688,10 @@ final class Byte128Vector extends ByteVector {
         @Override
         @ForceInline
         /*package-private*/
-        Byte128Mask indexInRange0(long offset, long limit) {
-            return (Byte128Mask) VectorSupport.indexInRange(
+        Byte128Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Byte128Mask) VectorSupport.indexPartiallyInUpperRange(
                 Byte128Mask.class, byte.class, VLENGTH, offset, limit,
-                (o, l) -> (Byte128Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Byte128Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -683,6 +683,15 @@ final class Byte128Vector extends ByteVector {
             Objects.requireNonNull(mask);
             Byte128Mask m = (Byte128Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Byte128Mask indexInRange0(long offset, long limit) {
+            return (Byte128Mask) VectorSupport.indexInRange(
+                Byte128Mask.class, byte.class, VLENGTH, offset, limit,
+                (o, l) -> (Byte128Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
@@ -720,10 +720,10 @@ final class Byte256Vector extends ByteVector {
         @Override
         @ForceInline
         /*package-private*/
-        Byte256Mask indexInRange0(long offset, long limit) {
-            return (Byte256Mask) VectorSupport.indexInRange(
+        Byte256Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Byte256Mask) VectorSupport.indexPartiallyInUpperRange(
                 Byte256Mask.class, byte.class, VLENGTH, offset, limit,
-                (o, l) -> (Byte256Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Byte256Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -715,6 +715,15 @@ final class Byte256Vector extends ByteVector {
             Objects.requireNonNull(mask);
             Byte256Mask m = (Byte256Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Byte256Mask indexInRange0(long offset, long limit) {
+            return (Byte256Mask) VectorSupport.indexInRange(
+                Byte256Mask.class, byte.class, VLENGTH, offset, limit,
+                (o, l) -> (Byte256Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
@@ -784,10 +784,10 @@ final class Byte512Vector extends ByteVector {
         @Override
         @ForceInline
         /*package-private*/
-        Byte512Mask indexInRange0(long offset, long limit) {
-            return (Byte512Mask) VectorSupport.indexInRange(
+        Byte512Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Byte512Mask) VectorSupport.indexPartiallyInUpperRange(
                 Byte512Mask.class, byte.class, VLENGTH, offset, limit,
-                (o, l) -> (Byte512Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Byte512Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -779,6 +779,15 @@ final class Byte512Vector extends ByteVector {
             Objects.requireNonNull(mask);
             Byte512Mask m = (Byte512Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Byte512Mask indexInRange0(long offset, long limit) {
+            return (Byte512Mask) VectorSupport.indexInRange(
+                Byte512Mask.class, byte.class, VLENGTH, offset, limit,
+                (o, l) -> (Byte512Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
@@ -672,10 +672,10 @@ final class Byte64Vector extends ByteVector {
         @Override
         @ForceInline
         /*package-private*/
-        Byte64Mask indexInRange0(long offset, long limit) {
-            return (Byte64Mask) VectorSupport.indexInRange(
+        Byte64Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Byte64Mask) VectorSupport.indexPartiallyInUpperRange(
                 Byte64Mask.class, byte.class, VLENGTH, offset, limit,
-                (o, l) -> (Byte64Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Byte64Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -667,6 +667,15 @@ final class Byte64Vector extends ByteVector {
             Objects.requireNonNull(mask);
             Byte64Mask m = (Byte64Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Byte64Mask indexInRange0(long offset, long limit) {
+            return (Byte64Mask) VectorSupport.indexInRange(
+                Byte64Mask.class, byte.class, VLENGTH, offset, limit,
+                (o, l) -> (Byte64Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
@@ -658,10 +658,10 @@ final class ByteMaxVector extends ByteVector {
         @Override
         @ForceInline
         /*package-private*/
-        ByteMaxMask indexInRange0(long offset, long limit) {
-            return (ByteMaxMask) VectorSupport.indexInRange(
+        ByteMaxMask indexPartiallyInUpperRange(long offset, long limit) {
+            return (ByteMaxMask) VectorSupport.indexPartiallyInUpperRange(
                 ByteMaxMask.class, byte.class, VLENGTH, offset, limit,
-                (o, l) -> (ByteMaxMask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (ByteMaxMask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -653,6 +653,15 @@ final class ByteMaxVector extends ByteVector {
             Objects.requireNonNull(mask);
             ByteMaxMask m = (ByteMaxMask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        ByteMaxMask indexInRange0(long offset, long limit) {
+            return (ByteMaxMask) VectorSupport.indexInRange(
+                ByteMaxMask.class, byte.class, VLENGTH, offset, limit,
+                (o, l) -> (ByteMaxMask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
@@ -649,10 +649,10 @@ final class Double128Vector extends DoubleVector {
         @Override
         @ForceInline
         /*package-private*/
-        Double128Mask indexInRange0(long offset, long limit) {
-            return (Double128Mask) VectorSupport.indexInRange(
+        Double128Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Double128Mask) VectorSupport.indexPartiallyInUpperRange(
                 Double128Mask.class, double.class, VLENGTH, offset, limit,
-                (o, l) -> (Double128Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Double128Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -644,6 +644,15 @@ final class Double128Vector extends DoubleVector {
             Objects.requireNonNull(mask);
             Double128Mask m = (Double128Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Double128Mask indexInRange0(long offset, long limit) {
+            return (Double128Mask) VectorSupport.indexInRange(
+                Double128Mask.class, double.class, VLENGTH, offset, limit,
+                (o, l) -> (Double128Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
@@ -653,10 +653,10 @@ final class Double256Vector extends DoubleVector {
         @Override
         @ForceInline
         /*package-private*/
-        Double256Mask indexInRange0(long offset, long limit) {
-            return (Double256Mask) VectorSupport.indexInRange(
+        Double256Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Double256Mask) VectorSupport.indexPartiallyInUpperRange(
                 Double256Mask.class, double.class, VLENGTH, offset, limit,
-                (o, l) -> (Double256Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Double256Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -648,6 +648,15 @@ final class Double256Vector extends DoubleVector {
             Objects.requireNonNull(mask);
             Double256Mask m = (Double256Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Double256Mask indexInRange0(long offset, long limit) {
+            return (Double256Mask) VectorSupport.indexInRange(
+                Double256Mask.class, double.class, VLENGTH, offset, limit,
+                (o, l) -> (Double256Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
@@ -661,10 +661,10 @@ final class Double512Vector extends DoubleVector {
         @Override
         @ForceInline
         /*package-private*/
-        Double512Mask indexInRange0(long offset, long limit) {
-            return (Double512Mask) VectorSupport.indexInRange(
+        Double512Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Double512Mask) VectorSupport.indexPartiallyInUpperRange(
                 Double512Mask.class, double.class, VLENGTH, offset, limit,
-                (o, l) -> (Double512Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Double512Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -656,6 +656,15 @@ final class Double512Vector extends DoubleVector {
             Objects.requireNonNull(mask);
             Double512Mask m = (Double512Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Double512Mask indexInRange0(long offset, long limit) {
+            return (Double512Mask) VectorSupport.indexInRange(
+                Double512Mask.class, double.class, VLENGTH, offset, limit,
+                (o, l) -> (Double512Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
@@ -647,10 +647,10 @@ final class Double64Vector extends DoubleVector {
         @Override
         @ForceInline
         /*package-private*/
-        Double64Mask indexInRange0(long offset, long limit) {
-            return (Double64Mask) VectorSupport.indexInRange(
+        Double64Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Double64Mask) VectorSupport.indexPartiallyInUpperRange(
                 Double64Mask.class, double.class, VLENGTH, offset, limit,
-                (o, l) -> (Double64Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Double64Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -642,6 +642,15 @@ final class Double64Vector extends DoubleVector {
             Objects.requireNonNull(mask);
             Double64Mask m = (Double64Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Double64Mask indexInRange0(long offset, long limit) {
+            return (Double64Mask) VectorSupport.indexInRange(
+                Double64Mask.class, double.class, VLENGTH, offset, limit,
+                (o, l) -> (Double64Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
@@ -646,10 +646,10 @@ final class DoubleMaxVector extends DoubleVector {
         @Override
         @ForceInline
         /*package-private*/
-        DoubleMaxMask indexInRange0(long offset, long limit) {
-            return (DoubleMaxMask) VectorSupport.indexInRange(
+        DoubleMaxMask indexPartiallyInUpperRange(long offset, long limit) {
+            return (DoubleMaxMask) VectorSupport.indexPartiallyInUpperRange(
                 DoubleMaxMask.class, double.class, VLENGTH, offset, limit,
-                (o, l) -> (DoubleMaxMask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (DoubleMaxMask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -641,6 +641,15 @@ final class DoubleMaxVector extends DoubleVector {
             Objects.requireNonNull(mask);
             DoubleMaxMask m = (DoubleMaxMask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        DoubleMaxMask indexInRange0(long offset, long limit) {
+            return (DoubleMaxMask) VectorSupport.indexInRange(
+                DoubleMaxMask.class, double.class, VLENGTH, offset, limit,
+                (o, l) -> (DoubleMaxMask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
@@ -653,10 +653,10 @@ final class Float128Vector extends FloatVector {
         @Override
         @ForceInline
         /*package-private*/
-        Float128Mask indexInRange0(long offset, long limit) {
-            return (Float128Mask) VectorSupport.indexInRange(
+        Float128Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Float128Mask) VectorSupport.indexPartiallyInUpperRange(
                 Float128Mask.class, float.class, VLENGTH, offset, limit,
-                (o, l) -> (Float128Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Float128Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -648,6 +648,15 @@ final class Float128Vector extends FloatVector {
             Objects.requireNonNull(mask);
             Float128Mask m = (Float128Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Float128Mask indexInRange0(long offset, long limit) {
+            return (Float128Mask) VectorSupport.indexInRange(
+                Float128Mask.class, float.class, VLENGTH, offset, limit,
+                (o, l) -> (Float128Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
@@ -661,10 +661,10 @@ final class Float256Vector extends FloatVector {
         @Override
         @ForceInline
         /*package-private*/
-        Float256Mask indexInRange0(long offset, long limit) {
-            return (Float256Mask) VectorSupport.indexInRange(
+        Float256Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Float256Mask) VectorSupport.indexPartiallyInUpperRange(
                 Float256Mask.class, float.class, VLENGTH, offset, limit,
-                (o, l) -> (Float256Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Float256Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -656,6 +656,15 @@ final class Float256Vector extends FloatVector {
             Objects.requireNonNull(mask);
             Float256Mask m = (Float256Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Float256Mask indexInRange0(long offset, long limit) {
+            return (Float256Mask) VectorSupport.indexInRange(
+                Float256Mask.class, float.class, VLENGTH, offset, limit,
+                (o, l) -> (Float256Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
@@ -677,10 +677,10 @@ final class Float512Vector extends FloatVector {
         @Override
         @ForceInline
         /*package-private*/
-        Float512Mask indexInRange0(long offset, long limit) {
-            return (Float512Mask) VectorSupport.indexInRange(
+        Float512Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Float512Mask) VectorSupport.indexPartiallyInUpperRange(
                 Float512Mask.class, float.class, VLENGTH, offset, limit,
-                (o, l) -> (Float512Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Float512Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -672,6 +672,15 @@ final class Float512Vector extends FloatVector {
             Objects.requireNonNull(mask);
             Float512Mask m = (Float512Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Float512Mask indexInRange0(long offset, long limit) {
+            return (Float512Mask) VectorSupport.indexInRange(
+                Float512Mask.class, float.class, VLENGTH, offset, limit,
+                (o, l) -> (Float512Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
@@ -649,10 +649,10 @@ final class Float64Vector extends FloatVector {
         @Override
         @ForceInline
         /*package-private*/
-        Float64Mask indexInRange0(long offset, long limit) {
-            return (Float64Mask) VectorSupport.indexInRange(
+        Float64Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Float64Mask) VectorSupport.indexPartiallyInUpperRange(
                 Float64Mask.class, float.class, VLENGTH, offset, limit,
-                (o, l) -> (Float64Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Float64Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -644,6 +644,15 @@ final class Float64Vector extends FloatVector {
             Objects.requireNonNull(mask);
             Float64Mask m = (Float64Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Float64Mask indexInRange0(long offset, long limit) {
+            return (Float64Mask) VectorSupport.indexInRange(
+                Float64Mask.class, float.class, VLENGTH, offset, limit,
+                (o, l) -> (Float64Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
@@ -646,10 +646,10 @@ final class FloatMaxVector extends FloatVector {
         @Override
         @ForceInline
         /*package-private*/
-        FloatMaxMask indexInRange0(long offset, long limit) {
-            return (FloatMaxMask) VectorSupport.indexInRange(
+        FloatMaxMask indexPartiallyInUpperRange(long offset, long limit) {
+            return (FloatMaxMask) VectorSupport.indexPartiallyInUpperRange(
                 FloatMaxMask.class, float.class, VLENGTH, offset, limit,
-                (o, l) -> (FloatMaxMask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (FloatMaxMask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -641,6 +641,15 @@ final class FloatMaxVector extends FloatVector {
             Objects.requireNonNull(mask);
             FloatMaxMask m = (FloatMaxMask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        FloatMaxMask indexInRange0(long offset, long limit) {
+            return (FloatMaxMask) VectorSupport.indexInRange(
+                FloatMaxMask.class, float.class, VLENGTH, offset, limit,
+                (o, l) -> (FloatMaxMask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
@@ -664,10 +664,10 @@ final class Int128Vector extends IntVector {
         @Override
         @ForceInline
         /*package-private*/
-        Int128Mask indexInRange0(long offset, long limit) {
-            return (Int128Mask) VectorSupport.indexInRange(
+        Int128Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Int128Mask) VectorSupport.indexPartiallyInUpperRange(
                 Int128Mask.class, int.class, VLENGTH, offset, limit,
-                (o, l) -> (Int128Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Int128Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -659,6 +659,15 @@ final class Int128Vector extends IntVector {
             Objects.requireNonNull(mask);
             Int128Mask m = (Int128Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Int128Mask indexInRange0(long offset, long limit) {
+            return (Int128Mask) VectorSupport.indexInRange(
+                Int128Mask.class, int.class, VLENGTH, offset, limit,
+                (o, l) -> (Int128Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
@@ -672,10 +672,10 @@ final class Int256Vector extends IntVector {
         @Override
         @ForceInline
         /*package-private*/
-        Int256Mask indexInRange0(long offset, long limit) {
-            return (Int256Mask) VectorSupport.indexInRange(
+        Int256Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Int256Mask) VectorSupport.indexPartiallyInUpperRange(
                 Int256Mask.class, int.class, VLENGTH, offset, limit,
-                (o, l) -> (Int256Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Int256Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -667,6 +667,15 @@ final class Int256Vector extends IntVector {
             Objects.requireNonNull(mask);
             Int256Mask m = (Int256Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Int256Mask indexInRange0(long offset, long limit) {
+            return (Int256Mask) VectorSupport.indexInRange(
+                Int256Mask.class, int.class, VLENGTH, offset, limit,
+                (o, l) -> (Int256Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
@@ -688,10 +688,10 @@ final class Int512Vector extends IntVector {
         @Override
         @ForceInline
         /*package-private*/
-        Int512Mask indexInRange0(long offset, long limit) {
-            return (Int512Mask) VectorSupport.indexInRange(
+        Int512Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Int512Mask) VectorSupport.indexPartiallyInUpperRange(
                 Int512Mask.class, int.class, VLENGTH, offset, limit,
-                (o, l) -> (Int512Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Int512Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -683,6 +683,15 @@ final class Int512Vector extends IntVector {
             Objects.requireNonNull(mask);
             Int512Mask m = (Int512Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Int512Mask indexInRange0(long offset, long limit) {
+            return (Int512Mask) VectorSupport.indexInRange(
+                Int512Mask.class, int.class, VLENGTH, offset, limit,
+                (o, l) -> (Int512Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
@@ -660,10 +660,10 @@ final class Int64Vector extends IntVector {
         @Override
         @ForceInline
         /*package-private*/
-        Int64Mask indexInRange0(long offset, long limit) {
-            return (Int64Mask) VectorSupport.indexInRange(
+        Int64Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Int64Mask) VectorSupport.indexPartiallyInUpperRange(
                 Int64Mask.class, int.class, VLENGTH, offset, limit,
-                (o, l) -> (Int64Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Int64Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -655,6 +655,15 @@ final class Int64Vector extends IntVector {
             Objects.requireNonNull(mask);
             Int64Mask m = (Int64Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Int64Mask indexInRange0(long offset, long limit) {
+            return (Int64Mask) VectorSupport.indexInRange(
+                Int64Mask.class, int.class, VLENGTH, offset, limit,
+                (o, l) -> (Int64Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
@@ -658,10 +658,10 @@ final class IntMaxVector extends IntVector {
         @Override
         @ForceInline
         /*package-private*/
-        IntMaxMask indexInRange0(long offset, long limit) {
-            return (IntMaxMask) VectorSupport.indexInRange(
+        IntMaxMask indexPartiallyInUpperRange(long offset, long limit) {
+            return (IntMaxMask) VectorSupport.indexPartiallyInUpperRange(
                 IntMaxMask.class, int.class, VLENGTH, offset, limit,
-                (o, l) -> (IntMaxMask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (IntMaxMask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -653,6 +653,15 @@ final class IntMaxVector extends IntVector {
             Objects.requireNonNull(mask);
             IntMaxMask m = (IntMaxMask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        IntMaxMask indexInRange0(long offset, long limit) {
+            return (IntMaxMask) VectorSupport.indexInRange(
+                IntMaxMask.class, int.class, VLENGTH, offset, limit,
+                (o, l) -> (IntMaxMask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
@@ -650,10 +650,10 @@ final class Long128Vector extends LongVector {
         @Override
         @ForceInline
         /*package-private*/
-        Long128Mask indexInRange0(long offset, long limit) {
-            return (Long128Mask) VectorSupport.indexInRange(
+        Long128Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Long128Mask) VectorSupport.indexPartiallyInUpperRange(
                 Long128Mask.class, long.class, VLENGTH, offset, limit,
-                (o, l) -> (Long128Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Long128Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -645,6 +645,15 @@ final class Long128Vector extends LongVector {
             Objects.requireNonNull(mask);
             Long128Mask m = (Long128Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Long128Mask indexInRange0(long offset, long limit) {
+            return (Long128Mask) VectorSupport.indexInRange(
+                Long128Mask.class, long.class, VLENGTH, offset, limit,
+                (o, l) -> (Long128Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
@@ -654,10 +654,10 @@ final class Long256Vector extends LongVector {
         @Override
         @ForceInline
         /*package-private*/
-        Long256Mask indexInRange0(long offset, long limit) {
-            return (Long256Mask) VectorSupport.indexInRange(
+        Long256Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Long256Mask) VectorSupport.indexPartiallyInUpperRange(
                 Long256Mask.class, long.class, VLENGTH, offset, limit,
-                (o, l) -> (Long256Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Long256Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -649,6 +649,15 @@ final class Long256Vector extends LongVector {
             Objects.requireNonNull(mask);
             Long256Mask m = (Long256Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Long256Mask indexInRange0(long offset, long limit) {
+            return (Long256Mask) VectorSupport.indexInRange(
+                Long256Mask.class, long.class, VLENGTH, offset, limit,
+                (o, l) -> (Long256Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
@@ -662,10 +662,10 @@ final class Long512Vector extends LongVector {
         @Override
         @ForceInline
         /*package-private*/
-        Long512Mask indexInRange0(long offset, long limit) {
-            return (Long512Mask) VectorSupport.indexInRange(
+        Long512Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Long512Mask) VectorSupport.indexPartiallyInUpperRange(
                 Long512Mask.class, long.class, VLENGTH, offset, limit,
-                (o, l) -> (Long512Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Long512Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -657,6 +657,15 @@ final class Long512Vector extends LongVector {
             Objects.requireNonNull(mask);
             Long512Mask m = (Long512Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Long512Mask indexInRange0(long offset, long limit) {
+            return (Long512Mask) VectorSupport.indexInRange(
+                Long512Mask.class, long.class, VLENGTH, offset, limit,
+                (o, l) -> (Long512Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
@@ -648,10 +648,10 @@ final class Long64Vector extends LongVector {
         @Override
         @ForceInline
         /*package-private*/
-        Long64Mask indexInRange0(long offset, long limit) {
-            return (Long64Mask) VectorSupport.indexInRange(
+        Long64Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Long64Mask) VectorSupport.indexPartiallyInUpperRange(
                 Long64Mask.class, long.class, VLENGTH, offset, limit,
-                (o, l) -> (Long64Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Long64Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -643,6 +643,15 @@ final class Long64Vector extends LongVector {
             Objects.requireNonNull(mask);
             Long64Mask m = (Long64Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Long64Mask indexInRange0(long offset, long limit) {
+            return (Long64Mask) VectorSupport.indexInRange(
+                Long64Mask.class, long.class, VLENGTH, offset, limit,
+                (o, l) -> (Long64Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
@@ -648,10 +648,10 @@ final class LongMaxVector extends LongVector {
         @Override
         @ForceInline
         /*package-private*/
-        LongMaxMask indexInRange0(long offset, long limit) {
-            return (LongMaxMask) VectorSupport.indexInRange(
+        LongMaxMask indexPartiallyInUpperRange(long offset, long limit) {
+            return (LongMaxMask) VectorSupport.indexPartiallyInUpperRange(
                 LongMaxMask.class, long.class, VLENGTH, offset, limit,
-                (o, l) -> (LongMaxMask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (LongMaxMask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -643,6 +643,15 @@ final class LongMaxVector extends LongVector {
             Objects.requireNonNull(mask);
             LongMaxMask m = (LongMaxMask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        LongMaxMask indexInRange0(long offset, long limit) {
+            return (LongMaxMask) VectorSupport.indexInRange(
+                LongMaxMask.class, long.class, VLENGTH, offset, limit,
+                (o, l) -> (LongMaxMask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
@@ -672,10 +672,10 @@ final class Short128Vector extends ShortVector {
         @Override
         @ForceInline
         /*package-private*/
-        Short128Mask indexInRange0(long offset, long limit) {
-            return (Short128Mask) VectorSupport.indexInRange(
+        Short128Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Short128Mask) VectorSupport.indexPartiallyInUpperRange(
                 Short128Mask.class, short.class, VLENGTH, offset, limit,
-                (o, l) -> (Short128Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Short128Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -667,6 +667,15 @@ final class Short128Vector extends ShortVector {
             Objects.requireNonNull(mask);
             Short128Mask m = (Short128Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Short128Mask indexInRange0(long offset, long limit) {
+            return (Short128Mask) VectorSupport.indexInRange(
+                Short128Mask.class, short.class, VLENGTH, offset, limit,
+                (o, l) -> (Short128Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
@@ -688,10 +688,10 @@ final class Short256Vector extends ShortVector {
         @Override
         @ForceInline
         /*package-private*/
-        Short256Mask indexInRange0(long offset, long limit) {
-            return (Short256Mask) VectorSupport.indexInRange(
+        Short256Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Short256Mask) VectorSupport.indexPartiallyInUpperRange(
                 Short256Mask.class, short.class, VLENGTH, offset, limit,
-                (o, l) -> (Short256Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Short256Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -683,6 +683,15 @@ final class Short256Vector extends ShortVector {
             Objects.requireNonNull(mask);
             Short256Mask m = (Short256Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Short256Mask indexInRange0(long offset, long limit) {
+            return (Short256Mask) VectorSupport.indexInRange(
+                Short256Mask.class, short.class, VLENGTH, offset, limit,
+                (o, l) -> (Short256Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
@@ -720,10 +720,10 @@ final class Short512Vector extends ShortVector {
         @Override
         @ForceInline
         /*package-private*/
-        Short512Mask indexInRange0(long offset, long limit) {
-            return (Short512Mask) VectorSupport.indexInRange(
+        Short512Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Short512Mask) VectorSupport.indexPartiallyInUpperRange(
                 Short512Mask.class, short.class, VLENGTH, offset, limit,
-                (o, l) -> (Short512Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Short512Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -715,6 +715,15 @@ final class Short512Vector extends ShortVector {
             Objects.requireNonNull(mask);
             Short512Mask m = (Short512Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Short512Mask indexInRange0(long offset, long limit) {
+            return (Short512Mask) VectorSupport.indexInRange(
+                Short512Mask.class, short.class, VLENGTH, offset, limit,
+                (o, l) -> (Short512Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
@@ -664,10 +664,10 @@ final class Short64Vector extends ShortVector {
         @Override
         @ForceInline
         /*package-private*/
-        Short64Mask indexInRange0(long offset, long limit) {
-            return (Short64Mask) VectorSupport.indexInRange(
+        Short64Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Short64Mask) VectorSupport.indexPartiallyInUpperRange(
                 Short64Mask.class, short.class, VLENGTH, offset, limit,
-                (o, l) -> (Short64Mask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (Short64Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -659,6 +659,15 @@ final class Short64Vector extends ShortVector {
             Objects.requireNonNull(mask);
             Short64Mask m = (Short64Mask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        Short64Mask indexInRange0(long offset, long limit) {
+            return (Short64Mask) VectorSupport.indexInRange(
+                Short64Mask.class, short.class, VLENGTH, offset, limit,
+                (o, l) -> (Short64Mask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
@@ -658,10 +658,10 @@ final class ShortMaxVector extends ShortVector {
         @Override
         @ForceInline
         /*package-private*/
-        ShortMaxMask indexInRange0(long offset, long limit) {
-            return (ShortMaxMask) VectorSupport.indexInRange(
+        ShortMaxMask indexPartiallyInUpperRange(long offset, long limit) {
+            return (ShortMaxMask) VectorSupport.indexPartiallyInUpperRange(
                 ShortMaxMask.class, short.class, VLENGTH, offset, limit,
-                (o, l) -> (ShortMaxMask) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> (ShortMaxMask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -653,6 +653,15 @@ final class ShortMaxVector extends ShortVector {
             Objects.requireNonNull(mask);
             ShortMaxMask m = (ShortMaxMask)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        ShortMaxMask indexInRange0(long offset, long limit) {
+            return (ShortMaxMask) VectorSupport.indexInRange(
+                ShortMaxMask.class, short.class, VLENGTH, offset, limit,
+                (o, l) -> (ShortMaxMask) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
@@ -931,10 +931,10 @@ final class $vectortype$ extends $abstractvectortype$ {
         @Override
         @ForceInline
         /*package-private*/
-        $masktype$ indexInRange0(long offset, long limit) {
-            return ($masktype$) VectorSupport.indexInRange(
+        $masktype$ indexPartiallyInUpperRange(long offset, long limit) {
+            return ($masktype$) VectorSupport.indexPartiallyInUpperRange(
                 $masktype$.class, $type$.class, VLENGTH, offset, limit,
-                (o, l) -> ($masktype$) TRUE_MASK.indexInRange0Helper(o, l));
+                (o, l) -> ($masktype$) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -926,6 +926,15 @@ final class $vectortype$ extends $abstractvectortype$ {
             Objects.requireNonNull(mask);
             $masktype$ m = ($masktype$)mask;
             return xor(m.not());
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        $masktype$ indexInRange0(long offset, long limit) {
+            return ($masktype$) VectorSupport.indexInRange(
+                $masktype$.class, $type$.class, VLENGTH, offset, limit,
+                (o, l) -> ($masktype$) TRUE_MASK.indexInRange0Helper(o, l));
         }
 
         // Unary operations

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexInRangeBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexInRangeBenchmark.java
@@ -34,7 +34,7 @@ import org.openjdk.jmh.annotations.*;
 @Measurement(iterations = 5, time = 1)
 @Fork(value = 1, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
 public class IndexInRangeBenchmark {
-    @Param({"1024", "1027"})
+    @Param({"7", "259", "1024"})
     private int size;
 
     private byte[] byteIn;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexInRangeBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexInRangeBenchmark.java
@@ -34,21 +34,10 @@ import org.openjdk.jmh.annotations.*;
 @Measurement(iterations = 5, time = 1)
 @Fork(value = 1, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
 public class IndexInRangeBenchmark {
-    @Param({"7", "259", "1024"})
+    @Param({"7", "256", "259", "512"})
     private int size;
 
-    private byte[] byteIn;
-    private byte[] byteOut;
-    private short[] shortIn;
-    private short[] shortOut;
-    private int[] intIn;
-    private int[] intOut;
-    private long[] longIn;
-    private long[] longOut;
-    private float[] floatIn;
-    private float[] floatOut;
-    private double[] doubleIn;
-    private double[] doubleOut;
+    private boolean[] mask;
 
     private static final VectorSpecies<Byte> bspecies = VectorSpecies.ofLargestShape(byte.class);
     private static final VectorSpecies<Short> sspecies = VectorSpecies.ofLargestShape(short.class);
@@ -59,34 +48,14 @@ public class IndexInRangeBenchmark {
 
     @Setup(Level.Trial)
     public void Setup() {
-        byteIn = new byte[size];
-        byteOut = new byte[size];
-        shortIn = new short[size];
-        shortOut = new short[size];
-        intIn = new int[size];
-        intOut = new int[size];
-        longIn = new long[size];
-        longOut = new long[size];
-        floatIn = new float[size];
-        floatOut = new float[size];
-        doubleIn = new double[size];
-        doubleOut = new double[size];
-
-        for (int i = 0; i < size; i++) {
-            byteIn[i] = (byte) i;
-            shortIn[i] = (short) i;
-            intIn[i] = i;
-            longIn[i] = i;
-            floatIn[i] = (float) i;
-            doubleIn[i] = (double) i;
-        }
+        mask = new boolean[512];
     }
 
     @Benchmark
     public void byteIndexInRange() {
         for (int i = 0; i < size; i += bspecies.length()) {
             var m = bspecies.indexInRange(i, size);
-            ByteVector.fromArray(bspecies, byteIn, i, m).intoArray(byteOut, i, m);
+            m.intoArray(mask, i);
         }
     }
 
@@ -94,7 +63,7 @@ public class IndexInRangeBenchmark {
     public void shortIndexInRange() {
         for (int i = 0; i < size; i += sspecies.length()) {
             var m = sspecies.indexInRange(i, size);
-            ShortVector.fromArray(sspecies, shortIn, i, m).intoArray(shortOut, i, m);
+            m.intoArray(mask, i);
         }
     }
 
@@ -102,7 +71,7 @@ public class IndexInRangeBenchmark {
     public void intIndexInRange() {
         for (int i = 0; i < size; i += ispecies.length()) {
             var m = ispecies.indexInRange(i, size);
-            IntVector.fromArray(ispecies, intIn, i, m).intoArray(intOut, i, m);
+            m.intoArray(mask, i);
         }
     }
 
@@ -110,7 +79,7 @@ public class IndexInRangeBenchmark {
     public void longIndexInRange() {
         for (int i = 0; i < size; i += lspecies.length()) {
             var m = lspecies.indexInRange(i, size);
-            LongVector.fromArray(lspecies, longIn, i, m).intoArray(longOut, i, m);
+            m.intoArray(mask, i);
         }
     }
 
@@ -118,7 +87,7 @@ public class IndexInRangeBenchmark {
     public void floatIndexInRange() {
         for (int i = 0; i < size; i += fspecies.length()) {
             var m = fspecies.indexInRange(i, size);
-            FloatVector.fromArray(fspecies, floatIn, i, m).intoArray(floatOut, i, m);
+            m.intoArray(mask, i);
         }
     }
 
@@ -126,7 +95,7 @@ public class IndexInRangeBenchmark {
     public void doubleIndexInRange() {
         for (int i = 0; i < size; i += dspecies.length()) {
             var m = dspecies.indexInRange(i, size);
-            DoubleVector.fromArray(dspecies, doubleIn, i, m).intoArray(doubleOut, i, m);
+            m.intoArray(mask, i);
         }
     }
 }

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexInRangeBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexInRangeBenchmark.java
@@ -1,0 +1,132 @@
+//
+// Copyright (c) 2023, Arm Limited. All rights reserved.
+// DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+//
+// This code is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License version 2 only, as
+// published by the Free Software Foundation.
+//
+// This code is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// version 2 for more details (a copy is included in the LICENSE file that
+// accompanied this code).
+//
+// You should have received a copy of the GNU General Public License version
+// 2 along with this work; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+// or visit www.oracle.com if you need additional information or have any
+// questions.
+//
+//
+package org.openjdk.bench.jdk.incubator.vector;
+
+import java.util.concurrent.TimeUnit;
+import jdk.incubator.vector.*;
+import org.openjdk.jmh.annotations.*;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 1, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+public class IndexInRangeBenchmark {
+    @Param({"1024", "1027"})
+    private int size;
+
+    private byte[] byteIn;
+    private byte[] byteOut;
+    private short[] shortIn;
+    private short[] shortOut;
+    private int[] intIn;
+    private int[] intOut;
+    private long[] longIn;
+    private long[] longOut;
+    private float[] floatIn;
+    private float[] floatOut;
+    private double[] doubleIn;
+    private double[] doubleOut;
+
+    private static final VectorSpecies<Byte> bspecies = VectorSpecies.ofLargestShape(byte.class);
+    private static final VectorSpecies<Short> sspecies = VectorSpecies.ofLargestShape(short.class);
+    private static final VectorSpecies<Integer> ispecies = VectorSpecies.ofLargestShape(int.class);
+    private static final VectorSpecies<Long> lspecies = VectorSpecies.ofLargestShape(long.class);
+    private static final VectorSpecies<Float> fspecies = VectorSpecies.ofLargestShape(float.class);
+    private static final VectorSpecies<Double> dspecies = VectorSpecies.ofLargestShape(double.class);
+
+    @Setup(Level.Trial)
+    public void Setup() {
+        byteIn = new byte[size];
+        byteOut = new byte[size];
+        shortIn = new short[size];
+        shortOut = new short[size];
+        intIn = new int[size];
+        intOut = new int[size];
+        longIn = new long[size];
+        longOut = new long[size];
+        floatIn = new float[size];
+        floatOut = new float[size];
+        doubleIn = new double[size];
+        doubleOut = new double[size];
+
+        for (int i = 0; i < size; i++) {
+            byteIn[i] = (byte) i;
+            shortIn[i] = (short) i;
+            intIn[i] = i;
+            longIn[i] = i;
+            floatIn[i] = (float) i;
+            doubleIn[i] = (double) i;
+        }
+    }
+
+    @Benchmark
+    public void byteIndexInRange() {
+        for (int i = 0; i < size; i += bspecies.length()) {
+            var m = bspecies.indexInRange(i, size);
+            ByteVector.fromArray(bspecies, byteIn, i, m).intoArray(byteOut, i, m);
+        }
+    }
+
+    @Benchmark
+    public void shortIndexInRange() {
+        for (int i = 0; i < size; i += sspecies.length()) {
+            var m = sspecies.indexInRange(i, size);
+            ShortVector.fromArray(sspecies, shortIn, i, m).intoArray(shortOut, i, m);
+        }
+    }
+
+    @Benchmark
+    public void intIndexInRange() {
+        for (int i = 0; i < size; i += ispecies.length()) {
+            var m = ispecies.indexInRange(i, size);
+            IntVector.fromArray(ispecies, intIn, i, m).intoArray(intOut, i, m);
+        }
+    }
+
+    @Benchmark
+    public void longIndexInRange() {
+        for (int i = 0; i < size; i += lspecies.length()) {
+            var m = lspecies.indexInRange(i, size);
+            LongVector.fromArray(lspecies, longIn, i, m).intoArray(longOut, i, m);
+        }
+    }
+
+    @Benchmark
+    public void floatIndexInRange() {
+        for (int i = 0; i < size; i += fspecies.length()) {
+            var m = fspecies.indexInRange(i, size);
+            FloatVector.fromArray(fspecies, floatIn, i, m).intoArray(floatOut, i, m);
+        }
+    }
+
+    @Benchmark
+    public void doubleIndexInRange() {
+        for (int i = 0; i < size; i += dspecies.length()) {
+            var m = dspecies.indexInRange(i, size);
+            DoubleVector.fromArray(dspecies, doubleIn, i, m).intoArray(doubleOut, i, m);
+        }
+    }
+}


### PR DESCRIPTION
The Vector API `"indexInRange(int offset, int limit)"` is used
to compute a vector mask whose lanes are set to true if the
index of the lane is inside the range specified by the `"offset"`
and `"limit"` arguments, otherwise the lanes are set to false.

There are two special cases for this API:
 1) If `"offset >= 0 && offset >= limit"`, all the lanes of the
generated mask are false.
 2) If` "offset >= 0 && limit - offset >= vlength"`, all the
lanes of the generated mask are true. Note that `"vlength"` is
the number of vector lanes.

For such special cases, we can simply use `"maskAll(false|true)"`
to implement the API. Otherwise, the original comparison with
`"iota" `vector is needed. And for further optimization, we have
optimal instruction supported by SVE (i.e. whilelo [1]), which
can implement the API directly if the `"offset >= 0"`.

As a summary, to optimize the API, we can use the if-else branches
to handle the specific cases in java level and intrinsify the
remaining case by C2 compiler:

```
  public VectorMask<E> indexInRange(int offset, int limit) {
      if (offset < 0) {
          return this.and(indexInRange0Helper(offset, limit));
      } else if (offset >= limit) {
          return this.and(vectorSpecies().maskAll(false));
      } else if (limit - offset >= length()) {
          return this.and(vectorSpecies().maskAll(true));
      }
      return this.and(indexInRange0(offset, limit));
 }
```

The last part (i.e. `"indexInRange0"`) in the above implementation
is expected to be intrinsified by C2 compiler if the necessary IRs
are supported. Otherwise, it will fall back to the original API
implementation (i.e. `"indexInRange0Helper"`). Regarding to the
intrinsifaction, the compiler will generate `"VectorMaskGen"` IR
with "limit - offset" as the input if the current platform supports
it. Otherwise, it generates `"VectorLoadConst + VectorMaskCmp"` based
on `"iota < limit - offset"`.

For the following java code which uses `"indexInRange"`:

```
static final VectorSpecies<Double> SPECIES =
                                   DoubleVector.SPECIES_PREFERRED;
static final int LENGTH = 1027;

public static double[] da;
public static double[] db;
public static double[] dc;

private static void func() {
    for (int i = 0; i < LENGTH; i += SPECIES.length()) {
        var m = SPECIES.indexInRange(i, LENGTH);
        var av = DoubleVector.fromArray(SPECIES, da, i, m);
        av.lanewise(VectorOperators.NEG).intoArray(dc, i, m);
    }
}
```

The core code generated with SVE 256-bit vector size is:

```
  ptrue   p2.d                  ; maskAll(true)
  ...
LOOP:
  ...
  sub     w11, w13, w14         ; limit - offset
  cmp     w14, w13
  b.cs    LABEL-1               ; if (offset >= limit) => uncommon-trap
  cmp     w11, #0x4
  b.lt    LABEL-2               ; if (limit - offset < vlength)
  mov     p1.b, p2.b
LABEL-3:
  ld1d    {z16.d}, p1/z, [x10]  ; load vector masked
  ...
  cmp     w14, w29
  b.cc    LOOP
  ...
LABEL-2:
  whilelo p1.d, x16, x10        ; VectorMaskGen
  ...
  b       LABEL-3
  ...
LABEL-1:
  uncommon-trap
```

Please note that if the array size `LENGTH` is aligned with
the vector size 256 (i.e. `LENGTH = 1024`), the branch "LABEL-2"
will be optimized out by compiler and it becomes another
uncommon-trap.

For NEON, the main CFG is the same with above. But the compiler
intrinsification is different. Here is the code:

```
  sub     x10, x10, x12          ; limit - offset
  scvtf   d16, x10
  dup     v16.2d, v16.d[0]       ; replicateD

  mov     x8, #0xd8d0
  movk    x8, #0x84cb, lsl #16
  movk    x8, #0xffff, lsl #32
  ldr     q17, [x8], #0          ; load the "iota" const vector
  fcmgt   v18.2d, v16.2d, v17.2d ; mask = iota < limit - offset
```

Here is the performance data of the new added benchmark on an ARM
SVE 256-bit platform:

```
Benchmark                               (size)  Before    After   Units
IndexInRangeBenchmark.byteIndexInRange   1024 11203.697 41404.431 ops/ms
IndexInRangeBenchmark.byteIndexInRange   1027  2365.920  8747.004 ops/ms
IndexInRangeBenchmark.doubleIndexInRange 1024  1227.505  6092.194 ops/ms
IndexInRangeBenchmark.doubleIndexInRange 1027   351.215  1156.683 ops/ms
IndexInRangeBenchmark.floatIndexInRange  1024  1468.876 11032.580 ops/ms
IndexInRangeBenchmark.floatIndexInRange  1027   699.645  2439.671 ops/ms
IndexInRangeBenchmark.intIndexInRange    1024  2842.187 11903.544 ops/ms
IndexInRangeBenchmark.intIndexInRange    1027   689.866  2547.424 ops/ms
IndexInRangeBenchmark.longIndexInRange   1024  1394.135  5902.973 ops/ms
IndexInRangeBenchmark.longIndexInRange   1027   355.621  1189.458 ops/ms
IndexInRangeBenchmark.shortIndexInRange  1024  5521.468 21578.340 ops/ms
IndexInRangeBenchmark.shortIndexInRange  1027  1264.816  4640.504 ops/ms

```
And the performance data with ARM NEON:

```
Benchmark                               (size)  Before    After   Units
IndexInRangeBenchmark.byteIndexInRange   1024  4026.548 15562.880 ops/ms
IndexInRangeBenchmark.byteIndexInRange   1027   305.314   576.559 ops/ms
IndexInRangeBenchmark.doubleIndexInRange 1024   289.224  2244.080 ops/ms
IndexInRangeBenchmark.doubleIndexInRange 1027    39.740    76.499 ops/ms
IndexInRangeBenchmark.floatIndexInRange  1024   675.264  4457.470 ops/ms
IndexInRangeBenchmark.floatIndexInRange  1027    79.918   144.952 ops/ms
IndexInRangeBenchmark.intIndexInRange    1024   740.139  4014.583 ops/ms
IndexInRangeBenchmark.intIndexInRange    1027    78.608   147.903 ops/ms
IndexInRangeBenchmark.longIndexInRange   1024   400.683  2209.551 ops/ms
IndexInRangeBenchmark.longIndexInRange   1027    41.146    69.599 ops/ms
IndexInRangeBenchmark.shortIndexInRange  1024  1821.736  8153.546 ops/ms
IndexInRangeBenchmark.shortIndexInRange  1027   158.810   243.205 ops/ms

```
The performance improves about `3.5x ~ 7.5x` on the vector size aligned
(1024 size) benchmarks both with NEON and SVE. And it improves about
`3.5x/1.8x` on the vector size not aligned (1027 size) benchmarks with
SVE/NEON respectively. We can also observe the similar improvement on
the x86 platforms.

[1] https://developer.arm.com/documentation/ddi0596/2020-12/SVE-Instructions/WHILELO--While-incrementing-unsigned-scalar-lower-than-scalar-

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293198](https://bugs.openjdk.org/browse/JDK-8293198): [vectorapi] Improve the implementation of VectorMask.indexInRange()


### Reviewers
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**) ⚠️ Review applies to [6f7c30be](https://git.openjdk.org/jdk/pull/12064/files/6f7c30be545442b0be18c1567580ac7b79a5380a)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer) ⚠️ Review applies to [9388e29d](https://git.openjdk.org/jdk/pull/12064/files/9388e29d7bcb1bbf136cb64e548bbd0e681e811d)
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12064/head:pull/12064` \
`$ git checkout pull/12064`

Update a local copy of the PR: \
`$ git checkout pull/12064` \
`$ git pull https://git.openjdk.org/jdk pull/12064/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12064`

View PR using the GUI difftool: \
`$ git pr show -t 12064`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12064.diff">https://git.openjdk.org/jdk/pull/12064.diff</a>

</details>
