### PR TITLE
8301149: Parallel: Refactor MutableNUMASpace::update_layout

### DIFF
--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -53,7 +53,18 @@ MutableNUMASpace::MutableNUMASpace(size_t alignment) : MutableSpace(alignment), 
     }
 #endif // LINUX
 
-  update_layout(true);
+  int lgrp_limit = (int)os::numa_get_groups_num();
+  int *lgrp_ids = NEW_C_HEAP_ARRAY(int, lgrp_limit, mtGC);
+  int lgrp_num = (int)os::numa_get_leaf_groups(lgrp_ids, lgrp_limit);
+  assert(lgrp_num > 0, "There should be at least one locality group");
+
+  lgrp_spaces()->reserve(lgrp_num);
+  // Add new spaces for the new nodes
+  for (int i = 0; i < lgrp_num; i++) {
+    lgrp_spaces()->append(new LGRPSpace(lgrp_ids[i], alignment));
+  }
+
+  FREE_C_HEAP_ARRAY(int, lgrp_ids);
 }
 
 MutableNUMASpace::~MutableNUMASpace() {
@@ -230,41 +241,6 @@ size_t MutableNUMASpace::unsafe_max_tlab_alloc(Thread *thr) const {
   return lgrp_spaces()->at(i)->space()->free_in_bytes();
 }
 
-
-// Check if the NUMA topology has changed. Add and remove spaces if needed.
-// The update can be forced by setting the force parameter equal to true.
-bool MutableNUMASpace::update_layout(bool force) {
-  // Check if the topology had changed.
-  bool changed = os::numa_topology_changed();
-  if (force || changed) {
-    // Compute lgrp intersection. Add/remove spaces.
-    int lgrp_limit = (int)os::numa_get_groups_num();
-    int *lgrp_ids = NEW_C_HEAP_ARRAY(int, lgrp_limit, mtGC);
-    int lgrp_num = (int)os::numa_get_leaf_groups(lgrp_ids, lgrp_limit);
-    assert(lgrp_num > 0, "There should be at least one locality group");
-    // Clear existing spaces
-    for (int i = 0; i < lgrp_spaces()->length(); ++i) {
-      delete lgrp_spaces()->at(i);
-    }
-    lgrp_spaces()->clear();
-    lgrp_spaces()->reserve(lgrp_num);
-    // Add new spaces for the new nodes
-    for (int i = 0; i < lgrp_num; i++) {
-      lgrp_spaces()->append(new LGRPSpace(lgrp_ids[i], alignment()));
-    }
-
-    FREE_C_HEAP_ARRAY(int, lgrp_ids);
-
-    if (changed) {
-      for (JavaThreadIteratorWithHandle jtiwh; JavaThread *thread = jtiwh.next(); ) {
-        thread->set_lgrp_id(-1);
-      }
-    }
-    return true;
-  }
-  return false;
-}
-
 // Bias region towards the first-touching lgrp. Set the right page sizes.
 void MutableNUMASpace::bias_region(MemRegion mr, int lgrp_id) {
   HeapWord *start = align_up(mr.start(), page_size());
@@ -302,40 +278,22 @@ void MutableNUMASpace::free_region(MemRegion mr) {
 
 // Update space layout. Perform adaptation.
 void MutableNUMASpace::update() {
-  if (update_layout(false)) {
-    // If the topology has changed, make all chunks zero-sized.
-    // And clear the alloc-rate statistics.
-    // In future we may want to handle this more gracefully in order
-    // to avoid the reallocation of the pages as much as possible.
+  bool should_initialize = false;
+  if (!os::numa_has_static_binding()) {
     for (int i = 0; i < lgrp_spaces()->length(); i++) {
-      LGRPSpace *ls = lgrp_spaces()->at(i);
-      MutableSpace *s = ls->space();
-      s->set_end(s->bottom());
-      s->set_top(s->bottom());
-      ls->clear_alloc_rate();
+      if (!lgrp_spaces()->at(i)->invalid_region().is_empty()) {
+        should_initialize = true;
+        break;
+      }
     }
+  }
+
+  if (should_initialize ||
+      (UseAdaptiveNUMAChunkSizing && adaptation_cycles() < samples_count())) {
     // A NUMA space is never mangled
     initialize(region(),
                SpaceDecorator::Clear,
                SpaceDecorator::DontMangle);
-  } else {
-    bool should_initialize = false;
-    if (!os::numa_has_static_binding()) {
-      for (int i = 0; i < lgrp_spaces()->length(); i++) {
-        if (!lgrp_spaces()->at(i)->invalid_region().is_empty()) {
-          should_initialize = true;
-          break;
-        }
-      }
-    }
-
-    if (should_initialize ||
-        (UseAdaptiveNUMAChunkSizing && adaptation_cycles() < samples_count())) {
-      // A NUMA space is never mangled
-      initialize(region(),
-                 SpaceDecorator::Clear,
-                 SpaceDecorator::DontMangle);
-    }
   }
 
   scan_pages(NUMAPageScanRate);

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -53,7 +53,7 @@ MutableNUMASpace::MutableNUMASpace(size_t alignment) : MutableSpace(alignment), 
     }
 #endif // LINUX
 
-  int lgrp_limit = (int)os::numa_get_groups_num();
+  size_t lgrp_limit = os::numa_get_groups_num();
   int *lgrp_ids = NEW_C_HEAP_ARRAY(int, lgrp_limit, mtGC);
   int lgrp_num = (int)os::numa_get_leaf_groups(lgrp_ids, lgrp_limit);
   assert(lgrp_num > 0, "There should be at least one locality group");

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.hpp
@@ -159,9 +159,6 @@ class MutableNUMASpace : public MutableSpace {
   void set_base_space_size(size_t v)                 { _base_space_size = v;      }
   size_t base_space_size() const                     { return _base_space_size;   }
 
-  // Check if the NUMA topology has changed. Add and remove spaces if needed.
-  // The update can be forced by setting the force parameter equal to true.
-  bool update_layout(bool force);
   // Bias region towards the lgrp.
   void bias_region(MemRegion mr, int lgrp_id);
   // Free pages in a given region.


### PR DESCRIPTION
Small cleanup to simplify the structure.

Test: hotspot_gc on boxes with two NUMA nodes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301149](https://bugs.openjdk.org/browse/JDK-8301149): Parallel: Refactor MutableNUMASpace::update_layout


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [a89680bb](https://git.openjdk.org/jdk/pull/12216/files/a89680bb067d7f3064d0dad2008424a8065a6d95)
 * [Leo Korinth](https://openjdk.org/census#lkorinth) (@lkorinth - **Reviewer**) ⚠️ Review applies to [b4f4d026](https://git.openjdk.org/jdk/pull/12216/files/b4f4d0268991236f87b5e7dd1205a6b717162ea8)
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12216/head:pull/12216` \
`$ git checkout pull/12216`

Update a local copy of the PR: \
`$ git checkout pull/12216` \
`$ git pull https://git.openjdk.org/jdk pull/12216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12216`

View PR using the GUI difftool: \
`$ git pr show -t 12216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12216.diff">https://git.openjdk.org/jdk/pull/12216.diff</a>

</details>
