### PR TITLE
JDK-8296403: [TESTBUG] IR test runner methods in TestLongRangeChecks.java invoke wrong test methods

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestLongRangeChecks.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestLongRangeChecks.java
@@ -195,7 +195,7 @@ public class TestLongRangeChecks {
 
     @Run(test = "testStrideNegScalePosInIntLoop2")
     private void testStrideNegScalePosInIntLoop2_runner() {
-        testStrideNegScalePosInIntLoop1(0, 100, 200, 0);
+        testStrideNegScalePosInIntLoop2(0, 100, 200, 0);
     }
 
     @Test
@@ -243,6 +243,6 @@ public class TestLongRangeChecks {
 
     @Run(test = "testStridePosScaleNegInIntLoop2")
     private void testStridePosScaleNegInIntLoop2_runner() {
-        testStridePosScaleNegInIntLoop1(0, 100, 200, 198);
+        testStridePosScaleNegInIntLoop2(0, 100, 200, 198);
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestLongRangeChecks.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestLongRangeChecks.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, 2022, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
The `testStrideNegScalePosInIntLoop2` and `testStridePosScaleNegInIntLoop2` tests of the IR test _TestLongRangeChecks.java_ invoke the wrong test methods.

Changing the test method calls to invoke the right ones.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296403](https://bugs.openjdk.org/browse/JDK-8296403): [TESTBUG] IR test runner methods in TestLongRangeChecks.java invoke wrong test methods


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [da08bbc0](https://git.openjdk.org/jdk/pull/12088/files/da08bbc0c8fea74fb76a65caddfcecc14ab4918e)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [da08bbc0](https://git.openjdk.org/jdk/pull/12088/files/da08bbc0c8fea74fb76a65caddfcecc14ab4918e)
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12088/head:pull/12088` \
`$ git checkout pull/12088`

Update a local copy of the PR: \
`$ git checkout pull/12088` \
`$ git pull https://git.openjdk.org/jdk pull/12088/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12088`

View PR using the GUI difftool: \
`$ git pr show -t 12088`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12088.diff">https://git.openjdk.org/jdk/pull/12088.diff</a>

</details>
