### PR TITLE
JDK-8300857: State return value for Types.asElement(NoType) explicitly

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/util/Types.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Types.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,17 +45,20 @@ public interface Types {
 
     /**
      * Returns the element corresponding to a type.
-     * The type may be a {@link DeclaredType} or {@link TypeVariable},
-     * or a pseudo-type for a {@linkplain TypeKind#PACKAGE package} or
-     * {@linkplain TypeKind#MODULE module}.
-     * Returns {@code null} if the type is not one with a
+     * The type may be one of:
+     * <ul>
+     * <li>a {@link DeclaredType}
+     * <li>a {@link TypeVariable}
+     * <li>a pseudo-type for a {@linkplain TypeKind#PACKAGE package} or
+     * {@linkplain TypeKind#MODULE module}
+     * </ul>
+     * The method returns {@code null} if the type is not one with a
      * corresponding element.
-     *
-     * <p>Types <em>without</em> corresponding elements include:
+     * Types <em>without</em> corresponding elements include:
      * <ul>
      * <li>{@linkplain TypeKind#isPrimitive() primitive types}
      * <li>{@linkplain TypeKind#EXECUTABLE executable types}
-     * <li>{@linkplain TypeKind#NONE "none" pseudo-types}
+     * <li>{@linkplain TypeKind#NONE "none"} pseudo-types
      * <li>{@linkplain TypeKind#NULL null types}
      * <li>{@link TypeKind#VOID void}
      * <li>{@linkplain TypeKind#WILDCARD wildcard type argument}

--- a/src/java.compiler/share/classes/javax/lang/model/util/Types.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Types.java
@@ -49,6 +49,19 @@ public interface Types {
      * Returns {@code null} if the type is not one with a
      * corresponding element.
      *
+     * <p>Types without corresponding elements include:
+     * <ul>
+     * <li>{@linkplain TypeKind#isPrimitive() primitive types}
+     * <li>{@linkplain TypeKind#EXECUTABLE executable types}
+     * <li>{@linkplain TypeKind#MODULE module pseudo-types}
+     * <li>{@linkplain TypeKind#NONE "none" pseudo-types}
+     * <li>{@linkplain TypeKind#NULL  null types}
+     * <li>{@linkplain TypeKind#PACKAGE package pseudo-types}
+     * <li>{@linkplain TypeKind#UNION union types}
+     * <li>{@link TypeKind#VOID void}
+     * <li>{@linkplain TypeKind#WILDCARD wildcard type argument}
+     * </ul>
+     *
      * @param t the type to map to an element
      * @return the element corresponding to the given type
      */

--- a/src/java.compiler/share/classes/javax/lang/model/util/Types.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Types.java
@@ -45,19 +45,18 @@ public interface Types {
 
     /**
      * Returns the element corresponding to a type.
-     * The type may be a {@code DeclaredType} or {@code TypeVariable}.
+     * The type may be a {@link DeclaredType} or {@link TypeVariable},
+     * or a pseudo-type for a {@linkplain TypeKind#PACKAGE package} or
+     * {@linkplain TypeKind#MODULE module}.
      * Returns {@code null} if the type is not one with a
      * corresponding element.
      *
-     * <p>Types without corresponding elements include:
+     * <p>Types <em>without</em> corresponding elements include:
      * <ul>
      * <li>{@linkplain TypeKind#isPrimitive() primitive types}
      * <li>{@linkplain TypeKind#EXECUTABLE executable types}
-     * <li>{@linkplain TypeKind#MODULE module pseudo-types}
      * <li>{@linkplain TypeKind#NONE "none" pseudo-types}
-     * <li>{@linkplain TypeKind#NULL  null types}
-     * <li>{@linkplain TypeKind#PACKAGE package pseudo-types}
-     * <li>{@linkplain TypeKind#UNION union types}
+     * <li>{@linkplain TypeKind#NULL null types}
      * <li>{@link TypeKind#VOID void}
      * <li>{@linkplain TypeKind#WILDCARD wildcard type argument}
      * </ul>

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/model/JavacTypes.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/model/JavacTypes.java
@@ -76,6 +76,8 @@ public class JavacTypes implements javax.lang.model.util.Types {
             case INTERSECTION:
             case ERROR:
             case TYPEVAR:
+            case PACKAGE:
+            case MODULE:
                 Type type = cast(Type.class, t);
                 return type.asElement();
             default:

--- a/test/langtools/tools/javac/processing/model/util/types/TestAsElement.java
+++ b/test/langtools/tools/javac/processing/model/util/types/TestAsElement.java
@@ -74,8 +74,6 @@ public class TestAsElement extends JavacTestingAbstractProcessor {
         }
     }
 
-
-
     private void expectNullAsElement(TypeMirror typeMirror) {
         var e = typeUtils.asElement(typeMirror);
         if (e != null) {
@@ -84,6 +82,7 @@ public class TestAsElement extends JavacTestingAbstractProcessor {
     }
 
     private void testRoundTripCases() {
+        expectRoundTrip(eltUtils.getTypeElement("java.lang.String"));
         expectRoundTrip(eltUtils.getPackageElement("java.lang"));
         expectRoundTrip(eltUtils.getModuleElement("java.base"));
     }
@@ -95,5 +94,4 @@ public class TestAsElement extends JavacTestingAbstractProcessor {
             throw new RuntimeException("Did not see round trip elt -> type -> elt on " + e);
         }
     }
-
 }

--- a/test/langtools/tools/javac/processing/model/util/types/TestAsElement.java
+++ b/test/langtools/tools/javac/processing/model/util/types/TestAsElement.java
@@ -74,7 +74,7 @@ public class TestAsElement extends JavacTestingAbstractProcessor {
         }
     }
 
-    
+
 
     private void expectNullAsElement(TypeMirror typeMirror) {
         var e = typeUtils.asElement(typeMirror);

--- a/test/langtools/tools/javac/processing/model/util/types/TestAsElement.java
+++ b/test/langtools/tools/javac/processing/model/util/types/TestAsElement.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8300857
+ * @summary Test Types.asElement in cases specified to return null
+ * @library /tools/javac/lib
+ * @build   JavacTestingAbstractProcessor TestAsElement
+ * @compile -processor TestAsElement -proc:only TestAsElement.java
+ */
+
+import java.util.*;
+import javax.annotation.processing.*;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
+import javax.lang.model.util.Types;
+import static java.util.Objects.*;
+
+/**
+ * Verify various kinds of TypeMirror have a null corresponding element.
+ */
+public class TestAsElement extends JavacTestingAbstractProcessor {
+    public boolean process(Set<? extends TypeElement> annotations,
+                           RoundEnvironment roundEnv) {
+        if (!roundEnv.processingOver()) {
+            testNullCases();
+            testRoundTripCases();
+
+        }
+        return true;
+    }
+
+    private void testNullCases() {
+        // Test all primitive types
+        for (TypeKind typeKind : TypeKind.values()) {
+            if (typeKind.isPrimitive() ) {
+                expectNullAsElement(typeUtils.getPrimitiveType(typeKind));
+            }
+        }
+        expectNullAsElement(typeUtils.getNoType(TypeKind.VOID));
+        expectNullAsElement(typeUtils.getNoType(TypeKind.NONE));
+        expectNullAsElement(typeUtils.getNullType());
+
+        Element objectElement = eltUtils.getTypeElement("java.lang.Object");
+        expectNullAsElement(typeUtils.getWildcardType(objectElement.asType(), null));
+
+        // Loop over the ExecutableTypes for Object's methods
+        for(var methodElt : ElementFilter.methodsIn(objectElement.getEnclosedElements())) {
+            expectNullAsElement(methodElt.asType());
+        }
+    }
+
+    
+
+    private void expectNullAsElement(TypeMirror typeMirror) {
+        var e = typeUtils.asElement(typeMirror);
+        if (e != null) {
+            throw new RuntimeException("Unexpected non-null value " + e);
+        }
+    }
+
+    private void testRoundTripCases() {
+        expectRoundTrip(eltUtils.getPackageElement("java.lang"));
+        expectRoundTrip(eltUtils.getModuleElement("java.base"));
+    }
+
+    private void expectRoundTrip(Element e) {
+        var type = e.asType();
+
+        if (! typeUtils.asElement(type).equals(e)) {
+            throw new RuntimeException("Did not see round trip elt -> type -> elt on " + e);
+        }
+    }
+
+}


### PR DESCRIPTION
Just sending out the proposed API changes for now, will add tests later.

Please also review the corresponding CSR [JDK-8300951](https://bugs.openjdk.org/browse/JDK-8300951).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8300951](https://bugs.openjdk.org/browse/JDK-8300951) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8300857](https://bugs.openjdk.org/browse/JDK-8300857): State return value for Types.asElement(NoType) explicitly
 * [JDK-8300951](https://bugs.openjdk.org/browse/JDK-8300951): State return value for Types.asElement(NoType) explicitly (**CSR**)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to [a60301ce](https://git.openjdk.org/jdk/pull/12159/files/a60301cecf4c0add9b2ebc3ecb2ac409bfe056f9)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12159/head:pull/12159` \
`$ git checkout pull/12159`

Update a local copy of the PR: \
`$ git checkout pull/12159` \
`$ git pull https://git.openjdk.org/jdk pull/12159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12159`

View PR using the GUI difftool: \
`$ git pr show -t 12159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12159.diff">https://git.openjdk.org/jdk/pull/12159.diff</a>

</details>
