### PR TITLE
8294402: Add diagnostic logging to VMProps.checkDockerSupport

### DIFF
--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -27,6 +27,7 @@ import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -406,6 +407,7 @@ public class VMProps implements Callable<Map<String, String>> {
      * @return true if CDS is supported by the VM to be tested.
      */
     protected String vmCDS() {
+        log("vmCDS()");
         return "" + WB.isCDSIncluded();
     }
 
@@ -650,6 +652,13 @@ public class VMProps implements Callable<Map<String, String>> {
         String fileName = System.getProperty("jtreg.ext.at.requires.logfile");
         if (fileName == null) {
             return;
+        }
+
+        // If path starts with the separator it will be used as is, as an absolute path.
+        // Otherwise it will be treated as a path relative to the jtreg current working directory.
+        String currentWorkDir = ".";
+        if(!fileName.startsWith(File.separator)) {
+            fileName = currentWorkDir + File.separator + fileName;
         }
 
         try {

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -514,6 +514,9 @@ public class VMProps implements Callable<Map<String, String>> {
     }
 
     private void redirectOutputToLogFile(String msg, ProcessBuilder pb, String fileNameBase) {
+        if (!Boolean.getBoolean("jtreg.log.vmprops")) {
+            return;
+        }
         String timeStamp = Instant.now().toString().replace(":", "-").replace(".", "-");
 
         String stdoutFileName = String.format("./%s-stdout--%s.log", fileNameBase, timeStamp);
@@ -655,6 +658,9 @@ public class VMProps implements Callable<Map<String, String>> {
      * @param msg
      */
     protected static void log(String msg) {
+        if (!Boolean.getBoolean("jtreg.log.vmprops")) {
+            return;
+        }
         // By jtreg design stderr produced here will be visible
         // in the output of a parent process.
         System.err.println("VMProps: " + msg);

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -514,6 +514,9 @@ public class VMProps implements Callable<Map<String, String>> {
 
     // Returns comma-separated file names for stdout and stderr.
     private String redirectOutputToLogFile(String msg, ProcessBuilder pb, String fileNameBase) {
+        if (!Boolean.getBoolean("jtreg.log.vmprops")) {
+            return "";
+        }
         String timeStamp = Instant.now().toString().replace(":", "-").replace(".", "-");
 
         String stdoutFileName = String.format("./%s-stdout--%s.log", fileNameBase, timeStamp);
@@ -686,6 +689,10 @@ public class VMProps implements Callable<Map<String, String>> {
      * @param msg
      */
     protected static void log(String msg) {
+        if (!Boolean.getBoolean("jtreg.log.vmprops")) {
+            return;
+        }
+
         // By jtreg design stderr produced here will be visible
         // in the output of a parent process. Note: stdout should not be used
         // for logging as jtreg parses that output directly and only echoes it

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -514,9 +514,6 @@ public class VMProps implements Callable<Map<String, String>> {
 
     // Returns comma-separated file names for stdout and stderr.
     private String redirectOutputToLogFile(String msg, ProcessBuilder pb, String fileNameBase) {
-        if (!Boolean.getBoolean("jtreg.log.vmprops")) {
-            return "";
-        }
         String timeStamp = Instant.now().toString().replace(":", "-").replace(".", "-");
 
         String stdoutFileName = String.format("./%s-stdout--%s.log", fileNameBase, timeStamp);
@@ -689,9 +686,6 @@ public class VMProps implements Callable<Map<String, String>> {
      * @param msg
      */
     protected static void log(String msg) {
-        if (!Boolean.getBoolean("jtreg.log.vmprops")) {
-            return;
-        }
         // By jtreg design stderr produced here will be visible
         // in the output of a parent process. Note: stdout should not be used
         // for logging as jtreg parses that output directly and only echoes it

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -512,52 +512,44 @@ public class VMProps implements Callable<Map<String, String>> {
         return "" + isSupported;
     }
 
-    // Returns comma-separated file names for stdout and stderr.
-    private String redirectOutputToLogFile(String msg, ProcessBuilder pb, String fileNameBase) {
-        if (!Boolean.getBoolean("jtreg.log.vmprops")) {
-            return "";
-        }
+    // Configures process builder to redirect process stdout and stderr to a file.
+    // Returns file names for stdout and stderr.
+    private Map<String, String> redirectOutputToLogFile(String msg, ProcessBuilder pb, String fileNameBase) {
+        Map<String, String> result = new HashMap<>();
         String timeStamp = Instant.now().toString().replace(":", "-").replace(".", "-");
 
         String stdoutFileName = String.format("./%s-stdout--%s.log", fileNameBase, timeStamp);
         pb.redirectOutput(new File(stdoutFileName));
         log(msg + ": child process stdout redirected to " + stdoutFileName);
+        result.put("stdout", stdoutFileName);
 
         String stderrFileName = String.format("./%s-stderr--%s.log", fileNameBase, timeStamp);
         pb.redirectError(new File(stderrFileName));
         log(msg + ": child process stderr redirected to " + stderrFileName);
+        result.put("stderr", stderrFileName);
 
-        return stdoutFileName + "," + stderrFileName;
+        return result;
     }
 
-    private void printLogfileContent(String logFileNames) {
-        if (logFileNames.isEmpty()) {
-            return;
-        }
-
-        log("------------- stdout: ");
-        try {
-            Files.lines(Path.of(logFileNames.split(",")[0]))
-                 .forEach(line -> log(line));
-        } catch (IOException ie) {
-            log("Exception while reading stdout file: " + ie);
-        }
-        log("------------- ");
-
-        log("------------- stderr: ");
-        try {
-            Files.lines(Path.of(logFileNames.split(",")[1]))
-                .forEach(line -> log(line));
-        } catch (IOException ie) {
-            log("Exception while reading stderr file: " + ie);
-        }
-        log("------------- ");
+    private void printLogfileContent(Map<String, String> logFileNames) {
+        logFileNames.entrySet().stream()
+            .forEach(entry ->
+                {
+                    log("------------- " + entry.getKey());
+                    try {
+                        Files.lines(Path.of(entry.getValue()))
+                            .forEach(line -> log(line));
+                    } catch (IOException ie) {
+                        log("Exception while reading file: " + ie);
+                    }
+                    log("-------------");
+                });
     }
 
     private boolean checkDockerSupport() throws IOException, InterruptedException {
         log("checkDockerSupport(): entering");
         ProcessBuilder pb = new ProcessBuilder(Container.ENGINE_COMMAND, "ps");
-        String logFileNames = redirectOutputToLogFile("checkDockerSupport(): <container> ps",
+        Map<String, String> logFileNames = redirectOutputToLogFile("checkDockerSupport(): <container> ps",
                                                       pb, "container-ps");
         Process p = pb.start();
         p.waitFor(10, TimeUnit.SECONDS);
@@ -684,20 +676,37 @@ public class VMProps implements Callable<Map<String, String>> {
     }
 
     /**
-     * Logs diagnostic message.
+     * Log diagnostic message.
      *
      * @param msg
      */
     protected static void log(String msg) {
-        if (!Boolean.getBoolean("jtreg.log.vmprops")) {
-            return;
-        }
+        // Always log to a file.
+        logToFile(msg);
 
+        // Also log to stderr; guarded by property to avoid excessive verbosity.
         // By jtreg design stderr produced here will be visible
         // in the output of a parent process. Note: stdout should not be used
         // for logging as jtreg parses that output directly and only echoes it
         // in the event of a failure.
-        System.err.println("VMProps: " + msg);
+        if (Boolean.getBoolean("jtreg.log.vmprops")) {
+            System.err.println("VMProps: " + msg);
+        }
+    }
+
+    /**
+     * Log diagnostic message to a file.
+     *
+     * @param msg
+     */
+    protected static void logToFile(String msg) {
+        String fileName = "./vmprops.log";
+        try {
+            Files.writeString(Paths.get(fileName), msg + "\n", Charset.forName("ISO-8859-1"),
+                    StandardOpenOption.APPEND, StandardOpenOption.CREATE);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to log into '" + fileName + "'", e);
+        }
     }
 
     /**

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -662,9 +662,9 @@ public class VMProps implements Callable<Map<String, String>> {
             return;
         }
         // By jtreg design stderr produced here will be visible
-        // in the output of a parent process.
-        // Avoid logging to stdout as it will be filtered out by the jtreg
-        // main process.
+        // in the output of a parent process. Note: stdout should not be used
+        // for logging as jtreg parses that output directly and only echoes it
+        // in the event of a failure.
         System.err.println("VMProps: " + msg);
     }
 

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -659,6 +659,7 @@ public class VMProps implements Callable<Map<String, String>> {
      * @param msg
      */
     protected static void log(String msg) {
+        System.err.println("VMProps: " + msg);
         logToFile(msg);
     }
 
@@ -676,7 +677,6 @@ public class VMProps implements Callable<Map<String, String>> {
         if (!Boolean.getBoolean("jtreg.log.vmprops")) {
             return;
         }
-
         String fileName = "./jtreg-vm-props.log";
         try {
             Files.writeString(Paths.get(fileName), msg + "\n", Charset.forName("ISO-8859-1"),

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -515,9 +515,17 @@ public class VMProps implements Callable<Map<String, String>> {
     private boolean checkDockerSupport() throws IOException, InterruptedException {
         log("checkDockerSupport(): entering");
         ProcessBuilder pb = new ProcessBuilder(Container.ENGINE_COMMAND, "ps");
+
+        // TODO: use property for file path if defined, plus timestamp
+        File out = new File("./container-ps-stdout.log");
+        pb.redirectOutput(out);
+        File err = new File("./container-ps-stderr.log");
+        pb.redirectError(err);
         Process p = pb.start();
         p.waitFor(10, TimeUnit.SECONDS);
         int exitValue = p.exitValue();
+
+        // TODO: log stdout and stderr file names
         log("checkDockerSupport(): exitValue = " + exitValue);
 
         return (exitValue == 0);
@@ -673,6 +681,7 @@ public class VMProps implements Callable<Map<String, String>> {
                     + fileName + "'", e);
         }
     }
+
 
     /**
      * This method is for the testing purpose only.

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -663,6 +663,8 @@ public class VMProps implements Callable<Map<String, String>> {
         }
         // By jtreg design stderr produced here will be visible
         // in the output of a parent process.
+        // Avoid logging to stdout as it will be filtered out by the jtreg
+        // main process.
         System.err.println("VMProps: " + msg);
     }
 

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -408,7 +408,6 @@ public class VMProps implements Callable<Map<String, String>> {
      * @return true if CDS is supported by the VM to be tested.
      */
     protected String vmCDS() {
-        log("vmCDS()");
         return "" + WB.isCDSIncluded();
     }
 
@@ -539,7 +538,7 @@ public class VMProps implements Callable<Map<String, String>> {
         log("------------- stdout: ");
         try {
             Files.lines(Path.of(logFileNames.split(",")[0]))
-                .forEach(line -> log(line));
+                 .forEach(line -> log(line));
         } catch (IOException ie) {
             log("Exception while reading stdout file: " + ie);
         }
@@ -565,7 +564,10 @@ public class VMProps implements Callable<Map<String, String>> {
         int exitValue = p.exitValue();
 
         log(String.format("checkDockerSupport(): exitValue = %s, pid = %s", exitValue, p.pid()));
-        printLogfileContent(logFileNames);
+        if (exitValue != 0) {
+            printLogfileContent(logFileNames);
+        }
+
         return (exitValue == 0);
     }
 

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -498,7 +498,7 @@ public class VMProps implements Callable<Map<String, String>> {
            }
         }
 
-        log("dockerSupport(): isSupported = " + isSupported);
+        log("dockerSupport(): platform check: isSupported = " + isSupported);
 
         if (isSupported) {
            try {
@@ -508,15 +508,19 @@ public class VMProps implements Callable<Map<String, String>> {
            }
          }
 
+        log("dockerSupport(): returning isSupported = " + isSupported);
         return "" + isSupported;
     }
 
     private boolean checkDockerSupport() throws IOException, InterruptedException {
+        log("checkDockerSupport(): entering");
         ProcessBuilder pb = new ProcessBuilder(Container.ENGINE_COMMAND, "ps");
         Process p = pb.start();
         p.waitFor(10, TimeUnit.SECONDS);
+        int exitValue = p.exitValue();
+        log("checkDockerSupport(): exitValue = " + exitValue);
 
-        return (p.exitValue() == 0);
+        return (exitValue == 0);
     }
 
     /**


### PR DESCRIPTION
Add log() and logToFile() methods to VMProps for diagnostic purposes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294402](https://bugs.openjdk.org/browse/JDK-8294402): Add diagnostic logging to VMProps.checkDockerSupport


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12239/head:pull/12239` \
`$ git checkout pull/12239`

Update a local copy of the PR: \
`$ git checkout pull/12239` \
`$ git pull https://git.openjdk.org/jdk pull/12239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12239`

View PR using the GUI difftool: \
`$ git pr show -t 12239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12239.diff">https://git.openjdk.org/jdk/pull/12239.diff</a>

</details>
