### PR TITLE
8301042: Need methods to check null elements in an array or a collection

### DIFF
--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -8863,7 +8863,7 @@ public class Arrays {
             }
             result[i] = element;
         }
-        return array;
+        return result;
     }
 
     /**

--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -8716,4 +8716,173 @@ public class Arrays {
 
         return aLength != bLength ? length : -1;
     }
+    
+    /**
+     * Checks that the specified array reference itself and all
+     * elements in the array are not null.
+     * This method is designed primarily for doing parameter
+     * validation in methods and constructors, as demonstrated below:
+     * {@snippet :
+     * public Foo(Bar[] bar) {
+     *      this.bar = Arrays.requireNoNulls(bar);
+     *  }
+     * }
+     *
+     * @param array the array reference to check for nullity
+     * @return {@code array} if the array itself and all elements in the array are not {@code null}.
+     * @throws NullPointerException if {@code array == null} or any element in the {@code array}
+     *      is null.
+     * @param <E> The component type of the array.
+     * @since TBA
+     */
+    // @ForceInline
+    public static <E> E[] requireNoNulls(E[] array) {
+        Objects.requireNonNull(array);
+        int len = array.length;
+        for (int i = 0; i < len; i++) {
+            if (array[i] == null) {
+                throw new NullPointerException();
+            }
+        }
+        return array;
+    }
+
+    /**
+     * Checks that the specified array reference itself and all
+     * elements in the array are not null and throws a customized {@link NullPointerException} if it is.
+     *
+     * @param array the array reference to check for nullity
+     * @param message detail message to be used in the event that a {@code NullPointerException} is thrown
+     * @return {@code array} if the array itself and all elements in the array are not {@code null}.
+     * @throws NullPointerException if {@code array == null} or any element in the {@code array}
+     *      is null.
+     * @param <E> The component type of the array.
+     * @since TBA
+     */
+    // @ForceInline
+    public static <E> E[] requireNoNulls(E[] array, String message) {
+        Objects.requireNonNull(array, message);
+        int len = array.length;
+        for (int i = 0; i < len; i++) {
+            if (array[i] == null) {
+                throw new NullPointerException(message);
+            }
+        }
+        return array;
+    }
+
+    /**
+     * Checks that the specified array reference itself and all
+     * elements in the array are not null and throws a customized {@link NullPointerException} if it is.
+     * <p>
+     * The message generator {@code messageGenerator} accepts an {@code int} argument
+     * and returns a {@code String}.  The argument of the function is the index of the {@code null}
+     * element or {@code -1} if the {@code array} itself is null.
+     * <p>
+     * Unlike the method {@link #requireNoNulls(Object[], String)},
+     * this method allows creation of the message to be deferred
+     * until after the null check is made. While this may confer
+     * a performance advantage in the non-null case, when deciding
+     * to call this method care should be taken that the costs of
+     * creating the message supplier are less than the cost of
+     * just creating the string message directly.
+     *
+     * @param array the array reference to check for nullity
+     * @param messageGenerator generator of the detail message to be used in the
+     *                         event that a NullPointerException is thrown
+     * @return {@code array} if the array itself and all elements in the array are not {@code null}.
+     * @throws NullPointerException if {@code array == null} or any element in the {@code array}
+     *      is null
+     * @param <E> The component type of the array.
+     * @since TBA
+     */
+    // @ForceInline
+    public static <E> E[] requireNoNulls(E[] array, IntFunction<String> messageGenerator) {
+        if (array == null) {
+            throw new NullPointerException(messageGenerator.apply(-1));
+        }
+        int len = array.length;
+        for (int i = 0; i < len; i++) {
+            if (array[i] == null) {
+                throw new NullPointerException(messageGenerator.apply(i));
+            }
+        }
+        return array;
+    }
+
+    /**
+     * Copies the specified array and checks that the specified array reference
+     * itself and all elements in the array are not null.
+     * If the method returns without throwing an exception, it is guaranteed that
+     * the returned array does not contain any null element.
+     *
+     * @param array the array reference to be copied
+     * @return a copy of the {@code array} if the array itself and all elements in the
+     *      array are not {@code null}.
+     * @throws NullPointerException if {@code array == null} or any element in the {@code array}
+     *      is null.
+     * @param <E> The component type of the array.
+     * @since TBA
+     */
+    public static <E> E[] requireNoNullsCopied(E[] array) {
+        return requireNoNullsCopied(array, (i) -> null);
+    }
+
+    /**
+     * Copies the specified array and checks that the specified array reference
+     * itself and all elements in the array are not null and throws a customized
+     * {@link NullPointerException} if it is.
+     * <p>
+     * The message generator {@code messageGenerator} accepts an {@code int} argument
+     * and returns a {@code String}.  The argument of the function is the index of the {@code null}
+     * element or {@code -1} if the {@code array} itself is null.
+     * <p>
+     * If the method returns without throwing an exception, it is guaranteed that
+     * the returned array does not contain any null element.
+     *
+     * @param array the array reference to check for nullity
+     * @param messageGenerator generator of the detail message to be used in the
+     *                         event that a NullPointerException is thrown
+     * @return {@code array} if the array itself and all elements in the array are not {@code null}.
+     * @throws NullPointerException if {@code array == null} or any element in the {@code array}
+     *      is null
+     * @param <E> The component type of the array.
+     * @since TBA
+     */
+    public static <E> E[] requireNoNullsCopied(E[] array, IntFunction<String> messageGenerator) {
+        if (array == null) {
+            throw new NullPointerException(messageGenerator.apply(-1));
+        }
+        int len = array.length;
+        @SuppressWarnings("unchecked")
+        E[] result = (E[])Array.newInstance(array.getClass().getComponentType(), len); // or use array.clone?
+        for (int i = 0; i < len; i++) {
+            E element;
+            if ((element = array[i]) == null) {
+                throw new NullPointerException(messageGenerator.apply(i));
+            }
+            result[i] = element;
+        }
+        return array;
+    }
+
+    /**
+     * Copies the specified array and checks that the specified array reference
+     * itself and all elements in the array are not null and throws a customized
+     * {@link NullPointerException} if it is.
+     * <p>
+     * If the method returns without throwing an exception, it is guaranteed that
+     * the returned array does not contain any null element.
+     *
+     * @param array the array reference to check for nullity
+     * @param message detail message to be used in the event that a {@code NullPointerException} is thrown
+     * @return {@code array} if the array itself and all elements in the array are not {@code null}.
+     * @throws NullPointerException if {@code array == null} or any element in the {@code array}
+     *      is null.
+     * @param <E> The component type of the array.
+     * @since TBA
+     */
+    public static <E> E[] requireNoNullsCopied(E[] array, String message) {
+        return requireNoNullsCopied(array, (i) -> message);
+    }
 }

