### PR TITLE
JDK-8300584: Accelerate AVX-512 CRC32C for small buffers

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -2760,46 +2760,38 @@ address StubGenerator::generate_updateBytesCRC32C(bool is_pclmulqdq_supported) {
 
   BLOCK_COMMENT("Entry:");
   __ enter(); // required for proper stackwalking of RuntimeStub frame
+  Label L_continue;
+
   if (VM_Version::supports_sse4_1() && VM_Version::supports_avx512_vpclmulqdq() &&
       VM_Version::supports_avx512bw() &&
       VM_Version::supports_avx512vl()) {
-    Label L_bigOK, L_continue;
-    __ cmpl(len, 384);
-    __ jcc(Assembler::above, L_bigOK);
-#ifdef _WIN64
-    __ push(y);
-    __ push(z);
-#endif
-    __ crc32c_ipl_alg2_alt2(crc, buf, len,
-                            a, j, k,
-                            l, y, z,
-                            c_farg0, c_farg1, c_farg2,
-                            is_pclmulqdq_supported);
-#ifdef _WIN64
-    __ pop(z);
-    __ pop(y);
-#endif
-    __ jmp(L_continue);
+    Label L_doSmall;
 
-    __ bind(L_bigOK);
+    __ cmpl(len, 384);
+    __ jcc(Assembler::lessEqual, L_doSmall);
+
     __ lea(j, ExternalAddress(StubRoutines::x86::crc32c_table_avx512_addr()));
     __ kernel_crc32_avx512(crc, buf, len, j, l, k);
-    __ bind(L_continue);
-  } else {
-#ifdef _WIN64
-    __ push(y);
-    __ push(z);
-#endif
-    __ crc32c_ipl_alg2_alt2(crc, buf, len,
-                            a, j, k,
-                            l, y, z,
-                            c_farg0, c_farg1, c_farg2,
-                            is_pclmulqdq_supported);
-#ifdef _WIN64
-    __ pop(z);
-    __ pop(y);
-#endif
+
+    __ jmp(L_continue);
+
+    __ bind(L_doSmall);
   }
+#ifdef _WIN64
+  __ push(y);
+  __ push(z);
+#endif
+  __ crc32c_ipl_alg2_alt2(crc, buf, len,
+                          a, j, k,
+                          l, y, z,
+                          c_farg0, c_farg1, c_farg2,
+                          is_pclmulqdq_supported);
+#ifdef _WIN64
+  __ pop(z);
+  __ pop(y);
+#endif
+
+  __ bind(L_continue);
   __ movl(rax, crc);
   __ vzeroupper();
   __ leave(); // required for proper stackwalking of RuntimeStub frame


### PR DESCRIPTION
Use AVX2 code for CRC32C for small buffers in the AVX-512 path.  Breakeven buffer size between the two algorithms is on the order of 384 bytes.

**Performance numbers for previous:**
```
Benchmark                    (count)   Mode  Cnt      Score     Error   Units
TestCRC32C.testCRC32CUpdate       64  thrpt    4  66974.957 ±   8.872  ops/ms
TestCRC32C.testCRC32CUpdate      128  thrpt    4  44224.810 ±  11.801  ops/ms
TestCRC32C.testCRC32CUpdate      256  thrpt    4  63997.611 ± 173.577  ops/ms
TestCRC32C.testCRC32CUpdate      512  thrpt    4  56068.683 ± 269.582  ops/ms
TestCRC32C.testCRC32CUpdate     2048  thrpt    4  27048.098 ±  87.350  ops/ms
TestCRC32C.testCRC32CUpdate    16384  thrpt    4   4066.736 ±  10.318  ops/ms
TestCRC32C.testCRC32CUpdate    65536  thrpt    4   1040.754 ±   6.419  ops/ms
```

**Performance numbers for this version:**
```
Benchmark                    (count)   Mode  Cnt       Score     Error   Units
TestCRC32C.testCRC32CUpdate       64  thrpt    3  161659.326 ±  74.974  ops/ms
TestCRC32C.testCRC32CUpdate      128  thrpt    3   88456.935 ±  11.940  ops/ms
TestCRC32C.testCRC32CUpdate      256  thrpt    3   73254.993 ±   5.004  ops/ms
TestCRC32C.testCRC32CUpdate      512  thrpt    3   56508.541 ± 298.229  ops/ms
TestCRC32C.testCRC32CUpdate     2048  thrpt    3   26701.995 ±  31.369  ops/ms
TestCRC32C.testCRC32CUpdate    16384  thrpt    3    4110.819 ±   4.618  ops/ms
TestCRC32C.testCRC32CUpdate    65536  thrpt    3    1045.821 ±   2.037  ops/ms

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300584](https://bugs.openjdk.org/browse/JDK-8300584): Accelerate AVX-512 CRC32C for small buffers


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12079/head:pull/12079` \
`$ git checkout pull/12079`

Update a local copy of the PR: \
`$ git checkout pull/12079` \
`$ git pull https://git.openjdk.org/jdk pull/12079/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12079`

View PR using the GUI difftool: \
`$ git pr show -t 12079`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12079.diff">https://git.openjdk.org/jdk/pull/12079.diff</a>

</details>
