### PR TITLE
8301164: Remove unused ResourceStack class

### DIFF
--- a/src/hotspot/share/utilities/stack.hpp
+++ b/src/hotspot/share/utilities/stack.hpp
@@ -160,27 +160,6 @@ private:
   E* _cache;      // Segment cache to avoid ping-ponging.
 };
 
-template <class E, MEMFLAGS F> class ResourceStack:  public Stack<E, F>, public ResourceObj
-{
-public:
-  // If this class becomes widely used, it may make sense to save the Thread
-  // and use it when allocating segments.
-//  ResourceStack(size_t segment_size = Stack<E, F>::default_segment_size()):
-  ResourceStack(size_t segment_size): Stack<E, F>(segment_size, max_uintx)
-    { }
-
-  // Set the segment pointers to nullptr so the parent dtor does not free them;
-  // that must be done by the ResourceMark code.
-  ~ResourceStack() { Stack<E, F>::reset(true); }
-
-protected:
-  virtual E*   alloc(size_t bytes);
-  virtual void free(E* addr, size_t bytes);
-
-private:
-  void clear(bool clear_cache = false);
-};
-
 template <class E, MEMFLAGS F>
 class StackIterator: public StackObj
 {

--- a/src/hotspot/share/utilities/stack.inline.hpp
+++ b/src/hotspot/share/utilities/stack.inline.hpp
@@ -244,18 +244,6 @@ void Stack<E, F>::zap_segment(E* seg, bool zap_link_field) const
 #endif
 
 template <class E, MEMFLAGS F>
-E* ResourceStack<E, F>::alloc(size_t bytes)
-{
-  return (E*) resource_allocate_bytes(bytes);
-}
-
-template <class E, MEMFLAGS F>
-void ResourceStack<E, F>::free(E* addr, size_t bytes)
-{
-  resource_free_bytes(Thread::current(), (char*) addr, bytes);
-}
-
-template <class E, MEMFLAGS F>
 void StackIterator<E, F>::sync()
 {
   _full_seg_size = _stack._full_seg_size;


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301164](https://bugs.openjdk.org/browse/JDK-8301164): Remove unused ResourceStack class


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12221/head:pull/12221` \
`$ git checkout pull/12221`

Update a local copy of the PR: \
`$ git checkout pull/12221` \
`$ git pull https://git.openjdk.org/jdk pull/12221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12221`

View PR using the GUI difftool: \
`$ git pr show -t 12221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12221.diff">https://git.openjdk.org/jdk/pull/12221.diff</a>

</details>
