### PR TITLE
8301344: G1: Remove DirtyCardToOopClosure forward declaration in g1OopClosures.hpp

### DIFF
--- a/src/hotspot/share/gc/g1/g1OopClosures.hpp
+++ b/src/hotspot/share/gc/g1/g1OopClosures.hpp
@@ -34,7 +34,6 @@ class HeapRegion;
 class G1CollectedHeap;
 class G1RemSet;
 class G1ConcurrentMark;
-class DirtyCardToOopClosure;
 class G1CMBitMap;
 class G1ParScanThreadState;
 class G1ScanEvacuatedObjClosure;


### PR DESCRIPTION
Trivial removing unused declaration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301344](https://bugs.openjdk.org/browse/JDK-8301344): G1: Remove DirtyCardToOopClosure forward declaration in g1OopClosures.hpp


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12293/head:pull/12293` \
`$ git checkout pull/12293`

Update a local copy of the PR: \
`$ git checkout pull/12293` \
`$ git pull https://git.openjdk.org/jdk pull/12293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12293`

View PR using the GUI difftool: \
`$ git pr show -t 12293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12293.diff">https://git.openjdk.org/jdk/pull/12293.diff</a>

</details>
