### PR TITLE
8301340: Make DirtyCardToOopClosure stack-allocated

### DIFF
--- a/src/hotspot/share/gc/shared/cardTableRS.cpp
+++ b/src/hotspot/share/gc/shared/cardTableRS.cpp
@@ -449,8 +449,8 @@ void CardTableRS::non_clean_card_iterate(TenuredSpace* sp,
   }
   // clear_cl finds contiguous dirty ranges of cards to process and clear.
 
-  DirtyCardToOopClosure* dcto_cl = sp->new_dcto_cl(cl);
-  ClearNoncleanCardWrapper clear_cl(dcto_cl, ct);
+  DirtyCardToOopClosure dcto_cl{sp, cl};
+  ClearNoncleanCardWrapper clear_cl(&dcto_cl, ct);
 
   clear_cl.do_MemRegion(mr);
 }

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -150,11 +150,6 @@ void DirtyCardToOopClosure::walk_mem_region_with_cl(MemRegion mr,
   }
 }
 
-DirtyCardToOopClosure*
-ContiguousSpace::new_dcto_cl(OopIterateClosure* cl) {
-  return new DirtyCardToOopClosure(this, cl);
-}
-
 void Space::initialize(MemRegion mr,
                        bool clear_space,
                        bool mangle_space) {

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -239,7 +239,7 @@ class Space: public CHeapObj<mtGC> {
 // 2. That the space is really made up of objects and not just
 //    blocks.
 
-class DirtyCardToOopClosure: public MemRegionClosureRO {
+class DirtyCardToOopClosure: public MemRegionClosure {
 protected:
   OopIterateClosure* _cl;
   Space* _sp;
@@ -472,8 +472,6 @@ class ContiguousSpace: public CompactibleSpace {
     assert(compaction_top() >= bottom() && compaction_top() <= end(), "should point inside space");
     set_top(compaction_top());
   }
-
-  DirtyCardToOopClosure* new_dcto_cl(OopIterateClosure* cl);
 
   // Apply "blk->do_oop" to the addresses of all reference fields in objects
   // starting with the _saved_mark_word, which was noted during a generation's

--- a/src/hotspot/share/memory/memRegion.hpp
+++ b/src/hotspot/share/memory/memRegion.hpp
@@ -105,15 +105,4 @@ public:
   virtual void do_MemRegion(MemRegion mr) = 0;
 };
 
-// A ResourceObj version of MemRegionClosure
-
-class MemRegionClosureRO: public MemRegionClosure {
-public:
-  void* operator new(size_t size) throw() {
-    return resource_allocate_bytes(size);
-  }
-
-  void  operator delete(void* p) {} // nothing to do
-};
-
 #endif // SHARE_MEMORY_MEMREGION_HPP


### PR DESCRIPTION
Simple change from resource-allocated to stack-allocated for a closure.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301340](https://bugs.openjdk.org/browse/JDK-8301340): Make DirtyCardToOopClosure stack-allocated


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12291/head:pull/12291` \
`$ git checkout pull/12291`

Update a local copy of the PR: \
`$ git checkout pull/12291` \
`$ git pull https://git.openjdk.org/jdk pull/12291/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12291`

View PR using the GUI difftool: \
`$ git pr show -t 12291`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12291.diff">https://git.openjdk.org/jdk/pull/12291.diff</a>

</details>
