### PR TITLE
JDK-8300416 java.security.MessageDigestSpi clone can result in thread-unsafe clones

### DIFF
--- a/src/java.base/share/classes/java/security/MessageDigestSpi.java
+++ b/src/java.base/share/classes/java/security/MessageDigestSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/security/MessageDigestSpi.java
+++ b/src/java.base/share/classes/java/security/MessageDigestSpi.java
@@ -205,9 +205,9 @@ public abstract class MessageDigestSpi {
      */
     public Object clone() throws CloneNotSupportedException {
         if (this instanceof Cloneable) {
-            var o = super.clone();
-            if (((MessageDigestSpi)o).tempArray != null) {
-                ((MessageDigestSpi)o).tempArray = tempArray.clone();
+            MessageDigestSpi o = (MessageDigestSpi)super.clone();
+            if (o.tempArray != null) {
+                o.tempArray = tempArray.clone();
             }
             return o;
         } else {

--- a/src/java.base/share/classes/java/security/MessageDigestSpi.java
+++ b/src/java.base/share/classes/java/security/MessageDigestSpi.java
@@ -205,7 +205,11 @@ public abstract class MessageDigestSpi {
      */
     public Object clone() throws CloneNotSupportedException {
         if (this instanceof Cloneable) {
-            return super.clone();
+            var o = super.clone();
+            if (((MessageDigestSpi)o).tempArray != null) {
+                ((MessageDigestSpi)o).tempArray = tempArray.clone();
+            }
+            return o;
         } else {
             throw new CloneNotSupportedException();
         }

--- a/src/java.base/share/classes/java/security/MessageDigestSpi.java
+++ b/src/java.base/share/classes/java/security/MessageDigestSpi.java
@@ -207,6 +207,10 @@ public abstract class MessageDigestSpi {
         if (this instanceof Cloneable) {
             MessageDigestSpi o = (MessageDigestSpi)super.clone();
             if (o.tempArray != null) {
+                // New byte arrays are allocated when the ByteBuffer argument
+                // to engineUpdate is not backed by a byte array.
+                // Here, the newly allocated byte array must also be cloned
+                // to prevent threads from sharing the same memory.
                 o.tempArray = tempArray.clone();
             }
             return o;

--- a/test/jdk/java/security/MessageDigest/TestCloneable.java
+++ b/test/jdk/java/security/MessageDigest/TestCloneable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,12 +23,16 @@
 
 /*
  * @test
- * @bug 8246077
+ * @bug 8246077 8300416
  * @summary Make sure that digest spi and the resulting digest impl are
- * consistent in the impl of Cloneable interface
+ * consistent in the impl of Cloneable interface, and that clones do not
+ * share memory.
  * @run testng TestCloneable
  */
+import java.nio.ByteBuffer;
 import java.security.*;
+import java.util.Arrays;
+import java.util.Random;
 import java.util.Objects;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -53,7 +57,7 @@ public class TestCloneable {
     @Test(dataProvider = "testData")
     public void test(String algo, String provName)
             throws NoSuchProviderException, NoSuchAlgorithmException,
-            CloneNotSupportedException {
+            CloneNotSupportedException, InterruptedException {
         System.out.print("Testing " + algo + " impl from " + provName);
         Provider p = Security.getProvider(provName);
         Provider.Service s = p.getService("MessageDigest", algo);
@@ -71,6 +75,50 @@ public class TestCloneable {
             System.out.println(": NOT Cloneable");
             Assert.assertThrows(CNSE, ()->md.clone());
         }
+
+        System.out.print("Testing " + algo + " impl from " + provName);
+        final var d1 = MessageDigest.getInstance(algo, provName);
+        final var buffer = ByteBuffer.allocateDirect(1024);
+        final var r = new Random(1024);
+
+        fillBuffer(r, buffer);
+        d1.update(buffer); // this statement triggers tempArray allocation
+        final var d2 = (MessageDigest) d1.clone();
+        assert Arrays.equals(d1.digest(), d2.digest());
+
+        final var t1 = updateThread(d1);
+        final var t2 = updateThread(d2);
+        t1.join();
+        t2.join();
+
+        System.out.println(": Shared data check");
+        if (!Arrays.equals(d1.digest(), d2.digest())) {
+            throw new AssertionError("digests differ");
+            // cloned digest shares some memory with original one
+            // and is thus not thread safe
+        }
+
         System.out.println("Test Passed");
+    }
+
+    private static void fillBuffer(final Random r, final ByteBuffer buffer) {
+        final byte[] bytes = new byte[buffer.capacity()];
+        r.nextBytes(bytes);
+        buffer.clear();
+        buffer.put(bytes);
+        buffer.flip();
+    }
+
+    public static Thread updateThread(final MessageDigest d) {
+        final var t = new Thread(() -> {
+            final var r = new Random(1024);
+            final ByteBuffer buffer = ByteBuffer.allocateDirect(1024);
+            for (int i = 0; i < 1024; i++) {
+                fillBuffer(r, buffer);
+                d.update(buffer);
+            }
+        });
+        t.start();
+        return t;
     }
 }

--- a/test/jdk/java/security/MessageDigest/TestCloneable.java
+++ b/test/jdk/java/security/MessageDigest/TestCloneable.java
@@ -92,10 +92,12 @@ public class TestCloneable {
         t2.join();
 
         System.out.println(": Shared data check");
+        // Random is producing the same sequence of bytes for each thread,
+        // and thus each MessageDigest should be equal. When the memory is
+        // shared, they inevitably overwrite each other's tempArray and
+        // you get different results.
         if (!Arrays.equals(d1.digest(), d2.digest())) {
             throw new AssertionError("digests differ");
-            // cloned digest shares some memory with original one
-            // and is thus not thread safe
         }
 
         System.out.println("Test Passed");


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8300416

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300416](https://bugs.openjdk.org/browse/JDK-8300416): java.security.MessageDigestSpi clone can result in thread-unsafe clones


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12348/head:pull/12348` \
`$ git checkout pull/12348`

Update a local copy of the PR: \
`$ git checkout pull/12348` \
`$ git pull https://git.openjdk.org/jdk pull/12348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12348`

View PR using the GUI difftool: \
`$ git pr show -t 12348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12348.diff">https://git.openjdk.org/jdk/pull/12348.diff</a>

</details>
