### PR TITLE
8300958: Parallel: Remove unused MutableNUMASpace::capacity_in_words

### DIFF
--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -231,24 +231,6 @@ size_t MutableNUMASpace::unsafe_max_tlab_alloc(Thread *thr) const {
 }
 
 
-size_t MutableNUMASpace::capacity_in_words(Thread* thr) const {
-  guarantee(thr != NULL, "No thread");
-  int lgrp_id = thr->lgrp_id();
-  if (lgrp_id == -1) {
-    if (lgrp_spaces()->length() > 0) {
-      return capacity_in_words() / lgrp_spaces()->length();
-    } else {
-      assert(false, "There should be at least one locality group");
-      return 0;
-    }
-  }
-  int i = lgrp_spaces()->find(&lgrp_id, LGRPSpace::equals);
-  if (i == -1) {
-    return 0;
-  }
-  return lgrp_spaces()->at(i)->space()->capacity_in_words();
-}
-
 // Check if the NUMA topology has changed. Add and remove spaces if needed.
 // The update can be forced by setting the force parameter equal to true.
 bool MutableNUMASpace::update_layout(bool force) {

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.hpp
@@ -218,7 +218,7 @@ class MutableNUMASpace : public MutableSpace {
   virtual size_t free_in_words() const;
 
   using MutableSpace::capacity_in_words;
-  virtual size_t capacity_in_words(Thread* thr) const;
+
   virtual size_t tlab_capacity(Thread* thr) const;
   virtual size_t tlab_used(Thread* thr) const;
   virtual size_t unsafe_max_tlab_alloc(Thread* thr) const;

--- a/src/hotspot/share/gc/parallel/mutableSpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.hpp
@@ -89,7 +89,6 @@ class MutableSpace: public CHeapObj<mtGC> {
 
   size_t capacity_in_bytes() const { return capacity_in_words() * HeapWordSize; }
   size_t capacity_in_words() const { return pointer_delta(end(), bottom()); }
-  virtual size_t capacity_in_words(Thread*) const { return capacity_in_words(); }
 
   // Returns a subregion containing all objects in this space.
   MemRegion used_region() { return MemRegion(bottom(), top()); }


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300958](https://bugs.openjdk.org/browse/JDK-8300958): Parallel: Remove unused MutableNUMASpace::capacity_in_words


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12162/head:pull/12162` \
`$ git checkout pull/12162`

Update a local copy of the PR: \
`$ git checkout pull/12162` \
`$ git pull https://git.openjdk.org/jdk pull/12162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12162`

View PR using the GUI difftool: \
`$ git pr show -t 12162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12162.diff">https://git.openjdk.org/jdk/pull/12162.diff</a>

</details>
