### PR TITLE
8300721: Cleanup ProblemList-svc-vthread.txt

### DIFF
--- a/test/hotspot/jtreg/ProblemList-svc-vthread.txt
+++ b/test/hotspot/jtreg/ProblemList-svc-vthread.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/ProblemList-svc-vthread.txt
+++ b/test/hotspot/jtreg/ProblemList-svc-vthread.txt
@@ -24,41 +24,36 @@
 ####
 # Bugs
 
-serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java          8264699 generic-all
+serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java 8264699 generic-all
 
 ####
-## Classes not unloaded as expected (TODO, need to check if FJ keep link)
+## Classes not unloaded as expected (TODO, need to check if FJ keeps a reference)
 
-vmTestbase/nsk/jvmti/CompiledMethodUnload/compmethunload001/TestDescription.java
+vmTestbase/nsk/jvmti/CompiledMethodUnload/compmethunload001/TestDescription.java 8300711 generic-all
 
 ####
 ## Tests for functionality which currently is not supported for virtual threads
 
-vmTestbase/nsk/jvmti/GetCurrentThreadCpuTime/curthrcputime001/TestDescription.java
-vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime001/TestDescription.java
-vmTestbase/nsk/jvmti/NotifyFramePop/nframepop002/TestDescription.java
-vmTestbase/nsk/jvmti/NotifyFramePop/nframepop003/TestDescription.java
-vmTestbase/nsk/jvmti/PopFrame/popframe004/TestDescription.java
-vmTestbase/nsk/jvmti/StopThread/stopthrd006/TestDescription.java
-vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t012/TestDescription.java
-vmTestbase/nsk/jvmti/SetLocalVariable/setlocal004/TestDescription.java
-vmTestbase/nsk/jvmti/SetLocalVariable/setlocal003/TestDescription.java
-vmTestbase/nsk/jvmti/SetLocalVariable/setlocal002/TestDescription.java
-vmTestbase/nsk/jvmti/SetLocalVariable/setlocal001/TestDescription.java
-vmTestbase/nsk/jvmti/unit/GetLocalVariable/getlocal003/TestDescription.java
+vmTestbase/nsk/jvmti/GetCurrentThreadCpuTime/curthrcputime001/TestDescription.java 8300708 generic-all
+vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime001/TestDescription.java 8300708 generic-all
+vmTestbase/nsk/jvmti/NotifyFramePop/nframepop002/TestDescription.java    8300708 generic-all
+vmTestbase/nsk/jvmti/NotifyFramePop/nframepop003/TestDescription.java    8300708 generic-all
+vmTestbase/nsk/jvmti/PopFrame/popframe004/TestDescription.java           8300708 generic-all
+vmTestbase/nsk/jvmti/StopThread/stopthrd006/TestDescription.java         8300708 generic-all
+vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t012/TestDescription.java 8300708 generic-all
+vmTestbase/nsk/jvmti/SetLocalVariable/setlocal004/TestDescription.java   8300708 generic-all
+vmTestbase/nsk/jvmti/SetLocalVariable/setlocal003/TestDescription.java   8300708 generic-all
+vmTestbase/nsk/jvmti/SetLocalVariable/setlocal002/TestDescription.java   8300708 generic-all
+vmTestbase/nsk/jvmti/SetLocalVariable/setlocal001/TestDescription.java   8300708 generic-all
+vmTestbase/nsk/jvmti/unit/GetLocalVariable/getlocal003/TestDescription.java 8300708 generic-all
 
 ####
-## Test fails because expect to find vthread in GetAllThreads
-vmTestbase/nsk/jvmti/scenarios/allocation/AP11/ap11t001/TestDescription.java
+## Test fails because it expects to find vthreads in GetAllThreads
+vmTestbase/nsk/jvmti/scenarios/allocation/AP11/ap11t001/TestDescription.java 8300712 generic-all
 
 ####
-## Breakpoint expects name of virtual thread which is set by test.
-
-vmTestbase/nsk/jvmti/Breakpoint/breakpoint001/TestDescription.java
-
-####
-## assert in /scratch/sspitsyn/loom2/open/src/hotspot/share/oops/instanceStackChunkKlass.cpp:1042
-vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage006/TestDescription.java
+## assert in src/hotspot/share/oops/instanceStackChunkKlass.cpp:1042
+vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage006/TestDescription.java 8300709 generic-all
 
 ####
 ## NSK JDWP Tests failing with wrapper
@@ -68,12 +63,6 @@ vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEa
 
 ##########
 ## NSK JDB Tests failing with wrapper
