### PR TITLE
8300916: Re-examine the initialization of JNU Charset in StaticProperty

### DIFF
--- a/src/java.base/share/classes/java/nio/charset/Charset.java
+++ b/src/java.base/share/classes/java/nio/charset/Charset.java
@@ -649,11 +649,19 @@ public abstract class Charset
      *
      * @since 1.5
      */
+    @SuppressWarnings("removal")
     public static Charset defaultCharset() {
         if (defaultCharset == null) {
             synchronized (Charset.class) {
                 // do not look for providers other than the standard one
-                Charset cs = standardProvider.charsetForName(StaticProperty.fileEncoding());
+                Charset cs;
+                if (System.getSecurityManager() == null) {
+                    cs = standardProvider.charsetForName(StaticProperty.fileEncoding());
+                } else {
+                    PrivilegedAction<Charset> pa =
+                        () -> standardProvider.charsetForName(StaticProperty.fileEncoding());
+                    cs = AccessController.doPrivileged(pa);
+                }
                 if (cs != null)
                     defaultCharset = cs;
                 else

--- a/src/java.base/share/classes/java/nio/charset/Charset.java
+++ b/src/java.base/share/classes/java/nio/charset/Charset.java
@@ -649,19 +649,11 @@ public abstract class Charset
      *
      * @since 1.5
      */
-    @SuppressWarnings("removal")
     public static Charset defaultCharset() {
         if (defaultCharset == null) {
             synchronized (Charset.class) {
                 // do not look for providers other than the standard one
-                Charset cs;
-                if (System.getSecurityManager() == null) {
-                    cs = standardProvider.charsetForName(StaticProperty.fileEncoding());
-                } else {
-                    PrivilegedAction<Charset> pa =
-                        () -> standardProvider.charsetForName(StaticProperty.fileEncoding());
-                    cs = AccessController.doPrivileged(pa);
-                }
+                Charset cs = standardProvider.charsetForName(StaticProperty.fileEncoding());
                 if (cs != null)
                     defaultCharset = cs;
                 else

--- a/src/java.base/share/classes/java/nio/charset/Charset.java
+++ b/src/java.base/share/classes/java/nio/charset/Charset.java
@@ -30,7 +30,6 @@ import jdk.internal.misc.VM;
 import jdk.internal.util.StaticProperty;
 import jdk.internal.vm.annotation.Stable;
 import sun.nio.cs.ThreadLocalCoders;
-import sun.security.action.GetPropertyAction;
 
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;

--- a/src/java.base/share/classes/java/nio/charset/Charset.java
+++ b/src/java.base/share/classes/java/nio/charset/Charset.java
@@ -628,8 +628,7 @@ public abstract class Charset
             });
     }
 
-    @Stable
-    private static Charset defaultCharset;
+    private @Stable static Charset defaultCharset;
 
     /**
      * Returns the default charset of this Java virtual machine.

--- a/src/java.base/share/classes/java/nio/charset/Charset.java
+++ b/src/java.base/share/classes/java/nio/charset/Charset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -653,7 +653,8 @@ public abstract class Charset
             synchronized (Charset.class) {
                 String csn = GetPropertyAction
                         .privilegedGetProperty("file.encoding");
-                Charset cs = lookup(csn);
+                // do not look for providers other than the standard one
+                Charset cs = standardProvider.charsetForName(csn);
                 if (cs != null)
                     defaultCharset = cs;
                 else

--- a/src/java.base/share/classes/java/nio/charset/Charset.java
+++ b/src/java.base/share/classes/java/nio/charset/Charset.java
@@ -630,7 +630,7 @@ public abstract class Charset
     }
 
     @Stable
-    private static volatile Charset defaultCharset;
+    private static Charset defaultCharset;
 
     /**
      * Returns the default charset of this Java virtual machine.

--- a/src/java.base/share/classes/java/nio/charset/Charset.java
+++ b/src/java.base/share/classes/java/nio/charset/Charset.java
@@ -27,6 +27,8 @@ package java.nio.charset;
 
 import jdk.internal.misc.ThreadTracker;
 import jdk.internal.misc.VM;
+import jdk.internal.util.StaticProperty;
+import jdk.internal.vm.annotation.Stable;
 import sun.nio.cs.ThreadLocalCoders;
 import sun.security.action.GetPropertyAction;
 
@@ -48,7 +50,6 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.jar.JarFile;
 
 
 /**
@@ -628,6 +629,7 @@ public abstract class Charset
             });
     }
 
+    @Stable
     private static volatile Charset defaultCharset;
 
     /**
@@ -651,10 +653,8 @@ public abstract class Charset
     public static Charset defaultCharset() {
         if (defaultCharset == null) {
             synchronized (Charset.class) {
-                String csn = GetPropertyAction
-                        .privilegedGetProperty("file.encoding");
                 // do not look for providers other than the standard one
-                Charset cs = standardProvider.charsetForName(csn);
+                Charset cs = standardProvider.charsetForName(StaticProperty.fileEncoding());
                 if (cs != null)
                     defaultCharset = cs;
                 else

--- a/src/java.base/share/classes/jdk/internal/util/StaticProperty.java
+++ b/src/java.base/share/classes/jdk/internal/util/StaticProperty.java
@@ -26,7 +26,6 @@
 package jdk.internal.util;
 
 import java.util.Properties;
-import java.nio.charset.Charset;
 
 /**
  * System Property access for internal use only.

--- a/src/java.base/share/classes/jdk/internal/util/StaticProperty.java
+++ b/src/java.base/share/classes/jdk/internal/util/StaticProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,6 @@ public final class StaticProperty {
     private static final String FILE_ENCODING;
     private static final String JAVA_PROPERTIES_DATE;
     private static final String SUN_JNU_ENCODING;
-    private static final Charset jnuCharset;
     private static final String JAVA_LOCALE_USE_OLD_ISO_CODES;
 
     private StaticProperty() {}
@@ -74,7 +73,6 @@ public final class StaticProperty {
         FILE_ENCODING = getProperty(props, "file.encoding");
         JAVA_PROPERTIES_DATE = getProperty(props, "java.properties.date", null);
         SUN_JNU_ENCODING = getProperty(props, "sun.jnu.encoding");
-        jnuCharset = Charset.forName(SUN_JNU_ENCODING, Charset.defaultCharset());
         JAVA_LOCALE_USE_OLD_ISO_CODES = getProperty(props, "java.locale.useOldISOCodes", "");
     }
 
@@ -234,16 +232,6 @@ public final class StaticProperty {
      */
     public static String jnuEncoding() {
         return SUN_JNU_ENCODING;
-    }
-
-    /**
-     * {@return {@code Charset} for {@code sun.jnu.encoding} system property}
-     *
-     * <strong>If {@code sun.jnu.encoding} system property has invalid
-     * encoding name, {@link Charset#defaultCharset()} is returned.</strong>
-     */
-    public static Charset jnuCharset() {
-        return jnuCharset;
     }
 
     /**

--- a/src/java.base/unix/classes/java/lang/ProcessEnvironment.java
+++ b/src/java.base/unix/classes/java/lang/ProcessEnvironment.java
@@ -54,10 +54,9 @@
 
 package java.lang;
 
-import java.io.*;
-import java.nio.charset.Charset;
 import java.util.*;
-import jdk.internal.util.StaticProperty;
+
+import static java.lang.ProcessImpl.JNU_CHARSET;
 
 
 final class ProcessEnvironment
@@ -165,7 +164,7 @@ final class ProcessEnvironment
         }
 
         public static Variable valueOfQueryOnly(String str) {
-            return new Variable(str, str.getBytes(ProcessImpl.JNU_CHARSET));
+            return new Variable(str, str.getBytes(JNU_CHARSET));
         }
 
         public static Variable valueOf(String str) {
@@ -174,7 +173,7 @@ final class ProcessEnvironment
         }
 
         public static Variable valueOf(byte[] bytes) {
-            return new Variable(new String(bytes, ProcessImpl.JNU_CHARSET), bytes);
+            return new Variable(new String(bytes, JNU_CHARSET), bytes);
         }
 
         public int compareTo(Variable variable) {
@@ -198,7 +197,7 @@ final class ProcessEnvironment
         }
 
         public static Value valueOfQueryOnly(String str) {
-            return new Value(str, str.getBytes(ProcessImpl.JNU_CHARSET));
+            return new Value(str, str.getBytes(JNU_CHARSET));
         }
 
         public static Value valueOf(String str) {
@@ -207,7 +206,7 @@ final class ProcessEnvironment
         }
 
         public static Value valueOf(byte[] bytes) {
-            return new Value(new String(bytes, ProcessImpl.JNU_CHARSET), bytes);
+            return new Value(new String(bytes, JNU_CHARSET), bytes);
         }
 
         public int compareTo(Value value) {

--- a/src/java.base/unix/classes/java/lang/ProcessEnvironment.java
+++ b/src/java.base/unix/classes/java/lang/ProcessEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -165,7 +165,7 @@ final class ProcessEnvironment
         }
 
         public static Variable valueOfQueryOnly(String str) {
-            return new Variable(str, str.getBytes(StaticProperty.jnuCharset()));
+            return new Variable(str, str.getBytes(ProcessImpl.JNU_CHARSET));
         }
 
         public static Variable valueOf(String str) {
@@ -174,7 +174,7 @@ final class ProcessEnvironment
         }
 
         public static Variable valueOf(byte[] bytes) {
-            return new Variable(new String(bytes, StaticProperty.jnuCharset()), bytes);
+            return new Variable(new String(bytes, ProcessImpl.JNU_CHARSET), bytes);
         }
 
         public int compareTo(Variable variable) {
@@ -198,7 +198,7 @@ final class ProcessEnvironment
         }
 
         public static Value valueOfQueryOnly(String str) {
-            return new Value(str, str.getBytes(StaticProperty.jnuCharset()));
+            return new Value(str, str.getBytes(ProcessImpl.JNU_CHARSET));
         }
 
         public static Value valueOf(String str) {
@@ -207,7 +207,7 @@ final class ProcessEnvironment
         }
 
         public static Value valueOf(byte[] bytes) {
-            return new Value(new String(bytes, StaticProperty.jnuCharset()), bytes);
+            return new Value(new String(bytes, ProcessImpl.JNU_CHARSET), bytes);
         }
 
         public int compareTo(Value value) {

--- a/src/java.base/unix/classes/java/lang/ProcessImpl.java
+++ b/src/java.base/unix/classes/java/lang/ProcessImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,6 +69,10 @@ final class ProcessImpl extends Process {
     // Linux platforms support a normal (non-forcible) kill signal.
     static final boolean SUPPORTS_NORMAL_TERMINATION = true;
 
+    // Cache for JNU Charset. The encoding name is guaranteed
+    // to be supported in this environment.
+    static final Charset JNU_CHARSET = Charset.forName(StaticProperty.jnuEncoding());
+
     private final int pid;
     private final ProcessHandleImpl processHandle;
     private int exitcode;
@@ -114,11 +118,11 @@ final class ProcessImpl extends Process {
                     LaunchMechanism lm;
                     if (s == null) {
                         lm = defaultLaunchMechanism;
-                        s = lm.name().toLowerCase(Locale.ENGLISH);
+                        s = lm.name().toLowerCase(Locale.ROOT);
                     } else {
                         try {
                             lm = LaunchMechanism.valueOf(
-                                s.toUpperCase(Locale.ENGLISH));
+                                s.toUpperCase(Locale.ROOT));
                         } catch (IllegalArgumentException e) {
                             lm = null;
                         }
@@ -152,7 +156,7 @@ final class ProcessImpl extends Process {
     private static byte[] toCString(String s) {
         if (s == null)
             return null;
-        byte[] bytes = s.getBytes(StaticProperty.jnuCharset());
+        byte[] bytes = s.getBytes(JNU_CHARSET);
         byte[] result = new byte[bytes.length + 1];
         System.arraycopy(bytes, 0,
                          result, 0,
@@ -176,7 +180,7 @@ final class ProcessImpl extends Process {
         byte[][] args = new byte[cmdarray.length-1][];
         int size = args.length; // For added NUL bytes
         for (int i = 0; i < args.length; i++) {
-            args[i] = cmdarray[i+1].getBytes(StaticProperty.jnuCharset());
+            args[i] = cmdarray[i+1].getBytes(JNU_CHARSET);
             size += args[i].length;
         }
         byte[] argBlock = new byte[size];


### PR DESCRIPTION
This issue was found during the review of this PR: https://github.com/openjdk/jdk/pull/12132 where `Charset` class was loaded/initialized at the phase 1 of the startup process. Since `Charset` depends on `StaticProperty`, loading of `Charset` class should be delayed. I basically moved cache for `jnuCharset` into the actual calling locations `ProcessImpl` and `ProcessEnvironment` for unix platforms so that initPhase1() won't initialize `Charset` class.
Unrelated, but I replaced `Locale.ENGLISH` with `Locale.ROOT` in the argument of `toLowerCase()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8301114](https://bugs.openjdk.org/browse/JDK-8301114) to be approved

### Issues
 * [JDK-8300916](https://bugs.openjdk.org/browse/JDK-8300916): Re-examine the initialization of JNU Charset in StaticProperty
 * [JDK-8301114](https://bugs.openjdk.org/browse/JDK-8301114): Re-examine the initialization of JNU Charset in StaticProperty (**CSR**)


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to [3f9165bb](https://git.openjdk.org/jdk/pull/12171/files/3f9165bb739305d7cb54024d415206b110d5a4ca)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [3f9165bb](https://git.openjdk.org/jdk/pull/12171/files/3f9165bb739305d7cb54024d415206b110d5a4ca)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12171/head:pull/12171` \
`$ git checkout pull/12171`

Update a local copy of the PR: \
`$ git checkout pull/12171` \
`$ git pull https://git.openjdk.org/jdk pull/12171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12171`

View PR using the GUI difftool: \
`$ git pr show -t 12171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12171.diff">https://git.openjdk.org/jdk/pull/12171.diff</a>

</details>
