### PR TITLE
8300811: jdb ThreadStartRequest and ThreadDeathRequest should use SUSPEND_NONE instead of SUSPEND_ALL

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/VMConnection.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/VMConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ package com.sun.tools.example.debug.tty;
 
 import com.sun.jdi.*;
 import com.sun.jdi.connect.*;
+import com.sun.jdi.request.EventRequest;
 import com.sun.jdi.request.EventRequestManager;
 import com.sun.jdi.request.ThreadStartRequest;
 import com.sun.jdi.request.ThreadDeathRequest;
@@ -469,6 +470,8 @@ class VMConnection {
 
         ThreadStartRequest tsr = erm.createThreadStartRequest();
         ThreadDeathRequest tdr = erm.createThreadDeathRequest();
+        tsr.setSuspendPolicy(EventRequest.SUSPEND_NONE);
+        tdr.setSuspendPolicy(EventRequest.SUSPEND_NONE);
         if (!trackVthreads) {
             tsr.addPlatformThreadsOnlyFilter();
             tdr.addPlatformThreadsOnlyFilter();


### PR DESCRIPTION
jdb creates a ThreadStartRequest and ThreadDeathRequest so it can track all created threads. It creates them with the SUSPEND_ALL policy. This is unnecessary since jdb always immediately resumes all threads after doing the thread bookkeeping. There is no interaction with the jdb user like there would be with something like a Breakpoint event, and therefore no reason to suspend.

I was debugging an app that does nothing except create threads and allow them to quickly exit. Changing the policy to SUSPEND_NONE sped up the execution of the app by about 100x (that's 100 times faster, not 100%)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300811](https://bugs.openjdk.org/browse/JDK-8300811): jdb ThreadStartRequest and ThreadDeathRequest should use SUSPEND_NONE instead of SUSPEND_ALL


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12152/head:pull/12152` \
`$ git checkout pull/12152`

Update a local copy of the PR: \
`$ git checkout pull/12152` \
`$ git pull https://git.openjdk.org/jdk pull/12152/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12152`

View PR using the GUI difftool: \
`$ git pr show -t 12152`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12152.diff">https://git.openjdk.org/jdk/pull/12152.diff</a>

</details>
