### PR TITLE
JDK-8301187: Memory leaks in OopMapCache

### DIFF
--- a/src/hotspot/share/interpreter/oopMapCache.cpp
+++ b/src/hotspot/share/interpreter/oopMapCache.cpp
@@ -540,6 +540,7 @@ void OopMapCache::lookup(const methodHandle& method,
     // at this time. We give the caller of lookup() a copy of the
     // interesting info via parameter entry_for, but we don't add it to
     // the cache. See the gory details in Method*.cpp.
+    tmp->flush();
     FREE_C_HEAP_OBJ(tmp);
     return;
   }
@@ -610,5 +611,6 @@ void OopMapCache::compute_one_oop_map(const methodHandle& method, int bci, Inter
   tmp->initialize();
   tmp->fill(method, bci);
   entry->resource_copy(tmp);
+  tmp->flush();
   FREE_C_HEAP_OBJ(tmp);
 }


### PR DESCRIPTION
Testing with https://github.com/openjdk/jdk/pull/12229 resulted in memory leak reports related to OopMapCache. Example.

```
Direct leak of 40 byte(s) in 1 object(s) allocated from:                                                                                                                                                                                                                                                                       
    #0 0x7fa997ab89cf in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69                                                                                                                                                                                                                       
    #1 0x7fa99409e79a in os::malloc(unsigned long, MEMFLAGS, NativeCallStack const&) src/hotspot/share/runtime/os.cpp:673                                                                                                                                                                                                      
    #2 0x7fa991c1c537 in AllocateHeap(unsigned long, MEMFLAGS, NativeCallStack const&, AllocFailStrategy::AllocFailEnum) src/hotspot/share/memory/allocation.cpp:42                                                                                                                                                            
    #3 0x7fa991c1c537 in AllocateHeap(unsigned long, MEMFLAGS, AllocFailStrategy::AllocFailEnum) src/hotspot/share/memory/allocation.cpp:52                                                                                                                                                                                    
    #4 0x7fa9940847d0 in OopMapCacheEntry::allocate_bit_mask() src/hotspot/share/interpreter/oopMapCache.cpp:307                                                                                                                                                                                                               
    #5 0x7fa9940847d0 in OopMapCacheEntry::set_mask(CellTypeState*, CellTypeState*, int) src/hotspot/share/interpreter/oopMapCache.cpp:354                                                                                                                                                                                     
    #6 0x7fa994084968 in OopMapForCacheEntry::fill_stackmap_for_opcodes(BytecodeStream*, CellTypeState*, CellTypeState*, int) src/hotspot/share/interpreter/oopMapCache.cpp:148                                                                                                                                                
    #7 0x7fa994084968 in OopMapForCacheEntry::fill_stackmap_for_opcodes(BytecodeStream*, CellTypeState*, CellTypeState*, int) src/hotspot/share/interpreter/oopMapCache.cpp:142                                                                                                                                                
    #8 0x7fa992ee878a in GenerateOopMap::interp1(BytecodeStream*) src/hotspot/share/oops/generateOopMap.cpp:1369                                                                                                                                                                                                               
    #9 0x7fa992ef2562 in GenerateOopMap::interp_bb(BasicBlock*) src/hotspot/share/oops/generateOopMap.cpp:1148                                                                                                                                                                                                                 
    #10 0x7fa99408127e in OopMapForCacheEntry::compute_map(Thread*) src/hotspot/share/interpreter/oopMapCache.cpp:116                                                                                                                                                                                                          
    #11 0x7fa994085b2f in OopMapCacheEntry::fill(methodHandle const&, int) src/hotspot/share/interpreter/oopMapCache.cpp:342                                                                                                                                                                                                   
    #12 0x7fa994085b2f in OopMapCacheEntry::fill(methodHandle const&, int) src/hotspot/share/interpreter/oopMapCache.cpp:331                                                                                                                                                                                                   
    #13 0x7fa994085b2f in OopMapCache::compute_one_oop_map(methodHandle const&, int, InterpreterOopMap*) src/hotspot/share/interpreter/oopMapCache.cpp:611                                                                                                                                                                     
    #14 0x7fa993efe5c2 in Method::mask_for(int, InterpreterOopMap*) src/hotspot/share/oops/method.cpp:321                                                                                                                                                                                                                      
    #15 0x7fa992ada14f in frame::oops_interpreted_do(OopClosure*, RegisterMap const*, bool) const src/hotspot/share/runtime/frame.cpp:946                                                                                                                                                                                      
    #16 0x7fa994595a24 in frame::oops_do(OopClosure*, CodeBlobClosure*, RegisterMap const*, DerivedPointerIterationMode) const src/hotspot/share/runtime/frame.hpp:469                                                                                                                                                         
    #17 0x7fa994595a24 in ShenandoahStackWatermark::process(frame const&, RegisterMap&, void*) src/hotspot/share/gc/shenandoah/shenandoahStackWatermark.cpp:138                                                                                                                                                                
    #18 0x7fa99468ac0f in StackWatermarkFramesIterator::process_one(void*) src/hotspot/share/runtime/stackWatermark.cpp:101                                                                                                                                                                                                    
    #19 0x7fa99468ef34 in StackWatermark::start_processing_impl(void*) src/hotspot/share/runtime/stackWatermark.cpp:215                                                                                                                                                                                                        
    #20 0x7fa994596916 in ShenandoahStackWatermark::start_processing_impl(void*) src/hotspot/share/gc/shenandoah/shenandoahStackWatermark.cpp:117                                                                                                                                                                              
    #21 0x7fa994690e62 in StackWatermark::start_processing() src/hotspot/share/runtime/stackWatermark.cpp:319                                                                                                                                                                                                                  
    #22 0x7fa994690e62 in StackWatermark::start_processing() src/hotspot/share/runtime/stackWatermark.cpp:315                                                                                                                                                                                                                  
    #23 0x7fa994690e62 in StackWatermark::on_safepoint() src/hotspot/share/runtime/stackWatermark.cpp:307                                                                                                                                                                                                                      
    #24 0x7fa99434ed85 in SafepointMechanism::process(JavaThread*, bool, bool) src/hotspot/share/runtime/safepointMechanism.cpp:157                                                                                                                                                                                            
    #25 0x7fa99312656c in SafepointMechanism::process_if_requested(JavaThread*, bool, bool) src/hotspot/share/runtime/safepointMechanism.inline.hpp:83                                                                                                                                                                         
    #26 0x7fa99312656c in SafepointMechanism::process_if_requested_with_exit_check(JavaThread*, bool) src/hotspot/share/runtime/safepointMechanism.inline.hpp:88                                                                                                                                                               
    #27 0x7fa99312656c in ThreadStateTransition::transition_from_vm(JavaThread*, JavaThreadState, bool) src/hotspot/share/runtime/interfaceSupport.inline.hpp:113                                                                                                                                                              
    #28 0x7fa99312656c in ThreadInVMfromJava::~ThreadInVMfromJava() src/hotspot/share/runtime/interfaceSupport.inline.hpp:140                                                                                                                                                                                                  
    #29 0x7fa99312656c in InterpreterRuntime::resolve_ldc(JavaThread*, Bytecodes::Code) src/hotspot/share/interpreter/interpreterRuntime.cpp:213
```

Loooks like temporary OopMapCacheEntry are created in two places in OopMapCache and are free'd directly, failing to call `flush()` before hand leading to leaks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301187](https://bugs.openjdk.org/browse/JDK-8301187): Memory leaks in OopMapCache


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12230/head:pull/12230` \
`$ git checkout pull/12230`

Update a local copy of the PR: \
`$ git checkout pull/12230` \
`$ git pull https://git.openjdk.org/jdk pull/12230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12230`

View PR using the GUI difftool: \
`$ git pr show -t 12230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12230.diff">https://git.openjdk.org/jdk/pull/12230.diff</a>

</details>
