### PR TITLE
8298413: [s390] CPUInfoTest fails due to uppercase feature string

### DIFF
--- a/src/hotspot/cpu/s390/vm_version_s390.cpp
+++ b/src/hotspot/cpu/s390/vm_version_s390.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,8 +82,8 @@ static const char* z_features[] = {"  ",
                                    "system-z, g5-z196, ldisp_fast, extimm, pcrel_load/store, cmpb, cond_load/store, interlocked_update",
                                    "system-z, g6-ec12, ldisp_fast, extimm, pcrel_load/store, cmpb, cond_load/store, interlocked_update, txm",
                                    "system-z, g7-z13, ldisp_fast, extimm, pcrel_load/store, cmpb, cond_load/store, interlocked_update, txm, vectorinstr",
-                                   "system-z, g8-z14, ldisp_fast, extimm, pcrel_load/store, cmpb, cond_load/store, interlocked_update, txm, vectorinstr, instrext2, venh1)",
-                                   "system-z, g9-z15, ldisp_fast, extimm, pcrel_load/store, cmpb, cond_load/store, interlocked_update, txm, vectorinstr, instrext2, venh1, instrext3, VEnh2 )"
+                                   "system-z, g8-z14, ldisp_fast, extimm, pcrel_load/store, cmpb, cond_load/store, interlocked_update, txm, vectorinstr, instrext2, venh1",
+                                   "system-z, g9-z15, ldisp_fast, extimm, pcrel_load/store, cmpb, cond_load/store, interlocked_update, txm, vectorinstr, instrext2, venh1, instrext3, venh2"
                                   };
 
 void VM_Version::initialize() {
@@ -374,7 +374,7 @@ void VM_Version::set_features_string() {
     strcpy(buf, "z/Architecture (unknown generation)");
   } else if (model_ix > 0) {
     _model_string = z_name[model_ix];
-    jio_snprintf(buf, sizeof(buf), "%s, out-of-support_as_of_", z_features[model_ix], z_EOS[model_ix]);
+    jio_snprintf(buf, sizeof(buf), "%s, out-of-support_as_of_%s", z_features[model_ix], z_EOS[model_ix]);
   } else if (model_ix < 0) {
     tty->print_cr("*** WARNING *** Ambiguous z/Architecture detection!");
     tty->print_cr("                oldest detected generation is %s", z_features[-model_ix]);


### PR DESCRIPTION
CPUInfoTest.java is failing on s390 due to an incorrect feature string. Feature Vector Enhancement is shown as VEnh2 instead of venh2. Beside that out-of-support date/(tbd) was not being included even if it was present there so this issue is also addressed by this fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298413](https://bugs.openjdk.org/browse/JDK-8298413): [s390] CPUInfoTest fails due to uppercase feature string


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12286/head:pull/12286` \
`$ git checkout pull/12286`

Update a local copy of the PR: \
`$ git checkout pull/12286` \
`$ git pull https://git.openjdk.org/jdk pull/12286/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12286`

View PR using the GUI difftool: \
`$ git pr show -t 12286`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12286.diff">https://git.openjdk.org/jdk/pull/12286.diff</a>

</details>
