### PR TITLE
8301567: The test/jdk/java/awt/AppContext/ApplicationThreadsStop/java.policy is unused

### DIFF
--- a/test/jdk/java/awt/AppContext/ApplicationThreadsStop/java.policy
+++ b/test/jdk/java/awt/AppContext/ApplicationThreadsStop/java.policy
@@ -1,5 +1,0 @@
-grant {
-    permission java.lang.RuntimePermission "accessClassInPackage.sun.awt";
-    permission java.awt.AWTPermission "createRobot";
-    permission java.util.PropertyPermission "AWT.EventQueueClass", "read";
-};


### PR DESCRIPTION
The test ApplicationThreadsStop.java was removed by the [JDK-8289616](https://bugs.openjdk.org/browse/JDK-8289616) but the related java.policy was not deleted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301567](https://bugs.openjdk.org/browse/JDK-8301567): The test/jdk/java/awt/AppContext/ApplicationThreadsStop/java.policy is unused


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12356/head:pull/12356` \
`$ git checkout pull/12356`

Update a local copy of the PR: \
`$ git checkout pull/12356` \
`$ git pull https://git.openjdk.org/jdk pull/12356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12356`

View PR using the GUI difftool: \
`$ git pr show -t 12356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12356.diff">https://git.openjdk.org/jdk/pull/12356.diff</a>

</details>
