### PR TITLE
JDK-8300698: Missing @since tag for ClassFileFormatVersion.RELEASE_21

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/ClassFileFormatVersion.java
+++ b/src/java.base/share/classes/java/lang/reflect/ClassFileFormatVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -267,6 +267,8 @@ public enum ClassFileFormatVersion {
     /**
      * The version recognized by the Java Platform, Standard Edition
      * 21.
+     *
+     * @since 21
      *
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jvms/se21/html/index.html">


### PR DESCRIPTION
The addition of the new enum constant for ClassFileFormatVersion.RELEASE_21 neglected to include an @since tag; this should be corrected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300698](https://bugs.openjdk.org/browse/JDK-8300698): Missing @since tag for ClassFileFormatVersion.RELEASE_21


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12107/head:pull/12107` \
`$ git checkout pull/12107`

Update a local copy of the PR: \
`$ git checkout pull/12107` \
`$ git pull https://git.openjdk.org/jdk pull/12107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12107`

View PR using the GUI difftool: \
`$ git pr show -t 12107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12107.diff">https://git.openjdk.org/jdk/pull/12107.diff</a>

</details>
