### PR TITLE
8300817: The build is broken after JDK-8294693

### DIFF
--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -459,7 +459,7 @@ public class Collections {
      * up to the second, repeatedly swapping a randomly selected element into
      * the "current position".  Elements are randomly selected from the
      * portion of the list that runs from the first element to the current
-     * position, inclusive.<p>
+     * position, inclusive.
      *
      * @implSpec This method runs in linear time.  If the specified list does
      * not implement the {@link RandomAccess} interface and is large, this


### PR DESCRIPTION
The next warning is fixed:
```
 === Output from failing command(s) repeated here ===
* For target jdk_modules_java.base__the.java.base_batch:
/home/runner/work/jdk/jdk/src/java.base/share/classes/java/util/Collections.java:462: warning: empty <p> tag
     * position, inclusive.<p>
                           ^
error: warnings found and -Werror specified 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300817](https://bugs.openjdk.org/browse/JDK-8300817): The build is broken after JDK-8294693


### Reviewers
 * [Tagir F. Valeev](https://openjdk.org/census#tvaleev) (@amaembo - Committer)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12129/head:pull/12129` \
`$ git checkout pull/12129`

Update a local copy of the PR: \
`$ git checkout pull/12129` \
`$ git pull https://git.openjdk.org/jdk pull/12129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12129`

View PR using the GUI difftool: \
`$ git pr show -t 12129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12129.diff">https://git.openjdk.org/jdk/pull/12129.diff</a>

</details>
