### PR TITLE
8301628: RISC-V: c2 fix pipeline class for several instructions

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -944,8 +944,8 @@ definitions %{
   int_def IMUL_COST            ( 1000, 10 * DEFAULT_COST);          // imul
   int_def IDIVSI_COST          ( 3400, 34 * DEFAULT_COST);          // idivdi
   int_def IDIVDI_COST          ( 6600, 66 * DEFAULT_COST);          // idivsi
-  int_def FMUL_SINGLE_COST     (  500,  5 * DEFAULT_COST);          // fadd, fmul, fmadd
-  int_def FMUL_DOUBLE_COST     (  700,  7 * DEFAULT_COST);          // fadd, fmul, fmadd
+  int_def FMUL_SINGLE_COST     (  500,  5 * DEFAULT_COST);          // fmul, fmadd
+  int_def FMUL_DOUBLE_COST     (  700,  7 * DEFAULT_COST);          // fmul, fmadd
   int_def FDIV_COST            ( 2000, 20 * DEFAULT_COST);          // fdiv
   int_def FSQRT_COST           ( 2500, 25 * DEFAULT_COST);          // fsqrt
   int_def VOLATILE_REF_COST    ( 1000, 10 * DEFAULT_COST);
@@ -6990,7 +6990,7 @@ instruct regI_not_reg(iRegINoSp dst, iRegI src1, immI_M1 m1) %{
     __ xori(as_Register($dst$$reg), as_Register($src1$$reg), -1);
   %}
 
-  ins_pipe(ialu_reg);
+  ins_pipe(ialu_reg_imm);
 %}
 
 instruct regL_not_reg(iRegLNoSp dst, iRegL src1, immL_M1 m1) %{
@@ -7002,7 +7002,7 @@ instruct regL_not_reg(iRegLNoSp dst, iRegL src1, immL_M1 m1) %{
     __ xori(as_Register($dst$$reg), as_Register($src1$$reg), -1);
   %}
 
-  ins_pipe(ialu_reg);
+  ins_pipe(ialu_reg_imm);
 %}
 
 
