### PR TITLE
JDK-8301163: jdk/internal/vm/Continuation/Fuzz.java increase COMPILATION_TIMEOUT for Linux ppc64le

### DIFF
--- a/test/jdk/jdk/internal/vm/Continuation/Fuzz.java
+++ b/test/jdk/jdk/internal/vm/Continuation/Fuzz.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -90,6 +90,9 @@ public class Fuzz implements Runnable {
         if (Platform.isSlowDebugBuild() && Platform.isOSX() && Platform.isAArch64()) {
             throw new SkippedException("Test is unstable with slowdebug bits "
                                        + "on macosx-aarch64");
+        }
+        if (Platform.isLinux() && Platform.isPPC()) {
+            COMPILATION_TIMEOUT = COMPILATION_TIMEOUT * 2;
         }
         warmup();
         for (int compileLevel : new int[]{4}) {

--- a/test/jdk/jdk/internal/vm/Continuation/Fuzz.java
+++ b/test/jdk/jdk/internal/vm/Continuation/Fuzz.java
@@ -82,7 +82,7 @@ public class Fuzz implements Runnable {
     static final boolean VERBOSE = false;
 
     static float timeoutFactor = Float.parseFloat(System.getProperty("test.timeout.factor", "1.0"));
-    static final int COMPILATION_TIMEOUT = (int)(5_000 * timeoutFactor); // ms
+    static int COMPILATION_TIMEOUT = (int)(5_000 * timeoutFactor); // ms
 
     static final Path TEST_DIR = Path.of(System.getProperty("test.src", "."));
 

--- a/test/jdk/jdk/internal/vm/Continuation/Fuzz.java
+++ b/test/jdk/jdk/internal/vm/Continuation/Fuzz.java
@@ -91,7 +91,7 @@ public class Fuzz implements Runnable {
             throw new SkippedException("Test is unstable with slowdebug bits "
                                        + "on macosx-aarch64");
         }
-        if (Platform.isLinux() && Platform.isPPC()) {
+        if (Platform.isPPC()) {
             COMPILATION_TIMEOUT = COMPILATION_TIMEOUT * 2;
         }
         warmup();


### PR DESCRIPTION
On our Linux ppc64le test machines we quite often see compilation timeouts in the test jdk/internal/vm/Continuation/Fuzz.java.
(especially when running with fastdebug binaries)
So it probably makes sense to use a higher compilation timeout (maybe factor 2) on this platform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301163](https://bugs.openjdk.org/browse/JDK-8301163): jdk/internal/vm/Continuation/Fuzz.java increase COMPILATION_TIMEOUT for Linux ppc64le


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12244/head:pull/12244` \
`$ git checkout pull/12244`

Update a local copy of the PR: \
`$ git checkout pull/12244` \
`$ git pull https://git.openjdk.org/jdk pull/12244/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12244`

View PR using the GUI difftool: \
`$ git pr show -t 12244`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12244.diff">https://git.openjdk.org/jdk/pull/12244.diff</a>

</details>
