### PR TITLE
8290918: Initial nroff manpage generation for JDK 21

### DIFF
--- a/src/java.base/share/man/keytool.1
+++ b/src/java.base/share/man/keytool.1
@@ -36,7 +36,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "KEYTOOL" "1" "2023" "JDK 20" "JDK Commands"
+.TH "KEYTOOL" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/java.rmi/share/man/rmiregistry.1
+++ b/src/java.rmi/share/man/rmiregistry.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "RMIREGISTRY" "1" "2023" "JDK 20" "JDK Commands"
+.TH "RMIREGISTRY" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/java.scripting/share/man/jrunscript.1
+++ b/src/java.scripting/share/man/jrunscript.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JRUNSCRIPT" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JRUNSCRIPT" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.compiler/share/man/javac.1
+++ b/src/jdk.compiler/share/man/javac.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAVAC" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JAVAC" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -723,7 +723,7 @@ a switch statement to the next.
 \f[V]finally\f[R]: Warns about \f[V]finally\f[R] clauses that do not
 terminate normally.
 .IP \[bu] 2
-\f[V]lossy-conversions\f[R]: Warns about possible lossy conversion in
+\f[V]lossy-conversions\f[R]: Warns about possible lossy conversions in
 compound assignment.
 .IP \[bu] 2
 \f[V]missing-explicit-ctor\f[R]: Warns about missing explicit

--- a/src/jdk.compiler/share/man/serialver.1
+++ b/src/jdk.compiler/share/man/serialver.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "SERIALVER" "1" "2023" "JDK 20" "JDK Commands"
+.TH "SERIALVER" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.hotspot.agent/share/man/jhsdb.1
+++ b/src/jdk.hotspot.agent/share/man/jhsdb.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JHSDB" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JHSDB" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.httpserver/share/man/jwebserver.1
+++ b/src/jdk.httpserver/share/man/jwebserver.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JWEBSERVER" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JWEBSERVER" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jartool/share/man/jar.1
+++ b/src/jdk.jartool/share/man/jar.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAR" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JAR" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jartool/share/man/jarsigner.1
+++ b/src/jdk.jartool/share/man/jarsigner.1
@@ -36,7 +36,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JARSIGNER" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JARSIGNER" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.javadoc/share/man/javadoc.1
+++ b/src/jdk.javadoc/share/man/javadoc.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAVADOC" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JAVADOC" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jcmd.1
+++ b/src/jdk.jcmd/share/man/jcmd.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JCMD" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JCMD" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jinfo.1
+++ b/src/jdk.jcmd/share/man/jinfo.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JINFO" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JINFO" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jmap.1
+++ b/src/jdk.jcmd/share/man/jmap.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JMAP" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JMAP" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jps.1
+++ b/src/jdk.jcmd/share/man/jps.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JPS" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JPS" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jstack.1
+++ b/src/jdk.jcmd/share/man/jstack.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JSTACK" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JSTACK" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jstat.1
+++ b/src/jdk.jcmd/share/man/jstat.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JSTAT" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JSTAT" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jconsole/share/man/jconsole.1
+++ b/src/jdk.jconsole/share/man/jconsole.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JCONSOLE" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JCONSOLE" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jdeps/share/man/javap.1
+++ b/src/jdk.jdeps/share/man/javap.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAVAP" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JAVAP" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jdeps/share/man/jdeprscan.1
+++ b/src/jdk.jdeps/share/man/jdeprscan.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JDEPRSCAN" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JDEPRSCAN" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jdeps/share/man/jdeps.1
+++ b/src/jdk.jdeps/share/man/jdeps.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JDEPS" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JDEPS" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jdi/share/man/jdb.1
+++ b/src/jdk.jdi/share/man/jdb.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JDB" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JDB" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jfr/share/man/jfr.1
+++ b/src/jdk.jfr/share/man/jfr.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JFR" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JFR" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jlink/share/man/jlink.1
+++ b/src/jdk.jlink/share/man/jlink.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JLINK" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JLINK" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jlink/share/man/jmod.1
+++ b/src/jdk.jlink/share/man/jmod.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JMOD" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JMOD" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jpackage/share/man/jpackage.1
+++ b/src/jdk.jpackage/share/man/jpackage.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JPACKAGE" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JPACKAGE" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jshell/share/man/jshell.1
+++ b/src/jdk.jshell/share/man/jshell.1
@@ -36,7 +36,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JSHELL" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JSHELL" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jstatd/share/man/jstatd.1
+++ b/src/jdk.jstatd/share/man/jstatd.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JSTATD" "1" "2023" "JDK 20" "JDK Commands"
+.TH "JSTATD" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP


### PR DESCRIPTION
Please review this simple update to the manpage to set the version to 21-ea.

This change also corrects a typo in javac.1 that was manually introduced by JDK-8300591

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290918](https://bugs.openjdk.org/browse/JDK-8290918): Initial nroff manpage generation for JDK 21


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12154/head:pull/12154` \
`$ git checkout pull/12154`

Update a local copy of the PR: \
`$ git checkout pull/12154` \
`$ git pull https://git.openjdk.org/jdk pull/12154/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12154`

View PR using the GUI difftool: \
`$ git pr show -t 12154`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12154.diff">https://git.openjdk.org/jdk/pull/12154.diff</a>

</details>
