### PR TITLE
8301338: Identical branch conditions in CompileBroker::print_heapinfo

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2782,13 +2782,13 @@ void CompileBroker::print_heapinfo(outputStream* out, const char* function, size
     ts.update(); // record starting point
     MutexLocker mu11(function_lock_1, Mutex::_safepoint_check_flag);
     MutexLocker mu22(function_lock_2, Mutex::_no_safepoint_check_flag);
-    if ((function_lock_1 != nullptr) || (function_lock_1 != nullptr)) {
+    if ((function_lock_1 != nullptr) || (function_lock_2 != nullptr)) {
       out->print_cr("\n__ Compile & CodeCache (function) lock wait took %10.3f seconds _________\n", ts.seconds());
     }
 
     ts.update(); // record starting point
     CodeCache::aggregate(out, granularity);
-    if ((function_lock_1 != nullptr) || (function_lock_1 != nullptr)) {
+    if ((function_lock_1 != nullptr) || (function_lock_2 != nullptr)) {
       out->print_cr("\n__ Compile & CodeCache (function) lock hold took %10.3f seconds _________\n", ts.seconds());
     }
   }


### PR DESCRIPTION
This was silently introduced by [JDK-8219586](https://bugs.openjdk.org/browse/JDK-8219586). SonarCloud complains:
 "Identical sub-expressions on both sides of operator "||".

There are two occurrences of:
```
 if ((function_lock_1 != NULL) || (function_lock_1 != NULL)) {
```

Additional testing:
 - [x] Linux x86_64 fastdebug, `-XX:+PrintCodeHeapAnalytics` adhoc run
 - [x] Linux x86_64 fastdebug, `compiler/codecache`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301338](https://bugs.openjdk.org/browse/JDK-8301338): Identical branch conditions in CompileBroker::print_heapinfo


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12288/head:pull/12288` \
`$ git checkout pull/12288`

Update a local copy of the PR: \
`$ git checkout pull/12288` \
`$ git pull https://git.openjdk.org/jdk pull/12288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12288`

View PR using the GUI difftool: \
`$ git pr show -t 12288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12288.diff">https://git.openjdk.org/jdk/pull/12288.diff</a>

</details>