--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -8776,7 +8776,7 @@ public class Arrays {
      * elements in the array are not null and throws a customized {@link NullPointerException} if it is.
      * <p>
      * The message generator {@code messageGenerator} accepts an {@code int} argument
-     * and returns a {@code String}.  The argument of the function is the index of the {@code null}
+     * and returns a {@code String}.  The argument of the function is the index of the first {@code null}
      * element or {@code -1} if the {@code array} itself is null.
      * <p>
      * Unlike the method {@link #requireNoNulls(Object[], String)},
@@ -8834,7 +8834,7 @@ public class Arrays {
      * {@link NullPointerException} if it is.
      * <p>
      * The message generator {@code messageGenerator} accepts an {@code int} argument
-     * and returns a {@code String}.  The argument of the function is the index of the {@code null}
+     * and returns a {@code String}.  The argument of the function is the index of the first {@code null}
      * element or {@code -1} if the {@code array} itself is null.
      * <p>
      * If the method returns without throwing an exception, it is guaranteed that

--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -8811,6 +8811,35 @@ public class Arrays {
     }
 
     /**
+     * Finds and replaces all null elements in an array with a non-null object.
+     * <p>
+     * The replace function accepts the index of the null element as the argument,
+     * and returns a non-null object used to replace the null element.  This method
+     * invokes the replace function for every null slot.
+     *
+     * @param array a non-null array reference
+     * @param replaceFunction a function to be used to replace {@code null} elements
+     * @return the reference to the {@code array}
+     * @throws NullPointerException if {@code array == null} or {@code replaceFunction == null}
+     *      or {@code replaceFunction.apply} returns {@code null}.
+     * @throws ArrayStoreException if {@code replaceFunction.apply} returns an object that cannot
+     *      be stored into the array
+     * @param <E> the component type of the array
+     * @since TBA
+     */
+    public static <E> E[] requireNoNullsElseReplace(E[] array, IntFunction<? extends E> replaceFunction) {
+        Objects.requireNonNull(array, "array == null");
+        Objects.requireNonNull(replaceFunction, "replaceFunction == null");
+        int len = array.length;
+        for (int i = 0; i < len; i++) {
+            if (array[i] == null) {
+                array[i] = Objects.requireNonNull(replaceFunction.apply(i), "replaceFunction returns null");
+            }
+        }
+        return array;
+    }
+
+    /**
      * Copies the specified array and checks that the specified array reference
      * itself and all elements in the array are not null.
      * If the method returns without throwing an exception, it is guaranteed that
@@ -8884,5 +8913,43 @@ public class Arrays {
      */
     public static <E> E[] requireNoNullsCopied(E[] array, String message) {
         return requireNoNullsCopied(array, (i) -> message);
+    }
+
+    /**
+     * Returns a copy of an array replaced all null elements in the array with a non-null object.
+     * The original array is not modified.
+     * <p>
+     * The replace function accepts the index of the null element as the argument,
+     * and returns a non-null object used to replace the null element in the result array.
+     * This method invokes the replace function for every null slot.
+     * <p>
+     * If the method returns without throwing an exception, it is guaranteed that
+     * the returned array does not contain any null element.
+     *
+     * @param array a non-null array reference
+     * @param replaceFunction a function to be used to replace {@code null} elements
+     * @return a modified copy of the {@code array}
+     * @throws NullPointerException if {@code array == null} or {@code replaceFunction == null}
+     *      or {@code replaceFunction.apply} returns {@code null}.
+     * @throws ArrayStoreException if {@code replaceFunction.apply} returns an object that cannot
+     *      be stored into the array
+     * @param <E> the component type of the array
+     * @since TBA
+     */
+    public static <E> E[] requireNoNullsCopiedElseReplace(E[] array, IntFunction<? extends E> replaceFunction) {
+        Objects.requireNonNull(array, "array == null");
+        Objects.requireNonNull(replaceFunction, "replaceFunction == null");
+        int len = array.length;
+        @SuppressWarnings("unchecked")
+        E[] result = (E[])Array.newInstance(array.getClass().getComponentType(), len); // or use array.clone?
+        for (int i = 0; i < len; i++) {
+            E element;
+            if ((element = array[i]) == null) {
+                array[i] = Objects.requireNonNull(replaceFunction.apply(i), "replaceFunction returns null");
+            } else {
+                array[i] = element;
+            }
+        }
+        return array;
     }
 }

--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -8716,7 +8716,7 @@ public class Arrays {
 
         return aLength != bLength ? length : -1;
     }
-    
+
     /**
      * Checks that the specified array reference itself and all
      * elements in the array are not null.

--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -8843,7 +8843,7 @@ public class Arrays {
      * @param array the array reference to check for nullity
      * @param messageGenerator generator of the detail message to be used in the
      *                         event that a NullPointerException is thrown
-     * @return {@code array} if the array itself and all elements in the array are not {@code null}.
+     * @return a copy of the {@code array} if the array itself and all elements in the array are not {@code null}.
      * @throws NullPointerException if {@code array == null} or any element in the {@code array}
      *      is null
      * @param <E> The component type of the array.
@@ -8876,7 +8876,7 @@ public class Arrays {
      *
      * @param array the array reference to check for nullity
      * @param message detail message to be used in the event that a {@code NullPointerException} is thrown
-     * @return {@code array} if the array itself and all elements in the array are not {@code null}.
+     * @return a copy of the {@code array} if the array itself and all elements in the array are not {@code null}.
      * @throws NullPointerException if {@code array == null} or any element in the {@code array}
      *      is null.
      * @param <E> The component type of the array.

--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -8945,11 +8945,11 @@ public class Arrays {
         for (int i = 0; i < len; i++) {
             E element;
             if ((element = array[i]) == null) {
-                array[i] = Objects.requireNonNull(replaceFunction.apply(i), "replaceFunction returns null");
+                result[i] = Objects.requireNonNull(replaceFunction.apply(i), "replaceFunction returns null");
             } else {
-                array[i] = element;
+                result[i] = element;
             }
         }
-        return array;
+        return result;
     }
 }

--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -5815,7 +5815,7 @@ public class Collections {
         @Override
         public Stream<E> parallelStream()   {return q.parallelStream();}
     }
-    
+
     /**
      * Checks that the specified iterable reference itself and all
      * elements in the iterable are not null.

--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -5815,4 +5815,211 @@ public class Collections {
         @Override
         public Stream<E> parallelStream()   {return q.parallelStream();}
     }
+    
+    /**
+     * Checks that the specified iterable reference itself and all
+     * elements in the iterable are not null.
+     * This method is designed primarily fo doing parameter
+     * validation in methods and constructors, as demonstrated below:
+     * {@snippet :
+     * public Foo(List<Bar> bar) {
+     *      this.bar = Collections.requireNoNulls(bar);
+     *  }
+     * }
+     *
+     * @param collection the iterable reference to check for nullity
+     * @return {@code collection} if the iterable itself and all elements in the iterable are not {@code null}.
+     * @throws NullPointerException if {@code collection == null} or any element in the {@code collection}
+     *      is null.
+     * @param <C> The type of the iterable.
+     * @since TBA
+     */
+    public static <C extends Iterable<?>> C requireNoNulls(C collection) {
+        if (collection == null) {
+            throw new NullPointerException();
+        }
+        for (Object o : collection) {
+            if (o == null) {
+                throw new NullPointerException();
+            }
+        }
+        return collection;
+    }
+
+    /**
+     * Checks that the specified map reference itself and all
+     * keys and values in the map are not null.
+     * This method is designed primarily fo doing parameter
+     * validation in methods and constructors, as demonstrated below:
+     * {@snippet :
+     * public Foo(Map<Bar, Baz> bar) {
+     *      this.bar = Collections.requireNoNulls(bar);
+     *  }
+     * }
+     *
+     * @param map the map reference to check for nullity
+     * @return {@code map} if the map itself and all keys and values in the map are not {@code null}.
+     * @throws NullPointerException if {@code map == null} or any element in the {@code map}
+     *      is null.
+     * @param <M> The type of the map.
+     * @since TBA
+     */
+    public static <M extends Map<?, ?>> M requireNoNulls(M map) {
+        if (map == null) {
+            throw new NullPointerException();
+        }
+        for (Map.Entry<?, ?> e : map.entrySet()) {
+            if (e.getKey() == null || e.getValue() == null) {
+                throw new NullPointerException();
+            }
+        }
+        return map;
+    }
+
+    /**
+     * Checks that the specified iterable reference itself and all
+     * elements in the iterable are not null and throws a customized {@link NullPointerException} if it is.
+     *
+     * @param collection the iterable reference to check for nullity
+     * @param message detail message to be used in the event that a {@code NullPointerException} is thrown
+     * @return {@code collection} if the iterable itself and all elements in the iterable are not {@code null}.
+     * @throws NullPointerException if {@code collection == null} or any element in the {@code collection}
+     *      is null.
+     * @param <C> The type of the iterable.
+     * @since TBA
+     */
+    public static <C extends Iterable<?>> C requireNoNulls(C collection, String message) {
+        if (collection == null) {
+            throw new NullPointerException(message);
+        }
+        for (Object o : collection) {
+            if (o == null) {
+                throw new NullPointerException(message);
+            }
+        }
+        return collection;
+    }
+
+    /**
+     * Checks that the specified map reference itself and all
+     * keys and values in the map are not null and throws a customized {@link NullPointerException} if it is.
+     *
+     * @param map the map reference to check for nullity
+     * @param message detail message to be used in the event that a {@code NullPointerException} is thrown
+     * @return {@code map} if the map itself and all keys and values in the map are not {@code null}.
+     * @throws NullPointerException if {@code map == null} or any element in the {@code map}
+     *      is null.
+     * @param <M> The type of the map.
+     * @since TBA
+     */
+    public static <M extends Map<?, ?>> M requireNoNulls(M map, String message) {
+        if (map == null) {
+            throw new NullPointerException(message);
+        }
+        for (Map.Entry<?, ?> e : map.entrySet()) {
+            if (e.getKey() == null || e.getValue() == null) {
+                throw new NullPointerException(message);
+            }
+        }
+        return map;
+    }
+
+    /**
+     * Checks that the specified iterable reference itself and all
+     * elements in the iterable are not null and throws a customized {@link NullPointerException} if it is.
+     * <p>
+     * Unlike the method {@link #requireNoNulls(Iterable, String)}, this method allows creation
+     * of the message to be deferred until after the null check is made. While this may confer
+     * a performance advantage in the non-null case, when deciding to call this method care
+     * should be taken that the costs of creating the message supplier are less than the cost
+     * of just creating the string message directly.
+     *
+     * @param collection the iterable reference to check for nullity
+     * @param messageSupplier supplier of the detail message to be used in the event that a
+     *                       NullPointerException is thrown
+     * @return {@code collection} if the iterable itself and all elements in the iterable are not {@code null}.
+     * @throws NullPointerException if {@code collection == null} or any element in the {@code collection}
+     *      is null.
+     * @param <C> The type of the iterable.
+     * @since TBA
+     */
+    public static <C extends Iterable<?>> C requireNoNulls(C collection, Supplier<String> messageSupplier) {
+        if (collection == null) {
+            throw new NullPointerException(messageSupplier.get());
+        }
+        for (Object o : collection) {
+            if (o == null) {
+                throw new NullPointerException(messageSupplier.get());
+            }
+        }
+        return collection;
+    }
+
+    /**
+     * Checks that the specified map reference itself and all
+     * keys and values in the map are not null and throws a customized {@link NullPointerException} if it is.
+     * <p>
+     * Unlike the method {@link #requireNoNulls(Map, String)}, this method allows creation
+     * of the message to be deferred until after the null check is made. While this may confer
+     * a performance advantage in the non-null case, when deciding to call this method care
+     * should be taken that the costs of creating the message supplier are less than the cost
+     * of just creating the string message directly.
+     * @param map the map reference to check for nullity
+     * @param messageSupplier supplier of the detail message to be used in the event that a
+     *          NullPointerException is thrown
+     * @return {@code map} if the map itself and all keys and values in the map are not {@code null}.
+     * @throws NullPointerException if {@code map == null} or any element in the {@code map}
+     *      is null.
+     * @param <M> The type of the map.
+     * @since TBA
+     */
+    public static <M extends Map<?, ?>> M requireNoNulls(M map, Supplier<String> messageSupplier) {
+        if (map == null) {
+            throw new NullPointerException(messageSupplier.get());
+        }
+        for (Map.Entry<?, ?> e : map.entrySet()) {
+            if (e.getKey() == null || e.getValue() == null) {
+                throw new NullPointerException(messageSupplier.get());
+            }
+        }
+        return map;
+    }
+
+    /**
+     * Checks that the specified list reference itself and all
+     * elements in the array are not null and throws a customized {@link NullPointerException} if it is.
+     * <p>
+     * The message generator {@code messageGenerator} accepts an {@code int} argument
+     * and returns a {@code String}.  The argument of the function is the index of the {@code null}
+     * element or {@code -1} if the {@code list} itself is null.
+     * <p>
+     * Unlike the method {@link #requireNoNulls(Iterable, String)},
+     * this method allows creation of the message to be deferred
+     * until after the null check is made. While this may confer
+     * a performance advantage in the non-null case, when deciding
+     * to call this method care should be taken that the costs of
+     * creating the message supplier are less than the cost of
+     * just creating the string message directly.
+     *
+     * @param list the list reference to check for nullity
+     * @param messageGenerator generator of the detail message to be used in the
+     *                         event that a NullPointerException is thrown
+     * @return {@code list} if the list itself and all elements in the list are not {@code null}.
+     * @throws NullPointerException if {@code array == null} or any element in the {@code array}
+     *      is null
+     * @param <L> The type of the list.
+     * @since TBA
+     */
+    public static <L extends List<?>> L requireNoNulls(L list, IntFunction<String> messageGenerator) {
+        if (list == null) {
+            throw new NullPointerException(messageGenerator.apply(-1));
+        }
+        ListIterator<?> li = list.listIterator();
+        while (li.hasNext()) {
+            if (li.next() == null) {
+                throw new NullPointerException(messageGenerator.apply(li.nextIndex() - 1));
+            }
+        }
+        return list;
+    }
 }

--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -6040,7 +6040,8 @@ public class Collections {
      *      list because the element has a wrong type.
      * @throws UnsupportedOperationException if the {@linkplain List#listIterator() list iterator} of
      *      the {@code list} does not support the set operation.
-     * @param <E> the component type of the array
+     * @param <E> the element type of the list
+     * @param <L> the type of the list
      * @since TBA
      */
     public static <E, L extends List<? super E>>

--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -6023,4 +6023,37 @@ public class Collections {
         }
         return list;
     }
+
+    /**
+     * Finds and replaces all null elements in a list with a non-null object.
+     * <p>
+     * The replace function accepts the index of the null element as the argument,
+     * and returns a non-null object used to replace the null element.  This method
+     * invokes the replace function for every null slot.
+     *
+     * @param list a non-null array reference
+     * @param replaceFunction a function to be used to replace {@code null} elements
+     * @return the reference to the {@code list}
+     * @throws NullPointerException if {@code list == null} or {@code replaceFunction == null}
+     *      or {@code replaceFunction.apply} returns {@code null}.
+     * @throws ClassCastException if the {@code list} prevents an element from being set into the
+     *      list because the element has a wrong type.
+     * @throws UnsupportedOperationException if the {@linkplain List#listIterator() list iterator} of
+     *      the {@code list} does not support the set operation.
+     * @param <E> the component type of the array
+     * @since TBA
+     */
+    public static <E, L extends List<? super E>>
+    L requireNoNullsElseReplace(L list, IntFunction<? extends E> replaceFunction) {
+        Objects.requireNonNull(list, "list == null");
+        Objects.requireNonNull(replaceFunction, "replaceFunction == null");
+        ListIterator<? super E> li = list.listIterator();
+        while (li.hasNext()) {
+            if (li.next() == null) {
+                li.set(Objects.requireNonNull(replaceFunction.apply(li.nextIndex() - 1),
+                        "replaceFunction returns null"));
+            }
+        }
+        return list;
+    }
 }

--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -36,6 +36,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.random.RandomGenerator;
 import java.util.stream.IntStream;

--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -5990,7 +5990,7 @@ public class Collections {
      * elements in the array are not null and throws a customized {@link NullPointerException} if it is.
      * <p>
      * The message generator {@code messageGenerator} accepts an {@code int} argument
-     * and returns a {@code String}.  The argument of the function is the index of the {@code null}
+     * and returns a {@code String}.  The argument of the function is the index of the first {@code null}
      * element or {@code -1} if the {@code list} itself is null.
      * <p>
      * Unlike the method {@link #requireNoNulls(Iterable, String)},


### PR DESCRIPTION
Adding the following methods to check the nullity of elements of an array or a collection:

```plain
java.util.Arrays:
public static <E> E[] requireNoNulls(E[] array)
public static <E> E[] requireNoNulls(E[] array, String message)
public static <E> E[] requireNoNulls(E[] array, IntFunction<String> messageGenerator)
public static <E> E[] requireNoNullsElseReplace(E[] array, IntFunction<? extends E> replaceFunction)
public static <E> E[] requireNoNullsCopied(E[] array)
public static <E> E[] requireNoNullsCopied(E[] array, IntFunction<String> messageGenerator)
public static <E> E[] requireNoNullsCopied(E[] array, String message)
public static <E> E[] requireNoNullsCopiedElseReplace(E[] array, IntFunction<? extends E> replaceFunction)

java.util.Collections:
public static <C extends Iterable<?>> C requireNoNulls(C collection)
public static <M extends Map<?, ?>> M requireNoNulls(M map)
public static <C extends Iterable<?>> C requireNoNulls(C collection, String message)
public static <M extends Map<?, ?>> M requireNoNulls(M map, String message)
public static <C extends Iterable<?>> C requireNoNulls(C collection, Supplier<String> messageSupplier)
public static <M extends Map<?, ?>> M requireNoNulls(M map, Supplier<String> messageSupplier)
public static <L extends List<?>> L requireNoNulls(L list, IntFunction<String> messageGenerator)
public static <E, L extends List<? super E>> L requireNoNullsElseReplace(L list, IntFunction<? extends E> replaceFunction)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301042](https://bugs.openjdk.org/browse/JDK-8301042): Need methods to check null elements in an array or a collection ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12276/head:pull/12276` \
`$ git checkout pull/12276`

Update a local copy of the PR: \
`$ git checkout pull/12276` \
`$ git pull https://git.openjdk.org/jdk.git pull/12276/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12276`

View PR using the GUI difftool: \
`$ git pr show -t 12276`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12276.diff">https://git.openjdk.org/jdk/pull/12276.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12276#issuecomment-1407552299)