### PR TITLE
8300591: @SuppressWarnings option "lossy-conversions" missing from jdk.compiler module javadoc

### DIFF
--- a/src/jdk.compiler/share/classes/module-info.java
+++ b/src/jdk.compiler/share/classes/module-info.java
@@ -162,6 +162,7 @@ import javax.tools.StandardLocation;
  * <tr><th scope="row">{@code fallthrough}          <td>falling through from one case of a {@code switch} statement to
  *                                                      the next
  * <tr><th scope="row">{@code finally}              <td>{@code finally} clauses that do not terminate normally
+ * <tr><th scope="row">{@code lossy-conversions}    <td>possible lossy conversions in compound assignment
  * <tr><th scope="row">{@code missing-explicit-ctor} <td>missing explicit constructors in public and protected classes
  *                                                      in exported packages
  * <tr><th scope="row">{@code module}               <td>module system related issues

--- a/src/jdk.compiler/share/man/javac.1
+++ b/src/jdk.compiler/share/man/javac.1
@@ -722,6 +722,9 @@ a switch statement to the next.
 \f[V]finally\f[R]: Warns about \f[V]finally\f[R] clauses that do not
 terminate normally.
 .IP \[bu] 2
+\f[V]lossy-conversions\f[R]: Warns about possible lossy conversion in
+compound assignment.
+.IP \[bu] 2
 \f[V]missing-explicit-ctor\f[R]: Warns about missing explicit
 constructors in public and protected classes in exported packages.
 .IP \[bu] 2


### PR DESCRIPTION
Hi,
@SuppressWarnings option "lossy-conversions" has been added to JDK 20 (see JDK-8286377), however the option description is missing in jdk.compiler module javadoc and javac man page.
This patch add missing javadoc decription to jdk.compiler module-info.java

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8300740](https://bugs.openjdk.org/browse/JDK-8300740) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8300591](https://bugs.openjdk.org/browse/JDK-8300591): @SuppressWarnings option "lossy-conversions" missing from jdk.compiler module javadoc
 * [JDK-8300740](https://bugs.openjdk.org/browse/JDK-8300740): Add @SuppressWarnings option "lossy-conversions" description to jdk.compiler module javadoc and javac man page (**CSR**)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12111/head:pull/12111` \
`$ git checkout pull/12111`

Update a local copy of the PR: \
`$ git checkout pull/12111` \
`$ git pull https://git.openjdk.org/jdk pull/12111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12111`

View PR using the GUI difftool: \
`$ git pr show -t 12111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12111.diff">https://git.openjdk.org/jdk/pull/12111.diff</a>

</details>
