### PR TITLE
6753661: JFileChooser font not reset after Look & Feel change

### DIFF
--- a/src/java.desktop/share/classes/sun/swing/plaf/synth/SynthFileChooserUI.java
+++ b/src/java.desktop/share/classes/sun/swing/plaf/synth/SynthFileChooserUI.java
@@ -193,6 +193,9 @@ public abstract class SynthFileChooserUI extends BasicFileChooserUI implements
 
     protected void uninstallDefaults(JFileChooser fc) {
         super.uninstallDefaults(fc);
+        if (fc.getFont() instanceof UIResource) {
+            fc.setFont(null);
+        }
 
         SynthContext context = getContext(getFileChooser(), ENABLED);
         style.uninstallDefaults(context);

--- a/test/jdk/javax/swing/JFileChooser/JFileChooserFontReset.java
+++ b/test/jdk/javax/swing/JFileChooser/JFileChooserFontReset.java
@@ -66,10 +66,10 @@ public class JFileChooserFontReset {
                     SwingUtilities.updateComponentTreeUI(fc);
                     Font curFont = fc.getFont();
                     System.out.println("current font " + curFont);
-                    if ((curFont != null && !curFont.equals(origFont)) ||
-                        (origFont != null && !origFont.equals(curFont))) {
-                          throw new RuntimeException(
-                           "JFileChooser font is not reset after Look & Feel change");
+                    if (curFont != origFont
+                        && (curFont != null && !curFont.equals(origFont))) {
+                        throw new RuntimeException(
+                         "JFileChooser font is not reset after Look & Feel change");
                     }
                 }
                 System.out.println("");

--- a/test/jdk/javax/swing/JFileChooser/JFileChooserFontReset.java
+++ b/test/jdk/javax/swing/JFileChooser/JFileChooserFontReset.java
@@ -70,9 +70,9 @@ public class JFileChooserFontReset {
                     throw new RuntimeException(
                          "JFileChooser font did not reset after Look & Feel change");
                 }
-	    }
-	    System.out.println("");
-	    System.out.println("");
+            }
+            System.out.println("");
+            System.out.println("");
         }
     }
 }

