### PR TITLE
8301229: Clean up SuspendibleThreadSet::_suspend_all

### DIFF
--- a/src/hotspot/share/gc/shared/suspendibleThreadSet.hpp
+++ b/src/hotspot/share/gc/shared/suspendibleThreadSet.hpp
@@ -41,11 +41,10 @@ class SuspendibleThreadSet : public AllStatic {
   friend class SuspendibleThreadSetLeaver;
 
 private:
+  static uint          _nthreads;
+  static uint          _nthreads_stopped;
   static volatile bool _suspend_all;
-
-  static uint   _nthreads;
-  static uint   _nthreads_stopped;
-  static double _suspend_all_start;
+  static double        _suspend_all_start;
 
   static bool is_synchronized();
 
@@ -55,14 +54,19 @@ private:
   // Removes the current thread from the set.
   static void leave();
 
-  static bool suspend_all() { return Atomic::load(&_suspend_all); }
+  // Suspends the current thread if a suspension is in progress.
+  static void yield_slow();
 
 public:
   // Returns true if an suspension is in progress.
-  static bool should_yield() { return suspend_all(); }
+  static bool should_yield() { return Atomic::load(&_suspend_all); }
 
   // Suspends the current thread if a suspension is in progress.
-  static void yield();
+  static void yield() {
+    if (should_yield()) {
+      yield_slow();
+    }
+  }
 
   // Returns when all threads in the set are suspended.
   static void synchronize();


### PR DESCRIPTION
The SuspendibleThreadSet::_suspend_all variable is read and set concurrently, yet relies only on volatiles in accessors. They should use Atomic instead. Also, the _suspend_all getter is called suspend_all(), but since this function doesn't suspend anything, the name looks really confusing where it is, and there is an alias should_yield() that just calls suspend_all(), and better explains what the code does. This CR aims to remove suspend_all() and have a single getter, being should_yield (which reads better everywhere it is used), and make sure the accessors do use Atomic.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301229](https://bugs.openjdk.org/browse/JDK-8301229): Clean up SuspendibleThreadSet::_suspend_all


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12256/head:pull/12256` \
`$ git checkout pull/12256`

Update a local copy of the PR: \
`$ git checkout pull/12256` \
`$ git pull https://git.openjdk.org/jdk pull/12256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12256`

View PR using the GUI difftool: \
`$ git pr show -t 12256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12256.diff">https://git.openjdk.org/jdk/pull/12256.diff</a>

</details>
