### PR TITLE
8300590: [JVMCI] BytecodeFrame.equals is broken

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.code/src/jdk/vm/ci/code/BytecodeFrame.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.code/src/jdk/vm/ci/code/BytecodeFrame.java
@@ -351,15 +351,15 @@ public final class BytecodeFrame extends BytecodePosition {
     }
 
     @Override
-    public int hashCode()
+    public int hashCode() {
         return Objects.hash(super.hashCode(),
-                            duringCall,
-                            numLocals,
-                            numLocks,
-                            numStack,
-                            rethrowException,
-                            Arrays.hashCode(slotKinds),
-                            Arrays.hashCode(values));
+                        duringCall,
+                        numLocals,
+                        numLocks,
+                        numStack,
+                        rethrowException,
+                        Arrays.hashCode(slotKinds),
+                        Arrays.hashCode(values));
     }
 
     @Override
@@ -373,16 +373,14 @@ public final class BytecodeFrame extends BytecodePosition {
         if (getClass() != obj.getClass()) {
             return false;
         }
-        // @formatter:off
         BytecodeFrame that = (BytecodeFrame) obj;
         return duringCall == that.duringCall &&
-               numLocals == that.numLocals &&
-               numLocks == that.numLocks &&
-               numStack == that.numStack &&
-               rethrowException == that.rethrowException &&
-               Arrays.equals(slotKinds, that.slotKinds) &&
-               Arrays.equals(values, that.values);
-        // @formatter:on
+                        numLocals == that.numLocals &&
+                        numLocks == that.numLocks &&
+                        numStack == that.numStack &&
+                        rethrowException == that.rethrowException &&
+                        Arrays.equals(slotKinds, that.slotKinds) &&
+                        Arrays.equals(values, that.values);
     }
 
     @Override

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.code/src/jdk/vm/ci/code/BytecodeFrame.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.code/src/jdk/vm/ci/code/BytecodeFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,8 +351,15 @@ public final class BytecodeFrame extends BytecodePosition {
     }
 
     @Override
-    public int hashCode() {
-        return (numLocals + 1) ^ (numStack + 11) ^ (numLocks + 7);
+    public int hashCode()
+        return Objects.hash(super.hashCode(),
+                            duringCall,
+                            numLocals,
+                            numLocks,
+                            numStack,
+                            rethrowException,
+                            Arrays.hashCode(slotKinds),
+                            Arrays.hashCode(values));
     }
 
     @Override
