### PR TITLE
JDK-8300592: ASan build does not correctly propagate options to some test launchers

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -426,7 +426,7 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_ADDRESS_SANITIZER],
         # ASan is simply incompatible with gcc -Wstringop-truncation. See
         # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85650
         # It's harmless to be suppressed in clang as well.
-        ASAN_CFLAGS="-fsanitize=address -Wno-stringop-truncation -fno-omit-frame-pointer -DADDRESS_SANITIZER"
+        ASAN_CFLAGS="-fsanitize=address -Wno-stringop-truncation -fno-omit-frame-pointer -fno-common -DADDRESS_SANITIZER"
         ASAN_LDFLAGS="-fsanitize=address"
         JVM_CFLAGS="$JVM_CFLAGS $ASAN_CFLAGS"
         JVM_LDFLAGS="$JVM_LDFLAGS $ASAN_LDFLAGS"
@@ -437,7 +437,6 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_ADDRESS_SANITIZER],
         LDFLAGS_JDKLIB="$LDFLAGS_JDKLIB $ASAN_LDFLAGS"
         LDFLAGS_JDKEXE="$LDFLAGS_JDKEXE $ASAN_LDFLAGS"
       ])
-
   AC_SUBST(ASAN_ENABLED)
 ])
 

--- a/make/common/TestFilesCompilation.gmk
+++ b/make/common/TestFilesCompilation.gmk
@@ -89,7 +89,7 @@ define SetupTestFilesCompilationBody
     $$(eval $$(call SetupNativeCompilation, BUILD_TEST_$$(name), \
         NAME := $$(unprefixed_name), \
         TYPE := $$($1_COMPILATION_TYPE), \
-        EXTRA_FILES := $$(file), \
+        EXTRA_FILES := $$(file) $$($1_EXTRA_FILES_$$(name)), \
         OBJECT_DIR := $$($1_OUTPUT_DIR)/support/$$(name), \
         OUTPUT_DIR := $$($1_OUTPUT_DIR)/$$($1_OUTPUT_SUBDIR), \
         CFLAGS := $$($1_BASE_CFLAGS) $$($1_CFLAGS) $$($1_CFLAGS_$$(name)), \

--- a/make/common/TestFilesCompilation.gmk
+++ b/make/common/TestFilesCompilation.gmk
@@ -89,7 +89,7 @@ define SetupTestFilesCompilationBody
     $$(eval $$(call SetupNativeCompilation, BUILD_TEST_$$(name), \
         NAME := $$(unprefixed_name), \
         TYPE := $$($1_COMPILATION_TYPE), \
-        EXTRA_FILES := $$(file) $$($1_EXTRA_FILES_$$(name)), \
+        EXTRA_FILES := $$(file) $$($1_EXTRA_FILES), \
         OBJECT_DIR := $$($1_OUTPUT_DIR)/support/$$(name), \
         OUTPUT_DIR := $$($1_OUTPUT_DIR)/$$($1_OUTPUT_SUBDIR), \
         CFLAGS := $$($1_BASE_CFLAGS) $$($1_CFLAGS) $$($1_CFLAGS_$$(name)), \

--- a/make/common/TestFilesCompilation.gmk
+++ b/make/common/TestFilesCompilation.gmk
@@ -45,6 +45,7 @@ include NativeCompilation.gmk
 #   SOURCE_DIRS A list of source directories to search
 #   OUTPUT_DIR Where to put the resulting files
 #   EXCLUDE A list of filenames to exclude from compilation
+#   EXTRA_FILES List of extra files not in SOURCE_DIRS
 SetupTestFilesCompilation = $(NamedParamsMacroTemplate)
 define SetupTestFilesCompilationBody
 

--- a/make/data/asan/asan_default_options.cpp
+++ b/make/data/asan/asan_default_options.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+extern "C" {
+
+#include "./asan_default_options.c"
+
+} // extern "C"

--- a/make/hotspot/lib/CompileGtest.gmk
+++ b/make/hotspot/lib/CompileGtest.gmk
@@ -28,6 +28,10 @@ $(eval $(call IncludeCustomExtension, hotspot/lib/CompileGtest.gmk))
 GTEST_TEST_SRC += $(TOPDIR)/test/hotspot/gtest
 GTEST_LAUNCHER_SRC := $(TOPDIR)/test/hotspot/gtest/gtestLauncher.cpp
 
+ifeq ($(ASAN_ENABLED), true)
+  GTEST_LAUNCHER_SRC += $(TOPDIR)/make/data/asan/asan_default_options.cpp
+endif
+
 # On Windows, there are no internal debug symbols so must set copying to true
 # to get any at all.
 ifeq ($(call isTargetOs, windows), true)

--- a/make/test/JtregNativeHotspot.gmk
+++ b/make/test/JtregNativeHotspot.gmk
@@ -1518,6 +1518,17 @@ else
   BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libnativeStack += -lpthread
 endif
 
+ifeq ($(ASAN_ENABLED), true)
+  # Any executable which launches the JVM and uses a custom launcher needs to explicitly link in the
+  # default ASan options.
+  BUILD_HOTSPOT_JTREG_EXECUTABLES_EXTRA_FILES_exeinvoke := $(TOPDIR)/make/data/asan/asan_default_options.c
+  BUILD_HOTSPOT_JTREG_EXECUTABLES_EXTRA_FILES_exestack-gap := $(TOPDIR)/make/data/asan/asan_default_options.c
+  BUILD_HOTSPOT_JTREG_EXECUTABLES_EXTRA_FILES_exestack-tls := $(TOPDIR)/make/data/asan/asan_default_options.c
+  BUILD_HOTSPOT_JTREG_EXECUTABLES_EXTRA_FILES_exeFPRegs := $(TOPDIR)/make/data/asan/asan_default_options.c
+  BUILD_HOTSPOT_JTREG_EXECUTABLES_EXTRA_FILES_exesigtest := $(TOPDIR)/make/data/asan/asan_default_options.c
+  BUILD_HOTSPOT_JTREG_EXECUTABLES_EXTRA_FILES_exedaemonDestroy := $(TOPDIR)/make/data/asan/asan_default_options.c
+endif
+
 # This evaluation is expensive and should only be done if this target was
 # explicitly called.
 ifneq ($(filter build-test-hotspot-jtreg-native, $(MAKECMDGOALS)), )

--- a/make/test/JtregNativeHotspot.gmk
+++ b/make/test/JtregNativeHotspot.gmk
@@ -1521,12 +1521,7 @@ endif
 ifeq ($(ASAN_ENABLED), true)
   # Any executable which launches the JVM and uses a custom launcher needs to explicitly link in the
   # default ASan options.
-  BUILD_HOTSPOT_JTREG_EXECUTABLES_EXTRA_FILES_exeinvoke := $(TOPDIR)/make/data/asan/asan_default_options.c
-  BUILD_HOTSPOT_JTREG_EXECUTABLES_EXTRA_FILES_exestack-gap := $(TOPDIR)/make/data/asan/asan_default_options.c
-  BUILD_HOTSPOT_JTREG_EXECUTABLES_EXTRA_FILES_exestack-tls := $(TOPDIR)/make/data/asan/asan_default_options.c
-  BUILD_HOTSPOT_JTREG_EXECUTABLES_EXTRA_FILES_exeFPRegs := $(TOPDIR)/make/data/asan/asan_default_options.c
-  BUILD_HOTSPOT_JTREG_EXECUTABLES_EXTRA_FILES_exesigtest := $(TOPDIR)/make/data/asan/asan_default_options.c
-  BUILD_HOTSPOT_JTREG_EXECUTABLES_EXTRA_FILES_exedaemonDestroy := $(TOPDIR)/make/data/asan/asan_default_options.c
+  BUILD_HOTSPOT_JTREG_EXTRA_FILES := $(TOPDIR)/make/data/asan/asan_default_options.c
 endif
 
 # This evaluation is expensive and should only be done if this target was
@@ -1544,6 +1539,7 @@ ifneq ($(filter build-test-hotspot-jtreg-native, $(MAKECMDGOALS)), )
       SOURCE_DIRS := $(BUILD_HOTSPOT_JTREG_NATIVE_SRC), \
       OUTPUT_DIR := $(BUILD_HOTSPOT_JTREG_OUTPUT_DIR), \
       EXCLUDE := $(BUILD_HOTSPOT_JTREG_EXCLUDE), \
+      EXTRA_FILES := $(BUILD_HOTSPOT_JTREG_EXTRA_FILES), \
   ))
 endif
 

--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -48,8 +48,6 @@ BUILD_JDK_JTREG_OUTPUT_DIR := $(OUTPUTDIR)/support/test/jdk/jtreg/native
 
 BUILD_JDK_JTREG_IMAGE_DIR := $(TEST_IMAGE_DIR)/jdk/jtreg
 
-
-
 BUILD_JDK_JTREG_EXECUTABLES_CFLAGS_exeJliLaunchTest := \
     -I$(TOPDIR)/src/java.base/share/native/libjli \
     -I$(TOPDIR)/src/java.base/$(OPENJDK_TARGET_OS_TYPE)/native/libjli \

--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -130,6 +130,16 @@ ifeq ($(call isTargetOs, linux), true)
   BUILD_JDK_JTREG_LIBRARIES_STRIP_SYMBOLS_libFib := false
 endif
 
+ifeq ($(ASAN_ENABLED), true)
+  # Any executable which launches the JVM and uses a custom launcher needs to explicitly link in the
+  # default ASan options.
+  BUILD_JDK_JTREG_EXECUTABLES_EXTRA_FILES_exelauncher := $(TOPDIR)/make/data/asan/asan_default_options.c
+  BUILD_JDK_JTREG_EXECUTABLES_EXTRA_FILES_exeJliLaunchTest := $(TOPDIR)/make/data/asan/asan_default_options.c
+  BUILD_JDK_JTREG_EXECUTABLES_EXTRA_FILES_exeCallerAccessTest := $(TOPDIR)/make/data/asan/asan_default_options.c
+  BUILD_JDK_JTREG_EXECUTABLES_EXTRA_FILES_exeJniInvocationTest := $(TOPDIR)/make/data/asan/asan_default_options.c
+  BUILD_JDK_JTREG_EXECUTABLES_EXTRA_FILES_exeNullCallerTest := $(TOPDIR)/make/data/asan/asan_default_options.c
+endif
+
 # This evaluation is expensive and should only be done if this target was
 # explicitly called.
 ifneq ($(filter build-test-jdk-jtreg-native, $(MAKECMDGOALS)), )

--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -48,6 +48,8 @@ BUILD_JDK_JTREG_OUTPUT_DIR := $(OUTPUTDIR)/support/test/jdk/jtreg/native
 
 BUILD_JDK_JTREG_IMAGE_DIR := $(TEST_IMAGE_DIR)/jdk/jtreg
 
+
+
 BUILD_JDK_JTREG_EXECUTABLES_CFLAGS_exeJliLaunchTest := \
     -I$(TOPDIR)/src/java.base/share/native/libjli \
     -I$(TOPDIR)/src/java.base/$(OPENJDK_TARGET_OS_TYPE)/native/libjli \
@@ -133,11 +135,7 @@ endif
 ifeq ($(ASAN_ENABLED), true)
   # Any executable which launches the JVM and uses a custom launcher needs to explicitly link in the
   # default ASan options.
-  BUILD_JDK_JTREG_EXECUTABLES_EXTRA_FILES_exelauncher := $(TOPDIR)/make/data/asan/asan_default_options.c
-  BUILD_JDK_JTREG_EXECUTABLES_EXTRA_FILES_exeJliLaunchTest := $(TOPDIR)/make/data/asan/asan_default_options.c
-  BUILD_JDK_JTREG_EXECUTABLES_EXTRA_FILES_exeCallerAccessTest := $(TOPDIR)/make/data/asan/asan_default_options.c
-  BUILD_JDK_JTREG_EXECUTABLES_EXTRA_FILES_exeJniInvocationTest := $(TOPDIR)/make/data/asan/asan_default_options.c
-  BUILD_JDK_JTREG_EXECUTABLES_EXTRA_FILES_exeNullCallerTest := $(TOPDIR)/make/data/asan/asan_default_options.c
+  BUILD_JDK_JTREG_EXTRA_FILES := $(TOPDIR)/make/data/asan/asan_default_options.c
 endif
 
 # This evaluation is expensive and should only be done if this target was
@@ -155,6 +153,7 @@ ifneq ($(filter build-test-jdk-jtreg-native, $(MAKECMDGOALS)), )
       SOURCE_DIRS := $(BUILD_JDK_JTREG_NATIVE_SRC), \
       OUTPUT_DIR := $(BUILD_JDK_JTREG_OUTPUT_DIR), \
       EXCLUDE := $(BUILD_JDK_JTREG_EXCLUDE), \
+      EXTRA_FILES := $(BUILD_JDK_JTREG_EXTRA_FILES), \
   ))
 endif
 


### PR DESCRIPTION
Update some custom launchers to set the default ASan options, without it the tests fail due to incompatibility with LSan. Additionally adds `-fno-common` for ASan build, as suggested by the docs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300592](https://bugs.openjdk.org/browse/JDK-8300592): ASan build does not correctly propagate options to some test launchers


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [16c015c9](https://git.openjdk.org/jdk/pull/12082/files/16c015c99322dcde3533693e0cc92b0310c0e9c7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12082/head:pull/12082` \
`$ git checkout pull/12082`

Update a local copy of the PR: \
`$ git checkout pull/12082` \
`$ git pull https://git.openjdk.org/jdk pull/12082/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12082`

View PR using the GUI difftool: \
`$ git pr show -t 12082`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12082.diff">https://git.openjdk.org/jdk/pull/12082.diff</a>

</details>
