### PR TITLE
8296935: Arrays.asList().set() with wrong types throws undocumented ArrayStoreException

### DIFF
--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -4112,11 +4112,26 @@ public class Arrays {
      * {@link Collections#unmodifiableList Collections.unmodifiableList}
      * or <a href="List.html#unmodifiable">Unmodifiable Lists</a>.
      *
-     * @implNote
-     * The {@link List} implementation returned by this method does not conform to the
-     * specification for {@link List#replaceAll} and {@link List#set}, in that in the
-     * event of encountering an element of an unsuitable type, an {@link ArrayStoreException}
-     * will be thrown instead of a {@link ClassCastException}.
+     * @apiNote
+     * The {@link List} returned by this method does not conform to the
+     * specification for {@link List#set} and {@link ListIterator#set}.
+     * It is possible for the type parameter {@code T} of the returned list
+     * to differ from the array's component type. This can occur, for example,
+     * if the array argument type has been upcast from its component type:
+     *
+     * {@snippet :
+     *    String[] strings = new String[1];
+     *    List<Object> objects = Arrays.asList((Object[])strings);
+     * }
+     *
+     * Writing an element into the returned list may result in an
+     * {@link ArrayStoreException} instead of {@link ClassCastException} being
+     * thrown if the element is incompatible with the underlying array's
+     * component type:
+     *
+     * {@snippet :
+     *    objects.set(0, Integer.valueOf(0)); // throws ArrayStoreException
+     * }
      *
      * @param <T> the class of the objects in the array
      * @param a the array by which the list will be backed

--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -4179,7 +4179,7 @@ public class Arrays {
 
         /**
          * {@inheritDoc}
-         * 
+         *
          * @throws ArrayStoreException if {@code element} cannot be stored into the array.
          */
         @Override
@@ -4224,7 +4224,7 @@ public class Arrays {
 
         /**
          * {@inheritDoc}
-         * 
+         *
          * @throws ArrayStoreException if {@code operator.apply} returns an object which cannot be
          *         stored into the array.
          */

--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -4169,7 +4169,11 @@ public class Arrays {
         @Override
         public E set(int index, E element) {
             E oldValue = a[index];
-            a[index] = element;
+            try {
+                a[index] = element;
+            } catch (ArrayStoreException e) {
+                throw new ClassCastException(e.getMessage());
+            }
             return oldValue;
         }
 
@@ -4211,7 +4215,12 @@ public class Arrays {
             Objects.requireNonNull(operator);
             E[] a = this.a;
             for (int i = 0; i < a.length; i++) {
-                a[i] = operator.apply(a[i]);
+                E result = operator.apply(a[i]);
+                try {
+                    a[i] = result;
+                } catch (ArrayStoreException e) {
+                    throw new ClassCastException(e.getMessage());
+                }
             }
         }
 

--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -4112,6 +4112,17 @@ public class Arrays {
      * {@link Collections#unmodifiableList Collections.unmodifiableList}
      * or <a href="List.html#unmodifiable">Unmodifiable Lists</a>.
      *
+     * @apiNote
+     * Modification methods of the returned list (such as {@link List#set} and
+     * {@link List#replaceAll}) will throw an {@link ArrayStoreException} when
+     * trying to set a wrong type of element into the list (and the backing
+     * array).  For example:
+     * {@snippet :
+     *   List<Object> list = Arrays.asList((Object[])new String[1]);
+     *   list.set(0, Integer.valueOf(0));    // throws ArrayStoreException
+     *   list.replaceAll(Objects::hashCode); // throws ArrayStoreException
+     * }
+     *
      * @param <T> the class of the objects in the array
      * @param a the array by which the list will be backed
      * @return a list view of the specified array
@@ -4166,14 +4177,15 @@ public class Arrays {
             return a[index];
         }
 
+        /**
+         * {@inheritDoc}
+         * 
+         * @throws ArrayStoreException if {@code element} cannot be stored into the array.
+         */
         @Override
         public E set(int index, E element) {
             E oldValue = a[index];
-            try {
-                a[index] = element;
-            } catch (ArrayStoreException e) {
-                throw new ClassCastException(e.getMessage());
-            }
+            a[index] = element;
             return oldValue;
         }
 
@@ -4210,17 +4222,18 @@ public class Arrays {
             }
         }
 
+        /**
+         * {@inheritDoc}
+         * 
+         * @throws ArrayStoreException if {@code operator.apply} returns an object which cannot be
+         *         stored into the array.
+         */
         @Override
         public void replaceAll(UnaryOperator<E> operator) {
             Objects.requireNonNull(operator);
             E[] a = this.a;
             for (int i = 0; i < a.length; i++) {
-                E result = operator.apply(a[i]);
-                try {
-                    a[i] = result;
-                } catch (ArrayStoreException e) {
-                    throw new ClassCastException(e.getMessage());
-                }
+                a[i] = operator.apply(a[i]);
             }
         }
 

--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -4113,15 +4113,10 @@ public class Arrays {
      * or <a href="List.html#unmodifiable">Unmodifiable Lists</a>.
      *
      * @implNote
-     * Modification methods of the returned list (such as {@link List#set} and
-     * {@link List#replaceAll}) will throw an {@link ArrayStoreException} when
-     * trying to set a wrong type of element into the list (and the backing
-     * array).  For example:
-     * {@snippet :
-     *   List<Object> list = Arrays.asList((Object[])new String[1]);
-     *   list.set(0, Integer.valueOf(0));    // throws ArrayStoreException
-     *   list.replaceAll(Objects::hashCode); // throws ArrayStoreException
-     * }
+     * The {@link List} implementation returned by this method does not conform to the
+     * specification for {@link List#replaceAll} and {@link List#set}, in that in the
+     * event of encountering an element of an unsuitable type, an {@link ArrayStoreException}
+     * will be thrown instead of a {@link ClassCastException}.
      *
      * @param <T> the class of the objects in the array
      * @param a the array by which the list will be backed
@@ -4177,11 +4172,6 @@ public class Arrays {
             return a[index];
         }
 
-        /**
-         * {@inheritDoc}
-         *
-         * @throws ArrayStoreException if {@code element} cannot be stored into the array.
-         */
         @Override
         public E set(int index, E element) {
             E oldValue = a[index];
@@ -4222,12 +4212,6 @@ public class Arrays {
             }
         }
 
-        /**
-         * {@inheritDoc}
-         *
-         * @throws ArrayStoreException if {@code operator.apply} returns an object which cannot be
-         *         stored into the array.
-         */
         @Override
         public void replaceAll(UnaryOperator<E> operator) {
             Objects.requireNonNull(operator);

--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -4112,7 +4112,7 @@ public class Arrays {
      * {@link Collections#unmodifiableList Collections.unmodifiableList}
      * or <a href="List.html#unmodifiable">Unmodifiable Lists</a>.
      *
-     * @apiNote
+     * @implNote
      * Modification methods of the returned list (such as {@link List#set} and
      * {@link List#replaceAll}) will throw an {@link ArrayStoreException} when
      * trying to set a wrong type of element into the list (and the backing

--- a/src/java.base/share/classes/java/util/List.java
+++ b/src/java.base/share/classes/java/util/List.java
@@ -586,9 +586,6 @@ public interface List<E> extends Collection<E> {
      *         is not supported by this list
      * @throws ClassCastException if the class of the specified element
      *         prevents it from being added to this list
-     * @throws ArrayStoreException if this list is backed by an array and
-     *         the class of the specified element prevents it from being
-     *         stored to the array
      * @throws NullPointerException if the specified element is null and
      *         this list does not permit null elements
      * @throws IllegalArgumentException if some property of the specified

--- a/src/java.base/share/classes/java/util/List.java
+++ b/src/java.base/share/classes/java/util/List.java
@@ -586,6 +586,9 @@ public interface List<E> extends Collection<E> {
      *         is not supported by this list
      * @throws ClassCastException if the class of the specified element
      *         prevents it from being added to this list
+     * @throws ArrayStoreException if this list is backed by an array and
+     *         the class of the specified element prevents it from being 
+     *         stored to the array
      * @throws NullPointerException if the specified element is null and
      *         this list does not permit null elements
      * @throws IllegalArgumentException if some property of the specified

--- a/src/java.base/share/classes/java/util/List.java
+++ b/src/java.base/share/classes/java/util/List.java
@@ -587,7 +587,7 @@ public interface List<E> extends Collection<E> {
      * @throws ClassCastException if the class of the specified element
      *         prevents it from being added to this list
      * @throws ArrayStoreException if this list is backed by an array and
-     *         the class of the specified element prevents it from being 
+     *         the class of the specified element prevents it from being
      *         stored to the array
      * @throws NullPointerException if the specified element is null and
      *         this list does not permit null elements


### PR DESCRIPTION
Document `java.util.Arrays.asList` that the list will throw an `ArrayStoreException` when attempting to set an element with a wrong type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 21 to be approved (needs to be created)

### Issue
 * [JDK-8296935](https://bugs.openjdk.org/browse/JDK-8296935): Arrays.asList().set() with wrong types throws undocumented ArrayStoreException


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12135/head:pull/12135` \
`$ git checkout pull/12135`

Update a local copy of the PR: \
`$ git checkout pull/12135` \
`$ git pull https://git.openjdk.org/jdk pull/12135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12135`

View PR using the GUI difftool: \
`$ git pr show -t 12135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12135.diff">https://git.openjdk.org/jdk/pull/12135.diff</a>

</details>