@@ -7012,7 +7012,7 @@ instruct regL_not_reg(iRegLNoSp dst, iRegL src1, immL_M1 m1) %{
 instruct addF_reg_reg(fRegF dst, fRegF src1, fRegF src2) %{
   match(Set dst (AddF src1 src2));
 
-  ins_cost(FMUL_SINGLE_COST);
+  ins_cost(DEFAULT_COST * 5);
   format %{ "fadd.s  $dst, $src1, $src2\t#@addF_reg_reg" %}
 
   ins_encode %{
@@ -7027,7 +7027,7 @@ instruct addF_reg_reg(fRegF dst, fRegF src1, fRegF src2) %{
 instruct addD_reg_reg(fRegD dst, fRegD src1, fRegD src2) %{
   match(Set dst (AddD src1 src2));
 
-  ins_cost(FMUL_DOUBLE_COST);
+  ins_cost(DEFAULT_COST * 5);
   format %{ "fadd.d  $dst, $src1, $src2\t#@addD_reg_reg" %}
 
   ins_encode %{
@@ -7042,7 +7042,7 @@ instruct addD_reg_reg(fRegD dst, fRegD src1, fRegD src2) %{
 instruct subF_reg_reg(fRegF dst, fRegF src1, fRegF src2) %{
   match(Set dst (SubF src1 src2));
 
-  ins_cost(FMUL_SINGLE_COST);
+  ins_cost(DEFAULT_COST * 5);
   format %{ "fsub.s  $dst, $src1, $src2\t#@subF_reg_reg" %}
 
   ins_encode %{
@@ -7057,7 +7057,7 @@ instruct subF_reg_reg(fRegF dst, fRegF src1, fRegF src2) %{
 instruct subD_reg_reg(fRegD dst, fRegD src1, fRegD src2) %{
   match(Set dst (SubD src1 src2));
 
-  ins_cost(FMUL_DOUBLE_COST);
+  ins_cost(DEFAULT_COST * 5);
   format %{ "fsub.d  $dst, $src1, $src2\t#@subD_reg_reg" %}
 
   ins_encode %{
@@ -7260,7 +7260,7 @@ instruct maxF_reg_reg(fRegF dst, fRegF src1, fRegF src2, rFlagsReg cr) %{
                  false /* is_double */, false /* is_min */);
   %}
 
-  ins_pipe(fp_dop_reg_reg_s);
+  ins_pipe(pipe_class_default);
 %}
 
 // Math.min(FF)F
@@ -7276,7 +7276,7 @@ instruct minF_reg_reg(fRegF dst, fRegF src1, fRegF src2, rFlagsReg cr) %{
                  false /* is_double */, true /* is_min */);
   %}
 
-  ins_pipe(fp_dop_reg_reg_s);
+  ins_pipe(pipe_class_default);
 %}
 
 // Math.max(DD)D
@@ -7292,7 +7292,7 @@ instruct maxD_reg_reg(fRegD dst, fRegD src1, fRegD src2, rFlagsReg cr) %{
                  true /* is_double */, false /* is_min */);
   %}
 
-  ins_pipe(fp_dop_reg_reg_d);
+  ins_pipe(pipe_class_default);
 %}
 
 // Math.min(DD)D
@@ -7308,59 +7308,67 @@ instruct minD_reg_reg(fRegD dst, fRegD src1, fRegD src2, rFlagsReg cr) %{
                  true /* is_double */, true /* is_min */);
   %}
 
-  ins_pipe(fp_dop_reg_reg_d);
+  ins_pipe(pipe_class_default);
 %}
 
 // Float.isInfinite
 instruct isIniniteF_reg_reg(iRegINoSp dst, fRegF src)
 %{
   match(Set dst (IsInfiniteF src));
+
   format %{ "isInfinite $dst, $src" %}
   ins_encode %{
     __ fclass_s(as_Register($dst$$reg), as_FloatRegister($src$$reg));
-    __ andi(as_Register($dst$$reg), as_Register($dst$$reg), 0b10000001);
+    __ andi(as_Register($dst$$reg), as_Register($dst$$reg), 0b0010000001);
     __ slt(as_Register($dst$$reg), zr, as_Register($dst$$reg));
   %}
-  ins_pipe(fp_dop_reg_reg_s);
+
+  ins_pipe(pipe_class_default);
 %}
 
 // Double.isInfinite
 instruct isInfiniteD_reg_reg(iRegINoSp dst, fRegD src)
 %{
   match(Set dst (IsInfiniteD src));
+
   format %{ "isInfinite $dst, $src" %}
   ins_encode %{
     __ fclass_d(as_Register($dst$$reg), as_FloatRegister($src$$reg));
-    __ andi(as_Register($dst$$reg), as_Register($dst$$reg), 0b10000001);
+    __ andi(as_Register($dst$$reg), as_Register($dst$$reg), 0b0010000001);
     __ slt(as_Register($dst$$reg), zr, as_Register($dst$$reg));
   %}
-  ins_pipe(fp_dop_reg_reg_d);
+
+  ins_pipe(pipe_class_default);
 %}
 
 // Float.isFinite
 instruct isFiniteF_reg_reg(iRegINoSp dst, fRegF src)
 %{
   match(Set dst (IsFiniteF src));
+
   format %{ "isFinite $dst, $src" %}
   ins_encode %{
     __ fclass_s(as_Register($dst$$reg), as_FloatRegister($src$$reg));
     __ andi(as_Register($dst$$reg), as_Register($dst$$reg), 0b0001111110);
     __ slt(as_Register($dst$$reg), zr, as_Register($dst$$reg));
   %}
-  ins_pipe(fp_dop_reg_reg_s);
+
+  ins_pipe(pipe_class_default);
 %}
 
 // Double.isFinite
 instruct isFiniteD_reg_reg(iRegINoSp dst, fRegD src)
 %{
   match(Set dst (IsFiniteD src));
+
   format %{ "isFinite $dst, $src" %}
   ins_encode %{
     __ fclass_d(as_Register($dst$$reg), as_FloatRegister($src$$reg));
     __ andi(as_Register($dst$$reg), as_Register($dst$$reg), 0b0001111110);
     __ slt(as_Register($dst$$reg), zr, as_Register($dst$$reg));
   %}
-  ins_pipe(fp_dop_reg_reg_d);
+
+  ins_pipe(pipe_class_default);
 %}
 
 instruct divF_reg_reg(fRegF dst, fRegF src1, fRegF src2) %{

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -7312,7 +7312,7 @@ instruct minD_reg_reg(fRegD dst, fRegD src1, fRegD src2, rFlagsReg cr) %{
 %}
 
 // Float.isInfinite
-instruct isIniniteF_reg_reg(iRegINoSp dst, fRegF src)
+instruct isInfiniteF_reg_reg(iRegINoSp dst, fRegF src)
 %{
   match(Set dst (IsInfiniteF src));
 


### PR DESCRIPTION
HI,

The current C2 instructions can use some more accurate ins_pipe, eg.:
```
instruct regI_not_reg(iRegINoSp dst, iRegI src1, immI_M1 m1) %{
  match(Set dst (XorI src1 m1));
  ins_cost(ALU_COST);
  format %{ "xori  $dst, $src1, -1\t#@regI_not_reg" %}

  ins_encode %{
    __ xori(as_Register($dst$$reg), as_Register($src1$$reg), -1);
  %}

  ins_pipe(ialu_reg);
%}
```

We can use the more accurate pipe_class `ialu_reg_imm` instead.

Please take a look and have some reviews. Thanks a lot.

## Testing:
- hotspot and jdk tier1 on unmatched board without new failures

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301628](https://bugs.openjdk.org/browse/JDK-8301628): RISC-V: c2 fix pipeline class for several instructions


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author) ⚠️ Review applies to [64666538](https://git.openjdk.org/jdk/pull/12379/files/64666538644bc93c5ba01d827cef39a6d89a6538)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12379/head:pull/12379` \
`$ git checkout pull/12379`

Update a local copy of the PR: \
`$ git checkout pull/12379` \
`$ git pull https://git.openjdk.org/jdk pull/12379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12379`

View PR using the GUI difftool: \
`$ git pr show -t 12379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12379.diff">https://git.openjdk.org/jdk/pull/12379.diff</a>

</details>
