### PR TITLE
8300659: Refactor TestMemoryAwareness to use WhiteBox api for host values

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -2355,13 +2355,13 @@ WB_ENTRY(jboolean, WB_IsContainerized(JNIEnv* env, jobject o))
 WB_END
 
 // Physical memory of the host machine (including containers)
-WB_ENTRY(jlong, WB_PhysicalMemory(JNIEnv* env, jobject o))
+WB_ENTRY(jlong, WB_HostPhysicalMemory(JNIEnv* env, jobject o))
   LINUX_ONLY(return os::Linux::physical_memory();)
   return os::physical_memory();
 WB_END
 
 // Physical swap of the host machine (including containers), Linux only.
-WB_ENTRY(jlong, WB_PhysicalSwap(JNIEnv* env, jobject o))
+WB_ENTRY(jlong, WB_HostPhysicalSwap(JNIEnv* env, jobject o))
   LINUX_ONLY(return (jlong)os::Linux::host_swap();)
   return -1; // Not used/implemented on other platforms
 WB_END
@@ -2765,8 +2765,8 @@ static JNINativeMethod methods[] = {
   {CC"validateCgroup",
       CC"(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)I",
                                                       (void*)&WB_ValidateCgroup },
-  {CC"physicalMemory",            CC"()J",            (void*)&WB_PhysicalMemory },
-  {CC"physicalSwap",              CC"()J",            (void*)&WB_PhysicalSwap },
+  {CC"hostPhysicalMemory",        CC"()J",            (void*)&WB_HostPhysicalMemory },
+  {CC"hostPhysicalSwap",          CC"()J",            (void*)&WB_HostPhysicalSwap },
   {CC"printOsInfo",               CC"()V",            (void*)&WB_PrintOsInfo },
   {CC"disableElfSectionCache",    CC"()V",            (void*)&WB_DisableElfSectionCache },
   {CC"resolvedMethodItemsCount",  CC"()J",            (void*)&WB_ResolvedMethodItemsCount },

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -113,6 +113,7 @@
 #include "jvmci/jvmciRuntime.hpp"
 #endif
 #ifdef LINUX
+#include "os_linux.hpp"
 #include "osContainer_linux.hpp"
 #include "cgroupSubsystem_linux.hpp"
 #endif
@@ -2353,6 +2354,18 @@ WB_ENTRY(jboolean, WB_IsContainerized(JNIEnv* env, jobject o))
   return false;
 WB_END
 
+// Physical memory of the host machine (including containers)
+WB_ENTRY(jlong, WB_PhysicalMemory(JNIEnv* env, jobject o))
+  LINUX_ONLY(return os::Linux::physical_memory();)
+  return os::physical_memory();
+WB_END
+
+// Physical swap of the host machine (including containers), Linux only.
+WB_ENTRY(jlong, WB_PhysicalSwap(JNIEnv* env, jobject o))
+  LINUX_ONLY(return (jlong)os::Linux::host_swap();)
+  return -1; // Not used/implemented on other platforms
+WB_END
+
 WB_ENTRY(jint, WB_ValidateCgroup(JNIEnv* env,
                                     jobject o,
                                     jstring proc_cgroups,
@@ -2752,6 +2765,8 @@ static JNINativeMethod methods[] = {
   {CC"validateCgroup",
       CC"(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)I",
                                                       (void*)&WB_ValidateCgroup },
+  {CC"physicalMemory",            CC"()J",            (void*)&WB_PhysicalMemory },
+  {CC"physicalSwap",              CC"()J",            (void*)&WB_PhysicalSwap },
   {CC"printOsInfo",               CC"()V",            (void*)&WB_PrintOsInfo },
   {CC"disableElfSectionCache",    CC"()V",            (void*)&WB_DisableElfSectionCache },
   {CC"resolvedMethodItemsCount",  CC"()J",            (void*)&WB_ResolvedMethodItemsCount },

--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -35,23 +35,26 @@
  *          jdk.jartool/sun.tools.jar
  * @build AttemptOOM jdk.test.whitebox.WhiteBox PrintContainerInfo CheckOperatingSystemMXBean
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar whitebox.jar jdk.test.whitebox.WhiteBox
- * @run driver TestMemoryAwareness
+ * @run main/othervm -Xbootclasspath/a:whitebox.jar -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI TestMemoryAwareness
  */
 import jdk.test.lib.containers.docker.Common;
 import jdk.test.lib.containers.docker.DockerRunOptions;
 import jdk.test.lib.containers.docker.DockerTestUtils;
+import jdk.test.whitebox.WhiteBox;
 import jdk.test.lib.process.OutputAnalyzer;
 
 import static jdk.test.lib.Asserts.assertNotNull;
 
 public class TestMemoryAwareness {
     private static final String imageName = Common.imageName("memory");
+    private static final WhiteBox wb = WhiteBox.getWhiteBox();
 
-    private static String getHostMaxMemory() throws Exception {
-        DockerRunOptions opts = Common.newOpts(imageName);
-        String goodMem = Common.run(opts).firstMatch("total physical memory: (\\d+)", 1);
-        assertNotNull(goodMem, "no match for 'total physical memory' in trace output");
-        return goodMem;
+    private static String getHostMaxMemory() {
+        return Long.valueOf(wb.physicalMemory()).toString();
+    }
+
+    private static String getHostSwap() {
+        return Long.valueOf(wb.physicalSwap()).toString();
     }
 
     public static void main(String[] args) throws Exception {
@@ -92,10 +95,9 @@ public class TestMemoryAwareness {
                 "200M", Integer.toString(((int) Math.pow(2, 20)) * (200 - 100)),
                 true /* additional cgroup fs mounts */
             );
-            final String hostMaxMem = getHostMaxMemory();
-            testOperatingSystemMXBeanIgnoresMemLimitExceedingPhysicalMemory(hostMaxMem);
-            testMetricsIgnoresMemLimitExceedingPhysicalMemory(hostMaxMem);
-            testContainerMemExceedsPhysical(hostMaxMem);
+            testOSMXBeanIgnoresMemLimitExceedingPhysicalMemory();
+            testMetricsExceedingPhysicalMemory();
+            testContainerMemExceedsPhysical();
         } finally {
             if (!DockerTestUtils.RETAIN_IMAGE_AFTER_TEST) {
                 DockerTestUtils.removeDockerImage(imageName);
@@ -122,9 +124,10 @@ public class TestMemoryAwareness {
 
     // JDK-8292083
     // Ensure that Java ignores container memory limit values above the host's physical memory.
-    private static void testContainerMemExceedsPhysical(final String hostMaxMem)
+    private static void testContainerMemExceedsPhysical()
             throws Exception {
         Common.logNewTestCase("container memory limit exceeds physical memory");
+        String hostMaxMem = getHostMaxMemory();
         String badMem = hostMaxMem + "0";
         // set a container memory limit to the bad value
         DockerRunOptions opts = Common.newOpts(imageName)
@@ -207,12 +210,17 @@ public class TestMemoryAwareness {
 
         // in case of warnings like : "Your kernel does not support swap limit capabilities
         // or the cgroup is not mounted. Memory limited without swap."
-        // the getTotalSwapSpaceSize and getFreeSwapSpaceSize return the system
-        // values as the container setup isn't supported in that case.
+        // the getTotalSwapSpaceSize either returns the system (or host) values, or 0
+        // if a container memory limit is in place and gets detected. A value of 0 is because,
+        // Metrics.getMemoryLimit() returns the same value as Metrics.getMemoryAndSwapLimit().
+        //
+        // getFreeSwapSpaceSize() are a function of what getTotalSwapSpaceSize() returns. Either
+        // a number > 0, or 0 if getTotalSwapSpaceSize() == 0.
         try {
             out.shouldContain("OperatingSystemMXBean.getTotalSwapSpaceSize: " + expectedSwap);
         } catch(RuntimeException ex) {
-            out.shouldMatch("OperatingSystemMXBean.getTotalSwapSpaceSize: [0-9]+");
+            String hostSwap = getHostSwap();
+            out.shouldMatch("OperatingSystemMXBean.getTotalSwapSpaceSize: (0|" + hostSwap + ")");
         }
 
         try {
@@ -224,17 +232,18 @@ public class TestMemoryAwareness {
 
 
     // JDK-8292541: Ensure OperatingSystemMXBean ignores container memory limits above the host's physical memory.
-    private static void testOperatingSystemMXBeanIgnoresMemLimitExceedingPhysicalMemory(final String hostMaxMem)
+    private static void testOSMXBeanIgnoresMemLimitExceedingPhysicalMemory()
             throws Exception {
+        String hostMaxMem = getHostMaxMemory();
         String badMem = hostMaxMem + "0";
         testOperatingSystemMXBeanAwareness(badMem, hostMaxMem, badMem, hostMaxMem);
     }
 
     // JDK-8292541: Ensure Metrics ignores container memory limits above the host's physical memory.
-    private static void testMetricsIgnoresMemLimitExceedingPhysicalMemory(final String hostMaxMem)
+    private static void testMetricsExceedingPhysicalMemory()
             throws Exception {
         Common.logNewTestCase("Metrics ignore container memory limit exceeding physical memory");
-        String badMem = hostMaxMem + "0";
+        String badMem = getHostMaxMemory() + "0";
         DockerRunOptions opts = Common.newOpts(imageName)
             .addJavaOpts("-XshowSettings:system")
             .addDockerOpts("--memory", badMem);

--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -50,11 +50,11 @@ public class TestMemoryAwareness {
     private static final WhiteBox wb = WhiteBox.getWhiteBox();
 
     private static String getHostMaxMemory() {
-        return Long.valueOf(wb.physicalMemory()).toString();
+        return Long.valueOf(wb.hostPhysicalMemory()).toString();
     }
 
     private static String getHostSwap() {
-        return Long.valueOf(wb.physicalSwap()).toString();
+        return Long.valueOf(wb.hostPhysicalSwap()).toString();
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -708,6 +708,8 @@ public class WhiteBox {
                                    String procSelfCgroup,
                                    String procSelfMountinfo);
   public native void printOsInfo();
+  public native long physicalMemory();
+  public native long physicalSwap();
 
   // Decoder
   public native void disableElfSectionCache();

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -708,8 +708,8 @@ public class WhiteBox {
                                    String procSelfCgroup,
                                    String procSelfMountinfo);
   public native void printOsInfo();
-  public native long physicalMemory();
-  public native long physicalSwap();
+  public native long hostPhysicalMemory();
+  public native long hostPhysicalSwap();
 
   // Decoder
   public native void disableElfSectionCache();


### PR DESCRIPTION
Please review this refactoring of a container test. It now uses WhiteBox to retrieve the host values it asserts for. In terms of functionality this is basically a no-op except for the now more precise assertion on systems with swap accounting disabled at the kernel level.

*Testing*
- [x] Container tests on Linux x86_64 cgv1 and cgv2
- [x] Container tests on Linux x86_64 cgv1 and cgv2 on systems with swapaccount=0
- [x] GHA in progress 

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300659](https://bugs.openjdk.org/browse/JDK-8300659): Refactor TestMemoryAwareness to use WhiteBox api for host values


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12097/head:pull/12097` \
`$ git checkout pull/12097`

Update a local copy of the PR: \
`$ git checkout pull/12097` \
`$ git pull https://git.openjdk.org/jdk pull/12097/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12097`

View PR using the GUI difftool: \
`$ git pr show -t 12097`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12097.diff">https://git.openjdk.org/jdk/pull/12097.diff</a>

</details>
