### PR TITLE
JDK-8300912: Update java/nio/MappedByteBuffer/PmemTest.java to run on x86_64 only

### DIFF
--- a/test/jdk/java/nio/MappedByteBuffer/PmemTest.java
+++ b/test/jdk/java/nio/MappedByteBuffer/PmemTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,7 @@
  * @summary Testing NVRAM mapped byte buffer support
  * @run main/manual PmemTest
  * @requires (os.family == "linux")
- * @requires ((os.arch == "x86_64")|(os.arch == "amd64")|(os.arch == "aarch64")|(os.arch == "ppc64le"))
+ * @requires (os.arch == "x86_64")
  */
 
 import java.io.File;


### PR DESCRIPTION
This task is created to update jtreg test to run on x86 only because pmem emulation is only supported on x86. For other architectures with external NVRAM, run test with java PmemTest.