### PR TITLE
JDK-8301636: Minor cleanup in CommentHelper and DocPretty

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocPretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocPretty.java
@@ -121,23 +121,12 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     public Void visitAttribute(AttributeTree node, Void p) {
         try {
             print(node.getName());
-            String quote;
-            switch (node.getValueKind()) {
-                case EMPTY:
-                    quote = null;
-                    break;
-                case UNQUOTED:
-                    quote = "";
-                    break;
-                case SINGLE:
-                    quote = "'";
-                    break;
-                case DOUBLE:
-                    quote = "\"";
-                    break;
-                default:
-                    throw new AssertionError();
-            }
+            String quote = switch (node.getValueKind()) {
+                case EMPTY -> null;
+                case UNQUOTED -> "";
+                case SINGLE -> "'";
+                case DOUBLE -> "\"";
+            };
             if (quote != null) {
                 print("=" + quote);
                 print(node.getValue());

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
@@ -81,8 +81,6 @@ public class CommentHelper {
     public final DocCommentTree dcTree;
     public final Element element;
 
-    public static final String SPACER = " ";
-
     /**
      * Creates a utility class to encapsulate the contextual information for a doc comment tree.
      *
@@ -99,27 +97,17 @@ public class CommentHelper {
     }
 
     public String getTagName(DocTree dtree) {
-        switch (dtree.getKind()) {
-            case AUTHOR:
-            case DEPRECATED:
-            case PARAM:
-            case PROVIDES:
-            case RETURN:
-            case SEE:
-            case SERIAL_DATA:
-            case SERIAL_FIELD:
-            case THROWS:
-            case UNKNOWN_BLOCK_TAG:
-            case USES:
-            case VERSION:
-                return ((BlockTagTree) dtree).getTagName();
-            case UNKNOWN_INLINE_TAG:
-                return ((InlineTagTree) dtree).getTagName();
-            case ERRONEOUS:
-                return "erroneous";
-            default:
-                return dtree.getKind().tagName;
-        }
+        return switch (dtree.getKind()) {
+            case AUTHOR, DEPRECATED, PARAM, PROVIDES, RETURN, SEE, SERIAL_DATA, SERIAL_FIELD,
+                    THROWS, UNKNOWN_BLOCK_TAG, USES, VERSION ->
+                    ((BlockTagTree) dtree).getTagName();
+            case UNKNOWN_INLINE_TAG ->
+                    ((InlineTagTree) dtree).getTagName();
+            case ERRONEOUS ->
+                    "erroneous";
+            default ->
+                    dtree.getKind().tagName;
+        };
     }
 
     public String getParameterName(ParamTree p) {
@@ -168,11 +156,6 @@ public class CommentHelper {
         return getTags(dtree);
     }
 
-    public TypeElement getReferencedClass(DocTree dtree) {
-        Element e = getReferencedElement(dtree);
-        return getReferencedClass(e);
-    }
-
     public TypeElement getReferencedClass(Element e) {
         Utils utils = configuration.utils;
         if (e == null) {
@@ -183,11 +166,6 @@ public class CommentHelper {
             return utils.getEnclosingTypeElement(e);
         }
         return null;
-    }
-
-    public String getReferencedModuleName(DocTree dtree) {
-        String s = getReferencedSignature(dtree);
-        return getReferencedModuleName(s);
     }
 
     public String getReferencedModuleName(String signature) {
@@ -219,22 +197,12 @@ public class CommentHelper {
         return (n == -1) ? null : signature.substring(n + 1);
     }
 
-    public PackageElement getReferencedPackage(DocTree dtree) {
-        Element e = getReferencedElement(dtree);
-        return getReferencedPackage(e);
-    }
-
     public PackageElement getReferencedPackage(Element e) {
         if (e != null) {
             Utils utils = configuration.utils;
             return utils.containingPackage(e);
         }
         return null;
-    }
-
-    public ModuleElement getReferencedModule(DocTree dtree) {
-        Element e = getReferencedElement(dtree);
-        return getReferencedModule(e);
     }
 
     public ModuleElement getReferencedModule(Element e) {
@@ -246,10 +214,6 @@ public class CommentHelper {
 
     public List<? extends DocTree> getFirstSentenceTrees(List<? extends DocTree> body) {
         return configuration.docEnv.getDocTrees().getFirstSentence(body);
-    }
-
-    public List<? extends DocTree> getFirstSentenceTrees(DocTree dtree) {
-        return getFirstSentenceTrees(getBody(dtree));
     }
 
     public Element getReferencedElement(DocTree dtree) {
@@ -388,14 +352,11 @@ public class CommentHelper {
     }
 
     public IdentifierTree getName(DocTree dtree) {
-        switch (dtree.getKind()) {
-            case PARAM:
-                return ((ParamTree)dtree).getName();
-            case SERIAL_FIELD:
-                return ((SerialFieldTree)dtree).getName();
-            default:
-                return null;
-            }
+        return switch (dtree.getKind()) {
+            case PARAM -> ((ParamTree) dtree).getName();
+            case SERIAL_FIELD -> ((SerialFieldTree) dtree).getName();
+            default -> null;
+        };
     }
 
     public List<? extends DocTree> getTags(DocTree dtree) {
@@ -553,12 +514,10 @@ public class CommentHelper {
      */
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("CommentHelper{" + "path=" + path + ", dcTree=" + dcTree);
-        sb.append(", element=");
-        sb.append(element.getEnclosingElement());
-        sb.append("::");
-        sb.append(element);
-        sb.append('}');
-        return sb.toString();
+        return "CommentHelper{"
+                + "path=" + path
+                + ", dcTree=" + dcTree
+                + ", element=" + element.getEnclosingElement() + "::" + element
+                + '}';
     }
 }


### PR DESCRIPTION
Please review some simple cleanup suggested by IntelliJ IDEA that would be too much of a distraction in an otherwise unrelated PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301636](https://bugs.openjdk.org/browse/JDK-8301636): Minor cleanup in CommentHelper and DocPretty


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12375/head:pull/12375` \
`$ git checkout pull/12375`

Update a local copy of the PR: \
`$ git checkout pull/12375` \
`$ git pull https://git.openjdk.org/jdk pull/12375/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12375`

View PR using the GUI difftool: \
`$ git pr show -t 12375`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12375.diff">https://git.openjdk.org/jdk/pull/12375.diff</a>

</details>
