### PR TITLE
8287134: HttpURLConnection chunked streaming mode doesn't enforce specified size

### DIFF
--- a/src/java.base/share/classes/java/net/HttpURLConnection.java
+++ b/src/java.base/share/classes/java/net/HttpURLConnection.java
@@ -277,9 +277,11 @@ public abstract class HttpURLConnection extends URLConnection {
      * <p>
      * This method must be called before the URLConnection is connected.
      *
-     * @param   chunklen The number of bytes to write in each chunk.
-     *          If chunklen is less than or equal to zero, a default
-     *          value will be used.
+     * @param   chunklen The number of bytes to be written on the wire in
+     *          each chunk. This includes a chunk size header given as a
+     *          hexidecimal string (minimum of 1 byte), two CRLF's (4 bytes)
+     *          and a minimum payload length of 1 byte. If chunklen is less
+     *          than or equal to 5, a default value will be used.
      *
      * @throws  IllegalStateException if URLConnection is already connected
      *          or if a different streaming mode is already enabled.

--- a/src/java.base/share/classes/java/net/HttpURLConnection.java
+++ b/src/java.base/share/classes/java/net/HttpURLConnection.java
@@ -277,11 +277,11 @@ public abstract class HttpURLConnection extends URLConnection {
      * <p>
      * This method must be called before the URLConnection is connected.
      *
-     * @param   chunklen The number of bytes to be written on the wire in
-     *          each chunk. This includes a chunk size header given as a
-     *          hexidecimal string (minimum of 1 byte), two CRLF's (4 bytes)
-     *          and a minimum payload length of 1 byte. If chunklen is less
-     *          than or equal to 5, a default value will be used.
+     * @param   chunklen The number of bytes to be written in each chunk,
+     *          including a chunk size header as a hexadecimal string
+     *          (minimum of 1 byte), two CRLF's (4 bytes) and a minimum
+     *          payload length of 1 byte. If chunklen is less than or equal
+     *          to 5, a higher default value will be used.
      *
      * @throws  IllegalStateException if URLConnection is already connected
      *          or if a different streaming mode is already enabled.


### PR DESCRIPTION
### **Description**
When using `HttpURLConnection::setChunkedStreamingMode()`, the current documentation does not make it clear that the `chunklen` parameter refers to the amount of bytes sent on the wire per HTTP/1.1 chunk and _not_ the  payload length per chunk. The `chunklen` parameter takes into account the bytes used for the chunk size header, two CRLF characters and the possible payload length inclusively.

### **Summary of Changes & Justification**
The API text has been updated to reflect the actual behavior of the method as described above to avoid a similar bug being submitted in the future and to make it clear what the `chunklen` parameter specifies.

This change will require a csr.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8300848](https://bugs.openjdk.org/browse/JDK-8300848) to be approved

### Issues
 * [JDK-8287134](https://bugs.openjdk.org/browse/JDK-8287134): HttpURLConnection chunked streaming mode doesn't enforce specified size
 * [JDK-8300848](https://bugs.openjdk.org/browse/JDK-8300848): HttpURLConnection chunked streaming mode doesn't enforce specified size (**CSR**)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12137/head:pull/12137` \
`$ git checkout pull/12137`

Update a local copy of the PR: \
`$ git checkout pull/12137` \
`$ git pull https://git.openjdk.org/jdk pull/12137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12137`

View PR using the GUI difftool: \
`$ git pr show -t 12137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12137.diff">https://git.openjdk.org/jdk/pull/12137.diff</a>

</details>
