### PR TITLE
8299324: inline_native_setCurrentThread lacks GC barrier for Shenandoah

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
@@ -199,7 +199,6 @@ void ShenandoahBarrierSetC2::satb_write_barrier_pre(GraphKit* kit,
 
   if (do_load) {
     // We need to generate the load of the previous value
-    assert(obj != NULL, "must have a base");
     assert(adr != NULL, "where are loading from?");
     assert(pre_val == NULL, "loaded already?");
     assert(val_type != NULL, "need a type");
@@ -499,10 +498,7 @@ Node* ShenandoahBarrierSetC2::store_at_resolved(C2Access& access, C2AccessValue&
   const TypePtr* adr_type = access.addr().type();
   Node* adr = access.addr().node();
 
-  bool anonymous = (decorators & ON_UNKNOWN_OOP_REF) != 0;
-  bool on_heap = (decorators & IN_HEAP) != 0;
-
-  if (!access.is_oop() || (!on_heap && !anonymous)) {
+  if (!access.is_oop()) {
     return BarrierSetC2::store_at_resolved(access, val);
   }
 


### PR DESCRIPTION
Allow Shenandoah barrier to emit the store barrier for native memory. I believe it is safe to delete the assert on L202 because `obj` is not used here. Tested with `hotspot:hotspot_gc` and `hotspot:loom` with `JAVA_OPTIONS=-XX:+UseShenandoahGC` (and again with  -XX:TieredStopAtLevel=1).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299324](https://bugs.openjdk.org/browse/JDK-8299324): inline_native_setCurrentThread lacks GC barrier for Shenandoah


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12300/head:pull/12300` \
`$ git checkout pull/12300`

Update a local copy of the PR: \
`$ git checkout pull/12300` \
`$ git pull https://git.openjdk.org/jdk pull/12300/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12300`

View PR using the GUI difftool: \
`$ git pr show -t 12300`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12300.diff">https://git.openjdk.org/jdk/pull/12300.diff</a>

</details>
