### PR TITLE
8301200: Don't scale timeout stress with timeout factor

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/test/StressOptions.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/test/StressOptions.java
@@ -211,12 +211,12 @@ public class StressOptions {
     }
 
     /**
-     * Obtain execution time in seconds adjusted for TIMEOUT_FACTOR.
+     * Obtain execution time in seconds.
      *
      * @return time
      */
     public long getTime() {
-        return Utils.adjustTimeout(time);
+        return time;
     }
 
     /**


### PR DESCRIPTION
The StressOptions updated to don't adjust time by timeoutFactor. Set stress time separately if more stress time is needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301200](https://bugs.openjdk.org/browse/JDK-8301200): Don't scale timeout stress with timeout factor


### Reviewers
 * [Leo Korinth](https://openjdk.org/census#lkorinth) (@lkorinth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12261/head:pull/12261` \
`$ git checkout pull/12261`

Update a local copy of the PR: \
`$ git checkout pull/12261` \
`$ git pull https://git.openjdk.org/jdk pull/12261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12261`

View PR using the GUI difftool: \
`$ git pr show -t 12261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12261.diff">https://git.openjdk.org/jdk/pull/12261.diff</a>

</details>
