### PR TITLE
8299683: [S390X] Problems with -XX:+VerifyStack

### DIFF
--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -2635,8 +2635,8 @@ void SharedRuntime::generate_deopt_blob() {
   // despite it's marked as "leaf call"!
   __ call_VM_leaf(CAST_FROM_FN_PTR(address, Deoptimization::fetch_unroll_info), Z_thread, exec_mode_reg);
   // Set an oopmap for the call site this describes all our saved volatile registers
-  int offs = __ offset();
-  oop_maps->add_gc_map(offs, map);
+  int oop_map_offs = __ offset();
+  oop_maps->add_gc_map(oop_map_offs, map);
 
   __ reset_last_Java_frame();
   // save the return value.
@@ -2690,8 +2690,7 @@ void SharedRuntime::generate_deopt_blob() {
   __ z_std(Z_FRET, offset_of(frame::z_abi_160_spill, spill[1]), Z_SP);
 
   // let the unpacker layout information in the skeletal frames just allocated.
-  offs = __ offset();
-  __ get_PC(Z_RET, offs);
+  __ get_PC(Z_RET, oop_map_offs - __ offset());
   __ set_last_Java_frame(/*sp*/Z_SP, /*pc*/Z_RET);
   __ call_VM_leaf(CAST_FROM_FN_PTR(address, Deoptimization::unpack_frames),
                   Z_thread/*thread*/, exec_mode_reg/*exec_mode*/);

--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2016, 2019 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -2754,8 +2754,7 @@ void SharedRuntime::generate_uncommon_trap_blob() {
   // set the "unpack" frame as last_Java_frame.
   // `Deoptimization::uncommon_trap' expects it and considers its
   // sender frame as the deoptee frame.
-  int offs = __ offset();
-  __ get_PC(Z_R1_scratch, offs);
+  __ get_PC(Z_R1_scratch);
   __ set_last_Java_frame(/*sp*/Z_SP, /*pc*/Z_R1_scratch);
 
   __ z_lgr(klass_index_reg, Z_ARG1);  // passed implicitly as ARG2
@@ -2820,8 +2819,7 @@ void SharedRuntime::generate_uncommon_trap_blob() {
   // skeletal interpreter frame, (resized) caller of deoptee, ...).
 
   // set the "unpack" frame as last_Java_frame
-  offs = __ offset();
-  __ get_PC(Z_R1_scratch, offs);
+  __ get_PC(Z_R1_scratch);
   __ set_last_Java_frame(/*sp*/Z_SP, /*pc*/Z_R1_scratch);
 
   // indicate it is the uncommon trap case

--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -2621,7 +2621,6 @@ void SharedRuntime::generate_deopt_blob() {
 
   // stack: ("unpack" frame, deoptee, caller_of_deoptee, ...).
 
-  {
   const Register unroll_block_reg  = Z_tmp_2;
 
   // we need to set `last_Java_frame' because `fetch_unroll_info' will
@@ -2679,7 +2678,6 @@ void SharedRuntime::generate_deopt_blob() {
 
   // stack: (skeletal interpreter frame, ..., optional skeletal
   // interpreter frame, caller of deoptee, ...).
-  }
 
   // push an "unpack" frame taking care of float / int return values.
   __ push_frame(RegisterSaver::live_reg_frame_size(RegisterSaver::all_registers));
@@ -2692,7 +2690,8 @@ void SharedRuntime::generate_deopt_blob() {
   __ z_std(Z_FRET, offset_of(frame::z_abi_160_spill, spill[1]), Z_SP);
 
   // let the unpacker layout information in the skeletal frames just allocated.
-  __ get_PC(Z_RET);
+  offs = __ offset();
+  __ get_PC(Z_RET, offs);
   __ set_last_Java_frame(/*sp*/Z_SP, /*pc*/Z_RET);
   __ call_VM_leaf(CAST_FROM_FN_PTR(address, Deoptimization::unpack_frames),
                   Z_thread/*thread*/, exec_mode_reg/*exec_mode*/);
@@ -2755,7 +2754,8 @@ void SharedRuntime::generate_uncommon_trap_blob() {
   // set the "unpack" frame as last_Java_frame.
   // `Deoptimization::uncommon_trap' expects it and considers its
   // sender frame as the deoptee frame.
-  __ get_PC(Z_R1_scratch);
+  int offs = __ offset();
+  __ get_PC(Z_R1_scratch, offs);
   __ set_last_Java_frame(/*sp*/Z_SP, /*pc*/Z_R1_scratch);
 
   __ z_lgr(klass_index_reg, Z_ARG1);  // passed implicitly as ARG2
@@ -2820,7 +2820,8 @@ void SharedRuntime::generate_uncommon_trap_blob() {
   // skeletal interpreter frame, (resized) caller of deoptee, ...).
 
   // set the "unpack" frame as last_Java_frame
-  __ get_PC(Z_R1_scratch);
+  offs = __ offset();
+  __ get_PC(Z_R1_scratch, offs);
   __ set_last_Java_frame(/*sp*/Z_SP, /*pc*/Z_R1_scratch);
 
   // indicate it is the uncommon trap case


### PR DESCRIPTION
Deoptimization and uncommon trap stubs require last Java PC to point to a PC which has an appropriate OopMap. Adjusting a offset for PC in last java frame.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299683](https://bugs.openjdk.org/browse/JDK-8299683): [S390X] Problems with -XX:+VerifyStack


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12161/head:pull/12161` \
`$ git checkout pull/12161`

Update a local copy of the PR: \
`$ git checkout pull/12161` \
`$ git pull https://git.openjdk.org/jdk pull/12161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12161`

View PR using the GUI difftool: \
`$ git pr show -t 12161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12161.diff">https://git.openjdk.org/jdk/pull/12161.diff</a>

</details>
