### PR TITLE
8300891: Deprecate for removal javax.swing.plaf.synth.SynthLookAndFeel.load(URL url)

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
@@ -619,11 +619,12 @@ public class SynthLookAndFeel extends BasicLookAndFeel {
      * Whilst this API may be safe for loading local resources that are
      * delivered with a {@code LookAndFeel} or application, and so have an
      * equal level of trust with application code, using it to load from
-     * from remote resources, particularly any which may have a lower level of
+     * remote resources, particularly any which may have a lower level of
      * trust, is strongly discouraged.
      * The alternative mechanisms to load styles from an {@code InputStream}
-     * using a resource co-located with the application or by
-     * providing a {@code SynthStyleFactory} are preferred.
+     * {@link load(InputStream, Class)}
+     * using a resource co-located with the application or by providing a
+     * {@code SynthStyleFactory} to {@link setStyleFactory} are preferred.
      * Consequently this method is deprecated and will be removed in a future release.
      *
      * @param url the <code>URL</code> to load the set of
@@ -632,6 +633,8 @@ public class SynthLookAndFeel extends BasicLookAndFeel {
      * @throws IllegalArgumentException if synthSet is <code>null</code>
      * @throws IOException if synthSet cannot be opened as an <code>InputStream</code>
      * @since 1.6
+     * @deprecated Use {@link load(InputStream, Class)} or
+     * {@link setStyleFactory} instead
      */
     @Deprecated(since = "21", forRemoval = true)
     public void load(URL url) throws ParseException, IOException {

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
@@ -622,7 +622,7 @@ public class SynthLookAndFeel extends BasicLookAndFeel {
      * from remote resources, particularly any which may have a lower level of
      * trust, is strongly discouraged.
      * The alternative mechanisms to load styles from an {@code InputStream}
-     * located as a resource co-located with the application or by
+     * using a resource co-located with the application or by
      * providing a {@code SynthStyleFactory} are preferred.
      * Consequently this method is deprecated and will be removed in a future release.
      *

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
@@ -622,10 +622,13 @@ public class SynthLookAndFeel extends BasicLookAndFeel {
      * remote resources, particularly any which may have a lower level of
      * trust, is strongly discouraged.
      * The alternative mechanisms to load styles from an {@code InputStream}
-     * {@link load(InputStream, Class)}
-     * using a resource co-located with the application or by providing a
-     * {@code SynthStyleFactory} to {@link setStyleFactory} are preferred.
-     * Consequently this method is deprecated and will be removed in a future release.
+     * {@linkplain #load(InputStream, Class)}
+     * using resources co-located with the application or by providing a
+     * {@code SynthStyleFactory} to
+     * {@linkplain #setStyleFactory setStyleFactory(SynthStyleFactory)}
+     * are preferred.
+     * Consequently this method is deprecated and will be removed in a future
+     * release.
      *
      * @param url the <code>URL</code> to load the set of
      *     <code>SynthStyle</code> from
@@ -633,8 +636,8 @@ public class SynthLookAndFeel extends BasicLookAndFeel {
      * @throws IllegalArgumentException if synthSet is <code>null</code>
      * @throws IOException if synthSet cannot be opened as an <code>InputStream</code>
      * @since 1.6
-     * @deprecated Use {@link load(InputStream, Class)} or
-     * {@link setStyleFactory} instead
+     * @deprecated Use {@link #load(InputStream, Class)} or
+     * {@link #setStyleFactory setStyleFactory(SynthStyleFactory)} instead
      */
     @Deprecated(since = "21", forRemoval = true)
     public void load(URL url) throws ParseException, IOException {

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
@@ -615,6 +615,16 @@ public class SynthLookAndFeel extends BasicLookAndFeel {
      * <code>new URL(synthFile, path)</code>. Refer to
      * <a href="doc-files/synthFileFormat.html">Synth File Format</a> for more
      * information.
+     * <p>
+     * Whilst this API may be safe for loading local resources that are
+     * delivered with a {@code LookAndFeel} or application, and so have an
+     * equal level of trust with application code, using it to load from
+     * from remote resources, particularly any which may have a lower level of
+     * trust, is strongly discouraged.
+     * The alternative mechanisms to load styles from an {@code InputStream}
+     * located as a resource co-located with the application or by
+     * providing a {@code SynthStyleFactory} are preferred.
+     * Consequently this method is deprecated and will be removed in a future release. 
      *
      * @param url the <code>URL</code> to load the set of
      *     <code>SynthStyle</code> from
@@ -623,6 +633,7 @@ public class SynthLookAndFeel extends BasicLookAndFeel {
      * @throws IOException if synthSet cannot be opened as an <code>InputStream</code>
      * @since 1.6
      */
+    @Deprecated(since = "21", forRemoval = true)
     public void load(URL url) throws ParseException, IOException {
         if (url == null) {
             throw new IllegalArgumentException(

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
@@ -624,7 +624,7 @@ public class SynthLookAndFeel extends BasicLookAndFeel {
      * The alternative mechanisms to load styles from an {@code InputStream}
      * located as a resource co-located with the application or by
      * providing a {@code SynthStyleFactory} are preferred.
-     * Consequently this method is deprecated and will be removed in a future release. 
+     * Consequently this method is deprecated and will be removed in a future release.
      *
      * @param url the <code>URL</code> to load the set of
      *     <code>SynthStyle</code> from

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/doc-files/synthFileFormat.html
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/doc-files/synthFileFormat.html
@@ -70,6 +70,8 @@ div.example {
     <p>
       This example loads the look and feel from an input stream, using
       the specified class as the resource base to resolve paths.
+    </p>
+    <p>
       It is also possible to load a look and feel from an arbitrary URL
       as in the following example.
     </p>
@@ -94,6 +96,11 @@ div.example {
       <li>Remote JAR file, e.g.
         <code>jar:http://host/synth-laf.jar!/laf.xml</code></li>
     </ul>
+    <p>Note: Synth's file format allows for the definition of code to be executed.
+       Loading any code from a remote location should be used only
+       with extreme caution from a trusted source over a secure connection.
+       It is strongly discouraged for an application or a LookAndFeel to do so.
+    </p>
     <p>
       While the DTD for synth is specified, the parser is not validating.
       Parsing will fail only if a necessary attribute is not


### PR DESCRIPTION
SynthLookAndFeel.load(URL) is problematic because applications need to trust the URL.
As documented in the bug report there are alternative mechanisms and JDK itself has not used this for the two Synth based L&Fs : Nimbus and GTK.
So deprecating - for removal - and adding warnings now in the docs is appropriate.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8301032](https://bugs.openjdk.org/browse/JDK-8301032) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8300891](https://bugs.openjdk.org/browse/JDK-8300891): Deprecate for removal javax.swing.plaf.synth.SynthLookAndFeel.load(URL url)
 * [JDK-8301032](https://bugs.openjdk.org/browse/JDK-8301032): Deprecate for removal javax.swing.plaf.synth.SynthLookAndFeel.load(URL url) (**CSR**)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to [738414c0](https://git.openjdk.org/jdk/pull/12175/files/738414c0fb21060ad7afdb6df1abefd9366849f7)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12175/head:pull/12175` \
`$ git checkout pull/12175`

Update a local copy of the PR: \
`$ git checkout pull/12175` \
`$ git pull https://git.openjdk.org/jdk pull/12175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12175`

View PR using the GUI difftool: \
`$ git pr show -t 12175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12175.diff">https://git.openjdk.org/jdk/pull/12175.diff</a>

</details>
