### PR TITLE
8301093: C2 fails assert(ctrl == kit.control()) failed: Control flow was added although the intrinsic bailed out

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5988,7 +5988,6 @@ bool LibraryCallKit::inline_vectorizedHashCode() {
   Node* initialValue   = argument(3);
   Node* basic_type     = argument(4);
 
-  array = must_be_not_null(array, true);
   if (basic_type == top()) {
     return false; // failed input validation
   }
@@ -5997,6 +5996,9 @@ bool LibraryCallKit::inline_vectorizedHashCode() {
   if (!basic_type_t->is_con()) {
     return false; // Only intrinsify if mode argument is constant
   }
+
+  array = must_be_not_null(array, true);
+
   BasicType bt = (BasicType)basic_type_t->get_con();
 
   // Resolve address of first element

--- a/test/hotspot/jtreg/compiler/intrinsics/TestArraysHashCode.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestArraysHashCode.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8301093
+ * @summary Verify failure to intrinsify does not pollute control flow
+ * @modules java.base/jdk.internal.util
+ *
+ * @run main/othervm -Xbatch -XX:-TieredCompilation compiler.intrinsics.TestArraysHashCode
+ */
+
+package compiler.intrinsics;
+
+import jdk.internal.util.ArraysSupport;
+
+public class TestArraysHashCode {
+    
+    static int type;
+    static byte[] bytes;
+
+    public static void main(String[] args) {
+        // read
+        bytes = new byte[256];
+        type = ArraysSupport.T_BOOLEAN;
+        testIntrinsicWithConstantType();
+        testIntrinsicWithNonConstantType();
+    }
+
+    private static void testIntrinsicWithConstantType() {
+        for (int i = 0; i < 20_000; i++) {
+            testIntrinsic(bytes, ArraysSupport.T_BOOLEAN);
+        }
+    }
+
+    // ok, but shouldn't be intrinsified due the non-constant type
+    private static void testIntrinsicWithNonConstantType() {
+        type = ArraysSupport.T_BOOLEAN;
+        for (int i = 0; i < 20_000; i++) {
+            testIntrinsic(bytes, type);
+        }
+    }
+
+    private static int testIntrinsic(byte[] bytes, int type) {
+        return ArraysSupport.vectorizedHashCode(bytes, 0, 256, 1, type);
+    }
+}

--- a/test/hotspot/jtreg/compiler/intrinsics/TestArraysHashCode.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestArraysHashCode.java
@@ -35,7 +35,7 @@ package compiler.intrinsics;
 import jdk.internal.util.ArraysSupport;
 
 public class TestArraysHashCode {
-    
+
     static int type;
     static byte[] bytes;
 


### PR DESCRIPTION
`must_be_not_null` can transform the graph, which will cause assert if intrinsification of `vectorizedHashCode` bails out after input validation. Solution is to move `must_be_not_null` to after the input validation.

Added regression test that invokes `ArraysSupport.vectorizedHashCode` with a non-constant type to trigger bailout.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301093](https://bugs.openjdk.org/browse/JDK-8301093): C2 fails assert(ctrl == kit.control()) failed: Control flow was added although the intrinsic bailed out


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12342/head:pull/12342` \
`$ git checkout pull/12342`

Update a local copy of the PR: \
`$ git checkout pull/12342` \
`$ git pull https://git.openjdk.org/jdk pull/12342/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12342`

View PR using the GUI difftool: \
`$ git pr show -t 12342`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12342.diff">https://git.openjdk.org/jdk/pull/12342.diff</a>

</details>
