### PR TITLE
8300864: Declare some fields in java.io as final

### DIFF
--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ import jdk.internal.util.ArraysSupport;
  */
 public class BufferedInputStream extends FilterInputStream {
 
-    private static int DEFAULT_BUFFER_SIZE = 8192;
+    private static final int DEFAULT_BUFFER_SIZE = 8192;
 
     /**
      * As this class is used early during bootstrap, it's motivated to use

--- a/src/java.base/share/classes/java/io/BufferedReader.java
+++ b/src/java.base/share/classes/java/io/BufferedReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,8 +85,8 @@ public class BufferedReader extends Reader {
     /** The skipLF flag when the mark was set */
     private boolean markedSkipLF = false;
 
-    private static int defaultCharBufferSize = 8192;
-    private static int defaultExpectedLineLength = 80;
+    private static final int DEFAULT_CHAR_BUFFER_SIZE = 8192;
+    private static final int DEFAULT_EXPECTED_LINE_LENGTH = 80;
 
     /**
      * Creates a buffering character-input stream that uses an input buffer of
@@ -113,7 +113,7 @@ public class BufferedReader extends Reader {
      * @param  in   A Reader
      */
     public BufferedReader(Reader in) {
-        this(in, defaultCharBufferSize);
+        this(in, DEFAULT_CHAR_BUFFER_SIZE);
     }
 
     /** Checks to make sure that the stream has not been closed */
@@ -414,7 +414,7 @@ public class BufferedReader extends Reader {
             }
 
             if (s == null)
-                s = new StringBuilder(defaultExpectedLineLength);
+                s = new StringBuilder(DEFAULT_EXPECTED_LINE_LENGTH);
             s.append(cb, startChar, i - startChar);
         }
     }

