### PR TITLE
8301098: Remove dead code FileMapInfo::stop_sharing_and_unmap()

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -2755,29 +2755,6 @@ bool FileMapInfo::validate_header() {
   }
 }
 
-// Unmap mapped regions of shared space.
-void FileMapInfo::stop_sharing_and_unmap(const char* msg) {
-  MetaspaceShared::set_shared_metaspace_range(nullptr, nullptr, nullptr);
-
-  FileMapInfo *map_info = FileMapInfo::current_info();
-  if (map_info) {
-    map_info->fail_continue("%s", msg);
-    for (int i = 0; i < MetaspaceShared::num_non_heap_regions; i++) {
-      if (!HeapShared::is_heap_region(i)) {
-        map_info->unmap_region(i);
-      }
-    }
-    // Dealloc the archive heap regions only without unmapping. The regions are part
-    // of the java heap. Unmapping of the heap regions are managed by GC.
-    map_info->dealloc_heap_regions(open_heap_regions,
-                                   num_open_heap_regions);
-    map_info->dealloc_heap_regions(closed_heap_regions,
-                                   num_closed_heap_regions);
-  } else if (DumpSharedSpaces) {
-    fail_stop("%s", msg);
-  }
-}
-
 #if INCLUDE_JVMTI
 ClassPathEntry** FileMapInfo::_classpath_entries_for_jvmti = nullptr;
 

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -492,9 +492,6 @@ public:
     NOT_CDS(return false;)
   }
 
-  // Stop CDS sharing and unmap CDS regions.
-  static void stop_sharing_and_unmap(const char* msg);
-
   static void allocate_shared_path_table(TRAPS);
   static void copy_shared_path_table(ClassLoaderData* loader_data, TRAPS);
   static void clone_shared_path_table(TRAPS);


### PR DESCRIPTION
Please review this trivial patch. The function `FileMapInfo::stop_sharing_and_unmap()` is no longer being used so it should be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301098](https://bugs.openjdk.org/browse/JDK-8301098): Remove dead code FileMapInfo::stop_sharing_and_unmap()


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12205/head:pull/12205` \
`$ git checkout pull/12205`

Update a local copy of the PR: \
`$ git checkout pull/12205` \
`$ git pull https://git.openjdk.org/jdk pull/12205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12205`

View PR using the GUI difftool: \
`$ git pr show -t 12205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12205.diff">https://git.openjdk.org/jdk/pull/12205.diff</a>

</details>
