### PR TITLE
JDK-8301378: CodeHeap has virtual methods that are not overridden

### DIFF
--- a/src/hotspot/share/memory/heap.hpp
+++ b/src/hotspot/share/memory/heap.hpp
@@ -175,8 +175,8 @@ class CodeHeap : public CHeapObj<mtCode> {
     return contains((void*)blob);
   }
 
-  virtual void* find_start(void* p)     const;   // returns the block containing p or null
-  virtual CodeBlob* find_blob(void* start) const;
+  void* find_start(void* p)     const;   // returns the block containing p or null
+  CodeBlob* find_blob(void* start) const;
   size_t alignment_unit()       const;           // alignment of any block
   size_t alignment_offset()     const;           // offset of first byte of any block, within the enclosing alignment unit
   static size_t header_size()         { return sizeof(HeapBlock); } // returns the header size for each heap block
@@ -192,9 +192,9 @@ class CodeHeap : public CHeapObj<mtCode> {
   int    freelist_length()       const           { return _freelist_length; } // number of elements in the freelist
 
   // returns the first block or null
-  virtual void* first() const                    { return next_used(first_block()); }
+  void* first() const                    { return next_used(first_block()); }
   // returns the next block given a block p or null
-  virtual void* next(void* p) const              { return next_used(next_block(block_start(p))); }
+  void* next(void* p) const              { return next_used(next_block(block_start(p))); }
 
   // Statistics
   size_t capacity() const;


### PR DESCRIPTION
Remove unused `virtual` specifiers on `CodeHeap` methods. Virtual dispatch is not free in C++ and usually incurs a vtable lookup unless the compiler can prove the type is final, which with the current setup is not feasible.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301378](https://bugs.openjdk.org/browse/JDK-8301378): CodeHeap has virtual methods that are not overridden


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12298/head:pull/12298` \
`$ git checkout pull/12298`

Update a local copy of the PR: \
`$ git checkout pull/12298` \
`$ git pull https://git.openjdk.org/jdk pull/12298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12298`

View PR using the GUI difftool: \
`$ git pr show -t 12298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12298.diff">https://git.openjdk.org/jdk/pull/12298.diff</a>

</details>
