### PR TITLE
8301133: IGV: NPE occurs when creating a diff graph with a graph in a different folder

### DIFF
--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Group.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Group.java
@@ -126,7 +126,7 @@ public class Group extends Properties.Entity implements ChangedEventProvider<Gro
 
     @Override
     public String getDisplayName() {
-        return getParent() == null ? "" : getParent().getElements().indexOf(this)+1 + " - " + getName();
+        return (getParent() == null ? "" : getParent().getElements().indexOf(this) + 1 + " - ") + getName();
     }
 
     public String getType() {

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Group.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Group.java
@@ -126,7 +126,7 @@ public class Group extends Properties.Entity implements ChangedEventProvider<Gro
 
     @Override
     public String getDisplayName() {
-        return getParent().getElements().indexOf(this)+1 + " - " + getName();
+        return getParent() == null ? "" : getParent().getElements().indexOf(this)+1 + " - " + getName();
     }
 
     public String getType() {


### PR DESCRIPTION
NullPointerException occurs when we create a diff graph with graphs in different folders. In this case, the graph's group doesn't have a parent. So the `getParent()` call in the Group class returns null.

A diff graph in the same folder show the text "[index] - [folder name]" in the tooltip. In this pull request, a diff graph with graphs in different folders shows the fixed string "Difference" because that string is set to the group name when a diff graph is created.

<img width="700" alt="スクリーンショット 2023-01-26 16 47 57" src="https://user-images.githubusercontent.com/60008/214790051-c236f580-3dcd-4e63-80ee-12a766736185.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301133](https://bugs.openjdk.org/browse/JDK-8301133): IGV: NPE occurs when creating a diff graph with a graph in a different folder


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12214/head:pull/12214` \
`$ git checkout pull/12214`

Update a local copy of the PR: \
`$ git checkout pull/12214` \
`$ git pull https://git.openjdk.org/jdk pull/12214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12214`

View PR using the GUI difftool: \
`$ git pr show -t 12214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12214.diff">https://git.openjdk.org/jdk/pull/12214.diff</a>

</details>
