### PR TITLE
8300942: JDK-8299684 breaks x86 build

### DIFF
--- a/test/jdk/java/nio/jni/libNewDirectByteBuffer.c
+++ b/test/jdk/java/nio/jni/libNewDirectByteBuffer.c
@@ -20,6 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+#include <stdint.h>
 #include <stdlib.h>
 #include "jni.h"
 
@@ -30,7 +31,7 @@ Java_NewDirectByteBuffer_newDirectByteBuffer
 {
     // Create the direct byte buffer, freeing the native memory if an exception
     // is thrown while constructing the buffer
-    return (*env)->NewDirectByteBuffer(env, (void*)addr, size);
+    return (*env)->NewDirectByteBuffer(env, (void*)(uintptr_t)addr, size);
 }
 
 // private static native long getDirectByteBufferCapacity(ByteBuffer buf)
@@ -46,5 +47,5 @@ JNIEXPORT jlong JNICALL
 Java_NewDirectByteBuffer_getDirectBufferAddress
     (JNIEnv *env, jclass cls, jobject buf)
 {
-    return (jlong)(*env)->GetDirectBufferAddress(env, buf);
+    return (jlong)(uintptr_t)(*env)->GetDirectBufferAddress(env, buf);
 }


### PR DESCRIPTION
Fix the build on x86.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300942](https://bugs.openjdk.org/browse/JDK-8300942): JDK-8299684 breaks x86 build


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12157/head:pull/12157` \
`$ git checkout pull/12157`

Update a local copy of the PR: \
`$ git checkout pull/12157` \
`$ git pull https://git.openjdk.org/jdk pull/12157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12157`

View PR using the GUI difftool: \
`$ git pr show -t 12157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12157.diff">https://git.openjdk.org/jdk/pull/12157.diff</a>

</details>
