### PR TITLE
8300924: Method::invoke throws wrong exception type when passing wrong number of arguments to method with 4 or more parameters

### DIFF
--- a/src/java.base/share/classes/jdk/internal/reflect/DirectMethodHandleAccessor.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/DirectMethodHandleAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
 import static java.lang.invoke.MethodType.genericMethodType;
-import static jdk.internal.reflect.MethodHandleAccessorFactory.SPECIALIZED_PARAM_COUNT;
 import static jdk.internal.reflect.MethodHandleAccessorFactory.LazyStaticHolder.JLIA;
 
 class DirectMethodHandleAccessor extends MethodAccessorImpl {
@@ -329,9 +328,6 @@ class DirectMethodHandleAccessor extends MethodAccessorImpl {
     }
 
     private static void checkArgumentCount(int paramCount, Object[] args) {
-        // only check argument count for specialized forms
-        if (paramCount > SPECIALIZED_PARAM_COUNT) return;
-
         int argc = args != null ? args.length : 0;
         if (argc != paramCount) {
             throw new IllegalArgumentException("wrong number of arguments: " + argc + " expected: " + paramCount);


### PR DESCRIPTION
A simple fix in core reflection to check if the number of actual and formal parameters differ before invoking the method or the constructor regardless of whether it's a specialized case or not.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300924](https://bugs.openjdk.org/browse/JDK-8300924): Method::invoke throws wrong exception type when passing wrong number of arguments to method with 4 or more parameters


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12170/head:pull/12170` \
`$ git checkout pull/12170`

Update a local copy of the PR: \
`$ git checkout pull/12170` \
`$ git pull https://git.openjdk.org/jdk pull/12170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12170`

View PR using the GUI difftool: \
`$ git pr show -t 12170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12170.diff">https://git.openjdk.org/jdk/pull/12170.diff</a>

</details>
