### PR TITLE
JDK-8301477: Replace NULL with nullptr in os/aix

### DIFF
--- a/src/hotspot/os/aix/attachListener_aix.cpp
+++ b/src/hotspot/os/aix/attachListener_aix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2018 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -85,7 +85,7 @@ class AixAttachListener: AllStatic {
   };
 
   static void set_path(char* path) {
-    if (path == NULL) {
+    if (path == nullptr) {
       _path[0] = '\0';
       _has_path = false;
     } else {
@@ -153,7 +153,7 @@ class ArgumentIterator : public StackObj {
       if (_pos < _end) {
         _pos += 1;
       }
-      return NULL;
+      return nullptr;
     }
     char* res = _pos;
     char* next_pos = strchr(_pos, '\0');
@@ -188,7 +188,7 @@ extern "C" {
     }
     if (AixAttachListener::has_path()) {
       ::unlink(AixAttachListener::path());
-      AixAttachListener::set_path(NULL);
+      AixAttachListener::set_path(nullptr);
     }
   }
 }
@@ -296,7 +296,7 @@ AixAttachOperation* AixAttachListener::read_request(int s) {
     assert(n <= left, "buffer was too small, impossible!");
     buf[max_len - 1] = '\0';
     if (n == -1) {
-      return NULL;      // reset by peer or other error
+      return nullptr;      // reset by peer or other error
     }
     if (n == 0) {
       break;
@@ -314,7 +314,7 @@ AixAttachOperation* AixAttachListener::read_request(int s) {
             char msg[32];
             os::snprintf_checked(msg, sizeof(msg), "%d\n", ATTACH_ERROR_BADVERSION);
             write_fully(s, msg, strlen(msg));
-            return NULL;
+            return nullptr;
           }
         }
       }
@@ -324,7 +324,7 @@ AixAttachOperation* AixAttachListener::read_request(int s) {
   } while (left > 0 && str_count < expected_str_count);
 
   if (str_count != expected_str_count) {
-    return NULL;        // incomplete request
+    return nullptr;        // incomplete request
   }
 
   // parse request
@@ -335,20 +335,20 @@ AixAttachOperation* AixAttachListener::read_request(int s) {
   char* v = args.next();
 
   char* name = args.next();
-  if (name == NULL || strlen(name) > AttachOperation::name_length_max) {
-    return NULL;
+  if (name == nullptr || strlen(name) > AttachOperation::name_length_max) {
+    return nullptr;
   }
 
   AixAttachOperation* op = new AixAttachOperation(name);
 
   for (int i=0; i<AttachOperation::arg_count_max; i++) {
     char* arg = args.next();
-    if (arg == NULL) {
-      op->set_arg(i, NULL);
+    if (arg == nullptr) {
+      op->set_arg(i, nullptr);
     } else {
       if (strlen(arg) > AttachOperation::arg_length_max) {
         delete op;
-        return NULL;
+        return nullptr;
       }
       op->set_arg(i, arg);
     }
@@ -377,13 +377,13 @@ AixAttachOperation* AixAttachListener::dequeue() {
     if (AixAttachListener::is_shutdown()) {
       ::close(listener());
       set_listener(-1);
-      return NULL;
+      return nullptr;
     }
     s = ::accept(listener(), &addr, &len);
     if (s == -1) {
       ::close(listener());
       set_listener(-1);
-      return NULL;      // log a warning?
+      return nullptr;      // log a warning?
     }
 
     // get the credentials of the peer and check the effective uid/guid
@@ -404,7 +404,7 @@ AixAttachOperation* AixAttachListener::dequeue() {
 
     // peer credential look okay so we read the request
     AixAttachOperation* op = read_request(s);
-    if (op == NULL) {
+    if (op == nullptr) {
       ::close(s);
       continue;
     } else {
@@ -580,7 +580,7 @@ void AttachListener::pd_data_dump() {
 }
 
 AttachOperationFunctionInfo* AttachListener::pd_find_operation(const char* n) {
-  return NULL;
+  return nullptr;
 }
 
 jint AttachListener::pd_set_flag(AttachOperation* op, outputStream* out) {

--- a/src/hotspot/os/aix/libo4.hpp
+++ b/src/hotspot/os/aix/libo4.hpp
@@ -45,7 +45,7 @@ public:
   //
   // See libo4.h for details on this API.
   //
-  // Specify NULL for numbers you are not interested in.
+  // Specify null for numbers you are not interested in.
   //
   // Returns false if an error happened. Activate OsMisc trace for
   // trace output.
@@ -61,7 +61,7 @@ public:
   //
   // See libo4.h for details on this API.
   //
-  // Specify NULL for numbers you are not interested in.
+  // Specify null for numbers you are not interested in.
   //
   // Returns false if an error happened. Activate OsMisc trace for
   // trace output.

--- a/src/hotspot/os/aix/libodm_aix.cpp
+++ b/src/hotspot/os/aix/libodm_aix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015, 2019 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -46,7 +46,7 @@ dynamicOdm::dynamicOdm() {
   if (!_odm_initialize || !_odm_set_path || !_odm_mount_class || !_odm_get_obj || !_odm_terminate) {
     trcVerbose("Couldn't find all required odm symbols from %s", libodmname);
     dlclose(_libhandle);
-    _libhandle = NULL;
+    _libhandle = nullptr;
     return;
   }
 }
@@ -56,7 +56,7 @@ dynamicOdm::~dynamicOdm() {
 }
 
 
-void odmWrapper::clean_data() { if (_data) { free(_data); _data = NULL; } }
+void odmWrapper::clean_data() { if (_data) { free(_data); _data = nullptr; } }
 
 
 int odmWrapper::class_offset(const char *field, bool is_aix_5)

--- a/src/hotspot/os/aix/libodm_aix.hpp
+++ b/src/hotspot/os/aix/libodm_aix.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015, 2019 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -53,7 +53,7 @@ class dynamicOdm {
  public:
   dynamicOdm();
   ~dynamicOdm();
-  bool odm_loaded() {return _libhandle != NULL; }
+  bool odm_loaded() {return _libhandle != nullptr; }
 };
 
 
@@ -68,8 +68,8 @@ class odmWrapper : private dynamicOdm {
 
  public:
   // Make sure everything gets initialized and cleaned up properly.
-  explicit odmWrapper(const char* odm_class_name, const char* odm_path = NULL) : _odm_class((CLASS_SYMBOL)-1),
-                                                                     _data(NULL), _initialized(false) {
+  explicit odmWrapper(const char* odm_class_name, const char* odm_path = nullptr) : _odm_class((CLASS_SYMBOL)-1),
+                                                                     _data(nullptr), _initialized(false) {
     if (!odm_loaded()) { return; }
     _initialized = ((*_odm_initialize)() != -1);
     if (_initialized) {
@@ -88,9 +88,9 @@ class odmWrapper : private dynamicOdm {
   int class_offset(const char *field, bool is_aix_5);
   char* data() { return _data; }
 
-  char* retrieve_obj(const char* name = NULL) {
+  char* retrieve_obj(const char* name = nullptr) {
     clean_data();
-    char *cnp = (char*)(void*)(*_odm_get_obj)(odm_class(), (char*) name, NULL, (name == NULL) ? ODM_NEXT : ODM_FIRST);
+    char *cnp = (char*)(void*)(*_odm_get_obj)(odm_class(), (char*) name, nullptr, (name == nullptr) ? ODM_NEXT : ODM_FIRST);
     if (cnp != (char*)-1) { _data = cnp; }
     return data();
   }

--- a/src/hotspot/os/aix/libperfstat_aix.cpp
+++ b/src/hotspot/os/aix/libperfstat_aix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2018 SAP SE. All rights reserved.
  * Copyright (c) 2022, IBM Corp.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -30,7 +30,7 @@
 #include <dlfcn.h>
 
 // Handle to the libperfstat.
-static void* g_libhandle = NULL;
+static void* g_libhandle = nullptr;
 
 typedef int (*fun_perfstat_cpu_t) (perfstat_id_t *name, PERFSTAT_CPU_T_LATEST* userbuff,
                                    int sizeof_userbuff, int desired_number);
@@ -60,15 +60,15 @@ typedef void (*fun_perfstat_reset_t) ();
 
 typedef cid_t (*fun_wpar_getcid_t) ();
 
-static fun_perfstat_cpu_total_t       g_fun_perfstat_cpu_total       = NULL;
-static fun_perfstat_cpu_t             g_fun_perfstat_cpu             = NULL;
-static fun_perfstat_memory_total_t    g_fun_perfstat_memory_total    = NULL;
-static fun_perfstat_netinterface_t    g_fun_perfstat_netinterface    = NULL;
-static fun_perfstat_partition_total_t g_fun_perfstat_partition_total = NULL;
-static fun_perfstat_process_t         g_fun_perfstat_process         = NULL;
-static fun_perfstat_wpar_total_t      g_fun_perfstat_wpar_total      = NULL;
-static fun_perfstat_reset_t           g_fun_perfstat_reset           = NULL;
-static fun_wpar_getcid_t              g_fun_wpar_getcid              = NULL;
+static fun_perfstat_cpu_total_t       g_fun_perfstat_cpu_total       = nullptr;
+static fun_perfstat_cpu_t             g_fun_perfstat_cpu             = nullptr;
+static fun_perfstat_memory_total_t    g_fun_perfstat_memory_total    = nullptr;
+static fun_perfstat_netinterface_t    g_fun_perfstat_netinterface    = nullptr;
+static fun_perfstat_partition_total_t g_fun_perfstat_partition_total = nullptr;
+static fun_perfstat_process_t         g_fun_perfstat_process         = nullptr;
+static fun_perfstat_wpar_total_t      g_fun_perfstat_wpar_total      = nullptr;
+static fun_perfstat_reset_t           g_fun_perfstat_reset           = nullptr;
+static fun_wpar_getcid_t              g_fun_wpar_getcid              = nullptr;
 
 bool libperfstat::init() {
 
@@ -114,21 +114,21 @@ void libperfstat::cleanup() {
 
   if (g_libhandle) {
     dlclose(g_libhandle);
-    g_libhandle = NULL;
+    g_libhandle = nullptr;
   }
 
-  g_fun_perfstat_cpu_total = NULL;
-  g_fun_perfstat_memory_total = NULL;
-  g_fun_perfstat_partition_total = NULL;
-  g_fun_perfstat_wpar_total = NULL;
-  g_fun_perfstat_reset = NULL;
-  g_fun_wpar_getcid = NULL;
+  g_fun_perfstat_cpu_total = nullptr;
+  g_fun_perfstat_memory_total = nullptr;
+  g_fun_perfstat_partition_total = nullptr;
+  g_fun_perfstat_wpar_total = nullptr;
+  g_fun_perfstat_reset = nullptr;
+  g_fun_wpar_getcid = nullptr;
 
 }
 
 int libperfstat::perfstat_cpu_total(perfstat_id_t *name, PERFSTAT_CPU_TOTAL_T_LATEST* userbuff,
                                     int sizeof_userbuff, int desired_number) {
-  if (g_fun_perfstat_cpu_total == NULL) {
+  if (g_fun_perfstat_cpu_total == nullptr) {
     return -1;
   }
   return g_fun_perfstat_cpu_total(name, userbuff, sizeof_userbuff, desired_number);
@@ -136,7 +136,7 @@ int libperfstat::perfstat_cpu_total(perfstat_id_t *name, PERFSTAT_CPU_TOTAL_T_LA
 
 int libperfstat::perfstat_cpu(perfstat_id_t *name, PERFSTAT_CPU_T_LATEST* userbuff,
                               int sizeof_userbuff, int desired_number) {
-  if (g_fun_perfstat_cpu == NULL) {
+  if (g_fun_perfstat_cpu == nullptr) {
     return -1;
   }
   return g_fun_perfstat_cpu(name, userbuff, sizeof_userbuff, desired_number);
@@ -145,7 +145,7 @@ int libperfstat::perfstat_cpu(perfstat_id_t *name, PERFSTAT_CPU_T_LATEST* userbu
 int libperfstat::perfstat_memory_total(perfstat_id_t *name,
                                        perfstat_memory_total_t* userbuff,
                                        int sizeof_userbuff, int desired_number) {
-  if (g_fun_perfstat_memory_total == NULL) {
+  if (g_fun_perfstat_memory_total == nullptr) {
     return -1;
   }
   return g_fun_perfstat_memory_total(name, userbuff, sizeof_userbuff, desired_number);
@@ -154,7 +154,7 @@ int libperfstat::perfstat_memory_total(perfstat_id_t *name,
 int libperfstat::perfstat_netinterface(perfstat_id_t *name,
                                        perfstat_netinterface_t* userbuff,
                                        int sizeof_userbuff, int desired_number) {
-  if (g_fun_perfstat_netinterface == NULL) {
+  if (g_fun_perfstat_netinterface == nullptr) {
     return -1;
   }
   return g_fun_perfstat_netinterface(name, userbuff, sizeof_userbuff, desired_number);
@@ -162,7 +162,7 @@ int libperfstat::perfstat_netinterface(perfstat_id_t *name,
 
 int libperfstat::perfstat_partition_total(perfstat_id_t *name, PERFSTAT_PARTITON_TOTAL_T_LATEST* userbuff,
                                           int sizeof_userbuff, int desired_number) {
-  if (g_fun_perfstat_partition_total == NULL) {
+  if (g_fun_perfstat_partition_total == nullptr) {
     return -1;
   }
   return g_fun_perfstat_partition_total(name, userbuff, sizeof_userbuff, desired_number);
@@ -170,7 +170,7 @@ int libperfstat::perfstat_partition_total(perfstat_id_t *name, PERFSTAT_PARTITON
 
 int libperfstat::perfstat_process(perfstat_id_t *name, perfstat_process_t* userbuff,
                                   int sizeof_userbuff, int desired_number) {
-  if (g_fun_perfstat_process == NULL) {
+  if (g_fun_perfstat_process == nullptr) {
     return -1;
   }
   return g_fun_perfstat_process(name, userbuff, sizeof_userbuff, desired_number);
@@ -178,20 +178,20 @@ int libperfstat::perfstat_process(perfstat_id_t *name, perfstat_process_t* userb
 
 int libperfstat::perfstat_wpar_total(perfstat_id_wpar_t *name, PERFSTAT_WPAR_TOTAL_T_LATEST* userbuff,
                                      int sizeof_userbuff, int desired_number) {
-  if (g_fun_perfstat_wpar_total == NULL) {
+  if (g_fun_perfstat_wpar_total == nullptr) {
     return -1;
   }
   return g_fun_perfstat_wpar_total(name, userbuff, sizeof_userbuff, desired_number);
 }
 
 void libperfstat::perfstat_reset() {
-  if (g_fun_perfstat_reset != NULL) {
+  if (g_fun_perfstat_reset != nullptr) {
     g_fun_perfstat_reset();
   }
 }
 
 cid_t libperfstat::wpar_getcid() {
-  if (g_fun_wpar_getcid == NULL) {
+  if (g_fun_wpar_getcid == nullptr) {
     return (cid_t) -1;
   }
   return g_fun_wpar_getcid();
@@ -210,10 +210,10 @@ bool libperfstat::get_cpuinfo(cpuinfo_t* pci) {
   PERFSTAT_CPU_TOTAL_T_LATEST psct;
   memset (&psct, '\0', sizeof(psct));
 
-  if (-1 == libperfstat::perfstat_cpu_total(NULL, &psct, sizeof(PERFSTAT_CPU_TOTAL_T_LATEST), 1)) {
-    if (-1 == libperfstat::perfstat_cpu_total(NULL, &psct, sizeof(perfstat_cpu_total_t_71), 1)) {
-      if (-1 == libperfstat::perfstat_cpu_total(NULL, &psct, sizeof(perfstat_cpu_total_t_61), 1)) {
-        if (-1 == libperfstat::perfstat_cpu_total(NULL, &psct, sizeof(perfstat_cpu_total_t_53), 1)) {
+  if (-1 == libperfstat::perfstat_cpu_total(nullptr, &psct, sizeof(PERFSTAT_CPU_TOTAL_T_LATEST), 1)) {
+    if (-1 == libperfstat::perfstat_cpu_total(nullptr, &psct, sizeof(perfstat_cpu_total_t_71), 1)) {
+      if (-1 == libperfstat::perfstat_cpu_total(nullptr, &psct, sizeof(perfstat_cpu_total_t_61), 1)) {
+        if (-1 == libperfstat::perfstat_cpu_total(nullptr, &psct, sizeof(perfstat_cpu_total_t_53), 1)) {
           trcVerbose("perfstat_cpu_total() failed (errno=%d)", errno);
           return false;
         }
@@ -248,12 +248,12 @@ bool libperfstat::get_partitioninfo(partitioninfo_t* ppi) {
 
   bool ame_details = true;
 
-  if (-1 == libperfstat::perfstat_partition_total(NULL, &pspt, sizeof(PERFSTAT_PARTITON_TOTAL_T_LATEST), 1)) {
-    if (-1 == libperfstat::perfstat_partition_total(NULL, &pspt, sizeof(perfstat_partition_total_t_71), 1)) {
+  if (-1 == libperfstat::perfstat_partition_total(nullptr, &pspt, sizeof(PERFSTAT_PARTITON_TOTAL_T_LATEST), 1)) {
+    if (-1 == libperfstat::perfstat_partition_total(nullptr, &pspt, sizeof(perfstat_partition_total_t_71), 1)) {
       ame_details = false;
-      if (-1 == libperfstat::perfstat_partition_total(NULL, &pspt, sizeof(perfstat_partition_total_t_61), 1)) {
-        if (-1 == libperfstat::perfstat_partition_total(NULL, &pspt, sizeof(perfstat_partition_total_t_53), 1)) {
-          if (-1 == libperfstat::perfstat_partition_total(NULL, &pspt, sizeof(perfstat_partition_total_t_53_5), 1)) {
+      if (-1 == libperfstat::perfstat_partition_total(nullptr, &pspt, sizeof(perfstat_partition_total_t_61), 1)) {
+        if (-1 == libperfstat::perfstat_partition_total(nullptr, &pspt, sizeof(perfstat_partition_total_t_53), 1)) {
+          if (-1 == libperfstat::perfstat_partition_total(nullptr, &pspt, sizeof(perfstat_partition_total_t_53_5), 1)) {
             trcVerbose("perfstat_partition_total() failed (errno=%d)", errno);
             return false;
           }
@@ -322,8 +322,8 @@ bool libperfstat::get_wparinfo(wparinfo_t* pwi) {
   PERFSTAT_WPAR_TOTAL_T_LATEST pswt;
   memset (&pswt, '\0', sizeof(pswt));
 
-  if (-1 == libperfstat::perfstat_wpar_total(NULL, &pswt, sizeof(PERFSTAT_WPAR_TOTAL_T_LATEST), 1)) {
-    if (-1 == libperfstat::perfstat_wpar_total(NULL, &pswt, sizeof(perfstat_wpar_total_t_61), 1)) {
+  if (-1 == libperfstat::perfstat_wpar_total(nullptr, &pswt, sizeof(PERFSTAT_WPAR_TOTAL_T_LATEST), 1)) {
+    if (-1 == libperfstat::perfstat_wpar_total(nullptr, &pswt, sizeof(perfstat_wpar_total_t_61), 1)) {
       trcVerbose("perfstat_wpar_total() failed (errno=%d)", errno);
       return false;
     }

--- a/src/hotspot/os/aix/loadlib_aix.cpp
+++ b/src/hotspot/os/aix/loadlib_aix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2019 SAP SE. All rights reserved.
  * Copyright (c) 2022, IBM Corp.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -64,17 +64,17 @@ class StringList {
   }
 
   // Append string to end of list.
-  // Returns NULL if oom.
+  // Returns null if oom.
   char* append(const char* s) {
     if (_cap == _num) {
       if (!enlarge()) {
-        return NULL;
+        return nullptr;
       }
     }
     assert0(_cap > _num);
     char* s2 = ::strdup(s);
     if (!s2) {
-      return NULL;
+      return nullptr;
     }
     _list[_num] = s2;
     trcVerbose("StringDir: added %s at pos %d", s2, _num);
@@ -85,13 +85,13 @@ class StringList {
 public:
 
   StringList()
-    : _list(NULL)
+    : _list(nullptr)
     , _cap(0)
     , _num(0)
   {}
 
   // String is copied into the list; pointer to copy is returned.
-  // Returns NULL if oom.
+  // Returns null if oom.
   char* add (const char* s) {
     for (int i = 0; i < _num; i++) {
       if (strcmp(_list[i], s) == 0) {
@@ -124,7 +124,7 @@ static void print_entry(const loaded_module_t* lm, outputStream* os) {
   }
 }
 
-static loaded_module_t* g_first = NULL;
+static loaded_module_t* g_first = nullptr;
 
 static loaded_module_t* find_entry_for_text_address(const void* p) {
   for (loaded_module_t* lm = g_first; lm; lm = lm->next) {
@@ -133,7 +133,7 @@ static loaded_module_t* find_entry_for_text_address(const void* p) {
       return lm;
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 static loaded_module_t* find_entry_for_data_address(const void* p) {
@@ -143,12 +143,12 @@ static loaded_module_t* find_entry_for_data_address(const void* p) {
       return lm;
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 // Adds a new entry to the list (ordered by text address ascending).
 static void add_entry_to_list(loaded_module_t* lm, loaded_module_t** start) {
-  loaded_module_t* last = NULL;
+  loaded_module_t* last = nullptr;
   loaded_module_t* lm2 = *start;
   while (lm2 && lm2->text < lm->text) {
     last = lm2;
@@ -169,7 +169,7 @@ static void free_entry_list(loaded_module_t** start) {
     ::free(lm);
     lm = lm2;
   }
-  *start = NULL;
+  *start = nullptr;
 }
 
 
@@ -181,12 +181,12 @@ static bool reload_table() {
 
   trcVerbose("reload module table...");
 
-  loaded_module_t* new_list = NULL;
-  const struct ld_info* ldi = NULL;
+  loaded_module_t* new_list = nullptr;
+  const struct ld_info* ldi = nullptr;
 
   // Call loadquery(L_GETINFO..) to get a list of all loaded Dlls from AIX. loadquery
   // requires a large enough buffer.
-  uint8_t* buffer = NULL;
+  uint8_t* buffer = nullptr;
   size_t buflen = 1024;
   for (;;) {
     buffer = (uint8_t*) ::realloc(buffer, buflen);
@@ -249,7 +249,7 @@ static bool reload_table() {
         goto cleanup;
       }
     } else {
-      lm->member = NULL;
+      lm->member = nullptr;
     }
 
     if (strcmp(lm->shortname, "libjvm.so") == 0) {
@@ -263,7 +263,7 @@ static bool reload_table() {
       lm->text, lm->text_len,
       lm->data, lm->data_len,
       lm->path, lm->shortname,
-      (lm->member ? lm->member : "NULL"),
+      (lm->member ? lm->member : "null"),
       lm->is_in_vm
     );
 
@@ -283,7 +283,7 @@ static bool reload_table() {
     free_entry_list(&g_first);
   }
   g_first = new_list;
-  new_list = NULL;
+  new_list = nullptr;
 
   rc = true;
 
@@ -362,7 +362,7 @@ bool LoadedLibraries::find_for_text_address(const void* p,
 
 bool LoadedLibraries::find_for_data_address (
   const void* p,
-  loaded_module_t* info // optional. can be NULL:
+  loaded_module_t* info // optional. can be null:
 ) {
   MiscUtils::AutoCritSect lck(&g_cs);
   if (!g_first) {

--- a/src/hotspot/os/aix/loadlib_aix.hpp
+++ b/src/hotspot/os/aix/loadlib_aix.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2013 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -70,7 +70,7 @@ struct loaded_module_t {
   // True if this module is part of the vm.
   bool is_in_vm;
 
-  // Next item in the list, or NULL if no such item exits
+  // Next item in the list, or null if no such item exits
   loaded_module_t* next;
 
 };
@@ -92,7 +92,7 @@ class LoadedLibraries
     // Optionally, information about the module is returned (info)
     static bool find_for_text_address (
       const void* p,
-      loaded_module_t* info // Optional, leave NULL if not needed.
+      loaded_module_t* info // Optional, leave null if not needed.
     );
 
     // Check whether the given address points into the data segment of a
@@ -100,7 +100,7 @@ class LoadedLibraries
     // Optionally, information about the module is returned (info)
     static bool find_for_data_address (
       const void* p,
-      loaded_module_t* info // Optional, leave NULL if not needed.
+      loaded_module_t* info // Optional, leave null if not needed.
     );
 
     // Output debug info

--- a/src/hotspot/os/aix/misc_aix.cpp
+++ b/src/hotspot/os/aix/misc_aix.cpp
@@ -31,7 +31,7 @@
 #include <errno.h>
 
 void MiscUtils::init_critsect(MiscUtils::critsect_t* cs) {
-  const int rc = pthread_mutex_init(cs, NULL);
+  const int rc = pthread_mutex_init(cs, nullptr);
   assert0(rc == 0);
 }
 

--- a/src/hotspot/os/aix/osThread_aix.cpp
+++ b/src/hotspot/os/aix/osThread_aix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2015 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -34,20 +34,20 @@
 #include "runtime/vmThread.hpp"
 
 void OSThread::pd_initialize() {
-  assert(this != NULL, "check");
+  assert(this != nullptr, "check");
   _thread_id        = 0;
   _kernel_thread_id = 0;
-  _siginfo = NULL;
-  _ucontext = NULL;
+  _siginfo = nullptr;
+  _ucontext = nullptr;
   _expanding_stack = 0;
-  _alt_sig_stack = NULL;
+  _alt_sig_stack = nullptr;
 
   _last_cpu_times.sys = _last_cpu_times.user = 0L;
 
   sigemptyset(&_caller_sigmask);
 
   _startThread_lock = new Monitor(Mutex::event, "startThread_lock");
-  assert(_startThread_lock != NULL, "check");
+  assert(_startThread_lock != nullptr, "check");
 }
 
 void OSThread::pd_destroy() {

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1009,9 +1009,9 @@ bool os::address_is_in_vm(address addr) {
   // Input could be a real pc or a function pointer literal. The latter
   // would be a function descriptor residing in the data segment of a module.
   loaded_module_t lm;
-  if (LoadedLibraries::find_for_text_address(addr, &lm) != nullptr) {
+  if (LoadedLibraries::find_for_text_address(addr, &lm)) {
     return lm.is_in_vm;
-  } else if (LoadedLibraries::find_for_data_address(addr, &lm) != nullptr) {
+  } else if (LoadedLibraries::find_for_data_address(addr, &lm)) {
     return lm.is_in_vm;
   } else {
     return false;
@@ -1028,13 +1028,13 @@ bool os::address_is_in_vm(address addr) {
 //   null is returned.
 static address resolve_function_descriptor_to_code_pointer(address p) {
 
-  if (LoadedLibraries::find_for_text_address(p, nullptr) != nullptr) {
+  if (LoadedLibraries::find_for_text_address(p, nullptr)) {
     // It is a real code pointer.
     return p;
-  } else if (LoadedLibraries::find_for_data_address(p, nullptr) != nullptr) {
+  } else if (LoadedLibraries::find_for_data_address(p, nullptr)) {
     // Pointer to data segment, potential function descriptor.
     address code_entry = (address)(((FunctionDescriptor*)p)->entry());
-    if (LoadedLibraries::find_for_text_address(code_entry, nullptr) != nullptr) {
+    if (LoadedLibraries::find_for_text_address(code_entry, nullptr)) {
       // It is a function descriptor.
       return code_entry;
     }
@@ -2429,8 +2429,8 @@ bool os::find(address addr, outputStream* st) {
   st->print(PTR_FORMAT ": ", addr);
 
   loaded_module_t lm;
-  if (LoadedLibraries::find_for_text_address(addr, &lm) != nullptr ||
-      LoadedLibraries::find_for_data_address(addr, &lm) != nullptr) {
+  if (LoadedLibraries::find_for_text_address(addr, &lm) ||
+      LoadedLibraries::find_for_data_address(addr, &lm)) {
     st->print_cr("%s", lm.path);
     return true;
   }

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -185,7 +185,7 @@ int       os::Aix::_extshm = -1;
 static volatile jlong max_real_time = 0;
 
 // Process break recorded at startup.
-static address g_brk_at_startup = NULL;
+static address g_brk_at_startup = nullptr;
 
 // This describes the state of multipage support of the underlying
 // OS. Note that this is of no interest to the outsize world and
@@ -237,7 +237,7 @@ static struct {
 // a specific wish address, e.g. to place the heap in a
 // compressed-oops-friendly way.
 static bool is_close_to_brk(address a) {
-  assert0(g_brk_at_startup != NULL);
+  assert0(g_brk_at_startup != nullptr);
   if (a >= g_brk_at_startup &&
       a < (g_brk_at_startup + MaxExpectedDataSegmentSize)) {
     return true;
@@ -391,8 +391,8 @@ static void query_multipage_support() {
   {
     const int shmid = ::shmget(IPC_PRIVATE, 1, IPC_CREAT | S_IRUSR | S_IWUSR);
     guarantee(shmid != -1, "shmget failed");
-    void* p = ::shmat(shmid, NULL, 0);
-    ::shmctl(shmid, IPC_RMID, NULL);
+    void* p = ::shmat(shmid, nullptr, 0);
+    ::shmctl(shmid, IPC_RMID, nullptr);
     guarantee(p != (void*) -1, "shmat failed");
     g_multipage_support.shmpsize = os::Aix::query_pagesize(p);
     ::shmdt(p);
@@ -461,12 +461,12 @@ static void query_multipage_support() {
       shm_buf.shm_pagesize = pagesize;
       if (::shmctl(shmid, SHM_PAGESIZE, &shm_buf) != 0) {
         const int en = errno;
-        ::shmctl(shmid, IPC_RMID, NULL); // As early as possible!
+        ::shmctl(shmid, IPC_RMID, nullptr); // As early as possible!
         trcVerbose("shmctl(SHM_PAGESIZE) failed with errno=%d", errno);
       } else {
         // Attach and double check pageisze.
-        void* p = ::shmat(shmid, NULL, 0);
-        ::shmctl(shmid, IPC_RMID, NULL); // As early as possible!
+        void* p = ::shmat(shmid, nullptr, 0);
+        ::shmctl(shmid, IPC_RMID, nullptr); // As early as possible!
         guarantee0(p != (void*) -1); // Should always work.
         const size_t real_pagesize = os::Aix::query_pagesize(p);
         if (real_pagesize != pagesize) {
@@ -539,24 +539,24 @@ void os::init_system_properties_values() {
     // Found the full path to libjvm.so.
     // Now cut the path to <java_home>/jre if we can.
     pslash = strrchr(buf, '/');
-    if (pslash != NULL) {
+    if (pslash != nullptr) {
       *pslash = '\0';            // Get rid of /libjvm.so.
     }
     pslash = strrchr(buf, '/');
-    if (pslash != NULL) {
+    if (pslash != nullptr) {
       *pslash = '\0';            // Get rid of /{client|server|hotspot}.
     }
     Arguments::set_dll_dir(buf);
 
-    if (pslash != NULL) {
+    if (pslash != nullptr) {
       pslash = strrchr(buf, '/');
-      if (pslash != NULL) {
+      if (pslash != nullptr) {
         *pslash = '\0';        // Get rid of /lib.
       }
     }
     Arguments::set_java_home(buf);
     if (!set_boot_path('/', ':')) {
-      vm_exit_during_initialization("Failed setting boot class path.", NULL);
+      vm_exit_during_initialization("Failed setting boot class path.", nullptr);
     }
   }
 
@@ -567,7 +567,7 @@ void os::init_system_properties_values() {
   // Get the user setting of LIBPATH.
   const char *v = ::getenv("LIBPATH");
   const char *v_colon = ":";
-  if (v == NULL) { v = ""; v_colon = ""; }
+  if (v == nullptr) { v = ""; v_colon = ""; }
 
   // Concatenate user and invariant part of ld_library_path.
   // That's +1 for the colon and +1 for the trailing '\0'.
@@ -636,7 +636,7 @@ bool os::Aix::get_meminfo(meminfo_t* pmi) {
 
     perfstat_memory_total_t psmt;
     memset (&psmt, '\0', sizeof(psmt));
-    const int rc = libperfstat::perfstat_memory_total(NULL, &psmt, sizeof(psmt), 1);
+    const int rc = libperfstat::perfstat_memory_total(nullptr, &psmt, sizeof(psmt), 1);
     if (rc == -1) {
       trcVerbose("perfstat_memory_total() failed (errno=%d)", errno);
       assert(0, "perfstat_memory_total() failed");
@@ -729,7 +729,7 @@ static void *thread_native_entry(Thread *thread) {
 
   // Note: at this point the thread object may already have deleted itself.
   // Prevent dereferencing it from here on out.
-  thread = NULL;
+  thread = nullptr;
 
   log_info(os, thread)("Thread finished (tid: " UINTX_FORMAT ", kernel thread id: " UINTX_FORMAT ").",
     os::current_thread_id(), (uintx) kernel_thread_id);
@@ -740,11 +740,11 @@ static void *thread_native_entry(Thread *thread) {
 bool os::create_thread(Thread* thread, ThreadType thr_type,
                        size_t req_stack_size) {
 
-  assert(thread->osthread() == NULL, "caller responsible");
+  assert(thread->osthread() == nullptr, "caller responsible");
 
   // Allocate the OSThread object.
   OSThread* osthread = new OSThread();
-  if (osthread == NULL) {
+  if (osthread == nullptr) {
     return false;
   }
 
@@ -790,7 +790,7 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
     log_warning(os, thread)("The %sthread stack size specified is invalid: " SIZE_FORMAT "k",
                             (thr_type == compiler_thread) ? "compiler " : ((thr_type == java_thread) ? "" : "VM "),
                             stack_size / K);
-    thread->set_osthread(NULL);
+    thread->set_osthread(nullptr);
     delete osthread;
     return false;
   }
@@ -831,7 +831,7 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
 
   if (ret != 0) {
     // Need to clean up stuff we've allocated so far.
-    thread->set_osthread(NULL);
+    thread->set_osthread(nullptr);
     delete osthread;
     return false;
   }
@@ -859,7 +859,7 @@ bool os::create_attached_thread(JavaThread* thread) {
   // Allocate the OSThread object
   OSThread* osthread = new OSThread();
 
-  if (osthread == NULL) {
+  if (osthread == nullptr) {
     return false;
   }
 
@@ -906,7 +906,7 @@ void os::pd_start_thread(Thread* thread) {
 
 // Free OS resources related to the OSThread
 void os::free_thread(OSThread* osthread) {
-  assert(osthread != NULL, "osthread not set");
+  assert(osthread != nullptr, "osthread not set");
 
   // We are told to free resources of the argument thread,
   // but we can only really operate on the current thread.
@@ -915,7 +915,7 @@ void os::free_thread(OSThread* osthread) {
 
   // Restore caller's signal mask
   sigset_t sigmask = osthread->caller_sigmask();
-  pthread_sigmask(SIG_SETMASK, &sigmask, NULL);
+  pthread_sigmask(SIG_SETMASK, &sigmask, nullptr);
 
   delete osthread;
 }
@@ -1009,9 +1009,9 @@ bool os::address_is_in_vm(address addr) {
   // Input could be a real pc or a function pointer literal. The latter
   // would be a function descriptor residing in the data segment of a module.
   loaded_module_t lm;
-  if (LoadedLibraries::find_for_text_address(addr, &lm) != NULL) {
+  if (LoadedLibraries::find_for_text_address(addr, &lm) != nullptr) {
     return lm.is_in_vm;
-  } else if (LoadedLibraries::find_for_data_address(addr, &lm) != NULL) {
+  } else if (LoadedLibraries::find_for_data_address(addr, &lm) != nullptr) {
     return lm.is_in_vm;
   } else {
     return false;
@@ -1025,22 +1025,22 @@ bool os::address_is_in_vm(address addr) {
 // If the input is a valid AIX function descriptor, it is resolved to the
 //   code entry point.
 // If the input is neither a valid function descriptor nor a valid code pointer,
-//   NULL is returned.
+//   null is returned.
 static address resolve_function_descriptor_to_code_pointer(address p) {
 
-  if (LoadedLibraries::find_for_text_address(p, NULL) != NULL) {
+  if (LoadedLibraries::find_for_text_address(p, nullptr) != nullptr) {
     // It is a real code pointer.
     return p;
-  } else if (LoadedLibraries::find_for_data_address(p, NULL) != NULL) {
+  } else if (LoadedLibraries::find_for_data_address(p, nullptr) != nullptr) {
     // Pointer to data segment, potential function descriptor.
     address code_entry = (address)(((FunctionDescriptor*)p)->entry());
-    if (LoadedLibraries::find_for_text_address(code_entry, NULL) != NULL) {
+    if (LoadedLibraries::find_for_text_address(code_entry, nullptr) != nullptr) {
       // It is a function descriptor.
       return code_entry;
     }
   }
 
-  return NULL;
+  return nullptr;
 }
 
 bool os::dll_address_to_function_name(address addr, char *buf,
@@ -1050,7 +1050,7 @@ bool os::dll_address_to_function_name(address addr, char *buf,
     *offset = -1;
   }
   // Buf is not optional, but offset is optional.
-  assert(buf != NULL, "sanity check");
+  assert(buf != nullptr, "sanity check");
   buf[0] = '\0';
 
   // Resolve function ptr literals first.
@@ -1059,7 +1059,7 @@ bool os::dll_address_to_function_name(address addr, char *buf,
     return false;
   }
 
-  return AixSymbols::get_function_name(addr, buf, buflen, offset, NULL, demangle);
+  return AixSymbols::get_function_name(addr, buf, buflen, offset, nullptr, demangle);
 }
 
 bool os::dll_address_to_library_name(address addr, char* buf,
@@ -1068,7 +1068,7 @@ bool os::dll_address_to_library_name(address addr, char* buf,
     *offset = -1;
   }
   // Buf is not optional, but offset is optional.
-  assert(buf != NULL, "sanity check");
+  assert(buf != nullptr, "sanity check");
   buf[0] = '\0';
 
   // Resolve function ptr literals first.
@@ -1093,13 +1093,13 @@ void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
 
   if (!filename || strlen(filename) == 0) {
     ::strncpy(ebuf, "dll_load: empty filename specified", ebuflen - 1);
-    return NULL;
+    return nullptr;
   }
 
   // RTLD_LAZY is currently not implemented. The dl is loaded immediately with all its dependants.
   void * result= ::dlopen(filename, RTLD_LAZY);
-  if (result != NULL) {
-    Events::log_dll_message(NULL, "Loaded shared library %s", filename);
+  if (result != nullptr) {
+    Events::log_dll_message(nullptr, "Loaded shared library %s", filename);
     // Reload dll cache. Don't do this in signal handling.
     LoadedLibraries::reload();
     log_info(os)("shared library load of %s was successful", filename);
@@ -1107,17 +1107,17 @@ void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
   } else {
     // error analysis when dlopen fails
     const char* error_report = ::dlerror();
-    if (error_report == NULL) {
+    if (error_report == nullptr) {
       error_report = "dlerror returned no error description";
     }
-    if (ebuf != NULL && ebuflen > 0) {
+    if (ebuf != nullptr && ebuflen > 0) {
       snprintf(ebuf, ebuflen - 1, "%s, LIBPATH=%s, LD_LIBRARY_PATH=%s : %s",
                filename, ::getenv("LIBPATH"), ::getenv("LD_LIBRARY_PATH"), error_report);
     }
-    Events::log_dll_message(NULL, "Loading shared library %s failed, %s", filename, error_report);
+    Events::log_dll_message(nullptr, "Loading shared library %s failed, %s", filename, error_report);
     log_info(os)("shared library load of %s failed, %s", filename, error_report);
   }
-  return NULL;
+  return nullptr;
 }
 
 void os::print_dll_info(outputStream *st) {
@@ -1330,7 +1330,7 @@ void os::jvm_path(char *buf, jint buflen) {
   int ret = dladdr(CAST_FROM_FN_PTR(void *, os::jvm_path), &dlinfo);
   assert(ret != 0, "cannot locate libjvm");
   char* rp = os::Posix::realpath((char *)dlinfo.dli_fname, buf, buflen);
-  assert(rp != NULL, "error in realpath(): maybe the 'path' argument is too long?");
+  assert(rp != nullptr, "error in realpath(): maybe the 'path' argument is too long?");
 
   if (Arguments::sun_java_launcher_is_altjvm()) {
     // Support for the java launcher's '-XXaltjvm=<path>' option. Typical
@@ -1349,19 +1349,19 @@ void os::jvm_path(char *buf, jint buflen) {
     if (strncmp(p, "/jre/lib/", 9) != 0) {
       // Look for JAVA_HOME in the environment.
       char* java_home_var = ::getenv("JAVA_HOME");
-      if (java_home_var != NULL && java_home_var[0] != 0) {
+      if (java_home_var != nullptr && java_home_var[0] != 0) {
         char* jrelib_p;
         int len;
 
         // Check the current module name "libjvm.so".
         p = strrchr(buf, '/');
-        if (p == NULL) {
+        if (p == nullptr) {
           return;
         }
         assert(strstr(p, "/libjvm") == p, "invalid library name");
 
         rp = os::Posix::realpath(java_home_var, buf, buflen);
-        if (rp == NULL) {
+        if (rp == nullptr) {
           return;
         }
 
@@ -1382,7 +1382,7 @@ void os::jvm_path(char *buf, jint buflen) {
         } else {
           // Go back to path of .so
           rp = os::Posix::realpath((char *)dlinfo.dli_fname, buf, buflen);
-          if (rp == NULL) {
+          if (rp == nullptr) {
             return;
           }
         }
@@ -1467,7 +1467,7 @@ static vmembk_t* vmembk_find(char* addr) {
       return p;
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 static void vmembk_remove(vmembk_t* p0) {
@@ -1493,9 +1493,9 @@ static void vmembk_print_on(outputStream* os) {
 }
 
 // Reserve and attach a section of System V memory.
-// If <requested_addr> is not NULL, function will attempt to attach the memory at the given
+// If <requested_addr> is not null, function will attempt to attach the memory at the given
 // address. Failing that, it will attach the memory anywhere.
-// If <requested_addr> is NULL, function will attach the memory anywhere.
+// If <requested_addr> is null, function will attach the memory anywhere.
 static char* reserve_shmated_memory (size_t bytes, char* requested_addr) {
 
   trcVerbose("reserve_shmated_memory " UINTX_FORMAT " bytes, wishaddress "
@@ -1503,11 +1503,11 @@ static char* reserve_shmated_memory (size_t bytes, char* requested_addr) {
 
   // We must prevent anyone from attaching too close to the
   // BRK because that may cause malloc OOM.
-  if (requested_addr != NULL && is_close_to_brk((address)requested_addr)) {
+  if (requested_addr != nullptr && is_close_to_brk((address)requested_addr)) {
     trcVerbose("Wish address " PTR_FORMAT " is too close to the BRK segment.", p2i(requested_addr));
     // Since we treat an attach to the wrong address as an error later anyway,
-    // we return NULL here
-    return NULL;
+    // we return null here
+    return nullptr;
   }
 
   // For old AS/400's (V5R4 and older) we should not even be here - System V shared memory is not
@@ -1523,7 +1523,7 @@ static char* reserve_shmated_memory (size_t bytes, char* requested_addr) {
   int shmid = shmget(IPC_PRIVATE, size, IPC_CREAT | S_IRUSR | S_IWUSR);
   if (shmid == -1) {
     trcVerbose("shmget(.., " UINTX_FORMAT ", ..) failed (errno: %d).", size, errno);
-    return NULL;
+    return nullptr;
   }
 
   // Important note:
@@ -1550,7 +1550,7 @@ static char* reserve_shmated_memory (size_t bytes, char* requested_addr) {
   const int errno_shmat = errno;
 
   // (A) Right after shmat and before handing shmat errors delete the shm segment.
-  if (::shmctl(shmid, IPC_RMID, NULL) == -1) {
+  if (::shmctl(shmid, IPC_RMID, nullptr) == -1) {
     trcVerbose("shmctl(%u, IPC_RMID) failed (%d)\n", shmid, errno);
     assert(false, "failed to remove shared memory segment!");
   }
@@ -1558,7 +1558,7 @@ static char* reserve_shmated_memory (size_t bytes, char* requested_addr) {
   // Handle shmat error. If we failed to attach, just return.
   if (addr == (char*)-1) {
     trcVerbose("Failed to attach segment at " PTR_FORMAT " (%d).", p2i(requested_addr), errno_shmat);
-    return NULL;
+    return nullptr;
   }
 
   // Just for info: query the real page size. In case setting the page size did not
@@ -1572,7 +1572,7 @@ static char* reserve_shmated_memory (size_t bytes, char* requested_addr) {
     trcVerbose("shm-allocated " PTR_FORMAT " .. " PTR_FORMAT " (" UINTX_FORMAT " bytes, " UINTX_FORMAT " %s pages)",
       p2i(addr), p2i(addr + size - 1), size, size/real_pagesize, describe_pagesize(real_pagesize));
   } else {
-    if (requested_addr != NULL) {
+    if (requested_addr != nullptr) {
       trcVerbose("failed to shm-allocate " UINTX_FORMAT " bytes at with address " PTR_FORMAT ".", size, p2i(requested_addr));
     } else {
       trcVerbose("failed to shm-allocate " UINTX_FORMAT " bytes at any address.", size);
@@ -1627,16 +1627,16 @@ static char* reserve_mmaped_memory(size_t bytes, char* requested_addr) {
 
   if (requested_addr && !is_aligned_to(requested_addr, os::vm_page_size()) != 0) {
     trcVerbose("Wish address " PTR_FORMAT " not aligned to page boundary.", p2i(requested_addr));
-    return NULL;
+    return nullptr;
   }
 
   // We must prevent anyone from attaching too close to the
   // BRK because that may cause malloc OOM.
-  if (requested_addr != NULL && is_close_to_brk((address)requested_addr)) {
+  if (requested_addr != nullptr && is_close_to_brk((address)requested_addr)) {
     trcVerbose("Wish address " PTR_FORMAT " is too close to the BRK segment.", p2i(requested_addr));
     // Since we treat an attach to the wrong address as an error later anyway,
-    // we return NULL here
-    return NULL;
+    // we return null here
+    return nullptr;
   }
 
   // In 64K mode, we lie and claim the global page size (os::vm_page_size()) is 64K
@@ -1666,7 +1666,7 @@ static char* reserve_mmaped_memory(size_t bytes, char* requested_addr) {
   // SPEC1170 mode active: behaviour like POSIX, MAP_FIXED will clobber existing mappings.
   // SPEC1170 mode not active: behaviour, unlike POSIX, is that no existing mappings will
   // get clobbered.
-  if (requested_addr != NULL) {
+  if (requested_addr != nullptr) {
     if (!os::Aix::xpg_sus_mode()) {  // not SPEC1170 Behaviour
       flags |= MAP_FIXED;
     }
@@ -1677,12 +1677,12 @@ static char* reserve_mmaped_memory(size_t bytes, char* requested_addr) {
 
   if (addr == MAP_FAILED) {
     trcVerbose("mmap(" PTR_FORMAT ", " UINTX_FORMAT ", ..) failed (%d)", p2i(requested_addr), size, errno);
-    return NULL;
-  } else if (requested_addr != NULL && addr != requested_addr) {
+    return nullptr;
+  } else if (requested_addr != nullptr && addr != requested_addr) {
     trcVerbose("mmap(" PTR_FORMAT ", " UINTX_FORMAT ", ..) succeeded, but at a different address than requested (" PTR_FORMAT "), will unmap",
                p2i(requested_addr), size, p2i(addr));
     ::munmap(addr, extra_size);
-    return NULL;
+    return nullptr;
   }
 
   // Handle alignment.
@@ -1761,7 +1761,7 @@ static void warn_fail_commit_memory(char* addr, size_t size, bool exec,
 
 void os::pd_commit_memory_or_exit(char* addr, size_t size, bool exec,
                                   const char* mesg) {
-  assert(mesg != NULL, "mesg must be specified");
+  assert(mesg != nullptr, "mesg must be specified");
   if (!pd_commit_memory(addr, size, exec)) {
     // Add extra info in product mode for vm_exit_out_of_memory():
     PRODUCT_ONLY(warn_fail_commit_memory(addr, size, exec, errno);)
@@ -1889,12 +1889,12 @@ char* os::pd_reserve_memory(size_t bytes, bool exec) {
   // In 4K mode always use mmap.
   // In 64K mode allocate small sizes with mmap, large ones with 64K shmatted.
   if (os::vm_page_size() == 4*K) {
-    return reserve_mmaped_memory(bytes, NULL /* requested_addr */);
+    return reserve_mmaped_memory(bytes, nullptr /* requested_addr */);
   } else {
     if (bytes >= Use64KPagesThreshold) {
-      return reserve_shmated_memory(bytes, NULL /* requested_addr */);
+      return reserve_shmated_memory(bytes, nullptr /* requested_addr */);
     } else {
-      return reserve_mmaped_memory(bytes, NULL /* requested_addr */);
+      return reserve_mmaped_memory(bytes, nullptr /* requested_addr */);
     }
   }
 }
@@ -1969,7 +1969,7 @@ static bool checked_mprotect(char* addr, size_t size, int prot) {
   //
   // See http://publib.boulder.ibm.com/infocenter/pseries/v5r3/index.jsp?topic=/com.ibm.aix.basetechref/doc/basetrf1/mprotect.htm
 
-  Events::log(NULL, "Protecting memory [" INTPTR_FORMAT "," INTPTR_FORMAT "] with protection modes %x", p2i(addr), p2i(addr+size), prot);
+  Events::log(nullptr, "Protecting memory [" INTPTR_FORMAT "," INTPTR_FORMAT "] with protection modes %x", p2i(addr), p2i(addr+size), prot);
   bool rc = ::mprotect(addr, size, prot) == 0 ? true : false;
 
   if (!rc) {
@@ -2008,7 +2008,7 @@ static bool checked_mprotect(char* addr, size_t size, int prot) {
         // A valid strategy is just to try again. This usually works. :-/
 
         ::usleep(1000);
-        Events::log(NULL, "Protecting memory [" INTPTR_FORMAT "," INTPTR_FORMAT "] with protection modes %x", p2i(addr), p2i(addr+size), prot);
+        Events::log(nullptr, "Protecting memory [" INTPTR_FORMAT "," INTPTR_FORMAT "] with protection modes %x", p2i(addr), p2i(addr+size), prot);
         if (::mprotect(addr, size, prot) == 0) {
           const bool read_protected_2 =
             (SafeFetch32((int*)addr, 0x12345678) == 0x12345678 &&
@@ -2058,7 +2058,7 @@ void os::large_page_init() {
 
 char* os::pd_reserve_memory_special(size_t bytes, size_t alignment, size_t page_size, char* req_addr, bool exec) {
   fatal("os::reserve_memory_special should not be called on AIX.");
-  return NULL;
+  return nullptr;
 }
 
 bool os::pd_release_memory_special(char* base, size_t bytes) {
@@ -2082,14 +2082,14 @@ bool os::can_execute_large_page_memory() {
 
 char* os::pd_attempt_map_memory_to_file_at(char* requested_addr, size_t bytes, int file_desc) {
   assert(file_desc >= 0, "file_desc is not valid");
-  char* result = NULL;
+  char* result = nullptr;
 
   // Always round to os::vm_page_size(), which may be larger than 4K.
   bytes = align_up(bytes, os::vm_page_size());
   result = reserve_mmaped_memory(bytes, requested_addr);
 
-  if (result != NULL) {
-    if (replace_existing_mapping_with_file_mapping(result, bytes, file_desc) == NULL) {
+  if (result != nullptr) {
+    if (replace_existing_mapping_with_file_mapping(result, bytes, file_desc) == nullptr) {
       vm_exit_during_initialization(err_msg("Error in mapping Java heap at the given filesystem directory"));
     }
   }
@@ -2099,7 +2099,7 @@ char* os::pd_attempt_map_memory_to_file_at(char* requested_addr, size_t bytes, i
 // Reserve memory at an arbitrary address, only if that area is
 // available (and not reserved for something else).
 char* os::pd_attempt_reserve_memory_at(char* requested_addr, size_t bytes, bool exec) {
-  char* addr = NULL;
+  char* addr = nullptr;
 
   // Always round to os::vm_page_size(), which may be larger than 4K.
   bytes = align_up(bytes, os::vm_page_size());
@@ -2429,8 +2429,8 @@ bool os::find(address addr, outputStream* st) {
   st->print(PTR_FORMAT ": ", addr);
 
   loaded_module_t lm;
-  if (LoadedLibraries::find_for_text_address(addr, &lm) != NULL ||
-      LoadedLibraries::find_for_data_address(addr, &lm) != NULL) {
+  if (LoadedLibraries::find_for_text_address(addr, &lm) != nullptr ||
+      LoadedLibraries::find_for_data_address(addr, &lm) != nullptr) {
     st->print_cr("%s", lm.path);
     return true;
   }
@@ -2561,7 +2561,7 @@ char* os::pd_map_memory(int fd, const char* file_name, size_t file_offset,
     prot |= PROT_EXEC;
   }
 
-  if (addr != NULL) {
+  if (addr != nullptr) {
     flags |= MAP_FIXED;
   }
 
@@ -2573,7 +2573,7 @@ char* os::pd_map_memory(int fd, const char* file_name, size_t file_offset,
   char* mapped_address = (char*)::mmap(addr, (size_t)bytes, prot, flags,
                                      fd, file_offset);
   if (mapped_address == MAP_FAILED) {
-    return NULL;
+    return nullptr;
   }
   return mapped_address;
 }
@@ -2931,8 +2931,8 @@ size_t os::current_stack_size() {
 int os::get_core_path(char* buffer, size_t bufferSize) {
   const char* p = get_current_directory(buffer, bufferSize);
 
-  if (p == NULL) {
-    assert(p != NULL, "failed to get current directory");
+  if (p == nullptr) {
+    assert(p != nullptr, "failed to get current directory");
     return 0;
   }
 

--- a/src/hotspot/os/aix/os_perf_aix.cpp
+++ b/src/hotspot/os/aix/os_perf_aix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2022, IBM Corp.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -181,7 +181,7 @@ static bool populate_lcpu_names(int ncpus, perfstat_id_t* lcpu_names) {
   perfstat_cpu_t* lcpu_stats;
   perfstat_id_t   name_holder;
 
-  assert(lcpu_names, "Names pointer NULL");
+  assert(lcpu_names, "Names pointer null");
 
   strncpy(name_holder.name, FIRST_CPU, IDENTIFIER_LENGTH);
 
@@ -209,7 +209,7 @@ static OSReturn perf_context_switch_rate(double* rate) {
   u_longlong_t ticks;
   perfstat_cpu_total_t cpu_stats;
 
-   if (libperfstat::perfstat_cpu_total(NULL, &cpu_stats, sizeof(perfstat_cpu_total_t), 1) < 0) {
+   if (libperfstat::perfstat_cpu_total(nullptr, &cpu_stats, sizeof(perfstat_cpu_total_t), 1) < 0) {
      return OS_ERR;
    }
 
@@ -238,13 +238,13 @@ class CPUPerformanceInterface::CPUPerformance : public CHeapObj<mtInternal> {
 
 CPUPerformanceInterface::CPUPerformance::CPUPerformance():
   _ncpus(0),
-  _lcpu_names(NULL),
-  _prev_ticks(NULL) {}
+  _lcpu_names(nullptr),
+  _prev_ticks(nullptr) {}
 
 bool CPUPerformanceInterface::CPUPerformance::initialize() {
   perfstat_cpu_total_t cpu_stats;
 
-  if (libperfstat::perfstat_cpu_total(NULL, &cpu_stats, sizeof(perfstat_cpu_total_t), 1) < 0) {
+  if (libperfstat::perfstat_cpu_total(nullptr, &cpu_stats, sizeof(perfstat_cpu_total_t), 1) < 0) {
     return false;
   }
   if (cpu_stats.ncpus <= 0) {
@@ -280,7 +280,7 @@ CPUPerformanceInterface::CPUPerformance::~CPUPerformance() {
 int CPUPerformanceInterface::CPUPerformance::cpu_load(int lcpu_number, double* lcpu_load) {
   cpu_tick_store_t ticks;
 
-  assert(lcpu_load != NULL, "NULL pointer passed to cpu_load");
+  assert(lcpu_load != nullptr, "null pointer passed to cpu_load");
   assert(lcpu_number < _ncpus, "Invalid lcpu passed to cpu_load");
 
   if (get_lcpu_ticks(&_lcpu_names[lcpu_number], &ticks) == OS_ERR) {
@@ -301,7 +301,7 @@ int CPUPerformanceInterface::CPUPerformance::cpu_load_total_process(double* tota
   cpu_tick_store_t total_ticks;
   cpu_tick_store_t prev_total_ticks;
 
-  assert(total_load != NULL, "NULL pointer passed to cpu_load_total_process");
+  assert(total_load != nullptr, "null pointer passed to cpu_load_total_process");
 
   memset(&total_ticks, 0, sizeof(cpu_tick_store_t));
   memset(&prev_total_ticks, 0, sizeof(cpu_tick_store_t));
@@ -369,7 +369,7 @@ int CPUPerformanceInterface::CPUPerformance::context_switch_rate(double* rate) {
 }
 
 CPUPerformanceInterface::CPUPerformanceInterface() {
-  _impl = NULL;
+  _impl = nullptr;
 }
 
 bool CPUPerformanceInterface::initialize() {
@@ -378,7 +378,7 @@ bool CPUPerformanceInterface::initialize() {
 }
 
 CPUPerformanceInterface::~CPUPerformanceInterface() {
-  if (_impl != NULL) {
+  if (_impl != nullptr) {
     delete _impl;
   }
 }
@@ -421,10 +421,10 @@ SystemProcessInterface::SystemProcesses::~SystemProcesses() {
 }
 
 char* SystemProcessInterface::SystemProcesses::allocate_string(const char* str) const {
-  if (str != NULL) {
+  if (str != nullptr) {
     return os::strdup_check_oom(str, mtInternal);
   }
-  return NULL;
+  return nullptr;
 }
 
 int SystemProcessInterface::SystemProcesses::system_processes(SystemProcess** system_processes, int* nprocs) const {
@@ -434,14 +434,14 @@ int SystemProcessInterface::SystemProcesses::system_processes(SystemProcess** sy
   perfstat_id_t name_holder;
   int records_allocated = 0;
 
-  assert(nprocs != NULL, "system_processes counter pointers is NULL!");
+  assert(nprocs != nullptr, "system_processes counter pointers is null!");
 
-  head = NULL;
+  head = nullptr;
   *nprocs = 0;
   strncpy(name_holder.name, "", IDENTIFIER_LENGTH);
 
-  // calling perfstat_<subsystem>(NULL, NULL, _, 0) returns number of available records
-  *nprocs = libperfstat::perfstat_process(NULL, NULL, sizeof(perfstat_process_t), 0);
+  // calling perfstat_<subsystem>(null, null, _, 0) returns number of available records
+  *nprocs = libperfstat::perfstat_process(nullptr, nullptr, sizeof(perfstat_process_t), 0);
   if(*nprocs < 1) {
     // expect at least 1 process
     return OS_ERR;
@@ -487,7 +487,7 @@ int SystemProcessInterface::system_processes(SystemProcess** system_procs, int* 
 }
 
 SystemProcessInterface::SystemProcessInterface() {
-  _impl = NULL;
+  _impl = nullptr;
 }
 
 bool SystemProcessInterface::initialize() {
@@ -496,13 +496,13 @@ bool SystemProcessInterface::initialize() {
 }
 
 SystemProcessInterface::~SystemProcessInterface() {
-  if (_impl != NULL) {
+  if (_impl != nullptr) {
     delete _impl;
   }
 }
 
 CPUInformationInterface::CPUInformationInterface() {
-  _cpu_info = NULL;
+  _cpu_info = nullptr;
 }
 
 bool CPUInformationInterface::initialize() {
@@ -517,23 +517,23 @@ bool CPUInformationInterface::initialize() {
 }
 
 CPUInformationInterface::~CPUInformationInterface() {
-  if (_cpu_info != NULL) {
-    if (_cpu_info->cpu_name() != NULL) {
+  if (_cpu_info != nullptr) {
+    if (_cpu_info->cpu_name() != nullptr) {
       const char* cpu_name = _cpu_info->cpu_name();
       FREE_C_HEAP_ARRAY(char, cpu_name);
-      _cpu_info->set_cpu_name(NULL);
+      _cpu_info->set_cpu_name(nullptr);
     }
-    if (_cpu_info->cpu_description() != NULL) {
+    if (_cpu_info->cpu_description() != nullptr) {
        const char* cpu_desc = _cpu_info->cpu_description();
        FREE_C_HEAP_ARRAY(char, cpu_desc);
-      _cpu_info->set_cpu_description(NULL);
+      _cpu_info->set_cpu_description(nullptr);
     }
     delete _cpu_info;
   }
 }
 
 int CPUInformationInterface::cpu_information(CPUInformation& cpu_info) {
-  if (_cpu_info == NULL) {
+  if (_cpu_info == nullptr) {
     return OS_ERR;
   }
 
@@ -568,13 +568,13 @@ int NetworkPerformanceInterface::NetworkPerformance::network_utilization(Network
   perfstat_id_t name_holder;
   int records_allocated = 0;
 
-  assert(network_interfaces != NULL, "network_interfaces is NULL");
+  assert(network_interfaces != nullptr, "network_interfaces is null");
 
-  *network_interfaces = NULL;
+  *network_interfaces = nullptr;
   strncpy(name_holder.name , FIRST_NETINTERFACE, IDENTIFIER_LENGTH);
 
-  // calling perfstat_<subsystem>(NULL, NULL, _, 0) returns number of available records
-  if ((n_records = libperfstat::perfstat_netinterface(NULL, NULL, sizeof(perfstat_netinterface_t), 0)) < 0) {
+  // calling perfstat_<subsystem>(null, null, _, 0) returns number of available records
+  if ((n_records = libperfstat::perfstat_netinterface(nullptr, nullptr, sizeof(perfstat_netinterface_t), 0)) < 0) {
     return OS_ERR;
   }
 
@@ -607,11 +607,11 @@ int NetworkPerformanceInterface::NetworkPerformance::network_utilization(Network
 }
 
 NetworkPerformanceInterface::NetworkPerformanceInterface() {
-  _impl = NULL;
+  _impl = nullptr;
 }
 
 NetworkPerformanceInterface::~NetworkPerformanceInterface() {
-  if (_impl != NULL) {
+  if (_impl != nullptr) {
     delete _impl;
   }
 }

--- a/src/hotspot/os/aix/porting_aix.cpp
+++ b/src/hotspot/os/aix/porting_aix.cpp
@@ -111,7 +111,7 @@ bool AixSymbols::get_function_name (
     char* p_name, size_t namelen,    // [out] optional: function name ("" if not available)
     int* p_displacement,             // [out] optional: displacement (-1 if not available)
     const struct tbtable** p_tb,     // [out] optional: ptr to traceback table to get further
-                                     //                 information (NULL if not available)
+                                     //                 information (null if not available)
     bool demangle                    // [in] whether to demangle the name
   ) {
   struct tbtable* tb = 0;
@@ -125,7 +125,7 @@ bool AixSymbols::get_function_name (
     *p_displacement = -1;
   }
   if (p_tb) {
-    *p_tb = NULL;
+    *p_tb = nullptr;
   }
 
   codeptr_t pc = (codeptr_t)pc0;
@@ -141,7 +141,7 @@ bool AixSymbols::get_function_name (
   // we read it (?).
   // As the pc cannot be trusted to be anything sensible lets make all reads via SafeFetch. Also
   // bail if this is not a text address right now.
-  if (!LoadedLibraries::find_for_text_address(pc, NULL)) {
+  if (!LoadedLibraries::find_for_text_address(pc, nullptr)) {
     trcVerbose("not a text address");
     return false;
   }
@@ -163,7 +163,7 @@ bool AixSymbols::get_function_name (
 
   // Find start of traceback table.
   // (starts after code, is marked by word-aligned (32bit) zeros)
-  while ((*pc2 != NULL) && (searchcount++ < MAX_FUNC_SEARCH_LEN)) {
+  while ((*pc2 != nullptr) && (searchcount++ < MAX_FUNC_SEARCH_LEN)) {
     CHECK_POINTER_READABLE(pc2)
     pc2++;
   }
@@ -280,7 +280,7 @@ bool AixSymbols::get_module_name(address pc,
   if (p_name && namelen > 0) {
     p_name[0] = '\0';
     loaded_module_t lm;
-    if (LoadedLibraries::find_for_text_address(pc, &lm) != NULL) {
+    if (LoadedLibraries::find_for_text_address(pc, &lm) != nullptr) {
       strncpy(p_name, lm.shortname, namelen);
       p_name[namelen - 1] = '\0';
       return true;
@@ -310,10 +310,10 @@ int dladdr(void* addr, Dl_info* info) {
   const char* const ZEROSTRING = "";
 
   // Always return a string, even if a "" one. Linux dladdr manpage
-  // does not say anything about returning NULL
+  // does not say anything about returning null
   info->dli_fname = ZEROSTRING;
   info->dli_sname = ZEROSTRING;
-  info->dli_saddr = NULL;
+  info->dli_saddr = nullptr;
 
   address p = (address) addr;
   loaded_module_t lm;
@@ -368,7 +368,7 @@ int dladdr(void* addr, Dl_info* info) {
       int displacement = 0;
 
       if (AixSymbols::get_function_name(p, funcname, sizeof(funcname),
-                      &displacement, NULL, true)) {
+                      &displacement, nullptr, true)) {
         if (funcname[0] != '\0') {
           const char* const interned = dladdr_fixed_strings.intern(funcname);
           info->dli_sname = interned;
@@ -418,7 +418,7 @@ int dladdr(void* addr, Dl_info* info) {
 // Print the traceback table for one stack frame.
 static void print_tbtable (outputStream* st, const struct tbtable* p_tb) {
 
-  if (p_tb == NULL) {
+  if (p_tb == nullptr) {
     st->print("<null>");
     return;
   }
@@ -496,7 +496,7 @@ static void print_tbtable (outputStream* st, const struct tbtable* p_tb) {
 // on one line.
 static void print_info_for_pc (outputStream* st, codeptr_t pc, char* buf,
                                size_t buf_size, bool demangle) {
-  const struct tbtable* tb = NULL;
+  const struct tbtable* tb = nullptr;
   int displacement = -1;
 
   if (!os::is_readable_pointer(pc)) {
@@ -547,7 +547,7 @@ static void print_stackframe(outputStream* st, stackptr_t sp, char* buf,
   codeptr_t lrsave = (codeptr_t) *(sp2);
   st->print (PTR_FORMAT " - " PTR_FORMAT " ", p2i(sp2), p2i(lrsave));
 
-  if (lrsave != NULL) {
+  if (lrsave != nullptr) {
     print_info_for_pc(st, lrsave, buf, buf_size, demangle);
   }
 
@@ -575,7 +575,7 @@ static bool is_valid_codepointer(codeptr_t p) {
   if (((uintptr_t)p) & 0x3) {
     return false;
   }
-  if (LoadedLibraries::find_for_text_address(p, NULL) == NULL) {
+  if (LoadedLibraries::find_for_text_address(p, nullptr) == nullptr) {
     return false;
   }
   return true;
@@ -608,7 +608,7 @@ static stackptr_t try_find_backchain (stackptr_t last_known_good_frame,
                                       stackptr_t stack_base, size_t stack_size)
 {
   if (!is_valid_stackpointer(last_known_good_frame, stack_base, stack_size)) {
-    return NULL;
+    return nullptr;
   }
 
   stackptr_t sp = last_known_good_frame;
@@ -621,7 +621,7 @@ static stackptr_t try_find_backchain (stackptr_t last_known_good_frame,
     sp ++;
   }
 
-  return NULL;
+  return nullptr;
 }
 
 static void decode_instructions_at_pc(const char* header,
@@ -690,8 +690,8 @@ void AixNativeCallstack::print_callstack_for_context(outputStream* st, const uco
 
   // Retrieve current stack base, size from the current thread. If there is none,
   // retrieve it from the OS.
-  stackptr_t stack_base = NULL;
-  size_t stack_size = NULL;
+  stackptr_t stack_base = nullptr;
+  size_t stack_size = nullptr;
   {
     AixMisc::stackbounds_t stackbounds;
     if (!AixMisc::query_stack_bounds_for_current_thread(&stackbounds)) {
@@ -738,7 +738,7 @@ void AixNativeCallstack::print_callstack_for_context(outputStream* st, const uco
 
   // Check and print rtoc.
   st->print("rtoc: "  PTR_FORMAT " ", p2i(cur_rtoc));
-  if (cur_rtoc == NULL || cur_rtoc == (codeptr_t)-1 ||
+  if (cur_rtoc == nullptr || cur_rtoc == (codeptr_t)-1 ||
       !os::is_readable_pointer(cur_rtoc)) {
     st->print("(invalid)");
   } else if (((uintptr_t)cur_rtoc) & 0x7) {
@@ -761,14 +761,14 @@ void AixNativeCallstack::print_callstack_for_context(outputStream* st, const uco
 
     // Check sp.
     bool retry = false;
-    if (sp == NULL) {
-      // The backchain pointer was NULL. This normally means the end of the chain. But the
+    if (sp == nullptr) {
+      // The backchain pointer was null. This normally means the end of the chain. But the
       // stack might be corrupted, and it may be worth looking for the stack chain.
       if (is_valid_stackpointer(sp_last, stack_base, stack_size) && (stack_base - 0x10) > sp_last) {
         // If we are not within <guess> 0x10 stackslots of the stack base, we assume that this
         // is indeed not the end of the chain but that the stack was corrupted. So lets try to
         // find the end of the chain.
-        st->print_cr("*** back chain pointer is NULL - end of stack or broken backchain ? ***");
+        st->print_cr("*** back chain pointer is null - end of stack or broken backchain ? ***");
         retry = true;
       } else {
         st->print_cr("*** end of backchain ***");
@@ -853,7 +853,7 @@ bool AixMisc::query_stack_bounds_for_current_thread(stackbounds_t* out) {
   // running on a user provided stack (when handing down a stack to pthread
   // create, see pthread_attr_setstackaddr).
   // Not sure what to do then.
-  if (pinfo.__pi_stackend == NULL || pinfo.__pi_stackaddr == NULL) {
+  if (pinfo.__pi_stackend == nullptr || pinfo.__pi_stackaddr == nullptr) {
     fprintf(stderr, "pthread_getthrds_np - invalid values\n");
     fflush(stdout);
     return false;

--- a/src/hotspot/os/aix/porting_aix.cpp
+++ b/src/hotspot/os/aix/porting_aix.cpp
@@ -163,7 +163,7 @@ bool AixSymbols::get_function_name (
 
   // Find start of traceback table.
   // (starts after code, is marked by word-aligned (32bit) zeros)
-  while ((*pc2 != nullptr) && (searchcount++ < MAX_FUNC_SEARCH_LEN)) {
+  while ((*pc2 != 0) && (searchcount++ < MAX_FUNC_SEARCH_LEN)) {
     CHECK_POINTER_READABLE(pc2)
     pc2++;
   }
@@ -280,7 +280,7 @@ bool AixSymbols::get_module_name(address pc,
   if (p_name && namelen > 0) {
     p_name[0] = '\0';
     loaded_module_t lm;
-    if (LoadedLibraries::find_for_text_address(pc, &lm) != nullptr) {
+    if (LoadedLibraries::find_for_text_address(pc, &lm)) {
       strncpy(p_name, lm.shortname, namelen);
       p_name[namelen - 1] = '\0';
       return true;
@@ -575,10 +575,7 @@ static bool is_valid_codepointer(codeptr_t p) {
   if (((uintptr_t)p) & 0x3) {
     return false;
   }
-  if (LoadedLibraries::find_for_text_address(p, nullptr) == nullptr) {
-    return false;
-  }
-  return true;
+  return LoadedLibraries::find_for_text_address(p, nullptr);
 }
 
 // Function tries to guess if the given combination of stack pointer, stack base
@@ -691,7 +688,7 @@ void AixNativeCallstack::print_callstack_for_context(outputStream* st, const uco
   // Retrieve current stack base, size from the current thread. If there is none,
   // retrieve it from the OS.
   stackptr_t stack_base = nullptr;
-  size_t stack_size = nullptr;
+  size_t stack_size = 0;
   {
     AixMisc::stackbounds_t stackbounds;
     if (!AixMisc::query_stack_bounds_for_current_thread(&stackbounds)) {

--- a/src/hotspot/os/aix/safepointMechanism_aix.cpp
+++ b/src/hotspot/os/aix/safepointMechanism_aix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,9 +94,9 @@ void SafepointMechanism::pd_initialize() {
     }
   }
   if (map_address == (char*)MAP_FAILED) {
-    map_address = (char*) ::mmap(NULL, map_size, prot, flags, -1, 0);
+    map_address = (char*) ::mmap(nullptr, map_size, prot, flags, -1, 0);
   }
-  guarantee(map_address != (char*)MAP_FAILED && map_address != NULL,
+  guarantee(map_address != (char*)MAP_FAILED && map_address != nullptr,
             "SafepointMechanism::pd_initialize: failed to allocate polling page");
   log_info(os)("SafePoint Polling address: " INTPTR_FORMAT, p2i(map_address));
   _polling_page = (address)(map_address);


### PR DESCRIPTION
Hi, this PR changes all occurrences of NULL to nullptr for the subdirectory os/aix. Unfortunately the script that does the change isn't perfect, and so we
need to comb through these manually to make sure nothing has gone wrong. I also review these changes but things slip past my eyes sometimes.

Here are some typical things to look out for:

1. No changes but copyright header changed (probably because I reverted some changes but forgot the copyright).
2. Macros having their NULL changed to nullptr, these are added to the script when I find them. They should be NULL.
3. nullptr in comments and logs. We try to use lower case "null" in these cases as it reads better. An exception is made when code expressions are in a comment.

An example of this:

```c++
// This function returns null
void* ret_null();
// This function returns true if *x == nullptr
bool is_nullptr(void** x);
```

Note how `nullptr` participates in a code expression here, we really are talking about the specific value `nullptr`.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301477](https://bugs.openjdk.org/browse/JDK-8301477): Replace NULL with nullptr in os/aix


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [f1968b0f](https://git.openjdk.org/jdk/pull/12313/files/f1968b0ff01f09559f847d057947941a5471e156)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [f1968b0f](https://git.openjdk.org/jdk/pull/12313/files/f1968b0ff01f09559f847d057947941a5471e156)
 * [Tyler Steele](https://openjdk.org/census#tsteele) (@backwaterred - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12313/head:pull/12313` \
`$ git checkout pull/12313`

Update a local copy of the PR: \
`$ git checkout pull/12313` \
`$ git pull https://git.openjdk.org/jdk pull/12313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12313`

View PR using the GUI difftool: \
`$ git pr show -t 12313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12313.diff">https://git.openjdk.org/jdk/pull/12313.diff</a>

</details>
