### PR TITLE
8300652: Parallel: Refactor oop marking stack in Full GC

### DIFF
--- a/src/hotspot/share/gc/parallel/psCompactionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.cpp
@@ -81,7 +81,7 @@ void ParCompactionManager::initialize(ParMarkBitMap* mbm) {
   // Create and register the ParCompactionManager(s) for the worker threads.
   for(uint i=0; i<parallel_gc_threads; i++) {
     _manager_array[i] = new ParCompactionManager();
-    oop_task_queues()->register_queue(i, _manager_array[i]->marking_stack());
+    oop_task_queues()->register_queue(i, _manager_array[i]->oop_stack());
     _objarray_task_queues->register_queue(i, &_manager_array[i]->_objarray_stack);
     region_task_queues()->register_queue(i, _manager_array[i]->region_stack());
   }
@@ -117,12 +117,12 @@ ParCompactionManager::gc_thread_compaction_manager(uint index) {
 
 inline void ParCompactionManager::publish_and_drain_oop_tasks() {
   oop obj;
-  while (marking_stack()->pop_overflow(obj)) {
-    if (!marking_stack()->try_push_to_taskqueue(obj)) {
+  while (oop_stack()->pop_overflow(obj)) {
+    if (!oop_stack()->try_push_to_taskqueue(obj)) {
       follow_contents(obj);
     }
   }
-  while (marking_stack()->pop_local(obj)) {
+  while (oop_stack()->pop_local(obj)) {
     follow_contents(obj);
   }
 }

--- a/src/hotspot/share/gc/parallel/psCompactionManager.hpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.hpp
@@ -48,7 +48,7 @@ class ParCompactionManager : public CHeapObj<mtGC> {
   friend class UpdateDensePrefixAndCompactionTask;
 
  private:
-  typedef GenericTaskQueue<oop, mtGC>             OopTaskQueue;
+  typedef OverflowTaskQueue<oop, mtGC>            OopTaskQueue;
   typedef GenericTaskQueueSet<OopTaskQueue, mtGC> OopTaskQueueSet;
 
   // 32-bit:  4K * 8 = 32KiB; 64-bit:  8K * 16 = 128KiB
@@ -66,11 +66,11 @@ class ParCompactionManager : public CHeapObj<mtGC> {
   static RegionTaskQueueSet*    _region_task_queues;
   static PSOldGen*              _old_gen;
 
-  OverflowTaskQueue<oop, mtGC>        _marking_stack;
+  OopTaskQueue                  _oop_stack;
   ObjArrayTaskQueue             _objarray_stack;
   size_t                        _next_shadow_region;
 
-  // Is there a way to reuse the _marking_stack for the
+  // Is there a way to reuse the _oop_stack for the
   // saving empty regions?  For now just create a different
   // type of TaskQueue.
   RegionTaskQueue              _region_stack;
@@ -108,7 +108,7 @@ class ParCompactionManager : public CHeapObj<mtGC> {
  protected:
   // Array of task queues.  Needed by the task terminator.
   static RegionTaskQueueSet* region_task_queues()      { return _region_task_queues; }
-  OverflowTaskQueue<oop, mtGC>*  marking_stack()       { return &_marking_stack; }
+  OopTaskQueue*  oop_stack()       { return &_oop_stack; }
 
   // Pushes onto the marking stack.  If the marking stack is full,
   // pushes onto the overflow stack.
@@ -221,7 +221,7 @@ class ParCompactionManager : public CHeapObj<mtGC> {
 };
 
 bool ParCompactionManager::marking_stacks_empty() const {
-  return _marking_stack.is_empty() && _objarray_stack.is_empty();
+  return _oop_stack.is_empty() && _objarray_stack.is_empty();
 }
 
 #endif // SHARE_GC_PARALLEL_PSCOMPACTIONMANAGER_HPP

--- a/src/hotspot/share/gc/parallel/psCompactionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.inline.hpp
@@ -78,7 +78,7 @@ inline bool ParCompactionManager::steal(int queue_num, size_t& region) {
 }
 
 inline void ParCompactionManager::push(oop obj) {
-  _marking_stack.push(obj);
+  _oop_stack.push(obj);
 }
 
 void ParCompactionManager::push_objarray(oop obj, size_t index)


### PR DESCRIPTION
Simple rename of the oop marking stack.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300652](https://bugs.openjdk.org/browse/JDK-8300652): Parallel: Refactor oop marking stack in Full GC


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12095/head:pull/12095` \
`$ git checkout pull/12095`

Update a local copy of the PR: \
`$ git checkout pull/12095` \
`$ git pull https://git.openjdk.org/jdk pull/12095/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12095`

View PR using the GUI difftool: \
`$ git pr show -t 12095`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12095.diff">https://git.openjdk.org/jdk/pull/12095.diff</a>

</details>
