### PR TITLE
8301305: const ResourceHashTableBase leaks mutable reference to elements

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -653,7 +653,7 @@ void ArchiveBuilder::make_shallow_copy(DumpRegion *dump_region, SourceObjInfo* s
 }
 
 address ArchiveBuilder::get_buffered_addr(address src_addr) const {
-  SourceObjInfo* p = _src_obj_table.get(src_addr);
+  const SourceObjInfo* p = _src_obj_table.get(src_addr);
   assert(p != nullptr, "must be");
 
   return p->buffered_addr();
@@ -661,7 +661,7 @@ address ArchiveBuilder::get_buffered_addr(address src_addr) const {
 
 address ArchiveBuilder::get_source_addr(address buffered_addr) const {
   assert(is_in_buffer_space(buffered_addr), "must be");
-  address* src_p = _buffered_to_src_table.get(buffered_addr);
+  const address* src_p = _buffered_to_src_table.get(buffered_addr);
   assert(src_p != nullptr && *src_p != nullptr, "must be");
   return *src_p;
 }

--- a/src/hotspot/share/cds/cdsHeapVerifier.cpp
+++ b/src/hotspot/share/cds/cdsHeapVerifier.cpp
@@ -224,7 +224,7 @@ void CDSHeapVerifier::add_static_obj_field(InstanceKlass* ik, oop field, Symbol*
   _table.put(field, info);
 }
 
-inline bool CDSHeapVerifier::do_entry(oop& orig_obj, HeapShared::CachedOopInfo& value) {
+inline bool CDSHeapVerifier::do_entry(const oop& orig_obj, const HeapShared::CachedOopInfo& value) {
   _archived_objs++;
 
   StaticFieldInfo* info = _table.get(orig_obj);
@@ -274,7 +274,7 @@ void CDSHeapVerifier::trace_to_root(outputStream* st, oop orig_obj) {
   }
 }
 
-int CDSHeapVerifier::trace_to_root(outputStream* st, oop orig_obj, oop orig_field, HeapShared::CachedOopInfo* info) {
+int CDSHeapVerifier::trace_to_root(outputStream* st, oop orig_obj, oop orig_field, const HeapShared::CachedOopInfo* info) {
   int level = 0;
   if (info->_referrer != nullptr) {
     HeapShared::CachedOopInfo* ref = HeapShared::archived_object_cache()->get(info->_referrer);

--- a/src/hotspot/share/cds/cdsHeapVerifier.hpp
+++ b/src/hotspot/share/cds/cdsHeapVerifier.hpp
@@ -69,7 +69,7 @@ class CDSHeapVerifier : public KlassClosure {
     }
     return nullptr;
   }
-  static int trace_to_root(outputStream* st, oop orig_obj, oop orig_field, HeapShared::CachedOopInfo* p);
+  static int trace_to_root(outputStream* st, oop orig_obj, oop orig_field, const HeapShared::CachedOopInfo* p);
 
   CDSHeapVerifier();
   ~CDSHeapVerifier();
@@ -80,7 +80,7 @@ public:
   virtual void do_klass(Klass* k);
 
   // For ResourceHashtable::iterate()
-  inline bool do_entry(oop& orig_obj, HeapShared::CachedOopInfo& value);
+  inline bool do_entry(const oop& orig_obj, const HeapShared::CachedOopInfo& value);
 
   static void verify();
 

--- a/src/hotspot/share/cds/dumpTimeClassInfo.hpp
+++ b/src/hotspot/share/cds/dumpTimeClassInfo.hpp
@@ -259,8 +259,8 @@ public:
     }
   }
 
-  template<class ITER> void iterate_all_live_classes(ITER* iter) const;
-  template<typename Function> void iterate_all_live_classes(Function function) const;
+  template<class ITER> void iterate_all_live_classes(ITER* iter);
+  template<typename Function> void iterate_all_live_classes(Function function);
 
 private:
   // It's unsafe to iterate on classes whose loader is dead.

--- a/src/hotspot/share/cds/dumpTimeClassInfo.inline.hpp
+++ b/src/hotspot/share/cds/dumpTimeClassInfo.inline.hpp
@@ -54,7 +54,10 @@ void DumpTimeSharedClassTable::iterate_all_live_classes(Function function) {
       }
     }
   };
-  DumpTimeSharedClassTableBaseType::iterate_all(wrapper);
+  // Some callers want to mutate 'info', so we do a mutable iterate.
+  // It seems like we never want to iterate over a `const DumpTimeSharedClassTable`,
+  // so for now we don't need a const overload of this function.
+  DumpTimeSharedClassTableBaseType::mutable_iterate_all(wrapper);
 }
 
 

