### PR TITLE
8286775: Remove identical per-compiler definitions of unsigned integral jtypes

### DIFF
--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -35,6 +35,7 @@
 #include COMPILER_HEADER(utilities/globalDefinitions)
 
 #include <cstddef>
+#include <cstdint>
 #include <type_traits>
 
 class oopDesc;
@@ -524,6 +525,13 @@ T2 checked_cast(T1 thing) {
 extern "C" {
   typedef int (*_sort_Fn)(const void *, const void *);
 }
+
+// Additional Java basic types
+
+typedef uint8_t  jubyte;
+typedef uint16_t jushort;
+typedef uint32_t juint;
+typedef uint64_t julong;
 
 // Unsigned byte types for os and stream.hpp
 

--- a/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
@@ -101,13 +101,6 @@ typedef unsigned int            uintptr_t;
 
 #endif // !LINUX && !_ALLBSD_SOURCE
 
-// Additional Java basic types
-
-typedef uint8_t  jubyte;
-typedef uint16_t jushort;
-typedef uint32_t juint;
-typedef uint64_t julong;
-
 // checking for nanness
 #if defined(__APPLE__)
 inline int g_isnan(double f) { return isnan(f); }

--- a/src/hotspot/share/utilities/globalDefinitions_visCPP.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_visCPP.hpp
@@ -85,13 +85,6 @@ typedef int64_t ssize_t;
 typedef int32_t ssize_t;
 #endif
 
-// Additional Java basic types
-
-typedef uint8_t  jubyte;
-typedef uint16_t jushort;
-typedef uint32_t juint;
-typedef uint64_t julong;
-
 // Non-standard stdlib-like stuff:
 inline int strcasecmp(const char *s1, const char *s2) { return _stricmp(s1,s2); }
 inline int strncasecmp(const char *s1, const char *s2, size_t n) {

--- a/src/hotspot/share/utilities/globalDefinitions_xlc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_xlc.hpp
@@ -91,16 +91,6 @@
   #endif
 #endif
 
-// Compiler-specific primitive types
-// All defs of int (uint16_6 etc) are defined in AIX' /usr/include/stdint.h
-
-// Additional Java basic types
-
-typedef uint8_t  jubyte;
-typedef uint16_t jushort;
-typedef uint32_t juint;
-typedef uint64_t julong;
-
 // checking for nanness
 inline int g_isnan(float  f) { return isnan(f); }
 inline int g_isnan(double f) { return isnan(f); }


### PR DESCRIPTION
Trivial update to share the common typedef's.

Testing: 
  - Oracle tier 1 - 5 builds
  - GHA (TBD)

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286775](https://bugs.openjdk.org/browse/JDK-8286775): Remove identical per-compiler definitions of unsigned integral jtypes


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12136/head:pull/12136` \
`$ git checkout pull/12136`

Update a local copy of the PR: \
`$ git checkout pull/12136` \
`$ git pull https://git.openjdk.org/jdk pull/12136/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12136`

View PR using the GUI difftool: \
`$ git pr show -t 12136`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12136.diff">https://git.openjdk.org/jdk/pull/12136.diff</a>

</details>
