### PR TITLE
8301004: httpclient: Add more debug to HttpResponseInputStream

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -545,8 +545,10 @@ public class ResponseSubscribers {
         @Override
         public void onSubscribe(Flow.Subscription s) {
             Objects.requireNonNull(s);
+            if (debug.on()) debug.log("onSubscribed called");
             try {
                 if (!subscribed.compareAndSet(false, true)) {
+                    if (debug.on()) debug.log("Already subscribed: canceling");
                     s.cancel();
                 } else {
                     // check whether the stream is already closed.
@@ -557,10 +559,14 @@ public class ResponseSubscribers {
                         closed = this.closed;
                         if (!closed) {
                             this.subscription = s;
-                            assert buffers.remainingCapacity() > 1; // should contain at least 2
+                            // should contain at least 2
+                            assert buffers.remainingCapacity() > 1
+                                    : "buffers capacity: " + buffers.remainingCapacity()
+                                    + "closed: " + closed + "failed: " + failed;
                         }
                     }
                     if (closed) {
+                        if (debug.on()) debug.log("Already closed: canceling");
                         s.cancel();
                         return;
                     }
@@ -571,6 +577,8 @@ public class ResponseSubscribers {
                 }
             } catch (Throwable t) {
                 failed = t;
+                if (debug.on())
+                    debug.log("onSubscribed failed", t);
                 try {
                     close();
                 } catch (IOException x) {
@@ -604,6 +612,8 @@ public class ResponseSubscribers {
 
         @Override
         public void onError(Throwable thrwbl) {
+            if (debug.on())
+                debug.log("onError called: " + thrwbl);
             subscription = null;
             failed = Objects.requireNonNull(thrwbl);
             // The client process that reads the input stream might
@@ -618,6 +628,8 @@ public class ResponseSubscribers {
 
         @Override
         public void onComplete() {
+            if (debug.on())
+                debug.log("onComplete called");
             subscription = null;
             onNext(LAST_LIST);
         }
@@ -631,6 +643,8 @@ public class ResponseSubscribers {
                 s = subscription;
                 subscription = null;
             }
+            if (debug.on())
+                debug.log("close called");
             // s will be null if already completed
             try {
                 if (s != null) {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
@@ -562,7 +562,7 @@ public class ResponseSubscribers {
                             // should contain at least 2
                             assert buffers.remainingCapacity() > 1
                                     : "buffers capacity: " + buffers.remainingCapacity()
-                                    + "closed: " + closed + "failed: " + failed;
+                                    + " closed: " + closed + "failed: " + failed;
                         }
                     }
                     if (closed) {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
@@ -562,7 +562,7 @@ public class ResponseSubscribers {
                             // should contain at least 2
                             assert buffers.remainingCapacity() > 1
                                     : "buffers capacity: " + buffers.remainingCapacity()
-                                    + " closed: " + closed + "failed: " + failed;
+                                    + " closed: " + closed + " failed: " + failed;
                         }
                     }
                     if (closed) {


### PR DESCRIPTION
The AsyncExecutorShutdown test has been observed failing (rarely) in our CI. The root cause seems to be an assertion error in HttpResponseInputStream. More debug traces could help with diagnosing how we reached this assertion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301004](https://bugs.openjdk.org/browse/JDK-8301004): httpclient: Add more debug to HttpResponseInputStream


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12169/head:pull/12169` \
`$ git checkout pull/12169`

Update a local copy of the PR: \
`$ git checkout pull/12169` \
`$ git pull https://git.openjdk.org/jdk pull/12169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12169`

View PR using the GUI difftool: \
`$ git pr show -t 12169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12169.diff">https://git.openjdk.org/jdk/pull/12169.diff</a>

</details>
