### PR TITLE
8299748: java/util/zip/Deinflate.java failing on s390x

### DIFF
--- a/test/jdk/java/util/zip/DeInflate.java
+++ b/test/jdk/java/util/zip/DeInflate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 7110149 8184306 6341887
  * @summary Test basic deflater & inflater functionality
+ * @library /test/lib
  * @key randomness
  */
 
@@ -32,6 +33,7 @@ import java.io.*;
 import java.nio.*;
 import java.util.*;
 import java.util.zip.*;
+import jdk.test.lib.Platform;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -268,7 +270,7 @@ public class DeInflate {
 
         byte[] dataIn = new byte[1024 * 512];
         rnd.nextBytes(dataIn);
-        byte[] dataOut1 = new byte[dataIn.length + 1024];
+        byte[] dataOut1 = new byte[dataIn.length + 1024 * (Platform.isS390x() ? 64 : 1)];
         byte[] dataOut2 = new byte[dataIn.length];
 
         Deflater defNotWrap = new Deflater(Deflater.DEFAULT_COMPRESSION, false);

--- a/test/jdk/java/util/zip/DeInflate.java
+++ b/test/jdk/java/util/zip/DeInflate.java
@@ -118,35 +118,32 @@ public class DeInflate {
         } catch (ReadOnlyBufferException robe) {}
     }
 
