### PR TITLE
8300540: Serial: Remove obsolete comments in GenMarkSweep

### DIFF
--- a/src/hotspot/share/gc/serial/genMarkSweep.cpp
+++ b/src/hotspot/share/gc/serial/genMarkSweep.cpp
@@ -236,16 +236,9 @@ void GenMarkSweep::mark_sweep_phase1(bool clear_all_softrefs) {
 
 void GenMarkSweep::mark_sweep_phase2() {
   // Now all live objects are marked, compute the new object addresses.
-
-  // It is not required that we traverse spaces in the same order in
-  // phase2, phase3 and phase4, but the ValidateMarkSweep live oops
-  // tracking expects us to do so. See comment under phase4.
-
-  GenCollectedHeap* gch = GenCollectedHeap::heap();
-
   GCTraceTime(Info, gc, phases) tm("Phase 2: Compute new object addresses", _gc_timer);
 
-  gch->prepare_for_compaction();
+  GenCollectedHeap::heap()->prepare_for_compaction();
 }
 
 class GenAdjustPointersClosure: public GenCollectedHeap::GenClosure {
@@ -286,20 +279,8 @@ public:
 
 void GenMarkSweep::mark_sweep_phase4() {
   // All pointers are now adjusted, move objects accordingly
-
-  // It is imperative that we traverse perm_gen first in phase4. All
-  // classes must be allocated earlier than their instances, and traversing
-  // perm_gen first makes sure that all Klass*s have moved to their new
-  // location before any instance does a dispatch through it's klass!
-
-  // The ValidateMarkSweep live oops tracking expects us to traverse spaces
-  // in the same order in phase2, phase3 and phase4. We don't quite do that
-  // here (perm_gen first rather than last), so we tell the validate code
-  // to use a higher index (saved from phase2) when verifying perm_gen.
-  GenCollectedHeap* gch = GenCollectedHeap::heap();
-
   GCTraceTime(Info, gc, phases) tm("Phase 4: Move objects", _gc_timer);
 
   GenCompactClosure blk;
-  gch->generation_iterate(&blk, true);
+  GenCollectedHeap::heap()->generation_iterate(&blk, true);
 }


### PR DESCRIPTION
Trivial change of removing stale comments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300540](https://bugs.openjdk.org/browse/JDK-8300540): Serial: Remove obsolete comments in GenMarkSweep


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12074/head:pull/12074` \
`$ git checkout pull/12074`

Update a local copy of the PR: \
`$ git checkout pull/12074` \
`$ git pull https://git.openjdk.org/jdk pull/12074/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12074`

View PR using the GUI difftool: \
`$ git pr show -t 12074`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12074.diff">https://git.openjdk.org/jdk/pull/12074.diff</a>

</details>
