### PR TITLE
8208077: File.listRoots performance degradation

### DIFF
--- a/src/java.base/windows/classes/java/io/WinNTFileSystem.java
+++ b/src/java.base/windows/classes/java/io/WinNTFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -745,7 +745,7 @@ class WinNTFileSystem extends FileSystem {
             .valueOf(new long[] {listRoots0()})
             .stream()
             .mapToObj(i -> new File((char)('A' + i) + ":" + slash))
-            .filter(f -> access(f.getPath()) && f.exists())
+            .filter(f -> access(f.getPath()))
             .toArray(File[]::new);
     }
     private static native int listRoots0();


### PR DESCRIPTION
The Windows implementation of File.listRoots was changed in JDK 10 to test the root directory of each "logical drive" to see that it exists. The motive was to filter out drive letters corresponding to removable media where the media is not present. This is problematic for a number of reasons that include performance (esp. for mapped drives), inconsistency with FileSystem::getRootDirectories, and surprising behavior when media is re-inserted. After re-examining this area again, the best thing seems to be just undo this change so that File.listRoots doesn't attempt to do the problematic filtering.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8208077](https://bugs.openjdk.org/browse/JDK-8208077): File.listRoots performance degradation


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12072/head:pull/12072` \
`$ git checkout pull/12072`

Update a local copy of the PR: \
`$ git checkout pull/12072` \
`$ git pull https://git.openjdk.org/jdk pull/12072/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12072`

View PR using the GUI difftool: \
`$ git pr show -t 12072`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12072.diff">https://git.openjdk.org/jdk/pull/12072.diff</a>

</details>
