### PR TITLE
JDK-8301392: Port fdlibm log1p to Java

### DIFF
--- a/src/java.base/share/classes/java/lang/FdLibm.java
+++ b/src/java.base/share/classes/java/lang/FdLibm.java
@@ -780,10 +780,10 @@ class FdLibm {
      * shown.
      */
     static class Log10 {
-        private static double ivln10    = 0x1.bcb7b1526e50ep-2;  // 4.34294481903251816668e-01
+        private static final double ivln10    = 0x1.bcb7b1526e50ep-2;  // 4.34294481903251816668e-01
 
-        private static double log10_2hi = 0x1.34413509f6p-2;     // 3.01029995663611771306e-01;
-        private static double log10_2lo = 0x1.9fef311f12b36p-42; // 3.69423907715893078616e-13;
+        private static final double log10_2hi = 0x1.34413509f6p-2;     // 3.01029995663611771306e-01;
+        private static final double log10_2lo = 0x1.9fef311f12b36p-42; // 3.69423907715893078616e-13;
 
         private Log10() {
             throw new UnsupportedOperationException();
@@ -904,38 +904,38 @@ class FdLibm {
             int k, hx, hu=0, ax;
 
             hx = __HI(x);           /* high word of x */
-            ax = hx & 0x7fffffff;
+            ax = hx & 0x7fff_ffff;
 
             k = 1;
-            if (hx < 0x3FDA827A) {                  /* x < 0.41422  */
-                if(ax >= 0x3ff00000) {                /* x <= -1.0 */
+            if (hx < 0x3FDA_827A) {                  /* x < 0.41422  */
+                if (ax >= 0x3ff0_0000)               /* x <= -1.0 */
                     if (x == -1.0) /* log1p(-1)=-inf */
                         return -INFINITY;
                     else
                         return Double.NaN;           /* log1p(x < -1) = NaN */
                 }
 
-                if (ax < 0x3e200000) {                 /* |x| < 2**-29 */
-                    if (TWO54 + x > 0.0                 /* raise inexact */
-                       && ax < 0x3c900000)            /* |x| < 2**-54 */
+                if (ax < 0x3e20_0000) {                /* |x| < 2**-29 */
+                    if (TWO54 + x > 0.0                /* raise inexact */
+                       && ax < 0x3c90_0000)            /* |x| < 2**-54 */
                         return x;
                     else
                         return x - x*x*0.5;
                 }
 
-                if (hx > 0 || hx <= 0xbfd2bec3) { /* -0.2929 < x < 0.41422 */
+                if (hx > 0 || hx <= 0xbfd2_bec3) { /* -0.2929 < x < 0.41422 */
                     k=0;
                     f=x;
                     hu=1;
                 }
             }
 
-            if (hx >= 0x7ff00000) {
+            if (hx >= 0x7ff0_0000) {
                 return x+x;
             }
 
             if (k != 0) {
-                if (hx < 0x43400000) {
+                if (hx < 0x4340_0000) {
                     u  = 1.0 + x;
                     hu = __HI(u);           /* high word of u */
                     k  = (hu >> 20) - 1023;
@@ -947,13 +947,13 @@ class FdLibm {
                     k  = (hu >> 20) - 1023;
                     c  = 0;
                 }
-                hu &= 0x000fffff;
-                if (hu < 0x6a09e) {
-                    u = __HI(u, hu | 0x3ff00000);        /* normalize u */
+                hu &= 0x000f_ffff;
+                if (hu < 0x6_a09e) {
+                    u = __HI(u, hu | 0x3ff0_0000);       /* normalize u */
                 } else {
                     k += 1;
-                    u = __HI(u, hu | 0x3fe00000);        /* normalize u/2 */
-                    hu = (0x00100000 - hu) >> 2;
+                    u = __HI(u, hu | 0x3fe0_0000);       /* normalize u/2 */
+                    hu = (0x0010_0000 - hu) >> 2;
                 }
                 f = u - 1.0;
             }

--- a/src/java.base/share/classes/java/lang/FdLibm.java
+++ b/src/java.base/share/classes/java/lang/FdLibm.java
@@ -931,7 +931,7 @@ class FdLibm {
             }
 
             if (hx >= 0x7ff0_0000) {
-                return x+x;
+                return x + x;
             }
 
             if (k != 0) {
@@ -979,7 +979,7 @@ class FdLibm {
             z = s * s;
             R = z * (Lp1 + z * (Lp2 + z * (Lp3 + z * (Lp4 + z * (Lp5 + z * (Lp6 + z*Lp7))))));
             if (k == 0) {
-                return f-(hfsq-s*(hfsq+R));
+                return f - (hfsq - s*(hfsq + R));
             } else {
                 return k * ln2_hi - ((hfsq - (s*(hfsq + R) + (k * ln2_lo+c))) - f);
             }

--- a/src/java.base/share/classes/java/lang/FdLibm.java
+++ b/src/java.base/share/classes/java/lang/FdLibm.java
@@ -908,7 +908,7 @@ class FdLibm {
 
             k = 1;
             if (hx < 0x3FDA_827A) {                  /* x < 0.41422  */
-                if (ax >= 0x3ff0_0000)               /* x <= -1.0 */
+                if (ax >= 0x3ff0_0000) {             /* x <= -1.0 */
                     if (x == -1.0) /* log1p(-1)=-inf */
                         return -INFINITY;
                     else

--- a/src/java.base/share/classes/java/lang/FdLibm.java
+++ b/src/java.base/share/classes/java/lang/FdLibm.java
@@ -899,74 +899,83 @@ class FdLibm {
         private static double Lp5 = 1.818357216161805012e-01;  /* 3FC74664 96CB03DE */
         private static double Lp6 = 1.531383769920937332e-01;  /* 3FC39A09 D078C69F */
         private static double Lp7 = 1.479819860511658591e-01;  /* 3FC2F112 DF3E5244 */
-        private static double zero = 0.0;
 
         public static double compute(double x) {
-            double hfsq,f=0,c=0,s,z,R,u;
-            int k,hx,hu=0,ax;
+            double hfsq, f=0, c=0, s, z, R, u;
+            int k, hx, hu=0, ax;
 
             hx = __HI(x);           /* high word of x */
-            ax = hx&0x7fffffff;
+            ax = hx & 0x7fffffff;
 
             k = 1;
             if (hx < 0x3FDA827A) {                  /* x < 0.41422  */
-                if(ax>=0x3ff00000) {                /* x <= -1.0 */
-                    /*
-                     * Added redundant test against hx to work around VC++
-                     * code generation problem.
-                     */
-                    if(x==-1.0 && (hx==0xbff00000)) /* log1p(-1)=-inf */
-                        return -two54/zero;
+                if(ax >= 0x3ff00000) {                /* x <= -1.0 */
+                    if (x == -1.0) /* log1p(-1)=-inf */
+                        return -two54 / 0.0;
                     else
                         return (x-x)/(x-x);           /* log1p(x<-1)=NaN */
                 }
-                if(ax<0x3e200000) {                 /* |x| < 2**-29 */
-                    if(two54+x>zero                 /* raise inexact */
-                       &&ax<0x3c900000)            /* |x| < 2**-54 */
+                if (ax < 0x3e200000) {                 /* |x| < 2**-29 */
+                    if (two54 + x>0.0                 /* raise inexact */
+                       && ax < 0x3c900000)            /* |x| < 2**-54 */
                         return x;
                     else
                         return x - x*x*0.5;
                 }
-                if(hx>0||hx<=(0xbfd2bec3)) {
-                    k=0;f=x;hu=1;}  /* -0.2929<x<0.41422 */
+                if (hx > 0 || hx <= (0xbfd2bec3)) {
+                    k=0;
+                    f=x;
+                    hu=1;}  /* -0.2929<x<0.41422 */
             }
             if (hx >= 0x7ff00000) return x+x;
-            if(k!=0) {
-                if(hx<0x43400000) {
-                    u  = 1.0+x;
+            if (k != 0) {
+                if (hx < 0x43400000) {
+                    u  = 1.0 + x;
                     hu = __HI(u);           /* high word of u */
-                    k  = (hu>>20)-1023;
-                    c  = (k>0)? 1.0-(u-x):x-(u-1.0);/* correction term */
+                    k  = (hu >> 20) - 1023;
+                    c  = (k > 0)? 1.0 - (u-x) : x-(u-1.0); /* correction term */
                     c /= u;
                 } else {
                     u  = x;
                     hu = __HI(u);           /* high word of u */
-                    k  = (hu>>20)-1023;
+                    k  = (hu >> 20) - 1023;
                     c  = 0;
                 }
                 hu &= 0x000fffff;
-                if(hu<0x6a09e) {
-                    u = __HI(u, hu|0x3ff00000);        /* normalize u */
+                if (hu < 0x6a09e) {
+                    u = __HI(u, hu | 0x3ff00000);        /* normalize u */
                 } else {
                     k += 1;
-                    u = __HI(u, hu|0x3fe00000);        /* normalize u/2 */
-                    hu = (0x00100000-hu)>>2;
+                    u = __HI(u, hu | 0x3fe00000);        /* normalize u/2 */
+                    hu = (0x00100000 - hu) >> 2;
                 }
-                f = u-1.0;
+                f = u - 1.0;
             }
             hfsq=0.5*f*f;
-            if(hu==0) {     /* |f| < 2**-20 */
-                if(f==zero) { if(k==0) return zero;
-                    else {c += k*ln2_lo; return k*ln2_hi+c;}}
-                R = hfsq*(1.0-0.66666666666666666*f);
-                if(k==0) return f-R; else
-                    return k*ln2_hi-((R-(k*ln2_lo+c))-f);
+            if (hu == 0) {     /* |f| < 2**-20 */
+                if (f == 0.0) {
+                    if(k==0) {
+                        return 0.0;
+                    } else {
+                        c += k * ln2_lo;
+                        return k * ln2_hi + c;
+                    }
+                }
+                R = hfsq * (1.0 - 0.66666666666666666*f);
+                if (k == 0) {
+                    return f-R;
+                } else {
+                    return k * ln2_hi - ((R-(k * ln2_lo+c)) - f);
+                }
             }
-            s = f/(2.0+f);
-            z = s*s;
-            R = z*(Lp1+z*(Lp2+z*(Lp3+z*(Lp4+z*(Lp5+z*(Lp6+z*Lp7))))));
-            if(k==0) return f-(hfsq-s*(hfsq+R)); else
-                return k*ln2_hi-((hfsq-(s*(hfsq+R)+(k*ln2_lo+c)))-f);
+            s = f/(2.0 + f);
+            z = s * s;
+            R = z * (Lp1 + z * (Lp2 + z * (Lp3 + z * (Lp4 + z * (Lp5 + z * (Lp6 + z*Lp7))))));
+            if(k==0) {
+                return f-(hfsq-s*(hfsq+R));
+            } else {
+                return k * ln2_hi - ((hfsq - (s*(hfsq + R) + (k * ln2_lo+c))) - f);
+            }
         }
     }
 }

--- a/src/java.base/share/classes/java/lang/FdLibm.java
+++ b/src/java.base/share/classes/java/lang/FdLibm.java
@@ -915,19 +915,25 @@ class FdLibm {
                     else
                         return (x-x)/(x-x);           /* log1p(x<-1)=NaN */
                 }
+
                 if (ax < 0x3e200000) {                 /* |x| < 2**-29 */
-                    if (two54 + x>0.0                 /* raise inexact */
+                    if (two54 + x > 0.0                 /* raise inexact */
                        && ax < 0x3c900000)            /* |x| < 2**-54 */
                         return x;
                     else
                         return x - x*x*0.5;
                 }
-                if (hx > 0 || hx <= (0xbfd2bec3)) {
+
+                if (hx > 0 || hx <= 0xbfd2bec3) {
                     k=0;
                     f=x;
-                    hu=1;}  /* -0.2929<x<0.41422 */
+                    hu=1;}  /* -0.2929 < x < 0.41422 */
             }
-            if (hx >= 0x7ff00000) return x+x;
+
+            if (hx >= 0x7ff00000) {
+                return x+x;
+            }
+
             if (k != 0) {
                 if (hx < 0x43400000) {
                     u  = 1.0 + x;
@@ -951,10 +957,11 @@ class FdLibm {
                 }
                 f = u - 1.0;
             }
-            hfsq=0.5*f*f;
+
+            hfsq = 0.5*f*f;
             if (hu == 0) {     /* |f| < 2**-20 */
                 if (f == 0.0) {
-                    if(k==0) {
+                    if (k == 0) {
                         return 0.0;
                     } else {
                         c += k * ln2_lo;
@@ -963,7 +970,7 @@ class FdLibm {
                 }
                 R = hfsq * (1.0 - 0.66666666666666666*f);
                 if (k == 0) {
-                    return f-R;
+                    return f - R;
                 } else {
                     return k * ln2_hi - ((R-(k * ln2_lo+c)) - f);
                 }
@@ -971,7 +978,7 @@ class FdLibm {
             s = f/(2.0 + f);
             z = s * s;
             R = z * (Lp1 + z * (Lp2 + z * (Lp3 + z * (Lp4 + z * (Lp5 + z * (Lp6 + z*Lp7))))));
-            if(k==0) {
+            if (k == 0) {
                 return f-(hfsq-s*(hfsq+R));
             } else {
                 return k * ln2_hi - ((hfsq - (s*(hfsq + R) + (k * ln2_lo+c))) - f);

--- a/src/java.base/share/classes/java/lang/FdLibm.java
+++ b/src/java.base/share/classes/java/lang/FdLibm.java
@@ -822,4 +822,151 @@ class FdLibm {
             return  z + y * log10_2hi;
         }
     }
+
+    /**
+     * Returns the natural logarithm of the sum of the argument and 1.
+     *
+     * Method :
+     *   1. Argument Reduction: find k and f such that
+     *                      1+x = 2^k * (1+f),
+     *         where  sqrt(2)/2 < 1+f < sqrt(2) .
+     *
+     *      Note. If k=0, then f=x is exact. However, if k!=0, then f
+     *      may not be representable exactly. In that case, a correction
+     *      term is need. Let u=1+x rounded. Let c = (1+x)-u, then
+     *      log(1+x) - log(u) ~ c/u. Thus, we proceed to compute log(u),
+     *      and add back the correction term c/u.
+     *      (Note: when x > 2**53, one can simply return log(x))
+     *
+     *   2. Approximation of log1p(f).
+     *      Let s = f/(2+f) ; based on log(1+f) = log(1+s) - log(1-s)
+     *               = 2s + 2/3 s**3 + 2/5 s**5 + .....,
+     *               = 2s + s*R
+     *      We use a special Reme algorithm on [0,0.1716] to generate
+     *      a polynomial of degree 14 to approximate R The maximum error
+     *      of this polynomial approximation is bounded by 2**-58.45. In
+     *      other words,
+     *                      2      4      6      8      10      12      14
+     *          R(z) ~ Lp1*s +Lp2*s +Lp3*s +Lp4*s +Lp5*s  +Lp6*s  +Lp7*s
+     *      (the values of Lp1 to Lp7 are listed in the program)
+     *      and
+     *          |      2          14          |     -58.45
+     *          | Lp1*s +...+Lp7*s    -  R(z) | <= 2
+     *          |                             |
+     *      Note that 2s = f - s*f = f - hfsq + s*hfsq, where hfsq = f*f/2.
+     *      In order to guarantee error in log below 1ulp, we compute log
+     *      by
+     *              log1p(f) = f - (hfsq - s*(hfsq+R)).
+     *
+     *      3. Finally, log1p(x) = k*ln2 + log1p(f).
+     *                           = k*ln2_hi+(f-(hfsq-(s*(hfsq+R)+k*ln2_lo)))
+     *         Here ln2 is split into two floating point number:
+     *                      ln2_hi + ln2_lo,
+     *         where n*ln2_hi is always exact for |n| < 2000.
+     *
+     * Special cases:
+     *      log1p(x) is NaN with signal if x < -1 (including -INF) ;
+     *      log1p(+INF) is +INF; log1p(-1) is -INF with signal;
+     *      log1p(NaN) is that NaN with no signal.
+     *
+     * Accuracy:
+     *      according to an error analysis, the error is always less than
+     *      1 ulp (unit in the last place).
+     *
+     * Constants:
+     * The hexadecimal values are the intended ones for the following
+     * constants. The decimal values may be used, provided that the
+     * compiler will convert from decimal to binary accurately enough
+     * to produce the hexadecimal values shown.
+     *
+     * Note: Assuming log() return accurate answer, the following
+     *       algorithm can be used to compute log1p(x) to within a few ULP:
+     *
+     *              u = 1+x;
+     *              if(u==1.0) return x ; else
+     *                         return log(u)*(x/(u-1.0));
+     *
+     *       See HP-15C Advanced Functions Handbook, p.193.
+     */
+    static class Log1p {
+        private static double ln2_hi  =  6.93147180369123816490e-01;  /* 3fe62e42 fee00000 */
+        private static double ln2_lo  =  1.90821492927058770002e-10;  /* 3dea39ef 35793c76 */
+        private static double two54   =  1.80143985094819840000e+16;  /* 43500000 00000000 */
+        private static double Lp1 = 6.666666666666735130e-01;  /* 3FE55555 55555593 */
+        private static double Lp2 = 3.999999999940941908e-01;  /* 3FD99999 9997FA04 */
+        private static double Lp3 = 2.857142874366239149e-01;  /* 3FD24924 94229359 */
+        private static double Lp4 = 2.222219843214978396e-01;  /* 3FCC71C5 1D8E78AF */
+        private static double Lp5 = 1.818357216161805012e-01;  /* 3FC74664 96CB03DE */
+        private static double Lp6 = 1.531383769920937332e-01;  /* 3FC39A09 D078C69F */
+        private static double Lp7 = 1.479819860511658591e-01;  /* 3FC2F112 DF3E5244 */
+        private static double zero = 0.0;
+
+        public static double compute(double x) {
+            double hfsq,f=0,c=0,s,z,R,u;
+            int k,hx,hu=0,ax;
+
+            hx = __HI(x);           /* high word of x */
+            ax = hx&0x7fffffff;
+
+            k = 1;
+            if (hx < 0x3FDA827A) {                  /* x < 0.41422  */
+                if(ax>=0x3ff00000) {                /* x <= -1.0 */
+                    /*
+                     * Added redundant test against hx to work around VC++
+                     * code generation problem.
+                     */
+                    if(x==-1.0 && (hx==0xbff00000)) /* log1p(-1)=-inf */
+                        return -two54/zero;
+                    else
+                        return (x-x)/(x-x);           /* log1p(x<-1)=NaN */
+                }
+                if(ax<0x3e200000) {                 /* |x| < 2**-29 */
+                    if(two54+x>zero                 /* raise inexact */
+                       &&ax<0x3c900000)            /* |x| < 2**-54 */
+                        return x;
+                    else
+                        return x - x*x*0.5;
+                }
+                if(hx>0||hx<=(0xbfd2bec3)) {
+                    k=0;f=x;hu=1;}  /* -0.2929<x<0.41422 */
+            }
+            if (hx >= 0x7ff00000) return x+x;
+            if(k!=0) {
+                if(hx<0x43400000) {
+                    u  = 1.0+x;
+                    hu = __HI(u);           /* high word of u */
+                    k  = (hu>>20)-1023;
+                    c  = (k>0)? 1.0-(u-x):x-(u-1.0);/* correction term */
+                    c /= u;
+                } else {
+                    u  = x;
+                    hu = __HI(u);           /* high word of u */
+                    k  = (hu>>20)-1023;
+                    c  = 0;
+                }
+                hu &= 0x000fffff;
+                if(hu<0x6a09e) {
+                    u = __HI(u, hu|0x3ff00000);        /* normalize u */
+                } else {
+                    k += 1;
+                    u = __HI(u, hu|0x3fe00000);        /* normalize u/2 */
+                    hu = (0x00100000-hu)>>2;
+                }
+                f = u-1.0;
+            }
+            hfsq=0.5*f*f;
+            if(hu==0) {     /* |f| < 2**-20 */
+                if(f==zero) { if(k==0) return zero;
+                    else {c += k*ln2_lo; return k*ln2_hi+c;}}
+                R = hfsq*(1.0-0.66666666666666666*f);
+                if(k==0) return f-R; else
+                    return k*ln2_hi-((R-(k*ln2_lo+c))-f);
+            }
+            s = f/(2.0+f);
+            z = s*s;
+            R = z*(Lp1+z*(Lp2+z*(Lp3+z*(Lp4+z*(Lp5+z*(Lp6+z*Lp7))))));
+            if(k==0) return f-(hfsq-s*(hfsq+R)); else
+                return k*ln2_hi-((hfsq-(s*(hfsq+R)+(k*ln2_lo+c)))-f);
+        }
+    }
 }

--- a/src/java.base/share/classes/java/lang/StrictMath.java
+++ b/src/java.base/share/classes/java/lang/StrictMath.java
@@ -2124,7 +2124,9 @@ public final class StrictMath {
      * log of {@code x}&nbsp;+&nbsp;1
      * @since 1.5
      */
-    public static native double log1p(double x);
+    public static double log1p(double x) {
+        return FdLibm.Log1p.compute(x);
+    }
 
     /**
      * Returns the first floating-point argument with the sign of the

--- a/test/jdk/java/lang/StrictMath/FdlibmTranslit.java
+++ b/test/jdk/java/lang/StrictMath/FdlibmTranslit.java
@@ -82,6 +82,10 @@ public class FdlibmTranslit {
         return Log10.compute(x);
     }
 
+    public static double log1p(double x) {
+        return Log1p.compute(x);
+    }
+
     /**
      * cbrt(x)
      * Return cube root of x
@@ -458,6 +462,153 @@ public class FdlibmTranslit {
             x = __HI(x, hx); //original: __HI(x) = hx;
             z  = y*log10_2lo + ivln10*StrictMath.log(x); // TOOD: switch to Translit.log when available
             return  z+y*log10_2hi;
+        }
+    }
+
+    /**
+     * Returns the natural logarithm of the sum of the argument and 1.
+     *
+     * Method :
+     *   1. Argument Reduction: find k and f such that
+     *                      1+x = 2^k * (1+f),
+     *         where  sqrt(2)/2 < 1+f < sqrt(2) .
+     *
+     *      Note. If k=0, then f=x is exact. However, if k!=0, then f
+     *      may not be representable exactly. In that case, a correction
+     *      term is need. Let u=1+x rounded. Let c = (1+x)-u, then
+     *      log(1+x) - log(u) ~ c/u. Thus, we proceed to compute log(u),
+     *      and add back the correction term c/u.
+     *      (Note: when x > 2**53, one can simply return log(x))
+     *
+     *   2. Approximation of log1p(f).
+     *      Let s = f/(2+f) ; based on log(1+f) = log(1+s) - log(1-s)
+     *               = 2s + 2/3 s**3 + 2/5 s**5 + .....,
+     *               = 2s + s*R
+     *      We use a special Reme algorithm on [0,0.1716] to generate
+     *      a polynomial of degree 14 to approximate R The maximum error
+     *      of this polynomial approximation is bounded by 2**-58.45. In
+     *      other words,
+     *                      2      4      6      8      10      12      14
+     *          R(z) ~ Lp1*s +Lp2*s +Lp3*s +Lp4*s +Lp5*s  +Lp6*s  +Lp7*s
+     *      (the values of Lp1 to Lp7 are listed in the program)
+     *      and
+     *          |      2          14          |     -58.45
+     *          | Lp1*s +...+Lp7*s    -  R(z) | <= 2
+     *          |                             |
+     *      Note that 2s = f - s*f = f - hfsq + s*hfsq, where hfsq = f*f/2.
+     *      In order to guarantee error in log below 1ulp, we compute log
+     *      by
+     *              log1p(f) = f - (hfsq - s*(hfsq+R)).
+     *
+     *      3. Finally, log1p(x) = k*ln2 + log1p(f).
+     *                           = k*ln2_hi+(f-(hfsq-(s*(hfsq+R)+k*ln2_lo)))
+     *         Here ln2 is split into two floating point number:
+     *                      ln2_hi + ln2_lo,
+     *         where n*ln2_hi is always exact for |n| < 2000.
+     *
+     * Special cases:
+     *      log1p(x) is NaN with signal if x < -1 (including -INF) ;
+     *      log1p(+INF) is +INF; log1p(-1) is -INF with signal;
+     *      log1p(NaN) is that NaN with no signal.
+     *
+     * Accuracy:
+     *      according to an error analysis, the error is always less than
+     *      1 ulp (unit in the last place).
+     *
+     * Constants:
+     * The hexadecimal values are the intended ones for the following
+     * constants. The decimal values may be used, provided that the
+     * compiler will convert from decimal to binary accurately enough
+     * to produce the hexadecimal values shown.
+     *
+     * Note: Assuming log() return accurate answer, the following
+     *       algorithm can be used to compute log1p(x) to within a few ULP:
+     *
+     *              u = 1+x;
+     *              if(u==1.0) return x ; else
+     *                         return log(u)*(x/(u-1.0));
+     *
+     *       See HP-15C Advanced Functions Handbook, p.193.
+     */
+    static class Log1p {
+        private static double ln2_hi  =  6.93147180369123816490e-01;  /* 3fe62e42 fee00000 */
+        private static double ln2_lo  =  1.90821492927058770002e-10;  /* 3dea39ef 35793c76 */
+        private static double two54   =  1.80143985094819840000e+16;  /* 43500000 00000000 */
+        private static double Lp1 = 6.666666666666735130e-01;  /* 3FE55555 55555593 */
+        private static double Lp2 = 3.999999999940941908e-01;  /* 3FD99999 9997FA04 */
+        private static double Lp3 = 2.857142874366239149e-01;  /* 3FD24924 94229359 */
+        private static double Lp4 = 2.222219843214978396e-01;  /* 3FCC71C5 1D8E78AF */
+        private static double Lp5 = 1.818357216161805012e-01;  /* 3FC74664 96CB03DE */
+        private static double Lp6 = 1.531383769920937332e-01;  /* 3FC39A09 D078C69F */
+        private static double Lp7 = 1.479819860511658591e-01;  /* 3FC2F112 DF3E5244 */
+        private static double zero = 0.0;
+
+        public static double compute(double x) {
+            double hfsq,f=0,c=0,s,z,R,u;
+            int k,hx,hu=0,ax;
+
+            hx = __HI(x);           /* high word of x */
+            ax = hx&0x7fffffff;
+
+            k = 1;
+            if (hx < 0x3FDA827A) {                  /* x < 0.41422  */
+                if(ax>=0x3ff00000) {                /* x <= -1.0 */
+                    /*
+                     * Added redundant test against hx to work around VC++
+                     * code generation problem.
+                     */
+                    if(x==-1.0 && (hx==0xbff00000)) /* log1p(-1)=-inf */
+                        return -two54/zero;
+                    else
+                        return (x-x)/(x-x);           /* log1p(x<-1)=NaN */
+                }
+                if(ax<0x3e200000) {                 /* |x| < 2**-29 */
+                    if(two54+x>zero                 /* raise inexact */
+                       &&ax<0x3c900000)            /* |x| < 2**-54 */
+                        return x;
+                    else
+                        return x - x*x*0.5;
+                }
+                if(hx>0||hx<=((int)0xbfd2bec3)) {
+                    k=0;f=x;hu=1;}  /* -0.2929<x<0.41422 */
+            }
+            if (hx >= 0x7ff00000) return x+x;
+            if(k!=0) {
+                if(hx<0x43400000) {
+                    u  = 1.0+x;
+                    hu = __HI(u);           /* high word of u */
+                    k  = (hu>>20)-1023;
+                    c  = (k>0)? 1.0-(u-x):x-(u-1.0);/* correction term */
+                    c /= u;
+                } else {
+                    u  = x;
+                    hu = __HI(u);           /* high word of u */
+                    k  = (hu>>20)-1023;
+                    c  = 0;
+                }
+                hu &= 0x000fffff;
+                if(hu<0x6a09e) {
+                    u = __HI(u, hu|0x3ff00000);        /* normalize u */
+                } else {
+                    k += 1;
+                    u = __HI(u, hu|0x3fe00000);        /* normalize u/2 */
+                    hu = (0x00100000-hu)>>2;
+                }
+                f = u-1.0;
+            }
+            hfsq=0.5*f*f;
+            if(hu==0) {     /* |f| < 2**-20 */
+                if(f==zero) { if(k==0) return zero;
+                    else {c += k*ln2_lo; return k*ln2_hi+c;}}
+                R = hfsq*(1.0-0.66666666666666666*f);
+                if(k==0) return f-R; else
+                    return k*ln2_hi-((R-(k*ln2_lo+c))-f);
+            }
+            s = f/(2.0+f);
+            z = s*s;
+            R = z*(Lp1+z*(Lp2+z*(Lp3+z*(Lp4+z*(Lp5+z*(Lp6+z*Lp7))))));
+            if(k==0) return f-(hfsq-s*(hfsq+R)); else
+                return k*ln2_hi-((hfsq-(s*(hfsq+R)+(k*ln2_lo+c)))-f);
         }
     }
 }

--- a/test/jdk/java/lang/StrictMath/Log1pTests.java
+++ b/test/jdk/java/lang/StrictMath/Log1pTests.java
@@ -254,7 +254,7 @@ public class Log1pTests {
 
          for (double testPoint : conditionalPoints) {
              failures += testRangeMidpoint(testPoint, Math.ulp(testPoint), 1000);
-         } 
+         }
 
          x = Tests.createRandomDouble(random);
 

--- a/test/jdk/java/lang/StrictMath/Log1pTests.java
+++ b/test/jdk/java/lang/StrictMath/Log1pTests.java
@@ -232,7 +232,7 @@ public class Log1pTests {
         failures += testRange(x, Math.ulp(x), 1000);
 
         // ... and just below subnormal threshold ...
-        x =  Math.nextDown(Double.MIN_NORMAL);
+        x = Math.nextDown(Double.MIN_NORMAL);
         failures += testRange(x, -Math.ulp(x), 1000);
 
         // ... and near 1.0 ...

--- a/test/jdk/java/lang/StrictMath/Log1pTests.java
+++ b/test/jdk/java/lang/StrictMath/Log1pTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,18 @@
 
 /*
  * @test
- * @bug 4851638
+ * @bug 4851638 8301392
+ * @key randomness
+ * @library /test/lib
+ * @build jdk.test.lib.RandomFactory
+ * @build Tests
+ * @build FdlibmTranslit
+ * @build Log1pTests
+ * @run main Log1pTests
  * @summary Tests for StrictMath.log1p
  */
+
+import jdk.test.lib.RandomFactory;
 
 /**
  * The tests in ../Math/Log1pTests.java test properties that should
@@ -40,6 +49,19 @@
 
 public class Log1pTests {
     private Log1pTests(){}
+
+    public static void main(String... args) {
+        int failures = 0;
+
+        failures += testLog1p();
+        failures += testAgainstTranslit();
+
+        if (failures > 0) {
+            System.err.println("Testing log1p incurred "
+                               + failures + " failures.");
+            throw new RuntimeException();
+        }
+    }
 
     static int testLog1pCase(double input, double expected) {
         return Tests.test("StrictMath.log1p(double)", input,
@@ -195,15 +217,47 @@ public class Log1pTests {
         return failures;
     }
 
-    public static void main(String [] argv) {
+    // Initialize shared random number generator
+    private static java.util.Random random = RandomFactory.getRandom();
+
+    /**
+     * Test StrictMath.log1p against transliteration port of log1p.
+     */
+    private static int testAgainstTranslit() {
         int failures = 0;
+        double x;
 
-        failures += testLog1p();
+        // Test just above subnormal threshold...
+        x = Double.MIN_NORMAL;
+        failures += testRange(x, Math.ulp(x), 1000);
 
-        if (failures > 0) {
-            System.err.println("Testing log1p incurred "
-                               + failures + " failures.");
-            throw new RuntimeException();
+        // ... and just below subnormal threshold ...
+         x =  Math.nextDown(Double.MIN_NORMAL);
+         failures += testRange(x, -Math.ulp(x), 1000);
+
+        // ... and near 1.0 ...
+         x = 1.0;
+         failures += testRange(x, Math.ulp(x), 1000);
+         x = Math.nextDown(1.0);
+         failures += testRange(x, -Math.ulp(x), 1000);
+
+         x = Tests.createRandomDouble(random);
+
+         // Make the increment twice the ulp value in case the random
+         // value is near an exponent threshold. Don't worry about test
+         // elements overflowing to infinity if the starting value is
+         // near Double.MAX_VALUE.
+         failures += testRange(x, 2.0 * Math.ulp(x), 1000);
+
+         return failures;
+    }
+
+    private static int testRange(double start, double increment, int count) {
+        int failures = 0;
+        double x = start;
+        for (int i = 0; i < count; i++, x += increment) {
+            failures += testLog1pCase(x, FdlibmTranslit.log1p(x));
         }
+        return failures;
     }
 }

--- a/test/jdk/java/lang/StrictMath/Log1pTests.java
+++ b/test/jdk/java/lang/StrictMath/Log1pTests.java
@@ -232,14 +232,20 @@ public class Log1pTests {
         failures += testRange(x, Math.ulp(x), 1000);
 
         // ... and just below subnormal threshold ...
-         x =  Math.nextDown(Double.MIN_NORMAL);
-         failures += testRange(x, -Math.ulp(x), 1000);
+        x =  Math.nextDown(Double.MIN_NORMAL);
+        failures += testRange(x, -Math.ulp(x), 1000);
 
         // ... and near 1.0 ...
-         x = 1.0;
-         failures += testRange(x, Math.ulp(x), 1000);
-         x = Math.nextDown(1.0);
-         failures += testRange(x, -Math.ulp(x), 1000);
+        x = 1.0;
+        failures += testRange(x, Math.ulp(x), 1000);
+        x = Math.nextDown(1.0);
+        failures += testRange(x, -Math.ulp(x), 1000);
+
+        // ... and near 2^-29 ...
+        x = 0x1.0p-29;
+        failures += testRange(x, Math.ulp(x), 1000);
+        x = Math.nextDown(1.0);
+        failures += testRange(x, -Math.ulp(x), 1000);
 
          x = Tests.createRandomDouble(random);
 

--- a/test/jdk/java/lang/StrictMath/Log1pTests.java
+++ b/test/jdk/java/lang/StrictMath/Log1pTests.java
@@ -235,17 +235,26 @@ public class Log1pTests {
         x = Math.nextDown(Double.MIN_NORMAL);
         failures += testRange(x, -Math.ulp(x), 1000);
 
-        // ... and near 1.0 ...
-        x = 1.0;
-        failures += testRange(x, Math.ulp(x), 1000);
-        x = Math.nextDown(1.0);
-        failures += testRange(x, -Math.ulp(x), 1000);
+         double[] conditionalPoints = {
+              1.0,
+             -0x1.0p-29,
+              0x1.0p-29,
 
-        // ... and near 2^-29 ...
-        x = 0x1.0p-29;
-        failures += testRange(x, Math.ulp(x), 1000);
-        x = Math.nextDown(1.0);
-        failures += testRange(x, -Math.ulp(x), 1000);
+             -0x1.0p-54,
+              0x1.0p-54,
+
+              -0.2930,
+              -0.2929,
+              -0.2928,
+
+               0.41421,
+               0.41422,
+               0.41423,
+         };
+
+         for (double testPoint : conditionalPoints) {
+             failures += testRangeMidpoint(testPoint, Math.ulp(testPoint), 1000);
+         } 
 
          x = Tests.createRandomDouble(random);
 
@@ -261,6 +270,15 @@ public class Log1pTests {
     private static int testRange(double start, double increment, int count) {
         int failures = 0;
         double x = start;
+        for (int i = 0; i < count; i++, x += increment) {
+            failures += testLog1pCase(x, FdlibmTranslit.log1p(x));
+        }
+        return failures;
+    }
+
+    private static int testRangeMidpoint(double midpoint, double increment, int count) {
+        int failures = 0;
+        double x = midpoint - increment*(count / 2) ;
         for (int i = 0; i < count; i++, x += increment) {
             failures += testLog1pCase(x, FdlibmTranslit.log1p(x));
         }

--- a/test/jdk/java/lang/StrictMath/Log1pTests.java
+++ b/test/jdk/java/lang/StrictMath/Log1pTests.java
@@ -235,24 +235,24 @@ public class Log1pTests {
         x = Math.nextDown(Double.MIN_NORMAL);
         failures += testRange(x, -Math.ulp(x), 1000);
 
-         double[] conditionalPoints = {
-              1.0,
-             -0x1.0p-29,
-              0x1.0p-29,
+        // Probe near decision points in the FDLIBM algorithm.
+        double[] decisionPoints = {
+             1.0,
+            -0x1.0p-29,
+             0x1.0p-29,
+            -0x1.0p-54,
+             0x1.0p-54,
 
-             -0x1.0p-54,
-              0x1.0p-54,
+            -0.2930, // approx. sqrt(2)/2 -1
+            -0.2929,
+            -0.2928,
 
-              -0.2930,
-              -0.2929,
-              -0.2928,
-
-               0.41421,
-               0.41422,
-               0.41423,
+             0.41421, // approx. sqrt(2) -1
+             0.41422,
+             0.41423,
          };
 
-         for (double testPoint : conditionalPoints) {
+         for (double testPoint : decisionPoints) {
              failures += testRangeMidpoint(testPoint, Math.ulp(testPoint), 1000);
          }
 


### PR DESCRIPTION
Another day, another PR to port FDLBIM to Java, this time for the log1p method.

Other than using the two-argument form of the __HI method in Java transliteration version rather than C macro, there are no appreciable differences between the original C source in 

src/java.base/share/native/libfdlibm/s_log1p.c

and the transliteration for testing purposes in

test/jdk/java/lang/StrictMath/FdlibmTranslit.java

The more idiomatic port in

src/java.base/share/classes/java/lang/FdLibm.java

has had a series of transformation applied layering on the transliteration. The intermediate commits show the progress.

The regression tests include probing around input values the implementation uses to decided which branch to take.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301392](https://bugs.openjdk.org/browse/JDK-8301392): Port fdlibm log1p to Java


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12301/head:pull/12301` \
`$ git checkout pull/12301`

Update a local copy of the PR: \
`$ git checkout pull/12301` \
`$ git pull https://git.openjdk.org/jdk pull/12301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12301`

View PR using the GUI difftool: \
`$ git pr show -t 12301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12301.diff">https://git.openjdk.org/jdk/pull/12301.diff</a>

</details>
