### PR TITLE
8301244: Tidy up compiler specific warnings files

### DIFF
--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -34,7 +34,7 @@
 #define ATTRIBUTE_SCANF(fmt,vargs)  __attribute__((format(scanf, fmt, vargs)))
 #endif
 
-#define PRAGMA_DISABLE_GCC_WARNING(option) PRAGMA(GCC diagnostic ignored option)
+#define PRAGMA_DISABLE_GCC_WARNING(option) _Pragma(STR(GCC diagnostic ignored option))
 
 #define PRAGMA_FORMAT_NONLITERAL_IGNORED                \
   PRAGMA_DISABLE_GCC_WARNING("-Wformat-nonliteral")     \
@@ -62,8 +62,8 @@
       (__clang_major__ >= 3 && __clang_minor__ >= 1)) || \
     ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 6)) || (__GNUC__ > 4)
 // Tested to work with clang version 3.1 and better.
-#define PRAGMA_DIAG_PUSH             PRAGMA(GCC diagnostic push)
-#define PRAGMA_DIAG_POP              PRAGMA(GCC diagnostic pop)
+#define PRAGMA_DIAG_PUSH             _Pragna("GCC diagnostic push")
+#define PRAGMA_DIAG_POP              _Pragma("GCC diagnostic pop")
 
 #endif // clang/gcc version check
 

--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -34,8 +34,7 @@
 #define ATTRIBUTE_SCANF(fmt,vargs)  __attribute__((format(scanf, fmt, vargs)))
 #endif
 
-#define PRAGMA_UTIL(pragma) _Pragma(#pragma)
-#define PRAGMA_DISABLE_GCC_WARNING(option) PRAGMA_UTIL(GCC diagnostic ignored option)
+#define PRAGMA_DISABLE_GCC_WARNING(option) PRAGMA(GCC diagnostic ignored option)
 
 #define PRAGMA_FORMAT_NONLITERAL_IGNORED                \
   PRAGMA_DISABLE_GCC_WARNING("-Wformat-nonliteral")     \
@@ -63,8 +62,8 @@
       (__clang_major__ >= 3 && __clang_minor__ >= 1)) || \
     ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 6)) || (__GNUC__ > 4)
 // Tested to work with clang version 3.1 and better.
-#define PRAGMA_DIAG_PUSH             PRAGMA_UTIL(GCC diagnostic push)
-#define PRAGMA_DIAG_POP              PRAGMA_UTIL(GCC diagnostic pop)
+#define PRAGMA_DIAG_PUSH             PRAGMA(GCC diagnostic push)
+#define PRAGMA_DIAG_POP              PRAGMA(GCC diagnostic pop)
 
 #endif // clang/gcc version check
 

--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -34,9 +34,7 @@
 #define ATTRIBUTE_SCANF(fmt,vargs)  __attribute__((format(scanf, fmt, vargs)))
 #endif
 
-#define PRAGMA_DISABLE_GCC_WARNING_AUX(x) _Pragma(#x)
-#define PRAGMA_DISABLE_GCC_WARNING(option_string) \
-  PRAGMA_DISABLE_GCC_WARNING_AUX(GCC diagnostic ignored option_string)
+#define PRAGMA_DISABLE_GCC_WARNING(option) PRAGMA(GCC diagnostic ignored option)
 
 #define PRAGMA_FORMAT_NONLITERAL_IGNORED                \
   PRAGMA_DISABLE_GCC_WARNING("-Wformat-nonliteral")     \

--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -62,7 +62,7 @@
       (__clang_major__ >= 3 && __clang_minor__ >= 1)) || \
     ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 6)) || (__GNUC__ > 4)
 // Tested to work with clang version 3.1 and better.
-#define PRAGMA_DIAG_PUSH             _Pragna("GCC diagnostic push")
+#define PRAGMA_DIAG_PUSH             _Pragma("GCC diagnostic push")
 #define PRAGMA_DIAG_POP              _Pragma("GCC diagnostic pop")
 
 #endif // clang/gcc version check

--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -96,6 +96,4 @@
 
 #endif // gcc10+
 
-#undef PRAGMA
-
 #endif // SHARE_UTILITIES_COMPILERWARNINGS_GCC_HPP

--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -34,7 +34,7 @@
 #define ATTRIBUTE_SCANF(fmt,vargs)  __attribute__((format(scanf, fmt, vargs)))
 #endif
 
-#define PRAGMA_DISABLE_GCC_WARNING(option_string) _Pragma(STR(GCC diagnostic ignored option_string))
+#define PRAGMA_DISABLE_GCC_WARNING(optstring) _Pragma(STR(GCC diagnostic ignored optstring))
 
 #define PRAGMA_FORMAT_NONLITERAL_IGNORED                \
   PRAGMA_DISABLE_GCC_WARNING("-Wformat-nonliteral")     \
