### PR TITLE
8301337: Remove unused os::_polling_page

### DIFF
--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -270,8 +270,6 @@
   volatile_nonstatic_field(oopDesc,            _mark,                                         markWord)                              \
   volatile_nonstatic_field(oopDesc,            _metadata._klass,                              Klass*)                                \
                                                                                                                                      \
-  static_field(os,                             _polling_page,                                 address)                               \
-                                                                                                                                     \
   static_field(StubRoutines,                _verify_oop_count,                                jint)                                  \
                                                                                                                                      \
   static_field(StubRoutines,                _throw_delayed_StackOverflowError_entry,          address)                               \

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -81,7 +81,6 @@
 # include <errno.h>
 
 OSThread*         os::_starting_thread    = nullptr;
-address           os::_polling_page       = nullptr;
 volatile unsigned int os::_rand_seed      = 1234567;
 int               os::_processor_count    = 0;
 int               os::_initial_active_processor_count = 0;

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -188,7 +188,6 @@ class os: AllStatic {
 
  private:
   static OSThread*          _starting_thread;
-  static address            _polling_page;
   static PageSizes          _page_sizes;
 
   static char*  pd_reserve_memory(size_t bytes, bool executable);

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -380,12 +380,6 @@
      static_field(CompressedKlassPointers,     _narrow_klass._base,                           address)                               \
      static_field(CompressedKlassPointers,     _narrow_klass._shift,                          int)                                   \
                                                                                                                                      \
-  /******/                                                                                                                           \
-  /* os */                                                                                                                           \
-  /******/                                                                                                                           \
-                                                                                                                                     \
-     static_field(os,                          _polling_page,                                 address)                               \
-                                                                                                                                     \
   /**********/                                                                                                                       \
   /* Memory */                                                                                                                       \
   /**********/                                                                                                                       \


### PR DESCRIPTION
Hi, please consider removing the unused field _polling_page in os.

Built tested many platforms + t1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301337](https://bugs.openjdk.org/browse/JDK-8301337): Remove unused os::_polling_page


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12287/head:pull/12287` \
`$ git checkout pull/12287`

Update a local copy of the PR: \
`$ git checkout pull/12287` \
`$ git pull https://git.openjdk.org/jdk pull/12287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12287`

View PR using the GUI difftool: \
`$ git pr show -t 12287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12287.diff">https://git.openjdk.org/jdk/pull/12287.diff</a>

</details>
