### PR TITLE
8301207: (jdeps) Deprecate jdeps -profile option

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
@@ -515,6 +515,9 @@ class JdepsTask {
             if (options.version || options.fullVersion) {
                 showVersion(options.fullVersion);
             }
+            if (options.showProfile && !options.nowarning) {
+                warning("warn.deprecated.option", "-profile");
+            }
             if (options.help || options.version || options.fullVersion) {
                 return EXIT_OK;
             }

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/resources/jdeps.properties
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/resources/jdeps.properties
@@ -99,8 +99,8 @@ main.opt.include=\n\
 \                                -p and -e which apply pattern to the dependences
 
 main.opt.P=\
-\  -P       -profile             Show profile containing a package
-
+\  -P       -profile             Show profile containing a package.  This option\n\
+\                                is deprecated and may be removed in a future release.
 main.opt.cp=\
 \  -cp <path>\n\
 \  -classpath <path>\n\
@@ -252,6 +252,7 @@ err.missing.dependences=\
 Missing dependencies: classes not found from the module path and classpath.\n\
 To suppress this error, use --ignore-missing-deps to continue.
 
+warn.deprecated.option={0} option is deprecated and may be removed in a future release.
 warn.invalid.arg=Path does not exist: {0}
 warn.skipped.entry={0}
 warn.split.package=split package: {0} {1}


### PR DESCRIPTION
jdeps -profile option shows which compact profile of the types that a class depends on instead.  By default jdeps shows the types and their modules that a class depend on.  Compact profiles becomes legacy since Java SE 9 when modules are defined.   The `-profile` option can be deprecated and removed in a future release to reduce the maintenance.

CSR: https://bugs.openjdk.org/browse/JDK-8301295

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8301295](https://bugs.openjdk.org/browse/JDK-8301295) to be approved

### Issues
 * [JDK-8301207](https://bugs.openjdk.org/browse/JDK-8301207): (jdeps) Deprecate jdeps -profile option
 * [JDK-8301295](https://bugs.openjdk.org/browse/JDK-8301295): (jdeps) Deprecate jdeps -profile option (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12297/head:pull/12297` \
`$ git checkout pull/12297`

Update a local copy of the PR: \
`$ git checkout pull/12297` \
`$ git pull https://git.openjdk.org/jdk pull/12297/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12297`

View PR using the GUI difftool: \
`$ git pr show -t 12297`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12297.diff">https://git.openjdk.org/jdk/pull/12297.diff</a>

</details>
