### PR TITLE
8301580: Error recovery does not clear returnResult

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5219,15 +5219,10 @@ public class Attr extends JCTree.Visitor {
 
     public void visitErroneous(JCErroneous tree) {
         if (tree.errs != null) {
-            Env<AttrContext> errEnv = env.dup(env.tree);
-            ResultInfo prevReturnResult = errEnv.info.returnResult;
-            try {
-                errEnv.info.returnResult = unknownExprInfo;
-                for (JCTree err : tree.errs)
-                    attribTree(err, errEnv, new ResultInfo(KindSelector.ERR, pt()));
-            } finally {
-                errEnv.info.returnResult = prevReturnResult;
-            }
+            Env<AttrContext> errEnv = env.dup(env.tree, env.info.dup());
+            errEnv.info.returnResult = unknownExprInfo;
+            for (JCTree err : tree.errs)
+                attribTree(err, errEnv, new ResultInfo(KindSelector.ERR, pt()));
         }
         result = tree.type = syms.errType;
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -5220,9 +5220,14 @@ public class Attr extends JCTree.Visitor {
     public void visitErroneous(JCErroneous tree) {
         if (tree.errs != null) {
             Env<AttrContext> errEnv = env.dup(env.tree);
-            errEnv.info.returnResult = unknownExprInfo;
-            for (JCTree err : tree.errs)
-                attribTree(err, errEnv, new ResultInfo(KindSelector.ERR, pt()));
+            ResultInfo prevReturnResult = errEnv.info.returnResult;
+            try {
+                errEnv.info.returnResult = unknownExprInfo;
+                for (JCTree err : tree.errs)
+                    attribTree(err, errEnv, new ResultInfo(KindSelector.ERR, pt()));
+            } finally {
+                errEnv.info.returnResult = prevReturnResult;
+            }
         }
         result = tree.type = syms.errType;
     }

--- a/test/langtools/jdk/jshell/SnippetHighlightTest.java
+++ b/test/langtools/jdk/jshell/SnippetHighlightTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8274148
+ * @bug 8274148 8301580
  * @summary Check snippet highlighting
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -97,6 +97,21 @@ public class SnippetHighlightTest extends KullaTesting {
         assertHighlights("void method() {}",
                          "Highlight[start=0, end=4, attributes=[KEYWORD]]",
                          "Highlight[start=5, end=11, attributes=[DECLARATION]]");
+    }
+
+    public void testClassErrorRecovery() { //JDK-8301580
+        assertHighlights("""
+                         class C {
+                            void m
+                            {
+                                return ;
+                            }
+                         }
+                         """,
+                         "Highlight[start=0, end=5, attributes=[KEYWORD]]",
+                         "Highlight[start=6, end=7, attributes=[DECLARATION]]",
+                         "Highlight[start=13, end=17, attributes=[KEYWORD]]",
+                         "Highlight[start=32, end=38, attributes=[KEYWORD]]");
     }
 
     private void assertHighlights(String code, String... expected) {

--- a/test/langtools/tools/javac/recovery/AttrRecovery.java
+++ b/test/langtools/tools/javac/recovery/AttrRecovery.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8301580
+ * @summary Verify error recovery w.r.t. Attr
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.jdeps/com.sun.tools.classfile
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main AttrRecovery
+ */
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+
+import toolbox.JavacTask;
+import toolbox.Task.Expect;
+import toolbox.Task.OutputKind;
+import toolbox.TestRunner;
+import toolbox.ToolBox;
+
+public class AttrRecovery extends TestRunner {
+
+    ToolBox tb;
+
+    public AttrRecovery() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public static void main(String[] args) throws Exception {
+        AttrRecovery t = new AttrRecovery();
+        t.runTests();
+    }
+
+    @Test
+    public void testFlowExits() throws Exception {
+        String code = """
+                      class C {
+                          void build
+                          {
+                              return ;
+                          }
+                      }
+                      """;
+        Path curPath = Path.of(".");
+        List<String> actual = new JavacTask(tb)
+                .options("-XDrawDiagnostics", "-XDdev", "-XDshould-stop.at=FLOW")
+                .sources(code)
+                .outdir(curPath)
+                .run(Expect.FAIL)
+                .getOutputLines(OutputKind.DIRECT);
+
+        List<String> expected = List.of(
+                "C.java:3:5: compiler.err.expected: '('",
+                "C.java:4:9: compiler.err.ret.outside.meth",
+                "2 errors"
+        );
+
+        if (!Objects.equals(actual, expected)) {
+            error("Expected: " + expected + ", but got: " + actual);
+        }
+    }
+
+}


### PR DESCRIPTION
Considering code like:
```
class C {
    void m
    {
        return;
    }
}
```

`void m` is wrapped in an erroneous tree (which is good), and if/when `Attr` is processing it in `visitErroneous`, it will create a new `Env` to attribute the erroneous part.

But, `Attr` will set a `returnResult` into the `Env`'s info - and that info is shared with the outter `Env`, so there will be a `returnResult` set after `visitErroneous`. `{ return ; }` is interpreted as an initializer, and there should be an error for the `return` there, but this error is missing, due to the set `returnResult`. This will then fail later in `Flow` with an exception:

```
$ javac -XDshould-stop.at=FLOW -XDdev /tmp/C.java
/tmp/C.java:3: error: '(' expected
    {
    ^
1 error
An exception has occurred in the compiler (19.0.1-internal). Please file a bug against the Java compiler via the Java bug reporting page (http://bugreport.java.com/) after checking the Bug Database (http://bugs.java.com/) for duplicates. Include your program, the following diagnostic, and the parameters passed to the Java compiler in your report. Thank you.
java.lang.AssertionError
        at jdk.compiler/com.sun.tools.javac.util.Assert.error(Assert.java:155)
        at jdk.compiler/com.sun.tools.javac.util.Assert.check(Assert.java:46)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$AliveAnalyzer.clearPendingExits(Flow.java:589)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$AliveAnalyzer.visitClassDef(Flow.java:544)
        ...
```

The proposal is to clear the `returnResult` from the `Env`'s info.

This exception may affect JShell.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301580](https://bugs.openjdk.org/browse/JDK-8301580): Error recovery does not clear returnResult


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12361/head:pull/12361` \
`$ git checkout pull/12361`

Update a local copy of the PR: \
`$ git checkout pull/12361` \
`$ git pull https://git.openjdk.org/jdk pull/12361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12361`

View PR using the GUI difftool: \
`$ git pr show -t 12361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12361.diff">https://git.openjdk.org/jdk/pull/12361.diff</a>

</details>
