### PR TITLE
8299807: newStringNoRepl should avoid copying arrays for ASCII compatible charsets

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -697,8 +697,13 @@ public final class String
 
     /*
      * Throws iae, instead of replacing, if malformed or unmappable.
+     * 
+     * @param  noShare 
+     *         {@code true} if the resulting string MUST NOT share the byte array,
+     *         {@code false} if the byte array can be exclusively used to construct
+     *         the string and is not modified or used for any other purpose.
      */
-    static String newStringUTF8NoRepl(byte[] bytes, int offset, int length, boolean noCopy) {
+    static String newStringUTF8NoRepl(byte[] bytes, int offset, int length, boolean noShare) {
         checkBoundsOffCount(offset, length, bytes.length);
         if (length == 0) {
             return "";
@@ -709,7 +714,7 @@ public final class String
             dp = StringCoding.countPositives(bytes, offset, length);
             int sl = offset + length;
             if (dp == length) {
-                if (noCopy && offset == 0 && length == bytes.length)
+                if (!noShare && offset == 0 && length == bytes.length)
                     return new String(bytes, LATIN1);
                 return new String(Arrays.copyOfRange(bytes, offset, offset + length), LATIN1);
             }
@@ -779,7 +784,7 @@ public final class String
             return "";
         }
         if (cs == UTF_8.INSTANCE) {
-            return newStringUTF8NoRepl(src, 0, src.length, true);
+            return newStringUTF8NoRepl(src, 0, src.length, false);
         }
         if (cs == ISO_8859_1.INSTANCE) {
             if (COMPACT_STRINGS)

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -697,8 +697,8 @@ public final class String
 
     /*
      * Throws iae, instead of replacing, if malformed or unmappable.
-     * 
-     * @param  noShare 
+     *
+     * @param  noShare
      *         {@code true} if the resulting string MUST NOT share the byte array,
      *         {@code false} if the byte array can be exclusively used to construct
      *         the string and is not modified or used for any other purpose.

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -714,9 +714,11 @@ public final class String
             dp = StringCoding.countPositives(bytes, offset, length);
             int sl = offset + length;
             if (dp == length) {
-                if (!noShare && offset == 0 && length == bytes.length)
+                if (noShare || length != bytes.length) {
+                    return new String(Arrays.copyOfRange(bytes, offset, offset + length), LATIN1);
+                } else {
                     return new String(bytes, LATIN1);
-                return new String(Arrays.copyOfRange(bytes, offset, offset + length), LATIN1);
+                }
             }
             dst = new byte[length];
             System.arraycopy(bytes, offset, dst, 0, dp);

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -698,7 +698,7 @@ public final class String
     /*
      * Throws iae, instead of replacing, if malformed or unmappable.
      */
-    static String newStringUTF8NoRepl(byte[] bytes, int offset, int length) {
+    static String newStringUTF8NoRepl(byte[] bytes, int offset, int length, boolean noCopy) {
         checkBoundsOffCount(offset, length, bytes.length);
         if (length == 0) {
             return "";
@@ -709,6 +709,8 @@ public final class String
             dp = StringCoding.countPositives(bytes, offset, length);
             int sl = offset + length;
             if (dp == length) {
+                if (noCopy && offset == 0 && length == bytes.length)
+                    return new String(bytes, LATIN1);
                 return new String(Arrays.copyOfRange(bytes, offset, offset + length), LATIN1);
             }
             dst = new byte[length];
@@ -777,7 +779,7 @@ public final class String
             return "";
         }
         if (cs == UTF_8.INSTANCE) {
-            return newStringUTF8NoRepl(src, 0, src.length);
+            return newStringUTF8NoRepl(src, 0, src.length, true);
         }
         if (cs == ISO_8859_1.INSTANCE) {
             if (COMPACT_STRINGS)
@@ -799,6 +801,8 @@ public final class String
         if (cd instanceof ArrayDecoder ad &&
                 ad.isASCIICompatible() &&
                 !StringCoding.hasNegatives(src, 0, src.length)) {
+            if (COMPACT_STRINGS)
+                return new String(src, LATIN1);
             return new String(src, 0, src.length, ISO_8859_1.INSTANCE);
         }
         int en = scale(len, cd.maxCharsPerByte());

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2472,7 +2472,7 @@ public final class System {
             }
 
             public String newStringUTF8NoRepl(byte[] bytes, int off, int len) {
-                return String.newStringUTF8NoRepl(bytes, off, len, false);
+                return String.newStringUTF8NoRepl(bytes, off, len, true);
             }
 
             public byte[] getBytesUTF8NoRepl(String s) {

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2472,7 +2472,7 @@ public final class System {
             }
 
             public String newStringUTF8NoRepl(byte[] bytes, int off, int len) {
-                return String.newStringUTF8NoRepl(bytes, off, len);
+                return String.newStringUTF8NoRepl(bytes, off, len, false);
             }
 
             public byte[] getBytesUTF8NoRepl(String s) {


### PR DESCRIPTION
This is the javadoc of `JavaLangAccess::newStringNoRepl`:

```java
    /**
     * Constructs a new {@code String} by decoding the specified subarray of
     * bytes using the specified {@linkplain java.nio.charset.Charset charset}.
     *
     * The caller of this method shall relinquish and transfer the ownership of
     * the byte array to the callee since the later will not make a copy.
     *
     * @param bytes the byte array source
     * @param cs the Charset
     * @return the newly created string
     * @throws CharacterCodingException for malformed or unmappable bytes
     */
```

It is recorded in the document that it should be able to directly construct strings with parameter byte array to reduce array allocation.

However, at present, `newStringNoRepl` always copies arrays for UTF-8 or other ASCII compatible charsets.

This PR fixes this problem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299807](https://bugs.openjdk.org/browse/JDK-8299807): newStringNoRepl should avoid copying arrays for ASCII compatible charsets


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12119/head:pull/12119` \
`$ git checkout pull/12119`

Update a local copy of the PR: \
`$ git checkout pull/12119` \
`$ git pull https://git.openjdk.org/jdk pull/12119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12119`

View PR using the GUI difftool: \
`$ git pr show -t 12119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12119.diff">https://git.openjdk.org/jdk/pull/12119.diff</a>

</details>