-    static void check(Deflater def, byte[] in, int len,
-                      byte[] out1, byte[] out2, boolean nowrap)
+    static void check(Deflater def, byte[] in, int len, boolean nowrap)
         throws Throwable
     {
-        Arrays.fill(out1, (byte)0);
-        Arrays.fill(out2, (byte)0);
-
+        byte[] tempBuffer = new byte[len];
         def.setInput(in, 0, len);
         def.finish();
         int m = 0;
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream(len);
         while (!def.finished()) {
-            int temp_counter = def.deflate(out1);
+            int temp_counter = def.deflate(tempBuffer);
             m += temp_counter;
-            baos.write(out1, 0, temp_counter);
+            baos.write(tempBuffer, 0, temp_counter);
         }
-        out1 = baos.toByteArray();
+        byte[] out1 = baos.toByteArray();
         baos.reset();
         Inflater inf = new Inflater(nowrap);
         inf.setInput(out1, 0, m);
         int n = 0;
 
         while (!inf.finished()) {
-            int temp_counter = inf.inflate(out2);
+            int temp_counter = inf.inflate(tempBuffer);
             n += temp_counter;
-            baos.write(out2, 0,  temp_counter);
+            baos.write(tempBuffer, 0,  temp_counter);
         }
-        out2 = baos.toByteArray();
+        byte[] out2 = baos.toByteArray();
         baos.close();
         if (n != len ||
             !Arrays.equals(Arrays.copyOf(in, len), Arrays.copyOf(out2, len)) ||
@@ -302,7 +299,7 @@ public class DeInflate {
                                           : new Random().nextInt(dataIn.length);
                         // use a new deflater
                         Deflater def = newDeflater(level, strategy, dowrap, dataOut2);
-                        check(def, dataIn, len, dataOut1, dataOut2, dowrap);
+                        check(def, dataIn, len, dowrap);
                         def.end();
 
                         // reuse the deflater (with reset) and test on stream, which

--- a/test/jdk/java/util/zip/DeInflate.java
+++ b/test/jdk/java/util/zip/DeInflate.java
@@ -47,7 +47,7 @@ public class DeInflate {
         Arrays.fill(out1, (byte)0);
         Arrays.fill(out2, (byte)0);
 
-        try(ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             try (DeflaterOutputStream defos = new DeflaterOutputStream(baos, def)) {
                 defos.write(in, 0, len);
             }

--- a/test/jdk/java/util/zip/DeInflate.java
+++ b/test/jdk/java/util/zip/DeInflate.java
@@ -161,7 +161,7 @@ public class DeInflate {
             }
             out2 = baos.toByteArray();
             if (n != len ||
-                !Arrays.equals(in, 0, len, out2, 0, len)) ||
+                !Arrays.equals(in, 0, len, out2, 0, len) ||
                 inf.inflate(out2) != 0) {
                 System.out.printf("m=%d, n=%d, len=%d, eq=%b%n",
                                   m, n, len, Arrays.equals(in, out2));

--- a/test/jdk/java/util/zip/DeInflate.java
+++ b/test/jdk/java/util/zip/DeInflate.java
@@ -47,11 +47,12 @@ public class DeInflate {
         Arrays.fill(out1, (byte)0);
         Arrays.fill(out2, (byte)0);
 
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (DeflaterOutputStream defos = new DeflaterOutputStream(baos, def)) {
-            defos.write(in, 0, len);
+        try(ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            try (DeflaterOutputStream defos = new DeflaterOutputStream(baos, def)) {
+                defos.write(in, 0, len);
+            }
+            out1 = baos.toByteArray();
         }
-        out1 = baos.toByteArray();
         int m = out1.length;
 
         Inflater inf = new Inflater(nowrap);

--- a/test/jdk/java/util/zip/DeInflate.java
+++ b/test/jdk/java/util/zip/DeInflate.java
@@ -143,7 +143,7 @@ public class DeInflate {
         def.setInput(in, 0, len);
         def.finish();
 
-        try(ByteArrayOutputStream baos = new ByteArrayOutputStream(len)) {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(len)) {
             while (!def.finished()) {
                 int temp_counter = def.deflate(tempBuffer);
                 m += temp_counter;

--- a/test/jdk/java/util/zip/DeInflate.java
+++ b/test/jdk/java/util/zip/DeInflate.java
@@ -161,7 +161,7 @@ public class DeInflate {
             }
             out2 = baos.toByteArray();
             if (n != len ||
-                !Arrays.equals(Arrays.copyOf(in, len), Arrays.copyOf(out2, len)) ||
+                !Arrays.equals(in, 0, len, out2, 0, len)) ||
                 inf.inflate(out2) != 0) {
                 System.out.printf("m=%d, n=%d, len=%d, eq=%b%n",
                                   m, n, len, Arrays.equals(in, out2));

--- a/test/jdk/java/util/zip/DeInflate.java
+++ b/test/jdk/java/util/zip/DeInflate.java
@@ -118,9 +118,20 @@ public class DeInflate {
         } catch (ReadOnlyBufferException robe) {}
     }
 
-    /*
-     * This method checks if a given Deflater and Inflater pair can correctly compress and decompress data.
-     * checks were performed for this functionality using various input scenarios and ByteBuffer instances.
+    /**
+     * Uses the {@code def} deflater to deflate the input data {@code in} of length {@code len}.
+     * A new {@link Inflater} is then created within this method to inflate the deflated data. The
+     * inflated data is then compared with the {@code in} to assert that it matches the original
+     * input data.
+     * This method repeats these checks for the different overloaded methods of
+     * {@code Deflater.deflate(...)} and {@code Inflater.inflate(...)}
+     *
+     * @param def    the deflater to use for deflating the contents in {@code in}
+     * @param in     the input content
+     * @param len    the length of the input content to use
+     * @param nowrap will be passed to the constructor of the {@code Inflater} used in this
+     *               method
+     * @throws Throwable if any error occurs during the check
      */
     static void check(Deflater def, byte[] in, int len, boolean nowrap)
         throws Throwable


### PR DESCRIPTION
DeInflate.java test fails on s390x platform because size for out1 array which is responsible for storing the compressed data is insufficient. And being unable to write whole compressed data on array, on s390 whole data can't be recovered after compression. This PR updates the check method in the DeInflate test to no longer rely on pre-defined lengths/sizes to determine whether deflate followed by an inflate of data worked correctly. These sizes can vary depending on the underlying zlib implementations. The updated check method now uses a `ByteArrayOutputStream` to deflate into and then inflate from. 

Thanks to @jaikiran for amazing PR description.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299748](https://bugs.openjdk.org/browse/JDK-8299748): java/util/zip/Deinflate.java failing on s390x


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [543d136a](https://git.openjdk.org/jdk/pull/12283/files/543d136ac6c96ddb2cade33c6cf8e921c1295955)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to [a1e2ace8](https://git.openjdk.org/jdk/pull/12283/files/a1e2ace8084b42ea2f999de950919bbd85a1f71b)
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - **Reviewer**)
 * [Andrey Turbanov](https://openjdk.org/census#aturbanov) (@turbanoff - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12283/head:pull/12283` \
`$ git checkout pull/12283`

Update a local copy of the PR: \
`$ git checkout pull/12283` \
`$ git pull https://git.openjdk.org/jdk.git pull/12283/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12283`

View PR using the GUI difftool: \
`$ git pr show -t 12283`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12283.diff">https://git.openjdk.org/jdk/pull/12283.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12283#issuecomment-1408156651)