### PR TITLE
JDK-8302666: Replace CHM with VarHandle in ForeachOrderedTask

### DIFF
--- a/src/java.base/share/classes/java/util/stream/ForEachOps.java
+++ b/src/java.base/share/classes/java/util/stream/ForEachOps.java
@@ -510,7 +510,7 @@ final class ForEachOps {
             // "happens-before" completion of the associated left-most leaf task
             // of right subtree (if any, which can be this task's right sibling)
             //
-            var leftDescendant = (ForEachOrderedTask<S, T>)NEXT.getAndSet(this, (ForEachOrderedTask<S, T>)null);
+            var leftDescendant = (ForEachOrderedTask<S, T>)NEXT.getAndSet(this, null);
             if (leftDescendant != null)
                 leftDescendant.tryComplete();
         }

--- a/src/java.base/share/classes/java/util/stream/ForEachOps.java
+++ b/src/java.base/share/classes/java/util/stream/ForEachOps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -380,7 +380,6 @@ final class ForEachOps {
             }
         }
 
-
         protected ForEachOrderedTask(PipelineHelper<T> helper,
                                      Spliterator<S> spliterator,
                                      Sink<T> action) {
@@ -511,8 +510,7 @@ final class ForEachOps {
             // "happens-before" completion of the associated left-most leaf task
             // of right subtree (if any, which can be this task's right sibling)
             //
-            @SuppressWarnings("unchecked")
-            var leftDescendant = (ForEachOrderedTask<S, T>)NEXT.getAndSet(this, null);
+            var leftDescendant = (ForEachOrderedTask<S, T>)NEXT.getAndSet(this, (ForEachOrderedTask<S, T>)null);
             if (leftDescendant != null)
                 leftDescendant.tryComplete();
         }


### PR DESCRIPTION
I noticed when looking at the code that there was no real need to use a CHM to perform the tracking of activation in an ordered fashion on ForEachOrderedTask, but instead a VarHandle can be used, reducing allocations and indirection.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302666](https://bugs.openjdk.org/browse/JDK-8302666): Replace CHM with VarHandle in ForeachOrderedTask


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12320/head:pull/12320` \
`$ git checkout pull/12320`

Update a local copy of the PR: \
`$ git checkout pull/12320` \
`$ git pull https://git.openjdk.org/jdk pull/12320/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12320`

View PR using the GUI difftool: \
`$ git pr show -t 12320`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12320.diff">https://git.openjdk.org/jdk/pull/12320.diff</a>

</details>
