### PR TITLE
8301552: Use AtomicReferenceArray for caching instead of CHM in ZoneOffset

### DIFF
--- a/src/java.base/share/classes/java/time/ZoneOffset.java
+++ b/src/java.base/share/classes/java/time/ZoneOffset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/time/ZoneOffset.java
+++ b/src/java.base/share/classes/java/time/ZoneOffset.java
@@ -461,19 +461,6 @@ public final class ZoneOffset
         SECONDS_CACHE_VH.setRelease(SECONDS_CACHE, slot, value);
     }
 
-    // Atomically sets a new value in SECONDS_CACHE if, and only if, the slot is null
-    // returning if the slot was set.
-/*    boolean trySetSecondsPerMinute(int slot) {
-        ZoneOffset cached = (ZoneOffset) SECONDS_CACHE_VH.get(SECONDS_CACHE, slot);
-        if (cached != null)
-            return cached;
-        synchronized (SECONDS_CACHE) {
-            ZoneOffset retry = SECONDS_CACHE.get(slot);
-            if (retry != null)
-                // Someone else beat us in the synchronization race
-                return retry;
-    }*/
-
     private static int cacheSlot(int totalSeconds) {
         return MAX_SECONDS_CACHE_SLOT + totalSeconds / (15 * SECONDS_PER_MINUTE);
     }

--- a/src/java.base/share/classes/jdk/internal/util/LazyReferenceArray.java
+++ b/src/java.base/share/classes/jdk/internal/util/LazyReferenceArray.java
@@ -1,0 +1,142 @@
+package jdk.internal.util;
+
+import jdk.internal.vm.annotation.Stable;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.function.IntFunction;
+
+/**
+ * An array of object references in which elements may be updated
+ * just once (lazily) and atomically. This contrasts to {@link AtomicReferenceArray } where
+ * any number of updates can be done and where there is no simple way to atomically compute
+ * a value (guaranteed to only be computed once) if it is missing.
+ * <p>
+ * This class is thread-safe.
+ * <p>
+ * The JVM may apply certain optimizations as it knows a component is updated just once
+ * as described by {@link Stable}.
+ *
+ * @param <E> The type of elements held in this array
+ */
+public final class LazyReferenceArray<E> {
+
+    private static final VarHandle ARRAY_VH = MethodHandles.arrayElementVarHandle(Object[].class);
+
+    @Stable
+    private final Object[] array;
+
+    /**
+     * Creates a new AtomicReferenceArray of the given length, with all
+     * elements initially null.
+     *
+     * @param length the length of the array
+     */
+    private LazyReferenceArray(int length) {
+        this.array = new Object[length];
+    }
+
+    /**
+     * {@return the length of the array}.
+     */
+    public int length() {
+        return array.length;
+    }
+
+    /**
+     * {@return the element at index {@code i} or {@code null} if
+     * no such element exists }
+     *
+     * @param index the element index
+     * @throws IndexOutOfBoundsException if {@code index < 0 or index >= length() }
+     */
+    @SuppressWarnings("unchecked")
+    public E getOrNull(int index) {
+        return getAcquire(index);
+    }
+
+    /**
+     * {@return the element at index {@code i} or, if no such element exists, throws
+     * a NoSuchElementException}.
+     *
+     * @param index the element index
+     * @throws NoSuchElementException    if no such element exists at the provided {@code index}
+     * @throws IndexOutOfBoundsException if {@code index < 0 or index >= length() }
+     */
+    public E getOrThrow(int index) {
+        E value = getOrNull(index);
+        if (value == null) {
+            throw new NoSuchElementException("No element at " + index);
+        }
+        return value;
+    }
+
+    /**
+     * If the specified index is not already associated with a value, atomically attempts
+     * to compute its value using the given mapping function and enters it into this
+     * array.
+     *
+     * <p>If the mapping function returns {@code null}, an exception is thrown.
+     * If the mapping function itself throws an (unchecked) exception, the
+     * exception is rethrown, and no mapping is recorded.  The most
+     * common usage is to construct a new object serving as an initial
+     * mapped value or memoized result, as in:
+     *
+     * <pre> {@code
+     * array.computeIfAbsent(index, i -> new Value(f(i)));
+     * }</pre>
+     *
+     * @param index to use as array index
+     * @param mappingFunction to apply if no previous value exists
+     * @return the element at the provided index (pre-existing or newly computed)
+     * @throws IndexOutOfBoundsException if {@code index < 0 or index >= length() }.
+     * @throws NullPointerException      if the provided {@code mappingFunction} is {@code null} or
+     *                                   the provided {@code mappingFunction} returns {@code null}.
+     */
+    public E computeIfAbsent(int index,
+                             IntFunction<? extends E> mappingFunction) {
+        Objects.checkIndex(index, array.length);
+        Objects.requireNonNull(mappingFunction);
+
+        E value = getAcquire(index);
+        if (value == null) {
+            synchronized (array) {
+                value = getAcquire(index);
+                if (value == null) {
+                    value = Objects.requireNonNull(
+                            mappingFunction.apply(index));
+                    setRelease(index, value);
+                }
+            }
+        }
+        return value;
+    }
+
+    // Use acquire/release to ensure happens-before so that newly
+    // constructed elements are always observed correctly
+    private E getAcquire(int index) {
+        return (E) ARRAY_VH.getAcquire(array, index);
+    }
+
+    void setRelease(int slot, Object value) {
+        ARRAY_VH.setRelease(array, slot, value);
+    }
+
+    /**
+     * {@return a new AtomicReferenceArray of the given length, with all
+     * elements initially null}.
+     *
+     * @param length the length of the array
+     * @throws IllegalArgumentException if the provided {@code length} is negative.
+     */
+    public static <E> LazyReferenceArray<E> create(int length) {
+        if (length < 0) {
+            throw new IllegalArgumentException();
+        }
+        return new LazyReferenceArray<>(length);
+    }
+
+}

