### PR TITLE
8300549: JFileChooser Approve button tooltip is null in Aqua L&F in CUSTOM_DIALOG mode

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaFileChooserUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaFileChooserUI.java
@@ -324,9 +324,9 @@ public class AquaFileChooserUI extends FileChooserUI {
         // Mac-specific, required
         newFolderExistsErrorText = getString("FileChooser.newFolderExistsErrorText", "That name is already taken");
         chooseButtonText = getString("FileChooser.chooseButtonText", "Choose");
+        chooseButtonToolTipText = getString("FileChooser.chooseButtonToolTipText", "Choose selected file");
         newFolderButtonText = getString("FileChooser.newFolderButtonText", "New");
         newFolderTitleText = getString("FileChooser.newFolderTitleText", "New Folder");
-        chooseButtonToolTipText = getString("FileChooser.chooseButtonToolTipText", "Choose");
 
         if (fc.getDialogType() == JFileChooser.SAVE_DIALOG) {
             fileNameLabelText = getString("FileChooser.saveDialogFileNameLabelText", "Save As:");
@@ -2054,9 +2054,9 @@ public class AquaFileChooserUI extends FileChooserUI {
             return fc.getApproveButtonMnemonic();
         }
 
-        // No fallback
         String getApproveButtonToolTipText(final JFileChooser fc) {
-            return getApproveButtonToolTipText(fc,chooseButtonToolTipText);
+            // Fallback to "Choose selected file"
+            return getApproveButtonToolTipText(fc, chooseButtonToolTipText);
         }
 
         String getApproveButtonToolTipText(final JFileChooser fc, final String fallbackText) {

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaFileChooserUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaFileChooserUI.java
@@ -162,6 +162,7 @@ public class AquaFileChooserUI extends FileChooserUI {
     protected String filenameTextFieldToolTipText = null;
     protected String filterComboBoxToolTipText = null;
     protected String openDirectoryButtonToolTipText = null;
+    protected String chooseButtonToolTipText = null;
 
     protected String cancelOpenButtonToolTipText = null;
     protected String cancelSaveButtonToolTipText = null;
@@ -325,6 +326,7 @@ public class AquaFileChooserUI extends FileChooserUI {
         chooseButtonText = getString("FileChooser.chooseButtonText", "Choose");
         newFolderButtonText = getString("FileChooser.newFolderButtonText", "New");
         newFolderTitleText = getString("FileChooser.newFolderTitleText", "New Folder");
+        chooseButtonToolTipText = getString("FileChooser.chooseButtonToolTipText", "Choose");
 
         if (fc.getDialogType() == JFileChooser.SAVE_DIALOG) {
             fileNameLabelText = getString("FileChooser.saveDialogFileNameLabelText", "Save As:");
@@ -397,6 +399,7 @@ public class AquaFileChooserUI extends FileChooserUI {
         cancelSaveButtonToolTipText = null;
         cancelChooseButtonToolTipText = null;
         cancelNewFolderButtonToolTipText = null;
+        chooseButtonToolTipText = null;
 
         saveButtonToolTipText = null;
         openButtonToolTipText = null;
@@ -2053,7 +2056,7 @@ public class AquaFileChooserUI extends FileChooserUI {
 
         // No fallback
         String getApproveButtonToolTipText(final JFileChooser fc) {
-            return getApproveButtonToolTipText(fc, null);
+            return getApproveButtonToolTipText(fc,chooseButtonToolTipText);
         }
 
         String getApproveButtonToolTipText(final JFileChooser fc, final String fallbackText) {

--- a/src/java.desktop/macosx/classes/com/apple/laf/resources/aqua.properties
+++ b/src/java.desktop/macosx/classes/com/apple/laf/resources/aqua.properties
@@ -60,6 +60,7 @@ FileChooser.saveTitle.textAndMnemonic=Save
 FileChooser.openTitle.textAndMnemonic=Open
 FileChooser.newFolderExistsError.textAndMnemonic=That name is already taken
 FileChooser.chooseButton.textAndMnemonic=Choose
+FileChooser.chooseButtonToolTip.textAndMnemonic=Choose selected file
 
 FileChooser.newFolderButton.textAndMnemonic=New Folder
 FileChooser.newFolderTitle.textAndMnemonic=New Folder


### PR DESCRIPTION
_JFilechooser_ returns _null_ for Approve button tool tip in `CUSTOM_DIALOG` mode (`getToolTipText()`). The fallback text has been set to "Choose" text. Observation found in validating the test of PR - #11901.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300549](https://bugs.openjdk.org/browse/JDK-8300549): JFileChooser Approve button tooltip is null in Aqua L&amp;F in CUSTOM_DIALOG mode


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12198/head:pull/12198` \
`$ git checkout pull/12198`

Update a local copy of the PR: \
`$ git checkout pull/12198` \
`$ git pull https://git.openjdk.org/jdk pull/12198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12198`

View PR using the GUI difftool: \
`$ git pr show -t 12198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12198.diff">https://git.openjdk.org/jdk/pull/12198.diff</a>

</details>