--- a/src/java.base/share/classes/java/io/ExpiringCache.java
+++ b/src/java.base/share/classes/java/io/ExpiringCache.java
@@ -41,7 +41,7 @@ class ExpiringCache {
     // Clear out old entries every few queries
     private int queryCount;
 
-    static final class Entry {
+    static class Entry {
         private long timestamp;
         private String val;
 

--- a/src/java.base/share/classes/java/io/ExpiringCache.java
+++ b/src/java.base/share/classes/java/io/ExpiringCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,21 +28,21 @@
 
 package java.io;
 
-import java.util.Iterator;
 import java.util.Map;
 import java.util.LinkedHashMap;
 import java.util.Set;
 
 class ExpiringCache {
-    private long millisUntilExpiration;
-    private Map<String,Entry> map;
+
+    private static final int QUERY_OVERFLOW = 300;
+    private static final int MAX_ENTRIES = 200;
+    private final long millisUntilExpiration;
+    private final Map<String,Entry> map;
     // Clear out old entries every few queries
     private int queryCount;
-    private int queryOverflow = 300;
-    private int MAX_ENTRIES = 200;
 
-    static class Entry {
-        private long   timestamp;
+    static final class Entry {
+        private long timestamp;
         private String val;
 
         Entry(long timestamp, String val) {
@@ -72,7 +72,7 @@ class ExpiringCache {
     }
 
     synchronized String get(String key) {
-        if (++queryCount >= queryOverflow) {
+        if (++queryCount >= QUERY_OVERFLOW) {
             cleanup();
         }
         Entry entry = entryFor(key);
@@ -83,7 +83,7 @@ class ExpiringCache {
     }
 
     synchronized void put(String key, String val) {
-        if (++queryCount >= queryOverflow) {
+        if (++queryCount >= QUERY_OVERFLOW) {
             cleanup();
         }
         Entry entry = entryFor(key);

--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -152,7 +152,7 @@ public class File
     /**
      * The FileSystem object representing the platform's local file system.
      */
-    private static final FileSystem fs = DefaultFileSystem.getFileSystem();
+    private static final FileSystem FS = DefaultFileSystem.getFileSystem();
 
     /**
      * This abstract pathname's normalized pathname string. A normalized
@@ -185,7 +185,7 @@ public class File
     final boolean isInvalid() {
         PathStatus s = status;
         if (s == null) {
-            s = fs.isInvalid(this) ? PathStatus.INVALID : PathStatus.CHECKED;
+            s = FS.isInvalid(this) ? PathStatus.INVALID : PathStatus.CHECKED;
             status = s;
         }
         return s == PathStatus.INVALID;
@@ -213,7 +213,7 @@ public class File
      *
      * @see     java.lang.System#getProperty(java.lang.String)
      */
-    public static final char separatorChar = fs.getSeparator();
+    public static final char separatorChar = FS.getSeparator();
 
     /**
      * The system-dependent default name-separator character, represented as a
@@ -232,7 +232,7 @@ public class File
      *
      * @see     java.lang.System#getProperty(java.lang.String)
      */
-    public static final char pathSeparatorChar = fs.getPathSeparator();
+    public static final char pathSeparatorChar = FS.getPathSeparator();
 
     /**
      * The system-dependent path-separator character, represented as a string
@@ -260,7 +260,7 @@ public class File
     private File(String child, File parent) {
         assert parent.path != null;
         assert (!parent.path.isEmpty());
-        this.path = fs.resolve(parent.path, child);
+        this.path = FS.resolve(parent.path, child);
         this.prefixLength = parent.prefixLength;
     }
 
@@ -277,8 +277,8 @@ public class File
         if (pathname == null) {
             throw new NullPointerException();
         }
-        this.path = fs.normalize(pathname);
-        this.prefixLength = fs.prefixLength(this.path);
+        this.path = FS.normalize(pathname);
+        this.prefixLength = FS.prefixLength(this.path);
     }
 
     /* Note: The two-argument File constructors do not interpret an empty
@@ -319,16 +319,16 @@ public class File
         }
         if (parent != null) {
             if (parent.isEmpty()) {
-                this.path = fs.resolve(fs.getDefaultParent(),
-                                       fs.normalize(child));
+                this.path = FS.resolve(FS.getDefaultParent(),
+                                       FS.normalize(child));
             } else {
-                this.path = fs.resolve(fs.normalize(parent),
-                                       fs.normalize(child));
+                this.path = FS.resolve(FS.normalize(parent),
+                                       FS.normalize(child));
             }
         } else {
-            this.path = fs.normalize(child);
+            this.path = FS.normalize(child);
         }
-        this.prefixLength = fs.prefixLength(this.path);
+        this.prefixLength = FS.prefixLength(this.path);
     }
 
     /**
@@ -362,16 +362,16 @@ public class File
         }
         if (parent != null) {
             if (parent.path.isEmpty()) {
-                this.path = fs.resolve(fs.getDefaultParent(),
-                                       fs.normalize(child));
+                this.path = FS.resolve(FS.getDefaultParent(),
+                                       FS.normalize(child));
             } else {
-                this.path = fs.resolve(parent.path,
-                                       fs.normalize(child));
+                this.path = FS.resolve(parent.path,
+                                       FS.normalize(child));
             }
         } else {
-            this.path = fs.normalize(child);
+            this.path = FS.normalize(child);
         }
-        this.prefixLength = fs.prefixLength(this.path);
+        this.prefixLength = FS.prefixLength(this.path);
     }
 
     /**
@@ -432,11 +432,11 @@ public class File
             throw new IllegalArgumentException("URI path component is empty");
 
         // Okay, now initialize
-        p = fs.fromURIPath(p);
+        p = FS.fromURIPath(p);
         if (File.separatorChar != '/')
             p = p.replace('/', File.separatorChar);
-        this.path = fs.normalize(p);
-        this.prefixLength = fs.prefixLength(this.path);
+        this.path = FS.normalize(p);
+        this.prefixLength = FS.prefixLength(this.path);
     }
 
 
@@ -501,7 +501,7 @@ public class File
         String p = this.getParent();
         if (p == null) return null;
         if (getClass() != File.class) {
-            p = fs.normalize(p);
+            p = FS.normalize(p);
         }
         return new File(p, this.prefixLength);
     }
@@ -531,7 +531,7 @@ public class File
      *          {@code false} otherwise
      */
     public boolean isAbsolute() {
-        return fs.isAbsolute(this);
+        return FS.isAbsolute(this);
     }
 
     /**
@@ -558,7 +558,7 @@ public class File
      * @see     java.io.File#isAbsolute()
      */
     public String getAbsolutePath() {
-        return fs.resolve(this);
+        return FS.resolve(this);
     }
 
     /**
@@ -576,9 +576,9 @@ public class File
     public File getAbsoluteFile() {
         String absPath = getAbsolutePath();
         if (getClass() != File.class) {
-            absPath = fs.normalize(absPath);
+            absPath = FS.normalize(absPath);
         }
-        return new File(absPath, fs.prefixLength(absPath));
+        return new File(absPath, FS.prefixLength(absPath));
     }
 
     /**
@@ -623,7 +623,7 @@ public class File
         if (isInvalid()) {
             throw new IOException("Invalid file path");
         }
-        return fs.canonicalize(fs.resolve(this));
+        return FS.canonicalize(FS.resolve(this));
     }
 
     /**
@@ -650,9 +650,9 @@ public class File
     public File getCanonicalFile() throws IOException {
         String canonPath = getCanonicalPath();
         if (getClass() != File.class) {
-            canonPath = fs.normalize(canonPath);
+            canonPath = FS.normalize(canonPath);
         }
-        return new File(canonPath, fs.prefixLength(canonPath));
+        return new File(canonPath, FS.prefixLength(canonPath));
     }
 
     private static String slashify(String path, boolean isDirectory) {
@@ -780,7 +780,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.checkAccess(this, FileSystem.ACCESS_READ);
+        return FS.checkAccess(this, FileSystem.ACCESS_READ);
     }
 
     /**
@@ -809,7 +809,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.checkAccess(this, FileSystem.ACCESS_WRITE);
+        return FS.checkAccess(this, FileSystem.ACCESS_WRITE);
     }
 
     /**
@@ -833,7 +833,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.hasBooleanAttributes(this, FileSystem.BA_EXISTS);
+        return FS.hasBooleanAttributes(this, FileSystem.BA_EXISTS);
     }
 
     /**
@@ -864,7 +864,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.hasBooleanAttributes(this, FileSystem.BA_DIRECTORY);
+        return FS.hasBooleanAttributes(this, FileSystem.BA_DIRECTORY);
     }
 
     /**
@@ -897,7 +897,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.hasBooleanAttributes(this, FileSystem.BA_REGULAR);
+        return FS.hasBooleanAttributes(this, FileSystem.BA_REGULAR);
     }
 
     /**
@@ -927,7 +927,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.hasBooleanAttributes(this, FileSystem.BA_HIDDEN);
+        return FS.hasBooleanAttributes(this, FileSystem.BA_HIDDEN);
     }
 
     /**
@@ -971,7 +971,7 @@ public class File
         if (isInvalid()) {
             return 0L;
         }
-        return fs.getLastModifiedTime(this);
+        return FS.getLastModifiedTime(this);
     }
 
     /**
@@ -1003,7 +1003,7 @@ public class File
         if (isInvalid()) {
             return 0L;
         }
-        return fs.getLength(this);
+        return FS.getLength(this);
     }
 
 
@@ -1042,7 +1042,7 @@ public class File
         if (isInvalid()) {
             throw new IOException("Invalid file path");
         }
-        return fs.createFileExclusively(path);
+        return FS.createFileExclusively(path);
     }
 
     /**
@@ -1072,7 +1072,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.delete(this);
+        return FS.delete(this);
     }
 
     /**
@@ -1175,11 +1175,11 @@ public class File
         if (isInvalid()) {
             return null;
         }
-        String[] s = fs.list(this);
+        String[] s = FS.list(this);
         if (s != null && getClass() != File.class) {
             String[] normalized = new String[s.length];
             for (int i = 0; i < s.length; i++) {
-                normalized[i] = fs.normalize(s[i]);
+                normalized[i] = FS.normalize(s[i]);
             }
             s = normalized;
         }
@@ -1378,7 +1378,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.createDirectory(this);
+        return FS.createDirectory(this);
     }
 
     /**
@@ -1462,7 +1462,7 @@ public class File
         if (this.isInvalid() || dest.isInvalid()) {
             return false;
         }
-        return fs.rename(this, dest);
+        return FS.rename(this, dest);
     }
 
     /**
@@ -1501,7 +1501,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.setLastModifiedTime(this, time);
+        return FS.setLastModifiedTime(this, time);
     }
 
     /**
@@ -1532,7 +1532,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.setReadOnly(this);
+        return FS.setReadOnly(this);
     }
 
     /**
@@ -1576,7 +1576,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.setPermission(this, FileSystem.ACCESS_WRITE, writable, ownerOnly);
+        return FS.setPermission(this, FileSystem.ACCESS_WRITE, writable, ownerOnly);
     }
 
     /**
@@ -1655,7 +1655,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.setPermission(this, FileSystem.ACCESS_READ, readable, ownerOnly);
+        return FS.setPermission(this, FileSystem.ACCESS_READ, readable, ownerOnly);
     }
 
     /**
@@ -1737,7 +1737,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.setPermission(this, FileSystem.ACCESS_EXECUTE, executable, ownerOnly);
+        return FS.setPermission(this, FileSystem.ACCESS_EXECUTE, executable, ownerOnly);
     }
 
     /**
@@ -1801,7 +1801,7 @@ public class File
         if (isInvalid()) {
             return false;
         }
-        return fs.checkAccess(this, FileSystem.ACCESS_EXECUTE);
+        return FS.checkAccess(this, FileSystem.ACCESS_EXECUTE);
     }
 
 
@@ -1850,7 +1850,7 @@ public class File
      * @see java.nio.file.FileStore
      */
     public static File[] listRoots() {
-        return fs.listRoots();
+        return FS.listRoots();
     }
 
 
@@ -1885,7 +1885,7 @@ public class File
         if (isInvalid()) {
             return 0L;
         }
-        long space = fs.getSpace(this, FileSystem.SPACE_TOTAL);
+        long space = FS.getSpace(this, FileSystem.SPACE_TOTAL);
         return space >= 0L ? space : Long.MAX_VALUE;
     }
 
@@ -1929,7 +1929,7 @@ public class File
         if (isInvalid()) {
             return 0L;
         }
-        long space = fs.getSpace(this, FileSystem.SPACE_FREE);
+        long space = FS.getSpace(this, FileSystem.SPACE_FREE);
         return space >= 0L ? space : Long.MAX_VALUE;
     }
 
@@ -1976,7 +1976,7 @@ public class File
         if (isInvalid()) {
             return 0L;
         }
-        long space = fs.getSpace(this, FileSystem.SPACE_USABLE);
+        long space = FS.getSpace(this, FileSystem.SPACE_USABLE);
         return space >= 0L ? space : Long.MAX_VALUE;
     }
 
@@ -1986,14 +1986,14 @@ public class File
         private TempDirectory() { }
 
         // temporary directory location
-        private static final File tmpdir = new File(StaticProperty.javaIoTmpDir());
+        private static final File TMPDIR = new File(StaticProperty.javaIoTmpDir());
 
         static File location() {
-            return tmpdir;
+            return TMPDIR;
         }
 
         // file name generation
-        private static final SecureRandom random = new SecureRandom();
+        private static final SecureRandom RANDOM = new SecureRandom();
         private static int shortenSubName(int subNameLength, int excess,
             int nameMin) {
             int newLength = Math.max(nameMin, subNameLength - excess);
@@ -2006,7 +2006,7 @@ public class File
         static File generateFile(String prefix, String suffix, File dir)
             throws IOException
         {
-            long n = random.nextLong();
+            long n = RANDOM.nextLong();
             String nus = Long.toUnsignedString(n);
 
             // Use only the file name from the supplied prefix
@@ -2017,7 +2017,7 @@ public class File
             int suffixLength = suffix.length();
 
             String name;
-            int nameMax = fs.getNameMax(dir.getPath());
+            int nameMax = FS.getNameMax(dir.getPath());
             int excess = prefixLength + nusLength + suffixLength - nameMax;
             if (excess <= 0) {
                 name = prefix + nus + suffix;
@@ -2055,7 +2055,7 @@ public class File
             }
 
             // Normalize the path component
-            name = fs.normalize(name);
+            name = FS.normalize(name);
 
             File f = new File(dir, name);
             if (!name.equals(f.getName()) || f.isInvalid()) {
@@ -2176,9 +2176,9 @@ public class File
                     throw se;
                 }
             }
-        } while (fs.hasBooleanAttributes(f, FileSystem.BA_EXISTS));
+        } while (FS.hasBooleanAttributes(f, FileSystem.BA_EXISTS));
 
-        if (!fs.createFileExclusively(f.getPath()))
+        if (!FS.createFileExclusively(f.getPath()))
             throw new IOException("Unable to create temporary file");
 
         return f;
@@ -2247,7 +2247,7 @@ public class File
      * @since   1.2
      */
     public int compareTo(File pathname) {
-        return fs.compare(this, pathname);
+        return FS.compare(this, pathname);
     }
 
     /**
@@ -2293,7 +2293,7 @@ public class File
      * @return  A hash code for this abstract pathname
      */
     public int hashCode() {
-        return fs.hashCode(this);
+        return FS.hashCode(this);
     }
 
     /**
@@ -2343,9 +2343,9 @@ public class File
         char sep = s.readChar(); // read the previous separator char
         if (sep != separatorChar)
             pathField = pathField.replace(sep, separatorChar);
-        String path = fs.normalize(pathField);
+        String path = FS.normalize(pathField);
         UNSAFE.putReference(this, PATH_OFFSET, path);
-        UNSAFE.putIntVolatile(this, PREFIX_LENGTH_OFFSET, fs.prefixLength(path));
+        UNSAFE.putIntVolatile(this, PREFIX_LENGTH_OFFSET, FS.prefixLength(path));
     }
 
     private static final jdk.internal.misc.Unsafe UNSAFE

--- a/src/java.base/share/classes/java/io/FileOutputStream.java
+++ b/src/java.base/share/classes/java/io/FileOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,7 @@ public class FileOutputStream extends OutputStream
     /**
      * Access to FileDescriptor internals.
      */
-    private static final JavaIOFileDescriptorAccess fdAccess =
+    private static final JavaIOFileDescriptorAccess FD_ACCESS =
         SharedSecrets.getJavaIOFileDescriptorAccess();
 
     /**
@@ -316,7 +316,7 @@ public class FileOutputStream extends OutputStream
      */
     @Override
     public void write(int b) throws IOException {
-        boolean append = fdAccess.getAppend(fd);
+        boolean append = FD_ACCESS.getAppend(fd);
         long comp = Blocker.begin();
         try {
             write(b, append);
@@ -346,7 +346,7 @@ public class FileOutputStream extends OutputStream
      */
     @Override
     public void write(byte[] b) throws IOException {
-        boolean append = fdAccess.getAppend(fd);
+        boolean append = FD_ACCESS.getAppend(fd);
         long comp = Blocker.begin();
         try {
             writeBytes(b, 0, b.length, append);
@@ -367,7 +367,7 @@ public class FileOutputStream extends OutputStream
      */
     @Override
     public void write(byte[] b, int off, int len) throws IOException {
-        boolean append = fdAccess.getAppend(fd);
+        boolean append = FD_ACCESS.getAppend(fd);
         long comp = Blocker.begin();
         try {
             writeBytes(b, off, len, append);

--- a/src/java.base/share/classes/java/io/ObjectStreamClass.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1905,7 +1905,7 @@ public final class ObjectStreamClass implements Serializable {
     private static class FieldReflector {
 
         /** handle for performing unsafe operations */
-        private static final Unsafe unsafe = Unsafe.getUnsafe();
+        private static final Unsafe UNSAFE = Unsafe.getUnsafe();
 
         /** fields to operate on */
         private final ObjectStreamField[] fields;
@@ -1944,7 +1944,7 @@ public final class ObjectStreamClass implements Serializable {
                 ObjectStreamField f = fields[i];
                 Field rf = f.getField();
                 long key = (rf != null) ?
-                    unsafe.objectFieldOffset(rf) : Unsafe.INVALID_FIELD_OFFSET;
+                    UNSAFE.objectFieldOffset(rf) : Unsafe.INVALID_FIELD_OFFSET;
                 readKeys[i] = key;
                 writeKeys[i] = usedKeys.add(key) ?
                     key : Unsafe.INVALID_FIELD_OFFSET;
@@ -1986,14 +1986,14 @@ public final class ObjectStreamClass implements Serializable {
                 long key = readKeys[i];
                 int off = offsets[i];
                 switch (typeCodes[i]) {
-                    case 'Z' -> Bits.putBoolean(buf, off, unsafe.getBoolean(obj, key));
-                    case 'B' -> buf[off] = unsafe.getByte(obj, key);
-                    case 'C' -> Bits.putChar(buf, off, unsafe.getChar(obj, key));
-                    case 'S' -> Bits.putShort(buf, off, unsafe.getShort(obj, key));
-                    case 'I' -> Bits.putInt(buf, off, unsafe.getInt(obj, key));
-                    case 'F' -> Bits.putFloat(buf, off, unsafe.getFloat(obj, key));
-                    case 'J' -> Bits.putLong(buf, off, unsafe.getLong(obj, key));
-                    case 'D' -> Bits.putDouble(buf, off, unsafe.getDouble(obj, key));
+                    case 'Z' -> Bits.putBoolean(buf, off, UNSAFE.getBoolean(obj, key));
+                    case 'B' -> buf[off] = UNSAFE.getByte(obj, key);
+                    case 'C' -> Bits.putChar(buf, off, UNSAFE.getChar(obj, key));
+                    case 'S' -> Bits.putShort(buf, off, UNSAFE.getShort(obj, key));
+                    case 'I' -> Bits.putInt(buf, off, UNSAFE.getInt(obj, key));
+                    case 'F' -> Bits.putFloat(buf, off, UNSAFE.getFloat(obj, key));
+                    case 'J' -> Bits.putLong(buf, off, UNSAFE.getLong(obj, key));
+                    case 'D' -> Bits.putDouble(buf, off, UNSAFE.getDouble(obj, key));
                     default  -> throw new InternalError();
                 }
             }
@@ -2015,14 +2015,14 @@ public final class ObjectStreamClass implements Serializable {
                 }
                 int off = offsets[i];
                 switch (typeCodes[i]) {
-                    case 'Z' -> unsafe.putBoolean(obj, key, Bits.getBoolean(buf, off));
-                    case 'B' -> unsafe.putByte(obj, key, buf[off]);
-                    case 'C' -> unsafe.putChar(obj, key, Bits.getChar(buf, off));
-                    case 'S' -> unsafe.putShort(obj, key, Bits.getShort(buf, off));
-                    case 'I' -> unsafe.putInt(obj, key, Bits.getInt(buf, off));
-                    case 'F' -> unsafe.putFloat(obj, key, Bits.getFloat(buf, off));
-                    case 'J' -> unsafe.putLong(obj, key, Bits.getLong(buf, off));
-                    case 'D' -> unsafe.putDouble(obj, key, Bits.getDouble(buf, off));
+                    case 'Z' -> UNSAFE.putBoolean(obj, key, Bits.getBoolean(buf, off));
+                    case 'B' -> UNSAFE.putByte(obj, key, buf[off]);
+                    case 'C' -> UNSAFE.putChar(obj, key, Bits.getChar(buf, off));
+                    case 'S' -> UNSAFE.putShort(obj, key, Bits.getShort(buf, off));
+                    case 'I' -> UNSAFE.putInt(obj, key, Bits.getInt(buf, off));
+                    case 'F' -> UNSAFE.putFloat(obj, key, Bits.getFloat(buf, off));
+                    case 'J' -> UNSAFE.putLong(obj, key, Bits.getLong(buf, off));
+                    case 'D' -> UNSAFE.putDouble(obj, key, Bits.getDouble(buf, off));
                     default  -> throw new InternalError();
                 }
             }
@@ -2043,7 +2043,7 @@ public final class ObjectStreamClass implements Serializable {
              */
             for (int i = numPrimFields; i < fields.length; i++) {
                 vals[offsets[i]] = switch (typeCodes[i]) {
-                    case 'L', '[' -> unsafe.getReference(obj, readKeys[i]);
+                    case 'L', '[' -> UNSAFE.getReference(obj, readKeys[i]);
                     default       -> throw new InternalError();
                 };
             }
@@ -2094,7 +2094,7 @@ public final class ObjectStreamClass implements Serializable {
                                 obj.getClass().getName());
                         }
                         if (!dryRun)
-                            unsafe.putReference(obj, key, val);
+                            UNSAFE.putReference(obj, key, val);
                     }
                     default -> throw new InternalError();
                 }

--- a/src/java.base/share/classes/java/io/StringReader.java
+++ b/src/java.base/share/classes/java/io/StringReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,8 +36,8 @@ import java.util.Objects;
 
 public class StringReader extends Reader {
 
+    private final int length;
     private String str;
-    private int length;
     private int next = 0;
     private int mark = 0;
 
@@ -47,8 +47,8 @@ public class StringReader extends Reader {
      * @param s  String providing the character stream.
      */
     public StringReader(String s) {
-        this.str = s;
         this.length = s.length();
+        this.str = s;
     }
 
     /** Check to make sure that the stream has not been closed */

--- a/src/java.base/share/classes/java/io/StringWriter.java
+++ b/src/java.base/share/classes/java/io/StringWriter.java
@@ -42,7 +42,7 @@ import java.util.Objects;
 
 public class StringWriter extends Writer {
 
-    private StringBuffer buf;
+    private final StringBuffer buf;
 
     /**
      * Create a new string writer using the default initial string-buffer


### PR DESCRIPTION
Some of the fields in java.io can be declared as final.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300864](https://bugs.openjdk.org/browse/JDK-8300864): Declare some fields in java.io as final


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12140/head:pull/12140` \
`$ git checkout pull/12140`

Update a local copy of the PR: \
`$ git checkout pull/12140` \
`$ git pull https://git.openjdk.org/jdk pull/12140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12140`

View PR using the GUI difftool: \
`$ git pr show -t 12140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12140.diff">https://git.openjdk.org/jdk/pull/12140.diff</a>

</details>
