### PR TITLE
8238170: BeanContextSupport remove and propertyChange can deadlock

### DIFF
--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
@@ -1122,8 +1122,8 @@ public class      BeanContextSupport extends BeanContextChildSupport
         Object source       = pce.getSource();
 
         if ("beanContext".equals(propertyName)) {
-            synchronized(BeanContext.globalHierarchyLock) {
-                synchronized(children) {
+            synchronized (BeanContext.globalHierarchyLock) {
+                synchronized (children) {
                     if (containsKey(source)
                             && children.get(source).isRemovePending())
                     {

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1121,16 +1121,22 @@ public class      BeanContextSupport extends BeanContextChildSupport
         String propertyName = pce.getPropertyName();
         Object source       = pce.getSource();
 
-        synchronized(children) {
-            if ("beanContext".equals(propertyName) &&
-                containsKey(source)                    &&
-                children.get(source).isRemovePending()) {
-                BeanContext bc = getBeanContextPeer();
+        if ("beanContext".equals(propertyName)) {
+            synchronized(BeanContext.globalHierarchyLock) {
+                synchronized(children) {
+                    if (containsKey(source)
+                            && children.get(source).isRemovePending())
+                    {
+                        BeanContext bc = getBeanContextPeer();
 
-                if (bc.equals(pce.getOldValue()) && !bc.equals(pce.getNewValue())) {
-                    remove(source, false);
-                } else {
-                    children.get(source).setRemovePending(false);
+                        if (bc.equals(pce.getOldValue())
+                                && !bc.equals(pce.getNewValue()))
+                        {
+                            remove(source, false);
+                        } else {
+                            children.get(source).setRemovePending(false);
+                        }
+                    }
                 }
             }
         }

--- a/test/jdk/java/beans/beancontext/BeanContextSupport/AddRemove.java
+++ b/test/jdk/java/beans/beancontext/BeanContextSupport/AddRemove.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.beans.beancontext.BeanContextSupport;
+
+/**
+ * @test
+ * @bug 8238170
+ * @summary Some basic tests
+ */
+public final class AddRemove {
+
+    public static void main(String[] args) {
+        BeanContextSupport bcs = new BeanContextSupport();
+        if (!bcs.isEmpty()) {
+            throw new RuntimeException("The new context is not empty");
+        }
+        Object child1 = new Object();
+        bcs.add(child1);
+        if (bcs.size() != 1) {
+            throw new RuntimeException("Expected one element");
+        }
+        Object child2 = new Object();
+        bcs.add(child2);
+        if (bcs.size() != 2) {
+            throw new RuntimeException("Expected two elements");
+        }
+        bcs.remove(child1);
+        if (bcs.size() != 1) {
+            throw new RuntimeException("Expected one element");
+        }
+        if (bcs.toArray()[0] != child2) {
+            throw new RuntimeException("Wrong element");
+        }
+        bcs.remove(child2);
+        if (!bcs.isEmpty()) {
+            throw new RuntimeException("The context is not empty");
+        }
+    }
+}

--- a/test/jdk/java/beans/beancontext/BeanContextSupport/NotificationDeadlock.java
+++ b/test/jdk/java/beans/beancontext/BeanContextSupport/NotificationDeadlock.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyVetoException;
+import java.beans.beancontext.BeanContextSupport;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @test
+ * @bug 8238170
+ * @summary Test for a possible deadlock in the BeanContextSupport
+ */
+public final class NotificationDeadlock {
+
+    private static volatile long endtime;
+
+    public static void main(String[] args) throws Exception {
+        // Will run the test no more than 5 seconds
+        endtime = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+
+        BeanContextSupport bcs = new BeanContextSupport();
+        Thread add = new Thread(() -> {
+            while (!isComplete()) {
+                bcs.add(bcs);
+            }
+        });
+        Thread remove = new Thread(() -> {
+            while (!isComplete()) {
+                Object[] objects = bcs.toArray();
+                for (Object object : objects) {
+                    bcs.remove(object);
+                }
+            }
+        });
+        Thread props = new Thread(() -> {
+            while (!isComplete()) {
+                Object[] objects = bcs.toArray();
+                for (Object object : objects) {
+                    PropertyChangeEvent beanContext = new PropertyChangeEvent(
+                            object, "beanContext", object, null);
+                    try {
+                        bcs.vetoableChange(beanContext);
+                    } catch (PropertyVetoException ignore) {
+                    }
+                    bcs.propertyChange(beanContext);
+                }
+            }
+        });
+        add.start();
+        remove.start();
+        props.start();
+        add.join();
+        remove.join();
+        props.join();
+    }
+
+    private static boolean isComplete() {
+        return endtime - System.nanoTime() < 0;
+    }
+}


### PR DESCRIPTION
Two methods in the BeanContextSupport class use two locks in a different order, which can cause a deadlock. 
```
Here is the first order: (1) first acquire BeanContext.globalHierarchyLock and then children:

    enter public method remove(Object) at line 484
    call remove(Object, boolean) at line 485
    acquire synchronization on BeanContext.globalHierarchyLock at line 502
    acquire synchronization on children at line 534

Here is the second order: (2) first acquire children and then BeanContext.globalHierarchyLock:

    enter public method propertyChange() at line 1110
    acquire synchronization on children at line 1114
    call remove(Object, boolean) at line 1121
    acquire synchronization on BeanContext.globalHierarchyLock at line 502 
```
The fix added the "BeanContext.globalHierarchyLock" before the usage of the "children" lock in the propertyChange method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8238170](https://bugs.openjdk.org/browse/JDK-8238170): BeanContextSupport remove and propertyChange can deadlock


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12158/head:pull/12158` \
`$ git checkout pull/12158`

Update a local copy of the PR: \
`$ git checkout pull/12158` \
`$ git pull https://git.openjdk.org/jdk pull/12158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12158`

View PR using the GUI difftool: \
`$ git pr show -t 12158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12158.diff">https://git.openjdk.org/jdk/pull/12158.diff</a>

</details>
