### PR TITLE
JDK-8300400: Update --release 20 symbol information for JDK 20 build 32

### DIFF
--- a/src/jdk.compiler/share/data/symbols/java.base-K.sym.txt
+++ b/src/jdk.compiler/share/data/symbols/java.base-K.sym.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -236,7 +236,7 @@ method name firstVariadicArg descriptor (I)Ljava/lang/foreign/Linker$Option; fla
 method name captureCallState descriptor ([Ljava/lang/String;)Ljava/lang/foreign/Linker$Option$CaptureCallState; flags 89
 
 class name java/lang/foreign/Linker$Option$CaptureCallState
-header extends java/lang/Object implements java/lang/foreign/Linker$Option nestHost java/lang/foreign/Linker sealed true flags 601
+header extends java/lang/Object implements java/lang/foreign/Linker$Option nestHost java/lang/foreign/Linker sealed true flags 601 classAnnotations @Ljdk/internal/javac/PreviewFeature;(feature=eLjdk/internal/javac/PreviewFeature$Feature;FOREIGN;)
 innerclass innerClass java/lang/foreign/Linker$Option outerClass java/lang/foreign/Linker innerClassName Option flags 609
 innerclass innerClass java/lang/foreign/Linker$Option$CaptureCallState outerClass java/lang/foreign/Linker$Option innerClassName CaptureCallState flags 609
 innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19


### PR DESCRIPTION
Bug JDK-8299740 in JDK 20 b32 introduced a change that should be reflected in the symbol file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300400](https://bugs.openjdk.org/browse/JDK-8300400): Update --release 20 symbol information for JDK 20 build 32


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12105/head:pull/12105` \
`$ git checkout pull/12105`

Update a local copy of the PR: \
`$ git checkout pull/12105` \
`$ git pull https://git.openjdk.org/jdk pull/12105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12105`

View PR using the GUI difftool: \
`$ git pr show -t 12105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12105.diff">https://git.openjdk.org/jdk/pull/12105.diff</a>

</details>
