### PR TITLE
8300806: Update googletest to v1.13.0

### DIFF
--- a/.github/actions/get-gtest/action.yml
+++ b/.github/actions/get-gtest/action.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ runs:
       uses: actions/checkout@v3
       with:
         repository: google/googletest
-        ref: 'release-${{ steps.version.outputs.value }}'
+        ref: 'v${{ steps.version.outputs.value }}'
         path: gtest
 
     - name: 'Export path to where GTest is installed'

--- a/doc/building.html
+++ b/doc/building.html
@@ -1094,8 +1094,8 @@ just unpacked.</p>
 <p>Building of Hotspot Gtest suite requires the source code of Google
 Test framework. The top directory, which contains both
 <code>googletest</code> and <code>googlemock</code> directories, should
-be specified via <code>--with-gtest</code>. The supported version of
-Google Test is 1.13.0, whose source code can be obtained:</p>
+be specified via <code>--with-gtest</code>. The minimum supported
+version of Google Test is 1.13.0, whose source code can be obtained:</p>
 <ul>
 <li>by downloading and unpacking the source bundle from <a
 href="https://github.com/google/googletest/releases/tag/v1.13.0">here</a></li>

--- a/doc/building.html
+++ b/doc/building.html
@@ -1095,13 +1095,13 @@ just unpacked.</p>
 Test framework. The top directory, which contains both
 <code>googletest</code> and <code>googlemock</code> directories, should
 be specified via <code>--with-gtest</code>. The supported version of
-Google Test is 1.8.1, whose source code can be obtained:</p>
+Google Test is 1.13.0, whose source code can be obtained:</p>
 <ul>
 <li>by downloading and unpacking the source bundle from <a
-href="https://github.com/google/googletest/releases/tag/release-1.8.1">here</a></li>
-<li>or by checking out <code>release-1.8.1</code> tag of
+href="https://github.com/google/googletest/releases/tag/v1.13.0">here</a></li>
+<li>or by checking out <code>v1.13.0</code> tag of
 <code>googletest</code> project:
-<code>git clone -b release-1.8.1 https://github.com/google/googletest</code></li>
+<code>git clone -b v1.13.0 https://github.com/google/googletest</code></li>
 </ul>
 <p>To execute the most basic tests (tier 1), use:</p>
 <pre><code>make run-test-tier1</code></pre>

--- a/doc/building.md
+++ b/doc/building.md
@@ -867,10 +867,10 @@ Download the latest `.tar.gz` file, unpack it, and point `--with-jtreg` to the
 Building of Hotspot Gtest suite requires the source code of Google Test framework.
 The top directory, which contains both `googletest` and `googlemock`
 directories, should be specified via `--with-gtest`.
-The supported version of Google Test is 1.8.1, whose source code can be obtained:
+The supported version of Google Test is 1.13.0, whose source code can be obtained:
 
