### PR TITLE
8300706: Use @snippet in java.text

### DIFF
--- a/src/java.base/share/classes/java/text/BreakIterator.java
+++ b/src/java.base/share/classes/java/text/BreakIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,7 +115,7 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  * <strong>Examples</strong>:<P>
  * Creating and using text boundaries:
  * <blockquote>
- * <pre>
+ * {@snippet lang=java :
  * public static void main(String args[]) {
  *      if (args.length == 1) {
  *          String stringToExamine = args[0];
@@ -131,12 +131,12 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  *          printLast(boundary, stringToExamine);
  *      }
  * }
- * </pre>
+ * }
  * </blockquote>
  *
  * Print each element in order:
  * <blockquote>
- * <pre>
+ * {@snippet lang=java :
  * public static void printEachForward(BreakIterator boundary, String source) {
  *     int start = boundary.first();
  *     for (int end = boundary.next();
@@ -145,12 +145,12 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  *          System.out.println(source.substring(start,end));
  *     }
  * }
- * </pre>
+ * }
  * </blockquote>
  *
  * Print each element in reverse order:
  * <blockquote>
- * <pre>
+ * {@snippet lang=java :
  * public static void printEachBackward(BreakIterator boundary, String source) {
  *     int end = boundary.last();
  *     for (int start = boundary.previous();
@@ -159,45 +159,45 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  *         System.out.println(source.substring(start,end));
  *     }
  * }
- * </pre>
+ * }
  * </blockquote>
  *
  * Print first element:
  * <blockquote>
- * <pre>
+ * {@snippet lang=java :
  * public static void printFirst(BreakIterator boundary, String source) {
  *     int start = boundary.first();
  *     int end = boundary.next();
  *     System.out.println(source.substring(start,end));
  * }
- * </pre>
+ * }
  * </blockquote>
  *
  * Print last element:
  * <blockquote>
- * <pre>
+ * {@snippet lang=java :
  * public static void printLast(BreakIterator boundary, String source) {
  *     int end = boundary.last();
  *     int start = boundary.previous();
  *     System.out.println(source.substring(start,end));
  * }
- * </pre>
+ * }
  * </blockquote>
  *
  * Print the element at a specified position:
  * <blockquote>
- * <pre>
+ *{@snippet lang=java :
  * public static void printAt(BreakIterator boundary, int pos, String source) {
  *     int end = boundary.following(pos);
  *     int start = boundary.previous();
  *     System.out.println(source.substring(start,end));
  * }
- * </pre>
+ * }
  * </blockquote>
  *
  * Find the next word:
  * <blockquote>
