### PR TITLE
8301367: Add exception handler method to the BaseLdapServer

### DIFF
--- a/test/jdk/com/sun/jndi/ldap/lib/BaseLdapServer.java
+++ b/test/jdk/com/sun/jndi/ldap/lib/BaseLdapServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -173,7 +173,7 @@ public class BaseLdapServer implements Closeable {
             if (!isRunning()) {
                 logger.log(INFO, "Connection Handler exit {0}", t.getMessage());
             } else {
-                t.printStackTrace();
+                handleSocketException(socket, t);
             }
         }
 
@@ -188,6 +188,15 @@ public class BaseLdapServer implements Closeable {
      * Override to customize the behavior.
      */
     protected void beforeConnectionHandled(Socket socket) { /* empty */ }
+
+    /*
+     * Called to handle exceptions observed on an established client connection.
+     *
+     * By default, an exception stack trace is printed.
+     */
+    protected void handleSocketException(Socket socket, Throwable exception) {
+        exception.printStackTrace();
+    }
 
     /*
      * Called after an LDAP request has been read in `handleConnection()`.


### PR DESCRIPTION
The proposed change adds a new exception handler method to the `test/jdk/com/sun/jndi/ldap/lib/BaseLdapServer.java` LDAP test library class. It will allow LDAP tests to customize the handling of server-side exceptions.   
The current `BaseLdapTestServer` implementation prints an exception and its stack trace to the standard error stream.

Existing tests in `test/jdk/com/sun/jndi/ldap` that use the modified library class are passing with the modified version.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301367](https://bugs.openjdk.org/browse/JDK-8301367): Add exception handler method to the BaseLdapServer


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12347/head:pull/12347` \
`$ git checkout pull/12347`

Update a local copy of the PR: \
`$ git checkout pull/12347` \
`$ git pull https://git.openjdk.org/jdk pull/12347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12347`

View PR using the GUI difftool: \
`$ git pr show -t 12347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12347.diff">https://git.openjdk.org/jdk/pull/12347.diff</a>

</details>
