### PR TITLE
8300997: Add curl support to createJMHBundle.sh

### DIFF
--- a/make/devkit/createJMHBundle.sh
+++ b/make/devkit/createJMHBundle.sh
@@ -38,7 +38,7 @@ JAR_DIR="$BUILD_DIR/jars"
 
 mkdir -p $BUILD_DIR $JAR_DIR
 cd $JAR_DIR
-rm -f $JAR_DIR/*
+rm -f *
 
 fetchJar() {
   url="https://repo.maven.apache.org/maven2/$1/$2/$3/$2-$3.jar"

--- a/make/devkit/createJMHBundle.sh
+++ b/make/devkit/createJMHBundle.sh
@@ -38,12 +38,24 @@ JAR_DIR="$BUILD_DIR/jars"
 
 mkdir -p $BUILD_DIR $JAR_DIR
 cd $JAR_DIR
-rm -f *
+rm -f $JAR_DIR/*
 
-wget https://repo.maven.apache.org/maven2/org/apache/commons/commons-math3/$COMMONS_MATH3_VERSION/commons-math3-$COMMONS_MATH3_VERSION.jar
-wget https://repo.maven.apache.org/maven2/net/sf/jopt-simple/jopt-simple/$JOPT_SIMPLE_VERSION/jopt-simple-$JOPT_SIMPLE_VERSION.jar
-wget https://repo.maven.apache.org/maven2/org/openjdk/jmh/jmh-core/$JMH_VERSION/jmh-core-$JMH_VERSION.jar
-wget https://repo.maven.apache.org/maven2/org/openjdk/jmh/jmh-generator-annprocess/$JMH_VERSION/jmh-generator-annprocess-$JMH_VERSION.jar
+fetchJar() {
+  url="https://repo.maven.apache.org/maven2/$1/$2/$3/$2-$3.jar"
+  if command -v curl > /dev/null; then
+      curl -O --fail $url
+  elif command -v wget > /dev/null; then
+      wget $url
+  else
+      echo "Could not find either curl or wget"
+      exit 1
+  fi
+}
+
+fetchJar org/apache/commons commons-math3 $COMMONS_MATH3_VERSION
+fetchJar net/sf/jopt-simple jopt-simple $JOPT_SIMPLE_VERSION
+fetchJar org/openjdk/jmh jmh-core $JMH_VERSION
+fetchJar org/openjdk/jmh jmh-generator-annprocess $JMH_VERSION
 
 tar -cvzf ../$BUNDLE_NAME *
 

--- a/make/devkit/createJMHBundle.sh
+++ b/make/devkit/createJMHBundle.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Please review this PR which updates make/devkit/createJMHBundle.sh to add support for curl instead of wget when downloading JMH dependencies.

This would reduce friction for MacOS devs who would like to run micros without installing wget first.

File download is extracted to a function taking the Maven directory, artifactId and version as input. The function builds the correct download URL and checks which of curl / wget is available.

Tested on MacOS 12.6.2 and Ubuntu 20.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300997](https://bugs.openjdk.org/browse/JDK-8300997): Add curl support to createJMHBundle.sh


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12164/head:pull/12164` \
`$ git checkout pull/12164`

Update a local copy of the PR: \
`$ git checkout pull/12164` \
`$ git pull https://git.openjdk.org/jdk pull/12164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12164`

View PR using the GUI difftool: \
`$ git pr show -t 12164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12164.diff">https://git.openjdk.org/jdk/pull/12164.diff</a>

</details>