@@ -54,8 +54,7 @@
 #define PRAGMA_STRINGOP_OVERFLOW_IGNORED PRAGMA_DISABLE_GCC_WARNING("-Wstringop-overflow")
 #endif
 
-#define PRAGMA_NONNULL_IGNORED \
-  PRAGMA_DISABLE_GCC_WARNING("-Wnonnull")
+#define PRAGMA_NONNULL_IGNORED PRAGMA_DISABLE_GCC_WARNING("-Wnonnull")
 
 #if defined(__clang_major__) && \
       (__clang_major__ >= 4 || \

--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -34,8 +34,7 @@
 #define ATTRIBUTE_SCANF(fmt,vargs)  __attribute__((format(scanf, fmt, vargs)))
 #endif
 
-#define PRAGMA(str) _Pragma(#str)
-#define PRAGMA_DISABLE_GCC_WARNING(option) PRAGMA(GCC diagnostic ignored option)
+#define PRAGMA_DISABLE_GCC_WARNING(option) _Pragma("GCC diagnostic ignored" #option)
 
 #define PRAGMA_FORMAT_NONLITERAL_IGNORED                \
   PRAGMA_DISABLE_GCC_WARNING("-Wformat-nonliteral")     \

--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -34,7 +34,7 @@
 #define ATTRIBUTE_SCANF(fmt,vargs)  __attribute__((format(scanf, fmt, vargs)))
 #endif
 
-#define PRAGMA_DISABLE_GCC_WARNING(option) _Pragma(STR(GCC diagnostic ignored option))
+#define PRAGMA_DISABLE_GCC_WARNING(option_string) _Pragma(STR(GCC diagnostic ignored option_string))
 
 #define PRAGMA_FORMAT_NONLITERAL_IGNORED                \
   PRAGMA_DISABLE_GCC_WARNING("-Wformat-nonliteral")     \

--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -34,7 +34,8 @@
 #define ATTRIBUTE_SCANF(fmt,vargs)  __attribute__((format(scanf, fmt, vargs)))
 #endif
 
-#define PRAGMA_DISABLE_GCC_WARNING(option) _Pragma("GCC diagnostic ignored" #option)
+#define PRAGMA_UTIL(pragma) _Pragma(#pragma)
+#define PRAGMA_DISABLE_GCC_WARNING(option) PRAGMA_UTIL(GCC diagnostic ignored option)
 
 #define PRAGMA_FORMAT_NONLITERAL_IGNORED                \
   PRAGMA_DISABLE_GCC_WARNING("-Wformat-nonliteral")     \
@@ -62,8 +63,8 @@
       (__clang_major__ >= 3 && __clang_minor__ >= 1)) || \
     ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 6)) || (__GNUC__ > 4)
 // Tested to work with clang version 3.1 and better.
-#define PRAGMA_DIAG_PUSH             _Pragma("GCC diagnostic push")
-#define PRAGMA_DIAG_POP              _Pragma("GCC diagnostic pop")
+#define PRAGMA_DIAG_PUSH             PRAGMA_UTIL(GCC diagnostic push)
+#define PRAGMA_DIAG_POP              PRAGMA_UTIL(GCC diagnostic pop)
 
 #endif // clang/gcc version check
 

--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -34,6 +34,7 @@
 #define ATTRIBUTE_SCANF(fmt,vargs)  __attribute__((format(scanf, fmt, vargs)))
 #endif
 
+#define PRAGMA(str) _Pragma(#str)
 #define PRAGMA_DISABLE_GCC_WARNING(option) PRAGMA(GCC diagnostic ignored option)
 
 #define PRAGMA_FORMAT_NONLITERAL_IGNORED                \
@@ -94,5 +95,7 @@
   PRAGMA_DIAG_POP
 
 #endif // gcc10+
+
+#undef PRAGMA
 
 #endif // SHARE_UTILITIES_COMPILERWARNINGS_GCC_HPP

--- a/src/hotspot/share/utilities/compilerWarnings_visCPP.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_visCPP.hpp
@@ -66,6 +66,4 @@
   __VA_ARGS__                                   \
   PRAGMA_DIAG_POP
 
-#undef PRAGMA
-
 #endif // SHARE_UTILITIES_COMPILERWARNINGS_VISCPP_HPP

--- a/src/hotspot/share/utilities/compilerWarnings_visCPP.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_visCPP.hpp
@@ -25,10 +25,11 @@
 #ifndef SHARE_UTILITIES_COMPILERWARNINGS_VISCPP_HPP
 #define SHARE_UTILITIES_COMPILERWARNINGS_VISCPP_HPP
 
