### PR TITLE
8301371: Interpreter store barriers on x86_64 don't have disjoint temp registers

### DIFF
--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -152,7 +152,10 @@ static void do_oop_store(InterpreterMacroAssembler* _masm,
                          Register val,
                          DecoratorSet decorators = 0) {
   assert(val == noreg || val == rax, "parameter is just for looks");
-  __ store_heap_oop(dst, val, rdx, rbx, LP64_ONLY(r8) NOT_LP64(rsi), decorators);
+  __ store_heap_oop(dst, val,
+                    NOT_LP64(rdx) LP64_ONLY(rscratch2),
+                    NOT_LP64(rbx) LP64_ONLY(r9),
+                    NOT_LP64(rsi) LP64_ONLY(r8), decorators);
 }
 
 static void do_oop_load(InterpreterMacroAssembler* _masm,


### PR DESCRIPTION
The interpreter store barriers on x86_64 use temp registers that sometimes intersects with registers that are part of the address. Therefore, when clobbering temp registers, the address gets destroyed. This has happened to be okay so far, based on how these registers are used in existing backends, but it doesn't work well for generational ZGC. This CR selects new temp registers that I have verified works for everyone on x86_64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301371](https://bugs.openjdk.org/browse/JDK-8301371): Interpreter store barriers on x86_64 don't have disjoint temp registers


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12309/head:pull/12309` \
`$ git checkout pull/12309`

Update a local copy of the PR: \
`$ git checkout pull/12309` \
`$ git pull https://git.openjdk.org/jdk pull/12309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12309`

View PR using the GUI difftool: \
`$ git pr show -t 12309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12309.diff">https://git.openjdk.org/jdk/pull/12309.diff</a>

</details>
