### PR TITLE
JDK-8301068: Replace NULL with nullptr in share/jvmci/

### DIFF
--- a/src/hotspot/share/jvmci/jvmci.cpp
+++ b/src/hotspot/share/jvmci/jvmci.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ bool JVMCI::can_initialize_JVMCI() {
   // The JVMCI API itself isn't available until phase 2 and ServiceLoader (which
   // JVMCI initialization requires) isn't usable until after phase 3. Testing
   // whether the system loader is initialized satisfies all these invariants.
-  if (SystemDictionary::java_system_loader() == NULL) {
+  if (SystemDictionary::java_system_loader() == nullptr) {
     return false;
   }
   assert(Universe::is_module_initialized(), "must be");
@@ -69,16 +69,16 @@ bool JVMCI::can_initialize_JVMCI() {
 
 void* JVMCI::get_shared_library(char*& path, bool load) {
   void* sl_handle = _shared_library_handle;
-  if (sl_handle != NULL || !load) {
+  if (sl_handle != nullptr || !load) {
     path = _shared_library_path;
     return sl_handle;
   }
   MutexLocker locker(JVMCI_lock);
-  path = NULL;
-  if (_shared_library_handle == NULL) {
+  path = nullptr;
+  if (_shared_library_handle == nullptr) {
     char path[JVM_MAXPATHLEN];
     char ebuf[1024];
-    if (JVMCILibPath != NULL) {
+    if (JVMCILibPath != nullptr) {
       if (!os::dll_locate_lib(path, sizeof(path), JVMCILibPath, JVMCI_SHARED_LIBRARY_NAME)) {
         fatal("Unable to create path to JVMCI shared library based on value of JVMCILibPath (%s)", JVMCILibPath);
       }
@@ -89,7 +89,7 @@ void* JVMCI::get_shared_library(char*& path, bool load) {
     }
 
     void* handle = os::dll_load(path, ebuf, sizeof ebuf);
-    if (handle == NULL) {
+    if (handle == nullptr) {
       fatal("Unable to load JVMCI shared library from %s: %s", path, ebuf);
     }
     _shared_library_handle = handle;
@@ -103,7 +103,7 @@ void* JVMCI::get_shared_library(char*& path, bool load) {
 
 void JVMCI::initialize_compiler(TRAPS) {
   if (JVMCILibDumpJNIConfig) {
-    JNIJVMCI::initialize_ids(NULL);
+    JNIJVMCI::initialize_ids(nullptr);
     ShouldNotReachHere();
   }
   JVMCIRuntime* runtime;
@@ -175,9 +175,9 @@ JVMCIRuntime* JVMCI::compiler_runtime(JavaThread* thread, bool create) {
 JavaThread* JVMCI::compilation_tick(JavaThread* thread) {
   if (thread->is_Compiler_thread()) {
     CompileTask *task = CompilerThread::cast(thread)->task();
-    if (task != NULL) {
+    if (task != nullptr) {
       JVMCICompileState *state = task->blocking_jvmci_compile_state();
-      if (state != NULL) {
+      if (state != nullptr) {
         state->inc_compilation_ticks();
       }
     }

--- a/src/hotspot/share/jvmci/jvmci.hpp
+++ b/src/hotspot/share/jvmci/jvmci.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ class JVMCI : public AllStatic {
   // Special libjvmci based JVMCIRuntime reserved for
   // threads trying to attach when in JVMCI shutdown.
   // This preserves the invariant that JVMCIRuntime::for_thread()
-  // never returns nullptr.
+  // never returns null.
   static JVMCIRuntime* _shutdown_compiler_runtime;
 
   // True when at least one JVMCIRuntime::initialize_HotSpotJVMCIRuntime()
@@ -98,7 +98,7 @@ class JVMCI : public AllStatic {
     max_EventLog_level = 4
   };
 
-  // Gets the Thread* value for the current thread or NULL if it's not available.
+  // Gets the Thread* value for the current thread or null if it's not available.
   static Thread* current_thread_or_null();
 
  public:
@@ -130,7 +130,7 @@ class JVMCI : public AllStatic {
   // Logs the fatal crash data in `buf` to the appropriate stream.
   static void fatal_log(const char* buf, size_t count);
 
-  // Gets the name of the opened JVMCI shared library crash data file or NULL
+  // Gets the name of the opened JVMCI shared library crash data file or null
   // if this file has not been created.
   static const char* fatal_log_filename() { return _fatal_log_filename; }
 

--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@
 // Allocate them with new so they are never destroyed (otherwise, a
 // forced exit could destroy these objects while they are still in
 // use).
-ConstantOopWriteValue* CodeInstaller::_oop_null_scope_value = new (mtJVMCI) ConstantOopWriteValue(NULL);
+ConstantOopWriteValue* CodeInstaller::_oop_null_scope_value = new (mtJVMCI) ConstantOopWriteValue(nullptr);
 ConstantIntValue*      CodeInstaller::_int_m1_scope_value = new (mtJVMCI) ConstantIntValue(-1);
 ConstantIntValue*      CodeInstaller::_int_0_scope_value =  new (mtJVMCI) ConstantIntValue((jint)0);
 ConstantIntValue*      CodeInstaller::_int_1_scope_value =  new (mtJVMCI) ConstantIntValue(1);
@@ -252,7 +252,7 @@ OopMap* CodeInstaller::create_oop_map(HotSpotCompiledCodeStream* stream, u1 debu
   assert(is_set(debug_info_flags, DI_HAS_REFERENCE_MAP), "must be");
   u2 max_register_size = stream->read_u2("maxRegisterSize");
   if (!_has_wide_vector && SharedRuntime::is_wide_vector(max_register_size)) {
-    if (SharedRuntime::polling_page_vectors_safepoint_handler_blob() == NULL) {
+    if (SharedRuntime::polling_page_vectors_safepoint_handler_blob() == nullptr) {
       JVMCI_ERROR_NULL("JVMCI is producing code using vectors larger than the runtime supports%s", stream->context());
     }
     _has_wide_vector = true;
@@ -377,7 +377,7 @@ Handle CodeInstaller::read_oop(HotSpotCompiledCodeStream* stream, u1 tag, JVMCI_
     JVMCI_ERROR_(Handle(), "unexpected oop tag: %d", tag)
   }
   if (obj == nullptr) {
-    JVMCI_THROW_MSG_(InternalError, "Constant was unexpectedly NULL", Handle());
+    JVMCI_THROW_MSG_(InternalError, "Constant was unexpectedly nullptr", Handle());
   } else {
     oopDesc::verify(obj);
   }
@@ -385,7 +385,7 @@ Handle CodeInstaller::read_oop(HotSpotCompiledCodeStream* stream, u1 tag, JVMCI_
 }
 
 ScopeValue* CodeInstaller::get_scope_value(HotSpotCompiledCodeStream* stream, u1 tag, BasicType type, ScopeValue* &second, JVMCI_TRAPS) {
-  second = NULL;
+  second = nullptr;
   switch (tag) {
     case ILLEGAL: {
       if (type != T_ILLEGAL) {
@@ -484,7 +484,7 @@ void CodeInstaller::record_object_value(ObjectValue* sv, HotSpotCompiledCodeStre
 
   u2 length = stream->read_u2("values:length");
   for (jint i = 0; i < length; i++) {
-    ScopeValue* cur_second = NULL;
+    ScopeValue* cur_second = nullptr;
     BasicType type = (BasicType) stream->read_u1("basicType");
     ScopeValue* value;
     u1 tag = stream->read_u1("tag");
@@ -506,22 +506,22 @@ void CodeInstaller::record_object_value(ObjectValue* sv, HotSpotCompiledCodeStre
       value = get_scope_value(stream, tag, type, cur_second, JVMCI_CHECK);
     }
 
-    if (isLongArray && cur_second == NULL) {
+    if (isLongArray && cur_second == nullptr) {
       // we're trying to put ints into a long array... this isn't really valid, but it's used for some optimizations.
       // add an int 0 constant
       cur_second = _int_0_scope_value;
     }
 
-    if (isByteArray && cur_second != NULL && (type == T_DOUBLE || type == T_LONG)) {
+    if (isByteArray && cur_second != nullptr && (type == T_DOUBLE || type == T_LONG)) {
       // we are trying to write a long in a byte Array. We will need to count the illegals to restore the type of
       // the thing we put inside.
-      cur_second = NULL;
+      cur_second = nullptr;
     }
 
-    if (cur_second != NULL) {
+    if (cur_second != nullptr) {
       sv->field_values()->append(cur_second);
     }
-    assert(value != NULL, "missing value");
+    assert(value != nullptr, "missing value");
     sv->field_values()->append(value);
   }
 }
@@ -573,9 +573,9 @@ GrowableArray<MonitorValue*>* CodeInstaller::read_monitor_values(HotSpotCompiled
   GrowableArray<MonitorValue*>* monitors = new GrowableArray<MonitorValue*>(length);
   for (int i = 0; i < length; i++) {
     bool eliminated = stream->read_bool("isEliminated");
-    ScopeValue* second = NULL;
+    ScopeValue* second = nullptr;
     ScopeValue* owner_value = get_scope_value(stream, stream->read_u1("tag"), T_OBJECT, second, JVMCI_CHECK_NULL);
-    assert(second == NULL, "monitor cannot occupy two stack slots");
+    assert(second == nullptr, "monitor cannot occupy two stack slots");
 
     ScopeValue* lock_data_value = get_scope_value(stream, stream->read_u1("tag"), T_LONG, second, JVMCI_CHECK_NULL);
     assert(second == lock_data_value, "monitor is LONG value that occupies two stack slots");
@@ -589,9 +589,9 @@ GrowableArray<MonitorValue*>* CodeInstaller::read_monitor_values(HotSpotCompiled
 
 void CodeInstaller::initialize_dependencies(HotSpotCompiledCodeStream* stream, u1 code_flags, OopRecorder* oop_recorder, JVMCI_TRAPS) {
   JavaThread* thread = stream->thread();
-  CompilerThread* compilerThread = thread->is_Compiler_thread() ? CompilerThread::cast(thread) : NULL;
+  CompilerThread* compilerThread = thread->is_Compiler_thread() ? CompilerThread::cast(thread) : nullptr;
   _oop_recorder = oop_recorder;
-  _dependencies = new Dependencies(&_arena, _oop_recorder, compilerThread != NULL ? compilerThread->log() : NULL);
+  _dependencies = new Dependencies(&_arena, _oop_recorder, compilerThread != nullptr ? compilerThread->log() : nullptr);
   if (is_set(code_flags, HCC_HAS_ASSUMPTIONS)) {
     u2 length = stream->read_u2("assumptions:length");
     for (int i = 0; i < length; ++i) {
@@ -714,7 +714,7 @@ JVMCI::CodeInstallResult CodeInstaller::install(JVMCICompiler* compiler,
                                        false);
     result = JVMCI::ok;
   } else {
-    if (compile_state != NULL) {
+    if (compile_state != nullptr) {
       jvmci_env()->set_compile_state(compile_state);
     }
 
@@ -728,7 +728,7 @@ JVMCI::CodeInstallResult CodeInstaller::install(JVMCICompiler* compiler,
     }
 
     JVMCIObject mirror = installed_code;
-    nmethod* nm = NULL; // nm is an out parameter of register_method
+    nmethod* nm = nullptr; // nm is an out parameter of register_method
     result = runtime()->register_method(jvmci_env(),
                                         method,
                                         nm,
@@ -754,7 +754,7 @@ JVMCI::CodeInstallResult CodeInstaller::install(JVMCICompiler* compiler,
                                         speculations_len);
     if (result == JVMCI::ok) {
       cb = nm;
-      if (compile_state == NULL) {
+      if (compile_state == nullptr) {
         // This compile didn't come through the CompileBroker so perform the printing here
         DirectiveSet* directive = DirectivesStack::getMatchingDirective(method, compiler);
         nm->maybe_print_nmethod(directive);
@@ -763,7 +763,7 @@ JVMCI::CodeInstallResult CodeInstaller::install(JVMCICompiler* compiler,
     }
   }
 
-  if (cb != NULL) {
+  if (cb != nullptr) {
     // Make sure the pre-calculated constants section size was correct.
     guarantee((cb->code_begin() - cb->content_begin()) >= _constants_size, "%d < %d", (int)(cb->code_begin() - cb->content_begin()), _constants_size);
   }
@@ -861,7 +861,7 @@ JVMCI::CodeInstallResult CodeInstaller::initialize_buffer(JVMCIObject compiled_c
   }
 
   buffer.initialize(total_size, locs_buffer_size);
-  if (buffer.blob() == NULL) {
+  if (buffer.blob() == nullptr) {
     return JVMCI::cache_full;
   }
   buffer.initialize_stubs_size(stubs_size);
@@ -1017,7 +1017,7 @@ void CodeInstaller::read_virtual_objects(HotSpotCompiledCodeStream* stream, JVMC
   if (length == 0) {
     return;
   }
-  GrowableArray<ScopeValue*> *objects = new GrowableArray<ScopeValue*>(length, length, NULL);
+  GrowableArray<ScopeValue*> *objects = new GrowableArray<ScopeValue*>(length, length, nullptr);
   stream->set_virtual_objects(objects);
   // Create the unique ObjectValues
   JavaThread* thread = stream->thread();
@@ -1076,9 +1076,9 @@ void CodeInstaller::record_scope(jint pc_offset, HotSpotCompiledCodeStream* stre
       bool reexecute = false;
       bool rethrow_exception = false;
 
-      DebugToken* locals_token = NULL;
-      DebugToken* stack_token = NULL;
-      DebugToken* monitors_token = NULL;
+      DebugToken* locals_token = nullptr;
+      DebugToken* stack_token = nullptr;
+      DebugToken* monitors_token = nullptr;
 
       if (full_info) {
         u1 frame_flags = stream->read_u1("flags");
@@ -1100,7 +1100,7 @@ void CodeInstaller::record_scope(jint pc_offset, HotSpotCompiledCodeStream* stre
       // has_ea_local_in_scope and arg_escape should be added to JVMCI
       const bool has_ea_local_in_scope = false;
       const bool arg_escape            = false;
-      _debug_recorder->describe_scope(pc_offset, method, NULL, bci, reexecute, rethrow_exception, is_mh_invoke, return_oop,
+      _debug_recorder->describe_scope(pc_offset, method, nullptr, bci, reexecute, rethrow_exception, is_mh_invoke, return_oop,
                                       has_ea_local_in_scope, arg_escape,
                                       locals_token, stack_token, monitors_token);
     }

--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
@@ -377,7 +377,7 @@ Handle CodeInstaller::read_oop(HotSpotCompiledCodeStream* stream, u1 tag, JVMCI_
     JVMCI_ERROR_(Handle(), "unexpected oop tag: %d", tag)
   }
   if (obj == nullptr) {
-    JVMCI_THROW_MSG_(InternalError, "Constant was unexpectedly nullptr", Handle());
+    JVMCI_THROW_MSG_(InternalError, "Constant was unexpectedly null", Handle());
   } else {
     oopDesc::verify(obj);
   }

--- a/src/hotspot/share/jvmci/jvmciCompiler.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompiler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,14 +33,14 @@
 #include "runtime/arguments.hpp"
 #include "runtime/handles.inline.hpp"
 
-JVMCICompiler* JVMCICompiler::_instance = NULL;
+JVMCICompiler* JVMCICompiler::_instance = nullptr;
 
 JVMCICompiler::JVMCICompiler() : AbstractCompiler(compiler_jvmci) {
   _bootstrapping = false;
   _bootstrap_compilation_request_handled = false;
   _methods_compiled = 0;
   _global_compilation_ticks = 0;
-  assert(_instance == NULL, "only one instance allowed");
+  assert(_instance == nullptr, "only one instance allowed");
   _instance = this;
 }
 
@@ -48,7 +48,7 @@ JVMCICompiler* JVMCICompiler::instance(bool require_non_null, TRAPS) {
   if (!EnableJVMCI) {
     THROW_MSG_NULL(vmSymbols::java_lang_InternalError(), "JVMCI is not enabled")
   }
-  if (_instance == NULL && require_non_null) {
+  if (_instance == nullptr && require_non_null) {
     THROW_MSG_NULL(vmSymbols::java_lang_InternalError(), "The JVMCI compiler instance has not been created");
   }
   return _instance;
@@ -127,12 +127,12 @@ bool JVMCICompiler::force_comp_at_level_simple(const methodHandle& method) {
     return false;
   } else {
     JVMCIRuntime* runtime = JVMCI::java_runtime();
-    if (runtime != NULL) {
+    if (runtime != nullptr) {
       JVMCIObject receiver = runtime->probe_HotSpotJVMCIRuntime();
       if (receiver.is_null()) {
         return false;
       }
-      JVMCIEnv* ignored_env = NULL;
+      JVMCIEnv* ignored_env = nullptr;
       objArrayHandle excludeModules(JavaThread::current(), HotSpotJVMCI::HotSpotJVMCIRuntime::excludeFromJVMCICompilation(ignored_env, HotSpotJVMCI::resolve(receiver)));
       if (excludeModules.not_null()) {
         ModuleEntry* moduleEntry = method->method_holder()->module();

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -1241,7 +1241,7 @@ bool matches(jobjectArray methods, Method* method, GrowableArray<Method*>** reso
     resolved_methods = init_resolved_methods(methods, JVMCIENV);
     *resolved_methods_ref = resolved_methods;
   }
-  assert(method != nullptr, "method should not be nullptr");
+  assert(method != nullptr, "method should not be null");
   assert(resolved_methods->length() == ((objArrayOop) JNIHandles::resolve(methods))->length(), "arrays must have the same length");
   for (int i = 0; i < resolved_methods->length(); i++) {
     Method* m = resolved_methods->at(i);

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,14 +70,14 @@
 JVMCIKlassHandle::JVMCIKlassHandle(Thread* thread, Klass* klass) {
   _thread = thread;
   _klass = klass;
-  if (klass != NULL) {
+  if (klass != nullptr) {
     _holder = Handle(_thread, klass->klass_holder());
   }
 }
 
 JVMCIKlassHandle& JVMCIKlassHandle::operator=(Klass* klass) {
   _klass = klass;
-  if (klass != NULL) {
+  if (klass != nullptr) {
     _holder = Handle(_thread, klass->klass_holder());
   }
   return *this;
@@ -125,9 +125,9 @@ Handle JavaArgumentUnboxer::next_arg(BasicType expectedType) {
 
 static JavaThread* get_current_thread(bool allow_null=true) {
   Thread* thread = Thread::current_or_null_safe();
-  if (thread == NULL) {
+  if (thread == nullptr) {
     assert(allow_null, "npe");
-    return NULL;
+    return nullptr;
   }
   return JavaThread::cast(thread);
 }
@@ -137,7 +137,7 @@ static JavaThread* get_current_thread(bool allow_null=true) {
 #define C2V_VMENTRY(result_type, name, signature)        \
   JNIEXPORT result_type JNICALL c2v_ ## name signature { \
   JavaThread* thread = get_current_thread();             \
-  if (thread == NULL) {                                  \
+  if (thread == nullptr) {                                  \
     env->ThrowNew(JNIJVMCI::InternalError::clazz(),      \
         err_msg("Cannot call into HotSpot from JVMCI shared library without attaching current thread")); \
     return;                                              \
@@ -148,7 +148,7 @@ static JavaThread* get_current_thread(bool allow_null=true) {
 #define C2V_VMENTRY_(result_type, name, signature, result) \
   JNIEXPORT result_type JNICALL c2v_ ## name signature { \
   JavaThread* thread = get_current_thread();             \
-  if (thread == NULL) {                                  \
+  if (thread == nullptr) {                                  \
     env->ThrowNew(JNIJVMCI::InternalError::clazz(),      \
         err_msg("Cannot call into HotSpot from JVMCI shared library without attaching current thread")); \
     return result;                                       \
@@ -156,7 +156,7 @@ static JavaThread* get_current_thread(bool allow_null=true) {
   C2V_BLOCK(result_type, name, signature)                \
   JVMCITraceMark jtm("CompilerToVM::" #name);
 
-#define C2V_VMENTRY_NULL(result_type, name, signature) C2V_VMENTRY_(result_type, name, signature, NULL)
+#define C2V_VMENTRY_NULL(result_type, name, signature) C2V_VMENTRY_(result_type, name, signature, nullptr)
 #define C2V_VMENTRY_0(result_type, name, signature) C2V_VMENTRY_(result_type, name, signature, 0)
 
 // Entry to native method implementation that does not transition
@@ -199,7 +199,7 @@ C2V_VMENTRY_NULL(jobject, getFlagValue, (JNIEnv* env, jobject c2vm, jobject name
   }
   const char* cstring = JVMCIENV->as_utf8_string(name);
   const JVMFlag* flag = JVMFlag::find_declared_flag(cstring);
-  if (flag == NULL) {
+  if (flag == nullptr) {
     return c2vm;
   }
   if (flag->is_bool()) {
@@ -329,7 +329,7 @@ C2V_END
 C2V_VMENTRY_NULL(jobject, asResolvedJavaMethod, (JNIEnv* env, jobject, jobject executable_handle))
   requireInHotSpot("asResolvedJavaMethod", JVMCI_CHECK_NULL);
   oop executable = JNIHandles::resolve(executable_handle);
-  oop mirror = NULL;
+  oop mirror = nullptr;
   int slot = 0;
 
   if (executable->klass() == vmClasses::reflect_Constructor_klass()) {
@@ -347,7 +347,7 @@ C2V_VMENTRY_NULL(jobject, asResolvedJavaMethod, (JNIEnv* env, jobject, jobject e
 }
 
 C2V_VMENTRY_NULL(jobject, getResolvedJavaMethod, (JNIEnv* env, jobject, jobject base, jlong offset))
-  Method* method = NULL;
+  Method* method = nullptr;
   JVMCIObject base_object = JVMCIENV->wrap(base);
   if (base_object.is_null()) {
     method = *((Method**)(offset));
@@ -359,7 +359,7 @@ C2V_VMENTRY_NULL(jobject, getResolvedJavaMethod, (JNIEnv* env, jobject, jobject 
       JVMCI_THROW_MSG_NULL(IllegalArgumentException, err_msg("Unexpected type: %s", obj->klass()->external_name()));
     }
   }
-  if (method == NULL) {
+  if (method == nullptr) {
     JVMCI_THROW_MSG_NULL(IllegalArgumentException, err_msg("Unexpected type: %s", JVMCIENV->klass_name(base_object)));
   }
   assert (method->is_method(), "invalid read");
@@ -368,7 +368,7 @@ C2V_VMENTRY_NULL(jobject, getResolvedJavaMethod, (JNIEnv* env, jobject, jobject 
 }
 
 C2V_VMENTRY_NULL(jobject, getConstantPool, (JNIEnv* env, jobject, ARGUMENT_PAIR(klass_or_method), jboolean is_klass))
-  ConstantPool* cp = NULL;
+  ConstantPool* cp = nullptr;
   if (UNPACK_PAIR(address, klass_or_method) == 0) {
     JVMCI_THROW_NULL(NullPointerException);
   }
@@ -419,7 +419,7 @@ C2V_VMENTRY_NULL(jobject, getResolvedJavaType0, (JNIEnv* env, jobject, jobject b
                         base_object.is_non_null() ? JVMCIENV->klass_name(base_object) : "null",
                         offset, compressed ? "true" : "false"));
   }
-  assert (klass == NULL || klass->is_klass(), "invalid read");
+  assert (klass == nullptr || klass->is_klass(), "invalid read");
   JVMCIObject result = JVMCIENV->get_jvmci_type(klass, JVMCI_CHECK_NULL);
   return JVMCIENV->get_jobject(result);
 }
@@ -834,7 +834,7 @@ C2V_VMENTRY_NULL(jobject, resolveMethod, (JNIEnv* env, jobject, ARGUMENT_PAIR(re
   Symbol* h_signature = method->signature();
 
   if (MethodHandles::is_signature_polymorphic_method(method())) {
-      // Signature polymorphic methods are already resolved, JVMCI just returns NULL in this case.
+      // Signature polymorphic methods are already resolved, JVMCI just returns null in this case.
       return nullptr;
   }
 
@@ -863,7 +863,7 @@ C2V_VMENTRY_NULL(jobject, resolveMethod, (JNIEnv* env, jobject, ARGUMENT_PAIR(re
   }
 
   if (m == nullptr) {
-    // Return NULL if there was a problem with lookup (uninitialized class, etc.)
+    // Return null if there was a problem with lookup (uninitialized class, etc.)
     return nullptr;
   }
 
@@ -937,7 +937,7 @@ C2V_VMENTRY_0(jint, installCode0, (JNIEnv *env, jobject,
   JVMCIObject compiled_code_handle = JVMCIENV->wrap(compiled_code);
   objArrayHandle object_pool_handle(thread, JVMCIENV->is_hotspot() ? (objArrayOop) JNIHandles::resolve(object_pool) : nullptr);
 
-  CodeBlob* cb = NULL;
+  CodeBlob* cb = nullptr;
   JVMCIObject installed_code_handle = JVMCIENV->wrap(installed_code);
   JVMCIPrimitiveArray speculations_handle = JVMCIENV->wrap(speculations_obj);
 
@@ -977,7 +977,7 @@ C2V_VMENTRY_0(jint, installCode0, (JNIEnv *env, jobject,
   }
 
   if (result != JVMCI::ok) {
-    assert(cb == NULL, "should be");
+    assert(cb == nullptr, "should be");
   } else {
     stats->on_install(cb);
     if (installed_code_handle.is_non_null()) {
@@ -1006,14 +1006,14 @@ C2V_END
 C2V_VMENTRY_NULL(jobject, disassembleCodeBlob, (JNIEnv* env, jobject, jobject installedCode))
   HandleMark hm(THREAD);
 
-  if (installedCode == NULL) {
+  if (installedCode == nullptr) {
     JVMCI_THROW_MSG_NULL(NullPointerException, "installedCode is null");
   }
 
   JVMCIObject installedCodeObject = JVMCIENV->wrap(installedCode);
   CodeBlob* cb = JVMCIENV->get_code_blob(installedCodeObject);
-  if (cb == NULL) {
-    return NULL;
+  if (cb == nullptr) {
+    return nullptr;
   }
 
   // We don't want the stringStream buffer to resize during disassembly as it
@@ -1027,7 +1027,7 @@ C2V_VMENTRY_NULL(jobject, disassembleCodeBlob, (JNIEnv* env, jobject, jobject in
   stringStream st(buffer, bufferSize);
   Disassembler::decode(cb, &st);
   if (st.size() <= 0) {
-    return NULL;
+    return nullptr;
   }
 
   JVMCIObject result = JVMCIENV->create_string(st.as_string(), JVMCI_CHECK_NULL);
@@ -1051,7 +1051,7 @@ C2V_VMENTRY_NULL(jobject, executeHotSpotNmethod, (JNIEnv* env, jobject, jobject 
 
   JVMCIObject nmethod_mirror = JVMCIENV->wrap(hs_nmethod);
   nmethod* nm = JVMCIENV->get_nmethod(nmethod_mirror);
-  if (nm == NULL || !nm->is_in_use()) {
+  if (nm == nullptr || !nm->is_in_use()) {
     JVMCI_THROW_NULL(InvalidInstalledCodeException);
   }
   methodHandle mh(THREAD, nm->method());
@@ -1064,7 +1064,7 @@ C2V_VMENTRY_NULL(jobject, executeHotSpotNmethod, (JNIEnv* env, jobject, jobject 
   JavaCalls::call(&result, mh, &jca, CHECK_NULL);
 
   if (jap.return_type() == T_VOID) {
-    return NULL;
+    return nullptr;
   } else if (is_reference_type(jap.return_type())) {
     return JNIHandles::make_local(THREAD, result.get_oop());
   } else {
@@ -1094,7 +1094,7 @@ C2V_END
 C2V_VMENTRY_NULL(jlongArray, getLineNumberTable, (JNIEnv* env, jobject, ARGUMENT_PAIR(method)))
   Method* method = UNPACK_PAIR(Method, method);
   if (!method->has_linenumber_table()) {
-    return NULL;
+    return nullptr;
   }
   u2 num_entries = 0;
   CompressedLineNumberReadStream streamForSize(method->compressed_linenumber_table());
@@ -1134,18 +1134,18 @@ C2V_END
 C2V_VMENTRY(void, reprofile, (JNIEnv* env, jobject, ARGUMENT_PAIR(method)))
   methodHandle method(THREAD, UNPACK_PAIR(Method, method));
   MethodCounters* mcs = method->method_counters();
-  if (mcs != NULL) {
+  if (mcs != nullptr) {
     mcs->clear_counters();
   }
   NOT_PRODUCT(method->set_compiled_invocation_count(0));
 
   CompiledMethod* code = method->code();
-  if (code != NULL) {
+  if (code != nullptr) {
     code->make_not_entrant();
   }
 
   MethodData* method_data = method->method_data();
-  if (method_data == NULL) {
+  if (method_data == nullptr) {
     ClassLoaderData* loader_data = method->method_holder()->class_loader_data();
     method_data = MethodData::allocate(loader_data, method, CHECK);
     method->set_method_data(method_data);
@@ -1194,12 +1194,12 @@ C2V_END
 
 C2V_VMENTRY_0(jboolean, isMature, (JNIEnv* env, jobject, jlong method_data_pointer))
   MethodData* mdo = (MethodData*) method_data_pointer;
-  return mdo != NULL && mdo->is_mature();
+  return mdo != nullptr && mdo->is_mature();
 C2V_END
 
 C2V_VMENTRY_0(jboolean, hasCompiledCodeForOSR, (JNIEnv* env, jobject, ARGUMENT_PAIR(method), int entry_bci, int comp_level))
   Method* method = UNPACK_PAIR(Method, method);
-  return method->lookup_osr_nmethod_for(entry_bci, comp_level, true) != NULL;
+  return method->lookup_osr_nmethod_for(entry_bci, comp_level, true) != nullptr;
 C2V_END
 
 C2V_VMENTRY_NULL(jobject, getSymbol, (JNIEnv* env, jobject, jlong symbol))
@@ -1221,7 +1221,7 @@ GrowableArray<Method*>* init_resolved_methods(jobjectArray methods, JVMCIEnv* JV
   GrowableArray<Method*>* resolved_methods = new GrowableArray<Method*>(methods_oop->length());
   for (int i = 0; i < methods_oop->length(); i++) {
     oop resolved = methods_oop->obj_at(i);
-    Method* resolved_method = NULL;
+    Method* resolved_method = nullptr;
     if (resolved->klass() == HotSpotJVMCI::HotSpotResolvedJavaMethodImpl::klass()) {
       resolved_method = HotSpotJVMCI::asMethod(JVMCIENV, resolved);
     }
@@ -1237,11 +1237,11 @@ GrowableArray<Method*>* init_resolved_methods(jobjectArray methods, JVMCIEnv* JV
  */
 bool matches(jobjectArray methods, Method* method, GrowableArray<Method*>** resolved_methods_ref, Handle* matched_jvmci_method_ref, Thread* THREAD, JVMCIEnv* JVMCIENV) {
   GrowableArray<Method*>* resolved_methods = *resolved_methods_ref;
-  if (resolved_methods == NULL) {
+  if (resolved_methods == nullptr) {
     resolved_methods = init_resolved_methods(methods, JVMCIENV);
     *resolved_methods_ref = resolved_methods;
   }
-  assert(method != NULL, "method should not be NULL");
+  assert(method != nullptr, "method should not be nullptr");
   assert(resolved_methods->length() == ((objArrayOop) JNIHandles::resolve(methods))->length(), "arrays must have the same length");
   for (int i = 0; i < resolved_methods->length(); i++) {
     Method* m = resolved_methods->at(i);
@@ -1259,7 +1259,7 @@ bool matches(jobjectArray methods, Method* method, GrowableArray<Method*>** reso
 methodHandle resolve_interface_call(Klass* spec_klass, Symbol* name, Symbol* signature, JavaCallArguments* args, TRAPS) {
   CallInfo callinfo;
   Handle receiver = args->receiver();
-  Klass* recvrKlass = receiver.is_null() ? (Klass*)NULL : receiver->klass();
+  Klass* recvrKlass = receiver.is_null() ? (Klass*)nullptr : receiver->klass();
   LinkInfo link_info(spec_klass, name, signature);
   LinkResolver::resolve_interface_call(
           callinfo, receiver, recvrKlass, link_info, true, CHECK_(methodHandle()));
@@ -1292,14 +1292,14 @@ void resync_vframestream_to_compiled_frame(vframeStream& vfst, intptr_t* stack_p
 }
 
 /*
- * Used by c2v_iterateFrames. Returns an array of any unallocated scope objects or NULL if none.
+ * Used by c2v_iterateFrames. Returns an array of any unallocated scope objects or nullptr if none.
  */
 GrowableArray<ScopeValue*>* get_unallocated_objects_or_null(GrowableArray<ScopeValue*>* scope_objects) {
-  GrowableArray<ScopeValue*>* unallocated = NULL;
+  GrowableArray<ScopeValue*>* unallocated = nullptr;
   for (int i = 0; i < scope_objects->length(); i++) {
     ObjectValue* sv = (ObjectValue*) scope_objects->at(i);
     if (sv->value().is_null()) {
-      if (unallocated == NULL) {
+      if (unallocated == nullptr) {
         unallocated = new GrowableArray<ScopeValue*>(scope_objects->length());
       }
       unallocated->append(sv);
@@ -1311,7 +1311,7 @@ GrowableArray<ScopeValue*>* get_unallocated_objects_or_null(GrowableArray<ScopeV
 C2V_VMENTRY_NULL(jobject, iterateFrames, (JNIEnv* env, jobject compilerToVM, jobjectArray initial_methods, jobjectArray match_methods, jint initialSkip, jobject visitor_handle))
 
   if (!thread->has_last_Java_frame()) {
-    return NULL;
+    return nullptr;
   }
   Handle visitor(THREAD, JNIHandles::resolve_non_null(visitor_handle));
 
@@ -1322,14 +1322,14 @@ C2V_VMENTRY_NULL(jobject, iterateFrames, (JNIEnv* env, jobject compilerToVM, job
   vframeStream vfst(thread);
   jobjectArray methods = initial_methods;
   methodHandle visitor_method;
-  GrowableArray<Method*>* resolved_methods = NULL;
+  GrowableArray<Method*>* resolved_methods = nullptr;
 
   while (!vfst.at_end()) { // frame loop
     bool realloc_called = false;
     intptr_t* frame_id = vfst.frame_id();
 
     // Previous compiledVFrame of this frame; use with at_scope() to reuse scope object pool.
-    compiledVFrame* prev_cvf = NULL;
+    compiledVFrame* prev_cvf = nullptr;
 
     for (; !vfst.at_end() && vfst.frame_id() == frame_id; vfst.next()) { // vframe loop
       int frame_number = 0;
@@ -1337,20 +1337,20 @@ C2V_VMENTRY_NULL(jobject, iterateFrames, (JNIEnv* env, jobject compilerToVM, job
       int bci = vfst.bci();
 
       Handle matched_jvmci_method;
-      if (methods == NULL || matches(methods, method, &resolved_methods, &matched_jvmci_method, THREAD, JVMCIENV)) {
+      if (methods == nullptr || matches(methods, method, &resolved_methods, &matched_jvmci_method, THREAD, JVMCIENV)) {
         if (initialSkip > 0) {
           initialSkip--;
           continue;
         }
         javaVFrame* vf;
-        if (prev_cvf != NULL && prev_cvf->frame_pointer()->id() == frame_id) {
+        if (prev_cvf != nullptr && prev_cvf->frame_pointer()->id() == frame_id) {
           assert(prev_cvf->is_compiled_frame(), "expected compiled Java frame");
           vf = prev_cvf->at_scope(vfst.decode_offset(), vfst.vframe_id());
         } else {
           vf = vfst.asJavaVFrame();
         }
 
-        StackValueCollection* locals = NULL;
+        StackValueCollection* locals = nullptr;
         typeArrayHandle localIsVirtual_h;
         if (vf->is_compiled_frame()) {
           // compiled method frame
@@ -1358,10 +1358,10 @@ C2V_VMENTRY_NULL(jobject, iterateFrames, (JNIEnv* env, jobject compilerToVM, job
 
           ScopeDesc* scope = cvf->scope();
           // native wrappers do not have a scope
-          if (scope != NULL && scope->objects() != NULL) {
+          if (scope != nullptr && scope->objects() != nullptr) {
             prev_cvf = cvf;
 
-            GrowableArray<ScopeValue*>* objects = NULL;
+            GrowableArray<ScopeValue*>* objects = nullptr;
             if (!realloc_called) {
               objects = scope->objects();
             } else {
@@ -1369,7 +1369,7 @@ C2V_VMENTRY_NULL(jobject, iterateFrames, (JNIEnv* env, jobject compilerToVM, job
               objects = get_unallocated_objects_or_null(scope->objects());
             }
 
-            if (objects != NULL) {
+            if (objects != nullptr) {
               RegisterMap reg_map(vf->register_map());
               bool realloc_failures = Deoptimization::realloc_objects(thread, vf->frame_pointer(), &reg_map, objects, CHECK_NULL);
               Deoptimization::reassign_fields(vf->frame_pointer(), &reg_map, objects, realloc_failures, false);
@@ -1434,19 +1434,19 @@ C2V_VMENTRY_NULL(jobject, iterateFrames, (JNIEnv* env, jobject compilerToVM, job
 
         args.push_oop(frame_reference);
         JavaCalls::call(&result, visitor_method, &args, CHECK_NULL);
-        if (result.get_oop() != NULL) {
+        if (result.get_oop() != nullptr) {
           return JNIHandles::make_local(thread, result.get_oop());
         }
         if (methods == initial_methods) {
           methods = match_methods;
-          if (resolved_methods != NULL && JNIHandles::resolve(match_methods) != JNIHandles::resolve(initial_methods)) {
-            resolved_methods = NULL;
+          if (resolved_methods != nullptr && JNIHandles::resolve(match_methods) != JNIHandles::resolve(initial_methods)) {
+            resolved_methods = nullptr;
           }
         }
         assert(initialSkip == 0, "There should be no match before initialSkip == 0");
         if (HotSpotJVMCI::HotSpotStackFrameReference::objectsMaterialized(JVMCIENV, frame_reference()) == JNI_TRUE) {
           // the frame has been deoptimized, we need to re-synchronize the frame and vframe
-          prev_cvf = NULL;
+          prev_cvf = nullptr;
           intptr_t* stack_pointer = (intptr_t*) HotSpotJVMCI::HotSpotStackFrameReference::stackPointer(JVMCIENV, frame_reference());
           resync_vframestream_to_compiled_frame(vfst, stack_pointer, frame_number, thread, CHECK_NULL);
         }
@@ -1455,7 +1455,7 @@ C2V_VMENTRY_NULL(jobject, iterateFrames, (JNIEnv* env, jobject compilerToVM, job
   } // end of frame loop
 
   // the end was reached without finding a matching method
-  return NULL;
+  return nullptr;
 C2V_END
 
 C2V_VMENTRY(void, resolveInvokeDynamicInPool, (JNIEnv* env, jobject, ARGUMENT_PAIR(cp), jint index))
@@ -1503,7 +1503,7 @@ C2V_VMENTRY_0(jint, isResolvedInvokeHandleInPool, (JNIEnv* env, jobject, ARGUMEN
       vmassert(!resolved_method->is_static(),"!");
       vmassert(MethodHandles::is_signature_polymorphic_method(resolved_method()),"!");
       vmassert(!MethodHandles::is_signature_polymorphic_static(resolved_method->intrinsic_id()), "!");
-      vmassert(cp_cache_entry->appendix_if_resolved(cp) == NULL, "!");
+      vmassert(cp_cache_entry->appendix_if_resolved(cp) == nullptr, "!");
 
       methodHandle m(THREAD, LinkResolver::linktime_resolve_virtual_method_or_null(link_info));
       vmassert(m == resolved_method, "!!");
@@ -1595,10 +1595,10 @@ C2V_VMENTRY(void, materializeVirtualObjects, (JNIEnv* env, jobject, jobject _hs_
   }
 
   // Reallocate the non-escaping objects and restore their fields.
-  assert (virtualFrames->at(last_frame_number)->scope() != NULL,"invalid scope");
+  assert (virtualFrames->at(last_frame_number)->scope() != nullptr,"invalid scope");
   GrowableArray<ScopeValue*>* objects = virtualFrames->at(last_frame_number)->scope()->objects();
 
-  if (objects == NULL) {
+  if (objects == nullptr) {
     // no objects to materialize
     return;
   }
@@ -1611,7 +1611,7 @@ C2V_VMENTRY(void, materializeVirtualObjects, (JNIEnv* env, jobject, jobject _hs_
 
     GrowableArray<ScopeValue*>* scopedValues = cvf->scope()->locals();
     StackValueCollection* locals = cvf->locals();
-    if (locals != NULL) {
+    if (locals != nullptr) {
       for (int i2 = 0; i2 < locals->size(); i2++) {
         StackValue* var = locals->at(i2);
         if (var->type() == T_OBJECT && scopedValues->at(i2)->is_object()) {
@@ -1624,7 +1624,7 @@ C2V_VMENTRY(void, materializeVirtualObjects, (JNIEnv* env, jobject, jobject _hs_
 
     GrowableArray<ScopeValue*>* scopeExpressions = cvf->scope()->expressions();
     StackValueCollection* expressions = cvf->expressions();
-    if (expressions != NULL) {
+    if (expressions != nullptr) {
       for (int i2 = 0; i2 < expressions->size(); i2++) {
         StackValue* var = expressions->at(i2);
         if (var->type() == T_OBJECT && scopeExpressions->at(i2)->is_object()) {
@@ -1637,7 +1637,7 @@ C2V_VMENTRY(void, materializeVirtualObjects, (JNIEnv* env, jobject, jobject _hs_
 
     GrowableArray<MonitorValue*>* scopeMonitors = cvf->scope()->monitors();
     GrowableArray<MonitorInfo*>* monitors = cvf->monitors();
-    if (monitors != NULL) {
+    if (monitors != nullptr) {
       for (int i2 = 0; i2 < monitors->length(); i2++) {
         cvf->update_monitor(i2, monitors->at(i2));
       }
@@ -1645,7 +1645,7 @@ C2V_VMENTRY(void, materializeVirtualObjects, (JNIEnv* env, jobject, jobject _hs_
   }
 
   // all locals are materialized by now
-  JVMCIENV->set_HotSpotStackFrameReference_localIsVirtual(hs_frame, NULL);
+  JVMCIENV->set_HotSpotStackFrameReference_localIsVirtual(hs_frame, nullptr);
   // update the locals array
   JVMCIObjectArray array = JVMCIENV->get_HotSpotStackFrameReference_locals(hs_frame);
   StackValueCollection* locals = virtualFrames->at(last_frame_number)->locals();
@@ -1736,7 +1736,7 @@ C2V_VMENTRY_NULL(jobject, getComponentType, (JNIEnv* env, jobject, ARGUMENT_PAIR
   }
 
   Klass* component_klass = java_lang_Class::as_Klass(component_mirror);
-  if (component_klass != NULL) {
+  if (component_klass != nullptr) {
     JVMCIKlassHandle klass_handle(THREAD, component_klass);
     JVMCIObject result = JVMCIENV->get_jvmci_type(klass_handle, JVMCI_CHECK_NULL);
     return JVMCIENV->get_jobject(result);
@@ -1769,7 +1769,7 @@ C2V_VMENTRY(void, ensureLinked, (JNIEnv* env, jobject, ARGUMENT_PAIR(klass)))
 C2V_END
 
 C2V_VMENTRY_0(jint, interpreterFrameSize, (JNIEnv* env, jobject, jobject bytecode_frame_handle))
-  if (bytecode_frame_handle == NULL) {
+  if (bytecode_frame_handle == nullptr) {
     JVMCI_THROW_0(NullPointerException);
   }
 
@@ -1828,38 +1828,38 @@ C2V_VMENTRY_0(jboolean, isInternedString, (JNIEnv* env, jobject, jobject object)
   }
   int len;
   jchar* name = java_lang_String::as_unicode_string(str(), len, CHECK_false);
-  return (StringTable::lookup(name, len) != NULL);
+  return (StringTable::lookup(name, len) != nullptr);
 C2V_END
 
 
 C2V_VMENTRY_NULL(jobject, unboxPrimitive, (JNIEnv* env, jobject, jobject object))
-  if (object == NULL) {
+  if (object == nullptr) {
     JVMCI_THROW_0(NullPointerException);
   }
   Handle box = JVMCIENV->asConstant(JVMCIENV->wrap(object), JVMCI_CHECK_NULL);
   BasicType type = java_lang_boxing_object::basic_type(box());
   jvalue result;
   if (java_lang_boxing_object::get_value(box(), &result) == T_ILLEGAL) {
-    return NULL;
+    return nullptr;
   }
   JVMCIObject boxResult = JVMCIENV->create_box(type, &result, JVMCI_CHECK_NULL);
   return JVMCIENV->get_jobject(boxResult);
 C2V_END
 
 C2V_VMENTRY_NULL(jobject, boxPrimitive, (JNIEnv* env, jobject, jobject object))
-  if (object == NULL) {
+  if (object == nullptr) {
     JVMCI_THROW_0(NullPointerException);
   }
   JVMCIObject box = JVMCIENV->wrap(object);
   BasicType type = JVMCIENV->get_box_type(box);
   if (type == T_ILLEGAL) {
-    return NULL;
+    return nullptr;
   }
   jvalue value = JVMCIENV->get_boxed_value(type, box);
   JavaValue box_result(T_OBJECT);
   JavaCallArguments jargs;
-  Klass* box_klass = NULL;
-  Symbol* box_signature = NULL;
+  Klass* box_klass = nullptr;
+  Symbol* box_signature = nullptr;
 #define BOX_CASE(bt, v, argtype, name)           \
   case bt: \
     jargs.push_##argtype(value.v); \
@@ -2056,7 +2056,7 @@ C2V_VMENTRY_NULL(jobject, readFieldValue, (JNIEnv* env, jobject, jobject object,
     JVMCI_THROW_0(NullPointerException);
   }
 
-  // asConstant will throw an NPE if a constant contains NULL
+  // asConstant will throw an NPE if a constant contains null
   Handle obj = JVMCIENV->asConstant(JVMCIENV->wrap(object), JVMCI_CHECK_NULL);
 
   Klass* expected_klass = UNPACK_PAIR(Klass, expected_type);
@@ -2073,7 +2073,7 @@ C2V_END
 
 C2V_VMENTRY_0(jboolean, isInstance, (JNIEnv* env, jobject, ARGUMENT_PAIR(klass), jobject object))
   Klass* klass = UNPACK_PAIR(Klass, klass);
-  if (object == NULL || klass == nullptr) {
+  if (object == nullptr || klass == nullptr) {
     JVMCI_THROW_0(NullPointerException);
   }
   Handle obj = JVMCIENV->asConstant(JVMCIENV->wrap(object), JVMCI_CHECK_0);
@@ -2102,7 +2102,7 @@ C2V_VMENTRY_0(jboolean, isTrustedForIntrinsics, (JNIEnv* env, jobject, ARGUMENT_
 C2V_END
 
 C2V_VMENTRY_NULL(jobject, asJavaType, (JNIEnv* env, jobject, jobject object))
-  if (object == NULL) {
+  if (object == nullptr) {
     JVMCI_THROW_0(NullPointerException);
   }
   Handle obj = JVMCIENV->asConstant(JVMCIENV->wrap(object), JVMCI_CHECK_NULL);
@@ -2117,12 +2117,12 @@ C2V_VMENTRY_NULL(jobject, asJavaType, (JNIEnv* env, jobject, jobject object))
     JVMCIObject type = JVMCIENV->get_jvmci_type(klass_handle, JVMCI_CHECK_NULL);
     return JVMCIENV->get_jobject(type);
   }
-  return NULL;
+  return nullptr;
 C2V_END
 
 
 C2V_VMENTRY_NULL(jobject, asString, (JNIEnv* env, jobject, jobject object))
-  if (object == NULL) {
+  if (object == nullptr) {
     JVMCI_THROW_0(NullPointerException);
   }
   Handle obj = JVMCIENV->asConstant(JVMCIENV->wrap(object), JVMCI_CHECK_NULL);
@@ -2133,7 +2133,7 @@ C2V_END
 
 
 C2V_VMENTRY_0(jboolean, equals, (JNIEnv* env, jobject, jobject x, jlong xHandle, jobject y, jlong yHandle))
-  if (x == NULL || y == NULL) {
+  if (x == nullptr || y == nullptr) {
     JVMCI_THROW_0(NullPointerException);
   }
   return JVMCIENV->resolve_oop_handle(xHandle) == JVMCIENV->resolve_oop_handle(yHandle);
@@ -2151,7 +2151,7 @@ C2V_END
 
 
 C2V_VMENTRY_0(jint, getArrayLength, (JNIEnv* env, jobject, jobject x))
-  if (x == NULL) {
+  if (x == nullptr) {
     JVMCI_THROW_0(NullPointerException);
   }
   Handle xobj = JVMCIENV->asConstant(JVMCIENV->wrap(x), JVMCI_CHECK_0);
@@ -2163,7 +2163,7 @@ C2V_VMENTRY_0(jint, getArrayLength, (JNIEnv* env, jobject, jobject x))
 
 
 C2V_VMENTRY_NULL(jobject, readArrayElement, (JNIEnv* env, jobject, jobject x, int index))
-  if (x == NULL) {
+  if (x == nullptr) {
     JVMCI_THROW_0(NullPointerException);
   }
   Handle xobj = JVMCIENV->asConstant(JVMCIENV->wrap(x), JVMCI_CHECK_NULL);
@@ -2171,7 +2171,7 @@ C2V_VMENTRY_NULL(jobject, readArrayElement, (JNIEnv* env, jobject, jobject x, in
     arrayOop array = arrayOop(xobj());
     BasicType element_type = ArrayKlass::cast(array->klass())->element_type();
     if (index < 0 || index >= array->length()) {
-      return NULL;
+      return nullptr;
     }
     JVMCIObject result;
 
@@ -2198,7 +2198,7 @@ C2V_VMENTRY_NULL(jobject, readArrayElement, (JNIEnv* env, jobject, jobject x, in
     assert(!result.is_null(), "must have a value");
     return JVMCIENV->get_jobject(result);
   }
-  return NULL;;
+  return nullptr;;
 C2V_END
 
 
@@ -2238,16 +2238,16 @@ C2V_VMENTRY_NULL(jlongArray, registerNativeMethods, (JNIEnv* env, jobject, jclas
       peerEnv->describe_pending_exception(true);
     }
     sl_handle = JVMCI::get_shared_library(sl_path, false);
-    if (sl_handle == NULL) {
+    if (sl_handle == nullptr) {
       JVMCI_THROW_MSG_0(InternalError, err_msg("Error initializing JVMCI runtime %d", runtime->id()));
     }
   }
 
-  if (mirror == NULL) {
+  if (mirror == nullptr) {
     JVMCI_THROW_0(NullPointerException);
   }
   Klass* klass = java_lang_Class::as_Klass(JNIHandles::resolve(mirror));
-  if (klass == NULL || !klass->is_instance_klass()) {
+  if (klass == nullptr || !klass->is_instance_klass()) {
     JVMCI_THROW_MSG_0(IllegalArgumentException, "clazz is for primitive type");
   }
 
@@ -2264,25 +2264,25 @@ C2V_VMENTRY_NULL(jlongArray, registerNativeMethods, (JNIEnv* env, jobject, jclas
       // 1) Try JNI short style
       stringStream st;
       char* pure_name = NativeLookup::pure_jni_name(method);
-      guarantee(pure_name != NULL, "Illegal native method name encountered");
+      guarantee(pure_name != nullptr, "Illegal native method name encountered");
       os::print_jni_name_prefix_on(&st, args_size);
       st.print_raw(pure_name);
       os::print_jni_name_suffix_on(&st, args_size);
       char* jni_name = st.as_string();
 
       address entry = (address) os::dll_lookup(sl_handle, jni_name);
-      if (entry == NULL) {
+      if (entry == nullptr) {
         // 2) Try JNI long style
         st.reset();
         char* long_name = NativeLookup::long_jni_name(method);
-        guarantee(long_name != NULL, "Illegal native method name encountered");
+        guarantee(long_name != nullptr, "Illegal native method name encountered");
         os::print_jni_name_prefix_on(&st, args_size);
         st.print_raw(pure_name);
         st.print_raw(long_name);
         os::print_jni_name_suffix_on(&st, args_size);
         char* jni_long_name = st.as_string();
         entry = (address) os::dll_lookup(sl_handle, jni_long_name);
-        if (entry == NULL) {
+        if (entry == nullptr) {
           JVMCI_THROW_MSG_0(UnsatisfiedLinkError, err_msg("%s [neither %s nor %s exist in %s]",
               method->name_and_sig_as_C_string(),
               jni_name, jni_long_name, sl_path));
@@ -2327,7 +2327,7 @@ C2V_VMENTRY_PREFIX(jboolean, isCurrentThreadAttached, (JNIEnv* env, jobject c2vm
 C2V_END
 
 C2V_VMENTRY_PREFIX(jlong, getCurrentJavaThread, (JNIEnv* env, jobject c2vm))
-  if (thread == NULL) {
+  if (thread == nullptr) {
     // Called from unattached JVMCI shared library thread
     return 0L;
   }
@@ -2486,7 +2486,7 @@ C2V_END
 
 C2V_VMENTRY_0(jlong, translate, (JNIEnv* env, jobject, jobject obj_handle, jboolean callPostTranslation))
   requireJVMCINativeLibrary(JVMCI_CHECK_0);
-  if (obj_handle == NULL) {
+  if (obj_handle == nullptr) {
     return 0L;
   }
   JVMCIEnv __peer_jvmci_env__(thread, !JVMCIENV->is_hotspot(), __FILE__, __LINE__);
@@ -2513,13 +2513,13 @@ C2V_VMENTRY_0(jlong, translate, (JNIEnv* env, jobject, jobject obj_handle, jbool
   } else if (thisEnv->isa_HotSpotNmethod(obj)) {
     if (peerEnv->is_hotspot()) {
       nmethod* nm = JVMCIENV->get_nmethod(obj);
-      if (nm != NULL) {
+      if (nm != nullptr) {
         JVMCINMethodData* data = nm->jvmci_nmethod_data();
-        if (data != NULL) {
+        if (data != nullptr) {
           // Only the mirror in the HotSpot heap is accessible
           // through JVMCINMethodData
           oop nmethod_mirror = data->get_nmethod_mirror(nm, /* phantom_ref */ true);
-          if (nmethod_mirror != NULL) {
+          if (nmethod_mirror != nullptr) {
             result = HotSpotJVMCI::wrap(nmethod_mirror);
           }
         }
@@ -2532,13 +2532,13 @@ C2V_VMENTRY_0(jlong, translate, (JNIEnv* env, jobject, jobject obj_handle, jbool
       jboolean isDefault = thisEnv->get_HotSpotNmethod_isDefault(obj);
       jlong compileIdSnapshot = thisEnv->get_HotSpotNmethod_compileIdSnapshot(obj);
       JVMCIObject name_string = thisEnv->get_InstalledCode_name(obj);
-      const char* cstring = name_string.is_null() ? NULL : thisEnv->as_utf8_string(name_string);
+      const char* cstring = name_string.is_null() ? nullptr : thisEnv->as_utf8_string(name_string);
       // Create a new HotSpotNmethod instance in the peer runtime
       result = peerEnv->new_HotSpotNmethod(mh, cstring, isDefault, compileIdSnapshot, JVMCI_CHECK_0);
       nmethod* nm = JVMCIENV->get_nmethod(obj);
       if (result.is_null()) {
         // exception occurred (e.g. OOME) creating a new HotSpotNmethod
-      } else if (nm == NULL) {
+      } else if (nm == nullptr) {
         // nmethod must have been unloaded
       } else {
         // Link the new HotSpotNmethod to the nmethod
@@ -2546,10 +2546,10 @@ C2V_VMENTRY_0(jlong, translate, (JNIEnv* env, jobject, jobject obj_handle, jbool
         // Only HotSpotNmethod instances in the HotSpot heap are tracked directly by the runtime.
         if (peerEnv->is_hotspot()) {
           JVMCINMethodData* data = nm->jvmci_nmethod_data();
-          if (data == NULL) {
+          if (data == nullptr) {
             JVMCI_THROW_MSG_0(IllegalArgumentException, "Cannot set HotSpotNmethod mirror for default nmethod");
           }
-          if (data->get_nmethod_mirror(nm, /* phantom_ref */ false) != NULL) {
+          if (data->get_nmethod_mirror(nm, /* phantom_ref */ false) != nullptr) {
             JVMCI_THROW_MSG_0(IllegalArgumentException, "Cannot overwrite existing HotSpotNmethod mirror for nmethod");
           }
           oop nmethod_mirror = HotSpotJVMCI::resolve(result);
@@ -2574,7 +2574,7 @@ C2V_VMENTRY_0(jlong, translate, (JNIEnv* env, jobject, jobject obj_handle, jbool
 C2V_VMENTRY_NULL(jobject, unhand, (JNIEnv* env, jobject, jlong obj_handle))
   requireJVMCINativeLibrary(JVMCI_CHECK_NULL);
   if (obj_handle == 0L) {
-    return NULL;
+    return nullptr;
   }
   jobject global_handle = (jobject) obj_handle;
   JVMCIObject global_handle_obj = JVMCIENV->wrap(global_handle);
@@ -2593,8 +2593,8 @@ C2V_VMENTRY(void, updateHotSpotNmethod, (JNIEnv* env, jobject, jobject code_hand
 C2V_VMENTRY_NULL(jbyteArray, getCode, (JNIEnv* env, jobject, jobject code_handle))
   JVMCIObject code = JVMCIENV->wrap(code_handle);
   CodeBlob* cb = JVMCIENV->get_code_blob(code);
-  if (cb == NULL) {
-    return NULL;
+  if (cb == nullptr) {
+    return nullptr;
   }
   // Make a resource copy of code before the allocation causes a safepoint
   int code_size = cb->code_size();
@@ -2643,12 +2643,12 @@ C2V_VMENTRY_NULL(jobject, asReflectionField, (JNIEnv* env, jobject, ARGUMENT_PAI
 C2V_VMENTRY_NULL(jobjectArray, getFailedSpeculations, (JNIEnv* env, jobject, jlong failed_speculations_address, jobjectArray current))
   FailedSpeculation* head = *((FailedSpeculation**)(address) failed_speculations_address);
   int result_length = 0;
-  for (FailedSpeculation* fs = head; fs != NULL; fs = fs->next()) {
+  for (FailedSpeculation* fs = head; fs != nullptr; fs = fs->next()) {
     result_length++;
   }
   int current_length = 0;
-  JVMCIObjectArray current_array = NULL;
-  if (current != NULL) {
+  JVMCIObjectArray current_array = nullptr;
+  if (current != nullptr) {
     current_array = JVMCIENV->wrap(current);
     current_length = JVMCIENV->get_length(current_array);
     if (current_length == result_length) {
@@ -2659,7 +2659,7 @@ C2V_VMENTRY_NULL(jobjectArray, getFailedSpeculations, (JNIEnv* env, jobject, jlo
   JVMCIObjectArray result = JVMCIENV->new_byte_array_array(result_length, JVMCI_CHECK_NULL);
   int result_index = 0;
   for (FailedSpeculation* fs = head; result_index < result_length; fs = fs->next()) {
-    assert(fs != NULL, "npe");
+    assert(fs != nullptr, "npe");
     JVMCIPrimitiveArray entry;
     if (result_index < current_length) {
       entry = (JVMCIPrimitiveArray) JVMCIENV->get_object_at(current_array, result_index);
@@ -2675,7 +2675,7 @@ C2V_VMENTRY_NULL(jobjectArray, getFailedSpeculations, (JNIEnv* env, jobject, jlo
 C2V_VMENTRY_0(jlong, getFailedSpeculationsAddress, (JNIEnv* env, jobject, ARGUMENT_PAIR(method)))
   methodHandle method(THREAD, UNPACK_PAIR(Method, method));
   MethodData* method_data = method->method_data();
-  if (method_data == NULL) {
+  if (method_data == nullptr) {
     ClassLoaderData* loader_data = method->method_holder()->class_loader_data();
     method_data = MethodData::allocate(loader_data, method, CHECK_0);
     method->set_method_data(method_data);
@@ -2692,7 +2692,7 @@ C2V_VMENTRY_0(jboolean, addFailedSpeculation, (JNIEnv* env, jobject, jlong faile
   int speculation_len = JVMCIENV->get_length(speculation_handle);
   char* speculation = NEW_RESOURCE_ARRAY(char, speculation_len);
   JVMCIENV->copy_bytes_to(speculation_handle, (jbyte*) speculation, 0, speculation_len);
-  return FailedSpeculation::add_failed_speculation(NULL, (FailedSpeculation**)(address) failed_speculations_address, (address) speculation, speculation_len);
+  return FailedSpeculation::add_failed_speculation(nullptr, (FailedSpeculation**)(address) failed_speculations_address, (address) speculation, speculation_len);
 }
 
 C2V_VMENTRY(void, callSystemExit, (JNIEnv* env, jobject, jint status))

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -1292,7 +1292,7 @@ void resync_vframestream_to_compiled_frame(vframeStream& vfst, intptr_t* stack_p
 }
 
 /*
- * Used by c2v_iterateFrames. Returns an array of any unallocated scope objects or nullptr if none.
+ * Used by c2v_iterateFrames. Returns an array of any unallocated scope objects or null if none.
  */
 GrowableArray<ScopeValue*>* get_unallocated_objects_or_null(GrowableArray<ScopeValue*>* scope_objects) {
   GrowableArray<ScopeValue*>* unallocated = nullptr;

--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -152,7 +152,7 @@ void CompilerToVM::Data::initialize(JVMCI_TRAPS) {
   vm_page_size = os::vm_page_size();
 
 #define SET_TRIGFUNC(name)                                      \
-  if (StubRoutines::name() != nullptr) {                           \
+  if (StubRoutines::name() != nullptr) {                        \
     name = StubRoutines::name();                                \
   } else {                                                      \
     name = CAST_FROM_FN_PTR(address, SharedRuntime::name);      \

--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -140,7 +140,7 @@ void CompilerToVM::Data::initialize(JVMCI_TRAPS) {
   BarrierSet* bs = BarrierSet::barrier_set();
   if (bs->is_a(BarrierSet::CardTableBarrierSet)) {
     CardTable::CardValue* base = ci_card_table_address();
-    assert(base != NULL, "unexpected byte_map_base");
+    assert(base != nullptr, "unexpected byte_map_base");
     cardtable_start_address = base;
     cardtable_shift = CardTable::card_shift();
   } else {
@@ -152,7 +152,7 @@ void CompilerToVM::Data::initialize(JVMCI_TRAPS) {
   vm_page_size = os::vm_page_size();
 
 #define SET_TRIGFUNC(name)                                      \
-  if (StubRoutines::name() != NULL) {                           \
+  if (StubRoutines::name() != nullptr) {                           \
     name = StubRoutines::name();                                \
   } else {                                                      \
     name = CAST_FROM_FN_PTR(address, SharedRuntime::name);      \
@@ -263,7 +263,7 @@ JVMCIObjectArray CompilerToVM::initialize_intrinsics(JVMCI_TRAPS) {
   do { \
     jvalue p; p.j = (jlong) (value); \
     JVMCIObject* e = longs.get(p.j); \
-    if (e == NULL) { \
+    if (e == nullptr) { \
       JVMCIObject h = JVMCIENV->create_box(T_LONG, &p, JVMCI_CHECK_NULL); \
       longs.put(p.j, h); \
       name = h; \
@@ -275,9 +275,9 @@ JVMCIObjectArray CompilerToVM::initialize_intrinsics(JVMCI_TRAPS) {
 #define CSTRING_TO_JSTRING(name, value) \
   JVMCIObject name; \
   do { \
-    if (value != NULL) { \
+    if (value != nullptr) { \
       JVMCIObject* e = strings.get(value); \
-      if (e == NULL) { \
+      if (e == nullptr) { \
         JVMCIObject h = JVMCIENV->create_string(value, JVMCI_CHECK_NULL); \
         strings.put(value, h); \
         name = h; \
@@ -314,7 +314,7 @@ jobjectArray readConfiguration0(JNIEnv *env, JVMCI_TRAPS) {
     CSTRING_TO_JSTRING(name, name_buf);
     CSTRING_TO_JSTRING(type, vmField.typeString);
     JVMCIObject box;
-    if (vmField.isStatic && vmField.typeString != NULL) {
+    if (vmField.isStatic && vmField.typeString != nullptr) {
       if (strcmp(vmField.typeString, "bool") == 0) {
         BOXED_BOOLEAN(box, *(jbyte*) vmField.address);
         assert(box.is_non_null(), "must have a box");
@@ -381,7 +381,7 @@ jobjectArray readConfiguration0(JNIEnv *env, JVMCI_TRAPS) {
 #ifdef ASSERT
 #define CHECK_FLAG(type, name) { \
   const JVMFlag* flag = JVMFlag::find_declared_flag(#name); \
-  assert(flag != NULL, "No such flag named " #name); \
+  assert(flag != nullptr, "No such flag named " #name); \
   assert(flag->is_##type(), "JVMFlag " #name " is not of type " #type); \
 }
 #else

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -1459,7 +1459,7 @@ Handle JVMCIEnv::asConstant(JVMCIObject constant, JVMCI_TRAPS) {
     }
     oop result = resolve_oop_handle(object_handle);
     if (result == nullptr) {
-      JVMCI_THROW_MSG_(InternalError, "Constant was unexpectedly nullptr", Handle());
+      JVMCI_THROW_MSG_(InternalError, "Constant was unexpectedly null", Handle());
     }
     return Handle(THREAD, result);
   } else {
@@ -1472,7 +1472,7 @@ JVMCIObject JVMCIEnv::wrap(jobject object) {
 }
 
 jlong JVMCIEnv::make_oop_handle(const Handle& obj) {
-  assert(!obj.is_null(), "should only create handle for non-nullptr oops");
+  assert(!obj.is_null(), "should only create handle for non-null oops");
   return _runtime->make_oop_handle(obj);
 }
 

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -1689,7 +1689,7 @@ nmethod* JVMCIEnv::get_nmethod(JVMCIObject obj) {
       return (JVMCIObjectArray) wrap(array);                                                                         \
     } else {                                                                                                         \
       JNIAccessMark jni(this);                                                                                       \
-      jobjectArray result = jni()->NewObjectArray(length, JNIJVMCI::className::clazz(), nullptr);                       \
+      jobjectArray result = jni()->NewObjectArray(length, JNIJVMCI::className::clazz(), nullptr);                    \
       return wrap(result);                                                                                           \
     }                                                                                                                \
   }                                                                                                                  \

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ JVMCICompileState::JVMCICompileState(CompileTask* task, JVMCICompiler* compiler)
   _task(task),
   _compiler(compiler),
   _retryable(true),
-  _failure_reason(NULL),
+  _failure_reason(nullptr),
   _failure_reason_on_C_heap(false) {
   // Get Jvmti capabilities under lock to get consistent values.
   MutexLocker mu(JvmtiThreadState_lock);
@@ -61,7 +61,7 @@ JVMCICompileState::JVMCICompileState(CompileTask* task, JVMCICompiler* compiler)
   _jvmti_can_access_local_variables     = JvmtiExport::can_access_local_variables() ? 1 : 0;
   _jvmti_can_post_on_exceptions         = JvmtiExport::can_post_on_exceptions() ? 1 : 0;
   _jvmti_can_pop_frame                  = JvmtiExport::can_pop_frame() ? 1 : 0;
-  _target_method_is_old                 = _task != NULL && _task->method()->is_old();
+  _target_method_is_old                 = _task != nullptr && _task->method()->is_old();
   if (task->is_blocking()) {
     task->set_blocking_jvmci_compile_state(this);
   }
@@ -173,8 +173,8 @@ void JVMCIEnv::copy_saved_properties(jbyte* properties, int properties_len, JVMC
 }
 
 void JVMCIEnv::init_env_mode_runtime(JavaThread* thread, JNIEnv* parent_env, bool attach_OOME_is_fatal) {
-  assert(thread != NULL, "npe");
-  _env = NULL;
+  assert(thread != nullptr, "npe");
+  _env = nullptr;
   _pop_frame_on_close = false;
   _detach_on_close = false;
   if (!UseJVMCINativeLibrary) {
@@ -184,7 +184,7 @@ void JVMCIEnv::init_env_mode_runtime(JavaThread* thread, JNIEnv* parent_env, boo
     return;
   }
 
-  if (parent_env != NULL) {
+  if (parent_env != nullptr) {
     // If the parent JNI environment is non-null then figure out whether it
     // is a HotSpot or shared library JNIEnv and set the state appropriately.
     _is_hotspot = thread->jni_environment() == parent_env;
@@ -194,7 +194,7 @@ void JVMCIEnv::init_env_mode_runtime(JavaThread* thread, JNIEnv* parent_env, boo
       return;
     }
     _runtime = thread->libjvmci_runtime();
-    assert(_runtime != NULL, "npe");
+    assert(_runtime != nullptr, "npe");
     _env = parent_env;
     return;
   }
@@ -206,12 +206,12 @@ void JVMCIEnv::init_env_mode_runtime(JavaThread* thread, JNIEnv* parent_env, boo
   _runtime = JVMCI::compiler_runtime(thread);
   _env = _runtime->init_shared_library_javavm();
 
-  if (_env != NULL) {
+  if (_env != nullptr) {
     // Creating the JVMCI shared library VM also attaches the current thread
     _detach_on_close = true;
   } else {
     _runtime->GetEnv(thread, (void**)&parent_env, JNI_VERSION_1_2);
-    if (parent_env != NULL) {
+    if (parent_env != nullptr) {
       // Even though there's a parent JNI env, there's no guarantee
       // it was opened by a JVMCIEnv scope and thus may not have
       // pushed a local JNI frame. As such, we use a new JNI local
@@ -223,12 +223,12 @@ void JVMCIEnv::init_env_mode_runtime(JavaThread* thread, JNIEnv* parent_env, boo
       JavaVMAttachArgs attach_args;
       attach_args.version = JNI_VERSION_1_2;
       attach_args.name = const_cast<char*>(thread->name());
-      attach_args.group = NULL;
+      attach_args.group = nullptr;
       jint attach_result = _runtime->AttachCurrentThread(thread, (void**) &_env, &attach_args);
       if (attach_result == JNI_OK) {
         _detach_on_close = true;
       } else if (!attach_OOME_is_fatal && attach_result == JNI_ENOMEM) {
-        _env = NULL;
+        _env = nullptr;
         _attach_threw_OOME = true;
         return;
       } else {
@@ -237,7 +237,7 @@ void JVMCIEnv::init_env_mode_runtime(JavaThread* thread, JNIEnv* parent_env, boo
     }
   }
 
-  assert(_env != NULL, "missing env");
+  assert(_env != nullptr, "missing env");
   assert(_throw_to_caller == false, "must be");
 
   JNIAccessMark jni(this, thread);
@@ -254,37 +254,37 @@ JVMCIEnv::JVMCIEnv(JavaThread* thread, JVMCICompileState* compile_state, const c
     _throw_to_caller(false), _file(file), _line(line), _attach_threw_OOME(false), _compile_state(compile_state) {
   // In case of OOME, there's a good chance a subsequent attempt to attach might succeed.
   // Other errors most likely indicate a non-recoverable error in the JVMCI runtime.
-  init_env_mode_runtime(thread, NULL, false);
+  init_env_mode_runtime(thread, nullptr, false);
   if (_attach_threw_OOME) {
     compile_state->set_failure(true, "Out of memory while attaching JVMCI compiler to current thread");
   }
 }
 
 JVMCIEnv::JVMCIEnv(JavaThread* thread, const char* file, int line):
-    _throw_to_caller(false), _file(file), _line(line), _attach_threw_OOME(false), _compile_state(NULL) {
-  init_env_mode_runtime(thread, NULL);
+    _throw_to_caller(false), _file(file), _line(line), _attach_threw_OOME(false), _compile_state(nullptr) {
+  init_env_mode_runtime(thread, nullptr);
 }
 
 JVMCIEnv::JVMCIEnv(JavaThread* thread, JNIEnv* parent_env, const char* file, int line):
-    _throw_to_caller(true), _file(file), _line(line), _attach_threw_OOME(false), _compile_state(NULL) {
+    _throw_to_caller(true), _file(file), _line(line), _attach_threw_OOME(false), _compile_state(nullptr) {
   init_env_mode_runtime(thread, parent_env);
-  assert(_env == NULL || parent_env == _env, "mismatched JNIEnvironment");
+  assert(_env == nullptr || parent_env == _env, "mismatched JNIEnvironment");
 }
 
 void JVMCIEnv::init(JavaThread* thread, bool is_hotspot, const char* file, int line) {
-  _compile_state = NULL;
+  _compile_state = nullptr;
   _throw_to_caller = false;
   _file = file;
   _line = line;
   _attach_threw_OOME = false;
   if (is_hotspot) {
-    _env = NULL;
+    _env = nullptr;
     _pop_frame_on_close = false;
     _detach_on_close = false;
     _is_hotspot = true;
     _runtime = JVMCI::java_runtime();
   } else {
-    init_env_mode_runtime(thread, NULL);
+    init_env_mode_runtime(thread, nullptr);
   }
 }
 
@@ -294,9 +294,9 @@ void JVMCIEnv::describe_pending_exception(bool clear) {
   if (!is_hotspot()) {
     JNIAccessMark jni(this, THREAD);
     if (jni()->ExceptionCheck()) {
-      jthrowable ex = !clear ? jni()->ExceptionOccurred() : NULL;
+      jthrowable ex = !clear ? jni()->ExceptionOccurred() : nullptr;
       jni()->ExceptionDescribe();
-      if (ex != NULL) {
+      if (ex != nullptr) {
         jni()->Throw(ex);
       }
     }
@@ -310,8 +310,8 @@ void JVMCIEnv::describe_pending_exception(bool clear) {
 // Shared code for translating an exception from HotSpot to libjvmci or vice versa.
 class ExceptionTranslation: public StackObj {
  protected:
-  JVMCIEnv*  _from_env; // Source of translation. Can be nullptr.
-  JVMCIEnv*  _to_env;   // Destination of translation. Never nullptr.
+  JVMCIEnv*  _from_env; // Source of translation. Can be null.
+  JVMCIEnv*  _to_env;   // Destination of translation. Never null.
 
   ExceptionTranslation(JVMCIEnv* from_env, JVMCIEnv* to_env) : _from_env(from_env), _to_env(to_env) {}
 
@@ -484,7 +484,7 @@ JVMCIEnv::~JVMCIEnv() {
     if (_pop_frame_on_close) {
       // Pop the JNI local frame that was pushed when entering this JVMCIEnv scope.
       JNIAccessMark jni(this);
-      jni()->PopLocalFrame(NULL);
+      jni()->PopLocalFrame(nullptr);
     }
 
     if (has_pending_exception()) {
@@ -737,7 +737,7 @@ JVMCIObject JVMCIEnv::create_box(BasicType type, jvalue* value, JVMCI_TRAPS) {
   } else {
     JNIAccessMark jni(this, THREAD);
     jobject box = jni()->NewObjectA(JNIJVMCI::box_class(type), JNIJVMCI::box_constructor(type), value);
-    assert(box != NULL, "");
+    assert(box != nullptr, "");
     return wrap(box);
   }
 }
@@ -1028,7 +1028,7 @@ JVMCIObject JVMCIEnv::new_StackTraceElement(const methodHandle& method, int bci,
     oop method_name = StringTable::intern(method_name_sym, CHECK_(JVMCIObject()));
     HotSpotJVMCI::StackTraceElement::set_methodName(this, obj(), method_name);
 
-    if (file_name_sym != NULL) {
+    if (file_name_sym != nullptr) {
       oop file_name = StringTable::intern(file_name_sym, CHECK_(JVMCIObject()));
       HotSpotJVMCI::StackTraceElement::set_fileName(this, obj(), file_name);
     }
@@ -1044,8 +1044,8 @@ JVMCIObject JVMCIEnv::new_StackTraceElement(const methodHandle& method, int bci,
     if (jni()->ExceptionCheck()) {
       return JVMCIObject();
     }
-    jobject file_name = NULL;
-    if (file_name_sym != NULL) {
+    jobject file_name = nullptr;
+    if (file_name_sym != nullptr) {
       file_name = jni()->NewStringUTF(file_name_sym->as_C_string());
       if (jni()->ExceptionCheck()) {
         return JVMCIObject();
@@ -1088,7 +1088,7 @@ JVMCIObject JVMCIEnv::new_HotSpotNmethod(const methodHandle& method, const char*
     return wrap(obj_h());
   } else {
     JNIAccessMark jni(this, THREAD);
-    jobject nameStr = name == NULL ? NULL : jni()->NewStringUTF(name);
+    jobject nameStr = name == nullptr ? nullptr : jni()->NewStringUTF(name);
     if (jni()->ExceptionCheck()) {
       return JVMCIObject();
     }
@@ -1159,7 +1159,7 @@ const char* JVMCIEnv::klass_name(JVMCIObject object) {
 
 JVMCIObject JVMCIEnv::get_jvmci_method(const methodHandle& method, JVMCI_TRAPS) {
   JVMCIObject method_object;
-  if (method() == NULL) {
+  if (method() == nullptr) {
     return method_object;
   }
 
@@ -1310,7 +1310,7 @@ JVMCIObjectArray JVMCIEnv::new_byte_array_array(int length, JVMCI_TRAPS) {
     return wrap(result);
   } else {
     JNIAccessMark jni(this, THREAD);
-    jobjectArray result = jni()->NewObjectArray(length, JNIJVMCI::byte_array(), NULL);
+    jobjectArray result = jni()->NewObjectArray(length, JNIJVMCI::byte_array(), nullptr);
     return wrap(result);
   }
 }
@@ -1458,8 +1458,8 @@ Handle JVMCIEnv::asConstant(JVMCIObject constant, JVMCI_TRAPS) {
       JVMCI_THROW_MSG_(NullPointerException, "Foreign object reference has been cleared", Handle());
     }
     oop result = resolve_oop_handle(object_handle);
-    if (result == NULL) {
-      JVMCI_THROW_MSG_(InternalError, "Constant was unexpectedly NULL", Handle());
+    if (result == nullptr) {
+      JVMCI_THROW_MSG_(InternalError, "Constant was unexpectedly nullptr", Handle());
     }
     return Handle(THREAD, result);
   } else {
@@ -1472,14 +1472,14 @@ JVMCIObject JVMCIEnv::wrap(jobject object) {
 }
 
 jlong JVMCIEnv::make_oop_handle(const Handle& obj) {
-  assert(!obj.is_null(), "should only create handle for non-NULL oops");
+  assert(!obj.is_null(), "should only create handle for non-nullptr oops");
   return _runtime->make_oop_handle(obj);
 }
 
 oop JVMCIEnv::resolve_oop_handle(jlong oopHandle) {
   assert(oopHandle != 0, "should be a valid handle");
   oop obj = *((oopDesc**) oopHandle);
-  if (obj != NULL) {
+  if (obj != nullptr) {
     oopDesc::verify(obj);
   }
   return obj;
@@ -1568,7 +1568,7 @@ void JVMCIEnv::invalidate_nmethod_mirror(JVMCIObject mirror, bool deoptimize, JV
   }
 
   nmethod* nm = JVMCIENV->get_nmethod(mirror);
-  if (nm == NULL) {
+  if (nm == nullptr) {
     // Nothing to do
     return;
   }
@@ -1615,30 +1615,30 @@ ConstantPool* JVMCIEnv::asConstantPool(JVMCIObject obj) {
 
 // Lookup an nmethod with a matching base and compile id
 nmethod* JVMCIEnv::lookup_nmethod(address code, jlong compile_id_snapshot) {
-  if (code == NULL) {
-    return NULL;
+  if (code == nullptr) {
+    return nullptr;
   }
 
   CodeBlob* cb = CodeCache::find_blob(code);
   if (cb == (CodeBlob*) code) {
     nmethod* nm = cb->as_nmethod_or_null();
-    if (nm != NULL && (compile_id_snapshot == 0 || nm->compile_id() == compile_id_snapshot)) {
+    if (nm != nullptr && (compile_id_snapshot == 0 || nm->compile_id() == compile_id_snapshot)) {
       return nm;
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 
 CodeBlob* JVMCIEnv::get_code_blob(JVMCIObject obj) {
   address code = (address) get_InstalledCode_address(obj);
-  if (code == NULL) {
-    return NULL;
+  if (code == nullptr) {
+    return nullptr;
   }
   if (isa_HotSpotNmethod(obj)) {
     jlong compile_id_snapshot = get_HotSpotNmethod_compileIdSnapshot(obj);
     nmethod* nm = lookup_nmethod(code, compile_id_snapshot);
-    if (nm != NULL && compile_id_snapshot != 0L && nm->is_not_entrant()) {
+    if (nm != nullptr && compile_id_snapshot != 0L && nm->is_not_entrant()) {
       // Zero the entry point so that the nmethod
       // cannot be invoked by the mirror but can
       // still be deoptimized.
@@ -1647,7 +1647,7 @@ CodeBlob* JVMCIEnv::get_code_blob(JVMCIObject obj) {
       nm = lookup_nmethod(code, compile_id_snapshot);
     }
 
-    if (nm == NULL) {
+    if (nm == nullptr) {
       // The HotSpotNmethod was pointing at some nmethod but the nmethod is no longer valid, so
       // clear the InstalledCode fields of this HotSpotNmethod so that it no longer refers to a
       // nmethod in the code cache.
@@ -1665,10 +1665,10 @@ CodeBlob* JVMCIEnv::get_code_blob(JVMCIObject obj) {
 
 nmethod* JVMCIEnv::get_nmethod(JVMCIObject obj) {
   CodeBlob* cb = get_code_blob(obj);
-  if (cb != NULL) {
+  if (cb != nullptr) {
     return cb->as_nmethod_or_null();
   }
-  return NULL;
+  return nullptr;
 }
 
 // Generate implementations for the initialize, new, isa, get and set methods for all the types and
@@ -1689,7 +1689,7 @@ nmethod* JVMCIEnv::get_nmethod(JVMCIObject obj) {
       return (JVMCIObjectArray) wrap(array);                                                                         \
     } else {                                                                                                         \
       JNIAccessMark jni(this);                                                                                       \
-      jobjectArray result = jni()->NewObjectArray(length, JNIJVMCI::className::clazz(), NULL);                       \
+      jobjectArray result = jni()->NewObjectArray(length, JNIJVMCI::className::clazz(), nullptr);                       \
       return wrap(result);                                                                                           \
     }                                                                                                                \
   }                                                                                                                  \

--- a/src/hotspot/share/jvmci/jvmciEnv.hpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ class JVMCIRuntime;
     if (env->ExceptionCheck()) { \
       if (env != JavaThread::current()->jni_environment()) { \
         char* sl_path; \
-        if (::JVMCI::get_shared_library(sl_path, false) != NULL) { \
+        if (::JVMCI::get_shared_library(sl_path, false) != nullptr) { \
           tty->print_cr("In JVMCI shared library (%s):", sl_path); \
         } \
       } \
@@ -64,11 +64,11 @@ class JVMCIKlassHandle : public StackObj {
   Thread*    _thread;
 
   Klass*        klass() const                     { return _klass; }
-  Klass*        non_null_klass() const            { assert(_klass != NULL, "resolving NULL _klass"); return _klass; }
+  Klass*        non_null_klass() const            { assert(_klass != nullptr, "resolving nullptr _klass"); return _klass; }
 
  public:
   /* Constructors */
-  JVMCIKlassHandle (Thread* thread) : _klass(NULL), _thread(thread) {}
+  JVMCIKlassHandle (Thread* thread) : _klass(nullptr), _thread(thread) {}
   JVMCIKlassHandle (Thread* thread, Klass* klass);
 
   JVMCIKlassHandle (const JVMCIKlassHandle &h): _klass(h._klass), _holder(h._holder), _thread(h._thread) {}
@@ -83,8 +83,8 @@ class JVMCIKlassHandle : public StackObj {
   bool    operator == (const JVMCIKlassHandle& h) const  { return klass() == h.klass(); }
 
   /* Null checks */
-  bool    is_null() const                      { return _klass == NULL; }
-  bool    not_null() const                     { return _klass != NULL; }
+  bool    is_null() const                      { return _klass == nullptr; }
+  bool    not_null() const                     { return _klass != nullptr; }
 };
 
 // A class that maintains the state needed for compilations requested
@@ -299,10 +299,10 @@ public:
   bool equals(JVMCIObject a, JVMCIObject b);
 
   // Convert into a JNI handle for the appropriate runtime
-  jobject get_jobject(JVMCIObject object)                       { assert(object.as_jobject() == NULL || is_hotspot() == object.is_hotspot(), "mismatch"); return object.as_jobject(); }
-  jarray get_jarray(JVMCIArray array)                           { assert(array.as_jobject() == NULL || is_hotspot() == array.is_hotspot(), "mismatch"); return array.as_jobject(); }
-  jobjectArray get_jobjectArray(JVMCIObjectArray objectArray)   { assert(objectArray.as_jobject() == NULL || is_hotspot() == objectArray.is_hotspot(), "mismatch"); return objectArray.as_jobject(); }
-  jbyteArray get_jbyteArray(JVMCIPrimitiveArray primitiveArray) { assert(primitiveArray.as_jobject() == NULL || is_hotspot() == primitiveArray.is_hotspot(), "mismatch"); return primitiveArray.as_jbyteArray(); }
+  jobject get_jobject(JVMCIObject object)                       { assert(object.as_jobject() == nullptr || is_hotspot() == object.is_hotspot(), "mismatch"); return object.as_jobject(); }
+  jarray get_jarray(JVMCIArray array)                           { assert(array.as_jobject() == nullptr || is_hotspot() == array.is_hotspot(), "mismatch"); return array.as_jobject(); }
+  jobjectArray get_jobjectArray(JVMCIObjectArray objectArray)   { assert(objectArray.as_jobject() == nullptr || is_hotspot() == objectArray.is_hotspot(), "mismatch"); return objectArray.as_jobject(); }
+  jbyteArray get_jbyteArray(JVMCIPrimitiveArray primitiveArray) { assert(primitiveArray.as_jobject() == nullptr || is_hotspot() == primitiveArray.is_hotspot(), "mismatch"); return primitiveArray.as_jbyteArray(); }
 
   JVMCIObject         wrap(jobject obj);
   JVMCIObjectArray    wrap(jobjectArray obj)  { return (JVMCIObjectArray)    wrap((jobject) obj); }
@@ -345,7 +345,7 @@ public:
   BasicType kindToBasicType(JVMCIObject kind, JVMCI_TRAPS);
 
 #define DO_THROW(name) \
-  void throw_##name(const char* msg = NULL);
+  void throw_##name(const char* msg = nullptr);
 
   DO_THROW(InternalError)
   DO_THROW(ArrayIndexOutOfBoundsException)
@@ -447,7 +447,7 @@ public:
 
   JVMCICompileState* compile_state() { return _compile_state; }
   void set_compile_state(JVMCICompileState* compile_state) {
-    assert(_compile_state == NULL, "set only once");
+    assert(_compile_state == nullptr, "set only once");
     _compile_state = compile_state;
   }
   // Generate declarations for the initialize, new, isa, get and set methods for all the types and

--- a/src/hotspot/share/jvmci/jvmciEnv.hpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.hpp
@@ -64,7 +64,7 @@ class JVMCIKlassHandle : public StackObj {
   Thread*    _thread;
 
   Klass*        klass() const                     { return _klass; }
-  Klass*        non_null_klass() const            { assert(_klass != nullptr, "resolving nullptr _klass"); return _klass; }
+  Klass*        non_null_klass() const            { assert(_klass != nullptr, "resolving null _klass"); return _klass; }
 
  public:
   /* Constructors */

--- a/src/hotspot/share/jvmci/jvmciExceptions.hpp
+++ b/src/hotspot/share/jvmci/jvmciExceptions.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ class JVMCIEnv;
 #define JVMCI_CHECK                                    JVMCIENV); if (JVMCI_HAS_PENDING_EXCEPTION) return       ; (void)(0
 #define JVMCI_CHECK_(result)                           JVMCIENV); if (JVMCI_HAS_PENDING_EXCEPTION) return result; (void)(0
 #define JVMCI_CHECK_0                                  JVMCI_CHECK_(0)
-#define JVMCI_CHECK_NULL                               JVMCI_CHECK_(NULL)
+#define JVMCI_CHECK_NULL                               JVMCI_CHECK_(nullptr)
 #define JVMCI_CHECK_false                              JVMCI_CHECK_(false)
 #define JVMCI_CHECK_OK                                 JVMCI_CHECK_(JVMCI::ok)
 
@@ -58,13 +58,13 @@ class JVMCIEnv;
   { JVMCIENV->fthrow_error( __FILE__, __LINE__, __VA_ARGS__); return ret; }
 
 #define JVMCI_ERROR_0(...)    JVMCI_ERROR_(0, __VA_ARGS__)
-#define JVMCI_ERROR_NULL(...) JVMCI_ERROR_(NULL, __VA_ARGS__)
+#define JVMCI_ERROR_NULL(...) JVMCI_ERROR_(nullptr, __VA_ARGS__)
 #define JVMCI_ERROR_OK(...)   JVMCI_ERROR_(JVMCI::ok, __VA_ARGS__)
 
 #define JVMCI_THROW(name) { JVMCIENV->throw_##name(); return; }
-#define JVMCI_THROW_NULL(name) { JVMCIENV->throw_##name(); return NULL; }
+#define JVMCI_THROW_NULL(name) { JVMCIENV->throw_##name(); return nullptr; }
 #define JVMCI_THROW_0(name) { JVMCIENV->throw_##name(); return 0; }
-#define JVMCI_THROW_MSG_NULL(name, msg) { JVMCIENV->throw_##name(msg); return NULL; }
+#define JVMCI_THROW_MSG_NULL(name, msg) { JVMCIENV->throw_##name(msg); return nullptr; }
 #define JVMCI_THROW_MSG_(name, msg, value) { JVMCIENV->throw_##name(msg); return (value); }
 #define JVMCI_THROW_MSG_0(name, msg) { JVMCIENV->throw_##name(msg); return 0; }
 #define JVMCI_THROW_MSG(name, msg) { JVMCIENV->throw_##name(msg); return; }

--- a/src/hotspot/share/jvmci/jvmciJavaClasses.cpp
+++ b/src/hotspot/share/jvmci/jvmciJavaClasses.cpp
@@ -199,7 +199,7 @@ void HotSpotJVMCI::compute_offsets(TRAPS) {
     return resolve(object)->is_a(className::klass());                                   \
   }                                                                                     \
   void HotSpotJVMCI::className::check(oop obj, const char* field_name, int offset) {    \
-    assert(obj != nullptr, "nullptr field access of %s.%s", #className, field_name); \
+    assert(obj != nullptr, "null field access of %s.%s", #className, field_name);       \
     assert(obj->is_a(className::klass()), "wrong class, " #className " expected, found %s", obj->klass()->external_name()); \
     assert(offset != 0, "must be valid offset");                                        \
   }                                                                                     \
@@ -225,28 +225,28 @@ void HotSpotJVMCI::compute_offsets(TRAPS) {
 #define STATIC_OBJECTARRAY_FIELD(className, name, signature) STATIC_OOPISH_FIELD(className, name, objArrayOop)
 #define STATIC_OOPISH_FIELD(className, name, type)                                                                        \
     type HotSpotJVMCI::className::name(JVMCIEnv* env) {                                                                   \
-      assert(className::klass() != nullptr && className::klass()->is_linked(), "Class not yet linked: " #className);         \
+      assert(className::klass() != nullptr && className::klass()->is_linked(), "Class not yet linked: " #className);      \
       InstanceKlass* ik = className::klass();                                                                             \
       oop base = ik->static_field_base_raw();                                                                             \
       oop result = HeapAccess<>::oop_load_at(base, className::_##name##_offset);                                          \
       return type(result);                                                                                                \
     }                                                                                                                     \
     void HotSpotJVMCI::className::set_##name(JVMCIEnv* env, type x) {                                                     \
-      assert(className::klass() != nullptr && className::klass()->is_linked(), "Class not yet linked: " #className);         \
-      assert(className::klass() != nullptr, "Class not yet loaded: " #className);                                            \
+      assert(className::klass() != nullptr && className::klass()->is_linked(), "Class not yet linked: " #className);      \
+      assert(className::klass() != nullptr, "Class not yet loaded: " #className);                                         \
       InstanceKlass* ik = className::klass();                                                                             \
       oop base = ik->static_field_base_raw();                                                                             \
       HeapAccess<>::oop_store_at(base, className::_##name##_offset, x);                                                   \
     }
 #define STATIC_PRIMITIVE_FIELD(className, name, jtypename)                                                                \
     jtypename HotSpotJVMCI::className::get_##name(JVMCIEnv* env) {                                                        \
-      assert(className::klass() != nullptr && className::klass()->is_linked(), "Class not yet linked: " #className);         \
+      assert(className::klass() != nullptr && className::klass()->is_linked(), "Class not yet linked: " #className);      \
       InstanceKlass* ik = className::klass();                                                                             \
       oop base = ik->static_field_base_raw();                                                                             \
       return *base->field_addr<jtypename>(className::_##name##_offset);                                                   \
     }                                                                                                                     \
     void HotSpotJVMCI::className::set_##name(JVMCIEnv* env, jtypename x) {                                                \
-      assert(className::klass() != nullptr && className::klass()->is_linked(), "Class not yet linked: " #className);         \
+      assert(className::klass() != nullptr && className::klass()->is_linked(), "Class not yet linked: " #className);      \
       InstanceKlass* ik = className::klass();                                                                             \
       oop base = ik->static_field_base_raw();                                                                             \
       *base->field_addr<jtypename>(className::_##name##_offset) = x;                                                      \
@@ -621,8 +621,8 @@ JVMCI_CLASSES_DO(EMPTY2, EMPTY0, FIELD2, FIELD2, FIELD2, FIELD2, FIELD2, FIELD3,
     return jni()->IsInstanceOf(object.as_jobject(), className::clazz()) != 0;                                                     \
   }                                                                                                                               \
   void JNIJVMCI::className::check(JVMCIEnv* jvmciEnv, JVMCIObject obj, const char* field_name, jfieldID offset) {                 \
-    assert(obj.is_non_null(), "nullptr field access of %s.%s", #className, field_name);                                     \
-    assert(jvmciEnv->isa_##className(obj), "wrong class, " #className " expected, found %s", jvmciEnv->klass_name(obj)); \
+    assert(obj.is_non_null(), "null field access of %s.%s", #className, field_name);                                              \
+    assert(jvmciEnv->isa_##className(obj), "wrong class, " #className " expected, found %s", jvmciEnv->klass_name(obj));          \
     assert(offset != 0, "must be valid offset");                                                                                  \
   }                                                                                                                               \
   jclass JNIJVMCI::className::_class = nullptr;

--- a/src/hotspot/share/jvmci/jvmciJavaClasses.cpp
+++ b/src/hotspot/share/jvmci/jvmciJavaClasses.cpp
@@ -486,11 +486,11 @@ void JNIJVMCI::initialize_ids(JNIEnv* env) {
 
 #define DO_BOX_CLASS(klass, basicType, type) \
   current_class_name = "java/lang/" #klass;                                                                       \
-  if (JVMCILibDumpJNIConfig == nullptr) {                                                                            \
+  if (JVMCILibDumpJNIConfig == nullptr) {                                                                         \
     _box_classes[basicType] = env->FindClass("java/lang/" #klass);                                                \
     JVMCI_EXCEPTION_CHECK(env, "FindClass(%s)", #klass);                                                          \
     _box_classes[basicType] = (jclass) env->NewGlobalRef(_box_classes[basicType]);                                \
-    assert(_box_classes[basicType] != nullptr, "uninitialized");                                                     \
+    assert(_box_classes[basicType] != nullptr, "uninitialized");                                                  \
     _box_fields[basicType] = env->GetFieldID(_box_classes[basicType], "value", #type);                            \
     JVMCI_EXCEPTION_CHECK(env, "GetFieldID(%s, value, %s)", #klass, #type);                                       \
     GET_JNI_METHOD(GetMethodID, _box_constructors[basicType], _box_classes[basicType], "<init>", "(" #type ")V"); \

--- a/src/hotspot/share/jvmci/jvmciJavaClasses.cpp
+++ b/src/hotspot/share/jvmci/jvmciJavaClasses.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ void HotSpotJVMCI::compute_offset(int &dest_offset, Klass* klass, const char* na
   InstanceKlass* ik = InstanceKlass::cast(klass);
   Symbol* name_symbol = SymbolTable::probe(name, (int)strlen(name));
   Symbol* signature_symbol = SymbolTable::probe(signature, (int)strlen(signature));
-  if (name_symbol == NULL || signature_symbol == NULL) {
+  if (name_symbol == nullptr || signature_symbol == nullptr) {
 #ifndef PRODUCT
     ik->print_on(tty);
 #endif
@@ -97,8 +97,8 @@ void HotSpotJVMCI::compute_offset(int &dest_offset, Klass* klass, const char* na
 
 #ifndef PRODUCT
 static void check_resolve_method(const char* call_type, Klass* resolved_klass, Symbol* method_name, Symbol* method_signature, TRAPS) {
-  Method* method = NULL;
-  LinkInfo link_info(resolved_klass, method_name, method_signature, NULL, LinkInfo::AccessCheck::skip, LinkInfo::LoaderConstraintCheck::skip);
+  Method* method = nullptr;
+  LinkInfo link_info(resolved_klass, method_name, method_signature, nullptr, LinkInfo::AccessCheck::skip, LinkInfo::LoaderConstraintCheck::skip);
   if (strcmp(call_type, "call_static") == 0) {
     method = LinkResolver::resolve_static_call_or_null(link_info);
   } else if (strcmp(call_type, "call_virtual") == 0) {
@@ -108,7 +108,7 @@ static void check_resolve_method(const char* call_type, Klass* resolved_klass, S
   } else {
     fatal("Unknown or unsupported call type: %s", call_type);
   }
-  if (method == NULL) {
+  if (method == nullptr) {
     fatal("Could not resolve %s.%s%s", resolved_klass->external_name(), method_name->as_C_string(), method_signature->as_C_string());
   }
 }
@@ -199,11 +199,11 @@ void HotSpotJVMCI::compute_offsets(TRAPS) {
     return resolve(object)->is_a(className::klass());                                   \
   }                                                                                     \
   void HotSpotJVMCI::className::check(oop obj, const char* field_name, int offset) {    \
-    assert(obj != NULL, "NULL field access of %s.%s", #className, field_name); \
+    assert(obj != nullptr, "nullptr field access of %s.%s", #className, field_name); \
     assert(obj->is_a(className::klass()), "wrong class, " #className " expected, found %s", obj->klass()->external_name()); \
     assert(offset != 0, "must be valid offset");                                        \
   }                                                                                     \
-  InstanceKlass* HotSpotJVMCI::className::_klass = NULL;
+  InstanceKlass* HotSpotJVMCI::className::_klass = nullptr;
 
 #define END_CLASS
 
@@ -225,28 +225,28 @@ void HotSpotJVMCI::compute_offsets(TRAPS) {
 #define STATIC_OBJECTARRAY_FIELD(className, name, signature) STATIC_OOPISH_FIELD(className, name, objArrayOop)
 #define STATIC_OOPISH_FIELD(className, name, type)                                                                        \
     type HotSpotJVMCI::className::name(JVMCIEnv* env) {                                                                   \
-      assert(className::klass() != NULL && className::klass()->is_linked(), "Class not yet linked: " #className);         \
+      assert(className::klass() != nullptr && className::klass()->is_linked(), "Class not yet linked: " #className);         \
       InstanceKlass* ik = className::klass();                                                                             \
       oop base = ik->static_field_base_raw();                                                                             \
       oop result = HeapAccess<>::oop_load_at(base, className::_##name##_offset);                                          \
       return type(result);                                                                                                \
     }                                                                                                                     \
     void HotSpotJVMCI::className::set_##name(JVMCIEnv* env, type x) {                                                     \
-      assert(className::klass() != NULL && className::klass()->is_linked(), "Class not yet linked: " #className);         \
-      assert(className::klass() != NULL, "Class not yet loaded: " #className);                                            \
+      assert(className::klass() != nullptr && className::klass()->is_linked(), "Class not yet linked: " #className);         \
+      assert(className::klass() != nullptr, "Class not yet loaded: " #className);                                            \
       InstanceKlass* ik = className::klass();                                                                             \
       oop base = ik->static_field_base_raw();                                                                             \
       HeapAccess<>::oop_store_at(base, className::_##name##_offset, x);                                                   \
     }
 #define STATIC_PRIMITIVE_FIELD(className, name, jtypename)                                                                \
     jtypename HotSpotJVMCI::className::get_##name(JVMCIEnv* env) {                                                        \
-      assert(className::klass() != NULL && className::klass()->is_linked(), "Class not yet linked: " #className);         \
+      assert(className::klass() != nullptr && className::klass()->is_linked(), "Class not yet linked: " #className);         \
       InstanceKlass* ik = className::klass();                                                                             \
       oop base = ik->static_field_base_raw();                                                                             \
       return *base->field_addr<jtypename>(className::_##name##_offset);                                                   \
     }                                                                                                                     \
     void HotSpotJVMCI::className::set_##name(JVMCIEnv* env, jtypename x) {                                                \
-      assert(className::klass() != NULL && className::klass()->is_linked(), "Class not yet linked: " #className);         \
+      assert(className::klass() != nullptr && className::klass()->is_linked(), "Class not yet linked: " #className);         \
       InstanceKlass* ik = className::klass();                                                                             \
       oop base = ik->static_field_base_raw();                                                                             \
       *base->field_addr<jtypename>(className::_##name##_offset) = x;                                                      \
@@ -266,7 +266,7 @@ void HotSpotJVMCI::compute_offsets(TRAPS) {
  *  oop HotSpotJVMCI::Architecture::wordKind(JVMCIEnv* env, oop obj) { ... }
  * void HotSpotJVMCI::Architecture::set_wordKind(JVMCIEnv* env, oop obj, oop x) { ... }
  *
- * InstanceKlass *HotSpotJVMCI::Architecture::_klass = NULL;
+ * InstanceKlass *HotSpotJVMCI::Architecture::_klass = nullptr;
  */
 JVMCI_CLASSES_DO(START_CLASS, END_CLASS, CHAR_FIELD, INT_FIELD, BOOLEAN_FIELD, LONG_FIELD, FLOAT_FIELD, OBJECT_FIELD, PRIMARRAY_FIELD, OBJECTARRAY_FIELD, STATIC_OBJECT_FIELD, STATIC_OBJECTARRAY_FIELD, STATIC_INT_FIELD, STATIC_BOOLEAN_FIELD, METHOD, CONSTRUCTOR)
 
@@ -296,7 +296,7 @@ JVMCI_CLASSES_DO(START_CLASS, END_CLASS, CHAR_FIELD, INT_FIELD, BOOLEAN_FIELD, L
  * this ensures the declaring class is initialized.
  */
 void JNIJVMCI::initialize_field_id(JNIEnv* env, jfieldID &fieldid, jclass clazz, const char* class_name, const char* name, const char* signature, bool static_field) {
-  if (JVMCILibDumpJNIConfig != NULL) {
+  if (JVMCILibDumpJNIConfig != nullptr) {
     fileStream* st = JVMCIGlobals::get_jni_config_file();
     st->print_cr("field %s %s %s", class_name, name, signature);
     return;
@@ -355,7 +355,7 @@ void JNIJVMCI::initialize_field_id(JNIEnv* env, jfieldID &fieldid, jclass clazz,
     }                                                                                       \
   }
 
-#define END_CLASS current_class_name = NULL; }
+#define END_CLASS current_class_name = nullptr; }
 
 #define FIELD(className, name, signature, static_field) initialize_field_id(env, className::_##name##_field_id, className::_class, current_class_name, #name, signature, static_field);
 #define CHAR_FIELD(className, name) FIELD(className, name, "C", false)
@@ -419,21 +419,21 @@ class ThrowableInitDumper : public SymbolClosure {
   void do_symbol(Symbol** p) {
     JavaThread* THREAD = JavaThread::current(); // For exception macros.
     Symbol* name = *p;
-    if (name == NULL) {
+    if (name == nullptr) {
       return;
     }
     Klass* k = SystemDictionary::resolve_or_null(name, CHECK_EXIT);
-    if (k != NULL && k->is_instance_klass()) {
+    if (k != nullptr && k->is_instance_klass()) {
       InstanceKlass* iklass = InstanceKlass::cast(k);
       if (iklass->is_subclass_of(vmClasses::Throwable_klass()) && iklass->is_public() && !iklass->is_abstract()) {
-        const char* class_name = NULL;
+        const char* class_name = nullptr;
         Array<Method*>* methods = iklass->methods();
         for (int i = 0; i < methods->length(); i++) {
           Method* m = methods->at(i);
           if (m->name() == vmSymbols::object_initializer_name() &&
               m->is_public() &&
               (m->signature() == vmSymbols::void_method_signature() || m->signature() == vmSymbols::string_void_signature())) {
-            if (class_name == NULL) {
+            if (class_name == nullptr) {
               class_name = name->as_C_string();
               _st->print_cr("class %s", class_name);
             }
@@ -451,7 +451,7 @@ class ThrowableInitDumper : public SymbolClosure {
  */
 void JNIJVMCI::initialize_ids(JNIEnv* env) {
   ResourceMark rm;
-  const char* current_class_name = NULL;
+  const char* current_class_name = nullptr;
   JVMCI_CLASSES_DO(START_CLASS, END_CLASS, CHAR_FIELD, INT_FIELD, BOOLEAN_FIELD, LONG_FIELD, FLOAT_FIELD, OBJECT_FIELD, OBJECT_FIELD, OBJECT_FIELD, STATIC_OBJECT_FIELD, STATIC_OBJECT_FIELD, STATIC_INT_FIELD, STATIC_BOOLEAN_FIELD, METHOD, CONSTRUCTOR)
 
   IN_CLASS(java_lang_Class);
@@ -486,11 +486,11 @@ void JNIJVMCI::initialize_ids(JNIEnv* env) {
 
 #define DO_BOX_CLASS(klass, basicType, type) \
   current_class_name = "java/lang/" #klass;                                                                       \
-  if (JVMCILibDumpJNIConfig == NULL) {                                                                            \
+  if (JVMCILibDumpJNIConfig == nullptr) {                                                                            \
     _box_classes[basicType] = env->FindClass("java/lang/" #klass);                                                \
     JVMCI_EXCEPTION_CHECK(env, "FindClass(%s)", #klass);                                                          \
     _box_classes[basicType] = (jclass) env->NewGlobalRef(_box_classes[basicType]);                                \
-    assert(_box_classes[basicType] != NULL, "uninitialized");                                                     \
+    assert(_box_classes[basicType] != nullptr, "uninitialized");                                                     \
     _box_fields[basicType] = env->GetFieldID(_box_classes[basicType], "value", #type);                            \
     JVMCI_EXCEPTION_CHECK(env, "GetFieldID(%s, value, %s)", #klass, #type);                                       \
     GET_JNI_METHOD(GetMethodID, _box_constructors[basicType], _box_classes[basicType], "<init>", "(" #type ")V"); \
@@ -502,11 +502,11 @@ void JNIJVMCI::initialize_ids(JNIEnv* env) {
 
   BOX_CLASSES(DO_BOX_CLASS);
 
-  if (JVMCILibDumpJNIConfig == NULL) {
+  if (JVMCILibDumpJNIConfig == nullptr) {
     _byte_array = env->FindClass("[B");
     JVMCI_EXCEPTION_CHECK(env, "FindClass([B)");
     _byte_array = (jclass) env->NewGlobalRef(_byte_array);
-    assert(_byte_array != NULL, "uninitialized");
+    assert(_byte_array != nullptr, "uninitialized");
   } else {
     fileStream* st = JVMCIGlobals::get_jni_config_file();
     st->print_cr("class [B");
@@ -525,7 +525,7 @@ void JNIJVMCI::initialize_ids(JNIEnv* env) {
   }                                                                                                                 \
 } while(0)
 
-  if (JVMCILibDumpJNIConfig != NULL) {
+  if (JVMCILibDumpJNIConfig != nullptr) {
     JavaThread* THREAD = JavaThread::current(); // For exception macros.
     fileStream* st = JVMCIGlobals::get_jni_config_file();
 
@@ -548,7 +548,7 @@ void JNIJVMCI::initialize_ids(JNIEnv* env) {
 }
 
 static void register_natives_for_class(JNIEnv* env, jclass clazz, const char* name, const JNINativeMethod *methods, jint nMethods) {
-  if (clazz == NULL) {
+  if (clazz == nullptr) {
     clazz = env->FindClass(name);
     if (env->ExceptionCheck()) {
       env->ExceptionDescribe();
@@ -567,7 +567,7 @@ void JNIJVMCI::register_natives(JNIEnv* env) {
     JNINativeMethod CompilerToVM_nmethods[] = {{ CC"registerNatives", CC"()V", FN_PTR(JVM_RegisterJVMCINatives) }};
     JNINativeMethod JVMCI_nmethods[] = {{ CC"initializeRuntime",   CC"()Ljdk/vm/ci/runtime/JVMCIRuntime;", FN_PTR(JVM_GetJVMCIRuntime) }};
 
-    register_natives_for_class(env, NULL, "jdk/vm/ci/hotspot/CompilerToVM", CompilerToVM_nmethods, 1);
+    register_natives_for_class(env, nullptr, "jdk/vm/ci/hotspot/CompilerToVM", CompilerToVM_nmethods, 1);
     register_natives_for_class(env, JVMCI::clazz(), "jdk/vm/ci/runtime/JVMCI", JVMCI_nmethods, 1);
   }
 }
@@ -621,11 +621,11 @@ JVMCI_CLASSES_DO(EMPTY2, EMPTY0, FIELD2, FIELD2, FIELD2, FIELD2, FIELD2, FIELD3,
     return jni()->IsInstanceOf(object.as_jobject(), className::clazz()) != 0;                                                     \
   }                                                                                                                               \
   void JNIJVMCI::className::check(JVMCIEnv* jvmciEnv, JVMCIObject obj, const char* field_name, jfieldID offset) {                 \
-    assert(obj.is_non_null(), "NULL field access of %s.%s", #className, field_name);                                     \
+    assert(obj.is_non_null(), "nullptr field access of %s.%s", #className, field_name);                                     \
     assert(jvmciEnv->isa_##className(obj), "wrong class, " #className " expected, found %s", jvmciEnv->klass_name(obj)); \
     assert(offset != 0, "must be valid offset");                                                                                  \
   }                                                                                                                               \
-  jclass JNIJVMCI::className::_class = NULL;
+  jclass JNIJVMCI::className::_class = nullptr;
 
 #define END_CLASS
 

--- a/src/hotspot/share/jvmci/jvmciJavaClasses.hpp
+++ b/src/hotspot/share/jvmci/jvmciJavaClasses.hpp
@@ -384,13 +384,13 @@ class HotSpotJVMCI {
 
 #undef HS_START_CLASS
 
-#define JNI_START_CLASS(simpleClassName, fullClassName)                                             \
-  START_CLASS(simpleClassName, fullClassName)                                                       \
-  friend class JNIJVMCI;                                                                            \
-  private:                                                                                          \
-  static void check(JVMCIEnv* jvmciEnv, JVMCIObject obj, const char* field_name, jfieldID offset);  \
-  static jclass _class;                                                                             \
-public:                                                                                             \
+#define JNI_START_CLASS(simpleClassName, fullClassName)                                                \
+  START_CLASS(simpleClassName, fullClassName)                                                          \
+  friend class JNIJVMCI;                                                                               \
+  private:                                                                                             \
+  static void check(JVMCIEnv* jvmciEnv, JVMCIObject obj, const char* field_name, jfieldID offset);     \
+  static jclass _class;                                                                                \
+public:                                                                                                \
  static jclass clazz() { assert(_class != nullptr, #fullClassName " uninitialized"); return _class; }  \
  static jclass fullClassName ##_class()  { assert(_class != nullptr, "uninit"); return _class; }
 

--- a/src/hotspot/share/jvmci/jvmciJavaClasses.hpp
+++ b/src/hotspot/share/jvmci/jvmciJavaClasses.hpp
@@ -148,7 +148,7 @@
   end_class                                                                                                   \
   start_class(JavaConstant, jdk_vm_ci_meta_JavaConstant)                                                      \
     static_object_field(JavaConstant, ILLEGAL, "Ljdk/vm/ci/meta/PrimitiveConstant;")                          \
-    static_object_field(JavaConstant, nullptr_POINTER, "Ljdk/vm/ci/meta/JavaConstant;")                          \
+    static_object_field(JavaConstant, NULL_POINTER, "Ljdk/vm/ci/meta/JavaConstant;")                          \
     jvmci_method(CallStaticObjectMethod, GetStaticMethodID, call_static, JVMCIObject, JavaConstant, forPrimitive, forPrimitive_signature, (JVMCIObject kind, jlong value, JVMCI_TRAPS)) \
   end_class                                                                                                   \
   start_class(ResolvedJavaMethod, jdk_vm_ci_meta_ResolvedJavaMethod)                                          \
@@ -284,13 +284,13 @@ class JVMCIEnv;
 #define STATIC_OBJECT_FIELD(simpleClassName, name, signature) STATIC_OOPISH_FIELD(simpleClassName, name, JVMCIObject, oop)
 #define STATIC_OBJECTARRAY_FIELD(simpleClassName, name, signature) STATIC_OOPISH_FIELD(simpleClassName, name, JVMCIObjectArray, objArrayOop)
 
-#define HS_START_CLASS(simpleClassName, fullClassName)                               \
-  START_CLASS(simpleClassName, fullClassName)                                        \
-  friend class HotSpotJVMCI;                                                         \
- private:                                                                            \
-  static void check(oop obj, const char* field_name, int offset);                    \
-  static InstanceKlass* _klass;                                                      \
- public:                                                                             \
+#define HS_START_CLASS(simpleClassName, fullClassName)                                  \
+  START_CLASS(simpleClassName, fullClassName)                                           \
+  friend class HotSpotJVMCI;                                                            \
+ private:                                                                               \
+  static void check(oop obj, const char* field_name, int offset);                       \
+  static InstanceKlass* _klass;                                                         \
+ public:                                                                                \
   static InstanceKlass* klass() { assert(_klass != nullptr, "uninit"); return _klass; } \
   static Symbol* symbol() { return vmSymbols::fullClassName(); }
 

--- a/src/hotspot/share/jvmci/jvmciJavaClasses.hpp
+++ b/src/hotspot/share/jvmci/jvmciJavaClasses.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,7 +148,7 @@
   end_class                                                                                                   \
   start_class(JavaConstant, jdk_vm_ci_meta_JavaConstant)                                                      \
     static_object_field(JavaConstant, ILLEGAL, "Ljdk/vm/ci/meta/PrimitiveConstant;")                          \
-    static_object_field(JavaConstant, NULL_POINTER, "Ljdk/vm/ci/meta/JavaConstant;")                          \
+    static_object_field(JavaConstant, nullptr_POINTER, "Ljdk/vm/ci/meta/JavaConstant;")                          \
     jvmci_method(CallStaticObjectMethod, GetStaticMethodID, call_static, JVMCIObject, JavaConstant, forPrimitive, forPrimitive_signature, (JVMCIObject kind, jlong value, JVMCI_TRAPS)) \
   end_class                                                                                                   \
   start_class(ResolvedJavaMethod, jdk_vm_ci_meta_ResolvedJavaMethod)                                          \
@@ -291,7 +291,7 @@ class JVMCIEnv;
   static void check(oop obj, const char* field_name, int offset);                    \
   static InstanceKlass* _klass;                                                      \
  public:                                                                             \
-  static InstanceKlass* klass() { assert(_klass != NULL, "uninit"); return _klass; } \
+  static InstanceKlass* klass() { assert(_klass != nullptr, "uninit"); return _klass; } \
   static Symbol* symbol() { return vmSymbols::fullClassName(); }
 
 #define FIELD(simpleClassName, name, type)                                                                   \
@@ -391,8 +391,8 @@ class HotSpotJVMCI {
   static void check(JVMCIEnv* jvmciEnv, JVMCIObject obj, const char* field_name, jfieldID offset);  \
   static jclass _class;                                                                             \
 public:                                                                                             \
- static jclass clazz() { assert(_class != NULL, #fullClassName " uninitialized"); return _class; }  \
- static jclass fullClassName ##_class()  { assert(_class != NULL, "uninit"); return _class; }
+ static jclass clazz() { assert(_class != nullptr, #fullClassName " uninitialized"); return _class; }  \
+ static jclass fullClassName ##_class()  { assert(_class != nullptr, "uninit"); return _class; }
 
 #undef METHOD
 #undef CONSTRUCTOR
@@ -473,16 +473,16 @@ class JNIJVMCI {
  public:
   static jmethodID Class_getName_method() { return _Class_getName_method; }
 
-  static jclass    byte_array()           { assert(_byte_array != NULL, "uninit");      return _byte_array; }
+  static jclass    byte_array()           { assert(_byte_array != nullptr, "uninit");      return _byte_array; }
 
-  static jclass    box_class(BasicType type)       { assert(_box_classes[type]!= NULL, "uninit");      return _box_classes[type]; }
-  static jfieldID  box_field(BasicType type)       { assert(_box_fields[type]!= NULL, "uninit");       return _box_fields[type]; }
-  static jmethodID box_constructor(BasicType type) { assert(_box_constructors[type]!= NULL, "uninit"); return _box_constructors[type]; }
+  static jclass    box_class(BasicType type)       { assert(_box_classes[type]!= nullptr, "uninit");      return _box_classes[type]; }
+  static jfieldID  box_field(BasicType type)       { assert(_box_fields[type]!= nullptr, "uninit");       return _box_fields[type]; }
+  static jmethodID box_constructor(BasicType type) { assert(_box_constructors[type]!= nullptr, "uninit"); return _box_constructors[type]; }
 
-  static jmethodID HotSpotResolvedJavaMethodImpl_fromMetaspace_method()     { assert(_HotSpotResolvedJavaMethodImpl_fromMetaspace_method     != NULL, "uninit"); return _HotSpotResolvedJavaMethodImpl_fromMetaspace_method; }
-  static jmethodID HotSpotConstantPool_fromMetaspace_method()           { assert(_HotSpotConstantPool_fromMetaspace_method           != NULL, "uninit"); return _HotSpotConstantPool_fromMetaspace_method; }
-  static jmethodID HotSpotResolvedObjectTypeImpl_fromMetaspace_method() { assert(_HotSpotResolvedObjectTypeImpl_fromMetaspace_method != NULL, "uninit"); return _HotSpotResolvedObjectTypeImpl_fromMetaspace_method; }
-  static jmethodID HotSpotResolvedPrimitiveType_fromMetaspace_method()  { assert(_HotSpotResolvedPrimitiveType_fromMetaspace_method  != NULL, "uninit"); return _HotSpotResolvedPrimitiveType_fromMetaspace_method; }
+  static jmethodID HotSpotResolvedJavaMethodImpl_fromMetaspace_method()     { assert(_HotSpotResolvedJavaMethodImpl_fromMetaspace_method     != nullptr, "uninit"); return _HotSpotResolvedJavaMethodImpl_fromMetaspace_method; }
+  static jmethodID HotSpotConstantPool_fromMetaspace_method()           { assert(_HotSpotConstantPool_fromMetaspace_method           != nullptr, "uninit"); return _HotSpotConstantPool_fromMetaspace_method; }
+  static jmethodID HotSpotResolvedObjectTypeImpl_fromMetaspace_method() { assert(_HotSpotResolvedObjectTypeImpl_fromMetaspace_method != nullptr, "uninit"); return _HotSpotResolvedObjectTypeImpl_fromMetaspace_method; }
+  static jmethodID HotSpotResolvedPrimitiveType_fromMetaspace_method()  { assert(_HotSpotResolvedPrimitiveType_fromMetaspace_method  != nullptr, "uninit"); return _HotSpotResolvedPrimitiveType_fromMetaspace_method; }
 
   static void initialize_ids(JNIEnv* env);
   static void initialize_field_id(JNIEnv* env, jfieldID &dest_offset, jclass klass, const char* klass_name, const char* name, const char* signature, bool static_field);

--- a/src/hotspot/share/jvmci/jvmciObject.hpp
+++ b/src/hotspot/share/jvmci/jvmciObject.hpp
@@ -65,7 +65,7 @@ class JVMCIArray : public JVMCIObject {
 class JVMCIObjectArray : public JVMCIArray {
  public:
   JVMCIObjectArray() {}
-  JVMCIObjectArray(void* v): JVMCIArray() { assert(v == nullptr, "must be nullptr"); }
+  JVMCIObjectArray(void* v): JVMCIArray() { assert(v == nullptr, "must be null"); }
   JVMCIObjectArray(jobject o, bool is_hotspot): JVMCIArray(o, is_hotspot) {}
 
   jobjectArray as_jobject() { return (jobjectArray) JVMCIArray::as_jobject(); }
@@ -74,7 +74,7 @@ class JVMCIObjectArray : public JVMCIArray {
 class JVMCIPrimitiveArray : public JVMCIArray {
  public:
   JVMCIPrimitiveArray() {}
-  JVMCIPrimitiveArray(void* v): JVMCIArray() { assert(v == nullptr, "must be nullptr"); }
+  JVMCIPrimitiveArray(void* v): JVMCIArray() { assert(v == nullptr, "must be null"); }
   JVMCIPrimitiveArray(jobject o, bool is_hotspot): JVMCIArray(o, is_hotspot) {}
 
   jbooleanArray as_jbooleanArray() { return (jbooleanArray) as_jobject(); }

--- a/src/hotspot/share/jvmci/jvmciObject.hpp
+++ b/src/hotspot/share/jvmci/jvmciObject.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ class JVMCIObject {
   bool _is_hotspot;
 
  public:
-  JVMCIObject(): _object(NULL), _is_hotspot(false) {}
+  JVMCIObject(): _object(nullptr), _is_hotspot(false) {}
   JVMCIObject(jobject o, bool is_hotspot): _object(o), _is_hotspot(is_hotspot) { }
 
   static JVMCIObject create(jobject o, bool is_hotspot) { JVMCIObject r(o, is_hotspot); return r; }
@@ -47,8 +47,8 @@ class JVMCIObject {
   jstring as_jstring() { return (jstring) _object; }
   bool is_hotspot() { return _is_hotspot; }
 
-  bool is_null() const { return _object == NULL; }
-  bool is_non_null() const { return _object != NULL; }
+  bool is_null() const { return _object == nullptr; }
+  bool is_non_null() const { return _object != nullptr; }
 
   operator JVMCIArray();
   operator JVMCIPrimitiveArray();
@@ -65,7 +65,7 @@ class JVMCIArray : public JVMCIObject {
 class JVMCIObjectArray : public JVMCIArray {
  public:
   JVMCIObjectArray() {}
-  JVMCIObjectArray(void* v): JVMCIArray() { assert(v == NULL, "must be NULL"); }
+  JVMCIObjectArray(void* v): JVMCIArray() { assert(v == nullptr, "must be nullptr"); }
   JVMCIObjectArray(jobject o, bool is_hotspot): JVMCIArray(o, is_hotspot) {}
 
   jobjectArray as_jobject() { return (jobjectArray) JVMCIArray::as_jobject(); }
@@ -74,7 +74,7 @@ class JVMCIObjectArray : public JVMCIArray {
 class JVMCIPrimitiveArray : public JVMCIArray {
  public:
   JVMCIPrimitiveArray() {}
-  JVMCIPrimitiveArray(void* v): JVMCIArray() { assert(v == NULL, "must be NULL"); }
+  JVMCIPrimitiveArray(void* v): JVMCIArray() { assert(v == nullptr, "must be nullptr"); }
   JVMCIPrimitiveArray(jobject o, bool is_hotspot): JVMCIArray(o, is_hotspot) {}
 
   jbooleanArray as_jbooleanArray() { return (jbooleanArray) as_jobject(); }

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,10 +91,10 @@ static void deopt_caller() {
 
 // Manages a scope for a JVMCI runtime call that attempts a heap allocation.
 // If there is a pending nonasync exception upon closing the scope and the runtime
-// call is of the variety where allocation failure returns NULL without an
+// call is of the variety where allocation failure returns null without an
 // exception, the following action is taken:
 //   1. The pending nonasync exception is cleared
-//   2. NULL is written to JavaThread::_vm_result
+//   2. null is written to JavaThread::_vm_result
 //   3. Checks that an OutOfMemoryError is Universe::out_of_memory_error_retry().
 class RetryableAllocationMark: public StackObj {
  private:
@@ -106,11 +106,11 @@ class RetryableAllocationMark: public StackObj {
       _thread = thread;
       _thread->set_in_retryable_allocation(true);
     } else {
-      _thread = NULL;
+      _thread = nullptr;
     }
   }
   ~RetryableAllocationMark() {
-    if (_thread != NULL) {
+    if (_thread != nullptr) {
       _thread->set_in_retryable_allocation(false);
       JavaThread* THREAD = _thread; // For exception macros.
       if (HAS_PENDING_EXCEPTION) {
@@ -122,7 +122,7 @@ class RetryableAllocationMark: public StackObj {
           ResourceMark rm;
           fatal("Unexpected exception in scope of retryable allocation: " INTPTR_FORMAT " of type %s", p2i(ex), ex->klass()->external_name());
         }
-        _thread->set_vm_result(NULL);
+        _thread->set_vm_result(nullptr);
       }
     }
   }
@@ -211,7 +211,7 @@ JRT_END
 JRT_ENTRY(void, JVMCIRuntime::dynamic_new_instance_common(JavaThread* current, oopDesc* type_mirror, bool null_on_fail))
   InstanceKlass* klass = InstanceKlass::cast(java_lang_Class::as_Klass(type_mirror));
 
-  if (klass == NULL) {
+  if (klass == nullptr) {
     ResourceMark rm(current);
     THROW(vmSymbols::java_lang_InstantiationException());
   }
@@ -259,7 +259,7 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
 
   Handle exception(current, ex);
   cm = CodeCache::find_compiled(pc);
-  assert(cm != NULL, "this is not a compiled method");
+  assert(cm != nullptr, "this is not a compiled method");
   // Adjust the pc as needed/
   if (cm->is_deopt_pc(pc)) {
     RegisterMap map(current,
@@ -271,7 +271,7 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
     assert(exception_frame.is_deoptimized_frame(), "must be deopted");
     pc = exception_frame.pc();
   }
-  assert(exception.not_null(), "NULL exceptions should be handled by throw_exception");
+  assert(exception.not_null(), "nullptr exceptions should be handled by throw_exception");
   assert(oopDesc::is_oop(exception()), "just checking");
   // Check that exception is a subclass of Throwable
   assert(exception->is_a(vmClasses::Throwable_klass()),
@@ -282,7 +282,7 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
   if (log_is_enabled(Info, exceptions)) {
     ResourceMark rm;
     stringStream tempst;
-    assert(cm->method() != NULL, "Unexpected null method()");
+    assert(cm->method() != nullptr, "Unexpected null method()");
     tempst.print("JVMCI compiled method <%s>\n"
                  " at PC" INTPTR_FORMAT " for thread " INTPTR_FORMAT,
                  cm->method()->print_value_string(), p2i(pc), p2i(current));
@@ -324,7 +324,7 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
   // ExceptionCache is used only for exceptions at call sites and not for implicit exceptions
   if (guard_pages_enabled) {
     address fast_continuation = cm->handler_for_exception_and_pc(exception, pc);
-    if (fast_continuation != NULL) {
+    if (fast_continuation != nullptr) {
       // Set flag if return address is a method handle call site.
       current->set_is_method_handle_return(cm->is_method_handle_return(pc));
       return fast_continuation;
@@ -333,8 +333,8 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
 
   // If the stack guard pages are enabled, check whether there is a handler in
   // the current method.  Otherwise (guard pages disabled), force an unwind and
-  // skip the exception cache update (i.e., just leave continuation==NULL).
-  address continuation = NULL;
+  // skip the exception cache update (i.e., just leave continuation==null).
+  address continuation = nullptr;
   if (guard_pages_enabled) {
 
     // New exception handling mechanism can support inlined methods
@@ -358,7 +358,7 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
     // (e.g., when loading the class of the catch type).
     // Checking for exception oop equality is not
     // sufficient because some exceptions are pre-allocated and reused.
-    if (continuation != NULL && !recursive_exception && !SharedRuntime::deopt_blob()->contains(continuation)) {
+    if (continuation != nullptr && !recursive_exception && !SharedRuntime::deopt_blob()->contains(continuation)) {
       cm->add_handler_for_exception_and_pc(exception, pc, continuation);
     }
   }
@@ -386,8 +386,8 @@ address JVMCIRuntime::exception_handler_for_pc(JavaThread* current) {
   address pc = current->exception_pc();
   // Still in Java mode
   DEBUG_ONLY(NoHandleMark nhm);
-  CompiledMethod* cm = NULL;
-  address continuation = NULL;
+  CompiledMethod* cm = nullptr;
+  address continuation = nullptr;
   {
     // Enter VM mode by calling the helper
     ResetNoHandleMark rnhm;
@@ -397,11 +397,11 @@ address JVMCIRuntime::exception_handler_for_pc(JavaThread* current) {
 
   // Now check to see if the compiled method we were called from is now deoptimized.
   // If so we must return to the deopt blob and deoptimize the nmethod
-  if (cm != NULL && caller_is_deopted()) {
+  if (cm != nullptr && caller_is_deopted()) {
     continuation = SharedRuntime::deopt_blob()->unpack_with_exception_in_tls();
   }
 
-  assert(continuation != NULL, "no handler found");
+  assert(continuation != nullptr, "no handler found");
   return continuation;
 }
 
@@ -583,8 +583,8 @@ JRT_END
 JRT_LEAF(void, JVMCIRuntime::log_object(JavaThread* thread, oopDesc* obj, bool as_string, bool newline))
   ttyLocker ttyl;
 
-  if (obj == NULL) {
-    tty->print("NULL");
+  if (obj == nullptr) {
+    tty->print("nullptr");
   } else if (oopDesc::is_oop_or_null(obj, true) && (!as_string || !java_lang_String::is_instance(obj))) {
     if (oopDesc::is_oop_or_null(obj, true)) {
       char buf[O_BUFLEN];
@@ -594,7 +594,7 @@ JRT_LEAF(void, JVMCIRuntime::log_object(JavaThread* thread, oopDesc* obj, bool a
     }
   } else {
     ResourceMark rm;
-    assert(obj != NULL && java_lang_String::is_instance(obj), "must be");
+    assert(obj != nullptr && java_lang_String::is_instance(obj), "must be");
     char *buf = java_lang_String::as_utf8_string(obj);
     tty->print_raw(buf);
   }
@@ -633,7 +633,7 @@ JRT_END
 JRT_ENTRY(void, JVMCIRuntime::vm_error(JavaThread* current, jlong where, jlong format, jlong value))
   ResourceMark rm(current);
   const char *error_msg = where == 0L ? "<internal JVMCI error>" : (char*) (address) where;
-  char *detail_msg = NULL;
+  char *detail_msg = nullptr;
   if (format != 0L) {
     const char* buf = (char*) (address) format;
     size_t detail_msg_length = strlen(buf) * 2;
@@ -645,8 +645,8 @@ JRT_END
 
 JRT_LEAF(oopDesc*, JVMCIRuntime::load_and_clear_exception(JavaThread* thread))
   oop exception = thread->exception_oop();
-  assert(exception != NULL, "npe");
-  thread->set_exception_oop(NULL);
+  assert(exception != nullptr, "npe");
+  thread->set_exception_oop(nullptr);
   thread->set_exception_pc(0);
   return exception;
 JRT_END
@@ -687,12 +687,12 @@ JRT_LEAF(void, JVMCIRuntime::vm_message(jboolean vmError, jlong format, jlong v1
   ResourceMark rm;
   const char *buf = (const char*) (address) format;
   if (vmError) {
-    if (buf != NULL) {
+    if (buf != nullptr) {
       fatal(buf, v1, v2, v3);
     } else {
       fatal("<anonymous error>");
     }
-  } else if (buf != NULL) {
+  } else if (buf != nullptr) {
     tty->print(buf, v1, v2, v3);
   } else {
     assert(v2 == 0, "v2 != 0");
@@ -760,7 +760,7 @@ void JVMCINMethodData::initialize(
 {
   _failed_speculations = failed_speculations;
   _nmethod_mirror_index = nmethod_mirror_index;
-  if (name != NULL) {
+  if (name != nullptr) {
     _has_name = true;
     char* dest = (char*) this->name();
     strcpy(dest, name);
@@ -782,7 +782,7 @@ void JVMCINMethodData::add_failed_speculation(nmethod* nm, jlong speculation) {
 
 oop JVMCINMethodData::get_nmethod_mirror(nmethod* nm, bool phantom_ref) {
   if (_nmethod_mirror_index == -1) {
-    return NULL;
+    return nullptr;
   }
   if (phantom_ref) {
     return nm->oop_at_phantom(_nmethod_mirror_index);
@@ -794,8 +794,8 @@ oop JVMCINMethodData::get_nmethod_mirror(nmethod* nm, bool phantom_ref) {
 void JVMCINMethodData::set_nmethod_mirror(nmethod* nm, oop new_mirror) {
   assert(_nmethod_mirror_index != -1, "cannot set JVMCI mirror for nmethod");
   oop* addr = nm->oop_addr_at(_nmethod_mirror_index);
-  assert(new_mirror != NULL, "use clear_nmethod_mirror to clear the mirror");
-  assert(*addr == NULL, "cannot overwrite non-null mirror");
+  assert(new_mirror != nullptr, "use clear_nmethod_mirror to clear the mirror");
+  assert(*addr == nullptr, "cannot overwrite non-null mirror");
 
   *addr = new_mirror;
 
@@ -807,14 +807,14 @@ void JVMCINMethodData::set_nmethod_mirror(nmethod* nm, oop new_mirror) {
 
 void JVMCINMethodData::invalidate_nmethod_mirror(nmethod* nm) {
   oop nmethod_mirror = get_nmethod_mirror(nm, /* phantom_ref */ false);
-  if (nmethod_mirror == NULL) {
+  if (nmethod_mirror == nullptr) {
     return;
   }
 
   // Update the values in the mirror if it still refers to nm.
   // We cannot use JVMCIObject to wrap the mirror as this is called
   // during GC, forbidding the creation of JNIHandles.
-  JVMCIEnv* jvmciEnv = NULL;
+  JVMCIEnv* jvmciEnv = nullptr;
   nmethod* current = (nmethod*) HotSpotJVMCI::InstalledCode::address(jvmciEnv, nmethod_mirror);
   if (nm == current) {
     if (nm->is_unloading()) {
@@ -865,7 +865,7 @@ int JVMCIRuntime::release_and_clear_oop_handles() {
       guarantee(*oop_ptr != nullptr, "unexpected cleared handle");
       // Satisfy OopHandles::release precondition that all
       // handles being released are null.
-      NativeAccess<>::oop_store(oop_ptr, (oop) NULL);
+      NativeAccess<>::oop_store(oop_ptr, (oop) nullptr);
     }
 
     // Do the bulk release
@@ -1379,7 +1379,7 @@ void JVMCIRuntime::initialize(JVMCI_TRAPS) {
   JavaThread* THREAD = JavaThread::current();
 
   int properties_len = 0;
-  jbyte* properties = NULL;
+  jbyte* properties = nullptr;
 
   MutexLocker locker(_lock);
   // Check again under _lock
@@ -1612,7 +1612,7 @@ void JVMCIRuntime::fatal_exception(JVMCIEnv* JVMCIENV, const char* message) {
   if (!report_error && Atomic::cmpxchg(&report_error, 0, 1) == 0) {
     // Only report an error once
     tty->print_raw_cr(message);
-    if (JVMCIENV != NULL) {
+    if (JVMCIENV != nullptr) {
       JVMCIENV->describe_pending_exception(true);
     } else {
       describe_pending_hotspot_exception(THREAD, true);
@@ -1666,7 +1666,7 @@ Klass* JVMCIRuntime::get_klass_by_name_impl(Klass*& accessing_klass,
 
   Handle loader;
   Handle domain;
-  if (accessing_klass != NULL) {
+  if (accessing_klass != nullptr) {
     loader = Handle(THREAD, accessing_klass->class_loader());
     domain = Handle(THREAD, accessing_klass->protection_domain());
   }
@@ -1701,13 +1701,13 @@ Klass* JVMCIRuntime::get_klass_by_name_impl(Klass*& accessing_klass,
                              cpool,
                              elem_sym,
                              require_local);
-    if (elem_klass != NULL) {
+    if (elem_klass != nullptr) {
       // Now make an array for it
       return elem_klass->array_klass(THREAD);
     }
   }
 
-  if (found_klass == NULL && !cpool.is_null() && cpool->has_preresolution()) {
+  if (found_klass == nullptr && !cpool.is_null() && cpool->has_preresolution()) {
     // Look inside the constant pool for pre-resolved class entries.
     for (int i = cpool->length() - 1; i >= 1; i--) {
       if (cpool->tag_at(i).is_klass()) {
@@ -1742,22 +1742,22 @@ Klass* JVMCIRuntime::get_klass_by_index_impl(const constantPoolHandle& cpool,
                                         Klass* accessor) {
   JVMCI_EXCEPTION_CONTEXT;
   Klass* klass = ConstantPool::klass_at_if_loaded(cpool, index);
-  Symbol* klass_name = NULL;
-  if (klass == NULL) {
+  Symbol* klass_name = nullptr;
+  if (klass == nullptr) {
     klass_name = cpool->klass_name_at(index);
   }
 
-  if (klass == NULL) {
+  if (klass == nullptr) {
     // Not found in constant pool.  Use the name to do the lookup.
     Klass* k = get_klass_by_name_impl(accessor,
                                         cpool,
                                         klass_name,
                                         false);
     // Calculate accessibility the hard way.
-    if (k == NULL) {
+    if (k == nullptr) {
       is_accessible = false;
     } else if (k->class_loader() != accessor->class_loader() &&
-               get_klass_by_name_impl(accessor, cpool, k->name(), true) == NULL) {
+               get_klass_by_name_impl(accessor, cpool, k->name(), true) == nullptr) {
       // Loaded only remotely.  Not linked yet.
       is_accessible = false;
     } else {
@@ -1765,7 +1765,7 @@ Klass* JVMCIRuntime::get_klass_by_index_impl(const constantPoolHandle& cpool,
       is_accessible = check_klass_accessibility(accessor, k);
     }
     if (!is_accessible) {
-      return NULL;
+      return nullptr;
     }
     return k;
   }
@@ -1823,7 +1823,7 @@ void JVMCIRuntime::get_field_by_index_impl(InstanceKlass* klass, fieldDescriptor
   // Perform the field lookup.
   Klass*  canonical_holder =
     InstanceKlass::cast(declared_holder)->find_field(name, signature, &field_desc);
-  if (canonical_holder == NULL) {
+  if (canonical_holder == nullptr) {
     return;
   }
 
@@ -1864,7 +1864,7 @@ Method* JVMCIRuntime::lookup_method(InstanceKlass* accessor,
       return LinkResolver::linktime_resolve_virtual_method_or_null(link_info);
     default:
       fatal("Unhandled bytecode: %s", Bytecodes::name(bc));
-      return NULL; // silence compiler warnings
+      return nullptr; // silence compiler warnings
   }
 }
 
@@ -1883,7 +1883,7 @@ Method* JVMCIRuntime::get_method_by_index_impl(const constantPoolHandle& cpool,
       return adapter;
     }
 
-    return NULL;
+    return nullptr;
   }
 
   int holder_index = cpool->klass_ref_index_at(index);
@@ -1907,7 +1907,7 @@ Method* JVMCIRuntime::get_method_by_index_impl(const constantPoolHandle& cpool,
     case Bytecodes::_invokestatic:
       {
         Method* m = ConstantPool::method_at_if_loaded(cpool, index);
-        if (m != NULL) {
+        if (m != nullptr) {
           return m;
         }
       }
@@ -1920,7 +1920,7 @@ Method* JVMCIRuntime::get_method_by_index_impl(const constantPoolHandle& cpool,
   if (holder_is_accessible) { // Our declared holder is loaded.
     constantTag tag = cpool->tag_ref_at(index);
     Method* m = lookup_method(accessor, holder, name_sym, sig_sym, bc, tag);
-    if (m != NULL) {
+    if (m != nullptr) {
       // We found the method.
       return m;
     }
@@ -1929,7 +1929,7 @@ Method* JVMCIRuntime::get_method_by_index_impl(const constantPoolHandle& cpool,
   // Either the declared holder was not loaded, or the method could
   // not be found.
 
-  return NULL;
+  return nullptr;
 }
 
 // ------------------------------------------------------------------
@@ -1944,7 +1944,7 @@ InstanceKlass* JVMCIRuntime::get_instance_klass_for_declared_method_holder(Klass
   } else {
     ShouldNotReachHere();
   }
-  return NULL;
+  return nullptr;
 }
 
 
@@ -1961,12 +1961,12 @@ Method* JVMCIRuntime::get_method_by_index(const constantPoolHandle& cpool,
 // class loads, evolution, breakpoints
 JVMCI::CodeInstallResult JVMCIRuntime::validate_compile_task_dependencies(Dependencies* dependencies, JVMCICompileState* compile_state, char** failure_detail) {
   // If JVMTI capabilities were enabled during compile, the compilation is invalidated.
-  if (compile_state != NULL && compile_state->jvmti_state_changed()) {
+  if (compile_state != nullptr && compile_state->jvmti_state_changed()) {
     *failure_detail = (char*) "Jvmti state change during compilation invalidated dependencies";
     return JVMCI::dependencies_failed;
   }
 
-  CompileTask* task = compile_state == NULL ? NULL : compile_state->task();
+  CompileTask* task = compile_state == nullptr ? nullptr : compile_state->task();
   Dependencies::DepType result = dependencies->validate_dependencies(task, failure_detail);
   if (result == Dependencies::end_marker) {
     return JVMCI::ok;
@@ -2089,17 +2089,17 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
                                                        int speculations_len) {
   JVMCI_EXCEPTION_CONTEXT;
   CompLevel comp_level = CompLevel_full_optimization;
-  char* failure_detail = NULL;
+  char* failure_detail = nullptr;
 
   bool install_default = JVMCIENV->get_HotSpotNmethod_isDefault(nmethod_mirror) != 0;
   assert(JVMCIENV->isa_HotSpotNmethod(nmethod_mirror), "must be");
   JVMCIObject name = JVMCIENV->get_InstalledCode_name(nmethod_mirror);
-  const char* nmethod_mirror_name = name.is_null() ? NULL : JVMCIENV->as_utf8_string(name);
+  const char* nmethod_mirror_name = name.is_null() ? nullptr : JVMCIENV->as_utf8_string(name);
   int nmethod_mirror_index;
   if (!install_default) {
     // Reserve or initialize mirror slot in the oops table.
     OopRecorder* oop_recorder = debug_info->oop_recorder();
-    nmethod_mirror_index = oop_recorder->allocate_oop_index(nmethod_mirror.is_hotspot() ? nmethod_mirror.as_jobject() : NULL);
+    nmethod_mirror_index = oop_recorder->allocate_oop_index(nmethod_mirror.is_hotspot() ? nmethod_mirror.as_jobject() : nullptr);
   } else {
     // A default HotSpotNmethod mirror is never tracked by the nmethod
     nmethod_mirror_index = -1;
@@ -2108,7 +2108,7 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
   JVMCI::CodeInstallResult result(JVMCI::ok);
 
   // We require method counters to store some method state (max compilation levels) required by the compilation policy.
-  if (method->get_method_counters(THREAD) == NULL) {
+  if (method->get_method_counters(THREAD) == nullptr) {
     result = JVMCI::cache_full;
     failure_detail = (char*) "can't create method counters";
   }
@@ -2139,7 +2139,7 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
     if (result != JVMCI::ok) {
       // While not a true deoptimization, it is a preemptive decompile.
       MethodData* mdp = method()->method_data();
-      if (mdp != NULL) {
+      if (mdp != nullptr) {
         mdp->inc_decompile_count();
 #ifdef ASSERT
         if (mdp->decompile_count() > (uint)PerMethodRecompilationCutoff) {
@@ -2168,7 +2168,7 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
 
 
       // Free codeBlobs
-      if (nm == NULL) {
+      if (nm == nullptr) {
         // The CodeCache is full.  Print out warning and disable compilation.
         {
           MutexUnlocker ml(Compile_lock);
@@ -2182,18 +2182,18 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
         nm->set_has_monitors(has_monitors);
 
         JVMCINMethodData* data = nm->jvmci_nmethod_data();
-        assert(data != NULL, "must be");
+        assert(data != nullptr, "must be");
         if (install_default) {
-          assert(!nmethod_mirror.is_hotspot() || data->get_nmethod_mirror(nm, /* phantom_ref */ false) == NULL, "must be");
+          assert(!nmethod_mirror.is_hotspot() || data->get_nmethod_mirror(nm, /* phantom_ref */ false) == nullptr, "must be");
           if (entry_bci == InvocationEntryBci) {
             // If there is an old version we're done with it
             CompiledMethod* old = method->code();
-            if (TraceMethodReplacement && old != NULL) {
+            if (TraceMethodReplacement && old != nullptr) {
               ResourceMark rm;
               char *method_name = method->name_and_sig_as_C_string();
               tty->print_cr("Replacing method %s", method_name);
             }
-            if (old != NULL ) {
+            if (old != nullptr ) {
               old->make_not_entrant();
             }
 
@@ -2238,7 +2238,7 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
   }
 
   // String creation must be done outside lock
-  if (failure_detail != NULL) {
+  if (failure_detail != nullptr) {
     // A failure to allocate the string is silently ignored.
     JVMCIObject message = JVMCIENV->create_string(failure_detail, JVMCIENV);
     JVMCIENV->set_HotSpotCompiledNmethod_installationFailureMessage(compiled_code, message);
@@ -2246,7 +2246,7 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
 
   if (result == JVMCI::ok) {
     JVMCICompileState* state = JVMCIENV->compile_state();
-    if (state != NULL) {
+    if (state != nullptr) {
       // Compilation succeeded, post what we know about it
       nm->post_compiled_method(state->task());
     }

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -271,7 +271,7 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
     assert(exception_frame.is_deoptimized_frame(), "must be deopted");
     pc = exception_frame.pc();
   }
-  assert(exception.not_null(), "nullptr exceptions should be handled by throw_exception");
+  assert(exception.not_null(), "null exceptions should be handled by throw_exception");
   assert(oopDesc::is_oop(exception()), "just checking");
   // Check that exception is a subclass of Throwable
   assert(exception->is_a(vmClasses::Throwable_klass()),
@@ -333,7 +333,7 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
 
   // If the stack guard pages are enabled, check whether there is a handler in
   // the current method.  Otherwise (guard pages disabled), force an unwind and
-  // skip the exception cache update (i.e., just leave continuation==null).
+  // skip the exception cache update (i.e., just leave continuation==nullptr).
   address continuation = nullptr;
   if (guard_pages_enabled) {
 
@@ -584,7 +584,7 @@ JRT_LEAF(void, JVMCIRuntime::log_object(JavaThread* thread, oopDesc* obj, bool a
   ttyLocker ttyl;
 
   if (obj == nullptr) {
-    tty->print("nullptr");
+    tty->print("null");
   } else if (oopDesc::is_oop_or_null(obj, true) && (!as_string || !java_lang_String::is_instance(obj))) {
     if (oopDesc::is_oop_or_null(obj, true)) {
       char buf[O_BUFLEN];

--- a/src/hotspot/share/jvmci/jvmciRuntime.hpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,7 @@ public:
   // Computes the size of a JVMCINMethodData object
   static int compute_size(const char* nmethod_mirror_name) {
     int size = sizeof(JVMCINMethodData);
-    if (nmethod_mirror_name != NULL) {
+    if (nmethod_mirror_name != nullptr) {
       size += (int) strlen(nmethod_mirror_name) + 1;
     }
     return size;
@@ -82,8 +82,8 @@ public:
   // Adds `speculation` to the failed speculations list.
   void add_failed_speculation(nmethod* nm, jlong speculation);
 
-  // Gets the JVMCI name of the nmethod (which may be NULL).
-  const char* name() { return _has_name ? (char*)(((address) this) + sizeof(JVMCINMethodData)) : NULL; }
+  // Gets the JVMCI name of the nmethod (which may be null).
+  const char* name() { return _has_name ? (char*)(((address) this) + sizeof(JVMCINMethodData)) : nullptr; }
 
   // Clears the HotSpotNmethod.address field in the  mirror. If nm
   // is dead, the HotSpotNmethod.entryPoint field is also cleared.
@@ -210,7 +210,7 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
   // If such a runtime exists, its _num_attached_threads is incremented
   // and the caller must subsequently attach `thread` to it.
   // JVMCI_lock must be held by current thread.
-  // If nullptr is returned, then `*count` contains the number of JVMCIRuntimes
+  // If null is returned, then `*count` contains the number of JVMCIRuntimes
   // currently allocated.
   static JVMCIRuntime* select_runtime(JavaThread* thread, JVMCIRuntime* skip, int* count);
 
@@ -235,7 +235,7 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
 
   // Ensures that a JVMCI shared library JavaVM exists for this runtime.
   // If the JavaVM was created by this call, then the thread-local JNI
-  // interface pointer for the JavaVM is returned otherwise nullptr is returned.
+  // interface pointer for the JavaVM is returned otherwise null is returned.
   JNIEnv* init_shared_library_javavm();
 
   // Determines if the JVMCI shared library JavaVM exists for this runtime.
@@ -338,7 +338,7 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
 
   // Shuts down this runtime by calling HotSpotJVMCIRuntime.shutdown().
   // If this is the last thread attached to this runtime, then
-  // `_HotSpotJVMCIRuntime_instance` is set to nullptr and `_init_state`
+  // `_HotSpotJVMCIRuntime_instance` is set to null and `_init_state`
   // to uninitialized.
   void shutdown();
 
@@ -349,7 +349,7 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
   void bootstrap_finished(TRAPS);
 
   // Look up a klass by name from a particular class loader (the accessor's).
-  // If require_local, result must be defined in that class loader, or NULL.
+  // If require_local, result must be defined in that class loader, or null.
   // If !require_local, a result from remote class loader may be reported,
   // if sufficient class loader constraints exist such that initiating
   // a class loading request from the given loader is bound to return
@@ -429,7 +429,7 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
   if (HAS_PENDING_EXCEPTION) { \
     char buf[256]; \
     jio_snprintf(buf, 256, "Uncaught exception at %s:%d", __FILE__, __LINE__); \
-    JVMCIRuntime::fatal_exception(NULL, buf); \
+    JVMCIRuntime::fatal_exception(nullptr, buf); \
     return; \
   } \
   (void)(0
@@ -438,7 +438,7 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
   if (HAS_PENDING_EXCEPTION) { \
     char buf[256]; \
     jio_snprintf(buf, 256, "Uncaught exception at %s:%d", __FILE__, __LINE__); \
-    JVMCIRuntime::fatal_exception(NULL, buf); \
+    JVMCIRuntime::fatal_exception(nullptr, buf); \
     return v; \
   } \
   (void)(0
@@ -474,7 +474,7 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
   // When allocation fails, these stubs:
   // 1. Exercise -XX:+HeapDumpOnOutOfMemoryError and -XX:OnOutOfMemoryError handling and also
   //    post a JVMTI_EVENT_RESOURCE_EXHAUSTED event if the failure is an OutOfMemroyError
-  // 2. Return NULL with a pending exception.
+  // 2. Return null with a pending exception.
   // Compiled code must ensure these stubs are not called twice for the same allocation
   // site due to the non-repeatable side effects in the case of OOME.
   static void new_instance(JavaThread* current, Klass* klass) { new_instance_common(current, klass, false); }
@@ -483,7 +483,7 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
   static void dynamic_new_array(JavaThread* current, oopDesc* element_mirror, jint length) { dynamic_new_array_common(current, element_mirror, length, false); }
   static void dynamic_new_instance(JavaThread* current, oopDesc* type_mirror) { dynamic_new_instance_common(current, type_mirror, false); }
 
-  // When allocation fails, these stubs return NULL and have no pending exception. Compiled code
+  // When allocation fails, these stubs return null and have no pending exception. Compiled code
   // can use these stubs if a failed allocation will be retried (e.g., by deoptimizing and
   // re-executing in the interpreter).
   static void new_instance_or_null(JavaThread* thread, Klass* klass) { new_instance_common(thread, klass, true); }

--- a/src/hotspot/share/jvmci/jvmci_globals.cpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@
 #include "utilities/defaultStream.hpp"
 #include "utilities/ostream.hpp"
 
-fileStream* JVMCIGlobals::_jni_config_file = NULL;
+fileStream* JVMCIGlobals::_jni_config_file = nullptr;
 
 // Return true if jvmci flags are consistent.
 bool JVMCIGlobals::check_jvmci_flags_are_consistent() {
@@ -151,9 +151,9 @@ bool JVMCIGlobals::check_jvmci_flags_are_consistent() {
 #endif // PRODUCT
 #undef CHECK_NOT_SET
 
-  if (JVMCILibDumpJNIConfig != NULL) {
+  if (JVMCILibDumpJNIConfig != nullptr) {
     _jni_config_file = new(mtJVMCI) fileStream(JVMCILibDumpJNIConfig);
-    if (_jni_config_file == NULL || !_jni_config_file->is_open()) {
+    if (_jni_config_file == nullptr || !_jni_config_file->is_open()) {
       jio_fprintf(defaultStream::error_stream(),
           "Could not open file for dumping JVMCI shared library JNI config: %s\n", JVMCILibDumpJNIConfig);
       return false;
@@ -184,12 +184,12 @@ bool JVMCIGlobals::enable_jvmci_product_mode(JVMFlagOrigin origin) {
     "UseJVMCINativeLibrary",
     "JVMCINativeLibraryThreadFraction",
     "JVMCINativeLibraryErrorFile",
-    NULL
+    nullptr
   };
 
-  for (int i = 0; JVMCIFlags[i] != NULL; i++) {
+  for (int i = 0; JVMCIFlags[i] != nullptr; i++) {
     JVMFlag *jvmciFlag = (JVMFlag *)JVMFlag::find_declared_flag(JVMCIFlags[i]);
-    if (jvmciFlag == NULL) {
+    if (jvmciFlag == nullptr) {
       return false;
     }
     jvmciFlag->clear_experimental();

--- a/src/hotspot/share/jvmci/jvmci_globals.hpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.hpp
@@ -129,10 +129,10 @@ class fileStream;
           "Maximum size of a compiled method.")                             \
           range(0, max_jint)                                                \
                                                                             \
-  product(ccstr, JVMCILibPath, nullptr, EXPERIMENTAL,                          \
+  product(ccstr, JVMCILibPath, nullptr, EXPERIMENTAL,                       \
           "LD path for loading the JVMCI shared library")                   \
                                                                             \
-  product(ccstr, JVMCILibDumpJNIConfig, nullptr, EXPERIMENTAL,                 \
+  product(ccstr, JVMCILibDumpJNIConfig, nullptr, EXPERIMENTAL,              \
           "Dumps to the given file a description of the classes, fields "   \
           "and methods the JVMCI shared library must provide")              \
                                                                             \
@@ -147,7 +147,7 @@ class fileStream;
           "The remaining compiler threads are used by C1.")                 \
           range(0.0, 1.0)                                                   \
                                                                             \
-  product(ccstr, JVMCINativeLibraryErrorFile, nullptr, EXPERIMENTAL,           \
+  product(ccstr, JVMCINativeLibraryErrorFile, nullptr, EXPERIMENTAL,        \
           "If an error in the JVMCI native library occurs, save the "       \
           "error data to this file"                                         \
           "[default: ./" LIBJVMCI_ERR_FILE "] (%p replaced with pid)")      \

--- a/src/hotspot/share/jvmci/jvmci_globals.hpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -129,10 +129,10 @@ class fileStream;
           "Maximum size of a compiled method.")                             \
           range(0, max_jint)                                                \
                                                                             \
-  product(ccstr, JVMCILibPath, NULL, EXPERIMENTAL,                          \
+  product(ccstr, JVMCILibPath, nullptr, EXPERIMENTAL,                          \
           "LD path for loading the JVMCI shared library")                   \
                                                                             \
-  product(ccstr, JVMCILibDumpJNIConfig, NULL, EXPERIMENTAL,                 \
+  product(ccstr, JVMCILibDumpJNIConfig, nullptr, EXPERIMENTAL,                 \
           "Dumps to the given file a description of the classes, fields "   \
           "and methods the JVMCI shared library must provide")              \
                                                                             \
@@ -147,7 +147,7 @@ class fileStream;
           "The remaining compiler threads are used by C1.")                 \
           range(0.0, 1.0)                                                   \
                                                                             \
-  product(ccstr, JVMCINativeLibraryErrorFile, NULL, EXPERIMENTAL,           \
+  product(ccstr, JVMCINativeLibraryErrorFile, nullptr, EXPERIMENTAL,           \
           "If an error in the JVMCI native library occurs, save the "       \
           "error data to this file"                                         \
           "[default: ./" LIBJVMCI_ERR_FILE "] (%p replaced with pid)")      \

--- a/src/hotspot/share/jvmci/metadataHandles.cpp
+++ b/src/hotspot/share/jvmci/metadataHandles.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
 jmetadata MetadataHandles::allocate_metadata_handle(Metadata* obj) {
   assert(obj->is_valid() && obj->is_metadata(), "must be");
 
-  if (_head == NULL) {
+  if (_head == nullptr) {
     // This is the first allocation.
     _head = new MetadataHandleBlock();
     _last = _head;
@@ -38,7 +38,7 @@ jmetadata MetadataHandles::allocate_metadata_handle(Metadata* obj) {
 
   HandleRecord* handle = get_handle();
 
-  if (handle != NULL) {
+  if (handle != nullptr) {
     handle->set_value(obj);
 #ifdef METADATA_TRACK_NAMES
     handle->set_name(obj->print_value_string());
@@ -47,7 +47,7 @@ jmetadata MetadataHandles::allocate_metadata_handle(Metadata* obj) {
   }
 
   // Check if an unused block follows last
-  if (_last->_next != NULL) {
+  if (_last->_next != nullptr) {
     // update last and retry
     _last = _last->_next;
     return allocate_metadata_handle(obj);
@@ -71,10 +71,10 @@ void MetadataHandles::rebuild_free_list() {
   assert(_allocate_before_rebuild == 0 && _free_list == 0, "just checking");
   int free = 0;
   int blocks = 0;
-  for (MetadataHandleBlock* current = _head; current != NULL; current = current->_next) {
+  for (MetadataHandleBlock* current = _head; current != nullptr; current = current->_next) {
     for (int index = 0; index < current->_top; index++) {
       HandleRecord* handle = &(current->_handles)[index];
-      if (handle->value() == NULL) {
+      if (handle->value() == nullptr) {
         // this handle was cleared out by a delete call, reuse it
         chain_free_list(handle);
         free++;
@@ -100,8 +100,8 @@ void MetadataHandles::rebuild_free_list() {
 void MetadataHandles::clear() {
   _free_list = 0;
   _last = _head;
-  if (_head != NULL) {
-    for (MetadataHandleBlock* block = _head; block != NULL; block = block->_next) {
+  if (_head != nullptr) {
+    for (MetadataHandleBlock* block = _head; block != nullptr; block = block->_next) {
       block->_top = 0;
     }
   }
@@ -110,13 +110,13 @@ void MetadataHandles::clear() {
 }
 
 void MetadataHandles::metadata_do(void f(Metadata*)) {
-  for (MetadataHandleBlock* current = _head; current != NULL; current = current->_next) {
+  for (MetadataHandleBlock* current = _head; current != nullptr; current = current->_next) {
     for (int index = 0; index < current->_top; index++) {
       HandleRecord* root = &(current->_handles)[index];
       Metadata* value = root->value();
       // traverse heap pointers only, not deleted handles or free list
       // pointers
-      if (value != NULL && ((intptr_t) value & ptr_tag) == 0) {
+      if (value != nullptr && ((intptr_t) value & ptr_tag) == 0) {
         assert(value->is_valid(), "invalid metadata %s", current->get_name(index));
         f(value);
       }
@@ -131,14 +131,14 @@ void MetadataHandles::metadata_do(void f(Metadata*)) {
 // Visit any live metadata handles and clean them up.  Since clearing of these handles is driven by
 // weak references they will be cleared at some point in the future when the reference cleaning logic is run.
 void MetadataHandles::do_unloading() {
-  for (MetadataHandleBlock* current = _head; current != NULL; current = current->_next) {
+  for (MetadataHandleBlock* current = _head; current != nullptr; current = current->_next) {
     for (int index = 0; index < current->_top; index++) {
       HandleRecord* handle = &(current->_handles)[index];
       Metadata* value = handle->value();
       // traverse heap pointers only, not deleted handles or free list
       // pointers
-      if (value != NULL && ((intptr_t) value & ptr_tag) == 0) {
-        Klass* klass = NULL;
+      if (value != nullptr && ((intptr_t) value & ptr_tag) == 0) {
+        Klass* klass = nullptr;
         if (value->is_klass()) {
           klass = (Klass*)value;
         } else if (value->is_method()) {
@@ -153,7 +153,7 @@ void MetadataHandles::do_unloading() {
         if (klass->class_loader_data()->is_unloading()) {
           // This needs to be marked so that it's no longer scanned
           // but can't be put on the free list yet. The
-          // HandleCleaner will set this to NULL and
+          // HandleCleaner will set this to null and
           // put it on the free list.
           jlong old_value = Atomic::cmpxchg((jlong*)handle, (jlong) value, (jlong) (ptr_tag));
           if (old_value == (jlong) value) {

--- a/src/hotspot/share/jvmci/metadataHandles.hpp
+++ b/src/hotspot/share/jvmci/metadataHandles.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,8 +47,8 @@ struct _jmetadata {
 
 #ifdef METADATA_TRACK_NAMES
   void initialize() {
-    _value = NULL;
-    _name = NULL;
+    _value = nullptr;
+    _name = nullptr;
   }
 #endif
 
@@ -59,11 +59,11 @@ struct _jmetadata {
 #ifdef METADATA_TRACK_NAMES
   const char* name() { return _name; }
   void set_name(const char* name) {
-    if (_name != NULL) {
+    if (_name != nullptr) {
       os::free((void*) _name);
-      _name = NULL;
+      _name = nullptr;
     }
-    if (name != NULL) {
+    if (name != nullptr) {
       _name = os::strdup(name);
     }
   }
@@ -83,7 +83,7 @@ class MetadataHandleBlock : public CHeapObj<mtJVMCI> {
 
   // Free handles always have their low bit set so those pointers can
   // be distinguished from handles which are in use.  The last handle
-  // on the free list has a NULL pointer with the tag bit set, so it's
+  // on the free list has a null pointer with the tag bit set, so it's
   // clear that the handle has been reclaimed.  The _free_list is
   // always a real pointer to a handle.
 
@@ -93,7 +93,7 @@ class MetadataHandleBlock : public CHeapObj<mtJVMCI> {
 
   MetadataHandleBlock() {
     _top = 0;
-    _next = NULL;
+    _next = nullptr;
 #ifdef METADATA_TRACK_NAMES
     for (int i = 0; i < block_size_in_handles; i++) {
       _handles[i].initialize();
@@ -113,7 +113,7 @@ class MetadataHandleBlock : public CHeapObj<mtJVMCI> {
 // JVMCI maintains direct references to metadata. To make these references safe in the face of
 // class redefinition, they are held in handles so they can be scanned during GC. They are
 // managed in a cooperative way between the Java code and HotSpot. A handle is filled in and
-// passed back to the Java code which is responsible for setting the handle to NULL when it
+// passed back to the Java code which is responsible for setting the handle to null when it
 // is no longer in use. This is done by jdk.vm.ci.hotspot.HandleCleaner. The
 // rebuild_free_list function notices when the handle is clear and reclaims it for re-use.
 class MetadataHandles : public CHeapObj<mtJVMCI> {
@@ -140,7 +140,7 @@ class MetadataHandles : public CHeapObj<mtJVMCI> {
   }
 
   HandleRecord* get_handle() {
-    assert(_last != NULL, "sanity");
+    assert(_last != nullptr, "sanity");
     // Try last block
     if (_last->_top < MetadataHandleBlock::block_size_in_handles) {
       _num_handles++;
@@ -149,7 +149,7 @@ class MetadataHandles : public CHeapObj<mtJVMCI> {
       // Try free list
       return get_free_handle();
     }
-    return NULL;
+    return nullptr;
   }
 
   void rebuild_free_list();
@@ -158,8 +158,8 @@ class MetadataHandles : public CHeapObj<mtJVMCI> {
 
  public:
   MetadataHandles() {
-    _head = NULL;
-    _last = NULL;
+    _head = nullptr;
+    _last = nullptr;
     _free_list = 0;
     _allocate_before_rebuild = 0;
     _num_blocks = 0;
@@ -178,7 +178,7 @@ class MetadataHandles : public CHeapObj<mtJVMCI> {
   void chain_free_list(HandleRecord* handle) {
     handle->set_value((Metadata*) (ptr_tag | _free_list));
 #ifdef METADATA_TRACK_NAMES
-    handle->set_name(NULL);
+    handle->set_name(nullptr);
 #endif
     _free_list = (intptr_t) handle;
     _num_free_handles++;

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.hpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,24 +30,24 @@
 class JVMCIVMStructs {
 public:
   /**
-   * The last entry has a NULL fieldName.
+   * The last entry has a nullptr fieldName.
    */
   static VMStructEntry localHotSpotVMStructs[];
 
   /**
-   * The last entry has a NULL typeName.
+   * The last entry has a nullptr typeName.
    */
   static VMTypeEntry localHotSpotVMTypes[];
 
   /**
    * Table of integer constants.
-   * The last entry has a NULL typeName.
+   * The last entry has a nullptr typeName.
    */
   static VMIntConstantEntry localHotSpotVMIntConstants[];
 
   /**
    * Table of long constants.
-   * The last entry has a NULL typeName.
+   * The last entry has a nullptr typeName.
    */
   static VMLongConstantEntry localHotSpotVMLongConstants[];
 

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.hpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.hpp
@@ -30,24 +30,24 @@
 class JVMCIVMStructs {
 public:
   /**
-   * The last entry has a nullptr fieldName.
+   * The last entry has a null fieldName.
    */
   static VMStructEntry localHotSpotVMStructs[];
 
   /**
-   * The last entry has a nullptr typeName.
+   * The last entry has a null typeName.
    */
   static VMTypeEntry localHotSpotVMTypes[];
 
   /**
    * Table of integer constants.
-   * The last entry has a nullptr typeName.
+   * The last entry has a null typeName.
    */
   static VMIntConstantEntry localHotSpotVMIntConstants[];
 
   /**
    * Table of long constants.
-   * The last entry has a nullptr typeName.
+   * The last entry has a null typeName.
    */
   static VMLongConstantEntry localHotSpotVMLongConstants[];
 


### PR DESCRIPTION
Hi, this PR changes all occurrences of NULL to nullptr for the subdirectory share/jvmci/. Unfortunately the script that does the change isn't perfect, and so we
need to comb through these manually to make sure nothing has gone wrong. I also review these changes but things slip past my eyes sometimes.

Here are some typical things to look out for:

1. No changes but copyright header changed (probably because I reverted some changes but forgot the copyright).
2. Macros having their NULL changed to nullptr, these are added to the script when I find them. They should be NULL.
3. nullptr in comments and logs. We try to use lower case "null" in these cases as it reads better. An exception is made when code expressions are in a comment.

An example of this:

```c++
// This function returns null
void* ret_null();
// This function returns true if *x == nullptr
bool is_nullptr(void** x);
```

Note how `nullptr` participates in a code expression here, we really are talking about the specific value `nullptr`.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301068](https://bugs.openjdk.org/browse/JDK-8301068): Replace NULL with nullptr in share/jvmci/


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12183/head:pull/12183` \
`$ git checkout pull/12183`

Update a local copy of the PR: \
`$ git checkout pull/12183` \
`$ git pull https://git.openjdk.org/jdk pull/12183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12183`

View PR using the GUI difftool: \
`$ git pr show -t 12183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12183.diff">https://git.openjdk.org/jdk/pull/12183.diff</a>

</details>
