### PR TITLE
8300653: G1EvacInfo should use common naming scheme for collection set

### DIFF
--- a/src/hotspot/share/gc/g1/g1EvacInfo.hpp
+++ b/src/hotspot/share/gc/g1/g1EvacInfo.hpp
@@ -28,34 +28,34 @@
 #include "memory/allocation.hpp"
 
 class G1EvacInfo : public StackObj {
-  uint _collectionset_regions;
+  uint _collection_set_regions;
   uint _allocation_regions;
-  size_t _collectionset_used_before;
-  size_t _collectionset_used_after;
+  size_t _collection_set_used_before;
+  size_t _collection_set_used_after;
   size_t _alloc_regions_used_before;
   size_t _bytes_used;
   uint   _regions_freed;
 
 public:
   G1EvacInfo() :
-    _collectionset_regions(0), _allocation_regions(0), _collectionset_used_before(0),
-    _collectionset_used_after(0), _alloc_regions_used_before(0),
+    _collection_set_regions(0), _allocation_regions(0), _collection_set_used_before(0),
+    _collection_set_used_after(0), _alloc_regions_used_before(0),
     _bytes_used(0), _regions_freed(0) { }
 
-  void set_collectionset_regions(uint collectionset_regions) {
-    _collectionset_regions = collectionset_regions;
+  void set_collection_set_regions(uint collection_set_regions) {
+    _collection_set_regions = collection_set_regions;
   }
 
   void set_allocation_regions(uint allocation_regions) {
     _allocation_regions = allocation_regions;
   }
 
-  void set_collectionset_used_before(size_t used) {
-    _collectionset_used_before = used;
+  void set_collection_set_used_before(size_t used) {
+    _collection_set_used_before = used;
   }
 
-  void increment_collectionset_used_after(size_t used) {
-    _collectionset_used_after += used;
+  void increment_collection_set_used_after(size_t used) {
+    _collection_set_used_after += used;
   }
 
   void set_alloc_regions_used_before(size_t used) {
@@ -70,13 +70,13 @@ public:
     _regions_freed += freed;
   }
 
-  uint   collectionset_regions()     { return _collectionset_regions; }
-  uint   allocation_regions()        { return _allocation_regions; }
-  size_t collectionset_used_before() { return _collectionset_used_before; }
-  size_t collectionset_used_after()  { return _collectionset_used_after; }
-  size_t alloc_regions_used_before() { return _alloc_regions_used_before; }
-  size_t bytes_used()                { return _bytes_used; }
-  uint   regions_freed()             { return _regions_freed; }
+  uint   collection_set_regions()     { return _collection_set_regions; }
+  uint   allocation_regions()         { return _allocation_regions; }
+  size_t collection_set_used_before() { return _collection_set_used_before; }
+  size_t collection_set_used_after()  { return _collection_set_used_after; }
+  size_t alloc_regions_used_before()  { return _alloc_regions_used_before; }
+  size_t bytes_used()                 { return _bytes_used; }
+  uint   regions_freed()              { return _regions_freed; }
 };
 
 #endif // SHARE_GC_G1_G1EVACINFO_HPP

--- a/src/hotspot/share/gc/g1/g1Trace.cpp
+++ b/src/hotspot/share/gc/g1/g1Trace.cpp
@@ -145,9 +145,9 @@ void G1NewTracer::send_evacuation_info_event(G1EvacInfo* info) {
   EventEvacuationInformation e;
   if (e.should_commit()) {
     e.set_gcId(GCId::current());
-    e.set_cSetRegions(info->collectionset_regions());
-    e.set_cSetUsedBefore(info->collectionset_used_before());
-    e.set_cSetUsedAfter(info->collectionset_used_after());
+    e.set_cSetRegions(info->collection_set_regions());
+    e.set_cSetUsedBefore(info->collection_set_used_before());
+    e.set_cSetUsedAfter(info->collection_set_used_after());
     e.set_allocationRegions(info->allocation_regions());
     e.set_allocationRegionsUsedBefore(info->alloc_regions_used_before());
     e.set_allocationRegionsUsedAfter(info->alloc_regions_used_before() + info->bytes_used());

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -271,7 +271,7 @@ void G1YoungCollector::calculate_collection_set(G1EvacInfo* evacuation_info, dou
   allocator()->release_mutator_alloc_regions();
 
   collection_set()->finalize_initial_collection_set(target_pause_time_ms, survivor_regions());
-  evacuation_info->set_collectionset_regions(collection_set()->region_length() +
+  evacuation_info->set_collection_set_regions(collection_set()->region_length() +
                                             collection_set()->optional_region_length());
 
   concurrent_mark()->verify_no_collection_set_oops();
@@ -1020,7 +1020,7 @@ void G1YoungCollector::post_evacuate_collection_set(G1EvacInfo* evacuation_info,
 
   _g1h->record_obj_copy_mem_stats();
 
-  evacuation_info->set_collectionset_used_before(collection_set()->bytes_used_before());
+  evacuation_info->set_collection_set_used_before(collection_set()->bytes_used_before());
   evacuation_info->set_bytes_used(_g1h->bytes_used_during_gc());
 
   _g1h->start_new_collection_set();

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -465,7 +465,7 @@ public:
 
   void report(G1CollectedHeap* g1h, G1EvacInfo* evacuation_info) {
     evacuation_info->set_regions_freed(_regions_freed);
-    evacuation_info->increment_collectionset_used_after(_after_used_bytes);
+    evacuation_info->increment_collection_set_used_after(_after_used_bytes);
 
     g1h->decrement_summary_bytes(_before_used_bytes);
     g1h->alloc_buffer_stats(G1HeapRegionAttr::Old)->add_failure_used_and_waste(_failure_used_words, _failure_waste_words);


### PR DESCRIPTION
Hi all,

  please review this imo trivial renaming of some identifiers containing `collectionset` to `collection_set`.

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300653](https://bugs.openjdk.org/browse/JDK-8300653): G1EvacInfo should use common naming scheme for collection set


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12096/head:pull/12096` \
`$ git checkout pull/12096`

Update a local copy of the PR: \
`$ git checkout pull/12096` \
`$ git pull https://git.openjdk.org/jdk pull/12096/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12096`

View PR using the GUI difftool: \
`$ git pr show -t 12096`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12096.diff">https://git.openjdk.org/jdk/pull/12096.diff</a>

</details>
