### PR TITLE
8300828: Avoid unnecessary array fill after creation in com.sun.media.sound

### DIFF
--- a/src/java.desktop/share/classes/com/sun/media/sound/ModelInstrument.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/ModelInstrument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,8 +113,6 @@ public abstract class ModelInstrument extends Instrument {
         // Check if instrument is percussion.
         if (percussion) {
             boolean[] ch = new boolean[16];
-            for (int i = 0; i < ch.length; i++)
-                ch[i] = false;
             ch[9] = true;
             return ch;
         }

--- a/src/java.desktop/share/classes/com/sun/media/sound/SoftChannel.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/SoftChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package com.sun.media.sound;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -44,9 +43,6 @@ public final class SoftChannel implements MidiChannel, ModelDirectedPlayer {
 
     private static final boolean[] dontResetControls = new boolean[128];
     static {
-        for (int i = 0; i < dontResetControls.length; i++)
-            dontResetControls[i] = false;
-
         dontResetControls[0] = true;   // Bank Select (MSB)
         dontResetControls[32] = true;  // Bank Select (LSB)
         dontResetControls[7] = true;   // Channel Volume (MSB)
@@ -1032,9 +1028,7 @@ public final class SoftChannel implements MidiChannel, ModelDirectedPlayer {
         }
         if (keybasedcontroller_active[noteNumber] == null) {
             keybasedcontroller_active[noteNumber] = new boolean[128];
-            Arrays.fill(keybasedcontroller_active[noteNumber], false);
             keybasedcontroller_value[noteNumber] = new double[128];
-            Arrays.fill(keybasedcontroller_value[noteNumber], 0);
         }
 
         if (value == -1) {

--- a/src/java.desktop/share/classes/com/sun/media/sound/SoftPerformer.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/SoftPerformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * This class decodes information from ModelPeformer for use in SoftVoice.
+ * This class decodes information from ModelPerformer for use in SoftVoice.
  * It also adds default connections if they where missing in ModelPerformer.
  *
  * @author Karl Helgason
@@ -694,13 +694,7 @@ public final class SoftPerformer {
         List<ModelConnectionBlock> connections = new ArrayList<>();
 
         midi_ctrl_connections = new int[128][];
-        for (int i = 0; i < midi_ctrl_connections.length; i++) {
-            midi_ctrl_connections[i] = null;
-        }
         midi_connections = new int[5][];
-        for (int i = 0; i < midi_connections.length; i++) {
-            midi_connections[i] = null;
-        }
 
         int ix = 0;
         boolean mustBeOnTop = false;


### PR DESCRIPTION
No need to fill elements of array with default values if it was just created. Java guarantees that all elements of array have default values after allocations: boolean - `false`, reference types - `null`, double - `0.`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300828](https://bugs.openjdk.org/browse/JDK-8300828): Avoid unnecessary array fill after creation in com.sun.media.sound


### Reviewers
 * @SWinxy (no known github.com user name / role)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12130/head:pull/12130` \
`$ git checkout pull/12130`

Update a local copy of the PR: \
`$ git checkout pull/12130` \
`$ git pull https://git.openjdk.org/jdk pull/12130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12130`

View PR using the GUI difftool: \
`$ git pr show -t 12130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12130.diff">https://git.openjdk.org/jdk/pull/12130.diff</a>

</details>
