### PR TITLE
8221785: Let possibly_parallel_threads_do cover the same threads as threads_do

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1781,28 +1781,24 @@ class G1RemarkThreadsClosure : public ThreadClosure {
   G1SATBMarkQueueSet& _qset;
   G1CMOopClosure _cm_cl;
   MarkingCodeBlobClosure _code_cl;
-  uintx _claim_token;
 
  public:
   G1RemarkThreadsClosure(G1CollectedHeap* g1h, G1CMTask* task) :
     _qset(G1BarrierSet::satb_mark_queue_set()),
     _cm_cl(g1h, task),
-    _code_cl(&_cm_cl, !CodeBlobToOopClosure::FixRelocations, true /* keepalive nmethods */),
-    _claim_token(Threads::thread_claim_token()) {}
+    _code_cl(&_cm_cl, !CodeBlobToOopClosure::FixRelocations, true /* keepalive nmethods */) {}
 
   void do_thread(Thread* thread) {
-    if (thread->claim_threads_do(true, _claim_token)) {
-      // Transfer any partial buffer to the qset for completed buffer processing.
-      _qset.flush_queue(G1ThreadLocalData::satb_mark_queue(thread));
-      if (thread->is_Java_thread()) {
-        // In theory it should not be necessary to explicitly walk the nmethods to find roots for concurrent marking
-        // however the liveness of oops reachable from nmethods have very complex lifecycles:
-        // * Alive if on the stack of an executing method
-        // * Weakly reachable otherwise
-        // Some objects reachable from nmethods, such as the class loader (or klass_holder) of the receiver should be
-        // live by the SATB invariant but other oops recorded in nmethods may behave differently.
-        JavaThread::cast(thread)->nmethods_do(&_code_cl);
-      }
+    // Transfer any partial buffer to the qset for completed buffer processing.
+    _qset.flush_queue(G1ThreadLocalData::satb_mark_queue(thread));
+    if (thread->is_Java_thread()) {
+      // In theory it should not be necessary to explicitly walk the nmethods to find roots for concurrent marking
+      // however the liveness of oops reachable from nmethods have very complex lifecycles:
+      // * Alive if on the stack of an executing method
+      // * Weakly reachable otherwise
+      // Some objects reachable from nmethods, such as the class loader (or klass_holder) of the receiver should be
+      // live by the SATB invariant but other oops recorded in nmethods may behave differently.
+      JavaThread::cast(thread)->nmethods_do(&_code_cl);
     }
   }
 };
@@ -1817,7 +1813,7 @@ public:
       ResourceMark rm;
 
       G1RemarkThreadsClosure threads_f(G1CollectedHeap::heap(), task);
-      Threads::threads_do(&threads_f);
+      Threads::possibly_parallel_threads_do(true /* is_par */, &threads_f);
     }
 
     do {

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1976,7 +1976,7 @@ public:
     }
 
     PCAddThreadRootsMarkingTaskClosure closure(worker_id);
-    Threads::possibly_parallel_threads_do(true /*parallel */, &closure);
+    Threads::possibly_parallel_threads_do(true /* is_par */, &closure);
 
     // Mark from OopStorages
     {

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -331,7 +331,7 @@ public:
     }
 
     PSThreadRootsTaskClosure closure(worker_id);
