### PR TITLE
8300830: Remove redundant assertion in src/hotspot/share/runtime/javaCalls.cpp

### DIFF
--- a/src/hotspot/share/runtime/javaCalls.cpp
+++ b/src/hotspot/share/runtime/javaCalls.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -94,8 +94,6 @@ JavaCallWrapper::JavaCallWrapper(const methodHandle& callee_method, Handle recei
 
   debug_only(_thread->inc_java_call_counter());
   _thread->set_active_handles(new_handles);     // install new handle block and reset Java frame linkage
-
-  assert (_thread->thread_state() != _thread_in_native, "cannot set native pc to NULL");
 
   MACOS_AARCH64_ONLY(_thread->enable_wx(WXExec));
 }


### PR DESCRIPTION
Trivial removal of redundant assertion: we previously set the state to _thread_in_Java so it can't be _thread_in_native.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300830](https://bugs.openjdk.org/browse/JDK-8300830): Remove redundant assertion in src/hotspot/share/runtime/javaCalls.cpp


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12134/head:pull/12134` \
`$ git checkout pull/12134`

Update a local copy of the PR: \
`$ git checkout pull/12134` \
`$ git pull https://git.openjdk.org/jdk pull/12134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12134`

View PR using the GUI difftool: \
`$ git pr show -t 12134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12134.diff">https://git.openjdk.org/jdk/pull/12134.diff</a>

</details>
