### PR TITLE
JDK-8300595: Use improved @see and @link syntax in javax.lang.model and javax.tools

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/element/Element.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Element.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/Element.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Element.java
@@ -132,8 +132,8 @@ public interface Element extends javax.lang.model.AnnotatedConstruct {
      *
      * If this element represents an unnamed {@linkplain
      * PackageElement#getSimpleName package} or unnamed {@linkplain
-     * ModuleElement#getSimpleName module}, an <a
-     * href=Name.html#empty_name>empty name</a> is returned.
+     * ModuleElement#getSimpleName module}, an {@linkplain
+     * Name##empty_name empty name} is returned.
      *
      * If it represents a {@linkplain ExecutableElement#getSimpleName
      * constructor}, the name "{@code <init>}" is returned.  If it
@@ -142,8 +142,8 @@ public interface Element extends javax.lang.model.AnnotatedConstruct {
      *
      * If it represents an {@linkplain TypeElement#getSimpleName
      * anonymous class} or {@linkplain ExecutableElement#getSimpleName
-     * instance initializer}, an <a href=Name.html#empty_name>empty
-     * name</a> is returned.
+     * instance initializer}, an {@linkplain Name##empty_name empty
+     * name} is returned.
      *
      * @see PackageElement#getSimpleName
      * @see ExecutableElement#getSimpleName

--- a/src/java.compiler/share/classes/javax/lang/model/element/ExecutableElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/ExecutableElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/ExecutableElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/ExecutableElement.java
@@ -142,7 +142,7 @@ public interface ExecutableElement extends Element, Parameterizable {
      * initializer}  For a constructor, the name {@code "<init>"} is
      * returned, for a static initializer, the name {@code "<clinit>"}
      * is returned, and for an anonymous class or instance
-     * initializer, an <a href=Name.html#empty_name>empty name</a> is
+     * initializer, an {@linkplain Name##empty_name empty name} is
      * returned.
      */
     @Override

--- a/src/java.compiler/share/classes/javax/lang/model/element/ModuleElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/ModuleElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/ModuleElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/ModuleElement.java
@@ -68,8 +68,8 @@ public interface ModuleElement extends Element, QualifiedNameable {
 
     /**
      * Returns the fully qualified name of this module.  For an
-     * {@linkplain #isUnnamed() unnamed module}, an <a
-     * href=Name.html#empty_name>empty name</a> is returned.
+     * {@linkplain #isUnnamed() unnamed module}, an {@linkplain
+     * Name##empty_name empty name} is returned.
      *
      * @apiNote If the module name consists of one identifier, then
      * this method returns that identifier, which is deemed to be
@@ -87,8 +87,8 @@ public interface ModuleElement extends Element, QualifiedNameable {
 
     /**
      * Returns the simple name of this module.  For an {@linkplain
-     * #isUnnamed() unnamed module}, an <a
-     * href=Name.html#empty_name>empty name</a> is returned.
+     * #isUnnamed() unnamed module}, an {@linkplain
+     * Name##empty_name empty name} is returned.
      *
      * @apiNote If the module name consists of one identifier, then
      * this method returns that identifier.  If the module name

--- a/src/java.compiler/share/classes/javax/lang/model/element/PackageElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/PackageElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/PackageElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/PackageElement.java
@@ -74,8 +74,8 @@ public interface PackageElement extends Element, QualifiedNameable {
     /**
      * Returns the fully qualified name of this package.  This is also
      * known as the package's <i>canonical</i> name.  For an
-     * {@linkplain #isUnnamed() unnamed package}, an <a
-     * href=Name.html#empty_name>empty name</a> is returned.
+     * {@linkplain #isUnnamed() unnamed package}, an {@linkplain
+     * Name##empty_name empty name} is returned.
      *
      * @apiNote The fully qualified name of a named package that is
      * not a subpackage of a named package is its simple name. The
@@ -92,8 +92,8 @@ public interface PackageElement extends Element, QualifiedNameable {
 
     /**
      * Returns the simple name of this package.  For an {@linkplain
-     * #isUnnamed() unnamed package}, an <a
-     * href=Name.html#empty_name>empty name</a> is returned.
+     * #isUnnamed() unnamed package}, an {@linkplain
+     * Name##empty_name empty name} is returned.
      *
      * @return the simple name of this package or an empty name if
      * this is an unnamed package

--- a/src/java.compiler/share/classes/javax/lang/model/element/TypeElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/TypeElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/TypeElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/TypeElement.java
@@ -148,7 +148,7 @@ public interface TypeElement extends Element, Parameterizable, QualifiedNameable
      * Returns the fully qualified name of this class or interface
      * element.  More precisely, it returns the <i>canonical</i> name.
      * For local and anonymous classes, which do not have canonical
-     * names, an <a href=Name.html#empty_name>empty name</a> is
+     * names, an {@linkplain Name##empty_name empty name} is
      * returned.
      *
      * <p>The name of a generic class or interface does not include any reference
@@ -169,8 +169,8 @@ public interface TypeElement extends Element, Parameterizable, QualifiedNameable
     /**
      * Returns the simple name of this class or interface element.
      *
-     * For an anonymous class, an <a href=Name.html#empty_name> empty
-     * name</a> is returned.
+     * For an anonymous class, an {@linkplain Name##empty_name empty
+     * name} is returned.
      *
      * @return the simple name of this class or interface,
      * an empty name for an anonymous class

--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -57,7 +57,7 @@ public interface Elements {
      *     <li>find non-empty packages with the given name returned by
      *         {@link #getPackageElement(ModuleElement, CharSequence)},
      *         where the provided ModuleSymbol is any
-     *         <a href="../../../../../java.base/java/lang/module/package-summary.html#root-modules">root module</a>,
+     *         {@linkplain java.lang.module##root-modules root module},
      *     </li>
      *     <li>if the above yields an empty list, search
      *         {@link #getAllModuleElements() all modules} for observable
@@ -144,7 +144,7 @@ public interface Elements {
      *     <li>find type elements with the given name returned by
      *         {@link #getTypeElement(ModuleElement, CharSequence)},
      *         where the provided ModuleSymbol is any
-     *         <a href="../../../../../java.base/java/lang/module/package-summary.html#root-modules">root module</a>,
+     *         {@linkplain java.lang.module##root-modules root module},
      *     </li>
      *     <li>if the above yields an empty list, search
      *         {@link #getAllModuleElements() all modules} for observable
@@ -811,9 +811,9 @@ public interface Elements {
      * {@return the file object for this element or {@code null} if
      * there is no such file object}
      *
-     * <p>The returned file object is for the <a
-     * href="../element/package-summary.html#accurate_model">reference
-     * representation</a> of the information used to construct the
+     * <p>The returned file object is for the {@linkplain
+     * javax.lang.model.element##accurate_model reference
+     * representation} of the information used to construct the
      * element. For example, if during compilation or annotation
      * processing, a source file for class {@code Foo} is compiled
      * into a class file, the file object returned for the element

--- a/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
@@ -388,8 +388,8 @@ public interface JavaFileManager extends Closeable, Flushable, OptionChecker {
 
     /**
      * Returns a {@linkplain FileObject file object} for input
-     * representing the specified <a href="JavaFileManager.html#relative_name">relative
-     * name</a> in the specified package in the given package-oriented location.
+     * representing the specified {@linkplain JavaFileManager##relative_name relative
+     * name} in the specified package in the given package-oriented location.
      *
      * <p>If the returned object represents a {@linkplain
      * JavaFileObject.Kind#SOURCE source} or {@linkplain
@@ -435,8 +435,8 @@ public interface JavaFileManager extends Closeable, Flushable, OptionChecker {
 
     /**
      * Returns a {@linkplain FileObject file object} for output
-     * representing the specified <a href="JavaFileManager.html#relative_name">relative
-     * name</a> in the specified package in the given location.
+     * representing the specified {@linkplain JavaFileManager##relative_name relative
+     * name} in the specified package in the given location.
      *
      * <p>Optionally, this file manager might consider the sibling as
      * a hint for where to place the output.  The exact semantics of
@@ -482,8 +482,8 @@ public interface JavaFileManager extends Closeable, Flushable, OptionChecker {
 
     /**
      * Returns a {@linkplain FileObject file object} for output
-     * representing the specified <a href="JavaFileManager.html#relative_name">relative
-     * name</a> in the specified package in the given location.
+     * representing the specified {@linkplain JavaFileManager##relative_name relative
+     * name} in the specified package in the given location.
      *
      * <p>The provided {@code originatingFiles} represent files that
      * were, in an unspecified way, used to create the content of


### PR DESCRIPTION
I'll update copyright years if needed before pushing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300595](https://bugs.openjdk.org/browse/JDK-8300595): Use improved @see and @link syntax in javax.lang.model and javax.tools


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to [1af9bae3](https://git.openjdk.org/jdk/pull/12086/files/1af9bae3f3ccbe725cab6f0e92b88397062fcd05)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12086/head:pull/12086` \
`$ git checkout pull/12086`

Update a local copy of the PR: \
`$ git checkout pull/12086` \
`$ git pull https://git.openjdk.org/jdk pull/12086/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12086`

View PR using the GUI difftool: \
`$ git pr show -t 12086`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12086.diff">https://git.openjdk.org/jdk/pull/12086.diff</a>

</details>
