### PR TITLE
8300929: Avoid unnecessary array fill after creation in java.awt.image

### DIFF
--- a/src/java.desktop/share/classes/java/awt/image/BandedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/BandedSampleModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -874,11 +874,7 @@ public final class BandedSampleModel extends ComponentSampleModel
         if (numBands <= 0) {
             throw new IllegalArgumentException("numBands must be > 0");
         }
-        int[] bandOffsets = new int[numBands];
-        for (int i=0; i < numBands; i++) {
-            bandOffsets[i] = 0;
-        }
-        return bandOffsets;
+        return new int[numBands];
     }
 
     private static int[] createIndicesArray(int numBands) {

--- a/src/java.desktop/share/classes/java/awt/image/ComponentColorModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/ComponentColorModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -518,9 +518,6 @@ public class ComponentColorModel extends ColorModel {
         case DataBuffer.TYPE_BYTE:
             {
                 byte[] bpixel = new byte[numComponents];
-                for (int i = 0; i < numColorComponents; i++) {
-                    bpixel[i] = 0;
-                }
                 if (supportsAlpha) {
                     bpixel[numColorComponents] =
                         (byte) ((1 << nBits[numColorComponents]) - 1);
@@ -535,9 +532,6 @@ public class ComponentColorModel extends ColorModel {
         case DataBuffer.TYPE_USHORT:
             {
                 short[] uspixel = new short[numComponents];
-                for (int i = 0; i < numColorComponents; i++) {
-                    uspixel[i] = 0;
-                }
                 if (supportsAlpha) {
                     uspixel[numColorComponents] =
                         (short) ((1 << nBits[numColorComponents]) - 1);
@@ -552,9 +546,6 @@ public class ComponentColorModel extends ColorModel {
         case DataBuffer.TYPE_INT:
             {
                 int[] ipixel = new int[numComponents];
-                for (int i = 0; i < numColorComponents; i++) {
-                    ipixel[i] = 0;
-                }
                 if (supportsAlpha) {
                     ipixel[numColorComponents] =
                         ((1 << nBits[numColorComponents]) - 1);
@@ -569,9 +560,6 @@ public class ComponentColorModel extends ColorModel {
         case DataBuffer.TYPE_SHORT:
             {
                 short[] spixel = new short[numComponents];
-                for (int i = 0; i < numColorComponents; i++) {
-                    spixel[i] = 0;
-                }
                 if (supportsAlpha) {
                     spixel[numColorComponents] = 32767;
                 }
@@ -2486,7 +2474,6 @@ public class ComponentColorModel extends ColorModel {
                             } else {
                                 if (zpixel == null) {
                                     zpixel = new byte[numComponents];
-                                    java.util.Arrays.fill(zpixel, (byte) 0);
                                 }
                                 raster.setDataElements(rX, rY, zpixel);
                             }
@@ -2514,7 +2501,6 @@ public class ComponentColorModel extends ColorModel {
                             } else {
                                 if (zpixel == null) {
                                     zpixel = new short[numComponents];
-                                    java.util.Arrays.fill(zpixel, (short) 0);
                                 }
                                 raster.setDataElements(rX, rY, zpixel);
                             }
@@ -2541,7 +2527,6 @@ public class ComponentColorModel extends ColorModel {
                             } else {
                                 if (zpixel == null) {
                                     zpixel = new int[numComponents];
-                                    java.util.Arrays.fill(zpixel, 0);
                                 }
                                 raster.setDataElements(rX, rY, zpixel);
                             }
@@ -2568,7 +2553,6 @@ public class ComponentColorModel extends ColorModel {
                             } else {
                                 if (zpixel == null) {
                                     zpixel = new short[numComponents];
-                                    java.util.Arrays.fill(zpixel, (short) 0);
                                 }
                                 raster.setDataElements(rX, rY, zpixel);
                             }
@@ -2593,7 +2577,6 @@ public class ComponentColorModel extends ColorModel {
                             } else {
                                 if (zpixel == null) {
                                     zpixel = new float[numComponents];
-                                    java.util.Arrays.fill(zpixel, 0.0f);
                                 }
                                 raster.setDataElements(rX, rY, zpixel);
                             }
@@ -2618,7 +2601,6 @@ public class ComponentColorModel extends ColorModel {
                             } else {
                                 if (zpixel == null) {
                                     zpixel = new double[numComponents];
-                                    java.util.Arrays.fill(zpixel, 0.0);
                                 }
                                 raster.setDataElements(rX, rY, zpixel);
                             }

--- a/src/java.desktop/share/classes/java/awt/image/ComponentSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/ComponentSampleModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -152,9 +152,6 @@ public class ComponentSampleModel extends SampleModel
             throw new IllegalArgumentException("Unsupported dataType.");
         }
         bankIndices = new int[numBands];
-        for (int i=0; i<numBands; i++) {
-            bankIndices[i] = 0;
-        }
         verify();
     }
 

--- a/src/java.desktop/share/classes/java/awt/image/DirectColorModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/DirectColorModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1212,7 +1212,6 @@ public class DirectColorModel extends PackedColorModel {
                             } else {
                                 if (zpixel == null) {
                                     zpixel = new int[numComponents];
-                                    java.util.Arrays.fill(zpixel, 0);
                                 }
                                 raster.setPixel(rX, rY, zpixel);
                             }
@@ -1235,7 +1234,6 @@ public class DirectColorModel extends PackedColorModel {
                             } else {
                                 if (zpixel == null) {
                                     zpixel = new int[numComponents];
-                                    java.util.Arrays.fill(zpixel, 0);
                                 }
                                 raster.setPixel(rX, rY, zpixel);
                             }
@@ -1258,7 +1256,6 @@ public class DirectColorModel extends PackedColorModel {
                             } else {
                                 if (zpixel == null) {
                                     zpixel = new int[numComponents];
-                                    java.util.Arrays.fill(zpixel, 0);
                                 }
                                 raster.setPixel(rX, rY, zpixel);
                             }

--- a/src/java.desktop/share/classes/java/awt/image/Raster.java
+++ b/src/java.desktop/share/classes/java/awt/image/Raster.java
@@ -366,10 +366,10 @@ public class Raster {
                                                      " be greater than 0");
         }
         int[] bankIndices = new int[bands];
-        int[] bandOffsets = new int[bands];
         for (int i = 0; i < bands; i++) {
             bankIndices[i] = i;
         }
+        int[] bandOffsets = new int[bands]; // leave default 0 values
 
         return createBandedRaster(dataType, w, h, w,
                                   bankIndices, bandOffsets,

--- a/src/java.desktop/share/classes/java/awt/image/Raster.java
+++ b/src/java.desktop/share/classes/java/awt/image/Raster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,8 +33,8 @@
  ******************************************************************
  ******************************************************************/
 
-
 package java.awt.image;
+
 import java.awt.Rectangle;
 import java.awt.Point;
 
@@ -369,7 +369,6 @@ public class Raster {
         int[] bandOffsets = new int[bands];
         for (int i = 0; i < bands; i++) {
             bankIndices[i] = i;
-            bandOffsets[i] = 0;
         }
 
         return createBandedRaster(dataType, w, h, w,


### PR DESCRIPTION
No need to fill elements of array with default values if it was just created. Java guarantees that all elements of numeric array have default values after allocations - 0.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300929](https://bugs.openjdk.org/browse/JDK-8300929): Avoid unnecessary array fill after creation in java.awt.image


### Reviewers
 * @SWinxy (no known github.com user name / role) ⚠️ Review applies to [52bf8583](https://git.openjdk.org/jdk/pull/12147/files/52bf858334d78739e81fb89464f1c3d1118c235a)
 * [Attila Szegedi](https://openjdk.org/census#attila) (@szegedi - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12147/head:pull/12147` \
`$ git checkout pull/12147`

Update a local copy of the PR: \
`$ git checkout pull/12147` \
`$ git pull https://git.openjdk.org/jdk pull/12147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12147`

View PR using the GUI difftool: \
`$ git pr show -t 12147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12147.diff">https://git.openjdk.org/jdk/pull/12147.diff</a>

</details>
