### PR TITLE
8301326: Optimize compiler/uncommontrap/TestDeoptOOM.java test

### DIFF
--- a/test/hotspot/jtreg/compiler/uncommontrap/TestDeoptOOM.java
+++ b/test/hotspot/jtreg/compiler/uncommontrap/TestDeoptOOM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,17 +67,22 @@ public class TestDeoptOOM {
 
     static LinkedList ll;
 
-    static void consume_all_memory() {
-        int size = 128 * 1024 * 1024;
-        while(size > 0) {
-            try {
-                while(true) {
-                    ll = new LinkedList(ll, size);
-                }
-            } catch(OutOfMemoryError oom) {
+    static void alloc_in_chunks(int size) {
+        try {
+            while(true) {
+                ll = new LinkedList(ll, size);
             }
-            size = size / 2;
+        } catch(OutOfMemoryError oom) {
         }
+    }
+
+    static void consume_all_memory() {
+        // O(MiB) allocations
+        alloc_in_chunks(1024*1024);
+        // O(KiB) allocations
+        alloc_in_chunks(1024);
+        // O(B) allocations
+        alloc_in_chunks(1);
     }
 
     static void free_memory() {


### PR DESCRIPTION
In Generational ZGC, especially in Windows Github Actions `hotspot/jtreg/compiler/uncommontrap/TestDeoptOOM.java` test have a tendency to timeout. Most of the time is spent trying to recover from allocation stalls, but the code is purposely triggering OOM exceptions. 

This enhancement proposes rewriting the code which consumes all memory, by reducing the number of OOM recoveries by an order of magnitude. This change should not effect the intent of the test. 

An alternative solution would instrumenting the WhiteboxAPI with the consume all memory functionality. However this would be a much more intrusive change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301326](https://bugs.openjdk.org/browse/JDK-8301326): Optimize compiler/uncommontrap/TestDeoptOOM.java test


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12284/head:pull/12284` \
`$ git checkout pull/12284`

Update a local copy of the PR: \
`$ git checkout pull/12284` \
`$ git pull https://git.openjdk.org/jdk pull/12284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12284`

View PR using the GUI difftool: \
`$ git pr show -t 12284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12284.diff">https://git.openjdk.org/jdk/pull/12284.diff</a>

</details>
