### PR TITLE
JDK-8301050: Detect Xen Virtualization on Linux aarch64

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -565,8 +565,9 @@ void VM_Version::initialize() {
 }
 
 #if defined(LINUX)
-static int check_info_file(const char* fpath, const char* virt1,
-                           const char* virt2) {
+static bool check_info_file(const char* fpath,
+                            const char* virt1, VirtualizationType vt1,
+                            const char* virt2, VirtualizationType vt2) {
   char line[500];
   FILE* fp = os::fopen(fpath, "r");
   if (fp == nullptr) {
@@ -574,16 +575,18 @@ static int check_info_file(const char* fpath, const char* virt1,
   }
   while (fgets(line, sizeof(line), fp) != nullptr) {
     if (strcasestr(line, virt1) != 0) {
+      Abstract_VM_Version::_detected_virtualization = vt1;
       fclose(fp);
-      return 1;
+      return true;
     }
     if (virt2 != NULL && strcasestr(line, virt2) != 0) {
+      Abstract_VM_Version::_detected_virtualization = vt2;
       fclose(fp);
-      return 2;
+      return true;
     }
   }
   fclose(fp);
-  return 0;
+  return false;
 }
 #endif
 
@@ -591,18 +594,10 @@ void VM_Version::check_virtualizations() {
 #if defined(LINUX)
   const char* pname_file = "/sys/devices/virtual/dmi/id/product_name";
   const char* tname_file = "/sys/hypervisor/type";
-  int resp = check_info_file(pname_file, "KVM", "VMWare");
-  if (resp == 1) {
-    Abstract_VM_Version::_detected_virtualization = KVM;
+  if (check_info_file(pname_file, "KVM", KVM, "VMWare", VMWare)) {
     return;
   }
-  if (resp == 2) {
-    Abstract_VM_Version::_detected_virtualization = VMWare;
-    return;
-  }
-  if (check_info_file(tname_file, "Xen", NULL) == 1) {
-    Abstract_VM_Version::_detected_virtualization = XenHVM;
-  }
+  check_info_file(tname_file, "Xen", XenHVM, NULL, NoDetectedVirtualization);
 #endif
 }
 

--- a/src/hotspot/share/runtime/abstract_vm_version.hpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,9 +71,10 @@ class Abstract_VM_Version: AllStatic {
   static int          _vm_build_number;
   static unsigned int _data_cache_line_flush_size;
 
+ public:
+
   static VirtualizationType _detected_virtualization;
 
- public:
   // Called as part of the runtime services initialization which is
   // called from the management module initialization (via init_globals())
   // after argument parsing and attaching of the main thread has


### PR DESCRIPTION
With https://bugs.openjdk.org/browse/JDK-8300266 KVM and VMWare virtualization detection has been added; this should be enhanced by Xen detection.
However it seems that for Xen we should look at other file system locations compared to the other virtualizations.
more /sys/hypervisor/type
xen
seems to be available there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301050](https://bugs.openjdk.org/browse/JDK-8301050): Detect Xen Virtualization on Linux aarch64


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12217/head:pull/12217` \
`$ git checkout pull/12217`

Update a local copy of the PR: \
`$ git checkout pull/12217` \
`$ git pull https://git.openjdk.org/jdk pull/12217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12217`

View PR using the GUI difftool: \
`$ git pr show -t 12217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12217.diff">https://git.openjdk.org/jdk/pull/12217.diff</a>

</details>
