### PR TITLE
8301132: Test update for deprecated sprintf in Xcode 14

### DIFF
--- a/test/jdk/sun/management/jmxremote/bootstrap/exelauncher.c
+++ b/test/jdk/sun/management/jmxremote/bootstrap/exelauncher.c
@@ -61,8 +61,9 @@ int main(int argc, char**argv) {
         fprintf(stderr, "Usage: %s jvm-path classpath class\n", argv[0]);
         return -1;
      }
-     cp_prop = (char*)malloc(strlen(CP_PROP)+strlen(argv[2]) +1);
-     sprintf(cp_prop, "%s%s", CP_PROP, argv[2]);
+     size_t propLen = strlen(CP_PROP) + strlen(argv[2]) + 1;
+     cp_prop = (char*)malloc(propLen);
+     snprintf(cp_prop, propLen, "%s%s", CP_PROP, argv[2]);
 
      options[0].optionString = cp_prop;
      vm_args.version = 0x00010002;

--- a/test/jdk/sun/management/windows/exerevokeall.c
+++ b/test/jdk/sun/management/windows/exerevokeall.c
@@ -99,12 +99,13 @@ static char *getTextualSid(SID* sid) {
     }
 
     // S-SID_REVISION
-    sprintf(name, "S-%lu-", SID_REVISION );
+    snprintf(name, sizeof(name), "S-%lu-", SID_REVISION );
 
     // Identifier authority
     if ((sia->Value[0] != 0) || (sia->Value[1] != 0))
     {
-        sprintf(name + strlen(name), "0x%02hx%02hx%02hx%02hx%02hx%02hx",
+        snprintf(name + strlen(name), sizeof(name) - strlen(name),
+                "0x%02hx%02hx%02hx%02hx%02hx%02hx",
                 (USHORT)sia->Value[0],
                 (USHORT)sia->Value[1],
                 (USHORT)sia->Value[2],
@@ -114,7 +115,7 @@ static char *getTextualSid(SID* sid) {
     }
     else
     {
-        sprintf(name + strlen(name), "%lu",
+        snprintf(name + strlen(name), sizeof(name) - strlen(name), "%lu",
                 (ULONG)(sia->Value[5]      )   +
                 (ULONG)(sia->Value[4] <<  8)   +
                 (ULONG)(sia->Value[3] << 16)   +
@@ -123,7 +124,7 @@ static char *getTextualSid(SID* sid) {
 
     // finally, the sub-authorities
     for (i=0 ; i<count; i++) {
-        sprintf(name + strlen(name), "-%lu",
+        snprintf(name + strlen(name), sizeof(name) - strlen(name), "-%lu",
                 *GetSidSubAuthority(sid, i) );
     }
 

--- a/test/jdk/sun/management/windows/exerevokeall.c
+++ b/test/jdk/sun/management/windows/exerevokeall.c
@@ -99,12 +99,12 @@ static char *getTextualSid(SID* sid) {
     }
 
     // S-SID_REVISION
-    snprintf(name, sizeof(name), "S-%lu-", SID_REVISION );
+    snprintf(name, len, "S-%lu-", SID_REVISION );
 
     // Identifier authority
     if ((sia->Value[0] != 0) || (sia->Value[1] != 0))
     {
-        snprintf(name + strlen(name), sizeof(name) - strlen(name),
+        snprintf(name + strlen(name), len - strlen(name),
                 "0x%02hx%02hx%02hx%02hx%02hx%02hx",
                 (USHORT)sia->Value[0],
                 (USHORT)sia->Value[1],
@@ -115,7 +115,7 @@ static char *getTextualSid(SID* sid) {
     }
     else
     {
-        snprintf(name + strlen(name), sizeof(name) - strlen(name), "%lu",
+        snprintf(name + strlen(name), len - strlen(name), "%lu",
                 (ULONG)(sia->Value[5]      )   +
                 (ULONG)(sia->Value[4] <<  8)   +
                 (ULONG)(sia->Value[3] << 16)   +
@@ -124,7 +124,7 @@ static char *getTextualSid(SID* sid) {
 
     // finally, the sub-authorities
     for (i=0 ; i<count; i++) {
-        snprintf(name + strlen(name), sizeof(name) - strlen(name), "-%lu",
+        snprintf(name + strlen(name), len - strlen(name), "-%lu",
                 *GetSidSubAuthority(sid, i) );
     }
 


### PR DESCRIPTION
The sprintf is deprecated in Xcode 14 because of security concerns. The issue was addressed in [JDK-8296812](https://bugs.openjdk.org/browse/JDK-8296812)/[JDK-8299378](https://bugs.openjdk.org/browse/JDK-8299378)/[JDK-8299635](https://bugs.openjdk.org/browse/JDK-8299635), but the test was not fully covered yet. This would be the last effort to fix the issue in test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301132](https://bugs.openjdk.org/browse/JDK-8301132): Test update for deprecated sprintf in Xcode 14


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12211/head:pull/12211` \
`$ git checkout pull/12211`

Update a local copy of the PR: \
`$ git checkout pull/12211` \
`$ git pull https://git.openjdk.org/jdk pull/12211/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12211`

View PR using the GUI difftool: \
`$ git pr show -t 12211`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12211.diff">https://git.openjdk.org/jdk/pull/12211.diff</a>

</details>
