### PR TITLE
8300269: The selected item in an editable JComboBox with titled border is not visible in Aqua LAF

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaComboBoxUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaComboBoxUI.java
@@ -457,7 +457,7 @@ public class AquaComboBoxUI extends BasicComboBoxUI implements Sizeable {
     class AquaComboBoxLayoutManager extends BasicComboBoxUI.ComboBoxLayoutManager {
         protected Rectangle rectangleForCurrentValue() {
             int width = comboBox.getWidth();
-            int height = 22;
+            int height = comboBox.getBorder() == null ? 22 : comboBox.getHeight();
             Insets insets = getInsets();
             int buttonSize = height - (insets.top + insets.bottom);
             if ( arrowButton != null )  {

--- a/test/jdk/javax/swing/JComboBox/JComboBoxWithTitledBorderTest.java
+++ b/test/jdk/javax/swing/JComboBox/JComboBoxWithTitledBorderTest.java
@@ -20,9 +20,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Robot;
+import java.awt.Toolkit;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.io.File;
@@ -31,6 +33,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+
 import javax.imageio.ImageIO;
 import javax.swing.BorderFactory;
 import javax.swing.JComboBox;
@@ -41,7 +44,6 @@ import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.UnsupportedLookAndFeelException;
-
 
 import static javax.swing.UIManager.getInstalledLookAndFeels;
 
@@ -164,8 +166,8 @@ public class JComboBoxWithTitledBorderTest {
 
     private static void captureScreen() {
         try {
-            final Rectangle screenBounds = new Rectangle(0, 0,
-                    1280, 720);
+            final Rectangle screenBounds = new Rectangle(
+                    Toolkit.getDefaultToolkit().getScreenSize());
             ImageIO.write(robot.createScreenCapture(screenBounds),
                     "png", new File("screen.png"));
         } catch (Exception e) {

--- a/test/jdk/javax/swing/JComboBox/JComboBoxWithTitledBorderTest.java
+++ b/test/jdk/javax/swing/JComboBox/JComboBoxWithTitledBorderTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import javax.imageio.ImageIO;
+import javax.swing.BorderFactory;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UIManager.LookAndFeelInfo;
+import javax.swing.UnsupportedLookAndFeelException;
+
+
+import static javax.swing.UIManager.getInstalledLookAndFeels;
+
+/*
+ * @test
+ * @key headful
+ * @bug 8300269
+ * @summary This test verifies the issue: Can't see the selected JComboBox
+ *          item if it has a titled border.
+ * @run main JComboBoxWithTitledBorderTest
+ */
+public class JComboBoxWithTitledBorderTest {
+    private static final String[] comboStrings =
+            {"First", "Second", "Third", "Fourth"};
+    private static JFrame frame;
+    private static JComboBox<String> combo;
+    private static Robot robot;
+
+    public static void main(String[] argv) throws Exception {
+        robot = new Robot();
+        robot.setAutoWaitForIdle(true);
+        robot.setAutoDelay(200);
+        List<String> lafs = Arrays.stream(getInstalledLookAndFeels())
+                .map(LookAndFeelInfo::getClassName)
+                .collect(Collectors.toList());
+        for (final String laf : lafs) {
+            try {
+                AtomicBoolean lafSetSuccess = new AtomicBoolean(false);
+                System.out.println("Setting LAF: " + laf);
+                SwingUtilities.invokeAndWait(() -> {
+                    lafSetSuccess.set(setLookAndFeel(laf));
+                    if (lafSetSuccess.get()) {
+                        createAndShowGUI(laf);
+                    }
+                });
+                if (!lafSetSuccess.get()) {
+                    continue;
+                }
+                robot.waitForIdle();
+
+                mouseClick(combo);
+
+                hitKeys(KeyEvent.VK_RIGHT, KeyEvent.VK_BACK_SPACE,
+                        KeyEvent.VK_ENTER);
+                String item = (String) combo.getSelectedItem();
+                System.out.println("Current item: " + item);
+                // Deletes the last character of the combo item and check
+                // whether its getting reflected in item. Bug JDK-8300269: It's
+                // not getting reflected in case of AquaLookAndFeel.
+                if ("Firs".equals(item)) {
+                    System.out.println("Test Passed for " + laf);
+                } else {
+                    captureScreen();
+                    throw new RuntimeException("Test Failed for " + laf);
+                }
+            } finally {
+                SwingUtilities.invokeAndWait(
+                        JComboBoxWithTitledBorderTest::disposeFrame);
+            }
+        }
+    }
+
+    private static void hitKeys(int... keys) {
+        for (int key : keys) {
+            robot.keyPress(key);
+        }
+        for (int i = keys.length - 1; i >= 0; i--) {
+            robot.keyRelease(keys[i]);
+        }
+    }
+
+    private static void mouseClick(JComponent jComponent) throws Exception {
+        final AtomicReference<Point> loc = new AtomicReference<>();
+        SwingUtilities
+                .invokeAndWait(() -> loc.set(jComponent.getLocationOnScreen()));
+        final Point location = loc.get();
+        robot.mouseMove(location.x + 25, location.y + 5);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+    }
+
+    private static void createAndShowGUI(final String laf) {
+        frame = new JFrame("JComboBox with Titled Border test");
+        frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+
+        JPanel panel = new JPanel();
+        combo = new JComboBox<>(comboStrings);
+        combo.setEditable(true);
+
+        // Create a titled border for the ComboBox with the LAF name as title.
+        String[] lafStrings = laf.split("[.]");
+        combo.setBorder(BorderFactory.createTitledBorder(
+                lafStrings[lafStrings.length - 1]));
+        panel.add(combo);
+        frame.getContentPane().add(panel);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    private static boolean setLookAndFeel(String lafName) {
+        try {
+            UIManager.setLookAndFeel(lafName);
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.out.println("Ignoring Unsupported LAF: " + lafName);
+            return false;
+        } catch (ClassNotFoundException | InstantiationException
+                | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+        return true;
+    }
+
+    private static void disposeFrame() {
+        if (frame != null) {
+            frame.dispose();
+            frame = null;
+        }
+    }
+
+    private static void captureScreen() {
+        try {
+            final Rectangle screenBounds = new Rectangle(0, 0,
+                    1280, 720);
+            ImageIO.write(robot.createScreenCapture(screenBounds),
+                    "png", new File("screen.png"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+}


### PR DESCRIPTION
The fixed height causes the titled border insets to reserve a majority of the height available for the component. This fixed height is meant for the default AquaComboBox usage, so the old default height is more applicable when a border, such as TitledBorder, is set on an Aqua Editable ComboBox.

A conditional to check for a border is added since this is the default for an AquaComboBox using AquaBorder in AquaComboBoxUI's rectangleForCurrentValue() step. A check for any border rather than an instance of a TitledBorder is used because this issue causes changes in other borders as well (I found it for LineBorder for example). 

The editable JComboBox is visible with a LineBorder, but the coordinates of the comboBox are aligned with the top of the arrowButton instead of the bottom (which was the case before the previous fix). So, the method now defaults to the behavior before the fix for any editable comboBox pre-fix if a different border is set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300269](https://bugs.openjdk.org/browse/JDK-8300269): The selected item in an editable JComboBox with titled border is not visible in Aqua LAF


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Contributors
 * Manukumar V S `<mvs@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12087/head:pull/12087` \
`$ git checkout pull/12087`

Update a local copy of the PR: \
`$ git checkout pull/12087` \
`$ git pull https://git.openjdk.org/jdk pull/12087/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12087`

View PR using the GUI difftool: \
`$ git pr show -t 12087`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12087.diff">https://git.openjdk.org/jdk/pull/12087.diff</a>

</details>
