### PR TITLE
JDK-8302281 - ImageReader and ImageWrite should implement Closable

### DIFF
--- a/src/java.desktop/share/classes/javax/imageio/ImageReader.java
+++ b/src/java.desktop/share/classes/javax/imageio/ImageReader.java
@@ -2879,6 +2879,7 @@ public abstract class ImageReader implements AutoCloseable {
 
     /**
      * @implNote The default implementation of this method invokes {@link #dispose()}.
+     * @since 21
      */
     public void close() {
         dispose();

--- a/src/java.desktop/share/classes/javax/imageio/ImageReader.java
+++ b/src/java.desktop/share/classes/javax/imageio/ImageReader.java
@@ -30,6 +30,7 @@ import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.awt.image.Raster;
 import java.awt.image.RenderedImage;
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -70,7 +71,7 @@ import javax.imageio.stream.ImageInputStream;
  * @see javax.imageio.spi.ImageReaderSpi
  *
  */
-public abstract class ImageReader implements AutoCloseable {
+public abstract class ImageReader implements Closeable {
 
     /**
      * The {@code ImageReaderSpi} that instantiated this object,

--- a/src/java.desktop/share/classes/javax/imageio/ImageReader.java
+++ b/src/java.desktop/share/classes/javax/imageio/ImageReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,7 +70,7 @@ import javax.imageio.stream.ImageInputStream;
  * @see javax.imageio.spi.ImageReaderSpi
  *
  */
-public abstract class ImageReader {
+public abstract class ImageReader implements AutoCloseable {
 
     /**
      * The {@code ImageReaderSpi} that instantiated this object,
@@ -2875,5 +2875,12 @@ public abstract class ImageReader {
         int destHeight = destRegion.y + destRegion.height;
         // Create a new image based on the type specifier
         return imageType.createBufferedImage(destWidth, destHeight);
+    }
+
+    /**
+     * @implNote The default implementation of this method invokes {@link #dispose()}.
+     */
+    public void close() {
+        dispose();
     }
 }

--- a/src/java.desktop/share/classes/javax/imageio/ImageWriter.java
+++ b/src/java.desktop/share/classes/javax/imageio/ImageWriter.java
@@ -30,6 +30,7 @@ import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.awt.image.RenderedImage;
 import java.awt.image.Raster;
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -59,7 +60,7 @@ import javax.imageio.spi.ImageWriterSpi;
  * @see javax.imageio.spi.ImageWriterSpi
  *
  */
-public abstract class ImageWriter implements ImageTranscoder, AutoCloseable {
+public abstract class ImageWriter implements ImageTranscoder, Closeable {
 
     /**
      * The {@code ImageWriterSpi} that instantiated this object,

--- a/src/java.desktop/share/classes/javax/imageio/ImageWriter.java
+++ b/src/java.desktop/share/classes/javax/imageio/ImageWriter.java
@@ -2018,6 +2018,7 @@ public abstract class ImageWriter implements ImageTranscoder, AutoCloseable {
 
     /**
      * @implNote The default implementation of this method invokes {@link #dispose()}.
+     * @since 21
      */
     public void close() {
         dispose();

--- a/src/java.desktop/share/classes/javax/imageio/ImageWriter.java
+++ b/src/java.desktop/share/classes/javax/imageio/ImageWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ import javax.imageio.spi.ImageWriterSpi;
  * @see javax.imageio.spi.ImageWriterSpi
  *
  */
-public abstract class ImageWriter implements ImageTranscoder {
+public abstract class ImageWriter implements ImageTranscoder, AutoCloseable {
 
     /**
      * The {@code ImageWriterSpi} that instantiated this object,
@@ -2014,5 +2014,12 @@ public abstract class ImageWriter implements ImageTranscoder {
      * especially native resources, are released.
      */
     public void dispose() {
+    }
+
+    /**
+     * @implNote The default implementation of this method invokes {@link #dispose()}.
+     */
+    public void close() {
+        dispose();
     }
 }

--- a/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ import java.nio.ByteOrder;
  * @see MemoryCacheImageInputStream
  *
  */
-public interface ImageInputStream extends DataInput, Closeable, AutoCloseable {
+public interface ImageInputStream extends DataInput, Closeable {
 
     /**
      * Sets the desired byte order for future reads of data values

--- a/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStream.java
@@ -994,7 +994,6 @@ public interface ImageInputStream extends DataInput, Closeable {
      * such as memory, disk space, or file descriptors.
      *
      * @throws IOException if an I/O error occurs.
-     * @since 21
      */
     void close() throws IOException;
 }

--- a/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStream.java
@@ -994,6 +994,7 @@ public interface ImageInputStream extends DataInput, Closeable, AutoCloseable {
      * such as memory, disk space, or file descriptors.
      *
      * @throws IOException if an I/O error occurs.
+     * @since 21
      */
     void close() throws IOException;
 }

--- a/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ import java.nio.ByteOrder;
  * @see MemoryCacheImageInputStream
  *
  */
-public interface ImageInputStream extends DataInput, Closeable {
+public interface ImageInputStream extends DataInput, Closeable, AutoCloseable {
 
     /**
      * Sets the desired byte order for future reads of data values


### PR DESCRIPTION
The fact that there is a `dispose()` method to be called is easily missed, as people tend to look for a method called `close()`, or assume that resources only need to get closed when they support try-with-resource. As a result, there is a risk of keeping resources opened longer than needed (or even run into a resource leak with long running processes) as the user cannot use try-with-resources currently.

This is not a big change, but it is useful for those working with ImageIO.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302281](https://bugs.openjdk.org/browse/JDK-8302281): ImageReader and ImageWrite should implement Closable


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12098/head:pull/12098` \
`$ git checkout pull/12098`

Update a local copy of the PR: \
`$ git checkout pull/12098` \
`$ git pull https://git.openjdk.org/jdk.git pull/12098/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12098`

View PR using the GUI difftool: \
`$ git pr show -t 12098`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12098.diff">https://git.openjdk.org/jdk/pull/12098.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12098#issuecomment-1426845416)