### PR TITLE
8301120: Cleanup utility classes java.util.Arrays and java.util.Collections

### DIFF
--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -25,7 +25,6 @@
 
 package java.util;
 
-import jdk.internal.misc.Unsafe;
 import jdk.internal.util.ArraysSupport;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 
@@ -2507,7 +2506,7 @@ public class Arrays {
      * @param a2 the other array to be tested for equality
      * @return {@code true} if the two arrays are equal
      */
-    public static boolean equals(short[] a, short a2[]) {
+    public static boolean equals(short[] a, short[] a2) {
         if (a==a2)
             return true;
         if (a==null || a2==null)
@@ -3509,7 +3508,7 @@ public class Arrays {
     @IntrinsicCandidate
     public static <T,U> T[] copyOf(U[] original, int newLength, Class<? extends T[]> newType) {
         @SuppressWarnings("unchecked")
-        T[] copy = ((Object)newType == (Object)Object[].class)
+        T[] copy = (newType == Object[].class)
             ? (T[]) new Object[newLength]
             : (T[]) Array.newInstance(newType.getComponentType(), newLength);
         System.arraycopy(original, 0, copy, 0,
@@ -3782,7 +3781,7 @@ public class Arrays {
         if (newLength < 0)
             throw new IllegalArgumentException(from + " > " + to);
         @SuppressWarnings("unchecked")
-        T[] copy = ((Object)newType == (Object)Object[].class)
+        T[] copy = (newType == Object[].class)
             ? (T[]) new Object[newLength]
             : (T[]) Array.newInstance(newType.getComponentType(), newLength);
         System.arraycopy(original, from, copy, 0,

--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -3508,7 +3508,7 @@ public class Arrays {
     @IntrinsicCandidate
     public static <T,U> T[] copyOf(U[] original, int newLength, Class<? extends T[]> newType) {
         @SuppressWarnings("unchecked")
-        T[] copy = (newType == Object[].class)
+        T[] copy = ((Object)newType == (Object)Object[].class)
             ? (T[]) new Object[newLength]
             : (T[]) Array.newInstance(newType.getComponentType(), newLength);
         System.arraycopy(original, 0, copy, 0,
@@ -3781,7 +3781,7 @@ public class Arrays {
         if (newLength < 0)
             throw new IllegalArgumentException(from + " > " + to);
         @SuppressWarnings("unchecked")
-        T[] copy = (newType == Object[].class)
+        T[] copy = ((Object)newType == (Object)Object[].class)
             ? (T[]) new Object[newLength]
             : (T[]) Array.newInstance(newType.getComponentType(), newLength);
         System.arraycopy(original, from, copy, 0,

--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -141,7 +141,6 @@ public class Collections {
      *         found to violate the {@link Comparable} contract
      * @see List#sort(Comparator)
      */
-    @SuppressWarnings("unchecked")
     public static <T extends Comparable<? super T>> void sort(List<T> list) {
         list.sort(null);
     }
@@ -175,7 +174,6 @@ public class Collections {
      *         found to violate the {@link Comparator} contract
      * @see List#sort(Comparator)
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
     public static <T> void sort(List<T> list, Comparator<? super T> c) {
         list.sort(c);
     }
@@ -267,7 +265,7 @@ public class Collections {
      * list listIterator.
      */
     private static <T> T get(ListIterator<? extends T> i, int index) {
-        T obj = null;
+        T obj;
         int pos = i.nextIndex();
         if (pos <= index) {
             do {
@@ -651,10 +649,10 @@ public class Collections {
      * @throws NoSuchElementException if the collection is empty.
      * @see Comparable
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({"unchecked"})
     public static <T> T min(Collection<? extends T> coll, Comparator<? super T> comp) {
         if (comp==null)
-            return (T)min((Collection) coll);
+            return (T)min((Collection<Comparable<Object>>) coll);
 
         Iterator<? extends T> i = coll.iterator();
         T candidate = i.next();
@@ -724,10 +722,10 @@ public class Collections {
      * @throws NoSuchElementException if the collection is empty.
      * @see Comparable
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({"unchecked"})
     public static <T> T max(Collection<? extends T> coll, Comparator<? super T> comp) {
         if (comp==null)
-            return (T)max((Collection) coll);
+            return (T)max((Collection<Comparable<Object>>) coll);
 
         Iterator<? extends T> i = coll.iterator();
         T candidate = i.next();
@@ -1067,7 +1065,7 @@ public class Collections {
         public String toString()                   {return c.toString();}
 
         public Iterator<E> iterator() {
-            return new Iterator<E>() {
+            return new Iterator<>() {
                 private final Iterator<? extends E> i = c.iterator();
 
                 public boolean hasNext() {return i.hasNext();}
@@ -1279,7 +1277,6 @@ public class Collections {
             private Object readResolve()        { return EMPTY_NAVIGABLE_SET; }
         }
 
-        @SuppressWarnings("rawtypes")
         private static final NavigableSet<?> EMPTY_NAVIGABLE_SET =
                 new EmptyNavigableSet<>();
 
@@ -1392,7 +1389,7 @@ public class Collections {
         public ListIterator<E> listIterator()   {return listIterator(0);}
 
         public ListIterator<E> listIterator(final int index) {
-            return new ListIterator<E>() {
+            return new ListIterator<>() {
                 private final ListIterator<? extends E> i
                     = list.listIterator(index);
 
@@ -1634,10 +1631,9 @@ public class Collections {
             @java.io.Serial
             private static final long serialVersionUID = 7854390611657943733L;
 
-            @SuppressWarnings({"unchecked", "rawtypes"})
+            @SuppressWarnings({"unchecked"})
             UnmodifiableEntrySet(Set<? extends Map.Entry<? extends K, ? extends V>> s) {
-                // Need to cast to raw in order to work around a limitation in the type system
-                super((Set)s);
+                super((Set<Map.Entry<K, V>>)s);
             }
 
             static <K, V> Consumer<Map.Entry<? extends K, ? extends V>> entryConsumer(
@@ -1721,7 +1717,7 @@ public class Collections {
             }
 
             public Iterator<Map.Entry<K,V>> iterator() {
-                return new Iterator<Map.Entry<K,V>>() {
+                return new Iterator<>() {
                     private final Iterator<? extends Map.Entry<? extends K, ? extends V>> i = c.iterator();
 
                     public boolean hasNext() {
@@ -1920,7 +1916,7 @@ public class Collections {
         private static final long serialVersionUID = -4858195264774772197L;
 
         /**
-         * A class for the {@link EMPTY_NAVIGABLE_MAP} which needs readResolve
+         * A class for the {@link #EMPTY_NAVIGABLE_MAP} which needs readResolve
          * to preserve singleton property.
          *
          * @param <K> type of keys, if there were any, and of bounds
@@ -1943,7 +1939,7 @@ public class Collections {
         }
 
         /**
-         * Singleton for {@link emptyNavigableMap()} which is also immutable.
+         * Singleton for {@link #emptyNavigableMap()} which is also immutable.
          */
         private static final EmptyNavigableMap<?,?> EMPTY_NAVIGABLE_MAP =
             new EmptyNavigableMap<>();
@@ -3191,7 +3187,7 @@ public class Collections {
             // JDK-6363904 - unwrapped iterator could be typecast to
             // ListIterator with unsafe set()
             final Iterator<E> it = c.iterator();
-            return new Iterator<E>() {
+            return new Iterator<>() {
                 public boolean hasNext() { return it.hasNext(); }
                 public E next()          { return it.next(); }
                 public void remove()     {        it.remove(); }
@@ -3582,7 +3578,7 @@ public class Collections {
         public ListIterator<E> listIterator(final int index) {
             final ListIterator<E> i = list.listIterator(index);
 
-            return new ListIterator<E>() {
+            return new ListIterator<>() {
                 public boolean hasNext()     { return i.hasNext(); }
                 public E next()              { return i.next(); }
                 public boolean hasPrevious() { return i.hasPrevious(); }
@@ -3890,7 +3886,7 @@ public class Collections {
             public Iterator<Map.Entry<K,V>> iterator() {
                 final Iterator<Map.Entry<K, V>> i = s.iterator();
 
-                return new Iterator<Map.Entry<K,V>>() {
+                return new Iterator<>() {
                     public boolean hasNext() { return i.hasNext(); }
                     public void remove()     { i.remove(); }
 
@@ -4745,7 +4741,6 @@ public class Collections {
 
         // Override default methods in Map
         @Override
-        @SuppressWarnings("unchecked")
         public V getOrDefault(Object k, V defaultValue) {
             return defaultValue;
         }
@@ -4826,7 +4821,7 @@ public class Collections {
     }
 
     static <E> Iterator<E> singletonIterator(final E e) {
-        return new Iterator<E>() {
+        return new Iterator<>() {
             private boolean hasNext = true;
             public boolean hasNext() {
                 return hasNext;
@@ -4859,7 +4854,7 @@ public class Collections {
      * @return A singleton {@code Spliterator}
      */
     static <T> Spliterator<T> singletonSpliterator(final T element) {
-        return new Spliterator<T>() {
+        return new Spliterator<>() {
             long est = 1;
 
             @Override
@@ -5061,7 +5056,7 @@ public class Collections {
 
         public Set<Map.Entry<K,V>> entrySet() {
             if (entrySet==null)
-                entrySet = Collections.<Map.Entry<K,V>>singleton(
+                entrySet = Collections.singleton(
                     new SimpleImmutableEntry<>(k, v));
             return entrySet;
         }
@@ -5429,8 +5424,8 @@ public class Collections {
 
         public boolean equals(Object o) {
             return (o == this) ||
-                (o instanceof ReverseComparator2 &&
-                 cmp.equals(((ReverseComparator2)o).cmp));
+                (o instanceof ReverseComparator2<?> that &&
+                 cmp.equals(that.cmp));
         }
 
         public int hashCode() {
@@ -5459,7 +5454,7 @@ public class Collections {
      * @see Enumeration
      */
     public static <T> Enumeration<T> enumeration(final Collection<T> c) {
-        return new Enumeration<T>() {
+        return new Enumeration<>() {
             private final Iterator<T> i = c.iterator();
 
             public boolean hasMoreElements() {


### PR DESCRIPTION
number of minor cleanups could be done in Arrays and Collections utility classes.
In Arrays:
- Redundant import jdk.internal.misc.Unsafe;
- C-style array declaration is used in public static boolean equals(short[] a, short a2[]) (that's the only place in the whole file)

In Collections:
- A few obsolete "unchecked" and "rawtypes" suppressions
- Unnecessary local variable initializer in get() method
- Raw type can be avoided in a number of casts
- Explicit type parameters could be omitted or converted to diamonds
- A couple of javadoc links on private APIs are malformed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301120](https://bugs.openjdk.org/browse/JDK-8301120): Cleanup utility classes java.util.Arrays and java.util.Collections


### Reviewers
 * [Stuart Marks](https://openjdk.org/census#smarks) (@stuart-marks - **Reviewer**)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12207/head:pull/12207` \
`$ git checkout pull/12207`

Update a local copy of the PR: \
`$ git checkout pull/12207` \
`$ git pull https://git.openjdk.org/jdk pull/12207/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12207`

View PR using the GUI difftool: \
`$ git pr show -t 12207`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12207.diff">https://git.openjdk.org/jdk/pull/12207.diff</a>

</details>
