### PR TITLE
JDK-8300531: Update MSVC optimization flags to match GCC/Clang

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -298,7 +298,8 @@ AC_DEFUN([FLAGS_SETUP_OPTIMIZATION],
     C_O_FLAG_DEBUG_JVM=""
     C_O_FLAG_NONE="-qnoopt"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
-    # -O2 is a combination of optimizations that favors speed over size.
+    # -O2 is a combination of optimizations that favors speed over size. -Oy- is equivalent to
+    # -fno-omit-frame-pointer for GCC/Clang.
     C_O_FLAG_HIGHEST_JVM="-O2 -Oy-"
     C_O_FLAG_HIGHEST="-O2 -Oy-"
     C_O_FLAG_HI="-O2 -Oy-"
@@ -307,7 +308,8 @@ AC_DEFUN([FLAGS_SETUP_OPTIMIZATION],
     C_O_FLAG_DEBUG="-Od"
     C_O_FLAG_DEBUG_JVM="-Od"
     C_O_FLAG_NONE="-Od"
-    # -O1 is a combination of optimizations that favors size over speed.
+    # -O1 is a combination of optimizations that favors size over speed. -Oy- is equivalent to
+    # -fno-omit-frame-pointer for GCC/Clang.
     C_O_FLAG_SIZE="-O1 -Oy-"
   fi
 

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -538,7 +538,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     TOOLCHAIN_CFLAGS_JVM="-qtbtable=full -qtune=balanced -fno-exceptions \
         -qalias=noansi -qstrict -qtls=default -qnortti -qnoeh -qignerrno -qstackprotect"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
-    TOOLCHAIN_CFLAGS_JVM="-nologo -MD -Zc:preprocessor -Zc:strictStrings -MP -GR- -Oy-"
+    TOOLCHAIN_CFLAGS_JVM="-nologo -MD -Zc:preprocessor -Zc:strictStrings -MP -GR-"
     TOOLCHAIN_CFLAGS_JDK="-nologo -MD -Zc:preprocessor -Zc:strictStrings -Zc:wchar_t-"
   fi
 

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -298,14 +298,20 @@ AC_DEFUN([FLAGS_SETUP_OPTIMIZATION],
     C_O_FLAG_DEBUG_JVM=""
     C_O_FLAG_NONE="-qnoopt"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
-    C_O_FLAG_HIGHEST_JVM="-O2 -Oy-"
-    C_O_FLAG_HIGHEST="-O2"
-    C_O_FLAG_HI="-O1"
-    C_O_FLAG_NORM="-O1"
+    # -O2 is a combination of optimizations that favors speed over size. -Ob3 was introduced
+    # starting in Visual Studio 2019 and is an even more aggressive inling hint than -Ob2 which is
+    # the default for -O1 and -O2.
+    C_O_FLAG_HIGHEST_JVM="-O2 -Ob3"
+    C_O_FLAG_HIGHEST="-O2 -Ob3"
+    C_O_FLAG_HI="-O2 -Ob3"
+    # -O2 is a combination of optimizations that favors speed over size.
+    C_O_FLAG_NORM="-O2"
+    # -Od disables optimizations.
     C_O_FLAG_DEBUG="-Od"
-    C_O_FLAG_DEBUG_JVM=""
+    C_O_FLAG_DEBUG_JVM="-Od"
     C_O_FLAG_NONE="-Od"
-    C_O_FLAG_SIZE="-Os"
+    # -O1 is a combination of optimizations that favors size over speed.
+    C_O_FLAG_SIZE="-O1"
   fi
 
   # Now copy to C++ flags
@@ -535,7 +541,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     TOOLCHAIN_CFLAGS_JVM="-qtbtable=full -qtune=balanced -fno-exceptions \
         -qalias=noansi -qstrict -qtls=default -qnortti -qnoeh -qignerrno -qstackprotect"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
-    TOOLCHAIN_CFLAGS_JVM="-nologo -MD -Zc:preprocessor -Zc:strictStrings -MP"
+    TOOLCHAIN_CFLAGS_JVM="-nologo -MD -Zc:preprocessor -Zc:strictStrings -MP -GR-"
     TOOLCHAIN_CFLAGS_JDK="-nologo -MD -Zc:preprocessor -Zc:strictStrings -Zc:wchar_t-"
   fi
 

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -298,13 +298,10 @@ AC_DEFUN([FLAGS_SETUP_OPTIMIZATION],
     C_O_FLAG_DEBUG_JVM=""
     C_O_FLAG_NONE="-qnoopt"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
-    # -O2 is a combination of optimizations that favors speed over size. -Ob3 was introduced
-    # starting in Visual Studio 2019 and is an even more aggressive inling hint than -Ob2 which is
-    # the default for -O1 and -O2.
-    C_O_FLAG_HIGHEST_JVM="-O2 -Ob3"
-    C_O_FLAG_HIGHEST="-O2 -Ob3"
-    C_O_FLAG_HI="-O2 -Ob3"
     # -O2 is a combination of optimizations that favors speed over size.
+    C_O_FLAG_HIGHEST_JVM="-O2"
+    C_O_FLAG_HIGHEST="-O2"
+    C_O_FLAG_HI="-O2"
     C_O_FLAG_NORM="-O2"
     # -Od disables optimizations.
     C_O_FLAG_DEBUG="-Od"

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -299,16 +299,16 @@ AC_DEFUN([FLAGS_SETUP_OPTIMIZATION],
     C_O_FLAG_NONE="-qnoopt"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     # -O2 is a combination of optimizations that favors speed over size.
-    C_O_FLAG_HIGHEST_JVM="-O2"
-    C_O_FLAG_HIGHEST="-O2"
-    C_O_FLAG_HI="-O2"
-    C_O_FLAG_NORM="-O2"
+    C_O_FLAG_HIGHEST_JVM="-O2 -Oy-"
+    C_O_FLAG_HIGHEST="-O2 -Oy-"
+    C_O_FLAG_HI="-O2 -Oy-"
+    C_O_FLAG_NORM="-O2 -Oy-"
     # -Od disables optimizations.
     C_O_FLAG_DEBUG="-Od"
     C_O_FLAG_DEBUG_JVM="-Od"
     C_O_FLAG_NONE="-Od"
     # -O1 is a combination of optimizations that favors size over speed.
-    C_O_FLAG_SIZE="-O1"
+    C_O_FLAG_SIZE="-O1 -Oy-"
   fi
 
   # Now copy to C++ flags

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -538,7 +538,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     TOOLCHAIN_CFLAGS_JVM="-qtbtable=full -qtune=balanced -fno-exceptions \
         -qalias=noansi -qstrict -qtls=default -qnortti -qnoeh -qignerrno -qstackprotect"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
-    TOOLCHAIN_CFLAGS_JVM="-nologo -MD -Zc:preprocessor -Zc:strictStrings -MP -GR-"
+    TOOLCHAIN_CFLAGS_JVM="-nologo -MD -Zc:preprocessor -Zc:strictStrings -MP"
     TOOLCHAIN_CFLAGS_JDK="-nologo -MD -Zc:preprocessor -Zc:strictStrings -Zc:wchar_t-"
   fi
 

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -538,7 +538,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     TOOLCHAIN_CFLAGS_JVM="-qtbtable=full -qtune=balanced -fno-exceptions \
         -qalias=noansi -qstrict -qtls=default -qnortti -qnoeh -qignerrno -qstackprotect"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
-    TOOLCHAIN_CFLAGS_JVM="-nologo -MD -Zc:preprocessor -Zc:strictStrings -MP -GR-"
+    TOOLCHAIN_CFLAGS_JVM="-nologo -MD -Zc:preprocessor -Zc:strictStrings -MP -GR- -Oy-"
     TOOLCHAIN_CFLAGS_JDK="-nologo -MD -Zc:preprocessor -Zc:strictStrings -Zc:wchar_t-"
   fi
 


### PR DESCRIPTION
Update MSVC CFlags to be more consistent with other compilers. Also disables RTTI in a simliar manner to GCC/Clang for the JVM.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300531](https://bugs.openjdk.org/browse/JDK-8300531): Update MSVC optimization flags to match GCC/Clang


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12073/head:pull/12073` \
`$ git checkout pull/12073`

Update a local copy of the PR: \
`$ git checkout pull/12073` \
`$ git pull https://git.openjdk.org/jdk.git pull/12073/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12073`

View PR using the GUI difftool: \
`$ git pr show -t 12073`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12073.diff">https://git.openjdk.org/jdk/pull/12073.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12073#issuecomment-1387179830)