### PR TITLE
JDK-8301513: Replace NULL with nullptr in os_cpu/windows_x86

### DIFF
--- a/src/hotspot/os_cpu/windows_x86/assembler_windows_x86.cpp
+++ b/src/hotspot/os_cpu/windows_x86/assembler_windows_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ void MacroAssembler::int3() {
 //
 void MacroAssembler::get_thread(Register thread) {
   prefix(FS_segment);
-  movptr(thread, ExternalAddress(NULL));
+  movptr(thread, ExternalAddress(nullptr));
   assert(os::win32::get_thread_ptr_offset() != 0,
          "Thread Pointer Offset has not been initialized");
   movl(thread, Address(thread, os::win32::get_thread_ptr_offset()));

--- a/src/hotspot/os_cpu/windows_x86/javaThread_windows_x86.cpp
+++ b/src/hotspot/os_cpu/windows_x86/javaThread_windows_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
 
 frame JavaThread::pd_last_frame() {
   assert(has_last_Java_frame(), "must have last_Java_sp() when suspended");
-  vmassert(_anchor.last_Java_pc() != NULL, "not walkable");
+  vmassert(_anchor.last_Java_pc() != nullptr, "not walkable");
   return frame(_anchor.last_Java_sp(), _anchor.last_Java_fp(), _anchor.last_Java_pc());
 }
 
@@ -58,15 +58,15 @@ bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava)
   // if we were running Java code when SIGPROF came in.
   if (isInJava) {
     frame ret_frame = os::fetch_frame_from_context(ucontext);
-    if (ret_frame.pc() == NULL || ret_frame.sp() == NULL ) {
+    if (ret_frame.pc() == nullptr || ret_frame.sp() == nullptr ) {
       // CONTEXT wasn't useful
       return false;
     }
 
     if (!ret_frame.safe_for_sender(this)) {
 #if COMPILER2_OR_JVMCI
-      // C2 and JVMCI use ebp as a general register see if NULL fp helps
-      frame ret_frame2(ret_frame.sp(), NULL, ret_frame.pc());
+      // C2 and JVMCI use ebp as a general register see if null fp helps
+      frame ret_frame2(ret_frame.sp(), nullptr, ret_frame.pc());
       if (!ret_frame2.safe_for_sender(this)) {
         // nothing else to try if the frame isn't good
         return false;

--- a/src/hotspot/os_cpu/windows_x86/javaThread_windows_x86.hpp
+++ b/src/hotspot/os_cpu/windows_x86/javaThread_windows_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,8 +33,8 @@
   void pd_initialize() {
     _anchor.clear();
 
-    _windows_saved_rsi = NULL;
-    _windows_saved_rdi = NULL;
+    _windows_saved_rsi = nullptr;
+    _windows_saved_rdi = nullptr;
   }
 
   frame pd_last_frame();

--- a/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
+++ b/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -227,7 +227,7 @@ bool os::win32::platform_print_native_stack(outputStream* st, const void* contex
                                             char *buf, int buf_size)
 {
   CONTEXT ctx;
-  if (context != NULL) {
+  if (context != nullptr) {
     memcpy(&ctx, context, sizeof(ctx));
   } else {
     RtlCaptureContext(&ctx);
@@ -251,7 +251,7 @@ bool os::win32::platform_print_native_stack(outputStream* st, const void* contex
     intptr_t* fp = (intptr_t*)stk.AddrFrame.Offset; // NOT necessarily the same as ctx.Rbp!
     address pc = (address)stk.AddrPC.Offset;
 
-    if (pc != NULL) {
+    if (pc != nullptr) {
       if (count == 2 && lastpc == pc) {
         // Skip it -- StackWalk64() may return the same PC
         // (but different SP) on the first try.
@@ -303,14 +303,14 @@ address os::fetch_frame_from_context(const void* ucVoid,
   address  epc;
   CONTEXT* uc = (CONTEXT*)ucVoid;
 
-  if (uc != NULL) {
+  if (uc != nullptr) {
     epc = (address)uc->REG_PC;
     if (ret_sp) *ret_sp = (intptr_t*)uc->REG_SP;
     if (ret_fp) *ret_fp = (intptr_t*)uc->REG_FP;
   } else {
-    epc = NULL;
-    if (ret_sp) *ret_sp = (intptr_t *)NULL;
-    if (ret_fp) *ret_fp = (intptr_t *)NULL;
+    epc = nullptr;
+    if (ret_sp) *ret_sp = (intptr_t *)nullptr;
+    if (ret_fp) *ret_fp = (intptr_t *)nullptr;
   }
 
   return epc;
@@ -369,7 +369,7 @@ bool os::win32::get_frame_at_stack_banging_point(JavaThread* thread,
     // more complex code with compiled code
     assert(!Interpreter::contains(pc), "Interpreted methods should have been handled above");
     CodeBlob* cb = CodeCache::find_blob(pc);
-    if (cb == NULL || !cb->is_nmethod() || cb->is_frame_complete_at(pc)) {
+    if (cb == nullptr || !cb->is_nmethod() || cb->is_frame_complete_at(pc)) {
       // Not sure where the pc points to, fallback to default
       // stack overflow handling
       return false;
@@ -404,7 +404,7 @@ frame os::current_frame() {
 }
 
 void os::print_context(outputStream *st, const void *context) {
-  if (context == NULL) return;
+  if (context == nullptr) return;
 
   const CONTEXT* uc = (const CONTEXT*)context;
 
@@ -451,7 +451,7 @@ void os::print_context(outputStream *st, const void *context) {
 }
 
 void os::print_tos_pc(outputStream *st, const void *context) {
-  if (context == NULL) return;
+  if (context == nullptr) return;
 
   const CONTEXT* uc = (const CONTEXT*)context;
 
@@ -468,7 +468,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
 }
 
 void os::print_register_info(outputStream *st, const void *context) {
-  if (context == NULL) return;
+  if (context == nullptr) return;
 
   const CONTEXT* uc = (const CONTEXT*)context;
 
@@ -532,7 +532,7 @@ juint os::cpu_microcode_revision() {
                "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0", &key);
   if (status == ERROR_SUCCESS) {
     DWORD size = sizeof(data);
-    status = RegQueryValueEx(key, "Update Revision", NULL, NULL, data, &size);
+    status = RegQueryValueEx(key, "Update Revision", nullptr, nullptr, data, &size);
     if (status == ERROR_SUCCESS) {
       if (size == 4) result = *((juint*)data);
       if (size == 8) result = *((juint*)data + 1); // upper 32-bits
@@ -554,7 +554,7 @@ void os::verify_stack_alignment() {
 #ifdef AMD64
   // The current_stack_pointer() calls generated get_previous_sp stub routine.
   // Only enable the assert after the routine becomes available.
-  if (StubRoutines::code1() != NULL) {
+  if (StubRoutines::code1() != nullptr) {
     assert(((intptr_t)os::current_stack_pointer() & (StackAlignmentInBytes-1)) == 0, "incorrect stack alignment");
   }
 #endif


### PR DESCRIPTION
Hi, this PR changes all occurrences of NULL to nullptr for the subdirectory os_cpu/windows_x86. Unfortunately the script that does the change isn't perfect, and so we
need to comb through these manually to make sure nothing has gone wrong. I also review these changes but things slip past my eyes sometimes.

Here are some typical things to look out for:

1. No changes but copyright header changed (probably because I reverted some changes but forgot the copyright).
2. Macros having their NULL changed to nullptr, these are added to the script when I find them. They should be NULL.
3. nullptr in comments and logs. We try to use lower case "null" in these cases as it reads better. An exception is made when code expressions are in a comment.

An example of this:

```c++
// This function returns null
void* ret_null();
// This function returns true if *x == nullptr
bool is_nullptr(void** x);
```

Note how `nullptr` participates in a code expression here, we really are talking about the specific value `nullptr`.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301513](https://bugs.openjdk.org/browse/JDK-8301513): Replace NULL with nullptr in os_cpu/windows_x86


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12341/head:pull/12341` \
`$ git checkout pull/12341`

Update a local copy of the PR: \
`$ git checkout pull/12341` \
`$ git pull https://git.openjdk.org/jdk pull/12341/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12341`

View PR using the GUI difftool: \
`$ git pr show -t 12341`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12341.diff">https://git.openjdk.org/jdk/pull/12341.diff</a>

</details>
