### PR TITLE
Update field access methods in ZipUtils to use the VarHandle API

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipUtils.java
+++ b/src/java.base/share/classes/java/util/zip/ZipUtils.java
@@ -166,11 +166,18 @@ class ZipUtils {
     }
 
     /**
+     * Fetches unsigned 8-bit value from byte array at specified offset.
+     */
+    public static final int get8(byte[] b, int off) {
+        return b[off] & 0xff;
+    }
+
+    /**
      * Fetches unsigned 16-bit value from byte array at specified offset.
      * The bytes are assumed to be in Intel (little-endian) byte order.
      */
     public static final int get16(byte[] b, int off) {
-        return (b[off] & 0xff) | ((b[off + 1] & 0xff) << 8);
+        return get8(b, off) | (get8(b, off + 1) << 8);
     }
 
     /**
@@ -178,7 +185,7 @@ class ZipUtils {
      * The bytes are assumed to be in Intel (little-endian) byte order.
      */
     public static final long get32(byte[] b, int off) {
-        return (get16(b, off) | ((long)get16(b, off+2) << 16)) & 0xffffffffL;
+        return get32S(b, off) & 0xffffffffL;
     }
 
     /**
@@ -200,19 +207,19 @@ class ZipUtils {
 
     // fields access methods
     static final int CH(byte[] b, int n) {
-        return b[n] & 0xff ;
+        return get8(b, n) ;
     }
 
     static final int SH(byte[] b, int n) {
-        return (b[n] & 0xff) | ((b[n + 1] & 0xff) << 8);
+        return get16(b, n);
     }
 
     static final long LG(byte[] b, int n) {
-        return ((SH(b, n)) | (SH(b, n + 2) << 16)) & 0xffffffffL;
+        return get32(b, n);
     }
 
     static final long LL(byte[] b, int n) {
-        return (LG(b, n)) | (LG(b, n + 4) << 32);
+        return get64(b, n);
     }
 
     static final long GETSIG(byte[] b) {

--- a/src/java.base/share/classes/java/util/zip/ZipUtils.java
+++ b/src/java.base/share/classes/java/util/zip/ZipUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This PR suggests to update the field access methods in ZipUtils to use the VarHandle API when reading multibyte values from byte arrays.

To facilitate this change,  we first remove duplication in existing methods such that:

- CH aliases to the new method get8
- SH aliases to get16
- LG aliases to get32
- LL aliases to get64
- get16 uses get8
- get32 uses get32S

(Note that CH, SH, LG, LL could now be removed in in favour of their targets. I consider this out of scope for this PR.)

To simplify review, the refactoring is done in  a separate commit 0e924a2 

Then, in commit 25ac0a6, the methods get16, get64 and get32S are updated to read values using the VarHandle API.

Performance:

I had problems getting stable results from the existing ZipFileOpen test, but when reading an existing xalan.jar (1565 entries), I'm seeing a ~3% speedup:

Baseline:

```
Benchmark                     Mode  Cnt       Score     Error  Units
ZipFileOpen.openCloseZipFile  avgt   25  136537.112 ± 340.233  ns/op
```

VarHandle:

```
Benchmark                     Mode  Cnt       Score     Error  Units
ZipFileOpen.openCloseZipFile  avgt   25  132600.030 ± 422.163  ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12273/head:pull/12273` \
`$ git checkout pull/12273`

Update a local copy of the PR: \
`$ git checkout pull/12273` \
`$ git pull https://git.openjdk.org/jdk pull/12273/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12273`

View PR using the GUI difftool: \
`$ git pr show -t 12273`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12273.diff">https://git.openjdk.org/jdk/pull/12273.diff</a>

</details>