- * <pre>{@code
+ * {@snippet lang=java :
  * public static int nextWordStartAfter(int pos, String text) {
  *     BreakIterator wb = BreakIterator.getWordInstance();
  *     wb.setText(text);
@@ -213,7 +213,7 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  *     }
  *     return BreakIterator.DONE;
  * }
- * }</pre>
+ * }
  * (The iterator returned by BreakIterator.getWordInstance() is unique in that
  * the break positions it returns don't represent both the start and end of the
  * thing being iterated over.  That is, a sentence-break iterator returns breaks

--- a/src/java.base/share/classes/java/text/CharacterIterator.java
+++ b/src/java.base/share/classes/java/text/CharacterIterator.java
@@ -64,7 +64,7 @@ package java.text;
  * Traverse the text from start to finish
  * {@snippet lang=java :
  * public void traverseForward(CharacterIterator iter) {
- *     for(char c = iter.first(); c != CharacterIterator.DONE; c = iter.next()) {
+ *     for (char c = iter.first(); c != CharacterIterator.DONE; c = iter.next()) {
  *         processChar(c);
  *     }
  * }
@@ -73,7 +73,7 @@ package java.text;
  * Traverse the text backwards, from end to start
  * {@snippet lang=java :
  * public void traverseBackward(CharacterIterator iter) {
- *     for(char c = iter.last(); c != CharacterIterator.DONE; c = iter.previous()) {
+ *     for (char c = iter.last(); c != CharacterIterator.DONE; c = iter.previous()) {
  *         processChar(c);
  *     }
  * }

--- a/src/java.base/share/classes/java/text/CharacterIterator.java
+++ b/src/java.base/share/classes/java/text/CharacterIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,27 +62,27 @@ package java.text;
  * <P>Examples:<P>
  *
  * Traverse the text from start to finish
- * <pre>{@code
+ * {@snippet lang=java :
  * public void traverseForward(CharacterIterator iter) {
  *     for(char c = iter.first(); c != CharacterIterator.DONE; c = iter.next()) {
  *         processChar(c);
  *     }
  * }
- * }</pre>
+ * }
  *
  * Traverse the text backwards, from end to start
- * <pre>{@code
+ * {@snippet lang=java :
  * public void traverseBackward(CharacterIterator iter) {
  *     for(char c = iter.last(); c != CharacterIterator.DONE; c = iter.previous()) {
  *         processChar(c);
  *     }
  * }
- * }</pre>
+ * }
  *
  * Traverse both forward and backward from a given position in the text.
  * Calls to notBoundary() in this example represents some
  * additional stopping criteria.
- * <pre>{@code
+ * {@snippet lang=java :
  * public void traverseOut(CharacterIterator iter, int pos) {
  *     for (char c = iter.setIndex(pos);
  *              c != CharacterIterator.DONE && notBoundary(c);
@@ -96,7 +96,7 @@ package java.text;
  *     int start = iter.getIndex();
  *     processSection(start, end);
  * }
- * }</pre>
+ * }
  *
  * @since 1.1
  * @see StringCharacterIterator

--- a/src/java.base/share/classes/java/text/DateFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DateFormatSymbols.java
@@ -79,7 +79,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * format pattern for a specific locale, you can do so with:
  * <blockquote>
  * {@snippet lang=java :
- * new SimpleDateFormat(aPattern, DateFormatSymbols.getInstance(aLocale)).
+ * new SimpleDateFormat(aPattern, DateFormatSymbols.getInstance(aLocale));
  * }
  * </blockquote>
  *

--- a/src/java.base/share/classes/java/text/DateFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DateFormatSymbols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,9 +78,9 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * If you decide to create a date-time formatter with a specific
  * format pattern for a specific locale, you can do so with:
  * <blockquote>
- * <pre>
+ * {@snippet lang=java :
  * new SimpleDateFormat(aPattern, DateFormatSymbols.getInstance(aLocale)).
- * </pre>
+ * }
  * </blockquote>
  *
  * <p>If the locale contains "rg" (region override)

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,12 +70,12 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  * {@code DecimalFormat}. If you need to customize the format object, do
  * something like this:
  *
- * <blockquote><pre>
+ * <blockquote>{@snippet lang=java :
  * NumberFormat f = NumberFormat.getInstance(loc);
  * if (f instanceof DecimalFormat) {
  *     ((DecimalFormat) f).setDecimalSeparatorAlwaysShown(true);
  * }
- * </pre></blockquote>
+ * }</blockquote>
  *
  * <p>A {@code DecimalFormat} comprises a <em>pattern</em> and a set of
  * <em>symbols</em>.  The pattern may be set directly using
@@ -340,7 +340,8 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *
  * <blockquote><pre><strong>{@code
  * // Print out a number using the localized number, integer, currency,
- * // and percent format for each locale}</strong>{@code
+ * // and percent format for each locale}</strong></pre>
+ * {@snippet lang=java :
  * Locale[] locales = NumberFormat.getAvailableLocales();
  * double myNumber = -1234.56;
  * NumberFormat form;
@@ -370,7 +371,7 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *         } catch (ParseException e) {}
  *     }
  * }
- * }</pre></blockquote>
+ * }</blockquote>
  *
  * @see          <a href="http://docs.oracle.com/javase/tutorial/i18n/format/decimalFormat.html">Java Tutorial</a>
  * @see          NumberFormat

--- a/src/java.base/share/classes/java/text/NumberFormat.java
+++ b/src/java.base/share/classes/java/text/NumberFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,28 +71,28 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  * To format a number for the current Locale, use one of the factory
  * class methods:
  * <blockquote>
- * <pre>{@code
+ * {@snippet lang=java :
  * myString = NumberFormat.getInstance().format(myNumber);
- * }</pre>
+ * }
  * </blockquote>
  * If you are formatting multiple numbers, it is
  * more efficient to get the format and use it multiple times so that
  * the system doesn't have to fetch the information about the local
  * language and country conventions multiple times.
  * <blockquote>
- * <pre>{@code
+ * {@snippet lang=java :
  * NumberFormat nf = NumberFormat.getInstance();
  * for (int i = 0; i < myNumber.length; ++i) {
  *     output.println(nf.format(myNumber[i]) + "; ");
  * }
- * }</pre>
+ * }
  * </blockquote>
  * To format a number for a different Locale, specify it in the
  * call to {@code getInstance}.
  * <blockquote>
- * <pre>{@code
+ * {@snippet lang=java :
  * NumberFormat nf = NumberFormat.getInstance(Locale.FRENCH);
- * }</pre>
+ * }
  * </blockquote>
  *
  * <p>If the locale contains "nu" (numbers) and/or "rg" (region override)
@@ -103,9 +103,9 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  *
  * <p>You can also use a {@code NumberFormat} to parse numbers:
  * <blockquote>
- * <pre>{@code
+ * {@snippet lang=java :
  * myNumber = nf.parse(myString);
- * }</pre>
+ * }
  * </blockquote>
  * Use {@code getInstance} or {@code getNumberInstance} to get the
  * normal number format. Use {@code getIntegerInstance} to get an


### PR DESCRIPTION
Some classes / interfaces in java.text have already implemented JEP 413.

This PR implements _JEP 413: Code Snippets in Java API Documentation_ for the rest of [java.text](https://docs.oracle.com/en/java/javase/19/docs/api/java.base/java/text/package-summary.html) including:
- BreakIterator
- CharacterIterator
- DateFormatSymbols
- DecimalFormat
- NumberFormat 

Code examples using \<pre> ... \</pre> blocks are replaced with the @ snippet syntax where applicable.