### PR TITLE
JDK-8300909: Update com/sun/jndi/dns/Test6991580.java manual test instruction

### DIFF
--- a/test/jdk/com/sun/jndi/dns/Test6991580.java
+++ b/test/jdk/com/sun/jndi/dns/Test6991580.java
@@ -63,7 +63,6 @@ public class Test6991580 {
             + "Don't forget to save the original content of the file.",
          "3. Type \"cd " + System.getProperty("test.classes") + "\".",
          "4. Type \"" + System.getProperty("java.home") + "/bin/java"
-                 + " --add-modules java.desktop,jdk.naming.dns"
                  + " --add-opens jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED"
                  + " IPv6NameserverPlatformParsingTest\".",
          "5. If you see",

--- a/test/jdk/com/sun/jndi/dns/Test6991580.java
+++ b/test/jdk/com/sun/jndi/dns/Test6991580.java
@@ -62,8 +62,10 @@ public class Test6991580 {
          "Modify the /etc/resolv.conf file if needed. "
             + "Don't forget to save the original content of the file.",
          "3. Type \"cd " + System.getProperty("test.classes") + "\".",
-         "4. Type \"" + System.getProperty("java.home") +
-                "/bin/java IPv6NameserverPlatformParsingTest\".",
+         "4. Type \"" + System.getProperty("java.home") + "/bin/java"
+                 + " --add-modules java.desktop,jdk.naming.dns"
+                 + " --add-opens jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED"
+                 + " IPv6NameserverPlatformParsingTest\".",
          "5. If you see",
          "\"PASS: Found IPv6 address and DnsClient parsed it correctly.\"",
          ", press PASS else press FAIL.",
@@ -317,7 +319,7 @@ class TestDialog extends Dialog implements ActionListener
 
                if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
 
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
+               printStr = remainingStr.substring( 0, posOfSpace + 1 ) + " \\";
                remainingStr = remainingStr.substring( posOfSpace + 1 );
              }
             //else just print


### PR DESCRIPTION
Test failed for exception in thread "main" java.lang.IllegalAccessError: class IPv6NameserverPlatformParsingTest (in unnamed module @0x72a8ab1a) cannot access class com.sun.jndi.dns.DnsContextFactory (in module jdk.naming.dns) because module jdk.naming.dns does not export com.sun.jndi.dns to unnamed module @0x72a8ab1a
	at IPv6NameserverPlatformParsingTest.main(IPv6NameserverPlatformParsingTest.java:46)

This task is created to update test instruction to include --add-modules and --add-opens jvm parameters to java command.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300909](https://bugs.openjdk.org/browse/JDK-8300909): Update com/sun/jndi/dns/Test6991580.java manual test instruction


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12351/head:pull/12351` \
`$ git checkout pull/12351`

Update a local copy of the PR: \
`$ git checkout pull/12351` \
`$ git pull https://git.openjdk.org/jdk pull/12351/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12351`

View PR using the GUI difftool: \
`$ git pr show -t 12351`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12351.diff">https://git.openjdk.org/jdk/pull/12351.diff</a>

</details>
