### PR TITLE
8300731: Avoid unnecessary array fill after creation in PaletteBuilder

### DIFF
--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/common/PaletteBuilder.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/common/PaletteBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -212,9 +212,6 @@ public class PaletteBuilder {
 
     protected void buildPalette() {
         reduceList = new ColorNode[MAXLEVEL + 1];
-        for (int i = 0; i < reduceList.length; i++) {
-            reduceList[i] = null;
-        }
 
         numNodes = 0;
         maxNodes = 0;


### PR DESCRIPTION
No need to fill elements of array with `null`: it was just created. Java guarantees that all elements of array are `null`s anyway.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300731](https://bugs.openjdk.org/browse/JDK-8300731): Avoid unnecessary array fill after creation in PaletteBuilder


### Reviewers
 * @SWinxy (no known github.com user name / role)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12101/head:pull/12101` \
`$ git checkout pull/12101`

Update a local copy of the PR: \
`$ git checkout pull/12101` \
`$ git pull https://git.openjdk.org/jdk pull/12101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12101`

View PR using the GUI difftool: \
`$ git pr show -t 12101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12101.diff">https://git.openjdk.org/jdk/pull/12101.diff</a>

</details>
