### PR TITLE
8301116: Parallelize TLAB resizing in G1

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2761,7 +2761,7 @@ G1JFRTracerMark::~G1JFRTracerMark() {
 }
 
 void G1CollectedHeap::prepare_for_mutator_after_young_collection() {
-  double start = os::elapsedTime();
+  Ticks start = Ticks::now();
 
   _survivor_evac_stats.adjust_desired_plab_size();
   _old_evac_stats.adjust_desired_plab_size();
@@ -2771,7 +2771,7 @@ void G1CollectedHeap::prepare_for_mutator_after_young_collection() {
   allocate_dummy_regions();
   _allocator->init_mutator_alloc_regions();
 
-  phase_times()->record_prepare_for_mutator_time_ms((os::elapsedTime() - start) * 1000.0);
+  phase_times()->record_prepare_for_mutator_time_ms((Ticks::now() - start).seconds() * 1000.0);
 }
 
 void G1CollectedHeap::retire_tlabs() {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -128,15 +128,20 @@ class G1JavaThreadsListClaimer : public StackObj {
 
   volatile uint _cur_claim;
 
+  // Attempts to claim _claim_step JavaThreads, returning an array of claimed
+  // JavaThread* with count elements. Returns null (and a zero count) if there
+  // are no more threads to claim.
+  JavaThread* const* claim(uint& count);
+
 public:
   G1JavaThreadsListClaimer(uint claim_step) : _list(), _claim_step(claim_step), _cur_claim(0) {
     assert(claim_step > 0, "must be");
   }
 
-  // Attempts to claim _claim_step JavaThreads, returning an array of claimed
-  // JavaThread* with count elements. Returns null (and a zero count) if there
-  // are no more threads to claim.
-  JavaThread* const* claim(uint& count);
+  // Executes the given closure on the elements of the JavaThread list, chunking the
+  // JavaThread set in claim_step chunks for each caller to reduce parallelization
+  // overhead.
+  void apply(ThreadClosure* cl);
 
   // Total number of JavaThreads that can be claimed.
   uint length() const { return _list.length(); }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -491,7 +491,7 @@ private:
   bool abort_concurrent_cycle();
   void verify_before_full_collection(bool explicit_gc);
   void prepare_heap_for_full_collection();
-  void prepare_heap_for_mutators();
+  void prepare_for_mutator_after_full_collection();
   void abort_refinement();
   void verify_after_full_collection();
   void print_heap_after_full_collection();
@@ -771,7 +771,7 @@ public:
   // Start a concurrent cycle.
   void start_concurrent_cycle(bool concurrent_operation_is_full_mark);
 
-  void prepare_for_mutator_after_young_gc();
+  void prepare_for_mutator_after_young_collection();
 
   void retire_tlabs();
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -135,7 +135,7 @@ public:
 
   // Attempts to claim _claim_step JavaThreads, returning an array of claimed
   // JavaThread* with count elements. Returns null (and a zero count) if there
-  // is no more to claim.
+  // are no more threads to claim.
   JavaThread* const* claim(uint& count);
 
   // Total number of JavaThreads that can be claimed.

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -771,7 +771,7 @@ public:
   // Start a concurrent cycle.
   void start_concurrent_cycle(bool concurrent_operation_is_full_mark);
 
-  void prepare_tlabs_for_mutator();
+  void prepare_for_mutator_after_young_gc();
 
   void retire_tlabs();
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -41,12 +41,26 @@
 #include "gc/shared/taskqueue.inline.hpp"
 #include "oops/stackChunkOop.hpp"
 #include "runtime/atomic.hpp"
+#include "runtime/threadSMR.inline.hpp"
 #include "utilities/bitMap.inline.hpp"
 
 inline bool G1STWIsAliveClosure::do_object_b(oop p) {
   // An object is reachable if it is outside the collection set,
   // or is inside and copied.
   return !_g1h->is_in_cset(p) || p->is_forwarded();
+}
+
+inline JavaThread* const* G1JavaThreadsListClaimer::claim(uint& count) {
+  count = 0;
+  if (_cur_claim >= _list.length()) {
+    return nullptr;
+  }
+  uint claim = Atomic::fetch_and_add(&_cur_claim, _claim_step);
+  if (claim >= _list.length()) {
+    return nullptr;
+  }
+  count = MIN2(_list.length() - claim, _claim_step);
+  return _list.list()->threads() + claim;
 }
 
 G1GCPhaseTimes* G1CollectedHeap::phase_times() const {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -63,6 +63,17 @@ inline JavaThread* const* G1JavaThreadsListClaimer::claim(uint& count) {
   return _list.list()->threads() + claim;
 }
 
+inline void G1JavaThreadsListClaimer::apply(ThreadClosure* cl) {
+  JavaThread* const* list;
+  uint count;
+
+  while ((list = claim(count)) != nullptr) {
+    for (uint i = 0; i < count; i++) {
+      cl->do_thread(list[i]);
+    }
+  }
+}
+
 G1GCPhaseTimes* G1CollectedHeap::phase_times() const {
   return _policy->phase_times();
 }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -52,7 +52,7 @@ inline bool G1STWIsAliveClosure::do_object_b(oop p) {
 
 inline JavaThread* const* G1JavaThreadsListClaimer::claim(uint& count) {
   count = 0;
-  if (_cur_claim >= _list.length()) {
+  if (Atomic::load(&_cur_claim) >= _list.length()) {
     return nullptr;
   }
   uint claim = Atomic::fetch_and_add(&_cur_claim, _claim_step);

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -228,7 +228,7 @@ void G1FullCollector::complete_collection() {
   // Prepare the bitmap for the next (potentially concurrent) marking.
   _heap->concurrent_mark()->clear_bitmap(_heap->workers());
 
-  _heap->prepare_heap_for_mutators();
+  _heap->prepare_for_mutator_after_full_collection();
 
   _heap->resize_all_tlabs();
 

--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
@@ -153,7 +153,7 @@ G1GCPhaseTimes::G1GCPhaseTimes(STWGCTimer* gc_timer, uint max_gc_threads) :
   _gc_par_phases[RedirtyCards] = new WorkerDataArray<double>("RedirtyCards", "Redirty Logged Cards (ms):", max_gc_threads);
   _gc_par_phases[RedirtyCards]->create_thread_work_items("Redirtied Cards:");
 
-  _gc_par_phases[ResizeThreadLABs] = new WorkerDataArray<double>("ResizeTLAB", "Resize TLAB (ms):", max_gc_threads);
+  _gc_par_phases[ResizeThreadLABs] = new WorkerDataArray<double>("ResizeTLABs", "Resize TLABs (ms):", max_gc_threads);
 
   _gc_par_phases[FreeCollectionSet] = new WorkerDataArray<double>("FreeCSet", "Free Collection Set (ms):", max_gc_threads);
   _gc_par_phases[YoungFreeCSet] = new WorkerDataArray<double>("YoungFreeCSet", "Young Free Collection Set (ms):", max_gc_threads);

--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.hpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.hpp
@@ -74,6 +74,7 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
     FreeCollectionSet,
     YoungFreeCSet,
     NonYoungFreeCSet,
+    ResizeThreadLABs,
     RebuildFreeList,
     SampleCollectionSetCandidates,
     MergePSS,
@@ -179,7 +180,6 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
   double _cur_optional_prepare_merge_heap_roots_time_ms;
 
   double _cur_prepare_tlab_time_ms;
-  double _cur_resize_tlab_time_ms;
 
   double _cur_concatenate_dirty_card_logs_time_ms;
 
@@ -199,7 +199,7 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
   double _recorded_young_cset_choice_time_ms;
   double _recorded_non_young_cset_choice_time_ms;
 
-  double _recorded_start_new_cset_time_ms;
+  double _recorded_prepare_for_mutator_time_ms;
 
   double _recorded_serial_free_cset_time_ms;
 
@@ -274,10 +274,6 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
 
   void record_prepare_tlab_time_ms(double ms) {
     _cur_prepare_tlab_time_ms = ms;
-  }
-
-  void record_resize_tlab_time_ms(double ms) {
-    _cur_resize_tlab_time_ms = ms;
   }
 
   void record_concatenate_dirty_card_logs_time_ms(double ms) {
@@ -356,8 +352,8 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
     _recorded_non_young_cset_choice_time_ms = time_ms;
   }
 
-  void record_start_new_cset_time_ms(double time_ms) {
-    _recorded_start_new_cset_time_ms = time_ms;
+  void record_prepare_for_mutator_time_ms(double time_ms) {
+    _recorded_prepare_for_mutator_time_ms = time_ms;
   }
 
   void record_cur_collection_start_sec(double time_ms) {

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -1022,9 +1022,7 @@ void G1YoungCollector::post_evacuate_collection_set(G1EvacInfo* evacuation_info,
 
   evacuation_info->set_bytes_used(_g1h->bytes_used_during_gc());
 
-  _g1h->start_new_collection_set();
-
-  _g1h->prepare_tlabs_for_mutator();
+  _g1h->prepare_for_mutator_after_young_gc();
 
   _g1h->gc_epilogue(false);
 

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -1022,7 +1022,7 @@ void G1YoungCollector::post_evacuate_collection_set(G1EvacInfo* evacuation_info,
 
   evacuation_info->set_bytes_used(_g1h->bytes_used_during_gc());
 
-  _g1h->prepare_for_mutator_after_young_gc();
+  _g1h->prepare_for_mutator_after_young_collection();
 
   _g1h->gc_epilogue(false);
 

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -706,6 +706,7 @@ public:
 class G1PostEvacuateCollectionSetCleanupTask2::ResizeTLABsTask : public G1AbstractSubTask {
   G1JavaThreadsListClaimer _claimer;
 
+  // There is not much work per thread so the number of threads per worker is high.
   static const uint ThreadsPerWorker = 250;
 
 public:

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -713,13 +713,14 @@ public:
   ResizeTLABsTask() : G1AbstractSubTask(G1GCPhaseTimes::ResizeThreadLABs), _claimer(ThreadsPerWorker) { }
 
   void do_work(uint worker_id) override {
-    JavaThread* const* list;
-    uint count;
-    while ((list = _claimer.claim(count)) != nullptr) {
-      for (uint i = 0; i < count; i++) {
-        list[i]->tlab().resize();
+    class ResizeClosure : public ThreadClosure {
+    public:
+
+      void do_thread(Thread* thread) {
+        static_cast<JavaThread*>(thread)->tlab().resize();
       }
-    }
+    } cl;
+    _claimer.apply(&cl);
   }
 
   double worker_cost() const override {

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -727,7 +727,7 @@ public:
   }
 
   double worker_cost() const override {
-    return (double)_list.length() / 10;
+    return (double)_list.length() / 20;
   }
 };
 

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -753,7 +753,7 @@ G1PostEvacuateCollectionSetCleanupTask2::G1PostEvacuateCollectionSetCleanupTask2
   }
   add_parallel_task(new RedirtyLoggedCardsTask(per_thread_states->rdcqs(), evac_failure_regions));
   if (UseTLAB && ResizeTLAB) {
-    add_serial_task(new ResizeTLABsTask());
+    add_parallel_task(new ResizeTLABsTask());
   }
   add_parallel_task(new FreeCollectionSetTask(evacuation_info,
                                               per_thread_states->surviving_young_words(),

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.hpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.hpp
@@ -60,6 +60,7 @@ public:
 // - Redirty Logged Cards
 // - Restore Preserved Marks (on evacuation failure)
 // - Free Collection Set
+// - Resize TLABs
 class G1PostEvacuateCollectionSetCleanupTask2 : public G1BatchedTask {
   class EagerlyReclaimHumongousObjectsTask;
   class ResetHotCardCacheTask;
@@ -70,7 +71,9 @@ class G1PostEvacuateCollectionSetCleanupTask2 : public G1BatchedTask {
   class ClearRetainedRegionBitmaps;
   class RedirtyLoggedCardsTask;
   class RestorePreservedMarksTask;
+  class ResizeTLABsTask;
   class FreeCollectionSetTask;
+  class ResizeTLABTask;
 
 public:
   G1PostEvacuateCollectionSetCleanupTask2(G1ParScanThreadStateSet* per_thread_states,

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.hpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.hpp
@@ -73,7 +73,6 @@ class G1PostEvacuateCollectionSetCleanupTask2 : public G1BatchedTask {
   class RestorePreservedMarksTask;
   class ResizeTLABsTask;
   class FreeCollectionSetTask;
-  class ResizeTLABTask;
 
 public:
   G1PostEvacuateCollectionSetCleanupTask2(G1ParScanThreadStateSet* per_thread_states,

--- a/src/hotspot/share/runtime/threadSMR.hpp
+++ b/src/hotspot/share/runtime/threadSMR.hpp
@@ -201,7 +201,7 @@ public:
 
   JavaThread *const thread_at(uint i) const { return _threads[i]; }
 
-  JavaThread *const *threads() const        { return _threads; }
+  JavaThread* const* threads()              { return _threads; }
 
   // Returns -1 if target is not found.
   int find_index_of_JavaThread(JavaThread* target);

--- a/src/hotspot/share/runtime/threadSMR.hpp
+++ b/src/hotspot/share/runtime/threadSMR.hpp
@@ -201,7 +201,7 @@ public:
 
   JavaThread *const thread_at(uint i) const { return _threads[i]; }
 
-  JavaThread* const* threads()              { return _threads; }
+  JavaThread *const *threads() const { return _threads; }
 
   // Returns -1 if target is not found.
   int find_index_of_JavaThread(JavaThread* target);

--- a/src/hotspot/share/runtime/threadSMR.hpp
+++ b/src/hotspot/share/runtime/threadSMR.hpp
@@ -201,7 +201,7 @@ public:
 
   JavaThread *const thread_at(uint i) const { return _threads[i]; }
 
-  JavaThread *const *threads() const { return _threads; }
+  JavaThread *const *threads() const        { return _threads; }
 
   // Returns -1 if target is not found.
   int find_index_of_JavaThread(JavaThread* target);

--- a/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
+++ b/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
@@ -183,6 +183,7 @@ public class TestGCLogMessages {
         new LogMessageWithLevelC2OrJVMCIOnly("Update Derived Pointers", Level.DEBUG),
         new LogMessageWithLevel("Redirty Logged Cards", Level.DEBUG),
         new LogMessageWithLevel("Redirtied Cards", Level.DEBUG),
+        new LogMessageWithLevel("Resize TLABs", Level.DEBUG),
         new LogMessageWithLevel("Free Collection Set", Level.DEBUG),
         new LogMessageWithLevel("Serial Free Collection Set", Level.TRACE),
         new LogMessageWithLevel("Young Free Collection Set", Level.TRACE),
@@ -192,8 +193,7 @@ public class TestGCLogMessages {
         new LogMessageWithLevel("Rebuild Free List", Level.DEBUG),
         new LogMessageWithLevel("Serial Rebuild Free List", Level.TRACE),
         new LogMessageWithLevel("Parallel Rebuild Free List", Level.TRACE),
-        new LogMessageWithLevel("Start New Collection Set", Level.DEBUG),
-        new LogMessageWithLevel("Resize TLABs", Level.DEBUG),
+        new LogMessageWithLevel("Prepare for Mutator", Level.DEBUG),
         new LogMessageWithLevel("Expand Heap After Collection", Level.DEBUG),
     };
 

--- a/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
+++ b/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
@@ -193,7 +193,7 @@ public class TestGCLogMessages {
         new LogMessageWithLevel("Rebuild Free List", Level.DEBUG),
         new LogMessageWithLevel("Serial Rebuild Free List", Level.TRACE),
         new LogMessageWithLevel("Parallel Rebuild Free List", Level.TRACE),
-        new LogMessageWithLevel("Prepare for Mutator", Level.DEBUG),
+        new LogMessageWithLevel("Prepare For Mutator", Level.DEBUG),
         new LogMessageWithLevel("Expand Heap After Collection", Level.DEBUG),
     };
 

--- a/test/jdk/jdk/jfr/event/gc/collection/TestG1ParallelPhases.java
+++ b/test/jdk/jdk/jfr/event/gc/collection/TestG1ParallelPhases.java
@@ -107,6 +107,7 @@ public class TestG1ParallelPhases {
             "RedirtyCards",
             "RecalculateUsed",
             "ResetHotCardCache",
+            "ResizeTLABs",
             "FreeCSet",
             "UpdateDerivedPointers",
             "EagerlyReclaimHumongousObjects",


### PR DESCRIPTION
Hi all,

  can I get reviews for this change that moves TLAB resizing into the second parallel post evacuation phase?

The change is fairly straightforward except maybe for the following:
* there is a new claimer for `JavaThreads` because the `Threads::possibly_parallel_threads_do` method to parallelize does not work well with very little per-thread work. Actually with a moderate amount of threads (~20) performance would already be many times slower than doing things serially.
* moving the TLAB resizing out of `G1CollectedHeap::prepare_tlabs_for_mutator` made that method and the enclosing timing a bit obsolete, so I repurposed it as a "do preparatory work for the mutator during young gc" phase. That resulted in minor cleanup and regularization of what is done during that phase (wrt to what the corresponding method for full gc does).

Testing: gha, local perf testing, tier1

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301116](https://bugs.openjdk.org/browse/JDK-8301116): Parallelize TLAB resizing in G1


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [6bff3cc1](https://git.openjdk.org/jdk/pull/12360/files/6bff3cc17a17e0d9ec282c50872b4a56e297b68a)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12360/head:pull/12360` \
`$ git checkout pull/12360`

Update a local copy of the PR: \
`$ git checkout pull/12360` \
`$ git pull https://git.openjdk.org/jdk pull/12360/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12360`

View PR using the GUI difftool: \
`$ git pr show -t 12360`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12360.diff">https://git.openjdk.org/jdk/pull/12360.diff</a>

</details>
