### PR TITLE
8217920: Lookup.defineClass injects a class that can access private members of any class in its own module

### DIFF
--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -597,8 +597,8 @@ public final class Module implements AnnotatedElement {
      *
      * <p> This method does not check if the given module reads this module. </p>
      *
-     * @apiNote A package {@code p} opened to module {@code M} means that code in
-     * {@code M} can do {@linkplain java.lang.reflect.AccessibleObject#setAccessible(boolean)
+     * @apiNote A package {@code p} opened to module {@code M} allows code in
+     * {@code M} do {@linkplain java.lang.reflect.AccessibleObject#setAccessible(boolean)
      * deep reflection} on all types in the package.
      * Further, if {@code M} reads this module, it can obtain a
      * {@link java.lang.invoke.MethodHandles.Lookup Lookup} object that is allowed to
@@ -658,8 +658,8 @@ public final class Module implements AnnotatedElement {
      *
      * <p> This method does not check if the given module reads this module. </p>
      *
-     * @apiNote A package {@code p} opened to module {@code M} means that code in
-     * {@code M} can do {@linkplain java.lang.reflect.AccessibleObject#setAccessible(boolean)
+     * @apiNote A package {@code p} opened to module {@code M} allows code in
+     * {@code M} do {@linkplain java.lang.reflect.AccessibleObject#setAccessible(boolean)
      * deep reflection} on all types in the package.
      * Further, if {@code M} reads this module, it can obtain a
      * {@link java.lang.invoke.MethodHandles.Lookup Lookup} object that is allowed to

--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -597,12 +597,13 @@ public final class Module implements AnnotatedElement {
      *
      * <p> This method does not check if the given module reads this module. </p>
      *
-     * <p> A package {@code p} opened to module {@code M} means that code in
-     * {@code M} can do deep reflection on all types in the package.
+     * @apiNote A package {@code p} opened to module {@code M} means that code in
+     * {@code M} can do {@linkplain java.lang.reflect.AccessibleObject#setAccessible(boolean)
+     * deep reflection} on all types in the package.
      * Further, if {@code M} reads this module, it can obtain a
      * {@link java.lang.invoke.MethodHandles.Lookup Lookup} object that is allowed to
      * {@link java.lang.invoke.MethodHandles.Lookup#defineClass(byte[]) define classes}
-     * in package {@code p}. </p>
+     * in package {@code p}.
      *
      * @param  pn
      *         The package name
@@ -657,6 +658,14 @@ public final class Module implements AnnotatedElement {
      *
      * <p> This method does not check if the given module reads this module. </p>
      *
+     * @apiNote A package {@code p} opened to module {@code M} means that code in
+     * {@code M} can do {@linkplain java.lang.reflect.AccessibleObject#setAccessible(boolean)
+     * deep reflection} on all types in the package.
+     * Further, if {@code M} reads this module, it can obtain a
+     * {@link java.lang.invoke.MethodHandles.Lookup Lookup} object that is allowed to
+     * {@link java.lang.invoke.MethodHandles.Lookup#defineClass(byte[]) define classes}
+     * in package {@code p}.
+     *
      * @param  pn
      *         The package name
      *
@@ -664,6 +673,8 @@ public final class Module implements AnnotatedElement {
      *         unconditionally
      *
      * @see ModuleDescriptor#opens()
+     * @see java.lang.reflect.AccessibleObject#setAccessible(boolean)
+     * @see java.lang.invoke.MethodHandles#privateLookupIn
      */
     public boolean isOpen(String pn) {
         Objects.requireNonNull(pn);

--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -598,12 +598,10 @@ public final class Module implements AnnotatedElement {
      * <p> This method does not check if the given module reads this module. </p>
      *
      * <p> A package {@code p} opened to module {@code M} means that code in
-     * {@code M} can do deep reflection on all types in the package and all
-     * their members for example via
-     * {@link java.lang.reflect.AccessibleObject#setAccessible(boolean) setAccessible},
-     * and if {@code M} reads this module, it can also obtain a
-     * {@link java.lang.invoke.MethodHandles.Lookup Lookup} object that can be used to
-     * {@link java.lang.invoke.MethodHandles.Lookup#defineClass(byte[]) inject classes}
+     * {@code M} can do deep reflection on all types in the package.
+     * Further, if {@code M} reads this module, it can obtain a
+     * {@link java.lang.invoke.MethodHandles.Lookup Lookup} object that is allowed to
+     * {@link java.lang.invoke.MethodHandles.Lookup#defineClass(byte[]) define classes}
      * in package {@code p}. </p>
      *
      * @param  pn

--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -597,6 +597,15 @@ public final class Module implements AnnotatedElement {
      *
      * <p> This method does not check if the given module reads this module. </p>
      *
+     * <p> A package {@code p} opened to module {@code M} means that code in
+     * {@code M} can do deep reflection on all types in the package and all
+     * their members for example via
+     * {@link java.lang.reflect.AccessibleObject#setAccessible(boolean) setAccessible},
+     * and if {@code M} reads this module, it can also obtain a
+     * {@link java.lang.invoke.MethodHandles.Lookup Lookup} object that can be used to
+     * {@link java.lang.invoke.MethodHandles.Lookup#defineClass(byte[]) inject classes}
+     * in package {@code p}. </p>
+     *
      * @param  pn
      *         The package name
      * @param  other

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -233,10 +233,10 @@ public class MethodHandles {
      * <p>
      * The resulting {@code Lookup} object has no {@code ORIGINAL} access.
      * <p>
-     * The {@code Lookup} object returned by this method has the access to
-     * {@linkplain Lookup#defineClass(byte[]) inject classes} in the runtime package
+     * The {@code Lookup} object returned by this method is allowed to
+     * {@linkplain Lookup#defineClass(byte[]) define classes} in the runtime package
      * of {@code targetClass}. Extreme caution should be taken when opening a package
-     * to another module.  The injected classes have the same full privilege
+     * to another module as such defined classes have the same full privilege
      * access as other members in the target module.
      *
      * @param targetClass the target class
@@ -876,11 +876,11 @@ public class MethodHandles {
      * {@link MethodHandles#privateLookupIn(Class, Lookup) privateLookupIn}
      * because it has no {@code MODULE} access.
      * <p>
-     * The {@code Lookup} object returned by {@code privateLookupIn} has the access to
-     * {@linkplain Lookup#defineClass(byte[]) inject classes} in the runtime package
+     * The {@code Lookup} object returned by {@code privateLookupIn} is allowed to
+     * {@linkplain Lookup#defineClass(byte[]) define classes} in the runtime package
      * of {@code T}. Extreme caution should be taken when opening a package
-     * to another module.  The injected classes have the same full privilege
-     * access as other members in the target module.
+     * to another module as such defined classes have the same full privilege
+     * access as other members in {@code M2}.
      *
      * <h2><a id="module-access-check"></a>Cross-module access checks</h2>
      *

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -232,6 +232,12 @@ public class MethodHandles {
      * {@code PRIVATE} access but no {@code MODULE} access.
      * <p>
      * The resulting {@code Lookup} object has no {@code ORIGINAL} access.
+     * <p>
+     * The {@code Lookup} object returned by this method has the access to
+     * {@linkplain Lookup#defineClass(byte[]) inject classes} in the runtime package
+     * of {@code targetClass}. Extreme caution should be taken when opening a package
+     * to another module.  The injected classes have the same full privilege
+     * access as other members in the target module.
      *
      * @param targetClass the target class
      * @param caller the caller lookup object
@@ -851,7 +857,7 @@ public class MethodHandles {
      * <p>
      * {@link MethodHandles#privateLookupIn(Class, Lookup) MethodHandles.privateLookupIn(T.class, lookup)}
      * can be used to teleport a {@code lookup} from class {@code C} to class {@code T}
-     * and create a new {@code Lookup} with <a href="#privacc">private access</a>
+     * and produce a new {@code Lookup} with <a href="#privacc">private access</a>
      * if the lookup class is allowed to do <em>deep reflection</em> on {@code T}.
      * The {@code lookup} must have {@link #MODULE} and {@link #PRIVATE} access
      * to call {@code privateLookupIn}.
@@ -869,6 +875,12 @@ public class MethodHandles {
      * it cannot be used to obtain another private {@code Lookup} by calling
      * {@link MethodHandles#privateLookupIn(Class, Lookup) privateLookupIn}
      * because it has no {@code MODULE} access.
+     * <p>
+     * The {@code Lookup} object returned by {@code privateLookupIn} has the access to
+     * {@linkplain Lookup#defineClass(byte[]) inject classes} in the runtime package
+     * of {@code T}. Extreme caution should be taken when opening a package
+     * to another module.  The injected classes have the same full privilege
+     * access as other members in the target module.
      *
      * <h2><a id="module-access-check"></a>Cross-module access checks</h2>
      *

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -232,12 +232,12 @@ public class MethodHandles {
      * {@code PRIVATE} access but no {@code MODULE} access.
      * <p>
      * The resulting {@code Lookup} object has no {@code ORIGINAL} access.
-     * <p>
-     * The {@code Lookup} object returned by this method is allowed to
+     *
+     * @apiNote The {@code Lookup} object returned by this method is allowed to
      * {@linkplain Lookup#defineClass(byte[]) define classes} in the runtime package
      * of {@code targetClass}. Extreme caution should be taken when opening a package
      * to another module as such defined classes have the same full privilege
-     * access as other members in the target module.
+     * access as other members in {@code targetClass}'s module.
      *
      * @param targetClass the target class
      * @param caller the caller lookup object


### PR DESCRIPTION
Currently, a `Lookup` object with `PACKAGE` access can be used to inject a class in the runtime package of the Lookup's lookup class via `Lookup::defineClass`.   The classes that are injected have the same access as other members in the module and can access private members of all types in the module via reflection.

However, changing `Lookup.defineClass` to require full privilege access (`PRIVATE` + `MODULE`) is an incompatible change that would break existing frameworks which use `privateLookupIn` and `Lookup::defineClass` to inject auxiliary classes in a module.   A module authorizes the framework by opening a package for it to access and `Lookup::defineClass` was the supported replacement for `setAccessible` on `ClassLoader::defineClass` hack in JDK 9.    

This PR proposes to keep existing behavior and provide better documentation to help developers to beware of the permissions given out when opening a package to another module. A class injected in a module has the same privilege as other module members.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8217920](https://bugs.openjdk.org/browse/JDK-8217920): Lookup.defineClass injects a class that can access private members of any class in its own module


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [487baca5](https://git.openjdk.org/jdk/pull/12236/files/487baca5e646dd1728334d09290cb3fb88542f3b)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12236/head:pull/12236` \
`$ git checkout pull/12236`

Update a local copy of the PR: \
`$ git checkout pull/12236` \
`$ git pull https://git.openjdk.org/jdk pull/12236/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12236`

View PR using the GUI difftool: \
`$ git pr show -t 12236`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12236.diff">https://git.openjdk.org/jdk/pull/12236.diff</a>

</details>
