### PR TITLE
8299325: java/net/httpclient/CancelRequestTest.java fails "test CancelRequestTest.testGetSendAsync("https://localhost:46509/https1/x/same/interrupt", true, true)"

### DIFF
--- a/test/jdk/java/net/httpclient/CancelRequestTest.java
+++ b/test/jdk/java/net/httpclient/CancelRequestTest.java
@@ -86,6 +86,7 @@ import jdk.httpclient.test.lib.http2.Http2TestServer;
 
 import static java.lang.System.arraycopy;
 import static java.lang.System.out;
+import static java.lang.System.err;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -354,14 +355,22 @@ public class CancelRequestTest implements HttpServerAdapters {
             } catch (ExecutionException x) {
                 assertEquals(response.isDone(), true);
                 Throwable wrapped = x.getCause();
-                assertTrue(CancellationException.class.isAssignableFrom(wrapped.getClass()));
-                Throwable cause = wrapped.getCause();
-                out.println("CancellationException cause: " + x);
-                assertTrue(IOException.class.isAssignableFrom(cause.getClass()));
-                if (cause instanceof HttpConnectTimeoutException) {
-                    cause.printStackTrace(out);
-                    throw new RuntimeException("Unexpected timeout exception", cause);
+                Throwable cause = wrapped;
+                if (mayInterruptIfRunning) {
+                    assertTrue(CancellationException.class.isAssignableFrom(wrapped.getClass()),
+                            "Unexpected exception: " + wrapped);
+                    cause = wrapped.getCause();
+                    out.println("CancellationException cause: " + x);
+                    if (cause instanceof HttpConnectTimeoutException) {
+                        cause.printStackTrace(out);
+                        throw new RuntimeException("Unexpected timeout exception", cause);
+                    }
                 }
+                if (!IOException.class.isAssignableFrom(cause.getClass())) {
+                    out.println("Unexpected cause: " + cause.getClass());
+                    cause.printStackTrace(out);
+                }
+                assertTrue(IOException.class.isAssignableFrom(cause.getClass()));
                 if (mayInterruptIfRunning) {
                     out.println("Got expected exception: " + wrapped);
                     out.println("\tcause: " + cause);
@@ -379,7 +388,7 @@ public class CancelRequestTest implements HttpServerAdapters {
             assertEquals(cf2.isCancelled(), false);
             assertEquals(latch.getCount(), 0);
 
-            var error = TRACKER.check(tracker, 200,
+            var error = TRACKER.check(tracker, 1000,
                     (t) -> t.getOutstandingOperations() > 0 || t.getOutstandingSubscribers() > 0,
                     "subscribers for testGetSendAsync(%s)\n\t step [%s]".formatted(req.uri(), i),
                     false);
@@ -491,7 +500,7 @@ public class CancelRequestTest implements HttpServerAdapters {
             assertEquals(cf2.isCancelled(), false);
             assertEquals(latch.getCount(), 0);
 
-            var error = TRACKER.check(tracker, 200,
+            var error = TRACKER.check(tracker, 1000,
                     (t) -> t.getOutstandingOperations() > 0 || t.getOutstandingSubscribers() > 0,
                     "subscribers for testPostSendAsync(%s)\n\t step [%s]".formatted(req.uri(), i),
                     false);
@@ -513,9 +522,11 @@ public class CancelRequestTest implements HttpServerAdapters {
 
             Thread main = Thread.currentThread();
             CompletableFuture<Thread> interruptingThread = new CompletableFuture<>();
+            var uriStr = uri + "/post/req=" + i;
             Runnable interrupt = () -> {
                 Thread current = Thread.currentThread();
-                out.printf("%s Interrupting main from: %s (%s)", now(), current, uri);
+                out.printf("%s Interrupting main from: %s (%s)%n", now(), current, uriStr);
+                err.printf("%s Interrupting main from: %s (%s)%n", now(), current, uriStr);
                 interruptingThread.complete(current);
                 main.interrupt();
             };
@@ -526,36 +537,44 @@ public class CancelRequestTest implements HttpServerAdapters {
                 return List.of(BODY.getBytes(UTF_8)).iterator();
             };
 
-            HttpRequest req = HttpRequest.newBuilder(URI.create(uri))
+            HttpRequest req = HttpRequest.newBuilder(URI.create(uriStr))
                     .POST(HttpRequest.BodyPublishers.ofByteArrays(iterable))
                     .build();
             String body = null;
             Exception failed = null;
             try {
+                out.println("Sending: " + uriStr);
                 body = client.send(req, BodyHandlers.ofString()).body();
             } catch (Exception x) {
                 failed = x;
             }
-
+            out.println(uriStr + ": got result or exception");
             if (failed instanceof InterruptedException) {
-                out.println("Got expected exception: " + failed);
+                out.println(uriStr + ": Got expected exception: " + failed);
             } else if (failed instanceof IOException) {
+                out.println(uriStr + ": got IOException: " + failed);
                 // that could be OK if the main thread was interrupted
                 // from the main thread: the interrupt status could have
                 // been caught by writing to the socket from the main
                 // thread.
-                if (interruptingThread.get() == main) {
-                    out.println("Accepting IOException: " + failed);
+                if (interruptingThread.isDone() && interruptingThread.get() == main) {
+                    out.println(uriStr + ": Accepting IOException: " + failed);
                     failed.printStackTrace(out);
                 } else {
+                    out.println(uriStr + ": unexpected exception: " + failed);
                     throw failed;
                 }
             } else if (failed != null) {
-                assertEquals(body, Stream.of(BODY.split("\\|")).collect(Collectors.joining()));
+                out.println(uriStr + ": unexpected exception: " + failed);
                 throw failed;
+            } else {
+                assert failed == null;
+                out.println(uriStr + ": got body: " + body);
+                assertEquals(body, Stream.of(BODY.split("\\|")).collect(Collectors.joining()));
             }
+            out.println("next iteration");
 
-            var error = TRACKER.check(tracker, 200,
+            var error = TRACKER.check(tracker, 1000,
                     (t) -> t.getOutstandingOperations() > 0 || t.getOutstandingSubscribers() > 0,
                     "subscribers for testPostInterrupt(%s)\n\t step [%s]".formatted(req.uri(), i),
                     false);

--- a/test/jdk/java/net/httpclient/CancelRequestTest.java
+++ b/test/jdk/java/net/httpclient/CancelRequestTest.java
@@ -366,7 +366,7 @@ public class CancelRequestTest implements HttpServerAdapters {
                         throw new RuntimeException("Unexpected timeout exception", cause);
                     }
                 }
-                if (!IOException.class.isAssignableFrom(cause.getClass())) {
+                if (!IOException.class.isInstance(cause)) {
                     out.println("Unexpected cause: " + cause.getClass());
                     cause.printStackTrace(out);
                 }


### PR DESCRIPTION
The CancelRequestTest has been observed failing (rare and intermittent, but at least twice) in our CI.
This fix increases the timeout waiting for resources to be released after cancelling the request, and add more diagnosis to the test code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299325](https://bugs.openjdk.org/browse/JDK-8299325): java/net/httpclient/CancelRequestTest.java fails "test CancelRequestTest.testGetSendAsync("https://localhost:46509/https1/x/same/interrupt", true, true)"


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [9847f7bc](https://git.openjdk.org/jdk/pull/12233/files/9847f7bc7e44728f899e61b7262ff3fa7e2ff4e4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12233/head:pull/12233` \
`$ git checkout pull/12233`

Update a local copy of the PR: \
`$ git checkout pull/12233` \
`$ git pull https://git.openjdk.org/jdk pull/12233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12233`

View PR using the GUI difftool: \
`$ git pr show -t 12233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12233.diff">https://git.openjdk.org/jdk/pull/12233.diff</a>

</details>
