### PR TITLE
8301214

### DIFF
--- a/test/jdk/java/rmi/transport/handshakeTimeout/HandshakeTimeout.java
+++ b/test/jdk/java/rmi/transport/handshakeTimeout/HandshakeTimeout.java
@@ -56,8 +56,7 @@ public class HandshakeTimeout {
 
     public static void main(String[] args) throws Exception {
 
-        System.setProperty("sun.rmi.transport.tcp.handshakeTimeout",
-                           String.valueOf(TIMEOUT / 2));
+        System.setProperty("sun.rmi.transport.tcp.handshakeTimeout", "1");
 
         /*
          * Listen on port, but never process connections made to it.


### PR DESCRIPTION
Please review this patch that reduces the socket timeout used in HandshakeTimeout test to its minimum value of 1 millisecond.

This change makes the test complete 10 seconds faster; before this change it took 5 seconds for the handshake to timeout, and the test attempts 2 handshakes.

The change also makes the test more likely to pass when it has to compete with other tests for CPU time.

