### PR TITLE
8301346: Remove dead emit_entry_barrier_stub definition

### DIFF
--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.hpp
@@ -35,9 +35,6 @@
                                   enum shift_kind kind = Assembler::LSL, unsigned shift = 0);
 
  public:
-  void emit_entry_barrier_stub(C2EntryBarrierStub* stub);
-  static int entry_barrier_stub_size();
-
   void string_compare(Register str1, Register str2,
                       Register cnt1, Register cnt2, Register result,
                       Register tmp1, Register tmp2, FloatRegister vtmp1,

--- a/src/hotspot/cpu/arm/c2_MacroAssembler_arm.hpp
+++ b/src/hotspot/cpu/arm/c2_MacroAssembler_arm.hpp
@@ -28,9 +28,6 @@
 // C2_MacroAssembler contains high-level macros for C2
 
  public:
-  void emit_entry_barrier_stub(C2EntryBarrierStub* stub) {}
-  static int entry_barrier_stub_size() { return 0; }
-
   // Compare char[] arrays aligned to 4 bytes.
   void char_arrays_equals(Register ary1, Register ary2,
                           Register limit, Register result,

--- a/src/hotspot/cpu/ppc/c2_MacroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/c2_MacroAssembler_ppc.hpp
@@ -28,9 +28,6 @@
 // C2_MacroAssembler contains high-level macros for C2
 
  public:
-  void emit_entry_barrier_stub(C2EntryBarrierStub* stub) {}
-  static int entry_barrier_stub_size() { return 0; }
-
   // Intrinsics for CompactStrings
   // Compress char[] to byte[] by compressing 16 bytes at once.
   void string_compress_16(Register src, Register dst, Register cnt,

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -39,9 +39,6 @@
                        VectorRegister vrs,
                        bool is_latin, Label& DONE);
  public:
-  void emit_entry_barrier_stub(C2EntryBarrierStub* stub);
-  static int entry_barrier_stub_size();
-
   void string_compare(Register str1, Register str2,
                       Register cnt1, Register cnt2, Register result,
                       Register tmp1, Register tmp2, Register tmp3,

--- a/src/hotspot/cpu/s390/c2_MacroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/c2_MacroAssembler_s390.hpp
@@ -29,9 +29,6 @@
 // C2_MacroAssembler contains high-level macros for C2
 
  public:
-  void emit_entry_barrier_stub(C2EntryBarrierStub* stub) {}
-  static int entry_barrier_stub_size() { return 0; }
-
   //-------------------------------------------
   // Special String Intrinsics Implementation.
   //-------------------------------------------

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -31,9 +31,6 @@ public:
   // C2 compiled method's prolog code.
   void verified_entry(int framesize, int stack_bang_size, bool fp_mode_24b, bool is_stub);
 
-  void emit_entry_barrier_stub(C2EntryBarrierStub* stub);
-  static int entry_barrier_stub_size();
-
   Assembler::AvxVectorLen vector_length_encoding(int vlen_in_bytes);
 
   // Code used by cmpFastLock and cmpFastUnlock mach instructions in .ad file.


### PR DESCRIPTION
[JDK-8297036](https://bugs.openjdk.org/browse/JDK-8297036) removed the implementation of `emit_entry_barrier_stub` and `entry_barrier_stub_size` but not the definition in the header files.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301346](https://bugs.openjdk.org/browse/JDK-8301346): Remove dead emit_entry_barrier_stub definition


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12294/head:pull/12294` \
`$ git checkout pull/12294`

Update a local copy of the PR: \
`$ git checkout pull/12294` \
`$ git pull https://git.openjdk.org/jdk pull/12294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12294`

View PR using the GUI difftool: \
`$ git pr show -t 12294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12294.diff">https://git.openjdk.org/jdk/pull/12294.diff</a>

</details>
