### PR TITLE
8300915: G1: incomplete SATB because nmethod entry barriers don't get armed

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -863,6 +863,9 @@ void CodeCache::on_gc_marking_cycle_start() {
   ++_gc_epoch;
 }
 
+// Once started the code cache marking cycle must only be finished after marking of
+// the java heap is complete. Otherwise nmethods could appear to be not on stack even
+// if they have frames in continuation StackChunks that were not yet visited.
 void CodeCache::on_gc_marking_cycle_finish() {
   assert(is_gc_marking_cycle_active(), "Marking cycle started before last one finished");
   ++_gc_epoch;

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3380,3 +3380,8 @@ void G1CollectedHeap::start_codecache_marking_cycle() {
   CodeCache::on_gc_marking_cycle_start();
   CodeCache::arm_all_nmethods();
 }
+
+void G1CollectedHeap::finish_codecache_marking_cycle() {
+  CodeCache::on_gc_marking_cycle_finish();
+  CodeCache::arm_all_nmethods();
+}

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3367,7 +3367,7 @@ void G1CollectedHeap::fill_with_dummy_object(HeapWord* start, HeapWord* end, boo
   region->fill_with_dummy_object(start, pointer_delta(end, start), zap);
 }
 
-void G1CollectedHeap::start_codecache_marking_cycle_if_inactive(bool concurrent_marking_start) {
+void G1CollectedHeap::start_codecache_marking_cycle_if_inactive(bool concurrent_mark_start) {
   // We can reach here with an active code cache marking cycle either because the
   // previous G1 concurrent marking cycle was undone (if heap occupancy after the
   // concurrent start young collection was below the threshold) or aborted. See
@@ -3378,7 +3378,7 @@ void G1CollectedHeap::start_codecache_marking_cycle_if_inactive(bool concurrent_
   if (!CodeCache::is_gc_marking_cycle_active()) {
     CodeCache::on_gc_marking_cycle_start();
   }
-  if (concurrent_marking_start) {
+  if (concurrent_mark_start) {
     CodeCache::arm_all_nmethods();
   }
 }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3369,10 +3369,14 @@ void G1CollectedHeap::fill_with_dummy_object(HeapWord* start, HeapWord* end, boo
 
 void G1CollectedHeap::start_codecache_marking_cycle_if_inactive() {
   if (!CodeCache::is_gc_marking_cycle_active()) {
-    CodeCache::on_gc_marking_cycle_start();
-    CodeCache::arm_all_nmethods();
+    start_codecache_marking_cycle();
   } else {
     assert(G1CollectedHeap::heap()->concurrent_mark()->has_aborted(),
            "Expected full gc after concurrent mark has aborted");
   }
+}
+
+void G1CollectedHeap::start_codecache_marking_cycle() {
+  CodeCache::on_gc_marking_cycle_start();
+  CodeCache::arm_all_nmethods();
 }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3372,7 +3372,7 @@ void G1CollectedHeap::start_codecache_marking_cycle_if_inactive() {
     CodeCache::on_gc_marking_cycle_start();
     CodeCache::arm_all_nmethods();
   } else {
-    assert(static_cast<G1CollectedHeap*>(Universe::heap())->_cm->has_aborted(),
-           "expected stw full gc after cm has aborted");
+    assert(G1CollectedHeap::heap()->concurrent_mark()->has_aborted(),
+           "Expected full gc after concurrent mark has aborted");
   }
 }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3367,26 +3367,18 @@ void G1CollectedHeap::fill_with_dummy_object(HeapWord* start, HeapWord* end, boo
   region->fill_with_dummy_object(start, pointer_delta(end, start), zap);
 }
 
-void G1CollectedHeap::start_codecache_marking_cycle_if_inactive(bool full_gc) {
-  // We can reach here with an active code cache marking cycle either because
-  // the previous G1 concurrent marking cycle
-  //
-  // (1) was aborted and a full gc is about to begin or
-  // (2) it was undone because the heap occupancy was below the threshold after
-  //     the initiating young gc (see G1ConcurrentMark::post_concurrent_undo_start())
-  //
-  // Especially in case (2) it is important that the active codecache cycle was not
-  // finished when executing the G1 undo operation. If it was (repeatedly) finished
-  // then nmethods with frames in continuation StackChunks could appear as not
-  // on stack because they were not marked as on stack in the undone concurrent marking.
-  //
-  // Also for (2) it is important to arm nmethod entry barriers even if no new
-  // code cache cycle is started. They are needed for a complete SATB. A full gc
-  // on the other hand doesn't need the barriers at all.
+void G1CollectedHeap::start_codecache_marking_cycle_if_inactive(bool concurrent_marking_start) {
+  // We can reach here with an active code cache marking cycle either because the
+  // previous G1 concurrent marking cycle was undone (if heap occupancy after the
+  // concurrent start young collection was below the threshold) or aborted. See
+  // CodeCache::on_gc_marking_cycle_finish() why this is.  We must not start a new code
+  // cache cycle then. If we are about to start a new g1 concurrent marking cycle we
+  // still have to arm all nmethod entry barriers. They are needed for adding oop
+  // constants to the SATB snapshot. Full GC does not need nmethods to be armed.
   if (!CodeCache::is_gc_marking_cycle_active()) {
     CodeCache::on_gc_marking_cycle_start();
   }
-  if (!full_gc) {
+  if (concurrent_marking_start) {
     CodeCache::arm_all_nmethods();
   }
 }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3369,13 +3369,10 @@ void G1CollectedHeap::fill_with_dummy_object(HeapWord* start, HeapWord* end, boo
 
 void G1CollectedHeap::start_codecache_marking_cycle_if_inactive() {
   if (!CodeCache::is_gc_marking_cycle_active()) {
-    // This is the normal case when we do not call collect when a
-    // concurrent mark is ongoing. We then start a new code marking
-    // cycle. If, on the other hand, a concurrent mark is ongoing, we
-    // will be conservative and use the last code marking cycle. Code
-    // caches marked between the two concurrent marks will live a bit
-    // longer than needed.
     CodeCache::on_gc_marking_cycle_start();
     CodeCache::arm_all_nmethods();
+  } else {
+    assert(static_cast<G1CollectedHeap*>(Universe::heap())->_cm->has_aborted(),
+           "expected stw full gc after cm has aborted");
   }
 }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -933,7 +933,7 @@ public:
 
   void fill_with_dummy_object(HeapWord* start, HeapWord* end, bool zap) override;
 
-  static void start_codecache_marking_cycle_if_inactive(bool concurrent_marking_start);
+  static void start_codecache_marking_cycle_if_inactive(bool concurrent_mark_start);
   static void finish_codecache_marking_cycle();
 
   // Apply the given closure on all cards in the Hot Card Cache, emptying it.

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -933,6 +933,7 @@ public:
 
   void fill_with_dummy_object(HeapWord* start, HeapWord* end, bool zap) override;
 
+  static void start_codecache_marking_cycle();
   static void start_codecache_marking_cycle_if_inactive();
 
   // Apply the given closure on all cards in the Hot Card Cache, emptying it.

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -933,8 +933,7 @@ public:
 
   void fill_with_dummy_object(HeapWord* start, HeapWord* end, bool zap) override;
 
-  static void start_codecache_marking_cycle();
-  static void start_codecache_marking_cycle_if_inactive();
+  static void start_codecache_marking_cycle_if_inactive(bool full_gc);
   static void finish_codecache_marking_cycle();
 
   // Apply the given closure on all cards in the Hot Card Cache, emptying it.

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -935,6 +935,7 @@ public:
 
   static void start_codecache_marking_cycle();
   static void start_codecache_marking_cycle_if_inactive();
+  static void finish_codecache_marking_cycle();
 
   // Apply the given closure on all cards in the Hot Card Cache, emptying it.
   void iterate_hcc_closure(G1CardTableEntryClosure* cl, uint worker_id);

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -933,7 +933,7 @@ public:
 
   void fill_with_dummy_object(HeapWord* start, HeapWord* end, bool zap) override;
 
-  static void start_codecache_marking_cycle_if_inactive(bool full_gc);
+  static void start_codecache_marking_cycle_if_inactive(bool concurrent_marking_start);
   static void finish_codecache_marking_cycle();
 
   // Apply the given closure on all cards in the Hot Card Cache, emptying it.

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1300,6 +1300,8 @@ void G1ConcurrentMark::remark() {
     assert(!restart_for_overflow(), "sanity");
     // Completely reset the marking state (except bitmaps) since marking completed.
     reset_at_marking_complete();
+
+    G1CollectedHeap::finish_codecache_marking_cycle();
   } else {
     // We overflowed.  Restart concurrent marking.
     _restart_for_overflow = true;
@@ -1315,8 +1317,6 @@ void G1ConcurrentMark::remark() {
     GCTraceTime(Debug, gc, phases) debug("Report Object Count", _gc_timer_cm);
     report_object_count(mark_finished);
   }
-
-  G1CollectedHeap::finish_codecache_marking_cycle();
 
   // Statistics
   double now = os::elapsedTime();

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -792,7 +792,7 @@ G1PreConcurrentStartTask::G1PreConcurrentStartTask(GCCause::Cause cause, G1Concu
 void G1ConcurrentMark::pre_concurrent_start(GCCause::Cause cause) {
   assert_at_safepoint_on_vm_thread();
 
-  G1CollectedHeap::start_codecache_marking_cycle_if_inactive(false /* full_gc */);
+  G1CollectedHeap::start_codecache_marking_cycle_if_inactive(true /* concurrent_marking_start */);
 
   ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_strong);
 

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -824,8 +824,7 @@ void G1ConcurrentMark::post_concurrent_mark_start() {
 
 void G1ConcurrentMark::post_concurrent_undo_start() {
   root_regions()->cancel_scan();
-  CodeCache::on_gc_marking_cycle_finish();
-  CodeCache::arm_all_nmethods();
+  G1CollectedHeap::finish_codecache_marking_cycle();
 }
 
 /*
@@ -1318,8 +1317,7 @@ void G1ConcurrentMark::remark() {
     report_object_count(mark_finished);
   }
 
-  CodeCache::on_gc_marking_cycle_finish();
-  CodeCache::arm_all_nmethods();
+  G1CollectedHeap::finish_codecache_marking_cycle();
 
   // Statistics
   double now = os::elapsedTime();

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -792,8 +792,7 @@ G1PreConcurrentStartTask::G1PreConcurrentStartTask(GCCause::Cause cause, G1Concu
 void G1ConcurrentMark::pre_concurrent_start(GCCause::Cause cause) {
   assert_at_safepoint_on_vm_thread();
 
-  CodeCache::on_gc_marking_cycle_start();
-  CodeCache::arm_all_nmethods();
+  G1CollectedHeap::start_codecache_marking_cycle();
 
   ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_strong);
 

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -792,7 +792,7 @@ G1PreConcurrentStartTask::G1PreConcurrentStartTask(GCCause::Cause cause, G1Concu
 void G1ConcurrentMark::pre_concurrent_start(GCCause::Cause cause) {
   assert_at_safepoint_on_vm_thread();
 
-  G1CollectedHeap::start_codecache_marking_cycle();
+  G1CollectedHeap::start_codecache_marking_cycle_if_inactive(false /* full_gc */);
 
   ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_strong);
 
@@ -824,7 +824,6 @@ void G1ConcurrentMark::post_concurrent_mark_start() {
 
 void G1ConcurrentMark::post_concurrent_undo_start() {
   root_regions()->cancel_scan();
-  G1CollectedHeap::finish_codecache_marking_cycle();
 }
 
 /*

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -792,7 +792,7 @@ G1PreConcurrentStartTask::G1PreConcurrentStartTask(GCCause::Cause cause, G1Concu
 void G1ConcurrentMark::pre_concurrent_start(GCCause::Cause cause) {
   assert_at_safepoint_on_vm_thread();
 
-  G1CollectedHeap::start_codecache_marking_cycle_if_inactive(true /* concurrent_marking_start */);
+  G1CollectedHeap::start_codecache_marking_cycle_if_inactive(true /* concurrent_mark_start */);
 
   ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_strong);
 

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -792,7 +792,8 @@ G1PreConcurrentStartTask::G1PreConcurrentStartTask(GCCause::Cause cause, G1Concu
 void G1ConcurrentMark::pre_concurrent_start(GCCause::Cause cause) {
   assert_at_safepoint_on_vm_thread();
 
-  G1CollectedHeap::start_codecache_marking_cycle_if_inactive();
+  CodeCache::on_gc_marking_cycle_start();
+  CodeCache::arm_all_nmethods();
 
   ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_strong);
 
@@ -824,6 +825,8 @@ void G1ConcurrentMark::post_concurrent_mark_start() {
 
 void G1ConcurrentMark::post_concurrent_undo_start() {
   root_regions()->cancel_scan();
+  CodeCache::on_gc_marking_cycle_finish();
+  CodeCache::arm_all_nmethods();
 }
 
 /*

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -197,7 +197,7 @@ void G1FullCollector::prepare_collection() {
 }
 
 void G1FullCollector::collect() {
-  G1CollectedHeap::start_codecache_marking_cycle_if_inactive();
+  G1CollectedHeap::start_codecache_marking_cycle_if_inactive(true /* full_gc */);
 
   phase1_mark_live_objects();
   verify_after_marking();

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -197,7 +197,7 @@ void G1FullCollector::prepare_collection() {
 }
 
 void G1FullCollector::collect() {
-  G1CollectedHeap::start_codecache_marking_cycle_if_inactive(false /* concurrent_marking_start */);
+  G1CollectedHeap::start_codecache_marking_cycle_if_inactive(false /* concurrent_mark_start */);
 
   phase1_mark_live_objects();
   verify_after_marking();

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -197,7 +197,7 @@ void G1FullCollector::prepare_collection() {
 }
 
 void G1FullCollector::collect() {
-  G1CollectedHeap::start_codecache_marking_cycle_if_inactive(true /* full_gc */);
+  G1CollectedHeap::start_codecache_marking_cycle_if_inactive(false /* concurrent_marking_start */);
 
   phase1_mark_live_objects();
   verify_after_marking();

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -211,8 +211,7 @@ void G1FullCollector::collect() {
 
   phase4_do_compaction();
 
-  CodeCache::on_gc_marking_cycle_finish();
-  CodeCache::arm_all_nmethods();
+  G1CollectedHeap::finish_codecache_marking_cycle();
 }
 
 void G1FullCollector::complete_collection() {


### PR DESCRIPTION
The change makes sure all nmethod entry barriers are armed when a G1 concurrent marking cycle starts by doing it unconditionally in `G1ConcurrentMark::pre_concurrent_start()`. The barrier is needed to add oop constants to the SATB.

This alone would be a conservative/minimal fix but I didn't like that `CodeCache::is_gc_marking_cycle_active()` can return true after a marking cycle start is undone. I.e. `G1ConcurrentMarkThread::_state == Idle && CodeCache::is_gc_marking_cycle_active()` is possible.
Edit: It felt like an inconsistency but maybe its actually ok not to finish the CC marking cycle when the G1 marking is undone. Please comment...
The changes in `G1ConcurrentMark::post_concurrent_undo_start()` were made to avoid it.


Testing

* Rebased this PR onto [JDK-8297487](https://bugs.openjdk.org/browse/JDK-8297487), replaced related assertions with guarantees, and then executed test/langtools:tier1 in a loop for 12h without seeing the issues reported in [JDK-8299956](https://bugs.openjdk.org/browse/JDK-8299956).

* CI testing at SAP: This includes most JCK and JTREG tiers 1-4, also in Xcomp mode, on the standard platforms and also on ppc64le.

* GHA: build failures because download of apache ant failed. `serviceability/jvmti/vthread/SuspendResumeAll/SuspendResumeAll.java` had a timeout on windows-x64. Should be unrelated. It succeeded in our CI testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300915](https://bugs.openjdk.org/browse/JDK-8300915): G1: incomplete SATB because nmethod entry barriers don't get armed


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [55b1aa40](https://git.openjdk.org/jdk/pull/12194/files/55b1aa4091c8090e1783c1606e1b456656df0099)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to [55b1aa40](https://git.openjdk.org/jdk/pull/12194/files/55b1aa4091c8090e1783c1606e1b456656df0099)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12194/head:pull/12194` \
`$ git checkout pull/12194`

Update a local copy of the PR: \
`$ git checkout pull/12194` \
`$ git pull https://git.openjdk.org/jdk pull/12194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12194`

View PR using the GUI difftool: \
`$ git pr show -t 12194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12194.diff">https://git.openjdk.org/jdk/pull/12194.diff</a>

</details>
