### PR TITLE
8299497: Usage of constructors of primitive wrapper classes should be avoided in java.desktop API docs

### DIFF
--- a/src/java.desktop/share/classes/java/awt/font/LineBreakMeasurer.java
+++ b/src/java.desktop/share/classes/java/awt/font/LineBreakMeasurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/java/awt/font/LineBreakMeasurer.java
+++ b/src/java.desktop/share/classes/java/awt/font/LineBreakMeasurer.java
@@ -198,7 +198,7 @@ import java.awt.font.FontRenderContext;
  *             // layout can be null if lineContainsText is true
  *             if (layout != null) {
  *                 layouts.addElement(layout);
- *                 penPositions.addElement(new Float(horizontalPos));
+ *                 penPositions.addElement(Float.valueOf(horizontalPos));
  *                 horizontalPos += layout.getAdvance();
  *                 maxAscent = Math.max(maxAscent, layout.getAscent());
  *                 maxDescent = Math.max(maxDescent,

--- a/src/java.desktop/share/classes/java/awt/image/renderable/ParameterBlock.java
+++ b/src/java.desktop/share/classes/java/awt/image/renderable/ParameterBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ import java.util.Vector;
  * downward cast and have return values of base type; an exception
  * will be thrown if the stored values do not have the correct type.
  * There is no way to distinguish between the results of
- * "short s; add(s)" and "add(new Short(s))".
+ * "short s; add(s)" and "add(Short.valueOf(s))".
  *
  * <p> Note that the get and set methods operate on references.
  * Therefore, one must be careful not to share references between


### PR DESCRIPTION
API docs of `java.awt.image.renderable.ParameterBlock` and `java.awt.font.LineBreakMeasurer` used deprecated constructors of `java.lang.Short` and `java.lang.Float`.

Replacing by `valueOf` factory methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299497](https://bugs.openjdk.org/browse/JDK-8299497): Usage of constructors of primitive wrapper classes should be avoided in java.desktop API docs


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12128/head:pull/12128` \
`$ git checkout pull/12128`

Update a local copy of the PR: \
`$ git checkout pull/12128` \
`$ git pull https://git.openjdk.org/jdk pull/12128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12128`

View PR using the GUI difftool: \
`$ git pr show -t 12128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12128.diff">https://git.openjdk.org/jdk/pull/12128.diff</a>

</details>
