### PR TITLE
ZIP entry copy without recompression

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -26,10 +26,11 @@
 package java.util.zip;
 
 import java.io.Closeable;
-import java.io.InputStream;
-import java.io.IOException;
 import java.io.EOFException;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.RandomAccessFile;
 import java.io.UncheckedIOException;
 import java.lang.ref.Cleaner.Cleanable;
@@ -467,6 +468,15 @@ public class ZipFile implements ZipConstants, Closeable {
             long avail = ((ZipFileInputStream)in).size() - inf.getBytesWritten();
             return (avail > (long) Integer.MAX_VALUE ?
                     Integer.MAX_VALUE : (int) avail);
+        }
+
+        @Override
+        public long transferTo(OutputStream out) throws IOException {
+            if (out instanceof  ZipOutputStream zos
+                    && in instanceof ZipFileInputStream zfi) {
+                return zfi.transferTo(zos.getUncompressed());
+            }
+            return super.transferTo(out);
         }
     }
 

--- a/test/jdk/java/util/zip/NoRecompressionCopy.java
+++ b/test/jdk/java/util/zip/NoRecompressionCopy.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.DigestOutputStream;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * @test
+ * @summary Check that entries can be copied from a ZipFile to a ZipOutputStream uncompressed
+ */
+
+public class NoRecompressionCopy {
+
+    public static void main(String[] args) throws Exception {
+
+        Path jar = createJarFile();
+
+        Path plainCopy = Path.of("zip-plain-copy.jar");
+        Path noRecompressionCopy = Path.of("zip-copy-no-recompression.jar");
+
+        copyZipPlain(jar, plainCopy);
+        checkCopy(jar, plainCopy);
+
+        copyZipNoRecompression(jar, noRecompressionCopy);
+        checkCopy(jar, noRecompressionCopy);
+
+
+        if (false) {
+            runPerformanceComparison(plainCopy, noRecompressionCopy);
+        }
+    }
+
+    private static void runPerformanceComparison(Path plainCopy, Path noRecompressionCopy) throws IOException {
+        Path bigJar = Path.of("../../../../src/utils/IdealGraphVisualizer/application/target/idealgraphvisualizer/idealgraphvisualizer/modules/ext/com.sun.hotspot.igv.View/xalan/xalan.jar");
+
+        for (int i = 0; i < 100; i++) {
+            copyZipPlain(bigJar, plainCopy);
+            copyZipNoRecompression(bigJar, noRecompressionCopy);
+        }
+
+
+        {
+            long before = System.nanoTime();
+            for (int i = 0; i < 100; i++) {
+                copyZipPlain(bigJar, null);
+            }
+            System.out.println("copyZipPlain took: " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - before));
+        }
+
+        {
+            long before = System.nanoTime();
+            for (int i = 0; i < 100; i++) {
+                copyZipNoRecompression(bigJar, null);
+            }
+            System.out.println("copyZipNoRecompression took: " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - before));
+        }
+    }
+
+    private static void copyZipNoRecompression(Path jar, Path output) throws IOException {
+        try(ZipFile zf = new ZipFile(jar.toFile());
+            ZipOutputStream out = new ZipOutputStream(getOut(output))) {
+            final Enumeration<? extends ZipEntry> entries = zf.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry entry = entries.nextElement();
+                try(InputStream in = zf.getInputStream(entry)) {
+                    out.putNextEntry(entry);
+                    in.transferTo(out);
+                }
+            }
+        }
+    }
+
+    private static void copyZipPlain(Path jar, Path output) throws IOException {
+        try(ZipFile zf = new ZipFile(jar.toFile());
+            ZipOutputStream out = new ZipOutputStream(getOut(output))) {
+            final Enumeration<? extends ZipEntry> entries = zf.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry entry = entries.nextElement();
+                try(InputStream in = zf.getInputStream(entry)) {
+                    out.putNextEntry(entry);
+                    copy(in, out);
+                }
+            }
+        }
+    }
+
+    private static OutputStream getOut(Path output) throws IOException {
+        return output == null ? OutputStream.nullOutputStream() : new BufferedOutputStream(Files.newOutputStream(output));
+    }
+
+    private static void copy(InputStream in, ZipOutputStream out) throws IOException {
+        byte[] buffer = new byte[8129];
+        int read;
+        while ((read = in.read(buffer)) != -1) {
+            out.write(buffer, 0, read);
+        }
+    }
+
+    private static void checkCopy(Path source, Path copy) throws Exception {
+        try(ZipFile szf = new ZipFile(source.toFile());
+            ZipFile czf = new ZipFile(copy.toFile())) {
+            Set<String> expectedEntries = szf.stream().map(ZipEntry::getName).collect(Collectors.toSet());
+            Set<String> actualEntries = czf.stream().map(ZipEntry::getName).collect(Collectors.toSet());
+
+            if (!expectedEntries.equals(actualEntries)) {
+                throw new Exception("Unexpected entries, expected %s, got %s".formatted(expectedEntries, actualEntries));
+            }
+
+            for (String name : expectedEntries)  {
+                compareStreams(name, szf, czf);
+            }
+        }
+    }
+
+    private static void compareStreams(String name, ZipFile szf, ZipFile czf) throws Exception {
+        byte[] d1 = digest(name, szf);
+        byte[] d2 = digest(name, czf);
+        if (!Arrays.equals(d1, d2)) {
+            throw new Exception("Contents of file %s are not equal in copies ZIP".formatted(name));
+        }
+    }
+
+    private static byte[] digest(String name, ZipFile szf) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+
+        try(InputStream in = szf.getInputStream(szf.getEntry(name));
+            OutputStream out = new DigestOutputStream(OutputStream.nullOutputStream(), digest)) {
+            in.transferTo(out);
+        }
+
+        return digest.digest();
+    }
+
+    private static Path createJarFile() throws IOException {
+        Path j = Path.of("a.zip");
+        try(ZipOutputStream out = new ZipOutputStream(Files.newOutputStream(j))) {
+            out.putNextEntry(new ZipEntry("a.txt"));
+            out.write("a".getBytes(StandardCharsets.UTF_8));
+        }
+        return j;
+    }
+}


### PR DESCRIPTION
A common use case for java.util.zip in build tools involves copying entries from a ZipFile or ZipInputStream to a ZipOutputStream without actually modifying the data.

Inflating an entry just to immediately deflate it again with no modifications seems wasteful.

This PR introduces ZipFileInflaterInputStream.transferTo which copies compressed data directly to ZipOutputStreams raw data stream.

I'm typically seeing a 15 X improvement when copying xalan.jar to a ZipOutputStream backed by a buffered file OutputStream, or 22 X when backed by OutputStream.nullOutputStream().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12099/head:pull/12099` \
`$ git checkout pull/12099`

Update a local copy of the PR: \
`$ git checkout pull/12099` \
`$ git pull https://git.openjdk.org/jdk pull/12099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12099`

View PR using the GUI difftool: \
`$ git pr show -t 12099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12099.diff">https://git.openjdk.org/jdk/pull/12099.diff</a>

</details>
