### PR TITLE
8299982: (bf) Buffer.checkIndex(int, int) should use Preconditions.checkIndex(int, int, BiFunction)

### DIFF
--- a/src/java.base/share/classes/java/nio/Buffer.java
+++ b/src/java.base/share/classes/java/nio/Buffer.java
@@ -33,6 +33,7 @@ import jdk.internal.foreign.MemorySessionImpl;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.misc.VM.BufferPool;
+import jdk.internal.util.Preconditions;
 import jdk.internal.vm.annotation.ForceInline;
 
 import java.io.FileDescriptor;
@@ -747,7 +748,14 @@ public abstract sealed class Buffer
     }
 
     final int checkIndex(int i, int nb) {               // package-private
-        return Objects.checkIndex(i, limit - nb + 1);
+        return Preconditions.checkIndex(i, limit - nb + 1,
+            (x, y) -> {
+                String msg = i < 0
+                    ? "position (" + i + ") < 0"
+                    : "position (" + i + ") + length (" + nb + ") > limit (" + limit + ")";
+                return new IndexOutOfBoundsException(msg);
+            }
+        );
     }
 
     final int markValue() {                             // package-private

--- a/src/java.base/share/classes/java/nio/Buffer.java
+++ b/src/java.base/share/classes/java/nio/Buffer.java
@@ -747,6 +747,7 @@ public abstract sealed class Buffer
         return Objects.checkIndex(i, limit);
     }
 
+    @ForceInline
     final int checkIndex(int i, int nb) {               // package-private
         return Preconditions.checkIndex(i, limit - nb + 1,
             (x, y) -> {

--- a/src/java.base/share/classes/java/nio/Buffer.java
+++ b/src/java.base/share/classes/java/nio/Buffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -747,9 +747,7 @@ public abstract sealed class Buffer
     }
 
     final int checkIndex(int i, int nb) {               // package-private
-        if ((i < 0) || (nb > limit - i))
-            throw new IndexOutOfBoundsException();
-        return i;
+        return Objects.checkIndex(i, limit - nb + 1);
     }
 
     final int markValue() {                             // package-private


### PR DESCRIPTION
Replace explicit check of indexes in `Buffer::checkIndex(int,int)` with a call to `Objects::checkIndex(int,int)` in order to improve the throughput of other methods which invoke `Buffer::checkIndex(int,int)`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299982](https://bugs.openjdk.org/browse/JDK-8299982): (bf) Buffer.checkIndex(int, int) should use Preconditions.checkIndex(int, int, BiFunction)


### Reviewers
 * [Uwe Schindler](https://openjdk.org/census#uschindler) (@uschindler - Author) ⚠️ Review applies to [c25837f8](https://git.openjdk.org/jdk/pull/12174/files/c25837f86b5766f2798df814c4def76ae52e2d62)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer) ⚠️ Review applies to [c25837f8](https://git.openjdk.org/jdk/pull/12174/files/c25837f86b5766f2798df814c4def76ae52e2d62)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to [4729bd9f](https://git.openjdk.org/jdk/pull/12174/files/4729bd9f55d76712e197f0a0911a07c1d5740e98)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12174/head:pull/12174` \
`$ git checkout pull/12174`

Update a local copy of the PR: \
`$ git checkout pull/12174` \
`$ git pull https://git.openjdk.org/jdk pull/12174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12174`

View PR using the GUI difftool: \
`$ git pr show -t 12174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12174.diff">https://git.openjdk.org/jdk/pull/12174.diff</a>

</details>
