### PR TITLE
8300550: BASIC_JVM_LIBS is set for buildjdk even if this is incorrect

### DIFF
--- a/make/autoconf/libraries.m4
+++ b/make/autoconf/libraries.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -90,6 +90,33 @@ AC_DEFUN_ONCE([LIB_DETERMINE_DEPENDENCIES],
 ])
 
 ################################################################################
+# Setup BASIC_JVM_LIBS that can be different depending on build/target platform
+################################################################################
+AC_DEFUN([LIB_SETUP_JVM_LIBS],
+[
+  # Atomic library
+  # 32-bit platforms needs fallback library for 8-byte atomic ops on Zero
+  if HOTSPOT_CHECK_JVM_VARIANT(zero); then
+    if test "x$OPENJDK_$1_OS" = xlinux &&
+        (test "x$OPENJDK_$1_CPU" = xarm ||
+         test "x$OPENJDK_$1_CPU" = xm68k ||
+         test "x$OPENJDK_$1_CPU" = xmips ||
+         test "x$OPENJDK_$1_CPU" = xmipsel ||
+         test "x$OPENJDK_$1_CPU" = xppc ||
+         test "x$OPENJDK_$1_CPU" = xsh ||
+         test "x$OPENJDK_$1_CPU" = xriscv32); then
+      BASIC_JVM_LIBS_$1="$BASIC_JVM_LIBS_$1 -latomic"
+    fi
+  fi
+
+  # Because RISC-V only has word-sized atomics, it requires libatomic where
+  # other common architectures do not, so link libatomic by default.
+  if test "x$OPENJDK_$1_OS" = xlinux && test "x$OPENJDK_$1_CPU" = xriscv64; then
+    BASIC_JVM_LIBS_$1="$BASIC_JVM_LIBS_$1 -latomic"
+  fi
+])
+
+################################################################################
 # Parse library options, and setup needed libraries
 ################################################################################
 AC_DEFUN_ONCE([LIB_SETUP_LIBRARIES],
@@ -109,6 +136,7 @@ AC_DEFUN_ONCE([LIB_SETUP_LIBRARIES],
   LIB_TESTS_SETUP_GTEST
 
   BASIC_JDKLIB_LIBS=""
+  BASIC_JDKLIB_LIBS_TARGET=""
   if test "x$TOOLCHAIN_TYPE" != xmicrosoft; then
     BASIC_JDKLIB_LIBS="-ljava -ljvm"
   fi
@@ -135,27 +163,6 @@ AC_DEFUN_ONCE([LIB_SETUP_LIBRARIES],
     BASIC_JVM_LIBS="$BASIC_JVM_LIBS -lrt"
   fi
 
-  # Atomic library
-  # 32-bit platforms needs fallback library for 8-byte atomic ops on Zero
-  if HOTSPOT_CHECK_JVM_VARIANT(zero); then
-    if test "x$OPENJDK_TARGET_OS" = xlinux &&
-        (test "x$OPENJDK_TARGET_CPU" = xarm ||
-         test "x$OPENJDK_TARGET_CPU" = xm68k ||
-         test "x$OPENJDK_TARGET_CPU" = xmips ||
-         test "x$OPENJDK_TARGET_CPU" = xmipsel ||
-         test "x$OPENJDK_TARGET_CPU" = xppc ||
-         test "x$OPENJDK_TARGET_CPU" = xsh ||
-         test "x$OPENJDK_TARGET_CPU" = xriscv32); then
-      BASIC_JVM_LIBS="$BASIC_JVM_LIBS -latomic"
-    fi
-  fi
-
-  # Because RISC-V only has word-sized atomics, it requires libatomic where
-  # other common architectures do not.  So link libatomic by default.
-  if test "x$OPENJDK_TARGET_OS" = xlinux && test "x$OPENJDK_TARGET_CPU" = xriscv64; then
-    BASIC_JVM_LIBS="$BASIC_JVM_LIBS -latomic"
-  fi
-
   # perfstat lib
   if test "x$OPENJDK_TARGET_OS" = xaix; then
     BASIC_JVM_LIBS="$BASIC_JVM_LIBS -lperfstat"
@@ -166,12 +173,14 @@ AC_DEFUN_ONCE([LIB_SETUP_LIBRARIES],
         comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib \
         wsock32.lib winmm.lib version.lib psapi.lib"
   fi
+  LIB_SETUP_JVM_LIBS(BUILD)
+  LIB_SETUP_JVM_LIBS(TARGET)
 
   JDKLIB_LIBS="$BASIC_JDKLIB_LIBS"
   JDKEXE_LIBS=""
-  JVM_LIBS="$BASIC_JVM_LIBS"
+  JVM_LIBS="$BASIC_JVM_LIBS $BASIC_JVM_LIBS_TARGET"
   OPENJDK_BUILD_JDKLIB_LIBS="$BASIC_JDKLIB_LIBS"
-  OPENJDK_BUILD_JVM_LIBS="$BASIC_JVM_LIBS"
+  OPENJDK_BUILD_JVM_LIBS="$BASIC_JVM_LIBS $BASIC_JVM_LIBS_BUILD"
 
   AC_SUBST(JDKLIB_LIBS)
   AC_SUBST(JDKEXE_LIBS)


### PR DESCRIPTION
We setup a bunch of default library (`-l<lib>`) flags for the JVM compilation in the variable BASIC_JVM_LIBS in LIB_SETUP_LIBRARIES. Almost all of these are dependent on OS, and are thus safe to use both the the target and build compilation (since we do not support cross-OS compilation). However, the recently added libatomic is only added for certain CPUs. This means that it needs to be different for the build and target CPUs, but we currently do not differentiate these. The typical end result of this is that when you try to cross-compile, the buildjdk will be build with flags that should only have been used when building for the target platform, and this can cause failures at runtime (e.g. if no libatomic is installed).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300550](https://bugs.openjdk.org/browse/JDK-8300550): BASIC_JVM_LIBS is set for buildjdk even if this is incorrect


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12075/head:pull/12075` \
`$ git checkout pull/12075`

Update a local copy of the PR: \
`$ git checkout pull/12075` \
`$ git pull https://git.openjdk.org/jdk pull/12075/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12075`

View PR using the GUI difftool: \
`$ git pr show -t 12075`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12075.diff">https://git.openjdk.org/jdk/pull/12075.diff</a>

</details>
