### PR TITLE
8301025: ClassCastException in switch with generic record

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -334,7 +334,7 @@ public class TransPatterns extends TreeTranslator {
             }
             JCMethodInvocation componentAccessor =
                     make.App(make.Select(convert(make.Ident(recordBinding), recordBinding.type), //TODO - cast needed????
-                             component.accessor));
+                             component.accessor)).setType(types.erasure(component.accessor.getReturnType()));
             if (deconstructorCalls == null) {
                 deconstructorCalls = Collections.newSetFromMap(new IdentityHashMap<>());
             }
@@ -482,7 +482,7 @@ public class TransPatterns extends TreeTranslator {
             LoadableConstant[] staticArgValues =
                     cases.stream()
                          .flatMap(c -> c.labels.stream())
-                         .map(l -> toLoadableConstant(l, types.classBound(seltype)))
+                         .map(l -> toLoadableConstant(l, seltype))
                          .filter(c -> c != null)
                          .toArray(s -> new LoadableConstant[s]);
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -482,7 +482,7 @@ public class TransPatterns extends TreeTranslator {
             LoadableConstant[] staticArgValues =
                     cases.stream()
                          .flatMap(c -> c.labels.stream())
-                         .map(l -> toLoadableConstant(l, seltype))
+                         .map(l -> toLoadableConstant(l, types.classBound(seltype)))
                          .filter(c -> c != null)
                          .toArray(s -> new LoadableConstant[s]);
 

--- a/test/langtools/tools/javac/T8301025.java
+++ b/test/langtools/tools/javac/T8301025.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8301025
+ * @enablePreview
+ * @compile T8301025.java
+ * @summary ClassCastException in switch with generic record
+ * @modules jdk.compiler
+ */
+public class T8301025 {
+    record TestRecord<T extends String>(T t) {}
+
+    public static void main(String argv[]) {
+        TestRecord r = new TestRecord("a");
+        switch (r) {
+            case TestRecord(String cS)-> {
+                System.out.println("String");
+            }
+            case TestRecord(Object cO)->{
+                System.out.println("Object");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add missing class bound propagation during pattern matching translation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301025](https://bugs.openjdk.org/browse/JDK-8301025): ClassCastException in switch with generic record


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12200/head:pull/12200` \
`$ git checkout pull/12200`

Update a local copy of the PR: \
`$ git checkout pull/12200` \
`$ git pull https://git.openjdk.org/jdk pull/12200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12200`

View PR using the GUI difftool: \
`$ git pr show -t 12200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12200.diff">https://git.openjdk.org/jdk/pull/12200.diff</a>

</details>
