### PR TITLE
8301618: Compare elements and type mirrors properly

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -1543,7 +1544,8 @@ public class HtmlDocletWriter {
         Element currentPageElement = (this instanceof PackageWriterImpl packageWriter)
                 ? packageWriter.packageElement : getCurrentPageElement();
         return currentPageElement != null && !utils.isModule(element)
-                && utils.containingPackage(currentPageElement) == utils.containingPackage(element);
+                && Objects.equals(utils.containingPackage(currentPageElement),
+                utils.containingPackage(element));
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/MemberSummaryBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/MemberSummaryBuilder.java
@@ -295,7 +295,7 @@ public abstract class MemberSummaryBuilder extends AbstractMemberBuilder {
             if (!(utils.isPublic(inheritedClass) || utils.isLinkable(inheritedClass))) {
                 continue;
             }
-            if (inheritedClass == typeElement) {
+            if (Objects.equals(inheritedClass, typeElement)) {
                 continue;
             }
             if (utils.hasHiddenTag(inheritedClass)) {
@@ -303,7 +303,7 @@ public abstract class MemberSummaryBuilder extends AbstractMemberBuilder {
             }
 
             List<? extends Element> members = inheritedMembersFromMap.stream()
-                    .filter(e -> utils.getEnclosingTypeElement(e) == inheritedClass)
+                    .filter(e -> Objects.equals(utils.getEnclosingTypeElement(e), inheritedClass))
                     .toList();
 
             if (!members.isEmpty()) {
@@ -318,13 +318,15 @@ public abstract class MemberSummaryBuilder extends AbstractMemberBuilder {
         }
     }
 
-    private void addSummaryFootNote(TypeElement inheritedClass, SortedSet<Element> inheritedMembers,
+    private void addSummaryFootNote(TypeElement inheritedClass, Iterable<Element> inheritedMembers,
                                     Content links, MemberSummaryWriter writer) {
-        for (Element member : inheritedMembers) {
+        boolean isFirst = true;
+        for (var iterator = inheritedMembers.iterator(); iterator.hasNext(); ) {
+            var member = iterator.next();
             TypeElement t = utils.isUndocumentedEnclosure(inheritedClass)
                     ? typeElement : inheritedClass;
-            writer.addInheritedMemberSummary(t, member, inheritedMembers.first() == member,
-                    inheritedMembers.last() == member, links);
+            writer.addInheritedMemberSummary(t, member, isFirst, !iterator.hasNext(), links);
+            isFirst = false;
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/MemberSummaryBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/MemberSummaryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/SerializedFormBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/SerializedFormBuilder.java
@@ -26,6 +26,7 @@
 package jdk.javadoc.internal.doclets.toolkit.builders;
 
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.SortedSet;
@@ -264,19 +265,15 @@ public class SerializedFormBuilder extends AbstractBuilder {
      */
     protected void buildSerializableMethods(Content target) throws DocletException {
         Content serializableMethodsHeader = methodWriter.getSerializableMethodsHeader();
-        Iterator<ExecutableElement> members = utils.serializationMethods(currentTypeElement).iterator();
-        if (members.hasNext()) {
-            while (members.hasNext()) {
-                currentMember = members.next();
-                Content methodsContent = methodWriter.getMethodsContentHeader(
-                        !members.hasNext());
+        for (var i = utils.serializationMethods(currentTypeElement).iterator(); i.hasNext(); ) {
+            currentMember = i.next();
+            Content methodsContent = methodWriter.getMethodsContentHeader(!i.hasNext());
 
-                buildMethodSubHeader(methodsContent);
-                buildDeprecatedMethodInfo(methodsContent);
-                buildMethodInfo(methodsContent);
+            buildMethodSubHeader(methodsContent);
+            buildDeprecatedMethodInfo(methodsContent);
+            buildMethodInfo(methodsContent);
 
-                serializableMethodsHeader.add(methodsContent);
-            }
+            serializableMethodsHeader.add(methodsContent);
         }
         if (!utils.serializationMethods(currentTypeElement).isEmpty()) {
             target.add(methodWriter.getSerializableMethods(
@@ -401,14 +398,13 @@ public class SerializedFormBuilder extends AbstractBuilder {
      */
     protected void buildSerializableFields(Content target)
             throws DocletException {
-        Iterator<VariableElement> members = utils.serializableFields(currentTypeElement).iterator();
-        if (members.hasNext()) {
+        Collection<VariableElement> members = utils.serializableFields(currentTypeElement);
+        if (!members.isEmpty()) {
             Content serializableFieldsHeader = fieldWriter.getSerializableFieldsHeader();
-            while (members.hasNext()) {
-                currentMember = members.next();
+            for (var i = members.iterator(); i.hasNext();) {
+                currentMember = i.next();
                 if (!utils.definesSerializableFields(currentTypeElement)) {
-                    Content fieldsContent = fieldWriter.getFieldsContentHeader(
-                            !members.hasNext());
+                    Content fieldsContent = fieldWriter.getFieldsContentHeader(!i.hasNext());
 
                     buildFieldSubHeader(fieldsContent);
                     buildFieldDeprecationInfo(fieldsContent);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/SerializedFormBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/SerializedFormBuilder.java
@@ -26,6 +26,7 @@
 package jdk.javadoc.internal.doclets.toolkit.builders;
 
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -263,12 +264,12 @@ public class SerializedFormBuilder extends AbstractBuilder {
      */
     protected void buildSerializableMethods(Content target) throws DocletException {
         Content serializableMethodsHeader = methodWriter.getSerializableMethodsHeader();
-        SortedSet<ExecutableElement> members = utils.serializationMethods(currentTypeElement);
-        if (!members.isEmpty()) {
-            for (ExecutableElement member : members) {
-                currentMember = member;
+        Iterator<ExecutableElement> members = utils.serializationMethods(currentTypeElement).iterator();
+        if (members.hasNext()) {
+            while (members.hasNext()) {
+                currentMember = members.next();
                 Content methodsContent = methodWriter.getMethodsContentHeader(
-                        currentMember == members.last());
+                        !members.hasNext());
 
                 buildMethodSubHeader(methodsContent);
                 buildDeprecatedMethodInfo(methodsContent);
@@ -400,14 +401,14 @@ public class SerializedFormBuilder extends AbstractBuilder {
      */
     protected void buildSerializableFields(Content target)
             throws DocletException {
-        SortedSet<VariableElement> members = utils.serializableFields(currentTypeElement);
-        if (!members.isEmpty()) {
+        Iterator<VariableElement> members = utils.serializableFields(currentTypeElement).iterator();
+        if (members.hasNext()) {
             Content serializableFieldsHeader = fieldWriter.getSerializableFieldsHeader();
-            for (VariableElement ve : members) {
-                currentMember = ve;
+            while (members.hasNext()) {
+                currentMember = members.next();
                 if (!utils.definesSerializableFields(currentTypeElement)) {
                     Content fieldsContent = fieldWriter.getFieldsContentHeader(
-                            currentMember == members.last());
+                            !members.hasNext());
 
                     buildFieldSubHeader(fieldsContent);
                     buildFieldDeprecationInfo(fieldsContent);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/SerializedFormBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/SerializedFormBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -418,7 +418,7 @@ public class Utils {
     }
 
     public boolean isFunctionalInterface(AnnotationMirror amirror) {
-        return amirror.getAnnotationType().equals(getFunctionalInterface()) &&
+        return typeUtils.isSameType(amirror.getAnnotationType(), getFunctionalInterface()) &&
                 configuration.docEnv.getSourceVersion()
                         .compareTo(SourceVersion.RELEASE_8) >= 0;
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberTable.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberTable.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberTable.java
@@ -53,6 +53,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -242,7 +243,7 @@ public class VisibleMemberTable {
     public List<Element> getVisibleMembers(Kind kind) {
         Predicate<Element> declaredAndLeafMembers = e -> {
             TypeElement encl = utils.getEnclosingTypeElement(e);
-            return encl == te || utils.isUndocumentedEnclosure(encl);
+            return Objects.equals(encl, te) || utils.isUndocumentedEnclosure(encl);
         };
         return getVisibleMembers(kind, declaredAndLeafMembers);
     }
@@ -255,7 +256,7 @@ public class VisibleMemberTable {
      * @return a list of visible enclosed members in this type
      */
     public List<Element> getMembers(Kind kind) {
-        Predicate<Element> onlyLocallyDeclaredMembers = e -> utils.getEnclosingTypeElement(e) == te;
+        Predicate<Element> onlyLocallyDeclaredMembers = e -> Objects.equals(utils.getEnclosingTypeElement(e), te);
         return getVisibleMembers(kind, onlyLocallyDeclaredMembers);
     }
 
@@ -904,7 +905,7 @@ public class VisibleMemberTable {
 
         List<ExecutableElement> propertyMethods = list.stream()
                 .map(e -> (ExecutableElement) e)
-                .filter(e -> utils.getEnclosingTypeElement(e) == te)
+                .filter(e -> Objects.equals(utils.getEnclosingTypeElement(e), te))
                 .toList();
 
         // Compute additional properties related sundries.


### PR DESCRIPTION
This makes jdk.javadoc compare javax.lang.model primitives correctly: elements with `Object.equals` and type mirrors with `Types.isSameType`.

jdk.javadoc sometimes compares elements using identity comparison (`==`) and type mirrors using equality comparison (`equals`). While this is generally wrong, we likely get away with it because of the implementation specifics. I've heard that javac is very forgiving in the sense that there's no difference between `==` and `equals` for elements. In addition to that, I noticed that more often than not there's no difference between `equals` and `isSameType` for type mirrors in the context of jdk.javadoc.

Since there's no guarantee that a different compiler implementation or the future javac itself will be implemented similarly, it's better to abandon these bad practices while we are still lucky.

----

With a change like this, there are two main concerns. The first is nullity. When it's not immediately obvious if `a`, `b`, or both can be null, it's not clear how to check for equality. To avoid introducing bugs to a code that I don't know that much, I use the `java.util.Objects.equals` method, which takes care of nullity the same way the existing code does: if any of `a` or `b` are null, `Objects.equals(a, b)` behaves exactly as `a == b`, provided `equals` is well-defined and returns false for the null argument.

The second concern is identity. If equality does not imply identity, it might be important to distinguish between equal elements and identical elements. There are a few cases in jdk.javadoc where it's identity that is required; for example, consider:

    SortedSet<ExecutableElement> members = utils.serializationMethods(currentTypeElement);
    for (ExecutableElement member : members) {
        currentMember = member;
        Content methodsContent = methodWriter.getMethodsContentHeader(
                currentMember == members.last());
    ...

Here's the loop computes a boolean indicating the last iteration. If `members` contained identical elements, then that check could misjudge the last iteration and exit prematurely. Thankfully, in that and the similar cases, iteration happens on a (sorted) set, which by definition cannot have duplicates, provided the comparator used by the set is consistent with `equals`, which is also consistent with `==`.  So in this case we can safely change `==` to `equals`.

However, when I fixed those iterations to use `equals`, it didn't feel right; it felt marginally less brittle than what there was before. I then restructured the loops to avoid equality comparison altogether, which had a side-benefit of widening abstractions from `SortedSet` to just `Iterable`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301618](https://bugs.openjdk.org/browse/JDK-8301618): Compare elements and type mirrors properly


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12369/head:pull/12369` \
`$ git checkout pull/12369`

Update a local copy of the PR: \
`$ git checkout pull/12369` \
`$ git pull https://git.openjdk.org/jdk pull/12369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12369`

View PR using the GUI difftool: \
`$ git pr show -t 12369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12369.diff">https://git.openjdk.org/jdk/pull/12369.diff</a>

</details>
