### PR TITLE
JDK-8301500: Replace NULL with nullptr in os_cpu/aix_ppc

### DIFF
--- a/src/hotspot/os_cpu/aix_ppc/javaThread_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/javaThread_aix_ppc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2014 SAP SE. All rights reserved.
  * Copyright (c) 2022, IBM Corp.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -61,17 +61,17 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
     ucontext_t* uc = (ucontext_t*) ucontext;
     address pc = (address)uc->uc_mcontext.jmp_context.iar;
 
-    if (pc == NULL) {
+    if (pc == nullptr) {
       // ucontext wasn't useful
       return false;
     }
 
     frame ret_frame((intptr_t*)uc->uc_mcontext.jmp_context.gpr[1/*REG_SP*/], pc);
 
-    if (ret_frame.fp() == NULL) {
+    if (ret_frame.fp() == nullptr) {
       // The found frame does not have a valid frame pointer.
       // Bail out because this will create big trouble later on, either
-      //  - when using istate, calculated as (NULL - ijava_state_size) or
+      //  - when using istate, calculated as (null - ijava_state_size) or
       //  - when using fp() directly in safe_for_sender()
       //
       // There is no conclusive description (yet) how this could happen, but it does.

--- a/src/hotspot/os_cpu/aix_ppc/javaThread_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/javaThread_aix_ppc.cpp
@@ -71,7 +71,7 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
     if (ret_frame.fp() == nullptr) {
       // The found frame does not have a valid frame pointer.
       // Bail out because this will create big trouble later on, either
-      //  - when using istate, calculated as (null - ijava_state_size) or
+      //  - when using istate, calculated as (nullptr - ijava_state_size) or
       //  - when using fp() directly in safe_for_sender()
       //
       // There is no conclusive description (yet) how this could happen, but it does.

--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -90,7 +90,7 @@ intptr_t* os::Aix::ucontext_get_sp(const ucontext_t * uc) {
 }
 
 intptr_t* os::Aix::ucontext_get_fp(const ucontext_t * uc) {
-  return NULL;
+  return nullptr;
 }
 
 void os::Posix::ucontext_set_pc(ucontext_t* uc, address new_pc) {
@@ -107,14 +107,14 @@ address os::fetch_frame_from_context(const void* ucVoid,
   address epc;
   const ucontext_t* uc = (const ucontext_t*)ucVoid;
 
-  if (uc != NULL) {
+  if (uc != nullptr) {
     epc = os::Posix::ucontext_get_pc(uc);
     if (ret_sp) *ret_sp = os::Aix::ucontext_get_sp(uc);
     if (ret_fp) *ret_fp = os::Aix::ucontext_get_fp(uc);
   } else {
-    epc = NULL;
-    if (ret_sp) *ret_sp = (intptr_t *)NULL;
-    if (ret_fp) *ret_fp = (intptr_t *)NULL;
+    epc = nullptr;
+    if (ret_sp) *ret_sp = (intptr_t *)nullptr;
+    if (ret_fp) *ret_fp = (intptr_t *)nullptr;
   }
 
   return epc;
@@ -141,9 +141,9 @@ frame os::fetch_compiled_frame_from_context(const void* ucVoid) {
 }
 
 frame os::get_sender_for_C_frame(frame* fr) {
-  if (*fr->sp() == NULL) {
+  if (*fr->sp() == nullptr) {
     // fr is the last C frame
-    return frame(NULL, NULL);
+    return frame(nullptr, nullptr);
   }
   return frame(fr->sender_sp(), fr->sender_pc());
 }
@@ -159,27 +159,27 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
                                              ucontext_t* uc, JavaThread* thread) {
 
   // Decide if this trap can be handled by a stub.
-  address stub = NULL;
+  address stub = nullptr;
 
   // retrieve program counter
-  address const pc = uc ? os::Posix::ucontext_get_pc(uc) : NULL;
+  address const pc = uc ? os::Posix::ucontext_get_pc(uc) : nullptr;
 
   // retrieve crash address
-  address const addr = info ? (const address) info->si_addr : NULL;
+  address const addr = info ? (const address) info->si_addr : nullptr;
 
-  if (info == NULL || uc == NULL) {
+  if (info == nullptr || uc == nullptr) {
     return false; // Fatal error
   }
 
   // If we are a java thread...
-  if (thread != NULL) {
+  if (thread != nullptr) {
 
     // Handle ALL stack overflow variations here
     if (sig == SIGSEGV && thread->is_in_full_stack(addr)) {
       // stack overflow
       if (os::Posix::handle_stack_overflow(thread, addr, pc, uc, &stub)) {
         return true; // continue
-      } else if (stub != NULL) {
+      } else if (stub != nullptr) {
         goto run_stub;
       } else {
         return false; // Fatal error
@@ -222,7 +222,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
       //     happens rarely.  In heap based and disjoint base compressd oop modes also loads
       //     are used for null checks.
 
-      CodeBlob *cb = NULL;
+      CodeBlob *cb = nullptr;
       int stop_type = -1;
       // Handle signal from NativeJump::patch_verified_entry().
       if (sig == SIGILL && nativeInstruction_at(pc)->is_sigill_not_entrant()) {
@@ -236,7 +236,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
       else if ((sig == USE_POLL_BIT_ONLY ? SIGTRAP : SIGSEGV) &&
                ((NativeInstruction*)pc)->is_safepoint_poll() &&
                CodeCache::contains((void*) pc) &&
-               ((cb = CodeCache::find_blob(pc)) != NULL) &&
+               ((cb = CodeCache::find_blob(pc)) != nullptr) &&
                cb->is_compiled()) {
         if (TraceTraps) {
           tty->print_cr("trap: safepoint_poll at " INTPTR_FORMAT " (%s)", p2i(pc),
@@ -249,7 +249,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
       else if (UseSIGTRAP && sig == SIGTRAP &&
                ((NativeInstruction*)pc)->is_safepoint_poll_return() &&
                CodeCache::contains((void*) pc) &&
-               ((cb = CodeCache::find_blob(pc)) != NULL) &&
+               ((cb = CodeCache::find_blob(pc)) != nullptr) &&
                cb->is_compiled()) {
         if (TraceTraps) {
           tty->print_cr("trap: safepoint_poll at return at " INTPTR_FORMAT " (nmethod)", p2i(pc));
@@ -313,7 +313,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
         bool msg_present = (stop_type & MacroAssembler::stop_msg_present);
         stop_type = (stop_type &~ MacroAssembler::stop_msg_present);
 
-        const char *msg = NULL;
+        const char *msg = nullptr;
         switch (stop_type) {
           case MacroAssembler::stop_stop              : msg = "stop"; break;
           case MacroAssembler::stop_untested          : msg = "untested"; break;
@@ -332,7 +332,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
         // End life with a fatal error, message and detail message and the context.
         // Note: no need to do any post-processing here (e.g. signal chaining)
         va_list va_dummy;
-        VMError::report_and_die(thread, uc, NULL, 0, msg, detail_msg, va_dummy);
+        VMError::report_and_die(thread, uc, nullptr, 0, msg, detail_msg, va_dummy);
         va_end(va_dummy);
 
         ShouldNotReachHere();
@@ -342,9 +342,9 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
         // BugId 4454115: A read from a MappedByteBuffer can fault here if the
         // underlying file has been truncated. Do not crash the VM in such a case.
         CodeBlob* cb = CodeCache::find_blob(pc);
-        CompiledMethod* nm = cb ? cb->as_compiled_method_or_null() : NULL;
+        CompiledMethod* nm = cb ? cb->as_compiled_method_or_null() : nullptr;
         bool is_unsafe_arraycopy = (thread->doing_unsafe_access() && UnsafeCopyMemory::contains_pc(pc));
-        if ((nm != NULL && nm->has_unsafe_access()) || is_unsafe_arraycopy) {
+        if ((nm != nullptr && nm->has_unsafe_access()) || is_unsafe_arraycopy) {
           address next_pc = pc + 4;
           if (is_unsafe_arraycopy) {
             next_pc = UnsafeCopyMemory::page_error_continue_pc(pc);
@@ -394,9 +394,9 @@ run_stub:
 
   // One of the above code blocks ininitalized the stub, so we want to
   // delegate control to that stub.
-  if (stub != NULL) {
+  if (stub != nullptr) {
     // Save all thread context in case we need to restore it.
-    if (thread != NULL) thread->set_saved_exception_pc(pc);
+    if (thread != nullptr) thread->set_saved_exception_pc(pc);
     os::Posix::ucontext_set_pc(uc, stub);
     return true;
   }
@@ -433,7 +433,7 @@ size_t os::Posix::default_stack_size(os::ThreadType thr_type) {
 // helper functions for fatal error handler
 
 void os::print_context(outputStream *st, const void *context) {
-  if (context == NULL) return;
+  if (context == nullptr) return;
 
   const ucontext_t* uc = (const ucontext_t*)context;
 
@@ -451,7 +451,7 @@ void os::print_context(outputStream *st, const void *context) {
 }
 
 void os::print_tos_pc(outputStream *st, const void *context) {
-  if (context == NULL) return;
+  if (context == nullptr) return;
 
   const ucontext_t* uc = (const ucontext_t*)context;
 
@@ -474,7 +474,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
 }
 
 void os::print_register_info(outputStream *st, const void *context) {
-  if (context == NULL) return;
+  if (context == nullptr) return;
 
   ucontext_t *uc = (ucontext_t*)context;
 


### PR DESCRIPTION
Hi, this PR changes all occurrences of NULL to nullptr for the subdirectory os_cpu/aix_ppc. Unfortunately the script that does the change isn't perfect, and so we
need to comb through these manually to make sure nothing has gone wrong. I also review these changes but things slip past my eyes sometimes.

Here are some typical things to look out for:

1. No changes but copyright header changed (probably because I reverted some changes but forgot the copyright).
2. Macros having their NULL changed to nullptr, these are added to the script when I find them. They should be NULL.
3. nullptr in comments and logs. We try to use lower case "null" in these cases as it reads better. An exception is made when code expressions are in a comment.

An example of this:

```c++
// This function returns null
void* ret_null();
// This function returns true if *x == nullptr
bool is_nullptr(void** x);
```

Note how `nullptr` participates in a code expression here, we really are talking about the specific value `nullptr`.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301500](https://bugs.openjdk.org/browse/JDK-8301500): Replace NULL with nullptr in os_cpu/aix_ppc


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12329/head:pull/12329` \
`$ git checkout pull/12329`

Update a local copy of the PR: \
`$ git checkout pull/12329` \
`$ git pull https://git.openjdk.org/jdk pull/12329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12329`

View PR using the GUI difftool: \
`$ git pr show -t 12329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12329.diff">https://git.openjdk.org/jdk/pull/12329.diff</a>

</details>
