### PR TITLE
8301313: RISC-V: C2: assert(false) failed: bad AD file due to missing match rule

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -10043,6 +10043,23 @@ instruct cmovI_cmpL(iRegINoSp dst, iRegI src, iRegL op1, iRegL op2, cmpOp cop) %
   ins_pipe(pipe_class_compare);
 %}
 
+instruct cmovI_cmpUL(iRegINoSp dst, iRegI src, iRegL op1, iRegL op2, cmpOpU cop) %{
+  match(Set dst (CMoveI (Binary cop (CmpUL op1 op2)) (Binary dst src)));
+  ins_cost(ALU_COST + BRANCH_COST);
+
+  format %{
+    "CMove $dst, ($op1 $cop $op2), $dst, $src\t#@cmovI_cmpUL\n\t"
+  %}
+
+  ins_encode %{
+    __ enc_cmove($cop$$cmpcode | C2_MacroAssembler::unsigned_branch_mask,
+                 as_Register($op1$$reg), as_Register($op2$$reg),
+                 as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(pipe_class_compare);
+%}
+
 instruct cmovL_cmpL(iRegLNoSp dst, iRegL src, iRegL op1, iRegL op2, cmpOp cop) %{
   match(Set dst (CMoveL (Binary cop (CmpL op1 op2)) (Binary dst src)));
   ins_cost(ALU_COST + BRANCH_COST);
@@ -10077,12 +10094,29 @@ instruct cmovL_cmpUL(iRegLNoSp dst, iRegL src, iRegL op1, iRegL op2, cmpOpU cop)
   ins_pipe(pipe_class_compare);
 %}
 
-instruct cmovI_cmpUL(iRegINoSp dst, iRegI src, iRegL op1, iRegL op2, cmpOpU cop) %{
-  match(Set dst (CMoveI (Binary cop (CmpUL op1 op2)) (Binary dst src)));
+instruct cmovL_cmpI(iRegLNoSp dst, iRegL src, iRegI op1, iRegI op2, cmpOp cop) %{
+  match(Set dst (CMoveL (Binary cop (CmpI op1 op2)) (Binary dst src)));
   ins_cost(ALU_COST + BRANCH_COST);
 
   format %{
-    "CMove $dst, ($op1 $cop $op2), $dst, $src\t#@cmovI_cmpUL\n\t"
+    "CMove $dst, ($op1 $cop $op2), $dst, $src\t#@cmovL_cmpI\n\t"
+  %}
+
+  ins_encode %{
+    __ enc_cmove($cop$$cmpcode,
+                 as_Register($op1$$reg), as_Register($op2$$reg),
+                 as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(pipe_class_compare);
+%}
+
+instruct cmovL_cmpU(iRegLNoSp dst, iRegL src, iRegI op1, iRegI op2, cmpOpU cop) %{
+  match(Set dst (CMoveL (Binary cop (CmpU op1 op2)) (Binary dst src)));
+  ins_cost(ALU_COST + BRANCH_COST);
+
+  format %{
+    "CMove $dst, ($op1 $cop $op2), $dst, $src\t#@cmovL_cmpU\n\t"
   %}
 
   ins_encode %{
@@ -10093,7 +10127,6 @@ instruct cmovI_cmpUL(iRegINoSp dst, iRegI src, iRegL op1, iRegL op2, cmpOpU cop)
 
   ins_pipe(pipe_class_compare);
 %}
-
 
 // ============================================================================
 // Procedure Call/Return Instructions


### PR DESCRIPTION
The RISC-V architecture does not support conditional move instructions or flags register for now. So we set `ConditionalMoveLimit` to 0 for this port to avoid the generation of the CMove node by C2. But turns out this could not avoid all CMove nodes generation: some CMove generations are not guarded by this parameter. Therefore, we still added several match rules in AD file for CMove nodes like `CMoveI_CmpI`/`CMoveL_CmpL` etc. to cover those scenarios:

https://github.com/openjdk/jdk/blob/ebb84ad70d3295d9a429904fcdacdb8ecd1bf434/src/hotspot/cpu/riscv/riscv.ad#L9994-L10096

In this case, we observed that CMoveL was generated in `PhaseIdealLoop::transform_long_range_checks`,  which is expected to match `cmoveL_cmpL` node:
https://github.com/openjdk/jdk/blob/ebb84ad70d3295d9a429904fcdacdb8ecd1bf434/src/hotspot/share/opto/loopnode.cpp#L1344-L1351

But `PhaseIdealLoop::optimize` after `PhaseIdealLoop::transform_long_range_checks` may replace CmpLNode with CmpINode in `CmpLNode::Ideal`:
https://github.com/openjdk/jdk/blob/ebb84ad70d3295d9a429904fcdacdb8ecd1bf434/src/hotspot/share/opto/subnode.cpp#L877-L886

There is no match rule in riscv.ad for CMoveL with CmpI, which result in the bad AD file crash.

With this fix, we should be able to cover all other CMove scenarios not guarded by `ConditionalMoveLimit`.

Testing:

- [x] jdk_foreign  with -XX:-TieredCompilation (linux-riscv64, fastdebug)
- [x] Tier1~3 on Unmatched board (linux-riscv64, release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301313](https://bugs.openjdk.org/browse/JDK-8301313): RISC-V: C2: assert(false) failed: bad AD file due to missing match rule


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Yadong Wang](https://openjdk.org/census#yadongwang) (@yadongw - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12295/head:pull/12295` \
`$ git checkout pull/12295`

Update a local copy of the PR: \
`$ git checkout pull/12295` \
`$ git pull https://git.openjdk.org/jdk pull/12295/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12295`

View PR using the GUI difftool: \
`$ git pr show -t 12295`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12295.diff">https://git.openjdk.org/jdk/pull/12295.diff</a>

</details>
