### PR TITLE
8300692: GCC 12 reports some compiler warnings in bundled freetype

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -428,6 +428,7 @@ else
           $(BUILD_LIBFREETYPE_CFLAGS), \
       EXTRA_HEADER_DIRS := $(BUILD_LIBFREETYPE_HEADER_DIRS), \
       DISABLED_WARNINGS_microsoft := 4267 4244 4996, \
+      DISABLED_WARNINGS_gcc := dangling-pointer stringop-overflow, \
       LDFLAGS := $(LDFLAGS_JDKLIB) \
           $(call SET_SHARED_LIBRARY_ORIGIN), \
   ))


### PR DESCRIPTION
Disabling warnings for bundled Freetype

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300692](https://bugs.openjdk.org/browse/JDK-8300692): GCC 12 reports some compiler warnings in bundled freetype


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12102/head:pull/12102` \
`$ git checkout pull/12102`

Update a local copy of the PR: \
`$ git checkout pull/12102` \
`$ git pull https://git.openjdk.org/jdk pull/12102/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12102`

View PR using the GUI difftool: \
`$ git pr show -t 12102`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12102.diff">https://git.openjdk.org/jdk/pull/12102.diff</a>

</details>
