### PR TITLE
8300488: Incorrect usage of CATCH_BAD_ALLOC as a macro call

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_TrayIcon.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_TrayIcon.cpp
@@ -1113,7 +1113,7 @@ Java_sun_awt_windows_WTrayIconPeer__1displayMessage(JNIEnv *env, jobject self,
     AwtToolkit::GetInstance().SyncCall(AwtTrayIcon::_DisplayMessage, dms);
     // global ref is deleted in _DisplayMessage
 
-    CATCH_BAD_ALLOC(NULL);
+    CATCH_BAD_ALLOC;
 }
 
 } /* extern "C" */


### PR DESCRIPTION
`CATCH_BAD_ALLOC` is a regular macro that does not take any parameters, awt_TrayIcon should not use it as a macro function as such

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300488](https://bugs.openjdk.org/browse/JDK-8300488): Incorrect usage of CATCH_BAD_ALLOC as a macro call


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12067/head:pull/12067` \
`$ git checkout pull/12067`

Update a local copy of the PR: \
`$ git checkout pull/12067` \
`$ git pull https://git.openjdk.org/jdk pull/12067/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12067`

View PR using the GUI difftool: \
`$ git pr show -t 12067`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12067.diff">https://git.openjdk.org/jdk/pull/12067.diff</a>

</details>