- * by downloading and unpacking the source bundle from [here](https://github.com/google/googletest/releases/tag/release-1.8.1)
- * or by checking out `release-1.8.1` tag of `googletest` project: `git clone -b release-1.8.1 https://github.com/google/googletest`
+ * by downloading and unpacking the source bundle from [here](https://github.com/google/googletest/releases/tag/v1.13.0)
+ * or by checking out `v1.13.0` tag of `googletest` project: `git clone -b v1.13.0 https://github.com/google/googletest`
 
 To execute the most basic tests (tier 1), use:
 ```

--- a/doc/building.md
+++ b/doc/building.md
@@ -864,10 +864,11 @@ https://ci.adoptopenjdk.net/view/Dependencies/job/dependency_pipeline/lastSucces
 Download the latest `.tar.gz` file, unpack it, and point `--with-jtreg` to the
 `jtreg` directory that you just unpacked.
 
-Building of Hotspot Gtest suite requires the source code of Google Test framework.
-The top directory, which contains both `googletest` and `googlemock`
-directories, should be specified via `--with-gtest`.
-The supported version of Google Test is 1.13.0, whose source code can be obtained:
+Building of Hotspot Gtest suite requires the source code of Google
+Test framework.  The top directory, which contains both `googletest`
+and `googlemock` directories, should be specified via `--with-gtest`.
+The minimum supported version of Google Test is 1.13.0, whose source
+code can be obtained:
 
  * by downloading and unpacking the source bundle from [here](https://github.com/google/googletest/releases/tag/v1.13.0)
  * or by checking out `v1.13.0` tag of `googletest` project: `git clone -b v1.13.0 https://github.com/google/googletest`

--- a/make/autoconf/lib-tests.m4
+++ b/make/autoconf/lib-tests.m4
@@ -27,8 +27,9 @@
 # Setup libraries and functionalities needed to test the JDK.
 ################################################################################
 
-# Minimum supported version
+# Minimum supported versions
 JTREG_MINIMUM_VERSION=7.1.1
+GTEST_MINIMUM_VERSION=1.13.0
 
 ###############################################################################
 #
@@ -59,9 +60,12 @@ AC_DEFUN_ONCE([LIB_TESTS_SETUP_GTEST],
         UTIL_FIXUP_PATH([GTEST_FRAMEWORK_SRC])
 
         # Verify that the version is the required one.
-        GTEST_VERSION_1="`$GREP GOOGLETEST_VERSION $GTEST_FRAMEWORK_SRC/CMakeLists.txt | $SED -E -e 's/set\(GOOGLETEST_VERSION (.*)\)/\1/'`"
-        if test "x$GTEST_VERSION_1" != "x1.13.0"; then
-          AC_MSG_ERROR([gtest at $GTEST_FRAMEWORK_SRC does not seem to be version 1.13.0])
+        # This is a simplified version of TOOLCHAIN_CHECK_COMPILER_VERSION
+        gtest_version="`$GREP GOOGLETEST_VERSION $GTEST_FRAMEWORK_SRC/CMakeLists.txt | $SED -E -e 's/set\(GOOGLETEST_VERSION (.*)\)/\1/'`"
+        comparable_actual_version=`$AWK -F. '{ printf("%05d%05d%05d%05d\n", [$]1, [$]2, [$]3, [$]4) }' <<< "$gtest_version"`
+        comparable_minimum_version=`$AWK -F. '{ printf("%05d%05d%05d%05d\n", [$]1, [$]2, [$]3, [$]4) }' <<< "$GTEST_MINIMUM_VERSION"`
+        if test $comparable_actual_version -lt $comparable_minimum_version ; then
+          AC_MSG_ERROR([gtest version is too old, at least version $GTEST_MINIMUM_VERSION is required])
         fi
       fi
     fi

--- a/make/autoconf/lib-tests.m4
+++ b/make/autoconf/lib-tests.m4
@@ -58,20 +58,10 @@ AC_DEFUN_ONCE([LIB_TESTS_SETUP_GTEST],
         AC_MSG_RESULT([$GTEST_FRAMEWORK_SRC])
         UTIL_FIXUP_PATH([GTEST_FRAMEWORK_SRC])
 
-        # Try to verify version. We require 1.8.1, but this can not be directly
-        # determined. :-( Instead, there are different, incorrect version
-        # numbers we can look for.
+        # Verify that the version is the required one.
         GTEST_VERSION_1="`$GREP GOOGLETEST_VERSION $GTEST_FRAMEWORK_SRC/CMakeLists.txt | $SED -E -e 's/set\(GOOGLETEST_VERSION (.*)\)/\1/'`"
-        if test "x$GTEST_VERSION_1" != "x1.9.0"; then
-          AC_MSG_ERROR([gtest at $GTEST_FRAMEWORK_SRC does not seem to be version 1.8.1])
-        fi
-
-        # We cannot grep for "AC_IN*T" as a literal since then m4 will treat it as a macro
-        # and expand it.
-        # Additional [] needed to keep m4 from mangling shell constructs.
-        [ GTEST_VERSION_2="`$GREP -A1 ^.C_INIT $GTEST_FRAMEWORK_SRC/configure.ac | $TAIL -n 1 | $SED -E -e 's/ +\[(.*)],/\1/'`" ]
-        if test "x$GTEST_VERSION_2" != "x1.8.0"; then
-          AC_MSG_ERROR([gtest at $GTEST_FRAMEWORK_SRC does not seem to be version 1.8.1 B])
+        if test "x$GTEST_VERSION_1" != "x1.13.0"; then
+          AC_MSG_ERROR([gtest at $GTEST_FRAMEWORK_SRC does not seem to be version 1.13.0])
         fi
       fi
     fi

--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 
 # Versions and download locations for dependencies used by GitHub Actions (GHA)
 
-GTEST_VERSION=1.8.1
+GTEST_VERSION=1.13.0
 JTREG_VERSION=7.1.1+1
 
 LINUX_X64_BOOT_JDK_EXT=tar.gz

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1236,7 +1236,7 @@ var getJibProfilesDependencies = function (input, common) {
         gtest: {
             organization: common.organization,
             ext: "tar.gz",
-            revision: "1.8.1"
+            revision: "1.13.0+1.0"
         },
     };
 

--- a/test/hotspot/gtest/gtestMain.cpp
+++ b/test/hotspot/gtest/gtestMain.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -230,7 +230,7 @@ static void runUnitTestsInner(int argc, char** argv) {
   bool is_vmassert_test = false;
   bool is_othervm_test = false;
   // death tests facility is used for both regular death tests, other vm and vmassert tests
-  if (::testing::internal::GTEST_FLAG(internal_run_death_test).length() > 0) {
+  if (::testing::GTEST_FLAG(internal_run_death_test).length() > 0) {
     // when we execute death test, filter value equals to test name
     const char* test_name = ::testing::GTEST_FLAG(filter).c_str();
     const char* const othervm_suffix = "_other_vm"; // TEST_OTHER_VM


### PR DESCRIPTION
Please review this PR which updates the required version of googletest to v1.13.0.

It’s been (quite) a while since we upgraded the version of googletest used to run the hotspot unit tests (test/hotspot/gtest). The current version (1.8.1) is from 2018 and there is build issue with Xcode 14.x which has been resolved in more recent versions of googletest.

The configure.ac file has been removed from googletest so the only file which contains the version is CMakeLists.txt, hence the removed logic from `make/autoconf/lib-tests.m4`.

Testing: tier1, gtest:all, GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300806](https://bugs.openjdk.org/browse/JDK-8300806): Update googletest to v1.13.0


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [d037905b](https://git.openjdk.org/jdk/pull/12125/files/d037905bd838da6c6afe9a1d321252a283121882)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12125/head:pull/12125` \
`$ git checkout pull/12125`

Update a local copy of the PR: \
`$ git checkout pull/12125` \
`$ git pull https://git.openjdk.org/jdk pull/12125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12125`

View PR using the GUI difftool: \
`$ git pr show -t 12125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12125.diff">https://git.openjdk.org/jdk/pull/12125.diff</a>

</details>
