### PR TITLE
JDK-8301511: Replace NULL with nullptr in os_cpu/linux_zero

### DIFF
--- a/src/hotspot/os_cpu/linux_zero/javaThread_linux_zero.cpp
+++ b/src/hotspot/os_cpu/linux_zero/javaThread_linux_zero.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2009, 2021, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -49,7 +49,7 @@ bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr,
     // Try to find the top-most Java frame on Zero stack then.
     intptr_t* sp = zero_stack()->sp();
     ZeroFrame* zf = top_zero_frame();
-    while (zf != NULL) {
+    while (zf != nullptr) {
       if (zf->is_interpreter_frame()) {
         interpreterState istate = zf->as_interpreter_frame()->interpreter_state();
         if (istate->self_link() == istate) {

--- a/src/hotspot/os_cpu/linux_zero/javaThread_linux_zero.hpp
+++ b/src/hotspot/os_cpu/linux_zero/javaThread_linux_zero.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2007, 2021, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -31,7 +31,7 @@
   ZeroFrame* _top_zero_frame;
 
   void pd_initialize() {
-    _top_zero_frame = NULL;
+    _top_zero_frame = nullptr;
   }
 
  public:
@@ -68,7 +68,7 @@
     frame_anchor()->zap();
   }
   void set_last_Java_frame(ZeroFrame* fp, intptr_t* sp) {
-    frame_anchor()->set(sp, NULL, fp);
+    frame_anchor()->set(sp, nullptr, fp);
   }
 
  public:

--- a/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
+++ b/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2007, 2008, 2009, 2010 Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -60,7 +60,7 @@ address os::current_stack_pointer() {
 
 frame os::get_sender_for_C_frame(frame* fr) {
   ShouldNotCallThis();
-  return frame(NULL, NULL); // silence compile warning.
+  return frame(nullptr, nullptr); // silence compile warning.
 }
 
 frame os::current_frame() {
@@ -71,7 +71,7 @@ frame os::current_frame() {
   //     set the sp to a close approximation of the real value in
   //     order to allow this step to complete.
   //   - Step 120 (printing native stack) tries to walk the stack.
-  //     The frame we create has a NULL pc, which is ignored as an
+  //     The frame we create has a null pc, which is ignored as an
   //     invalid frame.
   frame dummy = frame();
   dummy.set_sp((intptr_t *) current_stack_pointer());
@@ -177,7 +177,7 @@ address os::fetch_frame_from_context(const void* ucVoid,
   address epc;
   const ucontext_t* uc = (const ucontext_t*)ucVoid;
 
-  if (uc != NULL) {
+  if (uc != nullptr) {
     epc = os::Posix::ucontext_get_pc(uc);
     if (ret_sp) {
       *ret_sp = (intptr_t*) os::Linux::ucontext_get_sp(uc);
@@ -186,7 +186,7 @@ address os::fetch_frame_from_context(const void* ucVoid,
       *ret_fp = (intptr_t*) os::Linux::ucontext_get_fp(uc);
     }
   } else {
-    epc = NULL;
+    epc = nullptr;
     if (ret_sp) {
       *ret_sp = nullptr;
     }
@@ -202,7 +202,7 @@ frame os::fetch_frame_from_context(const void* ucVoid) {
   // This code is only called from error handler to get PC and SP.
   // We don't have the ready ZeroFrame* at this point, so fake the
   // frame with bare minimum.
-  if (ucVoid != NULL) {
+  if (ucVoid != nullptr) {
     const ucontext_t* uc = (const ucontext_t*)ucVoid;
     frame dummy = frame();
     dummy.set_pc(os::Posix::ucontext_get_pc(uc));
@@ -216,7 +216,7 @@ frame os::fetch_frame_from_context(const void* ucVoid) {
 bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
                                              ucontext_t* uc, JavaThread* thread) {
 
-  if (info != NULL && thread != NULL) {
+  if (info != nullptr && thread != nullptr) {
     // Handle ALL stack overflow variations here
     if (sig == SIGSEGV) {
       address addr = (address) info->si_addr;


### PR DESCRIPTION
Hi, this PR changes all occurrences of NULL to nullptr for the subdirectory os_cpu/linux_zero. Unfortunately the script that does the change isn't perfect, and so we
need to comb through these manually to make sure nothing has gone wrong. I also review these changes but things slip past my eyes sometimes.

Here are some typical things to look out for:

1. No changes but copyright header changed (probably because I reverted some changes but forgot the copyright).
2. Macros having their NULL changed to nullptr, these are added to the script when I find them. They should be NULL.
3. nullptr in comments and logs. We try to use lower case "null" in these cases as it reads better. An exception is made when code expressions are in a comment.

An example of this:

```c++
// This function returns null
void* ret_null();
// This function returns true if *x == nullptr
bool is_nullptr(void** x);
```

Note how `nullptr` participates in a code expression here, we really are talking about the specific value `nullptr`.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301511](https://bugs.openjdk.org/browse/JDK-8301511): Replace NULL with nullptr in os_cpu/linux_zero


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12339/head:pull/12339` \
`$ git checkout pull/12339`

Update a local copy of the PR: \
`$ git checkout pull/12339` \
`$ git pull https://git.openjdk.org/jdk pull/12339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12339`

View PR using the GUI difftool: \
`$ git pr show -t 12339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12339.diff">https://git.openjdk.org/jdk/pull/12339.diff</a>

</details>
