### PR TITLE
[PATCH] Prefer ArrayList to LinkedList in CertificateAuthoritiesExtension

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/CertificateAuthoritiesExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/CertificateAuthoritiesExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,7 +86,7 @@ final class CertificateAuthoritiesExtension {
                     "insufficient data");
             }
 
-            this.authorities = new LinkedList<>();
+            this.authorities = new ArrayList<>();
             while (listLen > 0) {
                 // opaque DistinguishedName<1..2^16-1>;
                 byte[] encoded = Record.getBytes16(m);


### PR DESCRIPTION
There is only `add`/`iterator` calls on this list. No removes from the head or something like this. Not sure why LinkedList was used, but ArrayList should be preferred as more efficient and widely used (more chances for JIT) collection
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12237/head:pull/12237` \
`$ git checkout pull/12237`

Update a local copy of the PR: \
`$ git checkout pull/12237` \
`$ git pull https://git.openjdk.org/jdk pull/12237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12237`

View PR using the GUI difftool: \
`$ git pr show -t 12237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12237.diff">https://git.openjdk.org/jdk/pull/12237.diff</a>

</details>
