### PR TITLE
8300725: Improve performance of ColorConvertOp for default destinations with alpha

### DIFF
--- a/src/java.desktop/share/classes/sun/java2d/cmm/lcms/LCMSTransform.java
+++ b/src/java.desktop/share/classes/sun/java2d/cmm/lcms/LCMSTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -424,9 +424,9 @@ final class LCMSTransform implements ColorTransform {
     public void colorConvert(Raster src, WritableRaster dst) {
 
         LCMSImageLayout srcIL, dstIL;
-        dstIL = LCMSImageLayout.createImageLayout(dst);
+        dstIL = LCMSImageLayout.createImageLayout(dst, false);
         if (dstIL != null) {
-            srcIL = LCMSImageLayout.createImageLayout(src);
+            srcIL = LCMSImageLayout.createImageLayout(src, false);
             if (srcIL != null) {
                 doTransform(srcIL, dstIL);
                 return;


### PR DESCRIPTION
The "default destination" for the ColorConverOp is used when the user passes "null" as the DST parameter. In this case, the "ColorConverOp.filter" creates the default image and uses ComponentColorModel: 8 bits per color component and optionally 8 bits for the alpha channel. For example for the ARGB source default destination will be RGBA format. Note that the RGBA format is not supported by BufferedImage directly, so the CUSTOM image type will be used.

Generic filtering of the CUSTOM image type is slow because we cannot pass that format directly to the CMM. But it would be good to support CUSTOM images that were created by the ColorConverOp.

Support of the default destination w/o alpha was implemented as part of the https://bugs.openjdk.org/browse/JDK-8005530. Since then we added support of the alpha to CMM code https://bugs.openjdk.org/browse/JDK-8012229.
Now we can improve the performance of the default destination if it has the alpha channel.

The numbers for filtering opaque and transparent images to the null destination:
<img width="705" alt="8300725" src="https://user-images.githubusercontent.com/14138494/213744370-241726f9-6653-403e-bb90-ce98fc089945.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300725](https://bugs.openjdk.org/browse/JDK-8300725): Improve performance of ColorConvertOp for default destinations with alpha


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12110/head:pull/12110` \
`$ git checkout pull/12110`

Update a local copy of the PR: \
`$ git checkout pull/12110` \
`$ git pull https://git.openjdk.org/jdk pull/12110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12110`

View PR using the GUI difftool: \
`$ git pr show -t 12110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12110.diff">https://git.openjdk.org/jdk/pull/12110.diff</a>

</details>
