### PR TITLE
JDK-8300594: Use generalized see and link tags in UnicastRemoteObject

### DIFF
--- a/src/java.rmi/share/classes/java/rmi/server/UnicastRemoteObject.java
+++ b/src/java.rmi/share/classes/java/rmi/server/UnicastRemoteObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,9 +122,7 @@ import sun.rmi.transport.LiveRef;
  * <ul>
  *
  * <li>The proxy's class is defined according to the specifications for the
- * <a href="{@docRoot}/java.base/java/lang/reflect/Proxy.html#membership">
- * {@code Proxy}
- * </a>
+ * {@link java.lang.reflect.Proxy##membership Proxy}
  * class, using the class loader of the remote object's class.
  *
  * <li>The proxy implements all the remote interfaces implemented by the


### PR DESCRIPTION
Use improved anchor syntax in UnicastRemoteObject.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300594](https://bugs.openjdk.org/browse/JDK-8300594): Use generalized see and link tags in UnicastRemoteObject


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Stuart Marks](https://openjdk.org/census#smarks) (@stuart-marks - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12083/head:pull/12083` \
`$ git checkout pull/12083`

Update a local copy of the PR: \
`$ git checkout pull/12083` \
`$ git pull https://git.openjdk.org/jdk pull/12083/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12083`

View PR using the GUI difftool: \
`$ git pr show -t 12083`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12083.diff">https://git.openjdk.org/jdk/pull/12083.diff</a>

</details>
