### PR TITLE
8300868: Reduce visibility in java.io.SerialCallbackContext

### DIFF
--- a/src/java.base/share/classes/java/io/SerialCallbackContext.java
+++ b/src/java.base/share/classes/java/io/SerialCallbackContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/SerialCallbackContext.java
+++ b/src/java.base/share/classes/java/io/SerialCallbackContext.java
@@ -29,7 +29,7 @@ package java.io;
  * Context during upcalls from object stream to class-defined
  * readObject/writeObject methods.
  * Holds object currently being deserialized and descriptor for current class.
- *
+ * <p>
  * This context keeps track of the thread it was constructed on, and allows
  * only a single call of defaultReadObject, readFields, defaultWriteObject
  * or writeFields which must be invoked on the same thread before the class's
@@ -45,29 +45,29 @@ final class SerialCallbackContext {
      */
     private Thread thread;
 
-    public SerialCallbackContext(Object obj, ObjectStreamClass desc) {
+    SerialCallbackContext(Object obj, ObjectStreamClass desc) {
         this.obj = obj;
         this.desc = desc;
         this.thread = Thread.currentThread();
     }
 
-    public Object getObj() throws NotActiveException {
+    Object getObj() throws NotActiveException {
         checkAndSetUsed();
         return obj;
     }
 
-    public ObjectStreamClass getDesc() {
+    ObjectStreamClass getDesc() {
         return desc;
     }
 
-    public void check() throws NotActiveException {
+    void check() throws NotActiveException {
         if (thread != null && thread != Thread.currentThread()) {
             throw new NotActiveException(
                 "expected thread: " + thread + ", but got: " + Thread.currentThread());
         }
     }
 
-    public void checkAndSetUsed() throws NotActiveException {
+    void checkAndSetUsed() throws NotActiveException {
         if (thread != Thread.currentThread()) {
              throw new NotActiveException(
               "not in readObject invocation or fields already read");
@@ -75,7 +75,7 @@ final class SerialCallbackContext {
         thread = null;
     }
 
-    public void setUsed() {
+    void setUsed() {
         thread = null;
     }
 }


### PR DESCRIPTION
This PR proposes to reduce the visibility for constructor and methods in `java.io.SerialCallbackContext`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300868](https://bugs.openjdk.org/browse/JDK-8300868): Reduce visibility in java.io.SerialCallbackContext


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to [6136a891](https://git.openjdk.org/jdk/pull/12143/files/6136a891126fbd97d7366f358d01fe68d9e52fc4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12143/head:pull/12143` \
`$ git checkout pull/12143`

Update a local copy of the PR: \
`$ git checkout pull/12143` \
`$ git pull https://git.openjdk.org/jdk pull/12143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12143`

View PR using the GUI difftool: \
`$ git pr show -t 12143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12143.diff">https://git.openjdk.org/jdk/pull/12143.diff</a>

</details>
