### PR TITLE
JDK-8301447: [REDO] CodeHeap has virtual methods that are not overridden

### DIFF
--- a/src/hotspot/share/memory/heap.hpp
+++ b/src/hotspot/share/memory/heap.hpp
@@ -175,8 +175,8 @@ class CodeHeap : public CHeapObj<mtCode> {
     return contains((void*)blob);
   }
 
-  virtual void* find_start(void* p)     const;   // returns the block containing p or null
-  virtual CodeBlob* find_blob(void* start) const;
+  void* find_start(void* p)     const;   // returns the block containing p or null
+  CodeBlob* find_blob(void* start) const;
   size_t alignment_unit()       const;           // alignment of any block
   size_t alignment_offset()     const;           // offset of first byte of any block, within the enclosing alignment unit
   static size_t header_size()         { return sizeof(HeapBlock); } // returns the header size for each heap block
@@ -192,9 +192,9 @@ class CodeHeap : public CHeapObj<mtCode> {
   int    freelist_length()       const           { return _freelist_length; } // number of elements in the freelist
 
   // returns the first block or null
-  virtual void* first() const                    { return next_used(first_block()); }
+  void* first() const                    { return next_used(first_block()); }
   // returns the next block given a block p or null
-  virtual void* next(void* p) const              { return next_used(next_block(block_start(p))); }
+  void* next(void* p) const              { return next_used(next_block(block_start(p))); }
 
   // Statistics
   size_t capacity() const;

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/CodeCache.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/CodeCache.java
@@ -49,13 +49,8 @@ public class CodeCache {
     Type type = db.lookupType("CodeCache");
 
     // Get array of CodeHeaps
-    // Note: CodeHeap may be subclassed with optional private heap mechanisms.
-    Type codeHeapType = db.lookupType("CodeHeap");
-    VirtualBaseConstructor<CodeHeap> heapConstructor =
-        new VirtualBaseConstructor<>(db, codeHeapType, "sun.jvm.hotspot.memory", CodeHeap.class);
-
     AddressField heapsField = type.getAddressField("_heaps");
-    heapArray = GrowableArray.create(heapsField.getValue(), heapConstructor);
+    heapArray = GrowableArray.create(heapsField.getValue(), new StaticBaseConstructor<>(CodeHeap.class));
 
     virtualConstructor = new VirtualConstructor(db);
     // Add mappings for all possible CodeBlob subclasses


### PR DESCRIPTION
Redo [JDK-8301378](https://bugs.openjdk.org/browse/JDK-8301378), this time also fixing the serviceability code.