### PR TITLE
8300489: Use ArraysSupport.vectorizedHashCode in j.l.CharacterName

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/Characters.java
+++ b/test/micro/org/openjdk/bench/java/lang/Characters.java
@@ -67,4 +67,17 @@ public class Characters {
     public boolean isWhitespace() {
         return Character.isWhitespace(codePoint);
     }
+
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    @Warmup(iterations = 5, time = 1)
+    @Measurement(iterations = 5, time = 1)
+    @Fork(3)
+    public static class CodePoints {
+        @Benchmark
+        public void codePointOf() {
+            Character.codePointOf("Latin Capital Letter B with hook");
+        }
+
+    }
 }


### PR DESCRIPTION
This patch makes use of `ArraysSupport.vectorizedHashCode` and helps verify the performance win also for range-based hash calculations. Also modernized and cleaned up the surrounding code somewhat. 

```
Benchmark                          Mode  Cnt    Score   Error  Units
Characters.CodePoints.codePointOf  avgt   15  153.753 ± 6.119  ns/op
Characters.CodePoints.codePointOf  avgt   15  134.753 ± 4.386  ns/op # after, 1.14x
```

For C1 and C2 on non-x86 platforms the performance is neutral. Interpreter sees a 1-2% regression due a few added calls.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300489](https://bugs.openjdk.org/browse/JDK-8300489): Use ArraysSupport.vectorizedHashCode in j.l.CharacterName


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12068/head:pull/12068` \
`$ git checkout pull/12068`

Update a local copy of the PR: \
`$ git checkout pull/12068` \
`$ git pull https://git.openjdk.org/jdk pull/12068/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12068`

View PR using the GUI difftool: \
`$ git pr show -t 12068`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12068.diff">https://git.openjdk.org/jdk/pull/12068.diff</a>

</details>
