### PR TITLE
JDK-8300266: Detect Virtualization on Linux aarch64

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -570,10 +570,10 @@ void VM_Version::check_virtualizations() {
   // check for various strings in the dmi data indicating virtualizations
   char line[500];
   FILE* fp = os::fopen(info_file, "r");
-  if (fp == NULL) {
+  if (fp == nullptr) {
     return;
   }
-  while (fgets(line, sizeof(line), fp) != NULL) {
+  while (fgets(line, sizeof(line), fp) != nullptr) {
     if (strcasestr(line, "KVM") != 0) {
       Abstract_VM_Version::_detected_virtualization = KVM;
       break;

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -560,6 +560,42 @@ void VM_Version::initialize() {
 #endif
 
   _spin_wait = get_spin_wait_desc();
+
+  check_virtualizations();
+}
+
+void VM_Version::check_virtualizations() {
+#if defined(LINUX)
+  const char* info_file = "/sys/devices/virtual/dmi/id/product_name";
+  // check for various strings in the dmi data indicating virtualizations
+  char line[500];
+  FILE* fp = os::fopen(info_file, "r");
+  if (fp == NULL) {
+    return;
+  }
+  while (fgets(line, sizeof(line), fp) != NULL) {
+    if (strcasestr(line, "KVM") != 0) {
+      Abstract_VM_Version::_detected_virtualization = KVM;
+      break;
+    }
+    if (strcasestr(line, "VMware") != 0) {
+      Abstract_VM_Version::_detected_virtualization = VMWare;
+      break;
+    }
+  }
+  fclose(fp);
+#endif
+}
+
+void VM_Version::print_platform_virtualization_info(outputStream* st) {
+#if defined(LINUX)
+    VirtualizationType vrt = VM_Version::get_detected_virtualization();
+    if (vrt == KVM) {
+      st->print_cr("KVM virtualization detected");
+    } else if (vrt == VMWare) {
+      st->print_cr("VMWare virtualization detected");
+    }
+#endif
 }
 
 void VM_Version::initialize_cpu_information(void) {

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -63,6 +63,9 @@ protected:
 public:
   // Initialization
   static void initialize();
+  static void check_virtualizations();
+
+  static void print_platform_virtualization_info(outputStream*);
 
   // Asserts
   static void assert_is_initialized() {


### PR DESCRIPTION
Currently we detect virtualization on Linux x86_64 (cpuid call) and Linux ppc64le ; the result is afterwards used e.g. in hs_err and JFR output.

On Linux aarch64 the detection is missing, this should be added.
One option would be to look at /sys/devices/virtual/dmi/id/product_name and related files , at least KVM and VMWare can be detected using these files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300266](https://bugs.openjdk.org/browse/JDK-8300266): Detect Virtualization on Linux aarch64


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12071/head:pull/12071` \
`$ git checkout pull/12071`

Update a local copy of the PR: \
`$ git checkout pull/12071` \
`$ git pull https://git.openjdk.org/jdk pull/12071/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12071`

View PR using the GUI difftool: \
`$ git pr show -t 12071`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12071.diff">https://git.openjdk.org/jdk/pull/12071.diff</a>

</details>
