### PR TITLE
8301274: update for deprecated sprintf for security components

### DIFF
--- a/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
+++ b/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
@@ -1223,17 +1223,17 @@ JNIEXPORT jboolean JNICALL Java_sun_security_mscapi_CSignature_verifyCngSignedHa
 
 #define DUMP_PROP(p) \
     if (::NCryptGetProperty(hKey, p, (PBYTE)buffer, 8192, &len, NCRYPT_SILENT_FLAG) == ERROR_SUCCESS) { \
-        sprintf(header, "%s %ls", #p, p); \
+        snprintf(header, sizeof(header), "%s %ls", #p, p); \
         dump(header, buffer, len); \
     }
 
 #define EXPORT_BLOB(p) \
     desc.cBuffers = 0; \
     if (::NCryptExportKey(hKey, NULL, p, &desc, (PBYTE)buffer, 8192, &len, NCRYPT_SILENT_FLAG) == ERROR_SUCCESS) { \
-        sprintf(header, "%s %ls (%ld)", #p, p, desc.cBuffers); \
+        snprintf(header, sizeof(header), "%s %ls (%ld)", #p, p, desc.cBuffers); \
         dump(header, buffer, len); \
         for (int i = 0; i < (int)desc.cBuffers; i++) { \
-            sprintf(header, "desc %ld", desc.pBuffers[i].BufferType); \
+            snprintf(header, sizeof(header), "desc %ld", desc.pBuffers[i].BufferType); \
             dump(header, (PBYTE)desc.pBuffers[i].pvBuffer, desc.pBuffers[i].cbBuffer); \
         } \
     }
@@ -1310,7 +1310,7 @@ void showProperty(NCRYPT_HANDLE hKey) {
     bbd.pBuffers = &bb;
     if(::NCryptExportKey(hKey, NULL, NCRYPT_PKCS8_PRIVATE_KEY_BLOB, NULL,
             (PBYTE)buffer, 8192, &len, NCRYPT_SILENT_FLAG) == ERROR_SUCCESS) {
-        sprintf(header, "NCRYPT_PKCS8_PRIVATE_KEY_BLOB %ls", NCRYPT_PKCS8_PRIVATE_KEY_BLOB);
+        snprintf(header, sizeof(header), "NCRYPT_PKCS8_PRIVATE_KEY_BLOB %ls", NCRYPT_PKCS8_PRIVATE_KEY_BLOB);
         dump(header, buffer, len);
     }
     EXPORT_BLOB(NCRYPT_PROTECTED_KEY_BLOB);
@@ -1445,7 +1445,7 @@ JNIEXPORT jstring JNICALL Java_sun_security_mscapi_CKey_getKeyType
 
         } else {
             char buffer[64];
-            if (sprintf(buffer, "%lu", dwAlgId)) {
+            if (snprintf(buffer, sizeof(buffer), "%lu", dwAlgId)) {
                 return env->NewStringUTF(buffer);
             }
         }


### PR DESCRIPTION
The sprintf is deprecated in Xcode 14 because of security concerns. The issue was addressed in [JDK-8296812](https://bugs.openjdk.org/browse/JDK-8296812) for building failure, and [JDK-8299378](https://bugs.openjdk.org/browse/JDK-8299378)/[JDK-8299635](https://bugs.openjdk.org/browse/JDK-8299635)/[JDK-8301132](https://bugs.openjdk.org/browse/JDK-8301132) for testing issues . This is a break-down update for sprintf uses in security components.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301274](https://bugs.openjdk.org/browse/JDK-8301274): update for deprecated sprintf for security components


### Reviewers
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12265/head:pull/12265` \
`$ git checkout pull/12265`

Update a local copy of the PR: \
`$ git checkout pull/12265` \
`$ git pull https://git.openjdk.org/jdk pull/12265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12265`

View PR using the GUI difftool: \
`$ git pr show -t 12265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12265.diff">https://git.openjdk.org/jdk/pull/12265.diff</a>

</details>
