### PR TITLE
8301641: NativeMemoryUsageTotal event uses reserved value for committed field

### DIFF
--- a/src/hotspot/share/services/nmtUsage.cpp
+++ b/src/hotspot/share/services/nmtUsage.cpp
@@ -115,7 +115,7 @@ size_t NMTUsage::total_reserved() const {
 }
 
 size_t NMTUsage::total_committed() const {
-  return _malloc_total + _vm_total.reserved;
+  return _malloc_total + _vm_total.committed;
 }
 
 size_t NMTUsage::reserved(MEMFLAGS flag) const {

--- a/test/jdk/jdk/jfr/event/runtime/TestNativeMemoryUsageEvents.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestNativeMemoryUsageEvents.java
@@ -152,7 +152,7 @@ public class TestNativeMemoryUsageEvents {
                 .filter(e -> e.getEventType().getName().equals(UsageTotalEvent))
                 .findFirst().orElse(null);
 
-        // Verify that the heap has grown between the first and last sample.
+        // Verify that the first total event has more reserved than committed memory.
         long firstReserved = firstTotal.getLong("reserved");
         long firstCommitted = firstTotal.getLong("committed");
         assertGreaterThan(firstReserved, firstCommitted, "initial reserved should be greater than initial committed");

--- a/test/jdk/jdk/jfr/event/runtime/TestNativeMemoryUsageEvents.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestNativeMemoryUsageEvents.java
@@ -147,6 +147,17 @@ public class TestNativeMemoryUsageEvents {
         assertGreaterThan(lastSample, firstSample, "heap should have grown and NMT should show that");
     }
 
+    private static void verifyTotalDiffBetweenReservedAndCommitted(List<RecordedEvent> events) throws Exception {
+        RecordedEvent firstTotal = events.stream()
+                .filter(e -> e.getEventType().getName().equals(UsageTotalEvent))
+                .findFirst().orElse(null);
+
+        // Verify that the heap has grown between the first and last sample.
+        long firstReserved = firstTotal.getLong("reserved");
+        long firstCommitted = firstTotal.getLong("committed");
+        assertGreaterThan(firstReserved, firstCommitted, "initial reserved should be greater than initial committed");
+    }
+
     private static void verifyNoUsageEvents(List<RecordedEvent> events) throws Exception {
         Events.hasNotEvent(events, UsageEvent);
         Events.hasNotEvent(events, UsageTotalEvent);
@@ -167,6 +178,7 @@ public class TestNativeMemoryUsageEvents {
             if (nmtEnabled) {
                 verifyExpectedEventTypes(events);
                 verifyHeapGrowth(events);
+                verifyTotalDiffBetweenReservedAndCommitted(events);
             } else {
                 verifyNoUsageEvents(events);
             }


### PR DESCRIPTION
Please review this small fix for the NativeMemoryUsageTotal JFR event.

**Summary**
The NativeMemoryUsageTotal event uses the reserved value for both reserved and committed.

**Testing**
Added new test and verified that it works locally. Now running it in mach5 to make sure it doesn't see any unexpected issues there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301641](https://bugs.openjdk.org/browse/JDK-8301641): NativeMemoryUsageTotal event uses reserved value for committed field


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12377/head:pull/12377` \
`$ git checkout pull/12377`

Update a local copy of the PR: \
`$ git checkout pull/12377` \
`$ git pull https://git.openjdk.org/jdk pull/12377/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12377`

View PR using the GUI difftool: \
`$ git pr show -t 12377`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12377.diff">https://git.openjdk.org/jdk/pull/12377.diff</a>

</details>
