### PR TITLE
JDK-8301354: Modernize utilities/breakpoint.hpp

### DIFF
--- a/src/hotspot/cpu/s390/templateInterpreterGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/templateInterpreterGenerator_s390.cpp
@@ -2397,7 +2397,7 @@ void TemplateInterpreterGenerator::stop_interpreter_at() {
   __ z_ldr(Z_F8, Z_ftos);        // Save ftos.
   // Use -XX:StopInterpreterAt=<num> to set the limit
   // and break at breakpoint().
-  __ call_VM(noreg, CAST_FROM_FN_PTR(address, breakpoint), false);
+  __ call_VM(noreg, CAST_FROM_FN_PTR(address, os::breakpoint), false);
   __ z_lgr(Z_tos, Z_tmp_1);      // Restore tos.
   __ z_lgr(Z_bytecode, Z_tmp_2); // Save Z_bytecode.
   __ z_ldr(Z_ftos, Z_F8);        // Restore ftos.

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -587,17 +587,6 @@ void os::init_system_properties_values() {
 #undef EXTENSIONS_DIR
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// breakpoint support
-
-void os::breakpoint() {
-  BREAKPOINT;
-}
-
-extern "C" void breakpoint() {
-  // use debugger to set breakpoint here
-}
-
 // retrieve memory information.
 // Returns false if something went wrong;
 // content of pmi undefined in this case.

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -498,17 +498,6 @@ void os::init_system_properties_values() {
 #undef EXTENSIONS_DIR
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// breakpoint support
-
-void os::breakpoint() {
-  BREAKPOINT;
-}
-
-extern "C" void breakpoint() {
-  // use debugger to set breakpoint here
-}
-
 //////////////////////////////////////////////////////////////////////////////
 // create new thread
 

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -517,17 +517,6 @@ void os::init_system_properties_values() {
 #undef EXTENSIONS_DIR
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// breakpoint support
-
-void os::breakpoint() {
-  BREAKPOINT;
-}
-
-extern "C" void breakpoint() {
-  // use debugger to set breakpoint here
-}
-
 //////////////////////////////////////////////////////////////////////////////
 // detecting pthread library
 

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -400,15 +400,6 @@ void os::init_system_properties_values() {
   return;
 }
 
-void os::breakpoint() {
-  DebugBreak();
-}
-
-// Invoked from the BREAKPOINT Macro
-extern "C" void breakpoint() {
-  os::breakpoint();
-}
-
 // RtlCaptureStackBackTrace Windows API may not exist prior to Windows XP.
 // So far, this method is only used by Native Memory Tracking, which is
 // only supported on Windows XP or later.
@@ -5579,7 +5570,7 @@ bool os::start_debugging(char *buf, int buflen) {
   bool yes = os::message_box("Unexpected Error", buf);
 
   if (yes) {
-    // os::breakpoint() calls DebugBreak(), which causes a breakpoint
+    // os::breakpoint() calls __debugbreak(), which causes a breakpoint
     // exception. If VM is running inside a debugger, the debugger will
     // catch the exception. Otherwise, the breakpoint exception will reach
     // the default windows exception handler, which can spawn a debugger and

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -637,7 +637,7 @@ static void check_crash_protection() {
 static void break_if_ptr_caught(void* ptr) {
   if (p2i(ptr) == (intptr_t)MallocCatchPtr) {
     log_warning(malloc, free)("ptr caught: " PTR_FORMAT, p2i(ptr));
-    breakpoint();
+    BREAKPOINT;
   }
 }
 #endif // ASSERT

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -68,6 +68,7 @@
 #include "services/nmtCommon.hpp"
 #include "services/threadService.hpp"
 #include "utilities/align.hpp"
+#include "utilities/breakpoint.hpp"
 #include "utilities/count_trailing_zeros.hpp"
 #include "utilities/defaultStream.hpp"
 #include "utilities/events.hpp"
@@ -346,6 +347,10 @@ bool os::dll_locate_lib(char *buffer, size_t buflen,
 
   FREE_C_HEAP_ARRAY(char*, fullfname);
   return retval;
+}
+
+void os::breakpoint() {
+  BREAKPOINT;
 }
 
 // --------------------- sun.misc.Signal (optional) ---------------------

--- a/src/hotspot/share/utilities/breakpoint.hpp
+++ b/src/hotspot/share/utilities/breakpoint.hpp
@@ -33,7 +33,15 @@
 
 #if defined(TARGET_COMPILER_gcc)
 
+#ifdef __has_builtin
+#if __has_builtin(__builtin_debugtrap)
 #define BREAKPOINT __builtin_debugtrap()
+#endif
+#endif
+
+#ifndef BREAKPOINT
+#define BREAKPOINT __builtin_trap()
+#endif
 
 #elif defined(TARGET_COMPILER_visCPP)
 

--- a/src/hotspot/share/utilities/breakpoint.hpp
+++ b/src/hotspot/share/utilities/breakpoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Google and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,44 @@
 #ifndef SHARE_UTILITIES_BREAKPOINT_HPP
 #define SHARE_UTILITIES_BREAKPOINT_HPP
 
-// If no more specific definition provided, default to calling a
-// function that is defined per-platform.  See also os::breakpoint().
-#ifndef BREAKPOINT
-extern "C" void breakpoint();
-#define BREAKPOINT ::breakpoint()
+#include <csignal>
+
+// BREAKPOINT
+//
+// Programatically triggers a breakpoint for debuggers.
+
+#if defined(TARGET_COMPILER_gcc)
+
+#define BREAKPOINT __builtin_debugtrap()
+
+#elif defined(TARGET_COMPILER_visCPP)
+
+#include <intrin.h>
+
+#pragma intrinsic(__debugbreak)
+
+#define BREAKPOINT __debugbreak()
+
+#elif defined(TARGET_COMPILER_xlc)
+
+#if defined(SIGTRAP)
+
+#define BREAKPOINT ::raise(SIGTRAP)
+
+#elif defined(SIGINT)
+
+#define BREAKPOINT ::raise(SIGINT)
+
+#else
+
+#error Neither SIGTRAP or SIGINT is defined.
+
+#endif
+
+#else
+
+#error Unknown toolchain.
+
 #endif
 
 #endif // SHARE_UTILITIES_BREAKPOINT_HPP


### PR DESCRIPTION
Cleanup `utilities/breakpoint.hpp` by utilizing compiler intrinsics when available, or normal signals for AIX/XLC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301354](https://bugs.openjdk.org/browse/JDK-8301354): Modernize utilities/breakpoint.hpp


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12296/head:pull/12296` \
`$ git checkout pull/12296`

Update a local copy of the PR: \
`$ git checkout pull/12296` \
`$ git pull https://git.openjdk.org/jdk pull/12296/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12296`

View PR using the GUI difftool: \
`$ git pr show -t 12296`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12296.diff">https://git.openjdk.org/jdk/pull/12296.diff</a>

</details>
