### PR TITLE
8299713: Test javax/swing/JTableHeader/6889007/bug6889007.java failed: Wrong type of cursor

### DIFF
--- a/test/jdk/javax/swing/JTableHeader/6889007/bug6889007.java
+++ b/test/jdk/javax/swing/JTableHeader/6889007/bug6889007.java
@@ -23,28 +23,42 @@
 
 /*
    @test
-  @key headful
+   @key headful
    @bug 6889007
    @summary No resize cursor during hovering mouse over JTable
-   @author Alexander Potochkin
 */
 
-import javax.swing.*;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
+import javax.swing.JFrame;
 import javax.swing.plaf.basic.BasicTableHeaderUI;
 import javax.swing.table.JTableHeader;
-import java.awt.*;
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
 
 public class bug6889007 {
 
+    static JFrame frame;
+    static Robot robot;
+    static volatile Point point;
+    static volatile int width;
+    static volatile int height;
+
     public static void main(String[] args) throws Exception {
-        Robot robot = new Robot();
-        robot.setAutoDelay(20);
+        try {
+            robot = new Robot();
+            robot.setAutoDelay(100);
 
-        final JFrame frame = new JFrame();
-        frame.setUndecorated(true);
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame();
+                frame.setUndecorated(true);
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
                 frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
                 JTableHeader th = new JTableHeader();
@@ -56,21 +70,33 @@ public class bug6889007 {
                 frame.pack();
                 frame.setLocationRelativeTo(null);
                 frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                point = frame.getLocationOnScreen();
+		width = frame.getWidth();
+		height = frame.getHeight();
+            });
+            int shift = 10;
+            int x = point.x;
+            int y = point.y + height/2;
+            for(int i = -shift; i < width + 2*shift; i++) {
+                robot.mouseMove(x++, y);
+		robot.waitForIdle();
             }
-        });
-        robot.waitForIdle();
-        Point point = frame.getLocationOnScreen();
-        int shift = 10;
-        int x = point.x;
-        int y = point.y + frame.getHeight()/2;
-        for(int i = -shift; i < frame.getWidth() + 2*shift; i++) {
-            robot.mouseMove(x++, y);
-        }
-        robot.waitForIdle();
-        // 9 is a magic test number
-        if (MyTableHeaderUI.getTestValue() != 9) {
-            throw new RuntimeException("Unexpected test number "
-                    + MyTableHeaderUI.getTestValue());
+            robot.waitForIdle();
+            // 9 is a magic test number
+            if (MyTableHeaderUI.getTestValue() != 9) {
+                throw new RuntimeException("Unexpected test number "
+                        + MyTableHeaderUI.getTestValue());
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
         }
         System.out.println("ok");
     }
@@ -83,6 +109,15 @@ public class bug6889007 {
             Cursor cursor = Cursor.getPredefinedCursor(Cursor.E_RESIZE_CURSOR);
             if (oldColumn != -1 && newColumn != -1 &&
                     header.getCursor() != cursor) {
+                try {
+                    Dimension screenSize =
+                               Toolkit.getDefaultToolkit().getScreenSize();
+                    Rectangle screen = new Rectangle(0, 0,
+                                               (int) screenSize.getWidth(),
+                                               (int) screenSize.getHeight());
+                    BufferedImage img = robot.createScreenCapture(screen);
+                    ImageIO.write(img, "png", new java.io.File("image.png"));
+		} catch (Exception e) {}
                 throw new RuntimeException("Wrong type of cursor!");
             }
         }

--- a/test/jdk/javax/swing/JTableHeader/6889007/bug6889007.java
+++ b/test/jdk/javax/swing/JTableHeader/6889007/bug6889007.java
@@ -75,15 +75,15 @@ public class bug6889007 {
             robot.delay(1000);
             SwingUtilities.invokeAndWait(() -> {
                 point = frame.getLocationOnScreen();
-		width = frame.getWidth();
-		height = frame.getHeight();
+                width = frame.getWidth();
+                height = frame.getHeight();
             });
             int shift = 10;
             int x = point.x;
             int y = point.y + height/2;
             for(int i = -shift; i < width + 2*shift; i++) {
                 robot.mouseMove(x++, y);
-		robot.waitForIdle();
+                robot.waitForIdle();
             }
             robot.waitForIdle();
             // 9 is a magic test number
@@ -117,7 +117,7 @@ public class bug6889007 {
                                                (int) screenSize.getHeight());
                     BufferedImage img = robot.createScreenCapture(screen);
                     ImageIO.write(img, "png", new java.io.File("image.png"));
-		} catch (Exception e) {}
+                } catch (Exception e) {}
                 throw new RuntimeException("Wrong type of cursor!");
             }
         }


### PR DESCRIPTION
Issue seems to be very old, very intermittent bug which is not reproducible in repeated test run,
so added some stability fixes like accessing swing components in EDT, delay, frame dispose and take a screenshot during fail.
Multiple runs on CI platforms is ok.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299713](https://bugs.openjdk.org/browse/JDK-8299713): Test javax/swing/JTableHeader/6889007/bug6889007.java failed: Wrong type of cursor


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12181/head:pull/12181` \
`$ git checkout pull/12181`

Update a local copy of the PR: \
`$ git checkout pull/12181` \
`$ git pull https://git.openjdk.org/jdk.git pull/12181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12181`

View PR using the GUI difftool: \
`$ git pr show -t 12181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12181.diff">https://git.openjdk.org/jdk/pull/12181.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12181#issuecomment-1403272052)