--- a/src/hotspot/share/cds/dumpTimeClassInfo.inline.hpp
+++ b/src/hotspot/share/cds/dumpTimeClassInfo.inline.hpp
@@ -40,7 +40,7 @@
 // This function must be called only inside a safepoint, where the value of
 // k->is_loader_alive() will not change.
 template<typename Function>
-void DumpTimeSharedClassTable::iterate_all_live_classes(Function function) const {
+void DumpTimeSharedClassTable::iterate_all_live_classes(Function function) {
   auto wrapper = [&] (InstanceKlass* k, DumpTimeClassInfo& info) {
     assert(SafepointSynchronize::is_at_safepoint(), "invariant");
     assert_lock_strong(DumpTimeTable_lock);
@@ -59,7 +59,7 @@ void DumpTimeSharedClassTable::iterate_all_live_classes(Function function) const
 
 
 template<class ITER>
-void DumpTimeSharedClassTable::iterate_all_live_classes(ITER* iter) const {
+void DumpTimeSharedClassTable::iterate_all_live_classes(ITER* iter) {
   auto function = [&] (InstanceKlass* k, DumpTimeClassInfo& v) {
     iter->do_entry(k, v);
   };

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -863,7 +863,7 @@ bool KlassSubGraphInfo::is_non_early_klass(Klass* k) {
 }
 
 // Initialize an archived subgraph_info_record from the given KlassSubGraphInfo.
-void ArchivedKlassSubGraphInfoRecord::init(KlassSubGraphInfo* info) {
+void ArchivedKlassSubGraphInfoRecord::init(const KlassSubGraphInfo* info) {
   _k = info->klass();
   _entry_field_records = nullptr;
   _subgraph_object_klasses = nullptr;
@@ -925,7 +925,7 @@ struct CopyKlassSubGraphInfoToArchive : StackObj {
   CompactHashtableWriter* _writer;
   CopyKlassSubGraphInfoToArchive(CompactHashtableWriter* writer) : _writer(writer) {}
 
-  bool do_entry(Klass* klass, KlassSubGraphInfo& info) {
+  bool do_entry(Klass* klass, const KlassSubGraphInfo& info) {
     if (info.subgraph_object_klasses() != nullptr || info.subgraph_entry_fields() != nullptr) {
       ArchivedKlassSubGraphInfoRecord* record =
         (ArchivedKlassSubGraphInfoRecord*)ArchiveBuilder::ro_region_alloc(sizeof(ArchivedKlassSubGraphInfoRecord));

--- a/src/hotspot/share/cds/heapShared.hpp
+++ b/src/hotspot/share/cds/heapShared.hpp
@@ -90,11 +90,11 @@ class KlassSubGraphInfo: public CHeapObj<mtClass> {
     }
   };
 
-  Klass* klass()            { return _k; }
-  GrowableArray<Klass*>* subgraph_object_klasses() {
+  Klass* klass() const { return _k; }
+  GrowableArray<Klass*>* subgraph_object_klasses() const {
     return _subgraph_object_klasses;
   }
-  GrowableArray<int>* subgraph_entry_fields() {
+  GrowableArray<int>* subgraph_entry_fields() const {
     return _subgraph_entry_fields;
   }
   void add_subgraph_entry_field(int static_field_offset, oop v,
@@ -126,7 +126,7 @@ class ArchivedKlassSubGraphInfoRecord {
  public:
   ArchivedKlassSubGraphInfoRecord() :
     _k(nullptr), _entry_field_records(nullptr), _subgraph_object_klasses(nullptr) {}
-  void init(KlassSubGraphInfo* info);
+  void init(const KlassSubGraphInfo* info);
   Klass* klass() const { return _k; }
   Array<int>* entry_field_records() const { return _entry_field_records; }
   Array<Klass*>* subgraph_object_klasses() const { return _subgraph_object_klasses; }

--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -444,7 +444,7 @@ void LoaderConstraintTable::merge_loader_constraints(Symbol* class_name,
 
 void LoaderConstraintTable::verify() {
   Thread* thread = Thread::current();
-  auto check = [&] (SymbolHandle& key, ConstraintSet& set) {
+  auto check = [&] (const SymbolHandle& key, const ConstraintSet& set) {
     // foreach constraint in the set, check the klass is in the dictionary or placeholder table.
     int len = set.num_constraints();
     for (int i = 0; i < len; i++) {
@@ -497,7 +497,7 @@ void LoaderConstraintTable::print_table_statistics(outputStream* st) {
 
 // Called with the system dictionary lock held
 void LoaderConstraintTable::print_on(outputStream* st) {
-  auto printer = [&] (SymbolHandle& key, ConstraintSet& set) {
+  auto printer = [&] (const SymbolHandle& key, const ConstraintSet& set) {
     int len = set.num_constraints();
     for (int i = 0; i < len; i++) {
       LoaderConstraint* probe = set.constraint_at(i);

--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -481,7 +481,7 @@ void LoaderConstraintTable::verify() {
 }
 
 void LoaderConstraintTable::print_table_statistics(outputStream* st) {
-  auto size = [&] (SymbolHandle& key, ConstraintSet& set) {
+  auto size = [&] (const SymbolHandle& key, const ConstraintSet& set) {
     // sizeof set is included in the size of the hashtable node
     int sum = 0;
     int len = set.num_constraints();

--- a/src/hotspot/share/classfile/moduleEntry.cpp
+++ b/src/hotspot/share/classfile/moduleEntry.cpp
@@ -634,7 +634,7 @@ ModuleEntry* ModuleEntryTable::lookup_only(Symbol* name) {
 // This should only occur at class unloading.
 void ModuleEntryTable::purge_all_module_reads() {
   assert_locked_or_safepoint(Module_lock);
-  auto purge = [&] (const SymbolHandle& key, ModuleEntry*& entry) {
+  auto purge = [&] (const SymbolHandle& key, ModuleEntry* entry) {
     entry->purge_reads();
   };
   _table.iterate_all(purge);
@@ -712,7 +712,7 @@ void ModuleEntryTable::patch_javabase_entries(JavaThread* current, Handle module
 
 void ModuleEntryTable::print(outputStream* st) {
   ResourceMark rm;
-  auto printer = [&] (const SymbolHandle& name, ModuleEntry*& entry) {
+  auto printer = [&] (const SymbolHandle& name, ModuleEntry* entry) {
     entry->print(st);
   };
   st->print_cr("Module Entry Table (table_size=%d, entries=%d)",
@@ -722,7 +722,7 @@ void ModuleEntryTable::print(outputStream* st) {
 }
 
 void ModuleEntryTable::modules_do(void f(ModuleEntry*)) {
-  auto do_f = [&] (const SymbolHandle& key, ModuleEntry*& entry) {
+  auto do_f = [&] (const SymbolHandle& key, ModuleEntry* entry) {
     f(entry);
   };
   assert_lock_strong(Module_lock);
@@ -730,7 +730,7 @@ void ModuleEntryTable::modules_do(void f(ModuleEntry*)) {
 }
 
 void ModuleEntryTable::modules_do(ModuleClosure* closure) {
-  auto do_f = [&] (const SymbolHandle& key, ModuleEntry*& entry) {
+  auto do_f = [&] (const SymbolHandle& key, ModuleEntry* entry) {
     closure->do_module(entry);
   };
   assert_lock_strong(Module_lock);
@@ -749,7 +749,7 @@ void ModuleEntry::print(outputStream* st) {
 }
 
 void ModuleEntryTable::verify() {
-  auto do_f = [&] (const SymbolHandle& key, ModuleEntry*& entry) {
+  auto do_f = [&] (const SymbolHandle& key, ModuleEntry* entry) {
     entry->verify();
   };
   assert_locked_or_safepoint(Module_lock);

--- a/src/hotspot/share/classfile/moduleEntry.cpp
+++ b/src/hotspot/share/classfile/moduleEntry.cpp
@@ -357,7 +357,7 @@ ModuleEntryTable::ModuleEntryTable() { }
 ModuleEntryTable::~ModuleEntryTable() {
   class ModuleEntryTableDeleter : public StackObj {
    public:
-    bool do_entry(const SymbolHandle& name, ModuleEntry*& entry) {
+    bool do_entry(const SymbolHandle& name, ModuleEntry* entry) {
       if (log_is_enabled(Info, module, unload) || log_is_enabled(Debug, module)) {
         ResourceMark rm;
         const char* str = name->as_C_string();
@@ -550,7 +550,7 @@ static int compare_module_by_name(ModuleEntry* a, ModuleEntry* b) {
 }
 
 void ModuleEntryTable::iterate_symbols(MetaspaceClosure* closure) {
-  auto syms = [&] (const SymbolHandle& key, ModuleEntry*& m) {
+  auto syms = [&] (const SymbolHandle& key, ModuleEntry* m) {
       m->iterate_symbols(closure);
   };
   _table.iterate_all(syms);
@@ -559,7 +559,7 @@ void ModuleEntryTable::iterate_symbols(MetaspaceClosure* closure) {
 Array<ModuleEntry*>* ModuleEntryTable::allocate_archived_entries() {
   Array<ModuleEntry*>* archived_modules = ArchiveBuilder::new_rw_array<ModuleEntry*>(_table.number_of_entries());
   int n = 0;
-  auto grab = [&] (const SymbolHandle& key, ModuleEntry*& m) {
+  auto grab = [&] (const SymbolHandle& key, ModuleEntry* m) {
     archived_modules->at_put(n++, m);
   };
   _table.iterate_all(grab);

--- a/src/hotspot/share/classfile/packageEntry.cpp
+++ b/src/hotspot/share/classfile/packageEntry.cpp
@@ -374,7 +374,7 @@ PackageEntry* PackageEntryTable::locked_lookup_only(Symbol* name) {
 // Verify the packages loaded thus far are in java.base's package list.
 void PackageEntryTable::verify_javabase_packages(GrowableArray<Symbol*> *pkg_list) {
   assert_lock_strong(Module_lock);
-  auto verifier = [&] (const SymbolHandle& name, PackageEntry*& entry) {
+  auto verifier = [&] (const SymbolHandle& name, PackageEntry* entry) {
     ModuleEntry* m = entry->module();
     Symbol* module_name = (m == nullptr ? nullptr : m->name());
     if (module_name != nullptr &&
@@ -410,7 +410,7 @@ bool PackageEntry::exported_pending_delete() const {
 // Remove dead entries from all packages' exported list
 void PackageEntryTable::purge_all_package_exports() {
   assert_locked_or_safepoint(Module_lock);
-  auto purge = [&] (const SymbolHandle& name, PackageEntry*& entry) {
+  auto purge = [&] (const SymbolHandle& name, PackageEntry* entry) {
     if (entry->exported_pending_delete()) {
       // exported list is pending deletion due to a transition
       // from qualified to unqualified
@@ -423,7 +423,7 @@ void PackageEntryTable::purge_all_package_exports() {
 }
 
 void PackageEntryTable::packages_do(void f(PackageEntry*)) {
-  auto doit = [&] (const SymbolHandle&name, PackageEntry*& entry) {
+  auto doit = [&] (const SymbolHandle&name, PackageEntry* entry) {
     f(entry);
   };
   assert_locked_or_safepoint(Module_lock);
@@ -433,7 +433,7 @@ void PackageEntryTable::packages_do(void f(PackageEntry*)) {
 
 GrowableArray<PackageEntry*>*  PackageEntryTable::get_system_packages() {
   GrowableArray<PackageEntry*>* loaded_class_pkgs = new GrowableArray<PackageEntry*>(50);
-  auto grab = [&] (const SymbolHandle& name, PackageEntry*& entry) {
+  auto grab = [&] (const SymbolHandle& name, PackageEntry* entry) {
     if (entry->has_loaded_class()) {
       loaded_class_pkgs->append(entry);
     }
@@ -446,7 +446,7 @@ GrowableArray<PackageEntry*>*  PackageEntryTable::get_system_packages() {
 }
 
 void PackageEntryTable::print(outputStream* st) {
-  auto printer = [&] (const SymbolHandle& name, PackageEntry*& entry) {
+  auto printer = [&] (const SymbolHandle& name, PackageEntry* entry) {
     entry->print(st);
   };
   st->print_cr("Package Entry Table (table_size=%d, entries=%d)",

--- a/src/hotspot/share/classfile/packageEntry.cpp
+++ b/src/hotspot/share/classfile/packageEntry.cpp
@@ -193,7 +193,7 @@ PackageEntryTable::PackageEntryTable() { }
 PackageEntryTable::~PackageEntryTable() {
   class PackageEntryTableDeleter : public StackObj {
    public:
-    bool do_entry(const SymbolHandle& name, PackageEntry*& entry) {
+    bool do_entry(const SymbolHandle& name, PackageEntry* entry) {
       if (log_is_enabled(Info, module, unload) || log_is_enabled(Debug, module)) {
         ResourceMark rm;
         const char* str = name->as_C_string();
@@ -270,7 +270,7 @@ static int compare_package_by_name(PackageEntry* a, PackageEntry* b) {
 }
 
 void PackageEntryTable::iterate_symbols(MetaspaceClosure* closure) {
-  auto syms = [&] (const SymbolHandle& key, PackageEntry*& p) {
+  auto syms = [&] (const SymbolHandle& key, PackageEntry* p) {
       p->iterate_symbols(closure);
   };
   _table.iterate_all(syms);
@@ -279,7 +279,7 @@ void PackageEntryTable::iterate_symbols(MetaspaceClosure* closure) {
 Array<PackageEntry*>* PackageEntryTable::allocate_archived_entries() {
   // First count the packages in named modules
   int n = 0;
-  auto count = [&] (const SymbolHandle& key, PackageEntry*& p) {
+  auto count = [&] (const SymbolHandle& key, PackageEntry* p) {
     if (p->module()->is_named()) {
       n++;
     }
@@ -289,7 +289,7 @@ Array<PackageEntry*>* PackageEntryTable::allocate_archived_entries() {
   Array<PackageEntry*>* archived_packages = ArchiveBuilder::new_rw_array<PackageEntry*>(n);
   // reset n
   n = 0;
-  auto grab = [&] (const SymbolHandle& key, PackageEntry*& p) {
+  auto grab = [&] (const SymbolHandle& key, PackageEntry* p) {
     if (p->module()->is_named()) {
       // We don't archive unnamed modules, or packages in unnamed modules. They will be
       // created on-demand at runtime as classes in such packages are loaded.

--- a/src/hotspot/share/classfile/placeholders.cpp
+++ b/src/hotspot/share/classfile/placeholders.cpp
@@ -333,7 +333,7 @@ void PlaceholderEntry::print_on(outputStream* st) const {
 }
 
 void PlaceholderTable::print_on(outputStream* st) {
-  auto printer = [&] (PlaceholderKey& key, PlaceholderEntry& entry) {
+  auto printer = [&] (const PlaceholderKey& key, const PlaceholderEntry& entry) {
       st->print("placeholder ");
       key.print_on(st);
       entry.print_on(st);

--- a/src/hotspot/share/classfile/protectionDomainCache.cpp
+++ b/src/hotspot/share/classfile/protectionDomainCache.cpp
@@ -211,7 +211,7 @@ WeakHandle ProtectionDomainCacheTable::add_if_absent(Handle protection_domain) {
 }
 
 void ProtectionDomainCacheTable::print_table_statistics(outputStream* st) {
-  auto size = [&] (WeakHandle& key, WeakHandle& value) {
+  auto size = [&] (const WeakHandle& key, const WeakHandle& value) {
     // The only storage is in OopStorage for an oop
     return sizeof(oop);
   };

--- a/src/hotspot/share/classfile/protectionDomainCache.cpp
+++ b/src/hotspot/share/classfile/protectionDomainCache.cpp
@@ -167,7 +167,7 @@ void ProtectionDomainCacheTable::unlink() {
 
 void ProtectionDomainCacheTable::print_on(outputStream* st) {
   assert_locked_or_safepoint(SystemDictionary_lock);
-  auto printer = [&] (WeakHandle& key, WeakHandle& value) {
+  auto printer = [&] (const WeakHandle& key, const WeakHandle& value) {
       st->print_cr("  protection_domain: " PTR_FORMAT, p2i(value.peek()));
   };
   st->print_cr("Protection domain cache table (table_size=%d, protection domains=%d)",
@@ -176,7 +176,7 @@ void ProtectionDomainCacheTable::print_on(outputStream* st) {
 }
 
 void ProtectionDomainCacheTable::verify() {
-  auto verifier = [&] (WeakHandle& key, WeakHandle& value) {
+  auto verifier = [&] (const WeakHandle& key, const WeakHandle& value) {
     guarantee(value.peek() == nullptr || oopDesc::is_oop(value.peek()), "must be an oop");
   };
   _pd_cache_table.iterate_all(verifier);

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -690,7 +690,7 @@ void SystemDictionaryShared::dumptime_classes_do(class MetaspaceClosure* it) {
       key.metaspace_pointers_do(it);
     }
   };
-  _dumptime_lambda_proxy_class_dictionary->iterate_all(do_lambda);
+  _dumptime_lambda_proxy_class_dictionary->mutable_iterate_all(do_lambda);
 }
 
 bool SystemDictionaryShared::add_verification_constraint(InstanceKlass* k, Symbol* name,
@@ -1226,7 +1226,7 @@ void SystemDictionaryShared::write_lambda_proxy_class_dictionary(LambdaProxyClas
   dictionary->reset();
   CompactHashtableWriter writer(_dumptime_lambda_proxy_class_dictionary->_count, &stats);
   CopyLambdaProxyClassInfoToArchive copy(&writer);
-  _dumptime_lambda_proxy_class_dictionary->iterate(&copy);
+  _dumptime_lambda_proxy_class_dictionary->mutable_iterate(&copy);
   writer.dump(dictionary, "lambda proxy class dictionary");
 }
 
@@ -1252,7 +1252,7 @@ void SystemDictionaryShared::write_to_archive(bool is_static_archive) {
 
 void SystemDictionaryShared::adjust_lambda_proxy_class_dictionary() {
   AdjustLambdaProxyClassInfo adjuster;
-  _dumptime_lambda_proxy_class_dictionary->iterate(&adjuster);
+  _dumptime_lambda_proxy_class_dictionary->mutable_iterate(&adjuster);
 }
 
 void SystemDictionaryShared::serialize_dictionary_headers(SerializeClosure* soc,
@@ -1468,7 +1468,7 @@ class CloneDumpTimeLambdaProxyClassTable: StackObj {
     assert(_cloned_table != nullptr, "_cloned_table is nullptr");
   }
 
-  bool do_entry(LambdaProxyClassKey& key, DumpTimeLambdaProxyClassInfo& info) {
+  bool do_entry(const LambdaProxyClassKey& key, const DumpTimeLambdaProxyClassInfo& info) {
     assert_lock_strong(DumpTimeTable_lock);
     bool created;
     // make copies then store in _clone_table

--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -126,7 +126,7 @@ void AsyncLogWriter::write() {
     swap(_buffer, _buffer_staging);
 
     // move counters to snapshot and reset them.
-    _stats.iterate([&] (LogFileStreamOutput* output, uint32_t& counter) {
+    _stats.mutable_iterate([&] (LogFileStreamOutput* output, uint32_t& counter) {
       if (counter > 0) {
         bool created = snapshot.put(output, counter);
         assert(created == true, "sanity check");
@@ -153,7 +153,7 @@ void AsyncLogWriter::write() {
 
   LogDecorations decorations(LogLevel::Warning, LogTagSetMapping<LogTag::__NO_TAG>::tagset(),
                              LogDecorators::All);
-  snapshot.iterate([&](LogFileStreamOutput* output, uint32_t& counter) {
+  snapshot.iterate([&](LogFileStreamOutput* output, uint32_t counter) {
     if (counter > 0) {
       stringStream ss;
       ss.print(UINT32_FORMAT_W(6) " messages dropped due to async logging", counter);

--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -1258,7 +1258,7 @@ class TagObjectCollector : public JvmtiTagMapKeyClosure {
   // - if it matches then we create a JNI local reference to the object
   // and record the reference and tag value.
   // Always return true so the iteration continues.
-  bool do_entry(JvmtiTagMapKey& key, jlong& value) {
+  bool do_entry(const JvmtiTagMapKey& key, jlong value) {
     for (int i = 0; i < _tag_count; i++) {
       if (_tags[i] == value) {
         // The reference in this tag map could be the only (implicitly weak)

--- a/src/hotspot/share/prims/jvmtiTagMapTable.hpp
+++ b/src/hotspot/share/prims/jvmtiTagMapTable.hpp
@@ -104,7 +104,7 @@ class JvmtiTagMapTable : public CHeapObj<mtServiceability> {
 // A supporting class for iterating over all entries in Hashmap
 class JvmtiTagMapKeyClosure {
  public:
-  virtual bool do_entry(JvmtiTagMapKey& key, jlong& value) = 0;
+  virtual bool do_entry(const JvmtiTagMapKey& key, jlong value) = 0;
 };
 
 #endif // SHARE_VM_PRIMS_TAGMAPTABLE_HPP

--- a/src/hotspot/share/utilities/resourceHash.hpp
+++ b/src/hotspot/share/utilities/resourceHash.hpp
@@ -120,14 +120,28 @@ class ResourceHashtableBase : public STORAGE {
     return get(key) != nullptr;
   }
 
-  V* get(K const& key) const {
+ /*
+  * Note that there are const and non-const overloads of 'get'.
+  * A const ResourceHashTableBase means that the V's in it
+  * are also const. So, the const version of 'get' returns
+  * V const* (pointer to constant V). The non-const version
+  * of 'get' returns V* (pointer to mutable V). This prevents
+  * the elements of a const ResourceHashTableBase from being
+  * modified through the pointer returned by 'get'.
+  */
+  V* get(K const& key) {
     unsigned hv = HASH(key);
-    Node const** ptr = lookup_node(hv, key);
+    Node ** ptr = lookup_node(hv, key);
     if (*ptr != nullptr) {
-      return const_cast<V*>(&(*ptr)->_value);
+      return &(*ptr)->_value;
     } else {
       return nullptr;
     }
+  }
+
+  V const* get(K const& key) const {
+    return const_cast<V const*>(
+      const_cast<ResourceHashtableBase*>(this)->get(key));
   }
 
  /**

--- a/src/hotspot/share/utilities/resourceHash.hpp
+++ b/src/hotspot/share/utilities/resourceHash.hpp
@@ -65,7 +65,7 @@ class ResourceHashtableBase : public STORAGE {
   }
 
   const Node* const* bucket_at(unsigned index) const {
-    Node** t = table();
+    const Node* const* t = table();
     return &t[index];
   }
 
@@ -241,7 +241,7 @@ class ResourceHashtableBase : public STORAGE {
 
   template<typename Function>
   void iterate(Function function) const { // lambda enabled API
-    Node* const* bucket = table();
+    Node* const* bucket = const_cast<Node* const*>(table()); // FIXME
     const unsigned sz = table_size();
     int cnt = _number_of_entries;
 
@@ -296,10 +296,10 @@ class ResourceHashtableBase : public STORAGE {
   TableStatistics statistics_calculate(Function size_function) const {
     NumberSeq summary;
     size_t literal_bytes = 0;
-    Node* const* bucket = table();
+    const Node* const* bucket = table();
     const unsigned sz = table_size();
     while (bucket < bucket_at(sz)) {
-      Node* node = *bucket;
+      const Node* node = *bucket;
       int count = 0;
       while (node != nullptr) {
         literal_bytes += size_function(node->_key, node->_value);

--- a/src/hotspot/share/utilities/resourceHash.hpp
+++ b/src/hotspot/share/utilities/resourceHash.hpp
@@ -90,7 +90,8 @@ class ResourceHashtableBase : public STORAGE {
   }
 
  protected:
-  Node** table() const { return STORAGE::table(); }
+  Node** table() { return STORAGE::table(); }
+  const Node* const* table() const { return STORAGE::table(); }
 
   ResourceHashtableBase() : STORAGE(), _number_of_entries(0) {}
   ResourceHashtableBase(unsigned size) : STORAGE(size), _number_of_entries(0) {}
@@ -332,8 +333,12 @@ protected:
     return TABLE_SIZE;
   }
 
-  Node** table() const {
-    return const_cast<Node**>(_table);
+  Node** table() {
+    return _table;
+  }
+
+  const Node* const* table() const {
+    return _table;
   }
 };
 

--- a/src/hotspot/share/utilities/resourceHash.hpp
+++ b/src/hotspot/share/utilities/resourceHash.hpp
@@ -90,14 +90,14 @@ class ResourceHashtableBase : public STORAGE {
   }
 
   // impl that works for both const and non-const tables
-  template<typename Table_t, typename Bucket_t, typename Node_t, typename Function>
-  static void iterate_impl(Table_t& rht, Function function) {
-    Bucket_t* bucket = rht.table();
+  template<typename Table, typename Function>
+  static void iterate_impl(Table& rht, Function function) {
+    auto* bucket = rht.table();
     const unsigned sz = rht.table_size();
     int cnt = rht._number_of_entries;
 
     while (cnt > 0 && bucket < rht.bucket_at(sz)) {
-      Node_t* node = *bucket;
+      auto* node = *bucket;
       while (node != nullptr) {
         bool cont = function(node->_key, node->_value);
         if (!cont) { return; }
@@ -268,12 +268,12 @@ class ResourceHashtableBase : public STORAGE {
 
   template<typename Function>
   void iterate(Function function) const { // lambda enabled API
-    iterate_impl<const ResourceHashtableBase, const Node* const, const Node>(*this, function);
+    iterate_impl(*this, function);
   }
 
   template<typename Function>
   void iterate(Function function) { // lambda enabled API
-    iterate_impl<ResourceHashtableBase, Node*, Node>(*this, function);
+    iterate_impl(*this, function);
   }
 
   // same as above, but unconditionally iterate all entries

--- a/src/hotspot/share/utilities/resourceHash.hpp
+++ b/src/hotspot/share/utilities/resourceHash.hpp
@@ -259,11 +259,11 @@ class ResourceHashtableBase : public STORAGE {
   }
 
   template<class ITER>
-  void iterate(ITER* iter) {
+  void mutable_iterate(ITER* iter) {
     auto function = [&] (K& k, V& v) {
       return iter->do_entry(k, v);
     };
-    iterate(function);
+    mutable_iterate(function);
   }
 
   template<typename Function>
@@ -272,7 +272,7 @@ class ResourceHashtableBase : public STORAGE {
   }
 
   template<typename Function>
-  void iterate(Function function) { // lambda enabled API
+  void mutable_iterate(Function function) { // lambda enabled API
     iterate_impl(*this, function);
   }
 
@@ -287,12 +287,12 @@ class ResourceHashtableBase : public STORAGE {
   }
 
   template<typename Function>
-  void iterate_all(Function function) { // lambda enabled API
+  void mutable_iterate_all(Function function) { // lambda enabled API
     auto wrapper = [&] (K& k, V& v) {
       function(k, v);
       return true;
     };
-    iterate(wrapper);
+    mutable_iterate(wrapper);
   }
 
   // ITER contains bool do_entry(K const&, V const&), which will be

--- a/test/hotspot/gtest/utilities/test_resourceHash.cpp
+++ b/test/hotspot/gtest/utilities/test_resourceHash.cpp
@@ -457,7 +457,7 @@ TEST_VM_F(ResourceHashtablePrintTest, print_test) {
     TestValue* tv = new TestValue(i);
     _test_table.put(i, tv);  // all the entries can be the same.
   }
-  auto printer = [&] (int& key, TestValue*& val) {
+  auto printer = [&] (int key, TestValue* val) {
     return sizeof(*val);
   };
   TableStatistics ts = _test_table.statistics_calculate(printer);


### PR DESCRIPTION
The current definition of `ResourceHashTableBase::get` is `const`, but returns `V*`, i.e. a mutable pointer to one of the values it stores.

This means that, even for a `const ResourceHashTableBase`, the elements can be modified through the mutable pointer returned by `get`.

This patch fixes this by making the current `get` implementation non-const, and then adds a `const` overload which returns `V const*`. This prevents the `V` from being modified through the pointer returned from `get` for `const ResourceHashTableBase`s.

Testing: tier 1-4 (ongoing)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301305](https://bugs.openjdk.org/browse/JDK-8301305): const ResourceHashTableBase leaks mutable reference to elements


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12278/head:pull/12278` \
`$ git checkout pull/12278`

Update a local copy of the PR: \
`$ git checkout pull/12278` \
`$ git pull https://git.openjdk.org/jdk pull/12278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12278`

View PR using the GUI difftool: \
`$ git pr show -t 12278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12278.diff">https://git.openjdk.org/jdk/pull/12278.diff</a>

</details>
