### PR TITLE
8302120: Prefer ArrayList to LinkedList in AggregatePainter

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/ParsedSynthStyle.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/ParsedSynthStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,8 @@
 package javax.swing.plaf.synth;
 
 import java.awt.Graphics;
-import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.List;
 
 import sun.swing.plaf.synth.DefaultSynthStyle;
 
@@ -265,10 +266,10 @@ class ParsedSynthStyle extends DefaultSynthStyle {
     }
 
     private static class AggregatePainter extends SynthPainter {
-        private java.util.List<SynthPainter> painters;
+        private final List<SynthPainter> painters;
 
         AggregatePainter(SynthPainter painter) {
-            painters = new LinkedList<SynthPainter>();
+            painters = new ArrayList<>();
             painters.add(painter);
         }
 


### PR DESCRIPTION
There is only add/iterator calls on this list. No removes from the head or something like this. Not sure why LinkedList was used, but ArrayList should be preferred as more efficient and widely used (more chances for JIT) collection

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302120](https://bugs.openjdk.org/browse/JDK-8302120): Prefer ArrayList to LinkedList in AggregatePainter


### Reviewers
 * @SWinxy (no known openjdk.org user name / role)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12254/head:pull/12254` \
`$ git checkout pull/12254`

Update a local copy of the PR: \
`$ git checkout pull/12254` \
`$ git pull https://git.openjdk.org/jdk pull/12254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12254`

View PR using the GUI difftool: \
`$ git pr show -t 12254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12254.diff">https://git.openjdk.org/jdk/pull/12254.diff</a>

</details>
