### PR TITLE
8298424: Remove redundant FOUND_CORES variable in build-performance.m4

### DIFF
--- a/make/autoconf/build-performance.m4
+++ b/make/autoconf/build-performance.m4
@@ -26,8 +26,7 @@
 AC_DEFUN([BPERF_CHECK_CORES],
 [
   AC_MSG_CHECKING([for number of cores])
-  NUM_CORES=1
-  FOUND_CORES=no
+  NUM_CORES=0
 
   if test -f /proc/cpuinfo; then
     # Looks like a Linux (or cygwin) system
@@ -35,30 +34,25 @@ AC_DEFUN([BPERF_CHECK_CORES],
     if test "$NUM_CORES" -eq "0"; then
       NUM_CORES=`cat /proc/cpuinfo  | grep -c ^CPU`
     fi
-    if test "$NUM_CORES" -ne "0"; then
-      FOUND_CORES=yes
-    fi
   elif test -x /usr/sbin/sysctl; then
     # Looks like a MacOSX system
     NUM_CORES=`/usr/sbin/sysctl -n hw.ncpu`
-    FOUND_CORES=yes
   elif test "x$OPENJDK_BUILD_OS" = xaix ; then
     NUM_LCPU=`lparstat -m 2> /dev/null | $GREP -o "lcpu=[[0-9]]*" | $CUT -d "=" -f 2`
     if test -n "$NUM_LCPU"; then
       NUM_CORES=$NUM_LCPU
-      FOUND_CORES=yes
     fi
   elif test -n "$NUMBER_OF_PROCESSORS"; then
     # On windows, look in the env
     NUM_CORES=$NUMBER_OF_PROCESSORS
-    FOUND_CORES=yes
   fi
 
-  if test "x$FOUND_CORES" = xyes; then
-    AC_MSG_RESULT([$NUM_CORES])
-  else
+  if test "$NUM_CORES" -eq "0"; then
+    NUM_CORES=1
     AC_MSG_RESULT([could not detect number of cores, defaulting to 1])
     AC_MSG_WARN([This will disable all parallelism from build!])
+  else
+    AC_MSG_RESULT([$NUM_CORES])
   fi
 ])
 


### PR DESCRIPTION
Beside any specific reason which I'm unaware of, IMO FOUND_CORES variable serves no purpose. So probably we could remove it, without any issue. 

Any suggestion/thoughts are appreciated :)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298424](https://bugs.openjdk.org/browse/JDK-8298424): Remove redundant FOUND_CORES variable in build-performance.m4


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Tyler Steele](https://openjdk.org/census#tsteele) (@backwaterred - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12285/head:pull/12285` \
`$ git checkout pull/12285`

Update a local copy of the PR: \
`$ git checkout pull/12285` \
`$ git pull https://git.openjdk.org/jdk pull/12285/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12285`

View PR using the GUI difftool: \
`$ git pr show -t 12285`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12285.diff">https://git.openjdk.org/jdk/pull/12285.diff</a>

</details>
