### PR TITLE
8301088: oopDesc::print_on should consistently use a trailing newline

### DIFF
--- a/src/hotspot/share/oops/oop.cpp
+++ b/src/hotspot/share/oops/oop.cpp
@@ -40,9 +40,9 @@
 
 void oopDesc::print_on(outputStream* st) const {
   if (*((juint*)this) == badHeapWordVal) {
-    st->print("BAD WORD");
+    st->print_cr("BAD WORD");
   } else if (*((juint*)this) == badMetaWordVal) {
-    st->print("BAD META WORD");
+    st->print_cr("BAD META WORD");
   } else {
     klass()->oop_print_on(cast_to_oop(this), st);
   }

--- a/src/hotspot/share/oops/stackChunkOop.cpp
+++ b/src/hotspot/share/oops/stackChunkOop.cpp
@@ -403,9 +403,9 @@ template void stackChunkOopDesc::fix_thawed_frame(const frame& f, const SmallReg
 
 void stackChunkOopDesc::print_on(bool verbose, outputStream* st) const {
   if (*((juint*)this) == badHeapWordVal) {
-    st->print("BAD WORD");
+    st->print_cr("BAD WORD");
   } else if (*((juint*)this) == badMetaWordVal) {
-    st->print("BAD META WORD");
+    st->print_cr("BAD META WORD");
   } else {
     InstanceStackChunkKlass::print_chunk(const_cast<stackChunkOopDesc*>(this), verbose, st);
   }


### PR DESCRIPTION
[JDK-8284161](https://bugs.openjdk.org/browse/JDK-8284161) added special printing when `oopDesc` contains `badHeapWordVal` or `badMetaWordVal`. However these two cases do not print a trailing newline. The previous behaviour was to always use a trailing newline.

Propose making this consistent with `*klass::oop_print_on` and `InstanceStackChunkKlass::print_chunk`, that both uses a trailing newline.

This new behaviour messes up some printing code, e.g. can be seen in print_location when printing hs_err files which assumes that it always prints a trailing newline.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301088](https://bugs.openjdk.org/browse/JDK-8301088): oopDesc::print_on should consistently use a trailing newline


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12195/head:pull/12195` \
`$ git checkout pull/12195`

Update a local copy of the PR: \
`$ git checkout pull/12195` \
`$ git pull https://git.openjdk.org/jdk pull/12195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12195`

View PR using the GUI difftool: \
`$ git pr show -t 12195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12195.diff">https://git.openjdk.org/jdk/pull/12195.diff</a>

</details>
