### PR TITLE
8301279: update for deprecated sprintf for management components

### DIFF
--- a/src/java.management/share/native/libmanagement/VMManagementImpl.c
+++ b/src/java.management/share/native/libmanagement/VMManagementImpl.c
@@ -44,7 +44,7 @@ Java_sun_management_VMManagementImpl_getVersion0
     // for internal use
     unsigned int micro = (unsigned int) jmm_version & 0xFF;
 
-    sprintf(buf, "%d.%d", major, minor);
+    snprintf(buf, sizeof(buf), "%d.%d", major, minor);
     version_string = (*env)->NewStringUTF(env, buf);
     return version_string;
 }

--- a/src/java.management/share/native/libmanagement/management.c
+++ b/src/java.management/share/native/libmanagement/management.c
@@ -57,6 +57,6 @@ JNIEXPORT jint JNICALL
 void throw_internal_error(JNIEnv* env, const char* msg) {
     char errmsg[128];
 
-    sprintf(errmsg, "errno: %d error: %s\n", errno, msg);
+    snprintf(errmsg, sizeof(errmsg), "errno: %d error: %s\n", errno, msg);
     JNU_ThrowInternalError(env, errmsg);
 }

--- a/src/jdk.management/share/native/libmanagement_ext/management_ext.c
+++ b/src/jdk.management/share/native/libmanagement_ext/management_ext.c
@@ -57,6 +57,6 @@ JNIEXPORT jint JNICALL
 void throw_internal_error(JNIEnv* env, const char* msg) {
     char errmsg[128];
 
-    sprintf(errmsg, "errno: %d error: %s\n", errno, msg);
+    snprintf(errmsg, sizeof(errmsg), "errno: %d error: %s\n", errno, msg);
     JNU_ThrowInternalError(env, errmsg);
 }


### PR DESCRIPTION
The sprintf is deprecated in Xcode 14 because of security concerns. The issue was addressed in [JDK-8296812](https://bugs.openjdk.org/browse/JDK-8296812) for building failure, and [JDK-8299378](https://bugs.openjdk.org/browse/JDK-8299378)/[JDK-8299635](https://bugs.openjdk.org/browse/JDK-8299635)/[JDK-8301132](https://bugs.openjdk.org/browse/JDK-8301132) for testing issues . This is a break-down update for sprintf uses in management components.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301279](https://bugs.openjdk.org/browse/JDK-8301279): update for deprecated sprintf for management components


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12266/head:pull/12266` \
`$ git checkout pull/12266`

Update a local copy of the PR: \
`$ git checkout pull/12266` \
`$ git pull https://git.openjdk.org/jdk pull/12266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12266`

View PR using the GUI difftool: \
`$ git pr show -t 12266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12266.diff">https://git.openjdk.org/jdk/pull/12266.diff</a>

</details>
