### PR TITLE
8300981: Build failure on 32-bit platforms after JDK-8281213

### DIFF
--- a/src/hotspot/share/services/memReporter.hpp
+++ b/src/hotspot/share/services/memReporter.hpp
@@ -76,8 +76,10 @@ class MemReporterBase : public StackObj {
   int64_t diff_in_current_scale(size_t s1, size_t s2) const {
     assert(_scale != 0, "wrong scale");
 
+#ifdef _LP64
     assert(s1 < INT64_MAX, "exceeded possible memory limits");
     assert(s2 < INT64_MAX, "exceeded possible memory limits");
+#endif
 
     bool is_negative = false;
     if (s1 < s2) {


### PR DESCRIPTION
Hi all,

Build failure was observed on x86_32 with `-Werror=type-limits` after JDK-8281213.

Since the asserts (L79 & L80) are always true on 32-bit platforms, it might be better to only enable them on 64-bit platforms.
```
 76   int64_t diff_in_current_scale(size_t s1, size_t s2) const {
 77     assert(_scale != 0, "wrong scale");
 78
 79     assert(s1 < INT64_MAX, "exceeded possible memory limits");
 80     assert(s2 < INT64_MAX, "exceeded possible memory limits");
 81
 82     bool is_negative = false;
 83     if (s1 < s2) {
 84       is_negative = true;
 85       swap(s1, s2);
 86     }
```

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300981](https://bugs.openjdk.org/browse/JDK-8300981): Build failure on 32-bit platforms after JDK-8281213


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12165/head:pull/12165` \
`$ git checkout pull/12165`

Update a local copy of the PR: \
`$ git checkout pull/12165` \
`$ git pull https://git.openjdk.org/jdk pull/12165/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12165`

View PR using the GUI difftool: \
`$ git pr show -t 12165`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12165.diff">https://git.openjdk.org/jdk/pull/12165.diff</a>

</details>
