### PR TITLE
8301465: Remove unnecessary nmethod arming in Full GC of Serial/Parallel

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -872,12 +872,6 @@ void CodeCache::on_gc_marking_cycle_finish() {
   update_cold_gc_count();
 }
 
-// Arm nmethods so that special actions are taken (nmethod_entry_barrier) for
-// on-stack nmethods. It's used in two places:
-// 1. Used before the start of concurrent marking so that oops inside on-stack
-//    nmethods are visited.
-// 2. Used at the end of (stw/concurrent) marking so that nmethod::_gc_epoch is
-//    up-to-date, which provides more accurate estimate of nmethod::is_cold.
 void CodeCache::arm_all_nmethods() {
   BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
   if (bs_nm != nullptr) {

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -872,6 +872,12 @@ void CodeCache::on_gc_marking_cycle_finish() {
   update_cold_gc_count();
 }
 
+// Arm nmethods so that special actions are taken (nmethod_entry_barrier) for
+// on-stack nmethods. It's used in two places:
+// 1. Used before the start of concurrent marking so that oops inside on-stack
+//    nmethods are visited.
+// 2. Used at the end of (stw/concurrent) marking so that nmethod::_gc_epoch is
+//    up-to-date, which provides more accurate estimate of nmethod::is_cold.
 void CodeCache::arm_all_nmethods() {
   BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
   if (bs_nm != nullptr) {

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -203,6 +203,13 @@ class CodeCache : AllStatic {
   static uint64_t previous_completed_gc_marking_cycle();
   static void on_gc_marking_cycle_start();
   static void on_gc_marking_cycle_finish();
+  // Arm nmethods so that special actions are taken (nmethod_entry_barrier) for
+  // on-stack nmethods. It's used in two places:
+  // 1. Used before the start of concurrent marking so that oops inside
+  //    on-stack nmethods are visited.
+  // 2. Used at the end of (stw/concurrent) marking so that nmethod::_gc_epoch
+  //    is up-to-date, which provides more accurate estimate of
+  //    nmethod::is_cold.
   static void arm_all_nmethods();
 
   static void flush_unlinked_nmethods();

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -962,7 +962,6 @@ void PSParallelCompact::pre_compact()
   heap->increment_total_collections(true);
 
   CodeCache::on_gc_marking_cycle_start();
-  CodeCache::arm_all_nmethods();
 
   heap->print_heap_before_gc();
   heap->trace_heap_before_gc(&_gc_tracer);

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -602,7 +602,6 @@ void GenCollectedHeap::do_collection(bool           full,
     }
 
     CodeCache::on_gc_marking_cycle_start();
-    CodeCache::arm_all_nmethods();
 
     collect_generation(_old_gen,
                        full,


### PR DESCRIPTION
Simple removing unnecessary code and adding API documentation.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301465](https://bugs.openjdk.org/browse/JDK-8301465): Remove unnecessary nmethod arming in Full GC of Serial/Parallel


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12311/head:pull/12311` \
`$ git checkout pull/12311`

Update a local copy of the PR: \
`$ git checkout pull/12311` \
`$ git pull https://git.openjdk.org/jdk pull/12311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12311`

View PR using the GUI difftool: \
`$ git pr show -t 12311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12311.diff">https://git.openjdk.org/jdk/pull/12311.diff</a>

</details>
