### PR TITLE
8300176: URLEncoder/URLDecoder static fields should be private static final

### DIFF
--- a/src/java.base/share/classes/java/net/URLDecoder.java
+++ b/src/java.base/share/classes/java/net/URLDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package java.net;
+
+import jdk.internal.util.StaticProperty;
 
 import java.io.*;
 import java.nio.charset.Charset;
@@ -89,7 +91,11 @@ public class URLDecoder {
     private URLDecoder() {}
 
     // The default charset
-    static String dfltEncName = URLEncoder.dfltEncName;
+    private static final String DEFAULT_ENCODING_NAME;
+
+    static {
+        DEFAULT_ENCODING_NAME = StaticProperty.fileEncoding();
+    }
 
     /**
      * Decodes a {@code x-www-form-urlencoded} string.
@@ -108,7 +114,7 @@ public class URLDecoder {
         String str = null;
 
         try {
-            str = decode(s, dfltEncName);
+            str = decode(s, DEFAULT_ENCODING_NAME);
         } catch (UnsupportedEncodingException e) {
             // The system should always have the default charset
         }

--- a/src/java.base/share/classes/java/net/URLDecoder.java
+++ b/src/java.base/share/classes/java/net/URLDecoder.java
@@ -91,11 +91,7 @@ public class URLDecoder {
     private URLDecoder() {}
 
     // The default charset
-    private static final String DEFAULT_ENCODING_NAME;
-
-    static {
-        DEFAULT_ENCODING_NAME = StaticProperty.fileEncoding();
-    }
+    private static final String DEFAULT_ENCODING_NAME = StaticProperty.fileEncoding();
 
     /**
      * Decodes a {@code x-www-form-urlencoded} string.

--- a/src/java.base/share/classes/java/net/URLEncoder.java
+++ b/src/java.base/share/classes/java/net/URLEncoder.java
@@ -119,7 +119,7 @@ public class URLEncoder {
          *
          */
 
-        DONT_NEED_ENCODING = new BitSet(256);
+        DONT_NEED_ENCODING = new BitSet(128);
 
         DONT_NEED_ENCODING.set('a', 'z' + 1);
         DONT_NEED_ENCODING.set('A', 'Z' + 1);

--- a/src/java.base/share/classes/java/net/URLEncoder.java
+++ b/src/java.base/share/classes/java/net/URLEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,9 +77,9 @@ import jdk.internal.util.StaticProperty;
  * @since   1.0
  */
 public class URLEncoder {
-    static BitSet dontNeedEncoding;
-    static final int caseDiff = ('a' - 'A');
-    static String dfltEncName;
+    private static final BitSet DONT_NEED_ENCODING;
+    private static final int CASE_DIFF = ('a' - 'A');
+    private static final String DEFAULT_ENCODING_NAME;
 
     static {
 
@@ -119,25 +119,25 @@ public class URLEncoder {
          *
          */
 
-        dontNeedEncoding = new BitSet(256);
+        DONT_NEED_ENCODING = new BitSet(256);
         int i;
         for (i = 'a'; i <= 'z'; i++) {
-            dontNeedEncoding.set(i);
+            DONT_NEED_ENCODING.set(i);
         }
         for (i = 'A'; i <= 'Z'; i++) {
-            dontNeedEncoding.set(i);
+            DONT_NEED_ENCODING.set(i);
         }
         for (i = '0'; i <= '9'; i++) {
-            dontNeedEncoding.set(i);
+            DONT_NEED_ENCODING.set(i);
         }
-        dontNeedEncoding.set(' '); /* encoding a space to a + is done
+        DONT_NEED_ENCODING.set(' '); /* encoding a space to a + is done
                                     * in the encode() method */
-        dontNeedEncoding.set('-');
-        dontNeedEncoding.set('_');
-        dontNeedEncoding.set('.');
-        dontNeedEncoding.set('*');
+        DONT_NEED_ENCODING.set('-');
+        DONT_NEED_ENCODING.set('_');
+        DONT_NEED_ENCODING.set('.');
+        DONT_NEED_ENCODING.set('*');
 
-        dfltEncName = StaticProperty.fileEncoding();
+        DEFAULT_ENCODING_NAME = StaticProperty.fileEncoding();
     }
 
     /**
@@ -162,7 +162,7 @@ public class URLEncoder {
         String str = null;
 
         try {
-            str = encode(s, dfltEncName);
+            str = encode(s, DEFAULT_ENCODING_NAME);
         } catch (UnsupportedEncodingException e) {
             // The system should always have the default charset
         }
@@ -230,7 +230,7 @@ public class URLEncoder {
         for (int i = 0; i < s.length();) {
             int c = s.charAt(i);
             //System.out.println("Examining character: " + c);
-            if (dontNeedEncoding.get(c)) {
+            if (DONT_NEED_ENCODING.get(c)) {
                 if (c == ' ') {
                     c = '+';
                     needToChange = true;
@@ -273,7 +273,7 @@ public class URLEncoder {
                         }
                     }
                     i++;
-                } while (i < s.length() && !dontNeedEncoding.get((c = s.charAt(i))));
+                } while (i < s.length() && !DONT_NEED_ENCODING.get((c = s.charAt(i))));
 
                 charArrayWriter.flush();
                 String str = charArrayWriter.toString();
@@ -284,12 +284,12 @@ public class URLEncoder {
                     // converting to use uppercase letter as part of
                     // the hex value if ch is a letter.
                     if (Character.isLetter(ch)) {
-                        ch -= caseDiff;
+                        ch -= CASE_DIFF;
                     }
                     out.append(ch);
                     ch = Character.forDigit(b & 0xF, 16);
                     if (Character.isLetter(ch)) {
-                        ch -= caseDiff;
+                        ch -= CASE_DIFF;
                     }
                     out.append(ch);
                 }

--- a/src/java.base/share/classes/java/net/URLEncoder.java
+++ b/src/java.base/share/classes/java/net/URLEncoder.java
@@ -124,7 +124,6 @@ public class URLEncoder {
         DONT_NEED_ENCODING.set('a', 'z' + 1);
         DONT_NEED_ENCODING.set('A', 'Z' + 1);
         DONT_NEED_ENCODING.set('0', '9' + 1);
-
         DONT_NEED_ENCODING.set(' '); /* encoding a space to a + is done
                                     * in the encode() method */
         DONT_NEED_ENCODING.set('-');

--- a/src/java.base/share/classes/java/net/URLEncoder.java
+++ b/src/java.base/share/classes/java/net/URLEncoder.java
@@ -120,16 +120,11 @@ public class URLEncoder {
          */
 
         DONT_NEED_ENCODING = new BitSet(256);
-        int i;
-        for (i = 'a'; i <= 'z'; i++) {
-            DONT_NEED_ENCODING.set(i);
-        }
-        for (i = 'A'; i <= 'Z'; i++) {
-            DONT_NEED_ENCODING.set(i);
-        }
-        for (i = '0'; i <= '9'; i++) {
-            DONT_NEED_ENCODING.set(i);
-        }
+
+        DONT_NEED_ENCODING.set('a', 'z' + 1);
+        DONT_NEED_ENCODING.set('A', 'Z' + 1);
+        DONT_NEED_ENCODING.set('0', '9' + 1);
+
         DONT_NEED_ENCODING.set(' '); /* encoding a space to a + is done
                                     * in the encode() method */
         DONT_NEED_ENCODING.set('-');


### PR DESCRIPTION
Made the `static` fields `private static final`, updated the naming as well to reflect this.

This meant I updated `URLDecoder` to set the `DEFAULT_ENCODING_NAME` itself since it had been previously getting it from `URLEncoder`.

Since these fields are only referenced from inside the classes nothing else needed updated

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300176](https://bugs.openjdk.org/browse/JDK-8300176): URLEncoder/URLDecoder static fields should be private static final


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to [b08138d1](https://git.openjdk.org/jdk/pull/12122/files/b08138d1e31b360eb392a307b5299c4119d7f7c6)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)
 * [Sergey Tsypanov](https://openjdk.org/census#stsypanov) (@stsypanov - Author)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12122/head:pull/12122` \
`$ git checkout pull/12122`

Update a local copy of the PR: \
`$ git checkout pull/12122` \
`$ git pull https://git.openjdk.org/jdk pull/12122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12122`

View PR using the GUI difftool: \
`$ git pr show -t 12122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12122.diff">https://git.openjdk.org/jdk/pull/12122.diff</a>

</details>
