### PR TITLE
8262895: [macos_aarch64] runtime/CompressedOops/CompressedClassPointers.java fails with 'Narrow klass base: 0x0000000000000000' missing from stdout/stderr

### DIFF
--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
@@ -27,6 +27,7 @@
  * @summary Testing address of compressed class pointer space as best as possible.
  * @requires vm.bits == 64 & !vm.graal.enabled
  * @requires vm.flagless
+ * @requires os.family != "mac"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -318,6 +319,12 @@ public class CompressedClassPointers {
     }
 
     public static void main(String[] args) throws Exception {
+        // Testing compressed class pointers without compressed oops.
+        // This is only possible if the platform supports it. Notably,
+        // on macOS, when compressed oops is disabled and the heap is
+        // given an arbitrary address, that address occasionally collides
+        // with where we would ideally have placed the compressed class
+        // space. Therefore, macOS is omitted for now.
         smallHeapTest();
         smallHeapTestWith1G();
         largeHeapTest();
@@ -326,19 +333,11 @@ public class CompressedClassPointers {
         heapBaseMinAddressTest();
         sharingTest();
 
-        if (!Platform.isOSX()) {
-            // Testing compressed class pointers without compressed oops.
-            // This is only possible if the platform supports it. Notably,
-            // on macOS, when compressed oops is disabled and the heap is
-            // given an arbitrary address, that address occasionally collides
-            // with where we would ideally have placed the compressed class
-            // space. Therefore, macOS is omitted for now.
-            smallHeapTestNoCoop();
-            smallHeapTestWith1GNoCoop();
-            largeHeapTestNoCoop();
-            largePagesTestNoCoop();
-            heapBaseMinAddressTestNoCoop();
-            sharingTestNoCoop();
-        }
+        smallHeapTestNoCoop();
+        smallHeapTestWith1GNoCoop();
+        largeHeapTestNoCoop();
+        largePagesTestNoCoop();
+        heapBaseMinAddressTestNoCoop();
+        sharingTestNoCoop();
     }
 }

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
@@ -25,6 +25,9 @@
  * @test
  * @bug 8024927
  * @summary Testing address of compressed class pointer space as best as possible.
+ * @comment Testing compressed class pointers without compressed oops is not possible
+            on MacOS because the heap is given an  arbitrary address that occasionally
+            collides with where we would ideally have placed the compressed class space.
  * @requires vm.bits == 64 & !vm.graal.enabled
  * @requires vm.flagless
  * @requires os.family != "mac"
@@ -319,12 +322,6 @@ public class CompressedClassPointers {
     }
 
     public static void main(String[] args) throws Exception {
-        // Testing compressed class pointers without compressed oops.
-        // This is only possible if the platform supports it. Notably,
-        // on macOS, when compressed oops is disabled and the heap is
-        // given an arbitrary address, that address occasionally collides
-        // with where we would ideally have placed the compressed class
-        // space. Therefore, macOS is omitted for now.
         smallHeapTest();
         smallHeapTestWith1G();
         largeHeapTest();

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
@@ -25,11 +25,11 @@
  * @test
  * @bug 8024927
  * @summary Testing address of compressed class pointer space as best as possible.
- * @comment Testing compressed class pointers without compressed oops is not possible
-            on MacOS because the heap is given an  arbitrary address that occasionally
-            collides with where we would ideally have placed the compressed class space.
  * @requires vm.bits == 64 & !vm.graal.enabled
  * @requires vm.flagless
+ * @comment Testing compressed class pointers without compressed oops is not possible
+ *          on MacOS because the heap is given an arbitrary address that occasionally
+ *          collides with where we would ideally have placed the compressed class space.
  * @requires os.family != "mac"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc


### PR DESCRIPTION
The test runtime/CompressedOops/CompressedClassPointers.java does not reliably pass on Mac OSX on either x86 or aarch64, so it is disabled for that platform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8262895](https://bugs.openjdk.org/browse/JDK-8262895): [macos_aarch64] runtime/CompressedOops/CompressedClassPointers.java fails with 'Narrow klass base: 0x0000000000000000' missing from stdout/stderr


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [521138a7](https://git.openjdk.org/jdk/pull/12234/files/521138a7c85b1736a7038c2d837d0ccf8f9d2ab8)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [717642ee](https://git.openjdk.org/jdk/pull/12234/files/717642ee62e6b5f6fe3f714afff875d34e1a0aab)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12234/head:pull/12234` \
`$ git checkout pull/12234`

Update a local copy of the PR: \
`$ git checkout pull/12234` \
`$ git pull https://git.openjdk.org/jdk pull/12234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12234`

View PR using the GUI difftool: \
`$ git pr show -t 12234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12234.diff">https://git.openjdk.org/jdk/pull/12234.diff</a>

</details>
