### PR TITLE
8301063: Remove dead code from GrowableArray

### DIFF
--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -320,21 +320,6 @@ public:
     return min;
   }
 
-  void truncate_to(int idx) {
-    for (int i = 0, j = idx; j < length(); i++, j++) {
-      at_put(i, at(j));
-    }
-    trunc_to(length() - idx);
-  }
-
-  void truncate_from(int idx) {
-    trunc_to(idx);
-  }
-
-  size_t data_size_in_bytes() const {
-    return _len * sizeof(E);
-  }
-
   void print() const {
     tty->print("Growable Array " PTR_FORMAT, p2i(this));
     tty->print(": length %d (capacity %d) { ", _len, _capacity);


### PR DESCRIPTION
While looking for a method to truncate a GrowableArray, I noticed that there are both `trunc_to` and `truncate_to` while the behavior of the latter is confusing. Since it's unused, I propose to remove it (together with `data_size_in_bytes` which is also unused). The `truncate_to` and `truncate_from` methods were added by [JDK-8271515](https://bugs.openjdk.org/browse/JDK-8271515) and were unused right from the beginning. `data_size_in_bytes` was introduced by [JDK-8254231](https://bugs.openjdk.org/browse/JDK-8254231) and became unused after [JDK-8283689](https://bugs.openjdk.org/browse/JDK-8283689).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301063](https://bugs.openjdk.org/browse/JDK-8301063): Remove dead code from GrowableArray


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12191/head:pull/12191` \
`$ git checkout pull/12191`

Update a local copy of the PR: \
`$ git checkout pull/12191` \
`$ git pull https://git.openjdk.org/jdk pull/12191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12191`

View PR using the GUI difftool: \
`$ git pr show -t 12191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12191.diff">https://git.openjdk.org/jdk/pull/12191.diff</a>

</details>
