### PR TITLE
8300962: Parallel: Remove PSParallelCompact::_total_invocations

### DIFF
--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -102,7 +102,6 @@ class ParallelScavengeHeap : public CollectedHeap {
   HeapWord* allocate_old_gen_and_record(size_t word_size);
 
  protected:
-  static inline size_t total_invocations();
   HeapWord* allocate_new_tlab(size_t min_size, size_t requested_size, size_t* actual_size) override;
 
   inline bool should_alloc_in_eden(size_t size) const;

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.inline.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.inline.hpp
@@ -30,10 +30,6 @@
 #include "gc/parallel/psParallelCompact.inline.hpp"
 #include "gc/parallel/psScavenge.hpp"
 
-inline size_t ParallelScavengeHeap::total_invocations() {
-  return PSParallelCompact::total_invocations();
-}
-
 inline bool ParallelScavengeHeap::should_alloc_in_eden(const size_t size) const {
   const size_t eden_size = young_gen()->eden_space()->capacity_in_words();
   return size < eden_size / 2;

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -837,7 +837,6 @@ void ParallelCompactData::verify_clear()
 STWGCTimer          PSParallelCompact::_gc_timer;
 ParallelOldTracer   PSParallelCompact::_gc_tracer;
 elapsedTimer        PSParallelCompact::_accumulated_time;
-unsigned int        PSParallelCompact::_total_invocations = 0;
 unsigned int        PSParallelCompact::_maximum_compaction_gc_num = 0;
 CollectorCounters*  PSParallelCompact::_counters = NULL;
 ParMarkBitMap       PSParallelCompact::_mark_bitmap;
@@ -965,9 +964,6 @@ void PSParallelCompact::pre_compact()
   CodeCache::on_gc_marking_cycle_start();
   CodeCache::arm_all_nmethods();
 
-  // We need to track unique mark sweep invocations as well.
-  _total_invocations++;
-
   heap->print_heap_before_gc();
   heap->trace_heap_before_gc(&_gc_tracer);
 
@@ -1070,11 +1066,12 @@ PSParallelCompact::compute_dense_prefix_via_density(const SpaceId id,
     ++full_count;
   }
 
-  assert(total_invocations() >= _maximum_compaction_gc_num, "sanity");
-  const size_t gcs_since_max = total_invocations() - _maximum_compaction_gc_num;
+  const uint total_invocations = ParallelScavengeHeap::heap()->total_full_collections();
+  assert(total_invocations >= _maximum_compaction_gc_num, "sanity");
+  const size_t gcs_since_max = total_invocations - _maximum_compaction_gc_num;
   const bool interval_ended = gcs_since_max > HeapMaximumCompactionInterval;
   if (maximum_compaction || cp == end_cp || interval_ended) {
-    _maximum_compaction_gc_num = total_invocations();
+    _maximum_compaction_gc_num = total_invocations;
     return sd.region_to_addr(cp);
   }
 
@@ -1369,12 +1366,13 @@ PSParallelCompact::compute_dense_prefix(const SpaceId id,
   // The gc number is saved whenever a maximum compaction is done, and used to
   // determine when the maximum compaction interval has expired.  This avoids
   // successive max compactions for different reasons.
-  assert(total_invocations() >= _maximum_compaction_gc_num, "sanity");
-  const size_t gcs_since_max = total_invocations() - _maximum_compaction_gc_num;
+  const uint total_invocations = ParallelScavengeHeap::heap()->total_full_collections();
+  assert(total_invocations >= _maximum_compaction_gc_num, "sanity");
+  const size_t gcs_since_max = total_invocations - _maximum_compaction_gc_num;
   const bool interval_ended = gcs_since_max > HeapMaximumCompactionInterval ||
-    total_invocations() == HeapFirstMaximumCompactionCount;
+    total_invocations == HeapFirstMaximumCompactionCount;
   if (maximum_compaction || full_cp == top_cp || interval_ended) {
-    _maximum_compaction_gc_num = total_invocations();
+    _maximum_compaction_gc_num = total_invocations;
     return sd.region_to_addr(full_cp);
   }
 

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -1019,7 +1019,6 @@ class PSParallelCompact : AllStatic {
   static STWGCTimer           _gc_timer;
   static ParallelOldTracer    _gc_tracer;
   static elapsedTimer         _accumulated_time;
-  static unsigned int         _total_invocations;
   static unsigned int         _maximum_compaction_gc_num;
   static CollectorCounters*   _counters;
   static ParMarkBitMap        _mark_bitmap;
@@ -1157,7 +1156,7 @@ class PSParallelCompact : AllStatic {
 
   // Public accessors
   static elapsedTimer* accumulated_time() { return &_accumulated_time; }
-  static unsigned int total_invocations() { return _total_invocations; }
+
   static CollectorCounters* counters()    { return _counters; }
 
   // Marking support


### PR DESCRIPTION
Simple change of removing redundant code.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300962](https://bugs.openjdk.org/browse/JDK-8300962): Parallel: Remove PSParallelCompact::_total_invocations


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12163/head:pull/12163` \
`$ git checkout pull/12163`

Update a local copy of the PR: \
`$ git checkout pull/12163` \
`$ git pull https://git.openjdk.org/jdk pull/12163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12163`

View PR using the GUI difftool: \
`$ git pr show -t 12163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12163.diff">https://git.openjdk.org/jdk/pull/12163.diff</a>

</details>
