### PR TITLE
JDK-8301507: Replace NULL with nullptr in os_cpu/linux_riscv

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/javaThread_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/javaThread_linux_riscv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -59,10 +59,10 @@ bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava)
   if (isInJava) {
     ucontext_t* uc = (ucontext_t*) ucontext;
 
-    intptr_t* ret_fp = NULL;
-    intptr_t* ret_sp = NULL;
+    intptr_t* ret_fp = nullptr;
+    intptr_t* ret_sp = nullptr;
     address addr = os::fetch_frame_from_context(uc, &ret_sp, &ret_fp);
-    if (addr == NULL || ret_sp == NULL ) {
+    if (addr == nullptr || ret_sp == nullptr ) {
       // ucontext wasn't useful
       return false;
     }
@@ -70,7 +70,7 @@ bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava)
     frame ret_frame(ret_sp, ret_fp, addr);
     if (!ret_frame.safe_for_sender(this)) {
 #ifdef COMPILER2
-      frame ret_frame2(ret_sp, NULL, addr);
+      frame ret_frame2(ret_sp, nullptr, addr);
       if (!ret_frame2.safe_for_sender(this)) {
         // nothing else to try if the frame isn't good
         return false;

--- a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -108,21 +108,21 @@ address os::fetch_frame_from_context(const void* ucVoid,
   address epc;
   const ucontext_t* uc = (const ucontext_t*)ucVoid;
 
-  if (uc != NULL) {
+  if (uc != nullptr) {
     epc = os::Posix::ucontext_get_pc(uc);
-    if (ret_sp != NULL) {
+    if (ret_sp != nullptr) {
       *ret_sp = os::Linux::ucontext_get_sp(uc);
     }
-    if (ret_fp != NULL) {
+    if (ret_fp != nullptr) {
       *ret_fp = os::Linux::ucontext_get_fp(uc);
     }
   } else {
-    epc = NULL;
-    if (ret_sp != NULL) {
-      *ret_sp = (intptr_t *)NULL;
+    epc = nullptr;
+    if (ret_sp != nullptr) {
+      *ret_sp = (intptr_t *)nullptr;
     }
-    if (ret_fp != NULL) {
-      *ret_fp = (intptr_t *)NULL;
+    if (ret_fp != nullptr) {
+      *ret_fp = (intptr_t *)nullptr;
     }
   }
 
@@ -142,8 +142,8 @@ frame os::fetch_compiled_frame_from_context(const void* ucVoid) {
 }
 
 frame os::fetch_frame_from_context(const void* ucVoid) {
-  intptr_t* frame_sp = NULL;
-  intptr_t* frame_fp = NULL;
+  intptr_t* frame_sp = nullptr;
+  intptr_t* frame_fp = nullptr;
   address epc = fetch_frame_from_context(ucVoid, &frame_sp, &frame_fp);
   if (!is_readable_pointer(epc)) {
     // Try to recover from calling into bad memory
@@ -162,7 +162,7 @@ frame os::get_sender_for_C_frame(frame* fr) {
 
 NOINLINE frame os::current_frame() {
   intptr_t **sender_sp = (intptr_t **)__builtin_frame_address(0);
-  if (sender_sp != NULL) {
+  if (sender_sp != nullptr) {
     frame myframe((intptr_t*)os::current_stack_pointer(),
                   sender_sp[frame::link_offset],
                   CAST_FROM_FN_PTR(address, os::current_frame));
@@ -183,12 +183,12 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
                                              ucontext_t* uc, JavaThread* thread) {
 
   // decide if this trap can be handled by a stub
-  address stub = NULL;
+  address stub = nullptr;
 
-  address pc = NULL;
+  address pc = nullptr;
 
   //%note os_trap_1
-  if (info != NULL && uc != NULL && thread != NULL) {
+  if (info != nullptr && uc != nullptr && thread != nullptr) {
     pc = (address) os::Posix::ucontext_get_pc(uc);
 
     address addr = (address) info->si_addr;
@@ -226,9 +226,9 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
         // here if the underlying file has been truncated.
         // Do not crash the VM in such a case.
         CodeBlob* cb = CodeCache::find_blob(pc);
-        CompiledMethod* nm = (cb != NULL) ? cb->as_compiled_method_or_null() : NULL;
+        CompiledMethod* nm = (cb != nullptr) ? cb->as_compiled_method_or_null() : nullptr;
         bool is_unsafe_arraycopy = (thread->doing_unsafe_access() && UnsafeCopyMemory::contains_pc(pc));
-        if ((nm != NULL && nm->has_unsafe_access()) || is_unsafe_arraycopy) {
+        if ((nm != nullptr && nm->has_unsafe_access()) || is_unsafe_arraycopy) {
           address next_pc = pc + NativeCall::instruction_size;
           if (is_unsafe_arraycopy) {
             next_pc = UnsafeCopyMemory::page_error_continue_pc(pc);
@@ -249,7 +249,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
         // End life with a fatal error, message and detail message and the context.
         // Note: no need to do any post-processing here (e.g. signal chaining)
         va_list va_dummy;
-        VMError::report_and_die(thread, uc, NULL, 0, msg, detail_msg, va_dummy);
+        VMError::report_and_die(thread, uc, nullptr, 0, msg, detail_msg, va_dummy);
         va_end(va_dummy);
 
         ShouldNotReachHere();
@@ -287,9 +287,9 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
     }
   }
 
-  if (stub != NULL) {
+  if (stub != nullptr) {
     // save all thread context in case we need to restore it
-    if (thread != NULL) {
+    if (thread != nullptr) {
       thread->set_saved_exception_pc(pc);
     }
 
@@ -340,7 +340,7 @@ static const char* reg_abi_names[] = {
 };
 
 void os::print_context(outputStream *st, const void *context) {
-  if (context == NULL) return;
+  if (context == nullptr) return;
 
   const ucontext_t *uc = (const ucontext_t*)context;
 
@@ -352,7 +352,7 @@ void os::print_context(outputStream *st, const void *context) {
 }
 
 void os::print_tos_pc(outputStream *st, const void *context) {
-  if (context == NULL) return;
+  if (context == nullptr) return;
 
   const ucontext_t* uc = (const ucontext_t*)context;
 
@@ -369,7 +369,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
 }
 
 void os::print_register_info(outputStream *st, const void *context) {
-  if (context == NULL) return;
+  if (context == nullptr) return;
 
   const ucontext_t *uc = (const ucontext_t*)context;
 

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -115,8 +115,8 @@ void VM_Version::get_os_cpu_info() {
 
   if (FILE *f = fopen("/proc/cpuinfo", "r")) {
     char buf[512], *p;
-    while (fgets(buf, sizeof (buf), f) != NULL) {
-      if ((p = strchr(buf, ':')) != NULL) {
+    while (fgets(buf, sizeof (buf), f) != nullptr) {
+      if ((p = strchr(buf, ':')) != nullptr) {
         if (strncmp(buf, "mmu", sizeof "mmu" - 1) == 0) {
           if (_vm_mode[0] != '\0') {
             continue;


### PR DESCRIPTION
Hi, this PR changes all occurrences of NULL to nullptr for the subdirectory os_cpu/linux_riscv. Unfortunately the script that does the change isn't perfect, and so we
need to comb through these manually to make sure nothing has gone wrong. I also review these changes but things slip past my eyes sometimes.

Here are some typical things to look out for:

1. No changes but copyright header changed (probably because I reverted some changes but forgot the copyright).
2. Macros having their NULL changed to nullptr, these are added to the script when I find them. They should be NULL.
3. nullptr in comments and logs. We try to use lower case "null" in these cases as it reads better. An exception is made when code expressions are in a comment.

An example of this:

```c++
// This function returns null
void* ret_null();
// This function returns true if *x == nullptr
bool is_nullptr(void** x);
```

Note how `nullptr` participates in a code expression here, we really are talking about the specific value `nullptr`.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301507](https://bugs.openjdk.org/browse/JDK-8301507): Replace NULL with nullptr in os_cpu/linux_riscv


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12336/head:pull/12336` \
`$ git checkout pull/12336`

Update a local copy of the PR: \
`$ git checkout pull/12336` \
`$ git pull https://git.openjdk.org/jdk pull/12336/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12336`

View PR using the GUI difftool: \
`$ git pr show -t 12336`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12336.diff">https://git.openjdk.org/jdk/pull/12336.diff</a>

</details>
