### PR TITLE
JDK-8298880: VectorLogicalOpIdentityTest.java IR test incorrectly use avx3 instead of avx512

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/VectorLogicalOpIdentityTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorLogicalOpIdentityTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -301,7 +302,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform AndV(AndV(a, b, m), b, m) ==> AndV(a, b, m)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.AND_V, "1"}, applyIfCPUFeatureOr = {"sve1", "true", "avx3", "true"})
+    @IR(counts = {IRNode.AND_V, "1"}, applyIfCPUFeatureOr = {"sve1", "true", "avx512", "true"})
     public static void testAndMaskSameValue1() {
         VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
         IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
@@ -322,7 +323,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform AndV(AndV(a, b, m), a, m) ==> AndV(a, b, m)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.AND_V, "1"}, applyIfCPUFeatureOr = {"sve1", "true", "avx3", "true"})
+    @IR(counts = {IRNode.AND_V, "1"}, applyIfCPUFeatureOr = {"sve1", "true", "avx512", "true"})
     public static void testAndMaskSameValue2() {
         VectorMask<Long> mask = VectorMask.fromArray(L_SPECIES, m, 0);
         LongVector av = LongVector.fromArray(L_SPECIES, la, 0);
@@ -343,7 +344,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform AndV(a, AndV(a, b, m), m) ==> AndV(a, b, m)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.AND_V, "1"}, applyIfCPUFeatureOr = {"sve1", "true", "avx3", "true"})
+    @IR(counts = {IRNode.AND_V, "1"}, applyIfCPUFeatureOr = {"sve1", "true", "avx512", "true"})
     public static void testAndMaskSameValue3() {
         VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
         IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
@@ -565,7 +566,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform OrV(OrV(a, b, m), b, m) ==> OrV(a, b, m)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.OR_V, "1"}, applyIfCPUFeatureOr = {"sve1", "true", "avx3", "true"})
+    @IR(counts = {IRNode.OR_V, "1"}, applyIfCPUFeatureOr = {"sve1", "true", "avx512", "true"})
     public static void testOrMaskSameValue1() {
         VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
         IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
@@ -586,7 +587,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform OrV(OrV(a, b, m), a, m) ==> OrV(a, b, m)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.OR_V, "1"}, applyIfCPUFeatureOr = {"sve1", "true", "avx3", "true"})
+    @IR(counts = {IRNode.OR_V, "1"}, applyIfCPUFeatureOr = {"sve1", "true", "avx512", "true"})
     public static void testOrMaskSameValue2() {
         VectorMask<Long> mask = VectorMask.fromArray(L_SPECIES, m, 0);
         LongVector av = LongVector.fromArray(L_SPECIES, la, 0);
@@ -607,7 +608,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform OrV(a, OrV(a, b, m), m) ==> OrV(a, b, m)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.OR_V, "1"}, applyIfCPUFeatureOr = {"sve1", "true", "avx3", "true"})
+    @IR(counts = {IRNode.OR_V, "1"}, applyIfCPUFeatureOr = {"sve1", "true", "avx512", "true"})
     public static void testOrMaskSameValue3() {
         VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
         IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);


### PR DESCRIPTION
A few tests of _compiler/vectorapi/VectorLogicalOpIdentityTest.java_ (`testAndMaskSameValue1`, `testAndMaskSameValue2`, `testAndMaskSameValue3`, `testOrMaskSameValue1`, `testOrMaskSameValue2`, and `testOrMaskSameValue3`) use _avx3_ in the `applyIfCPUFeatureOr` IR filter but the actual CPU extension filter is _avx512_.

Changing _avx3_ to _avx512_ in the `applyIfCPUFeatureOr` filter.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298880](https://bugs.openjdk.org/browse/JDK-8298880): VectorLogicalOpIdentityTest.java IR test incorrectly use avx3 instead of avx512


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12358/head:pull/12358` \
`$ git checkout pull/12358`

Update a local copy of the PR: \
`$ git checkout pull/12358` \
`$ git pull https://git.openjdk.org/jdk pull/12358/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12358`

View PR using the GUI difftool: \
`$ git pr show -t 12358`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12358.diff">https://git.openjdk.org/jdk/pull/12358.diff</a>

</details>
