### PR TITLE
8300810: Get rid of unused JDI removeListener() methods

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ThreadReferenceImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ThreadReferenceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -634,19 +634,6 @@ public class ThreadReferenceImpl extends ObjectReferenceImpl
     void addListener(ThreadListener listener) {
         synchronized (vm.state()) {
             listeners.add(new WeakReference<>(listener));
-        }
-    }
-
-    void removeListener(ThreadListener listener) {
-        synchronized (vm.state()) {
-            Iterator<WeakReference<ThreadListener>> iter = listeners.iterator();
-            while (iter.hasNext()) {
-                WeakReference<ThreadListener> ref = iter.next();
-                if (listener.equals(ref.get())) {
-                    iter.remove();
-                    break;
-                }
-            }
         }
     }
 

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/VMState.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/VMState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -180,17 +180,6 @@ class VMState {
             }
         }
         return false;
-    }
-
-    synchronized void removeListener(VMListener listener) {
-        Iterator<WeakReference<VMListener>> iter = listeners.iterator();
-        while (iter.hasNext()) {
-            WeakReference<VMListener> ref = iter.next();
-            if (listener.equals(ref.get())) {
-                iter.remove();
-                break;
-            }
-        }
     }
 
     List<ThreadReference> allThreads() {


### PR DESCRIPTION
Remove removeListener() methods. They are not called.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300810](https://bugs.openjdk.org/browse/JDK-8300810): Get rid of unused JDI removeListener() methods


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12151/head:pull/12151` \
`$ git checkout pull/12151`

Update a local copy of the PR: \
`$ git checkout pull/12151` \
`$ git pull https://git.openjdk.org/jdk pull/12151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12151`

View PR using the GUI difftool: \
`$ git pr show -t 12151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12151.diff">https://git.openjdk.org/jdk/pull/12151.diff</a>

</details>
