### PR TITLE
8300493: Use ArraysSupport.vectorizedHashCode in j.u.zip.ZipCoder

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2461,6 +2461,9 @@ public final class System {
                 return ModuleLayer.layers(loader);
             }
 
+            public int countPositives(byte[] bytes, int offset, int length) {
+                return StringCoding.countPositives(bytes, offset, length);
+            }
             public String newStringNoRepl(byte[] bytes, Charset cs) throws CharacterCodingException  {
                 return String.newStringNoRepl(bytes, cs);
             }

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -303,6 +303,11 @@ public interface JavaLangAccess {
     Stream<ModuleLayer> layers(ClassLoader loader);
 
     /**
+     * Count the number of leading positive bytes in the range.
+     */
+    int countPositives(byte[] ba, int off, int len);
+
+    /**
      * Constructs a new {@code String} by decoding the specified subarray of
      * bytes using the specified {@linkplain java.nio.charset.Charset charset}.
      *

--- a/test/micro/org/openjdk/bench/java/util/zip/ZipFileOpen.java
+++ b/test/micro/org/openjdk/bench/java/util/zip/ZipFileOpen.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.java.util.zip;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * Simple benchmark measuring cost of opening zip files, parsing CEN
+ * entries.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
+public class ZipFileOpen {
+
+    @Param({"512", "1024"})
+    private int size;
+
+    public File zipFile;
+
+    @Setup(Level.Trial)
+    public void beforeRun() throws IOException {
+        // Create a test Zip file with the number of entries.
+        File tempFile = Files.createTempFile("zip-micro", ".zip").toFile();
+        tempFile.deleteOnExit();
+        try (FileOutputStream fos = new FileOutputStream(tempFile);
+             ZipOutputStream zos = new ZipOutputStream(fos)) {
+
+            Random random = new Random(4711);
+            for (int i = 0; i < size; i++) {
+                String ename = "long-directory-name-" + (random.nextInt(90000) + 10000) + "-" + i + "/";
+                zos.putNextEntry(new ZipEntry(ename));
+
+                ename += "long-entry-name-"  + (random.nextInt(90000) + 10000)  + "-" + i;
+                zos.putNextEntry(new ZipEntry(ename));
+            }
+        }
+        zipFile = tempFile;
+    }
+
+    @Benchmark
+    public ZipFile openCloseZipFile() throws Exception {
+        // Some shared resources in ZipFile are cached in a shared structure
+        // and needs to be cleaned up to properly capture overhead of creating
+        // a ZipFile - otherwise opening the same zip file again will reuse the
+        // cached data and look artificially fast. By including the ZipFile.close()
+        // we aggressively clear those resources pre-emptively. The operations
+        // appears to be complex enough to not be subject to DCE but care needs
+        // to be taken to check that things like initCEN is properly accounted
+        // for if/when the ZipFile setup improves.
+        ZipFile zf = new ZipFile(zipFile);
+        zf.close();
+        return zf;
+    }
+}

--- a/test/micro/org/openjdk/bench/java/util/zip/ZipFileOpen.java
+++ b/test/micro/org/openjdk/bench/java/util/zip/ZipFileOpen.java
@@ -29,7 +29,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -60,12 +59,17 @@ public class ZipFileOpen {
         try (FileOutputStream fos = new FileOutputStream(tempFile);
              ZipOutputStream zos = new ZipOutputStream(fos)) {
 
-            Random random = new Random(4711);
+            // Vary dir and entry sizes, with a bias towards shorter entries.
+            String[] dirPrefixes = new String[] { "dir1", "dir2", "dir3",
+                    "longer-directory-name-", "ridiculously-long-pathname-to-help-exercize-vectorized-subroutines-"};
+            String[] entryPrefixes = new String[] { "e", "long-entry-name-",
+                    "ridiculously-long-entry-name-to-help-exercize-vectorized-subroutines-"};
+
             for (int i = 0; i < size; i++) {
-                String ename = "long-directory-name-" + (random.nextInt(90000) + 10000) + "-" + i + "/";
+                String ename = dirPrefixes[i % dirPrefixes.length] + i + "/";
                 zos.putNextEntry(new ZipEntry(ename));
 
-                ename += "long-entry-name-"  + (random.nextInt(90000) + 10000)  + "-" + i;
+                ename += entryPrefixes[i % entryPrefixes.length] + "-" + i;
                 zos.putNextEntry(new ZipEntry(ename));
             }
         }


### PR DESCRIPTION
`ZipCoder::checkedHashCode` emulates `StringLatin1::hashCode` but operates on a `byte[]` subrange. It can profitably use the recently introduced `ArraysSupport::vectorizedHashCode` method to see a speed-up, which translates to a small but significant speed-up on `ZipFile` creation.

Before:
```
Benchmark                     (size)  Mode  Cnt       Score      Error  Units
ZipFileOpen.openCloseZipFile     512  avgt   15   83007.325 ± 1446.716  ns/op
ZipFileOpen.openCloseZipFile    1024  avgt   15  154550.631 ± 2166.673  ns/op
```
After:
```
Benchmark                     (size)  Mode  Cnt       Score      Error  Units
ZipFileOpen.openCloseZipFile     512  avgt   15   79512.902 ±  814.449  ns/op
ZipFileOpen.openCloseZipFile    1024  avgt   15  147892.522 ± 2744.017  ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300493](https://bugs.openjdk.org/browse/JDK-8300493): Use ArraysSupport.vectorizedHashCode in j.u.zip.ZipCoder


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [0c7f0f4f](https://git.openjdk.org/jdk/pull/12077/files/0c7f0f4f700b8d3a01c853f065c24959caf75115)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12077/head:pull/12077` \
`$ git checkout pull/12077`

Update a local copy of the PR: \
`$ git checkout pull/12077` \
`$ git pull https://git.openjdk.org/jdk pull/12077/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12077`

View PR using the GUI difftool: \
`$ git pr show -t 12077`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12077.diff">https://git.openjdk.org/jdk/pull/12077.diff</a>

</details>
