### PR TITLE
8294066: IGV: Graph changes when deleting a graph in the same group with smaller index

### DIFF
--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/GraphRemoveCookie.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/GraphRemoveCookie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,10 +26,7 @@ package com.sun.hotspot.igv.coordinator.actions;
 import com.sun.hotspot.igv.data.InputGraph;
 import com.sun.hotspot.igv.view.DiagramViewModel;
 import com.sun.hotspot.igv.view.EditorTopComponent;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import org.openide.util.Lookup;
 import org.openide.windows.Mode;
 import org.openide.windows.TopComponent;
 import org.openide.windows.WindowManager;

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/GraphRemoveCookie.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/GraphRemoveCookie.java
@@ -52,6 +52,10 @@ public class GraphRemoveCookie implements RemoveCookie {
                     int firstPosition = model.getFirstPosition();
                     int secondPosition = model.getSecondPosition();
                     int targetPosition = list.indexOf(graph);
+                    if (targetPosition == firstPosition || targetPosition == secondPosition) {
+                        t.close();
+                        continue;
+                    }
                     if (targetPosition < firstPosition) {
                         firstPosition--;
                     }

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/GraphRemoveCookie.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/GraphRemoveCookie.java
@@ -24,6 +24,15 @@
 package com.sun.hotspot.igv.coordinator.actions;
 
 import com.sun.hotspot.igv.data.InputGraph;
+import com.sun.hotspot.igv.view.DiagramViewModel;
+import com.sun.hotspot.igv.view.EditorTopComponent;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.openide.util.Lookup;
+import org.openide.windows.Mode;
+import org.openide.windows.TopComponent;
+import org.openide.windows.WindowManager;
 
 public class GraphRemoveCookie implements RemoveCookie {
     private final InputGraph graph;
@@ -34,6 +43,38 @@ public class GraphRemoveCookie implements RemoveCookie {
 
     @Override
     public void remove() {
+        List<InputGraph> list = graph.getGroup().getGraphs();
+        WindowManager manager = WindowManager.getDefault();
+        for (Mode m : manager.getModes()) {
+            List<TopComponent> l = new ArrayList<>(Arrays.asList(manager.getOpenedTopComponents(m)));
+            for (TopComponent t : l) {
+                if (t instanceof EditorTopComponent) {
+                    EditorTopComponent etc = (EditorTopComponent) t;
+                    InputGraph openedGraph = etc.getModel().getGraph();
+                    if (graph.equals(openedGraph) || ) {
+                        etc.close();
+                        continue;
+                    }
+                    if (openedGraph.isDiffGraph()) {
+                        if (graph.equals(openedGraph.getFirstGraph()) || graph.equals(openedGraph.getSecondGraph())) {
+                            etc.close();
+                            continue;
+                        }
+                    }
+                    DiagramViewModel model = etc.getModel();
+                    int firstPosition = model.getFirstPosition();
+                    int secondPosition = model.getSecondPosition();
+                    int targetPosition = list.indexOf(graph);
+                    if (targetPosition < firstPosition) {
+                        firstPosition--;
+                    }
+                    if (targetPosition < secondPosition) {
+                        secondPosition--;
+                    }
+                    model.setPositions(firstPosition, secondPosition);
+                }
+            }
+        }
         graph.getGroup().removeElement(graph);
     }
 }

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/GraphRemoveCookie.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/GraphRemoveCookie.java
@@ -50,18 +50,10 @@ public class GraphRemoveCookie implements RemoveCookie {
             for (TopComponent t : l) {
                 if (t instanceof EditorTopComponent) {
                     EditorTopComponent etc = (EditorTopComponent) t;
-                    InputGraph openedGraph = etc.getModel().getGraph();
-                    if (graph.equals(openedGraph) || ) {
-                        etc.close();
+                    DiagramViewModel model = etc.getModel();
+                    if (!model.getGroup().getGraphs().contains(graph)) {
                         continue;
                     }
-                    if (openedGraph.isDiffGraph()) {
-                        if (graph.equals(openedGraph.getFirstGraph()) || graph.equals(openedGraph.getSecondGraph())) {
-                            etc.close();
-                            continue;
-                        }
-                    }
-                    DiagramViewModel model = etc.getModel();
                     int firstPosition = model.getFirstPosition();
                     int secondPosition = model.getSecondPosition();
                     int targetPosition = list.indexOf(graph);

--- a/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/GraphRemoveCookie.java
+++ b/src/utils/IdealGraphVisualizer/Coordinator/src/main/java/com/sun/hotspot/igv/coordinator/actions/GraphRemoveCookie.java
@@ -46,11 +46,9 @@ public class GraphRemoveCookie implements RemoveCookie {
         List<InputGraph> list = graph.getGroup().getGraphs();
         WindowManager manager = WindowManager.getDefault();
         for (Mode m : manager.getModes()) {
-            List<TopComponent> l = new ArrayList<>(Arrays.asList(manager.getOpenedTopComponents(m)));
-            for (TopComponent t : l) {
+            for (TopComponent t : manager.getOpenedTopComponents(m)) {
                 if (t instanceof EditorTopComponent) {
-                    EditorTopComponent etc = (EditorTopComponent) t;
-                    DiagramViewModel model = etc.getModel();
+                    DiagramViewModel model = ((EditorTopComponent) t).getModel();
                     if (!model.getGroup().getGraphs().contains(graph)) {
                         continue;
                     }


### PR DESCRIPTION
IGV displays a different graph when removing a graph that has a smaller index than the graph displayed in the window. We can reproduce this behavior with the following steps.

1. Open a graph file. Open a graph.
2. In the outline window, remove a graph that has a smaller index than the open graph.
3. The graph changes from the open graph to another graph.

With this pull request, IGV will keep the same graph when doing the above.

# Tests
There are no test classes corresponding to the classes this PR changes. So I did manual tests.

I open the graph at index 8, a diff graph that contains this graph, a graph that clones this graph, and a graph that is in a different folder.

<img width="650" alt="スクリーンショット_20230125_171428" src="https://user-images.githubusercontent.com/60008/214519649-a2e40f77-7ca8-42af-bd64-65f72f53d2cb.png">

I remove the graph at index 1. IGV still shows the same charts and the index of the chart changes from 8 to 7. This affects not only a single graph, but also diff graphs and clone graphs. The graph in another folder, which is "12. Global code motion...",  is not affected.

<img width="650" alt="スクリーンショット_20230125_171457" src="https://user-images.githubusercontent.com/60008/214519675-3e0262b7-86b3-4163-b059-7bd207373e65.png">

Next, I remove the graph at index 10. Its index is greater than the index of the display graph. This time, the diff graph contains the graph at index 12. So the index has changed from 12 to 11.

<img width="650" alt="スクリーンショット_20230125_171528" src="https://user-images.githubusercontent.com/60008/214519713-e5f898f1-5ab5-4fec-bc8c-c5869f50443f.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294066](https://bugs.openjdk.org/browse/JDK-8294066): IGV: Graph changes when deleting a graph in the same group with smaller index


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Tobias Holenstein](https://openjdk.org/census#tholenstein) (@tobiasholenstein - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12210/head:pull/12210` \
`$ git checkout pull/12210`

Update a local copy of the PR: \
`$ git checkout pull/12210` \
`$ git pull https://git.openjdk.org/jdk pull/12210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12210`

View PR using the GUI difftool: \
`$ git pr show -t 12210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12210.diff">https://git.openjdk.org/jdk/pull/12210.diff</a>

</details>
