### PR TITLE
JDK-8301069: Replace NULL with nullptr in share/libadt/

### DIFF
--- a/src/hotspot/share/libadt/dict.cpp
+++ b/src/hotspot/share/libadt/dict.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -141,7 +141,7 @@ void Dict::doubhash() {
 //------------------------------Insert----------------------------------------
 // Insert or replace a key/value pair in the given dictionary.  If the
 // dictionary is too full, it's size is doubled.  The prior value being
-// replaced is returned (NULL if this is a 1st insertion of that key).  If
+// replaced is returned (null if this is a 1st insertion of that key).  If
 // an old value is found, it's swapped with the prior key-value pair on the
 // list.  This moves a commonly searched-for value towards the list head.
 void*Dict::Insert(void* key, void* val, bool replace) {
@@ -177,7 +177,7 @@ void*Dict::Insert(void* key, void* val, bool replace) {
   b->_keyvals[b->_cnt + b->_cnt    ] = key;
   b->_keyvals[b->_cnt + b->_cnt + 1] = val;
   b->_cnt++;
-  return NULL;                  // Nothing found prior
+  return nullptr;                  // Nothing found prior
 }
 
 //------------------------------Delete---------------------------------------
@@ -195,11 +195,11 @@ void* Dict::Delete(void* key) {
       return prior;
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 //------------------------------FindDict-------------------------------------
-// Find a key-value pair in the given dictionary.  If not found, return NULL.
+// Find a key-value pair in the given dictionary.  If not found, return null.
 // If found, move key-value pair towards head of list.
 void* Dict::operator [](const void* key) const {
   uint i = _hash(key) & (_size - 1); // Get hash key, corrected for size
@@ -209,7 +209,7 @@ void* Dict::operator [](const void* key) const {
       return b->_keyvals[j + j + 1];
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 //------------------------------print------------------------------------------
@@ -287,7 +287,7 @@ void DictI::reset(const Dict* dict) {
 }
 
 //------------------------------next-------------------------------------------
-// Find the next key-value pair in the dictionary, or return a NULL key and
+// Find the next key-value pair in the dictionary, or return a null key and
 // value.
 void DictI::operator ++(void) {
   if (_j--) {                   // Still working in current bin?
@@ -306,5 +306,5 @@ void DictI::operator ++(void) {
     _value = _d->_bin[_i]._keyvals[_j+_j+1];
     return;
   }
-  _key = _value = NULL;
+  _key = _value = nullptr;
 }

--- a/src/hotspot/share/libadt/dict.cpp
+++ b/src/hotspot/share/libadt/dict.cpp
@@ -177,7 +177,7 @@ void*Dict::Insert(void* key, void* val, bool replace) {
   b->_keyvals[b->_cnt + b->_cnt    ] = key;
   b->_keyvals[b->_cnt + b->_cnt + 1] = val;
   b->_cnt++;
-  return nullptr;                  // Nothing found prior
+  return nullptr;              // Nothing found prior
 }
 
 //------------------------------Delete---------------------------------------

--- a/src/hotspot/share/libadt/dict.hpp
+++ b/src/hotspot/share/libadt/dict.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,11 +65,11 @@ class Dict : public AnyObj { // Dictionary structure
   uint32_t Size(void) const { return _cnt; }
 
   // Insert inserts the given key-value pair into the dictionary.  The prior
-  // value of the key is returned; NULL if the key was not previously defined.
+  // value of the key is returned; null if the key was not previously defined.
   void* Insert(void* key, void* val, bool replace = true); // A new key-value
   void* Delete(void* key);        // Delete & return old
 
-  // Find finds the value of a given key; or NULL if not found.
+  // Find finds the value of a given key; or null if not found.
   // The dictionary is NOT changed.
   void* operator [](const void* key) const;  // Do a lookup
 


### PR DESCRIPTION
Do the conversion in the share/libadt/ sub-directory and all of its files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301069](https://bugs.openjdk.org/browse/JDK-8301069): Replace NULL with nullptr in share/libadt/


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12184/head:pull/12184` \
`$ git checkout pull/12184`

Update a local copy of the PR: \
`$ git checkout pull/12184` \
`$ git pull https://git.openjdk.org/jdk pull/12184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12184`

View PR using the GUI difftool: \
`$ git pr show -t 12184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12184.diff">https://git.openjdk.org/jdk/pull/12184.diff</a>

</details>