--- a/test/jdk/javax/swing/JFileChooser/JFileChooserFontReset.java
+++ b/test/jdk/javax/swing/JFileChooser/JFileChooserFontReset.java
@@ -66,9 +66,10 @@ public class JFileChooserFontReset {
                     SwingUtilities.updateComponentTreeUI(fc);
                     Font curFont = fc.getFont();
                     System.out.println("current font " + curFont);
-                    if (curFont != null && !curFont.equals(origFont)) {
-                        throw new RuntimeException(
-                         "JFileChooser font did not reset after Look & Feel change");
+                    if ((curFont != null && !curFont.equals(origFont)) ||
+                        (origFont != null && !origFont.equals(curFont))) {
+                          throw new RuntimeException(
+                           "JFileChooser font is not reset after Look & Feel change");
                     }
                 }
                 System.out.println("");

--- a/test/jdk/javax/swing/JFileChooser/JFileChooserFontReset.java
+++ b/test/jdk/javax/swing/JFileChooser/JFileChooserFontReset.java
@@ -45,35 +45,36 @@ public class JFileChooserFontReset {
     }
 
     public static void main(String args[]) throws Exception {
-        for (UIManager.LookAndFeelInfo laf :
-                 UIManager.getInstalledLookAndFeels()) {
-            System.out.println("Testing L&F: " + laf.getClassName());
-            SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
-            JFileChooser fc = new JFileChooser();
-            Font origFont = fc.getFont();
-            System.out.println(" orig font " + origFont);
-            for (UIManager.LookAndFeelInfo newLaF :
-                UIManager.getInstalledLookAndFeels()) {
-                if (laf.equals(newLaF)) {
-                    // Skip same laf
-                    continue;
-                }
-                System.out.println("Transition to L&F: " + newLaF);
-                SwingUtilities.invokeAndWait(() -> setLookAndFeel(newLaF));
-                SwingUtilities.updateComponentTreeUI(fc);
-                SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
-                System.out.println("Back to L&F: " + laf);
-                SwingUtilities.updateComponentTreeUI(fc);
-                Font curFont = fc.getFont();
-                System.out.println("current font " + curFont);
-                if (curFont != null && !curFont.equals(origFont)) {
-                    throw new RuntimeException(
+        SwingUtilities.invokeAndWait(() -> {
+            for (UIManager.LookAndFeelInfo laf :
+                     UIManager.getInstalledLookAndFeels()) {
+                System.out.println("Testing L&F: " + laf.getClassName());
+                setLookAndFeel(laf);
+                JFileChooser fc = new JFileChooser();
+                Font origFont = fc.getFont();
+                System.out.println(" orig font " + origFont);
+                for (UIManager.LookAndFeelInfo newLaF :
+                    UIManager.getInstalledLookAndFeels()) {
+                    if (laf.equals(newLaF)) {
+                        continue;
+                    }
+                    System.out.println("Transition to L&F: " + newLaF);
+                    setLookAndFeel(newLaF);
+                    SwingUtilities.updateComponentTreeUI(fc);
+                    setLookAndFeel(laf);
+                    System.out.println("Back to L&F: " + laf);
+                    SwingUtilities.updateComponentTreeUI(fc);
+                    Font curFont = fc.getFont();
+                    System.out.println("current font " + curFont);
+                    if (curFont != null && !curFont.equals(origFont)) {
+                        throw new RuntimeException(
                          "JFileChooser font did not reset after Look & Feel change");
+                    }
                 }
+                System.out.println("");
+                System.out.println("");
             }
-            System.out.println("");
-            System.out.println("");
-        }
+        });
     }
 }
 

--- a/test/jdk/javax/swing/JFileChooser/JFileChooserFontReset.java
+++ b/test/jdk/javax/swing/JFileChooser/JFileChooserFontReset.java
@@ -30,23 +30,39 @@ import java.awt.Font;
 import javax.swing.JFileChooser;
 import javax.swing.UIManager;
 import javax.swing.SwingUtilities;
+import javax.swing.UnsupportedLookAndFeelException;
 
 public class JFileChooserFontReset {
+    private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
+        try {
+            UIManager.setLookAndFeel(laf.getClassName());
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.out.println("Unsupported L&F: " + laf.getClassName());
+        } catch (ClassNotFoundException | InstantiationException
+                | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public static void main(String args[]) throws Exception {
-        UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");
-        JFileChooser fc = new JFileChooser();
-        Font origFont = fc.getFont();
-        System.out.println("orig font " + origFont);
-        UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
-        SwingUtilities.updateComponentTreeUI(fc);
-        System.out.println("Nimbus font " + fc.getFont());
-        UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");
-        SwingUtilities.updateComponentTreeUI(fc);
-        Font curFont = fc.getFont();
-        System.out.println("current font " + curFont);
-        if (curFont != null && !curFont.equals(origFont)) {
-            throw new RuntimeException(
-                 "JFileChooser font did not reset after Look & Feel change");
+        for (UIManager.LookAndFeelInfo laf :
+                 UIManager.getInstalledLookAndFeels()) {
+            System.out.println("Testing L&F: " + laf.getClassName());
+            SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
+            JFileChooser fc = new JFileChooser();
+            Font origFont = fc.getFont();
+            System.out.println("orig font " + origFont);
+            UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
+            SwingUtilities.updateComponentTreeUI(fc);
+            System.out.println("Nimbus font " + fc.getFont());
+            SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
+            SwingUtilities.updateComponentTreeUI(fc);
+            Font curFont = fc.getFont();
+            System.out.println("current font " + curFont);
+            if (curFont != null && !curFont.equals(origFont)) {
+                throw new RuntimeException(
+                     "JFileChooser font did not reset after Look & Feel change");
+            }
         }
     }
 }

--- a/test/jdk/javax/swing/JFileChooser/JFileChooserFontReset.java
+++ b/test/jdk/javax/swing/JFileChooser/JFileChooserFontReset.java
@@ -51,18 +51,29 @@ public class JFileChooserFontReset {
             SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
             JFileChooser fc = new JFileChooser();
             Font origFont = fc.getFont();
-            System.out.println("orig font " + origFont);
-            UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
-            SwingUtilities.updateComponentTreeUI(fc);
-            System.out.println("Nimbus font " + fc.getFont());
-            SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
-            SwingUtilities.updateComponentTreeUI(fc);
-            Font curFont = fc.getFont();
-            System.out.println("current font " + curFont);
-            if (curFont != null && !curFont.equals(origFont)) {
-                throw new RuntimeException(
-                     "JFileChooser font did not reset after Look & Feel change");
-            }
+            System.out.println(" orig font " + origFont);
+            for (UIManager.LookAndFeelInfo newLaF :
+                UIManager.getInstalledLookAndFeels()) {
+                if (laf.equals(newLaF)) {
+                    // Skip same laf
+                    continue;
+                }
+                System.out.println("Transition to L&F: " + newLaF);
+                SwingUtilities.invokeAndWait(() -> setLookAndFeel(newLaF));
+                SwingUtilities.updateComponentTreeUI(fc);
+                SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
+                System.out.println("Back to L&F: " + laf);
+                SwingUtilities.updateComponentTreeUI(fc);
+                Font curFont = fc.getFont();
+                System.out.println("current font " + curFont);
+                if (curFont != null && !curFont.equals(origFont)) {
+                    throw new RuntimeException(
+                         "JFileChooser font did not reset after Look & Feel change");
+                }
+	    }
+	    System.out.println("");
+	    System.out.println("");
         }
     }
 }
+

--- a/test/jdk/javax/swing/JFileChooser/JFileChooserFontReset.java
+++ b/test/jdk/javax/swing/JFileChooser/JFileChooserFontReset.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 6753661
+ * @summary  Verifies if JFileChooser font reset after Look & Feel change
+ * @run main JFileChooserFontReset
+ */
+import java.awt.Font;
+import javax.swing.JFileChooser;
+import javax.swing.UIManager;
+import javax.swing.SwingUtilities;
+
+public class JFileChooserFontReset {
+    public static void main(String args[]) throws Exception {
+        UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");
+        JFileChooser fc = new JFileChooser();
+        Font origFont = fc.getFont();
+        System.out.println("orig font " + origFont);
+        UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
+        SwingUtilities.updateComponentTreeUI(fc);
+        System.out.println("Nimbus font " + fc.getFont());
+        UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");
+        SwingUtilities.updateComponentTreeUI(fc);
+        Font curFont = fc.getFont();
+        System.out.println("current font " + curFont);
+        if (curFont != null && !curFont.equals(origFont)) {
+            throw new RuntimeException(
+                 "JFileChooser font did not reset after Look & Feel change");
+        }
+    }
+}


### PR DESCRIPTION
Issue is observed that after changing the Look & Feel from Metal to Nimbus and back to Metal, the Nimbus font continues to be used by a JFileChooser.
This is because Synth  `installDefaults `methods set the font, but its inverse methods `uninstallDefaults `do not remove them.
Fix is made to reset the font if it is set by L&F.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6753661](https://bugs.openjdk.org/browse/JDK-6753661): JFileChooser font not reset after Look &amp; Feel change


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer) ⚠️ Review applies to [a704310e](https://git.openjdk.org/jdk/pull/12180/files/a704310e012c4350dc28414361bb6d4e268304e7)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12180/head:pull/12180` \
`$ git checkout pull/12180`

Update a local copy of the PR: \
`$ git checkout pull/12180` \
`$ git pull https://git.openjdk.org/jdk pull/12180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12180`

View PR using the GUI difftool: \
`$ git pr show -t 12180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12180.diff">https://git.openjdk.org/jdk/pull/12180.diff</a>

</details>
