### PR TITLE
8301047: Clean up type unsafe uses of oop from compiler code

### DIFF
--- a/src/hotspot/share/code/relocInfo.hpp
+++ b/src/hotspot/share/code/relocInfo.hpp
@@ -1014,7 +1014,7 @@ class oop_Relocation : public DataRelocation {
 
   void verify_oop_relocation();
 
-  address value() override { return cast_from_oop<address>(*oop_addr()); }
+  address value() override { return *reinterpret_cast<address*>(oop_addr()); }
 
   bool oop_is_immediate()  { return oop_index() == 0; }
 

--- a/src/hotspot/share/compiler/oopMap.hpp
+++ b/src/hotspot/share/compiler/oopMap.hpp
@@ -449,12 +449,12 @@ private:
 
 class SkipNullValue {
 public:
-  static inline bool should_skip(oop val);
+  static inline bool should_skip(void* val);
 };
 
 class IncludeAllValues {
 public:
-  static bool should_skip(oop value) { return false; }
+  static bool should_skip(void* value) { return false; }
 };
 
 template <typename OopFnT, typename DerivedOopFnT, typename ValueFilterT>

--- a/src/hotspot/share/compiler/oopMap.inline.hpp
+++ b/src/hotspot/share/compiler/oopMap.inline.hpp
@@ -47,8 +47,8 @@ inline const ImmutableOopMap* ImmutableOopMapPair::get_from(const ImmutableOopMa
   return set->oopmap_at_offset(_oopmap_offset);
 }
 
-inline bool SkipNullValue::should_skip(oop val) {
-  return val == (oop)nullptr || CompressedOops::is_base(val);
+inline bool SkipNullValue::should_skip(void* val) {
+  return val == nullptr || (UseCompressedOops && CompressedOops::is_base(val));
 }
 
 template <typename OopFnT, typename DerivedOopFnT, typename ValueFilterT>
@@ -84,14 +84,15 @@ void OopMapDo<OopFnT, DerivedOopFnT, ValueFilterT>::iterate_oops_do(const frame 
       }
       guarantee(loc != nullptr, "missing saved register");
       derived_pointer* derived_loc = (derived_pointer*)loc;
-      oop* base_loc = fr->oopmapreg_to_oop_location(omv.content_reg(), reg_map);
-      // Ignore nullptr oops and decoded nullptr narrow oops which
+      void** base_loc = (void**) fr->oopmapreg_to_location(omv.content_reg(), reg_map);
+
+      // Ignore nullptr oops and decoded null narrow oops which
       // equal to CompressedOops::base() when a narrow oop
       // implicit null check is used in compiled code.
       // The narrow_oop_base could be nullptr or be the address
       // of the page below heap depending on compressed oops mode.
-      if (base_loc != nullptr && *base_loc != (oop)nullptr && !CompressedOops::is_base(*base_loc)) {
-        _derived_oop_fn->do_derived_oop(base_loc, derived_loc);
+      if (base_loc != nullptr && !SkipNullValue::should_skip(*base_loc)) {
+        _derived_oop_fn->do_derived_oop((oop*)base_loc, derived_loc);
       }
     }
   }
@@ -102,7 +103,7 @@ void OopMapDo<OopFnT, DerivedOopFnT, ValueFilterT>::iterate_oops_do(const frame 
       OopMapValue omv = oms.current();
       if (omv.type() != OopMapValue::oop_value && omv.type() != OopMapValue::narrowoop_value)
         continue;
-      oop* loc = fr->oopmapreg_to_oop_location(omv.reg(),reg_map);
+      void** loc = (void**) fr->oopmapreg_to_location(omv.reg(),reg_map);
       // It should be an error if no location can be found for a
       // register mentioned as contained an oop of some kind.  Maybe
       // this was allowed previously because value_value items might
@@ -122,7 +123,7 @@ void OopMapDo<OopFnT, DerivedOopFnT, ValueFilterT>::iterate_oops_do(const frame 
       }
       guarantee(loc != nullptr, "missing saved register");
       if ( omv.type() == OopMapValue::oop_value ) {
-        oop val = *loc;
+        void* val = *loc;
         if (ValueFilterT::should_skip(val)) { // TODO: UGLY (basically used to decide if we're freezing/thawing continuation)
           // Ignore nullptr oops and decoded nullptr narrow oops which
           // equal to CompressedOops::base() when a narrow oop
@@ -131,7 +132,7 @@ void OopMapDo<OopFnT, DerivedOopFnT, ValueFilterT>::iterate_oops_do(const frame 
           // of the page below heap depending on compressed oops mode.
           continue;
         }
-        _oop_fn->do_oop(loc);
+        _oop_fn->do_oop((oop*)loc);
       } else if ( omv.type() == OopMapValue::narrowoop_value ) {
         narrowOop *nl = (narrowOop*)loc;
 #ifndef VM_LITTLE_ENDIAN

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -1054,7 +1054,6 @@ const int      badCodeHeapFreeVal = 0xDD;                   // value used to zap
 // (These must be implemented as #defines because C++ compilers are
 // not obligated to inline non-integral constants!)
 #define       badAddress        ((address)::badAddressVal)
-#define       badOop            (cast_to_oop(::badOopVal))
 #define       badHeapWord       (::badHeapWordVal)
 
 // Default TaskQueue size is 16K (32-bit) or 128K (64-bit)


### PR DESCRIPTION
In an ideal world, when you have an oop, its contents should also be an oop. It happens, however, that we have other forms of pointers sometimes, used with the oop type, in some compiler code. We should clean that up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301047](https://bugs.openjdk.org/browse/JDK-8301047): Clean up type unsafe uses of oop from compiler code


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Contributors
 * Axel Boldt-Christmas `<aboldtch@openjdk.org>`
 * Stefan Karlsson `<stefank@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12223/head:pull/12223` \
`$ git checkout pull/12223`

Update a local copy of the PR: \
`$ git checkout pull/12223` \
`$ git pull https://git.openjdk.org/jdk pull/12223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12223`

View PR using the GUI difftool: \
`$ git pr show -t 12223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12223.diff">https://git.openjdk.org/jdk/pull/12223.diff</a>

</details>
