### PR TITLE
JDK-8301170: perfMemory_windows.cpp add free_security_attr to early returns

### DIFF
--- a/src/hotspot/os/windows/perfMemory_windows.cpp
+++ b/src/hotspot/os/windows/perfMemory_windows.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1240,6 +1240,7 @@ static bool make_user_tmp_dir(const char* dirname) {
         if (PrintMiscellaneous && Verbose) {
           warning("%s directory is insecure\n", dirname);
         }
+        free_security_attr(pDirSA);
         return false;
       }
       // The administrator should be able to delete this directory.
@@ -1255,18 +1256,15 @@ static bool make_user_tmp_dir(const char* dirname) {
                                                         dirname, lasterror);
         }
       }
-    }
-    else {
+    } else {
       if (PrintMiscellaneous && Verbose) {
         warning("CreateDirectory failed: %d\n", GetLastError());
       }
+      free_security_attr(pDirSA);
       return false;
     }
   }
-
-  // free the security attributes structure
   free_security_attr(pDirSA);
-
   return true;
 }
 
@@ -1298,6 +1296,8 @@ static HANDLE create_sharedmem_resources(const char* dirname, const char* filena
   if (!make_user_tmp_dir(dirname)) {
     // could not make/find the directory or the found directory
     // was not secure
+    free_security_attr(lpFileSA);
+    free_security_attr(lpSmoSA);
     return NULL;
   }
 
@@ -1329,6 +1329,7 @@ static HANDLE create_sharedmem_resources(const char* dirname, const char* filena
     if (PrintMiscellaneous && Verbose) {
       warning("could not create file %s: %d\n", filename, lasterror);
     }
+    free_security_attr(lpSmoSA);
     return NULL;
   }
 


### PR DESCRIPTION
The some functions in perfMemory_windows.cpp seem to miss the free_security_attr
calls in early returns.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301170](https://bugs.openjdk.org/browse/JDK-8301170): perfMemory_windows.cpp add free_security_attr to early returns


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12245/head:pull/12245` \
`$ git checkout pull/12245`

Update a local copy of the PR: \
`$ git checkout pull/12245` \
`$ git pull https://git.openjdk.org/jdk pull/12245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12245`

View PR using the GUI difftool: \
`$ git pr show -t 12245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12245.diff">https://git.openjdk.org/jdk/pull/12245.diff</a>

</details>
