### PR TITLE
8301599: Serial: Refactor nested closures in DefNewGeneration

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -63,43 +63,75 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/stack.inline.hpp"
 
-//
-// DefNewGeneration functions.
+class IsAliveClosure: public BoolObjectClosure {
+  Generation* _young_gen;
+public:
+  IsAliveClosure(Generation* young_gen) : _young_gen(young_gen) {
+    assert(_young_gen->kind() == Generation::DefNew,
+        "Expected the young generation here");
+  }
 
-// Methods of protected closure types.
+  bool do_object_b(oop p) {
+    return cast_from_oop<HeapWord*>(p) >= _young_gen->reserved().end() || p->is_forwarded();
+  }
+};
 
-DefNewGeneration::IsAliveClosure::IsAliveClosure(Generation* young_gen) : _young_gen(young_gen) {
-  assert(_young_gen->kind() == Generation::DefNew, "Expected the young generation here");
-}
+class KeepAliveClosure: public OopClosure {
+  ScanWeakRefClosure* _cl;
+  CardTableRS* _rs;
+  HeapWord* _boundary;
 
-bool DefNewGeneration::IsAliveClosure::do_object_b(oop p) {
-  return cast_from_oop<HeapWord*>(p) >= _young_gen->reserved().end() || p->is_forwarded();
-}
+  template <class T>
+  inline void do_oop_work(T* p) {
+#ifdef ASSERT
+    {
+      // We never expect to see a null reference being processed
+      // as a weak reference.
+      oop obj = RawAccess<IS_NOT_NULL>::oop_load(p);
+      assert (oopDesc::is_oop(obj), "expected an oop while scanning weak refs");
+    }
+#endif // ASSERT
 
-DefNewGeneration::KeepAliveClosure::
-KeepAliveClosure(DefNewGeneration* g, ScanWeakRefClosure* cl) :
-  _cl(cl) {
-  _rs = GenCollectedHeap::heap()->rem_set();
-  _boundary = g->reserved().end();
-}
+    Devirtualizer::do_oop(_cl, p);
 
-void DefNewGeneration::KeepAliveClosure::do_oop(oop* p)       { DefNewGeneration::KeepAliveClosure::do_oop_work(p); }
-void DefNewGeneration::KeepAliveClosure::do_oop(narrowOop* p) { DefNewGeneration::KeepAliveClosure::do_oop_work(p); }
+    // Optimized for Defnew generation if it's the youngest generation:
+    // we set a younger_gen card if we have an older->youngest
+    // generation pointer.
+    oop obj = RawAccess<IS_NOT_NULL>::oop_load(p);
+    if ((cast_from_oop<HeapWord*>(obj) < _boundary) && GenCollectedHeap::heap()->is_in_reserved(p)) {
+      _rs->inline_write_ref_field_gc(p);
+    }
+  }
 
-DefNewGeneration::FastEvacuateFollowersClosure::
-FastEvacuateFollowersClosure(SerialHeap* heap,
-                             DefNewScanClosure* cur,
-                             DefNewYoungerGenClosure* older) :
-  _heap(heap), _scan_cur_or_nonheap(cur), _scan_older(older)
-{
-}
+public:
+  KeepAliveClosure(DefNewGeneration* g, ScanWeakRefClosure* cl) :
+    _cl(cl) {
+    _rs = GenCollectedHeap::heap()->rem_set();
+    _boundary = g->reserved().end();
+  }
 
-void DefNewGeneration::FastEvacuateFollowersClosure::do_void() {
-  do {
-    _heap->oop_since_save_marks_iterate(_scan_cur_or_nonheap, _scan_older);
-  } while (!_heap->no_allocs_since_save_marks());
-  guarantee(_heap->young_gen()->promo_failure_scan_is_complete(), "Failed to finish scan");
-}
+  void do_oop(oop* p)       { do_oop_work(p); }
+  void do_oop(narrowOop* p) { do_oop_work(p); }
+};
+
+class FastEvacuateFollowersClosure: public VoidClosure {
+  SerialHeap* _heap;
+  DefNewScanClosure* _scan_cur_or_nonheap;
+  DefNewYoungerGenClosure* _scan_older;
+public:
+  FastEvacuateFollowersClosure(SerialHeap* heap,
+                               DefNewScanClosure* cur,
+                               DefNewYoungerGenClosure* older) :
+    _heap(heap), _scan_cur_or_nonheap(cur), _scan_older(older)
+  {}
+
+  void do_void() {
+    do {
+      _heap->oop_since_save_marks_iterate(_scan_cur_or_nonheap, _scan_older);
+    } while (!_heap->no_allocs_since_save_marks());
+    guarantee(_heap->young_gen()->promo_failure_scan_is_complete(), "Failed to finish scan");
+  }
+};
 
 void CLDScanClosure::do_cld(ClassLoaderData* cld) {
   NOT_PRODUCT(ResourceMark rm);

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -76,15 +76,15 @@ bool DefNewGeneration::IsAliveClosure::do_object_b(oop p) {
   return cast_from_oop<HeapWord*>(p) >= _young_gen->reserved().end() || p->is_forwarded();
 }
 
-DefNewGeneration::FastKeepAliveClosure::
-FastKeepAliveClosure(DefNewGeneration* g, ScanWeakRefClosure* cl) :
+DefNewGeneration::KeepAliveClosure::
+KeepAliveClosure(DefNewGeneration* g, ScanWeakRefClosure* cl) :
   _cl(cl) {
   _rs = GenCollectedHeap::heap()->rem_set();
   _boundary = g->reserved().end();
 }
 
-void DefNewGeneration::FastKeepAliveClosure::do_oop(oop* p)       { DefNewGeneration::FastKeepAliveClosure::do_oop_work(p); }
-void DefNewGeneration::FastKeepAliveClosure::do_oop(narrowOop* p) { DefNewGeneration::FastKeepAliveClosure::do_oop_work(p); }
+void DefNewGeneration::KeepAliveClosure::do_oop(oop* p)       { DefNewGeneration::KeepAliveClosure::do_oop_work(p); }
+void DefNewGeneration::KeepAliveClosure::do_oop(narrowOop* p) { DefNewGeneration::KeepAliveClosure::do_oop_work(p); }
 
 DefNewGeneration::FastEvacuateFollowersClosure::
 FastEvacuateFollowersClosure(SerialHeap* heap,
@@ -578,7 +578,7 @@ void DefNewGeneration::collect(bool   full,
   // "evacuate followers".
   evacuate_followers.do_void();
 
-  FastKeepAliveClosure keep_alive(this, &scan_weak_ref);
+  KeepAliveClosure keep_alive(this, &scan_weak_ref);
   ReferenceProcessor* rp = ref_processor();
   ReferenceProcessorPhaseTimes pt(_gc_timer, rp->max_num_queues());
   SerialGCRefProcProxyTask task(is_alive, keep_alive, evacuate_followers);

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -167,13 +167,13 @@ protected:
     bool do_object_b(oop p);
   };
 
-  class FastKeepAliveClosure: public OopClosure {
+  class KeepAliveClosure: public OopClosure {
     ScanWeakRefClosure* _cl;
     CardTableRS* _rs;
     HeapWord* _boundary;
     template <class T> void do_oop_work(T* p);
   public:
-    FastKeepAliveClosure(DefNewGeneration* g, ScanWeakRefClosure* cl);
+    KeepAliveClosure(DefNewGeneration* g, ScanWeakRefClosure* cl);
     virtual void do_oop(oop* p);
     virtual void do_oop(narrowOop* p);
   };

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -159,36 +159,6 @@ protected:
     return n > alignment ? align_down(n, alignment) : alignment;
   }
 
- public:  // was "protected" but caused compile error on win32
-  class IsAliveClosure: public BoolObjectClosure {
-    Generation* _young_gen;
-  public:
-    IsAliveClosure(Generation* young_gen);
-    bool do_object_b(oop p);
-  };
-
-  class KeepAliveClosure: public OopClosure {
-    ScanWeakRefClosure* _cl;
-    CardTableRS* _rs;
-    HeapWord* _boundary;
-    template <class T> void do_oop_work(T* p);
-  public:
-    KeepAliveClosure(DefNewGeneration* g, ScanWeakRefClosure* cl);
-    virtual void do_oop(oop* p);
-    virtual void do_oop(narrowOop* p);
-  };
-
-  class FastEvacuateFollowersClosure: public VoidClosure {
-    SerialHeap* _heap;
-    DefNewScanClosure* _scan_cur_or_nonheap;
-    DefNewYoungerGenClosure* _scan_older;
-  public:
-    FastEvacuateFollowersClosure(SerialHeap* heap,
-                                 DefNewScanClosure* cur,
-                                 DefNewYoungerGenClosure* older);
-    void do_void();
-  };
-
  public:
   DefNewGeneration(ReservedSpace rs,
                    size_t initial_byte_size,

--- a/src/hotspot/share/gc/serial/defNewGeneration.inline.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.inline.hpp
@@ -37,7 +37,7 @@
 // Methods of protected closure types
 
 template <class T>
-inline void DefNewGeneration::FastKeepAliveClosure::do_oop_work(T* p) {
+inline void DefNewGeneration::KeepAliveClosure::do_oop_work(T* p) {
 #ifdef ASSERT
   {
     // We never expect to see a null reference being processed

--- a/src/hotspot/share/gc/serial/defNewGeneration.inline.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.inline.hpp
@@ -36,28 +36,6 @@
 
 // Methods of protected closure types
 
-template <class T>
-inline void DefNewGeneration::KeepAliveClosure::do_oop_work(T* p) {
-#ifdef ASSERT
-  {
-    // We never expect to see a null reference being processed
-    // as a weak reference.
-    oop obj = RawAccess<IS_NOT_NULL>::oop_load(p);
-    assert (oopDesc::is_oop(obj), "expected an oop while scanning weak refs");
-  }
-#endif // ASSERT
-
-  Devirtualizer::do_oop(_cl, p);
-
-  // Optimized for Defnew generation if it's the youngest generation:
-  // we set a younger_gen card if we have an older->youngest
-  // generation pointer.
-  oop obj = RawAccess<IS_NOT_NULL>::oop_load(p);
-  if ((cast_from_oop<HeapWord*>(obj) < _boundary) && GenCollectedHeap::heap()->is_in_reserved(p)) {
-    _rs->inline_write_ref_field_gc(p);
-  }
-}
-
 template <typename OopClosureType>
 void DefNewGeneration::oop_since_save_marks_iterate(OopClosureType* cl) {
   // No allocation in eden and from spaces, so no iteration required.


### PR DESCRIPTION
Simple refactoring broken into two commits:

1. Rename `KeepAliveClosure`.
2. Extract and move closures to cpp file.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301599](https://bugs.openjdk.org/browse/JDK-8301599): Serial: Refactor nested closures in DefNewGeneration


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12359/head:pull/12359` \
`$ git checkout pull/12359`

Update a local copy of the PR: \
`$ git checkout pull/12359` \
`$ git pull https://git.openjdk.org/jdk pull/12359/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12359`

View PR using the GUI difftool: \
`$ git pr show -t 12359`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12359.diff">https://git.openjdk.org/jdk/pull/12359.diff</a>

</details>