-
-####
-## JVMTI PopFrame not supported for vthreads (JVMTI_ERROR_OPAQUE_FRAME)
-
-vmTestbase/nsk/jdb/pop_exception/pop_exception001/pop_exception001.java
-vmTestbase/nsk/jdi/VirtualMachine/redefineClasses/redefineclasses002/TestDescription.java
 
 ####
 ## The tests expect an NPE to be uncaught, but nsk.share.MainWrapper
@@ -87,8 +76,8 @@ vmTestbase/nsk/jdb/where/where005/where005.java 8278470 generic-all
 # normally no frames above the test's main method. However, nsk.share.MainWrapper
 # introduces more frames above the test's main method, so the test fails.
 
-vmTestbase/nsk/jdb/list/list003/list003.java
-vmTestbase/nsk/jdb/repeat/repeat001/repeat001.java
+vmTestbase/nsk/jdb/list/list003/list003.java        8300707 generic-all
+vmTestbase/nsk/jdb/repeat/repeat001/repeat001.java  8300707 generic-all
 
 ####
 ## NSK JDI tests failing with wrapper
@@ -101,12 +90,15 @@ vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod011/TestDescription.java 8
 
 vmTestbase/nsk/jdi/ExceptionEvent/catchLocation/location002/TestDescription.java 8278470 generic-all
 
-
 ####
 ## JVMTI PopFrame() is returning OPAQUE_FRAME because vthreads are not supported.
 ## Note: vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes001 was converted
 ## to support vthreads and expect the OPAQUE_FRAME error. The others were
 ## not because they don't add any additional value.
+
+vmTestbase/nsk/jdb/pop_exception/pop_exception001/pop_exception001.java 8285414 generic-all
+
+vmTestbase/nsk/jdi/VirtualMachine/redefineClasses/redefineclasses002/TestDescription.java 8285414 generic-all
 
 vmTestbase/nsk/jdi/Scenarios/invokeMethod/popframes001/TestDescription.java 8285414 generic-all
 vmTestbase/nsk/jdi/BScenarios/hotswap/tc01x002/TestDescription.java 8285414 generic-all


### PR DESCRIPTION
There are a number of entries in ProblemList-svc-vthread.txt that don't have any CRs associated with them. CRs have since been created and the problemlist needs to be updated to reflect this. Here are links to the relevant CRs:

[JDK-8285414](https://bugs.openjdk.org/browse/JDK-8285414): [LOOM] Some nsk/jdi tests fail due to not expecting OPAQUE_FRAME from JVMTI PopFrame()
[JDK-8300712](https://bugs.openjdk.org/browse/JDK-8300712): nsk/jvmti/scenarios/allocation/AP11/ap11t001 fails with the virtual thread wrapper
[JDK-8300711](https://bugs.openjdk.org/browse/JDK-8300711): nsk/jvmti/CompiledMethodUnload/compmethunload001 fails with the virtual thread wrapper
[JDK-8300709](https://bugs.openjdk.org/browse/JDK-8300709): nsk/jvmti/GetObjectMonitorUsage/objmonusage006 test asserts with virtual thread wrapper
[JDK-8300708](https://bugs.openjdk.org/browse/JDK-8300708): some nsk jvmti tests fail with virtual thread wrapper due to missing jvmti missing some virtual thread support
[JDK-8300707](https://bugs.openjdk.org/browse/JDK-8300707): jdb "list" and "repeat" tests fails with virtual thread wrapper

Note the following two tests are covered by the pre-existing [JDK-8285414](https://bugs.openjdk.org/browse/JDK-8285414),  and were move down to the section with other tests problemlisted under this CR:

```
vmTestbase/nsk/jdb/pop_exception/pop_exception001/pop_exception001.java
vmTestbase/nsk/jdi/VirtualMachine/redefineClasses/redefineclasses002/TestDescription.java
```

Also, the following test has been removed, so it is being removed from the problemlist:

```
vmTestbase/nsk/jvmti/Breakpoint/breakpoint001/TestDescription.java
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300721](https://bugs.openjdk.org/browse/JDK-8300721): Cleanup ProblemList-svc-vthread.txt


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12109/head:pull/12109` \
`$ git checkout pull/12109`

Update a local copy of the PR: \
`$ git checkout pull/12109` \
`$ git pull https://git.openjdk.org/jdk pull/12109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12109`

View PR using the GUI difftool: \
`$ git pr show -t 12109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12109.diff">https://git.openjdk.org/jdk/pull/12109.diff</a>

</details>