+#define PRAGMA(str) _Pragma(#str)
+#define PRAGMA_DISABLE_MSVC_WARNING(num) PRAGMA(warning(disable : num))
+
 #define PRAGMA_DIAG_PUSH PRAGMA(warning(push))
 #define PRAGMA_DIAG_POP  PRAGMA(warning(pop))
-
-#define PRAGMA_DISABLE_MSVC_WARNING(num) PRAGMA(warning(disable : num))
 
 // The Visual Studio implementation of FORBID_C_FUNCTION explicitly does
 // nothing, because there doesn't seem to be a way to implement it for Visual
@@ -64,5 +65,7 @@
   PRAGMA_DISABLE_MSVC_WARNING(4996)             \
   __VA_ARGS__                                   \
   PRAGMA_DIAG_POP
+
+#undef PRAGMA
 
 #endif // SHARE_UTILITIES_COMPILERWARNINGS_VISCPP_HPP

--- a/src/hotspot/share/utilities/compilerWarnings_visCPP.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_visCPP.hpp
@@ -25,10 +25,11 @@
 #ifndef SHARE_UTILITIES_COMPILERWARNINGS_VISCPP_HPP
 #define SHARE_UTILITIES_COMPILERWARNINGS_VISCPP_HPP
 
-#define PRAGMA_DISABLE_MSVC_WARNING(num) _Pragma("warning(disable : " #num ")")
+#define PRAGMA_UTIL(pragma) _Pragma(#pragma)
+#define PRAGMA_DISABLE_MSVC_WARNING(num) PRAGMA_UTIL(warning(disable : num))
 
-#define PRAGMA_DIAG_PUSH _Pragma("warning(push)")
-#define PRAGMA_DIAG_POP  _Pragma("warning(pop)")
+#define PRAGMA_DIAG_PUSH PRAGMA_UTIL(warning(push))
+#define PRAGMA_DIAG_POP  PRAGMA_UTIL(warning(pop))
 
 // The Visual Studio implementation of FORBID_C_FUNCTION explicitly does
 // nothing, because there doesn't seem to be a way to implement it for Visual

--- a/src/hotspot/share/utilities/compilerWarnings_visCPP.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_visCPP.hpp
@@ -25,10 +25,10 @@
 #ifndef SHARE_UTILITIES_COMPILERWARNINGS_VISCPP_HPP
 #define SHARE_UTILITIES_COMPILERWARNINGS_VISCPP_HPP
 
-#define PRAGMA_DISABLE_MSVC_WARNING(num) PRAGMA(warning(disable : num))
+#define PRAGMA_DISABLE_MSVC_WARNING(num) _Pragma(STR(warning(disable : num)))
 
-#define PRAGMA_DIAG_PUSH PRAGMA(warning(push))
-#define PRAGMA_DIAG_POP  PRAGMA(warning(pop))
+#define PRAGMA_DIAG_PUSH _Pragma("warning(push)")
+#define PRAGMA_DIAG_POP  _Pragma("warning(pop)")
 
 // The Visual Studio implementation of FORBID_C_FUNCTION explicitly does
 // nothing, because there doesn't seem to be a way to implement it for Visual

--- a/src/hotspot/share/utilities/compilerWarnings_visCPP.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_visCPP.hpp
@@ -25,11 +25,10 @@
 #ifndef SHARE_UTILITIES_COMPILERWARNINGS_VISCPP_HPP
 #define SHARE_UTILITIES_COMPILERWARNINGS_VISCPP_HPP
 
-#define PRAGMA(str) _Pragma(#str)
-#define PRAGMA_DISABLE_MSVC_WARNING(num) PRAGMA(warning(disable : num))
+#define PRAGMA_DISABLE_MSVC_WARNING(num) _Pragma("warning(disable : " #num ")")
 
-#define PRAGMA_DIAG_PUSH PRAGMA(warning(push))
-#define PRAGMA_DIAG_POP  PRAGMA(warning(pop))
+#define PRAGMA_DIAG_PUSH _Pragma("warning(push)")
+#define PRAGMA_DIAG_POP  _Pragma("warning(pop)")
 
 // The Visual Studio implementation of FORBID_C_FUNCTION explicitly does
 // nothing, because there doesn't seem to be a way to implement it for Visual

--- a/src/hotspot/share/utilities/compilerWarnings_visCPP.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_visCPP.hpp
@@ -25,10 +25,10 @@
 #ifndef SHARE_UTILITIES_COMPILERWARNINGS_VISCPP_HPP
 #define SHARE_UTILITIES_COMPILERWARNINGS_VISCPP_HPP
 
