### PR TITLE
JDK-8294677: chunklevel::MAX_CHUNK_WORD_SIZE too small for some applications

### DIFF
--- a/src/hotspot/share/memory/metaspace/chunklevel.hpp
+++ b/src/hotspot/share/memory/metaspace/chunklevel.hpp
@@ -46,19 +46,13 @@ namespace metaspace {
 // From there on it goes:
 //
 // size    level
-// 4MB     0
-// 2MB     1
-// 1MB     2
-// 512K    3
-// 256K    4
-// 128K    5
-// 64K     6
-// 32K     7
-// 16K     8
-// 8K      9
-// 4K      10
-// 2K      11
-// 1K      12
+// 16MB    0
+// 8MB     1
+// 4MB     2
+// ...
+// 4K      12
+// 2K      13
+// 1K      14
 
 // Metachunk level (must be signed)
 typedef signed char chunklevel_t;
@@ -67,8 +61,8 @@ typedef signed char chunklevel_t;
 
 namespace chunklevel {
 
-static const size_t   MAX_CHUNK_BYTE_SIZE    = 4 * M;
-static const int      NUM_CHUNK_LEVELS       = 13;
+static const size_t   MAX_CHUNK_BYTE_SIZE    = 16 * M;
+static const int      NUM_CHUNK_LEVELS       = 15;
 static const size_t   MIN_CHUNK_BYTE_SIZE    = (MAX_CHUNK_BYTE_SIZE >> ((size_t)NUM_CHUNK_LEVELS - 1));
 
 static const size_t   MIN_CHUNK_WORD_SIZE    = MIN_CHUNK_BYTE_SIZE / sizeof(MetaWord);
@@ -101,22 +95,24 @@ inline size_t word_size_for_level(chunklevel_t level) {
 chunklevel_t level_fitting_word_size(size_t word_size);
 
 // Shorthands to refer to exact sizes
-static const chunklevel_t CHUNK_LEVEL_4M =     ROOT_CHUNK_LEVEL;
-static const chunklevel_t CHUNK_LEVEL_2M =    (ROOT_CHUNK_LEVEL + 1);
-static const chunklevel_t CHUNK_LEVEL_1M =    (ROOT_CHUNK_LEVEL + 2);
-static const chunklevel_t CHUNK_LEVEL_512K =  (ROOT_CHUNK_LEVEL + 3);
-static const chunklevel_t CHUNK_LEVEL_256K =  (ROOT_CHUNK_LEVEL + 4);
-static const chunklevel_t CHUNK_LEVEL_128K =  (ROOT_CHUNK_LEVEL + 5);
-static const chunklevel_t CHUNK_LEVEL_64K =   (ROOT_CHUNK_LEVEL + 6);
-static const chunklevel_t CHUNK_LEVEL_32K =   (ROOT_CHUNK_LEVEL + 7);
-static const chunklevel_t CHUNK_LEVEL_16K =   (ROOT_CHUNK_LEVEL + 8);
-static const chunklevel_t CHUNK_LEVEL_8K =    (ROOT_CHUNK_LEVEL + 9);
-static const chunklevel_t CHUNK_LEVEL_4K =    (ROOT_CHUNK_LEVEL + 10);
-static const chunklevel_t CHUNK_LEVEL_2K =    (ROOT_CHUNK_LEVEL + 11);
-static const chunklevel_t CHUNK_LEVEL_1K =    (ROOT_CHUNK_LEVEL + 12);
+static const chunklevel_t CHUNK_LEVEL_16M =    ROOT_CHUNK_LEVEL;
+static const chunklevel_t CHUNK_LEVEL_8M =    (ROOT_CHUNK_LEVEL + 1);
+static const chunklevel_t CHUNK_LEVEL_4M =    (ROOT_CHUNK_LEVEL + 2);
+static const chunklevel_t CHUNK_LEVEL_2M =    (ROOT_CHUNK_LEVEL + 3);
+static const chunklevel_t CHUNK_LEVEL_1M =    (ROOT_CHUNK_LEVEL + 4);
+static const chunklevel_t CHUNK_LEVEL_512K =  (ROOT_CHUNK_LEVEL + 5);
+static const chunklevel_t CHUNK_LEVEL_256K =  (ROOT_CHUNK_LEVEL + 6);
+static const chunklevel_t CHUNK_LEVEL_128K =  (ROOT_CHUNK_LEVEL + 7);
+static const chunklevel_t CHUNK_LEVEL_64K =   (ROOT_CHUNK_LEVEL + 8);
+static const chunklevel_t CHUNK_LEVEL_32K =   (ROOT_CHUNK_LEVEL + 9);
+static const chunklevel_t CHUNK_LEVEL_16K =   (ROOT_CHUNK_LEVEL + 10);
+static const chunklevel_t CHUNK_LEVEL_8K =    (ROOT_CHUNK_LEVEL + 11);
+static const chunklevel_t CHUNK_LEVEL_4K =    (ROOT_CHUNK_LEVEL + 12);
+static const chunklevel_t CHUNK_LEVEL_2K =    (ROOT_CHUNK_LEVEL + 13);
+static const chunklevel_t CHUNK_LEVEL_1K =    (ROOT_CHUNK_LEVEL + 14);
 
 STATIC_ASSERT(CHUNK_LEVEL_1K == HIGHEST_CHUNK_LEVEL);
-STATIC_ASSERT(CHUNK_LEVEL_4M == LOWEST_CHUNK_LEVEL);
+STATIC_ASSERT(CHUNK_LEVEL_16M == LOWEST_CHUNK_LEVEL);
 STATIC_ASSERT(ROOT_CHUNK_LEVEL == LOWEST_CHUNK_LEVEL);
 
 /////////////////////////////////////////////////////////

--- a/src/hotspot/share/memory/metaspace/metaspaceSettings.hpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceSettings.hpp
@@ -47,7 +47,7 @@ class Settings : public AllStatic {
   // Note that this only affects the non-class metaspace. Class space ignores this size (it is one
   //  single large mapping).
   static const size_t _virtual_space_node_default_word_size =
-      chunklevel::MAX_CHUNK_WORD_SIZE * NOT_LP64(2) LP64_ONLY(16); // 8MB (32-bit) / 64MB (64-bit)
+      chunklevel::MAX_CHUNK_WORD_SIZE * NOT_LP64(1) LP64_ONLY(4); // 16MB (32-bit) / 64MB (64-bit)
 
   // Alignment of the base address of a virtual space node
   static const size_t _virtual_space_node_reserve_alignment_words = chunklevel::MAX_CHUNK_WORD_SIZE;

--- a/test/hotspot/gtest/metaspace/test_chunkManager_stress.cpp
+++ b/test/hotspot/gtest/metaspace/test_chunkManager_stress.cpp
@@ -190,7 +190,7 @@ class ChunkManagerRandomChunkAllocTest {
 
   // adjust test if we change levels
   STATIC_ASSERT(HIGHEST_CHUNK_LEVEL == CHUNK_LEVEL_1K);
-  STATIC_ASSERT(LOWEST_CHUNK_LEVEL == CHUNK_LEVEL_4M);
+  STATIC_ASSERT(LOWEST_CHUNK_LEVEL == CHUNK_LEVEL_16M);
 
   void one_test() {
 

--- a/test/hotspot/gtest/metaspace/test_metaspace_misc.cpp
+++ b/test/hotspot/gtest/metaspace/test_metaspace_misc.cpp
@@ -46,8 +46,7 @@ TEST_VM(metaspace, misc_sizes)   {
   ASSERT_EQ(Settings::commit_granule_bytes(), Metaspace::commit_alignment());
   ASSERT_TRUE(is_aligned(Settings::virtual_space_node_default_word_size(),
               metaspace::chunklevel::MAX_CHUNK_WORD_SIZE));
-  ASSERT_EQ(Settings::virtual_space_node_default_word_size(),
-            metaspace::chunklevel::MAX_CHUNK_WORD_SIZE * NOT_LP64(2) LP64_ONLY(16));
+  ASSERT_EQ(Settings::virtual_space_node_default_word_size() * BytesPerWord, NOT_LP64(16) LP64_ONLY(64) * M);
   ASSERT_EQ(Settings::virtual_space_node_reserve_alignment_words(),
             Metaspace::reserve_alignment_words());
 
@@ -56,13 +55,20 @@ TEST_VM(metaspace, misc_sizes)   {
 TEST_VM(metaspace, misc_max_alloc_size)   {
 
   // Make sure we can allocate what we promise to allocate...
-  const size_t sz = Metaspace::max_allocation_word_size();
-  ClassLoaderData* cld = ClassLoaderData::the_null_class_loader_data();
-  MetaWord* p = cld->metaspace_non_null()->allocate(sz, Metaspace::NonClassType);
-  ASSERT_NOT_NULL(p);
-  // And also, successfully deallocate it.
-  cld->metaspace_non_null()->deallocate(p, sz, false);
-
+  for (int i = 0; i < 2; i ++) {
+    const bool in_class_space = (i == 0);
+    const Metaspace::MetadataType mdType = in_class_space ? Metaspace::ClassType : Metaspace::NonClassType;
+    const size_t sz = Metaspace::max_allocation_word_size();
+    ClassLoaderData* cld = ClassLoaderData::the_null_class_loader_data();
+    MetaWord* p = cld->metaspace_non_null()->allocate(sz, mdType);
+    if (p == nullptr) {
+      // Have we run into the GC threshold?
+      p = cld->metaspace_non_null()->expand_and_allocate(sz, mdType);
+      ASSERT_NOT_NULL(p);
+    }
+    // And also, successfully deallocate it.
+    cld->metaspace_non_null()->deallocate(p, sz, in_class_space);
+  }
 }
 
 TEST_VM(metaspace, chunklevel_utils)   {

--- a/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
+++ b/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
@@ -493,7 +493,7 @@ TEST_VM(metaspace, virtual_space_node_test_basics) {
 
   MutexLocker fcl(Metaspace_lock, Mutex::_no_safepoint_check_flag);
 
-  const size_t word_size = metaspace::chunklevel::MAX_CHUNK_WORD_SIZE * 10;
+  const size_t word_size = metaspace::chunklevel::MAX_CHUNK_WORD_SIZE * 3;
 
   SizeCounter scomm;
   SizeCounter sres;
@@ -580,13 +580,13 @@ TEST_VM(metaspace, virtual_space_node_test_5) {
 TEST_VM(metaspace, virtual_space_node_test_7) {
   // Test large allocation and freeing.
   {
-    VirtualSpaceNodeTest test(metaspace::chunklevel::MAX_CHUNK_WORD_SIZE * 100,
-        metaspace::chunklevel::MAX_CHUNK_WORD_SIZE * 100);
+    VirtualSpaceNodeTest test(metaspace::chunklevel::MAX_CHUNK_WORD_SIZE * 25,
+        metaspace::chunklevel::MAX_CHUNK_WORD_SIZE * 25);
     test.test_exhaust_node();
   }
   {
-    VirtualSpaceNodeTest test(metaspace::chunklevel::MAX_CHUNK_WORD_SIZE * 100,
-        metaspace::chunklevel::MAX_CHUNK_WORD_SIZE * 100);
+    VirtualSpaceNodeTest test(metaspace::chunklevel::MAX_CHUNK_WORD_SIZE * 25,
+        metaspace::chunklevel::MAX_CHUNK_WORD_SIZE * 25);
     test.test_exhaust_node();
   }
 

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassSpaceSize.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassSpaceSize.java
@@ -65,14 +65,14 @@ public class CompressedClassSpaceSize {
 
 
         // Make sure the minimum size is set correctly and printed
-        // (Note: ccs size shall be rounded up to the minimum size of 4m since metaspace reservations
-        //  are done in a 4m granularity. Note that this is **reserved** size and does not affect rss.
+        // (Note: ccs size are rounded up to the next larger root chunk boundary (16m).
+        // Note that this is **reserved** size and does not affect rss.
         pb = ProcessTools.createJavaProcessBuilder("-XX:+UnlockDiagnosticVMOptions",
                                                    "-XX:CompressedClassSpaceSize=1m",
                                                    "-Xlog:gc+metaspace=trace",
                                                    "-version");
         output = new OutputAnalyzer(pb.start());
-        output.shouldMatch("Compressed class space.*4194304")
+        output.shouldMatch("Compressed class space.*16777216")
               .shouldHaveExitValue(0);
 
 

--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/Settings.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/Settings.java
@@ -34,7 +34,7 @@ public final class Settings {
         return reclaimPolicy.equals("balanced") || reclaimPolicy.equals("aggessive");
     }
 
-    final static long rootChunkWordSize = 512 * 1024;
+    final static long rootChunkWordSize = 2048 * 1024;
 
     static Settings theSettings;
 

--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT1.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT1.java
@@ -175,7 +175,7 @@ public class TestMetaspaceAllocationMT1 {
 
             // Note: reserve limit must be a multiple of Metaspace::reserve_alignment_words()
             //  (512K on 64bit, 1M on 32bit)
-            long reserveLimit = (i == 2) ? 1024 * 1024 : 0;
+            long reserveLimit = (i == 2) ? Settings.rootChunkWordSize * 2 : 0;
 
             System.out.println("#### Test: ");
             System.out.println("#### testAllocationCeiling: " + testAllocationCeiling);

--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT2.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT2.java
@@ -174,8 +174,7 @@ public class TestMetaspaceAllocationMT2 {
             long commitLimit = (i == 1) ? 1024 * 256 : 0;
 
             // Note: reserve limit must be a multiple of Metaspace::reserve_alignment_words()
-            //  (512K on 64bit, 1M on 32bit)
-            long reserveLimit = (i == 2) ? 1024 * 1024 : 0;
+            long reserveLimit = (i == 2) ? Settings.rootChunkWordSize * 2 : 0;
 
             System.out.println("#### Test: ");
             System.out.println("#### testAllocationCeiling: " + testAllocationCeiling);


### PR DESCRIPTION
This patch is a workaround for a regression caused by the JEP-387 metaspace revamp. That revamp introduced a maximum limit to the size an individual metaspace allocation could have (4m). 

4m was deemed much more than enough; normally metaspace allocations are tiny. But we now had a customer trying to load a generated giant class. The class was inefficiently generated but valid nonetheless.

The patch increases the maximum chunk size in Metaspace from 4M to 16M. This fixes the customer case mentioned in the JBS note. However, this is just a workaround since we still have a limit, albeit a larger one. Therefore I am working on a prototype that removes the limit completely (https://bugs.openjdk.org/browse/JDK-8300729) but that needs some more cooking time.

For details, please see JBS text as well as JDK-8300729.

---

Patch increases the maximum chunk size.

This affects the granularity used to *reserve* (not: commit - no RSS increase, just address space) metaspace memory, which in turn affects CompressedClassSpaceSize granularity (it gets silently rounded up to a multiple of root chunk size) as well as class space placement. Thankfully all of this is well abstracted behind `Metaspace::reserve_alignment()` so almost no changes were necessary. The increase from 4m to 16m is also small enough to be benign.

Increasing the maximum chunk size also increases the memory and runtime footprint of some tests that explicitly test metaspace chunk management. I checked all of these tests and changed some to keep the footprint low.

Finally, the patch uncovered some minor test errors in metaspace tests:

The gtest "metaspace:get_chunk_with_commit_limit" was supposed to test allocation from a metaspace chunk when hit by a commit limit. The limit was too high, effectively disabling the commit-failed path of this test. I expanded the test to test a variation of commit limits, not only one. The test also produced wrong positives with `MetaspaceReclaimPolicy=none` - those are fixed now (see comment). Note that I plan to remove the `MetaspaceReclaimPolicy` switch since, in practice, it seems of very limited use, and this would cut down on test variations and code complexity.

The gtest "metaspace:misc_sizes" tests that we can allocate the max. root chunk size (abstracted via `Metaspace::max_allocation_word_size`). A larger root chunk size caused us to hit the GC threshold now. I adjusted the test and expanded it to test both class space and non-class metaspace.

The elastic metaspace jtreg tests (test/hotspot/jtreg/runtime/Metaspace/elastic...) needed adaption since they have the root chunk size hard-coded. There is also a minor issue with using word size, but I left that untouched and opened https://bugs.openjdk.org/browse/JDK-8300732 to deal with this later.

---

Tests:

I manually ran hotspot_metaspace tests (a collection of metaspace, gtests, cds tests and some GC tests) on x64 and x86, fastdebug and release. GHAs are in process, and more tests are planned.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294677](https://bugs.openjdk.org/browse/JDK-8294677): chunklevel::MAX_CHUNK_WORD_SIZE too small for some applications


### Reviewers
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12115/head:pull/12115` \
`$ git checkout pull/12115`

Update a local copy of the PR: \
`$ git checkout pull/12115` \
`$ git pull https://git.openjdk.org/jdk pull/12115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12115`

View PR using the GUI difftool: \
`$ git pr show -t 12115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12115.diff">https://git.openjdk.org/jdk/pull/12115.diff</a>

</details>
