### PR TITLE
JDK-8300823: UB: Compile::_phase_optimize_finished is initialized too late

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -977,6 +977,12 @@ void Compile::Init(bool aliasing) {
 
   _immutable_memory = NULL; // filled in at first inquiry
 
+#ifdef ASSERT
+  _type_verify_symmetry = true;
+  _phase_optimize_finished = false;
+  _exception_backedge = false;
+#endif
+
   // Globally visible Nodes
   // First set TOP to NULL to give safe behavior during creation of RootNode
   set_cached_top_node(NULL);
@@ -1070,12 +1076,6 @@ void Compile::Init(bool aliasing) {
   Copy::zero_to_bytes(_alias_cache, sizeof(_alias_cache));
   // A NULL adr_type hits in the cache right away.  Preload the right answer.
   probe_alias_cache(NULL)->_index = AliasIdxTop;
-
-#ifdef ASSERT
-  _type_verify_symmetry = true;
-  _phase_optimize_finished = false;
-  _exception_backedge = false;
-#endif
 }
 
 //---------------------------init_start----------------------------------------


### PR DESCRIPTION
Clang _Undefined Behaviour Sanitizer_ has pointed out a spurious load of the `bool` field `Compile::_phase_optimize_finished` with non-boolean values.

This is due to `Compile::_phase_optimize_finished` being initialized too late in the `Compile::Init` method (e.g. https://github.com/openjdk/jdk/blob/544c16e0bdd4335b2624158fd1f6521984aa5079/src/hotspot/share/opto/compile.cpp#L983 indirectly invokes `Compile::phase_optimize_finished()` to read the field).

So, moving the `_phase_optimize_finished` initialization (and the initialization of the other 2 fields in the same `ASSERT` block) up in the `Compile::Init` method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300823](https://bugs.openjdk.org/browse/JDK-8300823): UB: Compile::_phase_optimize_finished is initialized too late


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12192/head:pull/12192` \
`$ git checkout pull/12192`

Update a local copy of the PR: \
`$ git checkout pull/12192` \
`$ git pull https://git.openjdk.org/jdk pull/12192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12192`

View PR using the GUI difftool: \
`$ git pr show -t 12192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12192.diff">https://git.openjdk.org/jdk/pull/12192.diff</a>

</details>