-#define PRAGMA_DIAG_PUSH __pragma(warning(push))
-#define PRAGMA_DIAG_POP  __pragma(warning(pop))
+#define PRAGMA_DIAG_PUSH PRAGMA(warning(push))
+#define PRAGMA_DIAG_POP  PRAGMA(warning(pop))
 
-#define PRAGMA_DISABLE_MSVC_WARNING(num) __pragma(warning(disable : num))
+#define PRAGMA_DISABLE_MSVC_WARNING(num) PRAGMA(warning(disable : num))
 
 // The Visual Studio implementation of FORBID_C_FUNCTION explicitly does
 // nothing, because there doesn't seem to be a way to implement it for Visual

--- a/src/hotspot/share/utilities/compilerWarnings_visCPP.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_visCPP.hpp
@@ -25,11 +25,10 @@
 #ifndef SHARE_UTILITIES_COMPILERWARNINGS_VISCPP_HPP
 #define SHARE_UTILITIES_COMPILERWARNINGS_VISCPP_HPP
 
-#define PRAGMA_UTIL(pragma) _Pragma(#pragma)
-#define PRAGMA_DISABLE_MSVC_WARNING(num) PRAGMA_UTIL(warning(disable : num))
+#define PRAGMA_DISABLE_MSVC_WARNING(num) PRAGMA(warning(disable : num))
 
-#define PRAGMA_DIAG_PUSH PRAGMA_UTIL(warning(push))
-#define PRAGMA_DIAG_POP  PRAGMA_UTIL(warning(pop))
+#define PRAGMA_DIAG_PUSH PRAGMA(warning(push))
+#define PRAGMA_DIAG_POP  PRAGMA(warning(pop))
 
 // The Visual Studio implementation of FORBID_C_FUNCTION explicitly does
 // nothing, because there doesn't seem to be a way to implement it for Visual

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -28,10 +28,6 @@
 // Use this to mark code that needs to be cleaned up (for development only)
 #define NEEDS_CLEANUP
 
-// For when Pragmas need to be reliably nested in macros. Also handles
-// quotation marks, so use sites are not required to pass string literals
-#define PRAGMA(str) _Pragma(#str)
-
 // Makes a string of the argument (which is not macro-expanded)
 #define STR(a)  #a
 

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -28,9 +28,6 @@
 // Use this to mark code that needs to be cleaned up (for development only)
 #define NEEDS_CLEANUP
 
-// Identical to #pragma, but intended for macros and macro expansions
-#define PRAGMA(params) _Pragma(#params)
-
 // Makes a string of the argument (which is not macro-expanded)
 #define STR(a)  #a
 

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -28,6 +28,8 @@
 // Use this to mark code that needs to be cleaned up (for development only)
 #define NEEDS_CLEANUP
 
+#define PRAGMA(params) _Pragma(#params)
+
 // Makes a string of the argument (which is not macro-expanded)
 #define STR(a)  #a
 

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -28,6 +28,7 @@
 // Use this to mark code that needs to be cleaned up (for development only)
 #define NEEDS_CLEANUP
 
+// Identical to #pragma, but intended for macros and macro expansions
 #define PRAGMA(params) _Pragma(#params)
 
 // Makes a string of the argument (which is not macro-expanded)

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -28,6 +28,10 @@
 // Use this to mark code that needs to be cleaned up (for development only)
 #define NEEDS_CLEANUP
 
+// For when Pragmas need to be reliably nested in macros. Also handles
+// quotation marks, so use sites are not required to pass string literals
+#define PRAGMA(str) _Pragma(#str)
+
 // Makes a string of the argument (which is not macro-expanded)
 #define STR(a)  #a
 


### PR DESCRIPTION
Cleans up some code in compilerWarnings_*.hpp files to be slightly neater

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8301244](https://bugs.openjdk.org/browse/JDK-8301244): Tidy up compiler specific warnings files


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to [a3185f7c](https://git.openjdk.org/jdk/pull/12255/files/a3185f7cb0f10e6c47f2ab27d725acb23aeb77bb)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [a3185f7c](https://git.openjdk.org/jdk/pull/12255/files/a3185f7cb0f10e6c47f2ab27d725acb23aeb77bb)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12255/head:pull/12255` \
`$ git checkout pull/12255`

Update a local copy of the PR: \
`$ git checkout pull/12255` \
`$ git pull https://git.openjdk.org/jdk pull/12255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12255`

View PR using the GUI difftool: \
`$ git pr show -t 12255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12255.diff">https://git.openjdk.org/jdk/pull/12255.diff</a>

</details>
