### PR TITLE
6817009: Action.SELECTED_KEY not toggled when using key binding

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
@@ -1810,6 +1810,13 @@ public class SwingUtilities implements SwingConstants
         action.actionPerformed(new ActionEvent(sender,
                         ActionEvent.ACTION_PERFORMED, command, event.getWhen(),
                         modifiers));
+        if (event.getSource() instanceof JToggleButton) {
+            JToggleButton tb = (JToggleButton)event.getSource();
+            commandO = action.getValue(Action.SELECTED_KEY);
+            if (commandO != null) {
+                tb.setSelected(!tb.isSelected());
+            }
+        }
         return true;
     }
 

--- a/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
@@ -1810,8 +1810,7 @@ public class SwingUtilities implements SwingConstants
         action.actionPerformed(new ActionEvent(sender,
                         ActionEvent.ACTION_PERFORMED, command, event.getWhen(),
                         modifiers));
-        if (event.getSource() instanceof JToggleButton) {
-            JToggleButton tb = (JToggleButton)event.getSource();
+        if (event.getSource() instanceof JToggleButton tb) {
             commandO = action.getValue(Action.SELECTED_KEY);
             if (commandO != null) {
                 tb.setSelected(!tb.isSelected());

--- a/test/jdk/javax/swing/JToggleButton/TestSelectedKey.java
+++ b/test/jdk/javax/swing/JToggleButton/TestSelectedKey.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 6817009
+   @summary Verifies if AAction.SELECTED_KEY not toggled when using key binding
+   @run main TestSelectedKey
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.awt.Robot;
+
+import javax.swing.SwingUtilities;
+import javax.swing.JLabel;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.KeyStroke;
+import javax.swing.JToolBar;
+import javax.swing.JToggleButton;
+import javax.swing.JPopupMenu;
+import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JFrame;
+import javax.swing.InputMap;
+import javax.swing.JComponent;
+import javax.swing.ActionMap;
+
+public class TestSelectedKey {
+    private static Robot robot;
+    private static JFrame frame;
+    private static boolean toggled = false;
+
+    public static void main(String[] args) throws Exception {
+        robot = new Robot();
+        try {
+            SwingUtilities.invokeAndWait(() -> createGUI());
+            robot.waitForIdle();
+            robot.delay(1000);
+            robot.keyPress(KeyEvent.VK_CONTROL);
+            robot.keyPress(KeyEvent.VK_Z);
+            robot.keyRelease(KeyEvent.VK_Z);
+            robot.keyRelease(KeyEvent.VK_CONTROL);
+            robot.waitForIdle();
+            robot.delay(1000);
+            if (!toggled) {
+                throw new RuntimeException("JToggleButton not toggled via accelerator key");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createGUI() {
+        final JLabel label = new JLabel("Toggle me actions 0");
+        final JLabel selected = new JLabel("Toggle me selected: false");
+        AbstractAction action = new AbstractAction("Toggle me") {
+            private int count = 0;
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                label.setText("Toggle me actions " + (++count));
+            }
+        };
+        action.addPropertyChangeListener(new PropertyChangeListener() {
+            public void propertyChange(PropertyChangeEvent evt) {
+                if(Action.SELECTED_KEY.equals(evt.getPropertyName())) {
+                    selected.setText("Toggle me selected: " + evt.getNewValue());
+                    toggled = (boolean)evt.getNewValue();
+                }
+            }
+        });
+        action.putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_Z, KeyEvent.CTRL_DOWN_MASK));
+        // need to set manually or won't be updated by Swing
+        action.putValue(Action.SELECTED_KEY, Boolean.FALSE);
+
+        Box labels = new Box(BoxLayout.PAGE_AXIS);
+        labels.add(label);
+        labels.add(selected);
+
+        JToolBar toolBar = new JToolBar();
+        toolBar.add(new JToggleButton(action));
+
+        JPopupMenu popupMenu = new JPopupMenu();
+        popupMenu.add(new JCheckBoxMenuItem(action));
+        labels.setComponentPopupMenu(popupMenu);
+
+        frame = new JFrame("Test Action.SELECTED_KEY");
+        frame.getContentPane().add(toolBar, BorderLayout.PAGE_START);
+        frame.getContentPane().add(labels, BorderLayout.CENTER);
+
+        InputMap inputMap = frame.getRootPane().getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT);
+        ActionMap actionMap = frame.getRootPane().getActionMap();
+        inputMap.put((KeyStroke) action.getValue(Action.ACCELERATOR_KEY), "toggleAction");
+        actionMap.put("toggleAction", action);
+
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setPreferredSize(new Dimension(400, 200));
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+}

--- a/test/jdk/javax/swing/JToggleButton/TestSelectedKey.java
+++ b/test/jdk/javax/swing/JToggleButton/TestSelectedKey.java
@@ -22,8 +22,9 @@
  */
 
 /* @test
-   @bug 6817009
-   @summary Verifies if AAction.SELECTED_KEY not toggled when using key binding
+ * @key headful
+ * @bug 6817009
+ * @summary Verifies that Action.SELECTED_KEY is not toggled when key binding is used
    @run main TestSelectedKey
  */
 
@@ -93,7 +94,7 @@ public class TestSelectedKey {
         };
         action.addPropertyChangeListener(new PropertyChangeListener() {
             public void propertyChange(PropertyChangeEvent evt) {
-                if(Action.SELECTED_KEY.equals(evt.getPropertyName())) {
+                if (Action.SELECTED_KEY.equals(evt.getPropertyName())) {
                     selected.setText("Toggle me selected: " + evt.getNewValue());
                     toggled = (boolean)evt.getNewValue();
                 }


### PR DESCRIPTION
When the Action.SELECTED_KEY property action is assigned to ToggleButton and an accelerator key binding is mapped to the action, then pressing the accelerator key binding does not toggle the toggle button.
This is because SwingUtilities.notifyAction does not fire itemStateChanged event for such action related to SELECTED_KEY.
Fix is to get the Action.SELECTED_KEY command/action and fire itemStateChanged Event via JToggleButton.setSelected() call to notify propertyChange listener of the toggled property.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6817009](https://bugs.openjdk.org/browse/JDK-6817009): Action.SELECTED_KEY not toggled when using key binding


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer) ⚠️ Review applies to [4219c5c7](https://git.openjdk.org/jdk/pull/12253/files/4219c5c7a00f9b85cf72c393b3a4be943a142f3a)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**) ⚠️ Review applies to [4219c5c7](https://git.openjdk.org/jdk/pull/12253/files/4219c5c7a00f9b85cf72c393b3a4be943a142f3a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12253/head:pull/12253` \
`$ git checkout pull/12253`

Update a local copy of the PR: \
`$ git checkout pull/12253` \
`$ git pull https://git.openjdk.org/jdk.git pull/12253/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12253`

View PR using the GUI difftool: \
`$ git pr show -t 12253`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12253.diff">https://git.openjdk.org/jdk/pull/12253.diff</a>

</details>
