### PR TITLE
8300968: Accessorize raw oop load in DeadCounterClosure

### DIFF
--- a/src/hotspot/share/gc/shared/oopStorageSetParState.inline.hpp
+++ b/src/hotspot/share/gc/shared/oopStorageSetParState.inline.hpp
@@ -30,6 +30,7 @@
 #include "gc/shared/oopStorageParState.inline.hpp"
 #include "gc/shared/oopStorageSet.hpp"
 #include "memory/iterator.hpp"
+#include "oops/access.inline.hpp"
 #include "runtime/atomic.hpp"
 #include "utilities/debug.hpp"
 
@@ -54,7 +55,7 @@ public:
 
   virtual void do_oop(oop* p) {
     _cl->do_oop(p);
-    if (Atomic::load(p) == NULL) {
+    if (NativeAccess<ON_PHANTOM_OOP_REF | AS_NO_KEEPALIVE>::oop_load(p) == nullptr) {
       _num_dead++;              // Count both already NULL and cleared by closure.
     }
   }


### PR DESCRIPTION
The DeadCounterClosure class uses raw loads to check for dead phantom oop* entries. This isn't completely GC independent (because generational ZGC colours null pointers as well). We should accessorize this access so that all GCs become happy.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300968](https://bugs.openjdk.org/browse/JDK-8300968): Accessorize raw oop load in DeadCounterClosure


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12168/head:pull/12168` \
`$ git checkout pull/12168`

Update a local copy of the PR: \
`$ git checkout pull/12168` \
`$ git pull https://git.openjdk.org/jdk pull/12168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12168`

View PR using the GUI difftool: \
`$ git pr show -t 12168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12168.diff">https://git.openjdk.org/jdk/pull/12168.diff</a>

</details>
