### PR TITLE
8301148: Serial: Remove ContiguousSpace::reset_saved_mark

### DIFF
--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -323,7 +323,6 @@ TenuredGeneration::TenuredGeneration(ReservedSpace rs,
   HeapWord* bottom = (HeapWord*) _virtual_space.low();
   HeapWord* end    = (HeapWord*) _virtual_space.high();
   _the_space  = new TenuredSpace(_bts, MemRegion(bottom, end));
-  _the_space->reset_saved_mark();
   // If we don't shrink the heap in steps, '_shrink_factor' is always 100%.
   _shrink_factor = ShrinkHeapInSteps ? 0 : 100;
   _capacity_at_prologue = 0;

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -433,7 +433,6 @@ class ContiguousSpace: public CompactibleSpace {
   void set_top(HeapWord* value)    { _top = value; }
 
   void set_saved_mark()            { _saved_mark_word = top();    }
-  void reset_saved_mark()          { _saved_mark_word = bottom(); }
 
   bool saved_mark_at_top() const { return saved_mark_word() == top(); }
 


### PR DESCRIPTION
Simple change of removing redundant code.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301148](https://bugs.openjdk.org/browse/JDK-8301148): Serial: Remove ContiguousSpace::reset_saved_mark


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12215/head:pull/12215` \
`$ git checkout pull/12215`

Update a local copy of the PR: \
`$ git checkout pull/12215` \
`$ git pull https://git.openjdk.org/jdk pull/12215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12215`

View PR using the GUI difftool: \
`$ git pr show -t 12215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12215.diff">https://git.openjdk.org/jdk/pull/12215.diff</a>

</details>
