### PR TITLE
JDK-8299994: java/security/Policy/Root/Root.java fails when home directory is read-only

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -617,7 +617,6 @@ sun/security/pkcs11/rsa/TestKeyPairGenerator.java               8295343 linux-al
 sun/security/pkcs11/rsa/TestKeyFactory.java                     8295343 linux-all
 sun/security/pkcs11/KeyStore/Basic.java                         8295343 linux-all
 
-java/security/Policy/Root/Root.java                             8299994 generic-all
 sun/security/provider/certpath/OCSP/OCSPNoContentLength.java    8300939 generic-all
 
 ############################################################################

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -635,7 +635,8 @@ jdk_core_manual_no_input_security = \
     sun/security/smartcardio/TestMultiplePresent.java \
     sun/security/smartcardio/TestPresent.java \
     sun/security/smartcardio/TestTransmit.java \
-    sun/security/tools/jarsigner/compatibility/Compatibility.java
+    sun/security/tools/jarsigner/compatibility/Compatibility.java \
+    java/security/Policy/Root/Root.java
 
 jdk_core_manual_requires_human_input = \
     com/sun/jndi/dns/Test6991580.java \

--- a/test/jdk/java/security/Policy/Root/Root.java
+++ b/test/jdk/java/security/Policy/Root/Root.java
@@ -39,7 +39,9 @@ import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -52,7 +54,7 @@ public class Root {
     private static final Path SOURCE = Paths.get(SRC, "Root.policy");
     private static final Path TARGET = Paths.get(ROOT, ".java.policy");
     private static final Path BACKUP = Paths.get(ROOT, ".backup.policy");
-    private static final String USER = System.getProperty("user.name");
+    private static final String ROOT_USER_ID = "0";
 
     @BeforeTest
     public void setup() throws IOException {
@@ -74,11 +76,23 @@ public class Root {
     }
 
     @Test
-    private void test() {
+    private void test() throws InterruptedException, IOException {
         System.out.println("Run test as root user.");
 
-        if (!"root".equalsIgnoreCase(USER)) {
-            throw new RuntimeException("This test needs to be run with root privilege.");
+        Process process = Runtime.getRuntime().exec("id -u");
+        process.waitFor();
+        if (process.exitValue() != 0) {
+            throw new RuntimeException("Failed to retrieve user id.");
+        }
+
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(process.getInputStream()))) {
+            String line = reader.readLine();
+
+            if (!ROOT_USER_ID.equals(line)) {
+                throw new RuntimeException(
+                        "This test needs to be run with root privilege.");
+            }
         }
 
         Policy p = Policy.getPolicy();

--- a/test/jdk/java/security/Policy/Root/Root.java
+++ b/test/jdk/java/security/Policy/Root/Root.java
@@ -27,8 +27,12 @@
  * @summary User Policy Setting is not recognized on Netscape 6
  *          when invoked as root.
  * @library /test/lib
- * @run testng/othervm Root
+ * @run testng/othervm/manual Root
  */
+
+/*
+* Run test as root user.
+* */
 
 import org.testng.Assert;
 import org.testng.annotations.AfterTest;
@@ -47,15 +51,25 @@ public class Root {
     private static final String ROOT = System.getProperty("user.home");
     private static final Path SOURCE = Paths.get(SRC, "Root.policy");
     private static final Path TARGET = Paths.get(ROOT, ".java.policy");
+    private static final Path BACKUP = Paths.get(ROOT, ".backup.policy");
 
     @BeforeTest
     public void setup() throws IOException {
+        // Backup user policy file if it already exists
+        if (TARGET.toFile().exists()) {
+            Files.copy(TARGET, BACKUP, StandardCopyOption.REPLACE_EXISTING);
+        }
         Files.copy(SOURCE, TARGET, StandardCopyOption.REPLACE_EXISTING);
     }
 
     @AfterTest
     public void cleanUp() throws IOException {
         Files.delete(TARGET);
+        // Restore original policy file if backup exists
+        if (BACKUP.toFile().exists()) {
+            Files.copy(BACKUP, TARGET, StandardCopyOption.REPLACE_EXISTING);
+            Files.delete(BACKUP);
+        }
     }
 
     @Test

--- a/test/jdk/java/security/Policy/Root/Root.java
+++ b/test/jdk/java/security/Policy/Root/Root.java
@@ -52,6 +52,7 @@ public class Root {
     private static final Path SOURCE = Paths.get(SRC, "Root.policy");
     private static final Path TARGET = Paths.get(ROOT, ".java.policy");
     private static final Path BACKUP = Paths.get(ROOT, ".backup.policy");
+    private static final String USER = System.getProperty("user.name");
 
     @BeforeTest
     public void setup() throws IOException {
@@ -74,6 +75,12 @@ public class Root {
 
     @Test
     private void test() {
+        System.out.println("Run test as root user.");
+
+        if (!"root".equalsIgnoreCase(USER)) {
+            throw new RuntimeException("This test needs to be run with root privilege.");
+        }
+
         Policy p = Policy.getPolicy();
         Assert.assertTrue(p.implies(Root.class.getProtectionDomain(),
                 new AllPermission()));

--- a/test/jdk/java/security/Policy/Root/Root.java
+++ b/test/jdk/java/security/Policy/Root/Root.java
@@ -27,6 +27,7 @@
  * @summary User Policy Setting is not recognized on Netscape 6
  *          when invoked as root.
  * @library /test/lib
+ * @requires os.family != "windows"
  * @run testng/othervm/manual Root
  */
 
@@ -34,7 +35,6 @@
 * Run test as root user.
 * */
 
-import jdk.test.lib.Platform;
 import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
@@ -80,21 +80,19 @@ public class Root {
     private void test() throws InterruptedException, IOException {
         System.out.println("Run test as root user.");
 
-        if (!Platform.isWindows()) {
-            Process process = Runtime.getRuntime().exec("id -u");
-            process.waitFor();
-            if (process.exitValue() != 0) {
-                throw new RuntimeException("Failed to retrieve user id.");
-            }
+        Process process = Runtime.getRuntime().exec("id -u");
+        process.waitFor();
+        if (process.exitValue() != 0) {
+            throw new RuntimeException("Failed to retrieve user id.");
+        }
 
-            try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(process.getInputStream()))) {
-                String line = reader.readLine();
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(process.getInputStream()))) {
+            String line = reader.readLine();
 
-                if (!ROOT_USER_ID.equals(line)) {
-                    throw new RuntimeException(
-                            "This test needs to be run with root privilege.");
-                }
+            if (!ROOT_USER_ID.equals(line)) {
+                throw new RuntimeException(
+                        "This test needs to be run with root privilege.");
             }
         }
 

--- a/test/jdk/java/security/Policy/Root/Root.java
+++ b/test/jdk/java/security/Policy/Root/Root.java
@@ -34,6 +34,7 @@
 * Run test as root user.
 * */
 
+import jdk.test.lib.Platform;
 import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
@@ -79,19 +80,21 @@ public class Root {
     private void test() throws InterruptedException, IOException {
         System.out.println("Run test as root user.");
 
-        Process process = Runtime.getRuntime().exec("id -u");
-        process.waitFor();
-        if (process.exitValue() != 0) {
-            throw new RuntimeException("Failed to retrieve user id.");
-        }
+        if (!Platform.isWindows()) {
+            Process process = Runtime.getRuntime().exec("id -u");
+            process.waitFor();
+            if (process.exitValue() != 0) {
+                throw new RuntimeException("Failed to retrieve user id.");
+            }
 
-        try (BufferedReader reader = new BufferedReader(
-                new InputStreamReader(process.getInputStream()))) {
-            String line = reader.readLine();
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream()))) {
+                String line = reader.readLine();
 
-            if (!ROOT_USER_ID.equals(line)) {
-                throw new RuntimeException(
-                        "This test needs to be run with root privilege.");
+                if (!ROOT_USER_ID.equals(line)) {
+                    throw new RuntimeException(
+                            "This test needs to be run with root privilege.");
+                }
             }
         }
 


### PR DESCRIPTION
Root.java is changed to a manual test because it requires test to be run with the root user privilege, and it requires to modify the user policy file in the home director.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299994](https://bugs.openjdk.org/browse/JDK-8299994): java/security/Policy/Root/Root.java fails when home directory is read-only


### Reviewers
 * [Rajan Halade](https://openjdk.org/census#rhalade) (@rhalade - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12354/head:pull/12354` \
`$ git checkout pull/12354`

Update a local copy of the PR: \
`$ git checkout pull/12354` \
`$ git pull https://git.openjdk.org/jdk pull/12354/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12354`

View PR using the GUI difftool: \
`$ git pr show -t 12354`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12354.diff">https://git.openjdk.org/jdk/pull/12354.diff</a>

</details>
