### PR TITLE
8301267: Update of config.guess broke build on WSL

### DIFF
--- a/make/autoconf/build-aux/config.guess
+++ b/make/autoconf/build-aux/config.guess
@@ -68,11 +68,11 @@ if test $? = 0; then
 fi
 
 # Test and fix wsl
-echo $OUT | grep unknown-linux-gnu > /dev/null 2> /dev/null
+echo $OUT | grep '\(unknown\|pc\)-linux-gnu' > /dev/null 2> /dev/null
 if test $? = 0; then
   uname -r | grep -i microsoft > /dev/null 2> /dev/null
   if test $? = 0; then
-    OUT=`echo $OUT | sed -e 's/unknown-linux-gnu/pc-wsl/'`
+    OUT=`echo $OUT | sed -e 's/\(unknown\|pc\)-linux-gnu/pc-wsl/'`
   fi
 fi
 


### PR DESCRIPTION
After JDK-8300805, config.guess has changed output when running on WSL. This is caused by the autoconf-config.guess now reporting it as `x86_64-pc-linux-gnu` instead of `x86_64-unknown-linux-gnu`, and our wrapper script is expecting the latter.

This patch makes the wrapper script work with either variant.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301267](https://bugs.openjdk.org/browse/JDK-8301267): Update of config.guess broke build on WSL


### Reviewers
 * [Tim Bell](https://openjdk.org/census#tbell) (@tbell29552 - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12268/head:pull/12268` \
`$ git checkout pull/12268`

Update a local copy of the PR: \
`$ git checkout pull/12268` \
`$ git pull https://git.openjdk.org/jdk pull/12268/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12268`

View PR using the GUI difftool: \
`$ git pr show -t 12268`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12268.diff">https://git.openjdk.org/jdk/pull/12268.diff</a>

</details>
