### PR TITLE
8300526: Test runtime/jni/IsVirtualThread/IsVirtualThread.java should exercise alternative virtual thread implementation

### DIFF
--- a/test/hotspot/jtreg/runtime/jni/IsVirtualThread/IsVirtualThread.java
+++ b/test/hotspot/jtreg/runtime/jni/IsVirtualThread/IsVirtualThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,11 +21,21 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test id=default
+ * @bug 8284161
  * @summary Test JNI IsVirtualThread
  * @library /test/lib
- * @compile --enable-preview -source ${jdk.version} IsVirtualThread.java
- * @run main/native/othervm --enable-preview IsVirtualThread
+ * @enablePreview
+ * @run main/native/othervm IsVirtualThread
+ */
+
+/*
+ * @test id=no-vmcontinuations
+ * @requires vm.continuations
+ * @library /test/lib
+ * @enablePreview
+ * @run main/native/othervm -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations IsVirtualThread
  */
 
 import jdk.test.lib.Asserts;
@@ -40,18 +50,24 @@ public class IsVirtualThread {
         Thread thread = Thread.ofPlatform().unstarted(LockSupport::park);
         test(thread);   // not started
         thread.start();
-        test(thread);   // started, probably parked
-        LockSupport.unpark(thread);
-        thread.join();
+        try {
+            test(thread);   // started, probably parked
+        } finally {
+            LockSupport.unpark(thread);
+            thread.join();
+        }
         test(thread);   // terminated
 
         // test virtual thread
         Thread vthread = Thread.ofVirtual().unstarted(LockSupport::park);
         test(vthread);   // not started
         vthread.start();
-        test(vthread);   // started, probably parked
-        LockSupport.unpark(vthread);
-        vthread.join();
+        try {
+            test(vthread);   // started, probably parked
+        } finally {
+            LockSupport.unpark(vthread);
+            vthread.join();
+        }
         test(vthread);   // terminated
     }
 


### PR DESCRIPTION
test/hotspot/jtreg/runtime/jni/IsVirtualThread/IsVirtualThread.java is updated to exercise JNI IsVirtualThread when running with -XX:-VMContinuations.  On ports with VMContinuations supported, the test re-runs with the alternative implementation of virtual threads to ensure that the JNI function works as expected.

While in the area, the test is changed to used the jtreg `@enablePreview` tag and also changed to put a try-finally around the test for a started thread to ensure it doesn't it unparks in the event that the test fails.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300526](https://bugs.openjdk.org/browse/JDK-8300526): Test runtime/jni/IsVirtualThread/IsVirtualThread.java should exercise alternative virtual thread implementation


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12070/head:pull/12070` \
`$ git checkout pull/12070`

Update a local copy of the PR: \
`$ git checkout pull/12070` \
`$ git pull https://git.openjdk.org/jdk pull/12070/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12070`

View PR using the GUI difftool: \
`$ git pr show -t 12070`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12070.diff">https://git.openjdk.org/jdk/pull/12070.diff</a>

</details>
