### PR TITLE
8295951: intermittent cmp_baseline task failures with CDS files

### DIFF
--- a/make/jdk/src/classes/build/tools/classlist/HelloClasslist.java
+++ b/make/jdk/src/classes/build/tools/classlist/HelloClasslist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -147,6 +147,12 @@ public class HelloClasslist {
         invoke(handle("staticMethod_V", MethodType.methodType(void.class)));
 
         LOGGER.log(Level.FINE, "New Date: " + newDate + " - old: " + oldDate);
+
+        // The Striped64$Cell is loaded rarely only when there's a contention among
+        // multiple threads performing LongAdder.increment(). This results in
+        // an inconsistency in the classlist between builds (see JDK-8295951).
+        // To avoid the problem, load the class explicitly.
+        Class<?> striped64Class = Class.forName("java.util.concurrent.atomic.Striped64$Cell");
     }
 
     public HelloClasslist() {}


### PR DESCRIPTION
The cmp_baseline build target fails intermittently due to the `java/util/concurrent/atomic/Striped64$Cell` class is loaded sometimes when running the `HelloClasslist.java` app.
To avoid this problem, always load the `Striped64$Cell`class from the `HelloClasslist.java` app so that the generated classlist and CDS archive would be the same as the baseline build.

Ran the <platform>-cmp-baseline build target repeatedly on Oracle supported platforms.
