### PR TITLE
8293519: deprecation warnings should be emitted for uses of annotation methods inside other annotations

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
@@ -521,6 +521,7 @@ public class Annotate {
                 left.name, List.nil(), null);
         left.sym = method;
         left.type = method.type;
+        chk.checkDeprecated(left, env.info.scope.owner, method);
         if (method.owner != thisAnnotationType.tsym && !badAnnotation)
             log.error(left.pos(), Errors.NoAnnotationMember(left.name, thisAnnotationType));
         Type resultType = method.type.getReturnType();

--- a/test/langtools/tools/javac/annotations/DeprecationWarningTest.java
+++ b/test/langtools/tools/javac/annotations/DeprecationWarningTest.java
@@ -1,0 +1,15 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8293519
+ * @summary deprecation warnings should be emitted for uses of annotation methods inside other annotations
+ * @compile/fail/ref=DeprecationWarningTest.out -deprecation -Werror -XDrawDiagnostics DeprecationWarningTest.java
+ */
+
+// both classes can't be inside the same outermost class or the compiler wont emit the warning as `9.6.4.6 @Deprecated` mandates
+@interface Anno {
+    @Deprecated
+    boolean b() default false;
+}
+
+@Anno(b = true)
+class Foo {}

--- a/test/langtools/tools/javac/annotations/DeprecationWarningTest.out
+++ b/test/langtools/tools/javac/annotations/DeprecationWarningTest.out
@@ -1,0 +1,4 @@
+DeprecationWarningTest.java:14:7: compiler.warn.has.been.deprecated: b(), Anno
+- compiler.err.warnings.and.werror
+1 error
+1 warning


### PR DESCRIPTION
Javac is forgetting to double check if the left hand side in an annotation name-value pair is a deprecated method, basically in this case:
```
@interface Anno {
    @Deprecated
    boolean b() default false;
}

@Anno(b = true) // a warning should be issued here
class Foo {}
```
this PR is fixing this oversight,

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293519](https://bugs.openjdk.org/browse/JDK-8293519): deprecation warnings should be emitted for uses of annotation methods inside other annotations


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12280/head:pull/12280` \
`$ git checkout pull/12280`

Update a local copy of the PR: \
`$ git checkout pull/12280` \
`$ git pull https://git.openjdk.org/jdk pull/12280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12280`

View PR using the GUI difftool: \
`$ git pr show -t 12280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12280.diff">https://git.openjdk.org/jdk/pull/12280.diff</a>

</details>
