### PR TITLE
8301129: Link to debuginfo files should only be made after stripping

### DIFF
--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -1062,9 +1062,12 @@ define SetupNativeCompilationBody
           $1_DEBUGINFO_FILES := $$($1_SYMBOLS_DIR)/$$($1_NOSUFFIX).debuginfo
           # Setup the command line creating debuginfo files, to be run after linking.
           # It cannot be run separately since it updates the original target file
+          # Creating the debuglink is done in another command rather than all at once
+          # so we can run it after strip is called, since strip can sometimes mangle the
+          # embedded debuglink, which we want to avoid.
           $1_CREATE_DEBUGINFO_CMDS := \
               $$($1_OBJCOPY) --only-keep-debug $$($1_TARGET) $$($1_DEBUGINFO_FILES) $$(NEWLINE)
-          $1_CREATE_DEBUGINFO_LINK_CMDS := $(CD) $$($1_SYMBOLS_DIR) && \
+          $1_CREATE_DEBUGLINK_CMDS := $(CD) $$($1_SYMBOLS_DIR) && \
               $$($1_OBJCOPY) --add-gnu-debuglink=$$($1_DEBUGINFO_FILES) $$($1_TARGET)
 
         else ifeq ($(call isTargetOs, aix), true)
@@ -1194,7 +1197,7 @@ define SetupNativeCompilationBody
     $1_VARDEPS := $$($1_LD) $$($1_SYSROOT_LDFLAGS) $$($1_LDFLAGS) $$($1_EXTRA_LDFLAGS) \
         $$($1_LIBS) $$($1_EXTRA_LIBS) $$($1_MT) \
         $$($1_CREATE_DEBUGINFO_CMDS) $$($1_MANIFEST_VERSION) \
-        $$($1_STRIP_CMD) $$($1_CREATE_DEBUGINFO_LINK_CMDS)
+        $$($1_STRIP_CMD) $$($1_CREATE_DEBUGLINK_CMDS)
     $1_VARDEPS_FILE := $$(call DependOnVariable, $1_VARDEPS, \
         $$($1_OBJECT_DIR)/$$($1_NOSUFFIX).vardeps)
 
@@ -1257,7 +1260,7 @@ define SetupNativeCompilationBody
 		          test "$$$$?" = "1" ; \
 		  $$($1_CREATE_DEBUGINFO_CMDS)
 		  $$($1_STRIP_CMD)
-		  $$($1_CREATE_DEBUGINFO_LINK_CMDS)
+		  $$($1_CREATE_DEBUGLINK_CMDS)
                  ifeq ($(call isBuildOsEnv, windows.wsl2), true)
 		    $$(CHMOD) +x $$($1_TARGET)
                  endif
@@ -1269,7 +1272,7 @@ define SetupNativeCompilationBody
 		          $$($1_LIBS) $$($1_EXTRA_LIBS)) ; \
 		  $$($1_CREATE_DEBUGINFO_CMDS)
 		  $$($1_STRIP_CMD)
-		  $$($1_CREATE_DEBUGINFO_LINK_CMDS)
+		  $$($1_CREATE_DEBUGLINK_CMDS)
                 endif
                 ifeq ($(call isTargetOs, windows), true)
                   ifneq ($$($1_MANIFEST), )

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -1063,9 +1063,9 @@ define SetupNativeCompilationBody
           # Setup the command line creating debuginfo files, to be run after linking.
           # It cannot be run separately since it updates the original target file
           $1_CREATE_DEBUGINFO_CMDS := \
-              $$($1_OBJCOPY) --only-keep-debug $$($1_TARGET) $$($1_DEBUGINFO_FILES) $$(NEWLINE) \
-              $(CD) $$($1_SYMBOLS_DIR) && \
-                  $$($1_OBJCOPY) --add-gnu-debuglink=$$($1_DEBUGINFO_FILES) $$($1_TARGET)
+              $$($1_OBJCOPY) --only-keep-debug $$($1_TARGET) $$($1_DEBUGINFO_FILES) $$(NEWLINE)
+          $1_CREATE_DEBUGINFO_LINK_CMDS := $(CD) $$($1_SYMBOLS_DIR) && \
+              $$($1_OBJCOPY) --add-gnu-debuglink=$$($1_DEBUGINFO_FILES) $$($1_TARGET)
 
         else ifeq ($(call isTargetOs, aix), true)
           # AIX does not provide the equivalent of OBJCOPY to extract debug symbols,
@@ -1194,7 +1194,7 @@ define SetupNativeCompilationBody
     $1_VARDEPS := $$($1_LD) $$($1_SYSROOT_LDFLAGS) $$($1_LDFLAGS) $$($1_EXTRA_LDFLAGS) \
         $$($1_LIBS) $$($1_EXTRA_LIBS) $$($1_MT) \
         $$($1_CREATE_DEBUGINFO_CMDS) $$($1_MANIFEST_VERSION) \
-        $$($1_STRIP_CMD)
+        $$($1_STRIP_CMD) $$($1_CREATE_DEBUGINFO_LINK_CMDS)
     $1_VARDEPS_FILE := $$(call DependOnVariable, $1_VARDEPS, \
         $$($1_OBJECT_DIR)/$$($1_NOSUFFIX).vardeps)
 
@@ -1257,6 +1257,7 @@ define SetupNativeCompilationBody
 		          test "$$$$?" = "1" ; \
 		  $$($1_CREATE_DEBUGINFO_CMDS)
 		  $$($1_STRIP_CMD)
+		  $$($1_CREATE_DEBUGINFO_LINK_CMDS)
                  ifeq ($(call isBuildOsEnv, windows.wsl2), true)
 		    $$(CHMOD) +x $$($1_TARGET)
                  endif
@@ -1268,6 +1269,7 @@ define SetupNativeCompilationBody
 		          $$($1_LIBS) $$($1_EXTRA_LIBS)) ; \
 		  $$($1_CREATE_DEBUGINFO_CMDS)
 		  $$($1_STRIP_CMD)
+		  $$($1_CREATE_DEBUGINFO_LINK_CMDS)
                 endif
                 ifeq ($(call isTargetOs, windows), true)
                   ifneq ($$($1_MANIFEST), )


### PR DESCRIPTION
Links to debuginfo files should only be made after strip is run, as doing so before can cause strip to wreck the embedded link and make the executable entirely un-executable in certain strange cases. It's safer to always just make the link after strip is called regardless

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301129](https://bugs.openjdk.org/browse/JDK-8301129): Link to debuginfo files should only be made after stripping


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [cd369975](https://git.openjdk.org/jdk/pull/12209/files/cd3699759ecfe426e73b0bc86e9b15d25688718b)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [cd369975](https://git.openjdk.org/jdk/pull/12209/files/cd3699759ecfe426e73b0bc86e9b15d25688718b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12209/head:pull/12209` \
`$ git checkout pull/12209`

Update a local copy of the PR: \
`$ git checkout pull/12209` \
`$ git pull https://git.openjdk.org/jdk pull/12209/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12209`

View PR using the GUI difftool: \
`$ git pr show -t 12209`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12209.diff">https://git.openjdk.org/jdk/pull/12209.diff</a>

</details>
