### PR TITLE
JDK-8301097: Update GHA XCode to 12.5.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -235,7 +235,7 @@ jobs:
     uses: ./.github/workflows/build-macos.yml
     with:
       platform: macos-x64
-      xcode-toolset-version: '11.7'
+      xcode-toolset-version: '12.5.1'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.macos-x64 == 'true'
@@ -246,7 +246,7 @@ jobs:
     uses: ./.github/workflows/build-macos.yml
     with:
       platform: macos-aarch64
-      xcode-toolset-version: '12.4'
+      xcode-toolset-version: '12.5.1'
       extra-conf-options: '--openjdk-target=aarch64-apple-darwin'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}


### PR DESCRIPTION
We are using 11.7 for x86 and 12.4 for aarch64. We should probably be using the same version for both. I assume aarch64 is using a more recent one for better aarch64 support in XCode. 12.4 is not the last release in the 12.x series, that would be 12.5.1, so we should update both to use that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301097](https://bugs.openjdk.org/browse/JDK-8301097): Update GHA XCode to 12.5.1


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12203/head:pull/12203` \
`$ git checkout pull/12203`

Update a local copy of the PR: \
`$ git checkout pull/12203` \
`$ git pull https://git.openjdk.org/jdk pull/12203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12203`

View PR using the GUI difftool: \
`$ git pr show -t 12203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12203.diff">https://git.openjdk.org/jdk/pull/12203.diff</a>

</details>
