### PR TITLE
8301254: UNIX sun/font coding does not detect SuSE in openSUSE Leap distribution

### DIFF
--- a/src/java.desktop/unix/classes/sun/font/FcFontConfiguration.java
+++ b/src/java.desktop/unix/classes/sun/font/FcFontConfiguration.java
@@ -295,9 +295,13 @@ public class FcFontConfiguration extends FontConfiguration {
         return null;
     }
 
-    private String extractOsInfo(String s) {
+    private String extractInfo(String s) {
+        if (s == null) {
+            return null;
+        }
         if (s.startsWith("\"")) s = s.substring(1);
         if (s.endsWith("\"")) s = s.substring(0, s.length()-1);
+        s = s.replace(' ', '_');
         return s;
     }
 
@@ -323,8 +327,8 @@ public class FcFontConfiguration extends FontConfiguration {
                     try (FileInputStream fis = new FileInputStream(f)) {
                         props.load(fis);
                     }
-                    osName = props.getProperty("DISTRIB_ID");
-                    osVersion =  props.getProperty("DISTRIB_RELEASE");
+                    osName = extractInfo(props.getProperty("DISTRIB_ID"));
+                    osVersion = extractInfo(props.getProperty("DISTRIB_RELEASE"));
             } else if ((f = new File("/etc/redhat-release")).canRead()) {
                 osName = "RedHat";
                 osVersion = getVersionString(f);
@@ -342,13 +346,13 @@ public class FcFontConfiguration extends FontConfiguration {
                 try (FileInputStream fis = new FileInputStream(f)) {
                     props.load(fis);
                 }
-                osName = props.getProperty("NAME");
-                osVersion = props.getProperty("VERSION_ID");
-                osName = extractOsInfo(osName);
-                if (osName.equals("SLES") || osName.contains("SUSE")) {
+                osName = extractInfo(props.getProperty("NAME"));
+                osVersion = extractInfo(props.getProperty("VERSION_ID"));
+                if (osName.equals("SLES")) {
                     osName = "SuSE";
+                } else {
+                    osName = extractInfo(props.getProperty("ID"));
                 }
-                osVersion = extractOsInfo(osVersion);
             }
         } catch (Exception e) {
             if (FontUtilities.debugFonts()) {

--- a/src/java.desktop/unix/classes/sun/font/FcFontConfiguration.java
+++ b/src/java.desktop/unix/classes/sun/font/FcFontConfiguration.java
@@ -345,7 +345,9 @@ public class FcFontConfiguration extends FontConfiguration {
                 osName = props.getProperty("NAME");
                 osVersion = props.getProperty("VERSION_ID");
                 osName = extractOsInfo(osName);
-                if (osName.equals("SLES")) osName = "SuSE";
+                if (osName.equals("SLES") || osName.contains("SUSE")) {
+                    osName = "SuSE";
+                }
                 osVersion = extractOsInfo(osVersion);
             }
         } catch (Exception e) {

--- a/src/java.desktop/unix/classes/sun/font/MFontConfiguration.java
+++ b/src/java.desktop/unix/classes/sun/font/MFontConfiguration.java
@@ -86,7 +86,6 @@ public class MFontConfiguration extends FontConfiguration {
      */
     protected void setOsNameAndVersion(){
         super.setOsNameAndVersion();
-
         if (osName.equals("Linux")) {
             try {
                 File f;
@@ -121,7 +120,9 @@ public class MFontConfiguration extends FontConfiguration {
                     osName = props.getProperty("NAME");
                     osVersion = props.getProperty("VERSION_ID");
                     osName = extractOsInfo(osName);
-                    if (osName.equals("SLES")) osName = "SuSE";
+                    if (osName.equals("SLES") || osName.contains("SUSE")) {
+                        osName = "SuSE";
+                    }
                     osVersion = extractOsInfo(osVersion);
                 }
             } catch (Exception e) {

--- a/src/java.desktop/unix/classes/sun/font/MFontConfiguration.java
+++ b/src/java.desktop/unix/classes/sun/font/MFontConfiguration.java
@@ -111,20 +111,20 @@ public class MFontConfiguration extends FontConfiguration {
                     try (FileInputStream fis = new FileInputStream(f)) {
                         props.load(fis);
                     }
-                    osName = props.getProperty("DISTRIB_ID");
-                    osVersion =  props.getProperty("DISTRIB_RELEASE");
+                    osName = extractInfo(props.getProperty("DISTRIB_ID"));
+                    osVersion = extractInfo(props.getProperty("DISTRIB_RELEASE"));
                 } else if ((f = new File("/etc/os-release")).canRead()) {
                     Properties props = new Properties();
                     try (FileInputStream fis = new FileInputStream(f)) {
                         props.load(fis);
                     }
-                    osName = props.getProperty("NAME");
-                    osVersion = props.getProperty("VERSION_ID");
-                    osName = extractOsInfo(osName);
-                    if (osName.equals("SLES") || osName.contains("SUSE")) {
+                    osName = extractInfo(props.getProperty("NAME"));
+                    osVersion = extractInfo(props.getProperty("VERSION_ID"));
+                    if (osName.equals("SLES")) {
                         osName = "SuSE";
+                    } else {
+                        osName = extractInfo(props.getProperty("ID"));
                     }
-                    osVersion = extractOsInfo(osVersion);
                 }
             } catch (Exception e) {
             }
@@ -145,9 +145,13 @@ public class MFontConfiguration extends FontConfiguration {
         return null;
     }
 
-    private String extractOsInfo(String s) {
+    private String extractInfo(String s) {
+        if (s == null) {
+            return null;
+        }
         if (s.startsWith("\"")) s = s.substring(1);
         if (s.endsWith("\"")) s = s.substring(0, s.length()-1);
+        s = s.replace(' ', '_');
         return s;
     }
 

--- a/src/java.desktop/unix/classes/sun/font/MFontConfiguration.java
+++ b/src/java.desktop/unix/classes/sun/font/MFontConfiguration.java
@@ -86,6 +86,7 @@ public class MFontConfiguration extends FontConfiguration {
      */
     protected void setOsNameAndVersion(){
         super.setOsNameAndVersion();
+
         if (osName.equals("Linux")) {
             try {
                 File f;


### PR DESCRIPTION
[JDK-8278549](https://bugs.openjdk.org/browse/JDK-8278549)` UNIX sun/font coding misses SUSE distro detection on recent distro SUSE 15` adds SuSE detection by checking SLES os name property in `/etc/os-release` file.

`opensuse/leap:15.4` docker defines os name property as `"openSUSE Leap"` in `/etc/os-release` file which is not recognized as SuSE.

The issue is reproduced with Oracle jdk-19.0.2 with custom fontconfig.SuSE.properties file copied to jdk-19.0.2/lib directory.

The fix checks if os name property from  `/etc/os-release` contains `SUSE`  substring.

Steps to reproduce.
- Download Oracle jdk-19.0.2
- Copy custom [fontconfig.SuSE.properties](https://bugs.openjdk.org/secure/attachment/102435/fontconfig.SuSE.properties) file to jdk-19.0.2/lib directory.
- Run the `opensuse/leap:15.4` docker and install freetype and dejavu fonts (do not install fontconfig)
```
docker run --rm --security-opt seccomp=unconfined -it opensuse/leap:15.4 bash
zypper install -y dejavu-fonts
zypper install -y freetype2
```
- Run HelloImage java sample in the docker
```
import javax.imageio.ImageIO;
import java.awt.*;
import java.awt.image.BufferedImage;
import java.io.File;

public class HelloImage {

    public static void main(String[] args) throws Exception {

        BufferedImage buff = new BufferedImage(300, 200, BufferedImage.TYPE_INT_RGB);
        Graphics2D g = buff.createGraphics();
        g.setColor(Color.WHITE);
        g.fillRect(0, 0, buff.getWidth(), buff.getHeight());

        g.setColor(Color.BLUE);
        g.setFont(g.getFont().deriveFont(32f));
        g.drawString("Hello, Image!", 50, 50);
        g.dispose();

        File file = new File("hello-image.png");
        ImageIO.write(buff, "png", file);
    }
}
```

```
./jdk-19.0.2/bin/javac HelloImage.java
./jdk-19.0.2/bin/java HelloImage
Exception in thread "main" java.lang.NullPointerException: Cannot load from short array because "sun.awt.FontConfiguration.head" is null
	at java.desktop/sun.awt.FontConfiguration.getVersion(FontConfiguration.java:1261)
	at java.desktop/sun.awt.FontConfiguration.readFontConfigFile(FontConfiguration.java:221)
	at java.desktop/sun.awt.FontConfiguration.init(FontConfiguration.java:105)
	at java.desktop/sun.awt.X11FontManager.createFontConfiguration(X11FontManager.java:706)
	at java.desktop/sun.font.SunFontManager$2.run(SunFontManager.java:352)
	at java.desktop/sun.font.SunFontManager$2.run(SunFontManager.java:309)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
	at java.desktop/sun.font.SunFontManager.<init>(SunFontManager.java:309)
	at java.desktop/sun.awt.FcFontManager.<init>(FcFontManager.java:35)
	at java.desktop/sun.awt.X11FontManager.<init>(X11FontManager.java:56)
	at java.desktop/sun.font.PlatformFontInfo.createFontManager(PlatformFontInfo.java:37)
	at java.desktop/sun.font.FontManagerFactory.getInstance(FontManagerFactory.java:51)
	at java.desktop/java.awt.Font.getFont2D(Font.java:526)
	at java.desktop/java.awt.Font$FontAccessImpl.getFont2D(Font.java:265)
	at java.desktop/sun.font.FontUtilities.getFont2D(FontUtilities.java:151)
	at java.desktop/sun.java2d.SunGraphics2D.checkFontInfo(SunGraphics2D.java:671)
	at java.desktop/sun.java2d.SunGraphics2D.getFontInfo(SunGraphics2D.java:837)
	at java.desktop/sun.java2d.pipe.GlyphListPipe.drawString(GlyphListPipe.java:46)
	at java.desktop/sun.java2d.SunGraphics2D.drawString(SunGraphics2D.java:2931)
	at HelloImage.main(HelloImage.java:17)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301254](https://bugs.openjdk.org/browse/JDK-8301254): UNIX sun/font coding does not detect SuSE in openSUSE Leap distribution


### Reviewers
 * @SWinxy (no known openjdk.org user name / role) ⚠️ Review applies to [ba04df3f](https://git.openjdk.org/jdk/pull/12260/files/ba04df3f3d70a636465308fc573342151f997487)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12260/head:pull/12260` \
`$ git checkout pull/12260`

Update a local copy of the PR: \
`$ git checkout pull/12260` \
`$ git pull https://git.openjdk.org/jdk pull/12260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12260`

View PR using the GUI difftool: \
`$ git pr show -t 12260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12260.diff">https://git.openjdk.org/jdk/pull/12260.diff</a>

</details>
