### PR TITLE
8299863: URLFromURITest.java should import org.junit.jupiter.api.Test

### DIFF
--- a/test/jdk/java/net/URL/URLFromURITest.java
+++ b/test/jdk/java/net/URL/URLFromURITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import jdk.test.lib.RandomFactory;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 


### PR DESCRIPTION
URLFromURITest.java was mixing JUnit 4 and Jupiter APIs, this is just a simple cleanup to swap it to use only Jupiter.

I looked around to see if there were any other tests affected but this seems to be the only one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299863](https://bugs.openjdk.org/browse/JDK-8299863): URLFromURITest.java should import org.junit.jupiter.api.Test


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12117/head:pull/12117` \
`$ git checkout pull/12117`

Update a local copy of the PR: \
`$ git checkout pull/12117` \
`$ git pull https://git.openjdk.org/jdk pull/12117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12117`

View PR using the GUI difftool: \
`$ git pr show -t 12117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12117.diff">https://git.openjdk.org/jdk/pull/12117.diff</a>

</details>
