### PR TITLE
8301402: os::print_location gets is_global_handle assert

### DIFF
--- a/src/hotspot/share/runtime/jniHandles.cpp
+++ b/src/hotspot/share/runtime/jniHandles.cpp
@@ -242,15 +242,13 @@ bool JNIHandles::is_frame_handle(JavaThread* thr, jobject handle) {
 
 bool JNIHandles::is_global_handle(jobject handle) {
   assert(handle != nullptr, "precondition");
-  assert(!is_global_tagged(handle) || is_storage_handle(global_handles(), global_ptr(handle)), "invalid storage");
-  return is_global_tagged(handle);
+  return is_global_tagged(handle) && is_storage_handle(global_handles(), global_ptr(handle));
 }
 
 
 bool JNIHandles::is_weak_global_handle(jobject handle) {
   assert(handle != nullptr, "precondition");
-  assert(!is_weak_global_tagged(handle) || is_storage_handle(weak_global_handles(), weak_global_ptr(handle)), "invalid storage");
-  return is_weak_global_tagged(handle);
+  return is_weak_global_tagged(handle) && is_storage_handle(weak_global_handles(), weak_global_ptr(handle));
 }
 
 // We assume this is called at a safepoint: no lock is needed.


### PR DESCRIPTION
[JDK-8299089](https://bugs.openjdk.org/browse/JDK-8299089) introduced a change all valid handles are tagged. However the `is_[weak_]global_handle` methods are used in context where the jobject handle may not be a valid handle, so the underlying storage must be checked. 

It now checks both the tag and the storage.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301402](https://bugs.openjdk.org/browse/JDK-8301402): os::print_location gets is_global_handle assert


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12312/head:pull/12312` \
`$ git checkout pull/12312`

Update a local copy of the PR: \
`$ git checkout pull/12312` \
`$ git pull https://git.openjdk.org/jdk pull/12312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12312`

View PR using the GUI difftool: \
`$ git pr show -t 12312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12312.diff">https://git.openjdk.org/jdk/pull/12312.diff</a>

</details>
