### PR TITLE
8301616: Drag & maximize to another monitor places window incorrectly (Windows)

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
@@ -2187,7 +2187,7 @@ void AwtWindow::CheckWindowDPIChange() {
     if (prevScaleRec.screen != -1 && prevScaleRec.screen != m_screenNum) {
         Devices::InstanceAccess devices;
         AwtWin32GraphicsDevice *device = devices->GetDevice(m_screenNum);
-        if (device) {
+        if (device && !::IsZoomed(GetHWnd())) {
             if (prevScaleRec.scaleX != device->GetScaleX()
                     || prevScaleRec.scaleY != device->GetScaleY()) {
                 RECT rect;


### PR DESCRIPTION
The `AwtWindow::CheckWindowDPIChange()` hack was introduced for popup windows and breaks maximization logic, so reshape window only if it's not maximized.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301616](https://bugs.openjdk.org/browse/JDK-8301616): Drag &amp; maximize to another monitor places window incorrectly (Windows)


### Reviewers
 * [Alexey Ushakov](https://openjdk.org/census#avu) (@avu - Committer) ⚠️ Review applies to [07fee422](https://git.openjdk.org/jdk/pull/12367/files/07fee422920b32160235669c2ea2a5df0ce0c805)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**) ⚠️ Review applies to [07fee422](https://git.openjdk.org/jdk/pull/12367/files/07fee422920b32160235669c2ea2a5df0ce0c805)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12367/head:pull/12367` \
`$ git checkout pull/12367`

Update a local copy of the PR: \
`$ git checkout pull/12367` \
`$ git pull https://git.openjdk.org/jdk.git pull/12367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12367`

View PR using the GUI difftool: \
`$ git pr show -t 12367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12367.diff">https://git.openjdk.org/jdk/pull/12367.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12367#issuecomment-1412345086)