### PR TITLE
8300696 : [AIX] AttachReturnError fails

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -48,6 +48,9 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/vmError.hpp"
+#ifdef AIX
+#include "loadlib_aix.hpp"
+#endif
 #ifdef LINUX
 #include "os_linux.hpp"
 #endif
@@ -747,6 +750,8 @@ void os::dll_unload(void *lib) {
     log_info(os)("Attempt to unload shared library \"%s\" [" INTPTR_FORMAT "] failed, %s",
                   l_path, p2i(lib), error_report);
   }
+  // Update the dll cache
+  AIX_ONLY(LoadedLibraries::reload());
   LINUX_ONLY(os::free(l_pathdup));
 }
 


### PR DESCRIPTION
AttachReturnError.java fails because "VM.dynlibs" prints a list of loaded dynamic libs referring to a cache. The cache may contain stale entries related to unloaded libraries (libReturnError.so in this case). Reloading this cache after unloading libraries solves the problem.

Reported Issue : [JDK-8300696](https://bugs.openjdk.org/browse/JDK-8300696)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300696](https://bugs.openjdk.org/browse/JDK-8300696): [AIX] AttachReturnError fails


### Reviewers
 * [Tyler Steele](https://openjdk.org/census#tsteele) (@backwaterred - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12138/head:pull/12138` \
`$ git checkout pull/12138`

Update a local copy of the PR: \
`$ git checkout pull/12138` \
`$ git pull https://git.openjdk.org/jdk pull/12138/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12138`

View PR using the GUI difftool: \
`$ git pr show -t 12138`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12138.diff">https://git.openjdk.org/jdk/pull/12138.diff</a>

</details>