--- a/src/java.base/share/classes/jdk/internal/util/LazyReferenceArray.java
+++ b/src/java.base/share/classes/jdk/internal/util/LazyReferenceArray.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package jdk.internal.util;
 
 import jdk.internal.vm.annotation.Stable;

--- a/test/jdk/java/time/tck/java/time/zone/TCKFixedZoneRules.java
+++ b/test/jdk/java/time/tck/java/time/zone/TCKFixedZoneRules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/time/tck/java/time/zone/TCKFixedZoneRules.java
+++ b/test/jdk/java/time/tck/java/time/zone/TCKFixedZoneRules.java
@@ -138,9 +138,10 @@ public class TCKFixedZoneRules {
 
     @Test(dataProvider="rules")
     public void test_isValidOffset_LDT_ZO(ZoneRules test, ZoneOffset expectedOffset) {
-        if (expectedOffset == ZoneOffset.UTC)
+        if (expectedOffset == ZoneOffset.UTC) {
             // The tests below are not made to work with ZoneOffset.UTC
             return;
+        }
         assertEquals(test.isValidOffset(LDT, ZoneOffset.UTC), false);
         assertEquals(test.isValidOffset(LDT, null), false);
 

--- a/test/jdk/java/time/tck/java/time/zone/TCKFixedZoneRules.java
+++ b/test/jdk/java/time/tck/java/time/zone/TCKFixedZoneRules.java
@@ -85,9 +85,9 @@ import org.testng.annotations.Test;
 @Test
 public class TCKFixedZoneRules {
 
+
     private static final ZoneOffset OFFSET_PONE = ZoneOffset.ofHours(1);
     private static final ZoneOffset OFFSET_PTWO = ZoneOffset.ofHours(2);
-    private static final ZoneOffset OFFSET_M18 = ZoneOffset.ofHours(-18);
     private static final LocalDateTime LDT = LocalDateTime.of(2010, 12, 3, 11, 30);
     private static final Instant INSTANT = LDT.toInstant(OFFSET_PONE);
 
@@ -98,9 +98,11 @@ public class TCKFixedZoneRules {
     @DataProvider(name="rules")
     Object[][] data_rules() {
         return new Object[][] {
-            {make(OFFSET_PONE), OFFSET_PONE},
-            {make(OFFSET_PTWO), OFFSET_PTWO},
-            {make(OFFSET_M18), OFFSET_M18},
+                {make(ZoneOffset.MIN), ZoneOffset.MIN},
+                {make(ZoneOffset.UTC), ZoneOffset.UTC},
+                {make(OFFSET_PONE), OFFSET_PONE},
+                {make(OFFSET_PTWO), OFFSET_PTWO},
+                {make(ZoneOffset.MAX), ZoneOffset.MAX},
         };
     }
 
@@ -136,7 +138,9 @@ public class TCKFixedZoneRules {
 
     @Test(dataProvider="rules")
     public void test_isValidOffset_LDT_ZO(ZoneRules test, ZoneOffset expectedOffset) {
-        assertEquals(test.isValidOffset(LDT, expectedOffset), true);
+        if (expectedOffset == ZoneOffset.UTC)
+            // The tests below are not made to work with ZoneOffset.UTC
+            return;
         assertEquals(test.isValidOffset(LDT, ZoneOffset.UTC), false);
         assertEquals(test.isValidOffset(LDT, null), false);
 

--- a/test/jdk/jdk/internal/util/LazyReferenceArray/BasicLazyReferenceArrayTest.java
+++ b/test/jdk/jdk/internal/util/LazyReferenceArray/BasicLazyReferenceArrayTest.java
@@ -53,7 +53,7 @@ final class BasicLazyReferenceArrayTest {
     }
 
     @Test
-    void emptyGet() {
+    void emptyGetOrNull() {
         for (int i = 0; i < LENGTH; i++) {
             assertNull(instance.getOrNull(i));
         }

--- a/test/jdk/jdk/internal/util/LazyReferenceArray/BasicLazyReferenceArrayTest.java
+++ b/test/jdk/jdk/internal/util/LazyReferenceArray/BasicLazyReferenceArrayTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @modules java.base/jdk.internal.util
+ * @summary Verify basic LazyReferenceArray operations
+ * @run junit BasicLazyReferenceArrayTest
+ */
+
+import jdk.internal.util.LazyReferenceArray;
+import org.junit.jupiter.api.*;
+
+import java.util.NoSuchElementException;
+import java.util.function.IntFunction;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+final class BasicLazyReferenceArrayTest {
+
+    private static final int LENGTH = 10;
+
+    LazyReferenceArray<Integer> instance;
+
+    @BeforeEach
+    void setup() {
+        instance = LazyReferenceArray.create(LENGTH);
+    }
+
+    @Test
+    void length() {
+        assertEquals(LENGTH, instance.length());
+    }
+
+    @Test
+    void emptyGet() {
+        for (int i = 0; i < LENGTH; i++) {
+            assertNull(instance.getOrNull(i));
+        }
+    }
+
+    @Test
+    void emptyGetOrThrow() {
+        for (int i = 0; i < LENGTH; i++) {
+            final int val = i;
+            assertThrows(NoSuchElementException.class,
+                    () -> instance.getOrThrow(val));
+        }
+    }
+
+    @Test
+    void compute() {
+        for (int i = 0; i < LENGTH; i++) {
+            Integer val = instance.computeIfAbsent(i, intIdentity());
+            assertEquals(i, val);
+        }
+    }
+
+    @Test
+    void nulls() {
+        // Mapper is null
+        assertThrows(NullPointerException.class,
+                () -> instance.computeIfAbsent(0, null));
+        // Mapper returns null
+        assertThrows(NullPointerException.class,
+                () -> instance.computeIfAbsent(0, i -> null));
+    }
+
+    @Test
+    void indexes() {
+        assertThrows(IndexOutOfBoundsException.class,
+                () -> instance.computeIfAbsent(-1, intIdentity()));
+        assertThrows(IndexOutOfBoundsException.class,
+                () -> instance.computeIfAbsent(LENGTH, intIdentity()));
+    }
+
+    @Test
+    void get() {
+        for (int i = 0; i < LENGTH; i++) {
+            Integer val = instance.computeIfAbsent(i, intIdentity());
+            assertEquals(i, instance.getOrNull(i));
+        }
+
+    }
+
+    private static IntFunction<Integer> intIdentity() {
+        return i -> i;
+    }
+
+}

--- a/test/micro/org/openjdk/bench/java/time/ZoneOffsetBench.java
+++ b/test/micro/org/openjdk/bench/java/time/ZoneOffsetBench.java
@@ -49,7 +49,7 @@ import java.util.stream.IntStream;
 public class ZoneOffsetBench {
 
     // An array with all the cached values [-18h, 18h]
-    private static final int CACHED_SECONDS[] = IntStream.rangeClosed(-18, 18 - 1)
+    private static final int CACHED_SECONDS[] = IntStream.range(-18, 18)
             // Convert hour to seconds
             .map(h -> h * 3600)
             // Include each even quarter of an hour

--- a/test/micro/org/openjdk/bench/java/time/ZoneOffsetBench.java
+++ b/test/micro/org/openjdk/bench/java/time/ZoneOffsetBench.java
@@ -60,14 +60,6 @@ public class ZoneOffsetBench {
             .sorted()
             .toArray();
 
-    @Setup
-    public void setup() {
-        for (int s : CACHED_SECONDS) {
-            ZoneOffset zo = ZoneOffset.ofTotalSeconds(s);
-            System.out.println(zo.getId() + " = " + zo.getTotalSeconds());
-        }
-    }
-
     @Benchmark
     public void getFromCache(Blackhole bh) {
         for (int s : CACHED_SECONDS) {

--- a/test/micro/org/openjdk/bench/java/time/ZoneOffsetBench.java
+++ b/test/micro/org/openjdk/bench/java/time/ZoneOffsetBench.java
@@ -32,6 +32,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
 
 import java.time.ZoneOffset;
 import java.util.concurrent.TimeUnit;
@@ -40,8 +41,8 @@ import java.util.stream.IntStream;
 /**
  * Examine ZoneOffset.ofTotalSeconds operations
  */
-@BenchmarkMode(Mode.Throughput)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
 @Fork(3)
@@ -59,12 +60,10 @@ public class ZoneOffsetBench {
             .toArray();
 
     @Benchmark
-    public long getFromCache() {
-        long sum = 0;
+    public void getFromCache(Blackhole bh) {
         for (int s : CACHED_SECONDS) {
             ZoneOffset zo = ZoneOffset.ofTotalSeconds(s);
-            sum += zo.getTotalSeconds();
+            bh.consume(zo.getTotalSeconds());
         }
-        return sum;
     }
 }

--- a/test/micro/org/openjdk/bench/java/time/ZoneOffsetBench.java
+++ b/test/micro/org/openjdk/bench/java/time/ZoneOffsetBench.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.time;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.time.ZoneOffset;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+/**
+ * Examine ZoneOffset.ofTotalSeconds operations
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(3)
+@State(Scope.Benchmark)
+public class ZoneOffsetBench {
+
+    // An array with all the cached values [-18h, 18h]
+    private static final int CACHED_SECONDS[] = IntStream.rangeClosed(-18, 18 - 1)
+            // Convert hour to seconds
+            .map(h -> h * 3600)
+            // Include each even quarter of an hour
+            .flatMap(s -> IntStream.iterate(s, l -> l + 3600 / 4).limit(4))
+            // There some overlaps so remove these
+            .distinct()
+            .toArray();
+
+    @Benchmark
+    public long getFromCache() {
+        long sum = 0;
+        for (int s : CACHED_SECONDS) {
+            ZoneOffset zo = ZoneOffset.ofTotalSeconds(s);
+            sum += zo.getTotalSeconds();
+        }
+        return sum;
+    }
+}

--- a/test/micro/org/openjdk/bench/java/time/ZoneOffsetBench.java
+++ b/test/micro/org/openjdk/bench/java/time/ZoneOffsetBench.java
@@ -52,12 +52,21 @@ public class ZoneOffsetBench {
     // An array with all the cached values [-18h, 18h]
     private static final int CACHED_SECONDS[] = IntStream.range(-18, 18)
             // Convert hour to seconds
-            .map(h -> h * 3600)
+            .map(h -> h * 3_600)
             // Include each even quarter of an hour
-            .flatMap(s -> IntStream.iterate(s, l -> l + 3600 / 4).limit(4))
+            .flatMap(s -> IntStream.iterate(s, l -> l + 3_600 / 4).limit(4 + 1))
             // There some overlaps so remove these
             .distinct()
+            .sorted()
             .toArray();
+
+    @Setup
+    public void setup() {
+        for (int s : CACHED_SECONDS) {
+            ZoneOffset zo = ZoneOffset.ofTotalSeconds(s);
+            System.out.println(zo.getId() + " = " + zo.getTotalSeconds());
+        }
+    }
 
     @Benchmark
     public void getFromCache(Blackhole bh) {


### PR DESCRIPTION
`ZoneOffset` instances are cached by the `ZoneOffset` class itself for values in the range [-18h, 18h] for each second that is on an even quarter of an hour (i.e. at most 2*18*4+1 = 145 values). 

Instead of using a `ConcurrentHashMap` for caching instanced, we could instead use an `AtomicReferenceArray` with direct slot value access for said even seconds. This will improve performance and reduce the number of object even though the backing array will go from an initial 32 in the CHM to an initial/final 145 in the ARA. The CHM will contain much more objects and array slots for typical numbers of entries in the cache and will compute hash/bucket/collision on the hot code path for each cache access.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301552](https://bugs.openjdk.org/browse/JDK-8301552): Use AtomicReferenceArray for caching instead of CHM in ZoneOffset (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12346/head:pull/12346` \
`$ git checkout pull/12346`

Update a local copy of the PR: \
`$ git checkout pull/12346` \
`$ git pull https://git.openjdk.org/jdk.git pull/12346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12346`

View PR using the GUI difftool: \
`$ git pr show -t 12346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12346.diff">https://git.openjdk.org/jdk/pull/12346.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12346#issuecomment-1410660065)