### PR TITLE
8301637: ThreadLocalRandom.current().doubles().parallel() contention

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
@@ -437,6 +437,10 @@ public final class ThreadLocalRandom extends Random {
         public long nextLong() {
             return ThreadLocalRandom.current().nextLong();
         }
+
+        public double nextDouble() {
+            return ThreadLocalRandom.current().nextDouble();
+        }
     }
 
     /**


### PR DESCRIPTION
ThreadLocalRandom.current().doubles().parallel() had a bad regression, because it called the superclass methods of the ThreadLocalRandomProxy's nextDouble() method instead of delegating to the ThreadLocalRandom.current().

Affects all versions of ThreadLocalRandom since Java 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301637](https://bugs.openjdk.org/browse/JDK-8301637): ThreadLocalRandom.current().doubles().parallel() contention


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12366/head:pull/12366` \
`$ git checkout pull/12366`

Update a local copy of the PR: \
`$ git checkout pull/12366` \
`$ git pull https://git.openjdk.org/jdk pull/12366/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12366`

View PR using the GUI difftool: \
`$ git pr show -t 12366`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12366.diff">https://git.openjdk.org/jdk/pull/12366.diff</a>

</details>
