### PR TITLE
8301342: Prefer ArrayList to LinkedList in LayoutComparator

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/LayoutComparator.java
+++ b/src/java.desktop/share/classes/javax/swing/LayoutComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,8 @@
  */
 package javax.swing;
 
+import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.LinkedList;
 import java.util.ListIterator;
 import java.awt.Component;
 import java.awt.ComponentOrientation;
@@ -70,7 +70,7 @@ final class LayoutComparator implements Comparator<Component>, java.io.Serializa
         // each Component and then search from the Window down until the
         // hierarchy branches.
         if (a.getParent() != b.getParent()) {
-            LinkedList<Component> aAncestory = new LinkedList<Component>();
+            ArrayList<Component> aAncestory = new ArrayList<>();
 
             for(; a != null; a = a.getParent()) {
                 aAncestory.add(a);
@@ -83,7 +83,7 @@ final class LayoutComparator implements Comparator<Component>, java.io.Serializa
                 throw new ClassCastException();
             }
 
-            LinkedList<Component> bAncestory = new LinkedList<Component>();
+            ArrayList<Component> bAncestory = new ArrayList<>();
 
             for(; b != null; b = b.getParent()) {
                 bAncestory.add(b);


### PR DESCRIPTION
There is only add/iterator calls on this list. No removes from the head or something like this. Not sure why LinkedList was used, but ArrayList should be preferred as more efficient and widely used (more chances for JIT) collection

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301342](https://bugs.openjdk.org/browse/JDK-8301342): Prefer ArrayList to LinkedList in LayoutComparator


### Reviewers
 * @SWinxy (no known github.com user name / role)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12274/head:pull/12274` \
`$ git checkout pull/12274`

Update a local copy of the PR: \
`$ git checkout pull/12274` \
`$ git pull https://git.openjdk.org/jdk pull/12274/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12274`

View PR using the GUI difftool: \
`$ git pr show -t 12274`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12274.diff">https://git.openjdk.org/jdk/pull/12274.diff</a>

</details>
