### PR TITLE
8301612: OopLoadProxy constructor should be explicit

### DIFF
--- a/src/hotspot/share/oops/accessBackend.hpp
+++ b/src/hotspot/share/oops/accessBackend.hpp
@@ -1230,7 +1230,7 @@ namespace AccessInternal {
   private:
     P *const _addr;
   public:
-    OopLoadProxy(P* addr) : _addr(addr) {}
+    explicit OopLoadProxy(P* addr) : _addr(addr) {}
 
     inline operator oop() {
       return load<decorators | INTERNAL_VALUE_IS_OOP, P, oop>(_addr);


### PR DESCRIPTION
The implicit conversion via constructor `OopLoadProxy(P* addr)` can cause problems when using the access API and nullptr.
For example code like
```c++
oop o = (_obj == NULL) ? nullptr : NativeAccess<>::oop_load(_obj);
```
will compile but is wrong and will crash.
This is because it will be interpreted as:
```c++
oop o = static_cast<oop>((_obj == NULL) ? OopLoadProxy(nullptr) : NativeAccess<>::oop_load(_obj));
```
while the intent of the programmer probably was:
```c++
oop o = (_obj == NULL) ? (oop)nullptr : NativeAccess<>::oop_load(_obj);
```
or more explicitly:
```c++
oop o = (_obj == NULL) ? static_cast<oop>(nullptr) : static_cast<oop>(NativeAccess<>::oop_load(_obj));
```

Marking `OopLoadProxy(P* addr)` explicit will make this example, and similar code not compile.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301612](https://bugs.openjdk.org/browse/JDK-8301612): OopLoadProxy constructor should be explicit


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12364/head:pull/12364` \
`$ git checkout pull/12364`

Update a local copy of the PR: \
`$ git checkout pull/12364` \
`$ git pull https://git.openjdk.org/jdk pull/12364/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12364`

View PR using the GUI difftool: \
`$ git pr show -t 12364`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12364.diff">https://git.openjdk.org/jdk/pull/12364.diff</a>

</details>