@@ -360,21 +367,22 @@ public final class BytecodeFrame extends BytecodePosition {
         if (this == obj) {
             return true;
         }
-        if (obj instanceof BytecodeFrame && super.equals(obj)) {
-            BytecodeFrame that = (BytecodeFrame) obj;
-            // @formatter:off
-            if (this.duringCall == that.duringCall &&
-                this.rethrowException == that.rethrowException &&
-                this.numLocals == that.numLocals &&
-                this.numLocks == that.numLocks &&
-                this.numStack == that.numStack &&
-                Arrays.equals(this.values, that.values)) {
-                return true;
-            }
-            // @formatter:off
-            return true;
+        if (!super.equals(obj)) {
+            return false;
         }
-        return false;
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        // @formatter:off
+        BytecodeFrame that = (BytecodeFrame) obj;
+        return duringCall == that.duringCall &&
+               numLocals == that.numLocals &&
+               numLocks == that.numLocks &&
+               numStack == that.numStack &&
+               rethrowException == that.rethrowException &&
+               Arrays.equals(slotKinds, that.slotKinds) &&
+               Arrays.equals(values, that.values);
+        // @formatter:on
     }
 
     @Override

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestBytecodeFrame.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestBytecodeFrame.java
@@ -95,21 +95,21 @@ public class TestBytecodeFrame extends MethodUniverse {
 
         // The BytecodeFrame objects below will not all pass BytecodeFrame.verifyInvariants
         // but that's fine for simply testing equals and hashCode.
-        BytecodeFrame caller = new BytecodeFrame(null, m3, 0, true,  true,  values,  slotKinds, 1, 1, 0);
-        BytecodeFrame f1 =  new BytecodeFrame(caller, m1, 0, true,  true,  values,  slotKinds,  1, 1, 0);
+        BytecodeFrame caller = new BytecodeFrame(null, m3, 0, false, true,  values,  slotKinds, 1, 1, 0);
+        BytecodeFrame f1 =  new BytecodeFrame(caller, m1, 0, false,  true,  values,  slotKinds,  1, 1, 0);
                                                                                                            // Differing field
-        assertNotEquals(f1, new BytecodeFrame(caller, m2, 0, true,  true,  values,  slotKinds,  1, 1, 0)); // method
-        assertNotEquals(f1, new BytecodeFrame(caller, m1, 1, true,  true,  values,  slotKinds,  1, 1, 0)); // bci
-        assertNotEquals(f1, new BytecodeFrame(caller, m1, 0, false, true,  values,  slotKinds,  1, 1, 0)); // rethrowException
-        assertNotEquals(f1, new BytecodeFrame(caller, m1, 0, true,  false, values,  slotKinds,  1, 1, 0)); // duringCall
-        assertNotEquals(f1, new BytecodeFrame(caller, m1, 0, true,  true,  values2, slotKinds,  1, 1, 0)); // values
-        assertNotEquals(f1, new BytecodeFrame(caller, m1, 0, true,  true,  values,  slotKinds2, 1, 1, 0)); // slotKinds
-        assertNotEquals(f1, new BytecodeFrame(caller, m1, 0, true,  false, values,  slotKinds,  2, 1, 0)); // numLocals
-        assertNotEquals(f1, new BytecodeFrame(caller, m1, 0, true,  false, values,  slotKinds,  1, 2, 0)); // numStack
-        assertNotEquals(f1, new BytecodeFrame(caller, m1, 0, true,  false, values,  slotKinds,  1, 1, 1)); // numLocks
+        assertNotEquals(f1, new BytecodeFrame(caller, m2, 0, false, true,  values,  slotKinds,  1, 1, 0)); // method
+        assertNotEquals(f1, new BytecodeFrame(caller, m1, 1, false, true,  values,  slotKinds,  1, 1, 0)); // bci
+        assertNotEquals(f1, new BytecodeFrame(caller, m1, 0, true,  true,  values,  slotKinds,  1, 1, 0)); // rethrowException
+        assertNotEquals(f1, new BytecodeFrame(caller, m1, 0, false, false, values,  slotKinds,  1, 1, 0)); // duringCall
+        assertNotEquals(f1, new BytecodeFrame(caller, m1, 0, false, true,  values2, slotKinds,  1, 1, 0)); // values
+        assertNotEquals(f1, new BytecodeFrame(caller, m1, 0, false, true,  values,  slotKinds2, 1, 1, 0)); // slotKinds
+        assertNotEquals(f1, new BytecodeFrame(caller, m1, 0, false, false, values,  slotKinds,  2, 1, 0)); // numLocals
+        assertNotEquals(f1, new BytecodeFrame(caller, m1, 0, false, false, values,  slotKinds,  1, 2, 0)); // numStack
+        assertNotEquals(f1, new BytecodeFrame(caller, m1, 0, false, false, values,  slotKinds,  1, 1, 1)); // numLocks
         assertEquals(f1, f1);
 
-        BytecodeFrame f2 = new BytecodeFrame(caller, m1, 0, true,  true,  values,  slotKinds, 1, 1, 0);
+        BytecodeFrame f2 = new BytecodeFrame(caller, m1, 0, false,  true,  values,  slotKinds, 1, 1, 0);
         assertEquals(f1, f2);
     }
 }

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestBytecodeFrame.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestBytecodeFrame.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @requires vm.jvmci
+ * @library ../../../../../
+ * @modules jdk.internal.vm.ci/jdk.vm.ci.meta
+ *          jdk.internal.vm.ci/jdk.vm.ci.code
+ *          jdk.internal.vm.ci/jdk.vm.ci.runtime
+ *          java.base/jdk.internal.misc
+ * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseJVMCICompiler jdk.vm.ci.runtime.test.TestBytecodeFrame
+ */
+
+package jdk.vm.ci.runtime.test;
+
+import jdk.vm.ci.code.BytecodeFrame;
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.JavaValue;
+import jdk.vm.ci.meta.JavaConstant;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.Iterator;
+
+import org.junit.Assert;
+
+public class TestBytecodeFrame extends MethodUniverse {
+
+    private static void assertEquals(BytecodeFrame f1, BytecodeFrame f2) {
+        Assert.assertEquals(f1, f2);
+        Assert.assertEquals(f1.hashCode(), f2.hashCode());
+    }
+
+    private static void assertNotEquals(BytecodeFrame f1, BytecodeFrame f2) {
+        Assert.assertNotEquals(f1, f2);
+        Assert.assertNotEquals(f1.hashCode(), f2.hashCode());
+    }
+
+    /**
+     * Tests the {@link BytecodeFrame#equals} and {@link BytecodeFrame#hashCode}.
+     */
+    @Test
+    public void equalsAndHashcodeTest() {
+        Iterator<ResolvedJavaMethod> iter = methods.values().iterator();
+        ResolvedJavaMethod m1 = iter.next();
+        ResolvedJavaMethod m2 = iter.next();
+        ResolvedJavaMethod m3 = iter.next();
+
+        JavaValue[] values = {
+            JavaConstant.INT_0,
+            JavaConstant.INT_1,
+            JavaConstant.INT_2,
+            JavaConstant.NULL_POINTER,
+        };
+        JavaKind[] slotKinds = {
+            JavaKind.Int,
+            JavaKind.Int,
+            JavaKind.Int,
+            JavaKind.Object,
+        };
+        JavaValue[] values2 = {
+            JavaConstant.INT_1,
+            JavaConstant.INT_2,
+            JavaConstant.NULL_POINTER,
+            JavaConstant.INT_0,
+        };
+        JavaKind[] slotKinds2 = {
+            JavaKind.Int,
+            JavaKind.Int,
+            JavaKind.Object,
+            JavaKind.Int,
+        };
+
+        // The BytecodeFrame objects below will not all pass BytecodeFrame.verifyInvariants
+        // but that's fine for simply testing equals and hashCode.
+        BytecodeFrame caller = new BytecodeFrame(null, m3, 0, true,  true,  values,  slotKinds, 1, 1, 0);
+        BytecodeFrame f1 =  new BytecodeFrame(caller, m1, 0, true,  true,  values,  slotKinds,  1, 1, 0);
+                                                                                                           // Differing field
+        assertNotEquals(f1, new BytecodeFrame(caller, m2, 0, true,  true,  values,  slotKinds,  1, 1, 0)); // method
+        assertNotEquals(f1, new BytecodeFrame(caller, m1, 1, true,  true,  values,  slotKinds,  1, 1, 0)); // bci
+        assertNotEquals(f1, new BytecodeFrame(caller, m1, 0, false, true,  values,  slotKinds,  1, 1, 0)); // rethrowException
+        assertNotEquals(f1, new BytecodeFrame(caller, m1, 0, true,  false, values,  slotKinds,  1, 1, 0)); // duringCall
+        assertNotEquals(f1, new BytecodeFrame(caller, m1, 0, true,  true,  values2, slotKinds,  1, 1, 0)); // values
+        assertNotEquals(f1, new BytecodeFrame(caller, m1, 0, true,  true,  values,  slotKinds2, 1, 1, 0)); // slotKinds
+        assertNotEquals(f1, new BytecodeFrame(caller, m1, 0, true,  false, values,  slotKinds,  2, 1, 0)); // numLocals
+        assertNotEquals(f1, new BytecodeFrame(caller, m1, 0, true,  false, values,  slotKinds,  1, 2, 0)); // numStack
+        assertNotEquals(f1, new BytecodeFrame(caller, m1, 0, true,  false, values,  slotKinds,  1, 1, 1)); // numLocks
+        assertEquals(f1, f1);
+
+        BytecodeFrame f2 = new BytecodeFrame(caller, m1, 0, true,  true,  values,  slotKinds, 1, 1, 0);
+        assertEquals(f1, f2);
+    }
+}


### PR DESCRIPTION
`BytecodeFrame.equals` returns true even when the frames are found to be not equal: https://github.com/openjdk/jdk/blob/7bf0d1465e73d83aae30f1cd9fd318af9e9c1b70/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.code/src/jdk/vm/ci/code/BytecodeFrame.java#L375

This PR fixes that, adds a test and improves both `BytecodeFrame.hashCode` and `BytecodeFrame.equals` to take all fields into account.

Given the nature of the bug in `BytecodeFrame.equals` that this PR fixes, it's pretty clear that `BytecodeFrame` has never been (reliably) used as a key in a map.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300590](https://bugs.openjdk.org/browse/JDK-8300590): [JVMCI] BytecodeFrame.equals is broken


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**) ⚠️ Review applies to [4674af35](https://git.openjdk.org/jdk/pull/12084/files/4674af35673d6564e4e93521850f6636cc55c65f)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12084/head:pull/12084` \
`$ git checkout pull/12084`

Update a local copy of the PR: \
`$ git checkout pull/12084` \
`$ git pull https://git.openjdk.org/jdk pull/12084/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12084`

View PR using the GUI difftool: \
`$ git pr show -t 12084`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12084.diff">https://git.openjdk.org/jdk/pull/12084.diff</a>

</details>
