### PR TITLE
8300917: Regression 2x and bimodal startup on Mac aarch64 in b27

### DIFF
--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -114,7 +114,7 @@ public final class Module implements AnnotatedElement {
 
     // true, if this module allows restricted native access "by definition".
     // otherwise false, where lateEnableNativeAccess needs to be consulted
-    // in order to determine if native access is enabled.
+    // in order to determine if native access is actually enabled.
     // Having a two-staged construct prevents synchronization for modules
     // that allows access by definition.
     private final boolean enableNativeAccessByDefinition;

--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -302,7 +302,7 @@ public final class Module implements AnnotatedElement {
     }
 
     private static boolean casLateEnableNativeAccess(Module target) {
-        // Tentatively first check if already enabled. If so, we do not need to enter the
+        // Tentatively, first check if already enabled. If so, we do not need to enter the
         // synchronization block as we are dealing with a @Stable boolean variable.
         // This is a form of double-checked locking but, we do not need to declare
         // the primitive boolean variable `volatile` as it is a @Stable primitive, and

--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -306,7 +306,7 @@ public final class Module implements AnnotatedElement {
         // synchronization block as we are dealing with a @Stable boolean variable.
         // This is a form of double-checked locking but, we do not need to declare
         // the primitive boolean variable `volatile` as it is a @Stable primitive, and
-        // we do not need strict guarantees only enter the synchronized area at most
+        // we do not need strict guarantees only to enter the synchronized area at most
         // once.
         if (!target.lateEnableNativeAccess) {
             synchronized (target) {


### PR DESCRIPTION
This PR proposes a two-staged handling of the "enable native access" functionality. It also proposes a non-strict tentative check-for-set.

The objective of these measures is to reduce contention in synchronization blocks. Crucially, I/O operations are also moved outside synchronization blocks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300917](https://bugs.openjdk.org/browse/JDK-8300917): Regression 2x and bimodal startup on Mac aarch64 in b27


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12182/head:pull/12182` \
`$ git checkout pull/12182`

Update a local copy of the PR: \
`$ git checkout pull/12182` \
`$ git pull https://git.openjdk.org/jdk pull/12182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12182`

View PR using the GUI difftool: \
`$ git pr show -t 12182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12182.diff">https://git.openjdk.org/jdk/pull/12182.diff</a>

</details>
