### PR TITLE
8300657: Remove null filtering in CLD oop handle area

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -211,9 +211,7 @@ int ClassLoaderData::ChunkedHandleList::count() const {
 
 inline void ClassLoaderData::ChunkedHandleList::oops_do_chunk(OopClosure* f, Chunk* c, const juint size) {
   for (juint i = 0; i < size; i++) {
-    if (c->_data[i] != NULL) {
-      f->do_oop(&c->_data[i]);
-    }
+    f->do_oop(&c->_data[i]);
   }
 }
 


### PR DESCRIPTION
In the CLD oop handle area, there is a null check before calling do_oop. This is unnecessary, as the closures all perform the same null filtering. Since it's a raw access, it also causes trouble for generational ZGC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300657](https://bugs.openjdk.org/browse/JDK-8300657): Remove null filtering in CLD oop handle area


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12145/head:pull/12145` \
`$ git checkout pull/12145`

Update a local copy of the PR: \
`$ git checkout pull/12145` \
`$ git pull https://git.openjdk.org/jdk pull/12145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12145`

View PR using the GUI difftool: \
`$ git pr show -t 12145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12145.diff">https://git.openjdk.org/jdk/pull/12145.diff</a>

</details>