-    Threads::possibly_parallel_threads_do(true /*parallel */, &closure);
+    Threads::possibly_parallel_threads_do(true /* is_par */, &closure);
 
     // Scavenge OopStorages
     {

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
@@ -78,18 +78,15 @@ private:
 public:
   ShenandoahSATBAndRemarkThreadsClosure(SATBMarkQueueSet& satb_qset, OopClosure* cl) :
     _satb_qset(satb_qset),
-    _cl(cl),
-    _claim_token(Threads::thread_claim_token()) {}
+    _cl(cl)  {}
 
   void do_thread(Thread* thread) {
-    if (thread->claim_threads_do(true, _claim_token)) {
-      // Transfer any partial buffer to the qset for completed buffer processing.
-      _satb_qset.flush_queue(ShenandoahThreadLocalData::satb_mark_queue(thread));
-      if (thread->is_Java_thread()) {
-        if (_cl != NULL) {
-          ResourceMark rm;
-          thread->oops_do(_cl, NULL);
-        }
+    // Transfer any partial buffer to the qset for completed buffer processing.
+    _satb_qset.flush_queue(ShenandoahThreadLocalData::satb_mark_queue(thread));
+    if (thread->is_Java_thread()) {
+      if (_cl != NULL) {
+        ResourceMark rm;
+        thread->oops_do(_cl, NULL);
       }
     }
   }
@@ -125,7 +122,7 @@ public:
       ShenandoahMarkRefsClosure             mark_cl(q, rp);
       ShenandoahSATBAndRemarkThreadsClosure tc(satb_mq_set,
                                                ShenandoahIUBarrier ? &mark_cl : NULL);
-      Threads::threads_do(&tc);
+      Threads::possibly_parallel_threads_do(true /* is_par */, &tc);
     }
     _cm->mark_loop(worker_id, _terminator, rp,
                    false /*not cancellable*/,

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -254,6 +254,8 @@ void Threads::threads_do(ThreadClosure* tc) {
 }
 
 void Threads::possibly_parallel_threads_do(bool is_par, ThreadClosure* tc) {
+  assert_at_safepoint();
+
   uintx claim_token = Threads::thread_claim_token();
   ALL_JAVA_THREADS(p) {
     if (p->claim_threads_do(is_par, claim_token)) {

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -260,9 +260,11 @@ void Threads::possibly_parallel_threads_do(bool is_par, ThreadClosure* tc) {
       tc->do_thread(p);
     }
   }
-  VMThread* vmt = VMThread::vm_thread();
-  if (vmt->claim_threads_do(is_par, claim_token)) {
-    tc->do_thread(vmt);
+  for (NonJavaThread::Iterator njti; !njti.end(); njti.step()) {
+    Thread* current = njti.current();
+    if (current->claim_threads_do(is_par, claim_token)) {
+      tc->do_thread(current);
+    }
   }
 }
 

--- a/src/hotspot/share/runtime/threads.hpp
+++ b/src/hotspot/share/runtime/threads.hpp
@@ -82,6 +82,7 @@ class Threads: AllStatic {
   // Does not include JNI_VERSION_1_1
   static jboolean is_supported_jni_version(jint version);
 
+private:
   // The "thread claim token" provides a way for threads to be claimed
   // by parallel worker tasks.
   //
@@ -98,6 +99,8 @@ class Threads: AllStatic {
   // New threads get their token set to 0 and change_thread_claim_token()
   // never sets the global token to 0.
   static uintx thread_claim_token() { return _thread_claim_token; }
+
+public:
   static void change_thread_claim_token();
   static void assert_all_threads_claimed() NOT_DEBUG_RETURN;
 

--- a/test/hotspot/gtest/runtime/test_threads.cpp
+++ b/test/hotspot/gtest/runtime/test_threads.cpp
@@ -149,16 +149,15 @@ public:
     CountThreads count2(thread_claim_token(), false); // Claimed by PPTD below
     possibly_parallel_threads_do(true, &count2);
     ASSERT_EQ(count1.java_threads_count(), count2.java_threads_count());
-    ASSERT_EQ(1u, count2.non_java_threads_count()); // Only VM thread
+    ASSERT_EQ(count1.non_java_threads_count(), count2.non_java_threads_count());
 
     CheckClaims check2(thread_claim_token());
     threads_do(&check2);
     ASSERT_EQ(count2.java_threads_count(), check2.java_threads_claimed());
     ASSERT_EQ(0u, check2.java_threads_unclaimed());
-    ASSERT_EQ(1u, check2.non_java_threads_claimed()); // Only VM thread
+    ASSERT_EQ(0u, check2.non_java_threads_unclaimed());
     ASSERT_EQ(count1.non_java_threads_count(),
-              check2.non_java_threads_claimed() +
-              check2.non_java_threads_unclaimed());
+              check2.non_java_threads_claimed());
 
     change_thread_claim_token(); // Expect overflow.
     ASSERT_EQ(uintx(1), thread_claim_token());

--- a/test/hotspot/gtest/runtime/test_threads.cpp
+++ b/test/hotspot/gtest/runtime/test_threads.cpp
@@ -147,7 +147,7 @@ public:
     ASSERT_EQ(max_uintx, thread_claim_token());
 
     CountThreads count2(thread_claim_token(), false); // Claimed by PPTD below
-    possibly_parallel_threads_do(true, &count2);
+    possibly_parallel_threads_do(true /* is_par */, &count2);
     ASSERT_EQ(count1.java_threads_count(), count2.java_threads_count());
     ASSERT_EQ(count1.non_java_threads_count(), count2.non_java_threads_count());
 


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that makes `Threads::possibly_parallel_threads_do` iterate over the same set of threads as `threads_do` to have parity? I.e. over all java and non-java threads.

Originally this CR has been created to make a new method that keeps iterating only over java threads and the VM thread, but it's a bit weird to have both variants as the overhead of the extra threads is negligible and otherwise just confusing.

So I made `Threads::possibly_parallel_threads_do` iterate over all threads; all uses support that afaict, also all uses correctly change the claim token (mostly in the enclosing `StrongRootsScope`).

This allows some minimally better hiding of the token mechanism.

One other reason for not doing this in the first place (as in [JDK-8221102](https://bugs.openjdk.org/browse/JDK-8221102), or as discussed [here](https://mail.openjdk.org/pipermail/hotspot-dev/2019-April/037541.html)) has been the fear that there would be a problem with threads being created during iteration and the (common) call to 'Threads::assert_all_threads_claimed`. However all calls so far are during a safepoint, and none seem to create new threads. I suggest to defer looking at this problem when it is important.

Moreover I need that functionality is required for (JDK-8211104)[https://bugs.openjdk.org/browse/JDK-8211104]. :)

Testing: tier1-4, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8221785](https://bugs.openjdk.org/browse/JDK-8221785): Let possibly_parallel_threads_do cover the same threads as threads_do


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**) ⚠️ Review applies to [34e67f56](https://git.openjdk.org/jdk/pull/12201/files/34e67f56a1de6136c0e1dad4fd3ad97bc0895dcc)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [34e67f56](https://git.openjdk.org/jdk/pull/12201/files/34e67f56a1de6136c0e1dad4fd3ad97bc0895dcc)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12201/head:pull/12201` \
`$ git checkout pull/12201`

Update a local copy of the PR: \
`$ git checkout pull/12201` \
`$ git pull https://git.openjdk.org/jdk pull/12201/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12201`

View PR using the GUI difftool: \
`$ git pr show -t 12201`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12201.diff">https://git.openjdk.org/jdk/pull/12201.diff</a>

</details>
