### PR TITLE
8301630: C2: 8297933 broke type speculation in some cases

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -2818,7 +2818,7 @@ ciKlass* TypePtr::speculative_type() const {
   if (_speculative != NULL && _speculative->isa_oopptr()) {
     const TypeOopPtr* speculative = _speculative->join(this)->is_oopptr();
     if (speculative->klass_is_exact()) {
-      return speculative->klass();
+      return speculative->exact_klass();
     }
   }
   return NULL;

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -4910,6 +4910,11 @@ template<class T> TypePtr::MeetResult TypePtr::meet_aryptr(PTR& ptr, const Type*
       // instance_id = InstanceBot;
       elem = Type::BOTTOM;
       result = NOT_SUBTYPE;
+      if (above_centerline(ptr) || ptr == Constant) {
+        ptr = NotNull;
+        res_xk = false;
+        return NOT_SUBTYPE;
+      }
     }
   } else {// Non integral arrays.
     // Must fall to bottom if exact klasses in upper lattice
@@ -4945,7 +4950,7 @@ template<class T> TypePtr::MeetResult TypePtr::meet_aryptr(PTR& ptr, const Type*
       return result;
     case Constant: {
       if (this_ptr == Constant) {
-          res_xk = true;
+        res_xk = true;
       } else if(above_centerline(this_ptr)) {
         res_xk = true;
       } else {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestTypeSpeculation.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestTypeSpeculation.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import compiler.lib.ir_framework.*;
+import java.util.Objects;
+
+/*
+ * @test
+ * @summary C2: optimize long range checks in long counted loops
+ * @library /test/lib /
+ * @requires vm.compiler2.enabled
+ * @run driver compiler.c2.irTests.TestTypeSpeculation
+ */
+
+public class TestTypeSpeculation {
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("-XX:TypeProfileLevel=222");
+    }
+
+    private static final Integer[] testIntegerArray = new Integer[] {42};
+    private static final Long[] testLongArray = new Long[] {42L};
+    private static final Double[] testDoubleArray = new Double[] {42.0D};
+    private static final Integer testInteger = 42;
+    private static final Long testLong = 42L;
+    private static final Double testDouble = 42.0D;
+
+    
+    @DontInline
+    public void test1_no_inline() {
+    }
+
+    public void test1_helper(Number[] arg) {
+        if (arg instanceof Long[]) {
+            test1_no_inline();
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.CALL, "= 2", IRNode.CLASS_CHECK_TRAP, "= 1", IRNode.NULL_CHECK_TRAP, "= 1"})
+    public void test1(Number[] array) {
+        test1_helper(array);
+    }
+
+    @Run(test = "test1")
+    @Warmup(10000)
+    public void test1_verifier(RunInfo info) {
+        if (info.isWarmUp()) {
+            // pollute profile
+            test1_helper(testLongArray);
+            test1_helper(testDoubleArray);
+        }
+        test1(testIntegerArray);
+    }
+
+    @DontInline
+    public void test2_no_inline() {
+    }
+
+    public void test2_helper(Number arg) {
+        if (arg instanceof Long) {
+            test2_no_inline();
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.CALL, "= 2", IRNode.CLASS_CHECK_TRAP, "= 1", IRNode.NULL_CHECK_TRAP, "= 1"})
+    public void test2(Number array) {
+        test2_helper(array);
+    }
+
+    @Run(test = "test2")
+    @Warmup(10000)
+    public void test2_verifier(RunInfo info) {
+        if (info.isWarmUp()) {
+            // pollute profile
+            test2_helper(testLong);
+            test2_helper(testDouble);
+        }
+        test2(testInteger);
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestTypeSpeculation.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestTypeSpeculation.java
@@ -46,7 +46,7 @@ public class TestTypeSpeculation {
     private static final Long testLong = 42L;
     private static final Double testDouble = 42.0D;
 
-    
+
     @DontInline
     public void test1_no_inline() {
     }

--- a/test/hotspot/jtreg/compiler/types/TestSpeculationBrokenWithIntArrays.java
+++ b/test/hotspot/jtreg/compiler/types/TestSpeculationBrokenWithIntArrays.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8301630
+ * @summary C2: 8297933 broke type speculation in some cases
+ *
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation
+ *                   -XX:TypeProfileLevel=222 -XX:CompileOnly=TestSpeculationBrokenWithIntArrays::testHelper
+ *                   -XX:CompileOnly=TestSpeculationBrokenWithIntArrays::testHelper2
+ *                   -XX:CompileOnly=TestSpeculationBrokenWithIntArrays::test TestSpeculationBrokenWithIntArrays
+ *
+ */
+
+public class TestSpeculationBrokenWithIntArrays {
+    static int[] int_array = new int[10];
+    static short[] short_array = new short[10];
+    static byte[] byte_array = new byte[10];
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            testHelper(int_array);
+            testHelper2(short_array);
+        }
+        for (int i = 0; i < 20_000; i++) {
+            test(int_array);
+            test(short_array);
+            test(byte_array);
+        }
+    }
+
+    private static void test(Object o) {
+        testHelper(o);
+        if (o instanceof short[]) {
+            testHelper2(o);
+        }
+    }
+
+    private static void testHelper(Object o) {
+    }
+
+    private static void testHelper2(Object o) {
+    }
+}


### PR DESCRIPTION
With 8297933, a TypeAryPtr is a lot more likely to have a null _klass
and that breaks TypePtr::speculative_type().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301630](https://bugs.openjdk.org/browse/JDK-8301630): C2: 8297933 broke type speculation in some cases


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12368/head:pull/12368` \
`$ git checkout pull/12368`

Update a local copy of the PR: \
`$ git checkout pull/12368` \
`$ git pull https://git.openjdk.org/jdk pull/12368/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12368`

View PR using the GUI difftool: \
`$ git pr show -t 12368`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12368.diff">https://git.openjdk.org/jdk/pull/12368.diff</a>

</details>
