### PR TITLE
8300463: Build failure on Windows 32 after JDK-8296401

### DIFF
--- a/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
@@ -997,7 +997,7 @@ inline size_t ConcurrentHashTable<CONFIG, F>::
       if (dels < num_del) {
         ndel[dels] = rem_n;
       } else {
-        guarantee(dels < static_cast<size_t>(std::numeric_limits<int>::max()),
+        guarantee(dels < INT_MAX,
                   "Growable array size is limited by a (signed) int, something is seriously bad if we reach this point, better exit");
         extra.append(rem_n);
       }

--- a/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
@@ -997,7 +997,7 @@ inline size_t ConcurrentHashTable<CONFIG, F>::
       if (dels < num_del) {
         ndel[dels] = rem_n;
       } else {
-        guarantee(dels < std::numeric_limits<int>::max(),
+        guarantee(dels < static_cast<size_t>(std::numeric_limits<int>::max()),
                   "Growable array size is limited by a (signed) int, something is seriously bad if we reach this point, better exit");
         extra.append(rem_n);
       }


### PR DESCRIPTION
This issue also triggers when building slowdebug on linux-aarch64 with GCC-9.4.0. Given that std::numeric_limits<int>::max() returns positive integer number and size_t is an unsigned type, I guess it's safe to do simple static_cast here both on 32-bit and 64-bit platfoms. Slowdebug on linux-aarch64 builds fine with this fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300463](https://bugs.openjdk.org/browse/JDK-8300463): Build failure on Windows 32 after JDK-8296401


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12178/head:pull/12178` \
`$ git checkout pull/12178`

Update a local copy of the PR: \
`$ git checkout pull/12178` \
`$ git pull https://git.openjdk.org/jdk pull/12178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12178`

View PR using the GUI difftool: \
`$ git pr show -t 12178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12178.diff">https://git.openjdk.org/jdk/pull/12178.diff</a>

</details>
