### PR TITLE
8300119: CgroupMetrics.getTotalMemorySize0() can report invalid results on 32 bit systems

### DIFF
--- a/src/java.base/linux/native/libjava/CgroupMetrics.c
+++ b/src/java.base/linux/native/libjava/CgroupMetrics.c
@@ -39,5 +39,7 @@ JNIEXPORT jlong JNICALL
 Java_jdk_internal_platform_CgroupMetrics_getTotalMemorySize0
   (JNIEnv *env, jclass ignored)
 {
-    return sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGESIZE);
+    jlong pages = sysconf(_SC_PHYS_PAGES);
+    jlong page_size = sysconf(_SC_PAGESIZE);
+    return pages * page_size;
 }


### PR DESCRIPTION
This is a fix for https://bugs.openjdk.org/browse/JDK-8300119 (CgroupMetrics.getTotalMemorySize0() can report invalid results on 32 bit systems). Thanks to @jerboaa Severin Gehwolf for figuring out the solution.

The problem is demonstrated by test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java which fails on 32-bit x86 in HEAD, and passes after applying this patch.

I tested this on an amd64 system with a cross-compiled JDK. I needed to override the default docker container for the test, to get one with a 32-bit userland. (the precise choice was also dictated by ABI matching my main development machine):

```
$JT_HOME/bin/jtreg -v -Djdk.test.docker.retain.image=true -Djdk.test.docker.image.name=i386/debian -Djdk.test.docker.image.version=testing-slim -jdk:$JAVA_HOME test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300119](https://bugs.openjdk.org/browse/JDK-8300119): CgroupMetrics.getTotalMemorySize0() can report invalid results on 32 bit systems


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12069/head:pull/12069` \
`$ git checkout pull/12069`

Update a local copy of the PR: \
`$ git checkout pull/12069` \
`$ git pull https://git.openjdk.org/jdk pull/12069/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12069`

View PR using the GUI difftool: \
`$ git pr show -t 12069`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12069.diff">https://git.openjdk.org/jdk/pull/12069.diff</a>

</details>
