### PR TITLE
8301659: Resolve initialization reordering issues on Windows for libawt and libsaproc

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/GDIHashtable.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/GDIHashtable.cpp
@@ -129,10 +129,10 @@ void GDIHashtable::List::clear() {
 GDIHashtable::BatchDestructionManager::BatchDestructionManager(UINT nFirstThreshold,
                                                                UINT nSecondThreshold,
                                                                UINT nDestroyPeriod) :
+  m_nCounter(0),
   m_nFirstThreshold(nFirstThreshold),
   m_nSecondThreshold(nSecondThreshold),
   m_nDestroyPeriod(nDestroyPeriod),
-  m_nCounter(0),
   m_bBatchingEnabled(TRUE)
 {
 }

--- a/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
+++ b/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
@@ -124,8 +124,9 @@ class AutoJavaByteArray {
 public:
   // check env->ExceptionOccurred() after ctor
   AutoJavaByteArray(JNIEnv* env, jbyteArray byteArray, jint releaseMode = JNI_ABORT)
-    : env(env), byteArray(byteArray), releaseMode(releaseMode),
-      bytePtr(env->GetByteArrayElements(byteArray, nullptr)) {
+    : env(env), byteArray(byteArray),
+      bytePtr(env->GetByteArrayElements(byteArray, nullptr)),
+      releaseMode(releaseMode) {
   }
 
   ~AutoJavaByteArray() {


### PR DESCRIPTION
Small, trivial change to resolve initialization order reordering in constructors, required for [JDK-8288293](https://bugs.openjdk.org/browse/JDK-8288293)

gcc will fail to compile a Windows JDK with the following errors, which causes a build failure eventually:
`GDIHashtable.cpp: m_nCounter is initialized before m_nDestroyPeriod [-Werror=reorder]` for libawt
`sawindbg.cpp: bytePtr is initialized before releaseMode [-Werror=reorder]` for libsaproc

Reordering these initializer lists to appear in the order of their declarations will resolve the build failure

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301659](https://bugs.openjdk.org/browse/JDK-8301659): Resolve initialization reordering issues on Windows for libawt and libsaproc


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12382/head:pull/12382` \
`$ git checkout pull/12382`

Update a local copy of the PR: \
`$ git checkout pull/12382` \
`$ git pull https://git.openjdk.org/jdk pull/12382/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12382`

View PR using the GUI difftool: \
`$ git pr show -t 12382`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12382.diff">https://git.openjdk.org/jdk/pull/12382.diff</a>

</details>
