### PR TITLE
8301828: Avoid unnecessary array fill after creation in javax.swing.text

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/ParagraphView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/ParagraphView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
  */
 package javax.swing.text;
 
-import java.util.Arrays;
 import java.awt.*;
 import java.awt.font.TextAttribute;
 import java.awt.geom.Rectangle2D;
@@ -1046,7 +1045,6 @@ public class ParagraphView extends FlowView implements TabExpander {
             int rowStartOffset = getStartOffset();
             int rowEndOffset = getEndOffset();
             int[] spaceMap = new int[rowEndOffset - rowStartOffset];
-            Arrays.fill(spaceMap, 0);
             for (int i = getViewCount() - 1; i >= 0 ; i--) {
                 View view = getView(i);
                 if (view instanceof GlyphView) {

--- a/src/java.desktop/share/classes/javax/swing/text/html/TableView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/TableView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1013,9 +1013,6 @@ import javax.swing.text.*;
          */
         private void updatePercentagesAndAdjustmentWeights(int span) {
             adjustmentWeights = new int[columnRequirements.length];
-            for (int i = 0; i < columnRequirements.length; i++) {
-                adjustmentWeights[i] = 0;
-            }
             if (relativeCells) {
                 percentages = new int[columnRequirements.length];
             } else {


### PR DESCRIPTION
No need to fill elements of array with default values if it was just created. Java guarantees that all elements of numeric array have default values after allocations - 0.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301828](https://bugs.openjdk.org/browse/JDK-8301828): Avoid unnecessary array fill after creation in javax.swing.text


### Reviewers
 * @SWinxy (no known github.com user name / role)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12235/head:pull/12235` \
`$ git checkout pull/12235`

Update a local copy of the PR: \
`$ git checkout pull/12235` \
`$ git pull https://git.openjdk.org/jdk pull/12235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12235`

View PR using the GUI difftool: \
`$ git pr show -t 12235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12235.diff">https://git.openjdk.org/jdk/pull/12235.diff</a>

</details>
