### PR TITLE
JDK-8284236: Remove java/lang/ref/ReferenceEnqueue.java from ProblemList-Xcomp.txt

### DIFF
--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -28,5 +28,4 @@
 #############################################################################
 
 java/lang/invoke/MethodHandles/CatchExceptionTest.java 8146623 generic-all
-java/lang/ref/ReferenceEnqueue.java 8284236 generic-all
 


### PR DESCRIPTION
This test failure is no longer reproducible.   It was added to the problem list from JDK-8286368 as a clean up after JEP 425 Virtual Threads integration.  This PR removes it from the problem list.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284236](https://bugs.openjdk.org/browse/JDK-8284236): Remove java/lang/ref/ReferenceEnqueue.java from ProblemList-Xcomp.txt


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12371/head:pull/12371` \
`$ git checkout pull/12371`

Update a local copy of the PR: \
`$ git checkout pull/12371` \
`$ git pull https://git.openjdk.org/jdk pull/12371/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12371`

View PR using the GUI difftool: \
`$ git pr show -t 12371`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12371.diff">https://git.openjdk.org/jdk/pull/12371.diff</a>

</details>
