### PR TITLE
JDK-8301201: Allow \n@ inside inline tags using inlineContent

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -622,11 +622,6 @@ public class DocCommentParser {
                     }
                     nextChar();
                     break;
-
-                case '@':
-                    if (newline)
-                        break loop;
-                    // fallthrough
 
                 default:
                     if (textStart == -1)

--- a/test/langtools/tools/javac/doctree/DocCommentTester.java
+++ b/test/langtools/tools/javac/doctree/DocCommentTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -919,7 +919,7 @@ public class DocCommentTester {
         String normalize(String s) {
             String s2 = s.trim().replaceFirst("\\.\\s*\\n *@", ".\n@");
             StringBuilder sb = new StringBuilder();
-            Pattern p = Pattern.compile("\\{@(code|literal)( )?");
+            Pattern p = Pattern.compile("(?i)\\{@([a-z][a-z0-9.:-]*)( )?");
             Matcher m = p.matcher(s2);
             int start = 0;
             while (m.find(start)) {

--- a/test/langtools/tools/javac/doctree/IndexTest.java
+++ b/test/langtools/tools/javac/doctree/IndexTest.java
@@ -241,6 +241,7 @@ DocComment[DOC_COMMENT, pos:1
      * abc {@index
      * @return def} xyz
      */
+    @NormalizeTags(false) // see DocCommentTester.PrettyChecker
     void bad_nl_at_in_term() {}
 /*
 DocComment[DOC_COMMENT, pos:1

--- a/test/langtools/tools/javac/doctree/TagTest.java
+++ b/test/langtools/tools/javac/doctree/TagTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8078320 8273244 8284908
+ * @bug 7021614 8078320 8273244 8284908 8301201
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file
@@ -178,6 +178,43 @@ DocComment[DOC_COMMENT, pos:1
     Erroneous[ERRONEOUS, pos:1, prefPos:13
       code: compiler.err.dc.unterminated.inline.tag
       body: {@abc_def_ghi
+    ]
+  body: empty
+  block tags: empty
+]
+*/
+
+    /**
+     * {@code
+     * abc
+     * @def
+     * ghi
+     * }
+     */
+    void inline_text_at() { }
+/*
+DocComment[DOC_COMMENT, pos:1
+  firstSentence: 1
+    Literal[CODE, pos:1, |_abc|_@def|_ghi|_]
+  body: empty
+  block tags: empty
+]
+*/
+
+    /**
+     * {@tag abc
+     * @def
+     * ghi
+     * }
+     */
+    void inline_content_at() { }
+/*
+DocComment[DOC_COMMENT, pos:1
+  firstSentence: 1
+    UnknownInlineTag[UNKNOWN_INLINE_TAG, pos:1
+      tag:tag
+      content: 1
+        Text[TEXT, pos:7, abc|_@def|_ghi|_]
     ]
   body: empty
   block tags: empty


### PR DESCRIPTION
Please review a simple change to allow the use of _newline_ _whitespace_ `@` inside inline tags that allow rich content (that is, those parsed with `inlineContent`) as compared to those that only allow plain text (that is, those parsed with `inlineText`).

The fix is to delete the code which recognizes `@` as the beginning of a block tag. Compare to the similar fix in [JDK-8241780](https://bugs.openjdk.org/browse/JDK-8241780)

The general `TagTest.java` is updated for the new feature.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301201](https://bugs.openjdk.org/browse/JDK-8301201): Allow \n@ inside inline tags using inlineContent


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12264/head:pull/12264` \
`$ git checkout pull/12264`

Update a local copy of the PR: \
`$ git checkout pull/12264` \
`$ git pull https://git.openjdk.org/jdk pull/12264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12264`

View PR using the GUI difftool: \
`$ git pr show -t 12264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12264.diff">https://git.openjdk.org/jdk/pull/12264.diff</a>

</details>
