### PR TITLE
8297454: javax/swing/JComponent/7154030/bug7154030.java failed with "Exception: Failed to show opaque button"

### DIFF
--- a/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
+++ b/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
@@ -102,6 +102,8 @@ public class bug7154030 {
 
             robot.waitForIdle(1000);
             robot.delay(1000);
+            robot.mouseMove(0, 0);
+            robot.waitForIdle();
 
             Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
             Rectangle screen = new Rectangle(0, 0, (int) screenSize.getWidth(), (int) screenSize.getHeight());


### PR DESCRIPTION
Test intermittently failed in CI macos system owing to robot screencapture failing to compare the images.
Seems like from artifacts, that composite image created by robot contains mouse cursor, which when compared are not giving exact pixel color. This has occurred in the past also for some tests for which we have made the mouseMove to move mouse cursor outside the area being captured for pixel comparison.
Similar fix is done whereby mouse is moved to outside the captured area. Several iterations in CI are ok.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297454](https://bugs.openjdk.org/browse/JDK-8297454): javax/swing/JComponent/7154030/bug7154030.java failed with "Exception: Failed to show opaque button"


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12179/head:pull/12179` \
`$ git checkout pull/12179`

Update a local copy of the PR: \
`$ git checkout pull/12179` \
`$ git pull https://git.openjdk.org/jdk pull/12179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12179`

View PR using the GUI difftool: \
`$ git pr show -t 12179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12179.diff">https://git.openjdk.org/jdk/pull/12179.diff</a>

</details>
