### PR TITLE
8301306: java/net/httpclient/* fail with -Xcomp

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1437,7 +1437,6 @@ void Arguments::set_mode_flags(Mode mode) {
     break;
   case _comp:
     UseInterpreter           = false;
-    BackgroundCompilation    = false;
     ClipInlining             = false;
     break;
   }

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1437,6 +1437,7 @@ void Arguments::set_mode_flags(Mode mode) {
     break;
   case _comp:
     UseInterpreter           = false;
+    BackgroundCompilation    = false;
     ClipInlining             = false;
     break;
   }

--- a/test/jdk/java/net/httpclient/AbstractThrowingPushPromises.java
+++ b/test/jdk/java/net/httpclient/AbstractThrowingPushPromises.java
@@ -728,7 +728,7 @@ public abstract class AbstractThrowingPushPromises implements HttpServerAdapters
                 sharedClient == null ? null : sharedClient.toString();
         sharedClient = null;
         Thread.sleep(100);
-        AssertionError fail = TRACKER.check(500);
+        AssertionError fail = TRACKER.check(5000);
         try {
             http2TestServer.stop();
             https2TestServer.stop();

--- a/test/jdk/java/net/httpclient/ByteArrayPublishers.java
+++ b/test/jdk/java/net/httpclient/ByteArrayPublishers.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8222968
  * @summary ByteArrayPublisher is not thread-safe resulting in broken re-use of HttpRequests
- * @run main/othervm ByteArrayPublishers
+ * @run main/othervm -Dsun.net.httpserver.idleInterval=50000 ByteArrayPublishers
  */
 
 import java.net.InetAddress;

--- a/test/jdk/java/net/httpclient/HttpClientLocalAddrTest.java
+++ b/test/jdk/java/net/httpclient/HttpClientLocalAddrTest.java
@@ -63,11 +63,13 @@ import jdk.httpclient.test.lib.http2.Http2TestServer;
  * @run testng/othervm
  *      -Djdk.httpclient.HttpClient.log=frames,ssl,requests,responses,errors
  *      -Djdk.internal.httpclient.debug=true
+ *      -Dsun.net.httpserver.idleInterval=50000
  *      HttpClientLocalAddrTest
  *
  * @run testng/othervm/java.security.policy=httpclient-localaddr-security.policy
  *      -Djdk.httpclient.HttpClient.log=frames,ssl,requests,responses,errors
  *      -Djdk.internal.httpclient.debug=true
+ *      -Dsun.net.httpserver.idleInterval=50000
  *      HttpClientLocalAddrTest
  *
  */

--- a/test/jdk/java/net/httpclient/ManyRequestsLegacy.java
+++ b/test/jdk/java/net/httpclient/ManyRequestsLegacy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,10 +31,10 @@
  * @compile ../../../com/sun/net/httpserver/LogFilter.java
  * @compile ../../../com/sun/net/httpserver/EchoHandler.java
  * @compile ../../../com/sun/net/httpserver/FileServerHandler.java
- * @run main/othervm/timeout=40 ManyRequestsLegacy
- * @run main/othervm/timeout=40 -Dtest.insertDelay=true ManyRequestsLegacy
- * @run main/othervm/timeout=40 -Dtest.chunkSize=64 ManyRequestsLegacy
- * @run main/othervm/timeout=40 -Dtest.insertDelay=true
+ * @run main/othervm/timeout=80 -Dsun.net.httpserver.idleInterval=50000 ManyRequestsLegacy
+ * @run main/othervm/timeout=80 -Dtest.insertDelay=true -Dsun.net.httpserver.idleInterval=50000 ManyRequestsLegacy
+ * @run main/othervm/timeout=80 -Dtest.chunkSize=64 -Dsun.net.httpserver.idleInterval=50000 ManyRequestsLegacy
+ * @run main/othervm/timeout=80 -Dtest.insertDelay=true -Dsun.net.httpserver.idleInterval=50000
  *                              -Dtest.chunkSize=64 ManyRequestsLegacy
  * @summary Send a large number of requests asynchronously using the legacy
  *          URL.openConnection(), to help sanitize results of the test

--- a/test/jdk/java/net/httpclient/Response204V2Test.java
+++ b/test/jdk/java/net/httpclient/Response204V2Test.java
@@ -289,7 +289,7 @@ public class Response204V2Test implements HttpServerAdapters {
                 sharedClient == null ? null : sharedClient.toString();
         sharedClient = null;
         Thread.sleep(100);
-        AssertionError fail = TRACKER.check(500);
+        AssertionError fail = TRACKER.check(5000);
         try {
             http2TestServer.stop();
             https2TestServer.stop();

--- a/test/jdk/java/net/httpclient/SpecialHeadersTest.java
+++ b/test/jdk/java/net/httpclient/SpecialHeadersTest.java
@@ -30,6 +30,7 @@
  * @build jdk.httpclient.test.lib.common.HttpServerAdapters
  *        jdk.httpclient.test.lib.http2.Http2TestServer
  *        jdk.test.lib.net.SimpleSSLContext
+ * @requests (vm.compMode != "Xcomp")
  * @run testng/othervm
  *       -Djdk.httpclient.HttpClient.log=requests,headers,errors
  *       SpecialHeadersTest

--- a/test/jdk/java/net/vthread/HttpALot.java
+++ b/test/jdk/java/net/vthread/HttpALot.java
@@ -35,7 +35,6 @@
  * @run main/othervm/timeout=600
  *     -Dsun.net.httpserver.nodelay=true
  *     -Dsun.net.client.defaultConnectTimeout=5000
- *     -Dsun.net.client.defaultReadTimeout=50000
  *     HttpALot
  */
 

--- a/test/jdk/java/net/vthread/HttpALot.java
+++ b/test/jdk/java/net/vthread/HttpALot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@
  * @run main/othervm/timeout=600
  *     -Dsun.net.httpserver.nodelay=true
  *     -Dsun.net.client.defaultConnectTimeout=5000
- *     -Dsun.net.client.defaultReadTimeout=5000
+ *     -Dsun.net.client.defaultReadTimeout=50000
  *     HttpALot
  */
 


### PR DESCRIPTION
Hi all,
I think `BackgroundCompilation` should not be set to false when `-Xcomp` be used, which causes the java thread to block for longer, then causing the following tests failed frequently on the AArch64 and LoongArch64 architecture.

java/net/vthread/HttpALot.java (release -Xcomp)
java/net/httpclient/ByteArrayPublishers.java （fastdebug -Xcomp）
java/net/httpclient/ManyRequestsLegacy.java （fastdebug -Xcomp）
java/net/httpclient/HttpClientLocalAddrTest.java （fastdebug -Xcomp）
java/net/httpclient/SpecialHeadersTest.java  (fastdebug -Xcomp）

This PR fix the issue, Please help review it.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301306](https://bugs.openjdk.org/browse/JDK-8301306): java/net/httpclient/* fail with -Xcomp


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12282/head:pull/12282` \
`$ git checkout pull/12282`

Update a local copy of the PR: \
`$ git checkout pull/12282` \
`$ git pull https://git.openjdk.org/jdk pull/12282/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12282`

View PR using the GUI difftool: \
`$ git pr show -t 12282`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12282.diff">https://git.openjdk.org/jdk/pull/12282.diff</a>

</details>
