### PR TITLE
8300819: -Dfile.encoding=Cp943C option does not work as expected since jdk18

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/StaticProperty.java
+++ b/src/java.base/share/classes/jdk/internal/util/StaticProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/util/StaticProperty.java
+++ b/src/java.base/share/classes/jdk/internal/util/StaticProperty.java
@@ -74,7 +74,8 @@ public final class StaticProperty {
         FILE_ENCODING = getProperty(props, "file.encoding");
         JAVA_PROPERTIES_DATE = getProperty(props, "java.properties.date", null);
         SUN_JNU_ENCODING = getProperty(props, "sun.jnu.encoding");
-        jnuCharset = Charset.forName(SUN_JNU_ENCODING, Charset.defaultCharset());
+        var cs = Charset.forName(SUN_JNU_ENCODING, null);
+        jnuCharset = cs != null ? cs : Charset.defaultCharset();
         JAVA_LOCALE_USE_OLD_ISO_CODES = getProperty(props, "java.locale.useOldISOCodes", "");
     }
 

--- a/test/jdk/java/nio/charset/Charset/DefaultCharsetTest2.java
+++ b/test/jdk/java/nio/charset/Charset/DefaultCharsetTest2.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8300819
+ * @summary -Dfile.encoding=Cp943C option does not work as expected since jdk18
+ * @requires os.family == "linux"
+ * @run main/othervm -Dfile.encoding=Cp943C DefaultCharsetTest2
+ *
+ */
+
+import java.nio.charset.Charset;
+
+public class DefaultCharsetTest2 {
+    public static void main(String[] args) {
+        Charset cs = Charset.defaultCharset();
+        String output = cs.getClass().getModule().toString();
+        if (!"module jdk.charsets".equals(output))
+            throw new RuntimeException("Default charset is " +
+                cs + ", " + output);
+    }
+}


### PR DESCRIPTION
On jdk17, following testcase works fine on Linux platform.

Testcase
```
$ cat cstest1.java
import java.nio.charset.*;

public class cstest1 {
  public static void main(String[] args) throws Exception {
    Charset cs = Charset.defaultCharset();
    System.out.println(cs + ", " + cs.getClass() + ", " + cs.getClass().getModule());
  }
}
```
```
$ ~/jdk-17.0.6+10/bin/java -Dfile.encoding=Cp943C -showversion cstest1
openjdk version "17.0.6" 2023-01-17
OpenJDK Runtime Environment Temurin-17.0.6+10 (build 17.0.6+10)
OpenJDK 64-Bit Server VM Temurin-17.0.6+10 (build 17.0.6+10, mixed mode, sharing)
x-IBM943C, class sun.nio.cs.ext.IBM943C, module jdk.charsets
```

But it does not work as expected on jdk18 and jdk21b06
```
$ ~/jdk-18.0.2.1+1/bin/java -Dfile.encoding=Cp943C -showversion cstest1
openjdk version "18.0.2.1" 2022-08-18
OpenJDK Runtime Environment Temurin-18.0.2.1+1 (build 18.0.2.1+1)
OpenJDK 64-Bit Server VM Temurin-18.0.2.1+1 (build 18.0.2.1+1, mixed mode, sharing)
UTF-8, class sun.nio.cs.UTF_8, module java.base
$ ~/jdk-21/bin/java -Dfile.encoding=Cp943C -showversion cstest1
openjdk version "21-ea" 2023-09-19
OpenJDK Runtime Environment (build 21-ea+6-365)
OpenJDK 64-Bit Server VM (build 21-ea+6-365, mixed mode, sharing)
UTF-8, class sun.nio.cs.UTF_8, module java.base
```

Fixed result is as follows:
```
$ java -Dfile.encoding=Cp943C -showversion PrintDefaultCharset
openjdk version "21-internal" 2023-09-19
OpenJDK Runtime Environment (build 21-internal-adhoc.jdktest.jdk)
OpenJDK 64-Bit Server VM (build 21-internal-adhoc.jdktest.jdk, mixed mode, sharing)
x-IBM943C
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300819](https://bugs.openjdk.org/browse/JDK-8300819): -Dfile.encoding=Cp943C option does not work as expected since jdk18 ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12132/head:pull/12132` \
`$ git checkout pull/12132`

Update a local copy of the PR: \
`$ git checkout pull/12132` \
`$ git pull https://git.openjdk.org/jdk.git pull/12132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12132`

View PR using the GUI difftool: \
`$ git pr show -t 12132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12132.diff">https://git.openjdk.org/jdk/pull/12132.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12132#issuecomment-1399521907)