### PR TITLE
8300647: Miscellaneous hashCode improvements in java.base

### DIFF
--- a/src/java.base/share/classes/sun/security/util/DerValue.java
+++ b/src/java.base/share/classes/sun/security/util/DerValue.java
@@ -25,6 +25,7 @@
 
 package sun.security.util;
 
+import jdk.internal.util.ArraysSupport;
 import sun.nio.cs.UTF_32BE;
 import sun.util.calendar.CalendarDate;
 import sun.util.calendar.CalendarSystem;
@@ -1257,11 +1258,7 @@ public class DerValue {
      */
     @Override
     public int hashCode() {
-        int result = tag;
-        for (int i = start; i < end; i++) {
-            result = 31 * result + buffer[i];
-        }
-        return result;
+        return ArraysSupport.vectorizedHashCode(buffer, start, end - start, tag, ArraysSupport.T_BYTE);
     }
 
     /**

--- a/src/java.base/unix/classes/java/lang/ProcessEnvironment.java
+++ b/src/java.base/unix/classes/java/lang/ProcessEnvironment.java
@@ -145,11 +145,11 @@ final class ProcessEnvironment
 
         public boolean equals(Object o) {
             return o instanceof ExternalData
-                && arrayEquals(getBytes(), ((ExternalData) o).getBytes());
+                && Arrays.equals(getBytes(), ((ExternalData) o).getBytes());
         }
 
         public int hashCode() {
-            return arrayHash(getBytes());
+            return Arrays.hashCode(getBytes());
         }
     }
 
@@ -178,7 +178,7 @@ final class ProcessEnvironment
         }
 
         public int compareTo(Variable variable) {
-            return arrayCompare(getBytes(), variable.getBytes());
+            return Arrays.compare(getBytes(), variable.getBytes());
         }
 
         public boolean equals(Object o) {
@@ -211,7 +211,7 @@ final class ProcessEnvironment
         }
 
         public int compareTo(Value value) {
-            return arrayCompare(getBytes(), value.getBytes());
+            return Arrays.compare(getBytes(), value.getBytes());
         }
 
         public boolean equals(Object o) {
@@ -410,33 +410,6 @@ final class ProcessEnvironment
         public boolean remove(Object o) {
             return s.remove(Variable.valueOfQueryOnly(o));
         }
-    }
-
-    // Replace with general purpose method someday
-    private static int arrayCompare(byte[]x, byte[] y) {
-        int min = x.length < y.length ? x.length : y.length;
-        for (int i = 0; i < min; i++)
-            if (x[i] != y[i])
-                return x[i] - y[i];
-        return x.length - y.length;
-    }
-
-    // Replace with general purpose method someday
-    private static boolean arrayEquals(byte[] x, byte[] y) {
-        if (x.length != y.length)
-            return false;
-        for (int i = 0; i < x.length; i++)
-            if (x[i] != y[i])
-                return false;
-        return true;
-    }
-
-    // Replace with general purpose method someday
-    private static int arrayHash(byte[] x) {
-        int hash = 0;
-        for (int i = 0; i < x.length; i++)
-            hash = 31 * hash + x[i];
-        return hash;
     }
 
 }

--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -25,6 +25,8 @@
 
 package jdk.nio.zipfs;
 
+import jdk.internal.util.ArraysSupport;
+
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -3381,11 +3383,9 @@ class ZipFileSystem extends FileSystem {
         void name(byte[] name, int len) {
             this.name = name;
             this.len = len;
-            // calculate the hashcode the same way as Arrays.hashCode() does
-            int result = 1;
-            for (int i = 0; i < len; i++)
-                result = 31 * result + name[i];
-            this.hashcode = result;
+            // calculate the hashcode the same way as Arrays.hashCode(byte[]) does,
+            // except taking a range
+            this.hashcode = ArraysSupport.vectorizedHashCode(name, 0, len, 1, ArraysSupport.T_BYTE);
         }
 
         @Override


### PR DESCRIPTION
Went through the jdk and found a few more places where `ArraysSupport::vectorizedHashCode` can be used, and a few where adhoc methods could be replaced with a plain call to `java.util.Arrays` equivalents. This patch addresses that.

After this, #12068, and #12077 I think we're reaching the limit of sensible direct use of `AS::vectorizedHashCode`. I've found a few places outside of java.base where `vectorizedHashCode` might be applicable, but none that seem important enough to warrant an export of this method outside of java.base.