### PR TITLE
8299155: C2: SubTypeCheckNode::verify() should not produce dependencies / oop pool entries

### DIFF
--- a/src/hotspot/share/opto/subtypenode.cpp
+++ b/src/hotspot/share/opto/subtypenode.cpp
@@ -170,7 +170,7 @@ bool SubTypeCheckNode::verify(PhaseGVN* phase) {
     const Type* cached_t = Value(phase); // cache the type to validate consistency
     switch (C->static_subtype_check(superk, subk)) {
       case Compile::SSC_easy_test: {
-        return verify_helper(phase, load_klass(phase, obj_or_subklass), cached_t);
+        return verify_helper(phase, load_klass(phase), cached_t);
       }
       case Compile::SSC_full_test: {
         Node* p1 = phase->transform(new AddPNode(superklass, superklass, phase->MakeConX(in_bytes(Klass::super_check_offset_offset()))));
@@ -180,7 +180,7 @@ bool SubTypeCheckNode::verify(PhaseGVN* phase) {
         int cacheoff_con = in_bytes(Klass::secondary_super_cache_offset());
         bool might_be_cache = (phase->find_int_con(chk_off, cacheoff_con) == cacheoff_con);
         if (!might_be_cache) {
-          Node* subklass = load_klass(phase, obj_or_subklass);
+          Node* subklass = load_klass(phase);
           Node* chk_off_X = chk_off;
 #ifdef _LP64
           chk_off_X = phase->transform(new ConvI2LNode(chk_off_X));
@@ -203,7 +203,8 @@ bool SubTypeCheckNode::verify(PhaseGVN* phase) {
   return true;
 }
 
-Node* SubTypeCheckNode::load_klass(PhaseGVN* phase, Node* obj_or_subklass) const {
+Node* SubTypeCheckNode::load_klass(PhaseGVN* phase) const {
+  Node* obj_or_subklass = in(ObjOrSubKlass);
   const Type* sub_t = phase->type(obj_or_subklass);
   Node* subklass = NULL;
   if (sub_t->isa_oopptr()) {

--- a/src/hotspot/share/opto/subtypenode.hpp
+++ b/src/hotspot/share/opto/subtypenode.hpp
@@ -58,7 +58,7 @@ private:
   static bool is_oop(PhaseGVN* phase, Node* n);
 #endif // ASSERT
 
-  Node* load_klass(PhaseGVN* phase, Node* obj_or_subklass) const;
+  Node* load_klass(PhaseGVN* phase) const;
 };
 
 #endif // SHARE_OPTO_SUBTYPENODE_HPP


### PR DESCRIPTION
This patch simply guarantees a new LoadKlassNode is not created (and
processed by igvn) unless it's really needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299155](https://bugs.openjdk.org/browse/JDK-8299155): C2: SubTypeCheckNode::verify() should not produce dependencies / oop pool entries


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12383/head:pull/12383` \
`$ git checkout pull/12383`

Update a local copy of the PR: \
`$ git checkout pull/12383` \
`$ git pull https://git.openjdk.org/jdk pull/12383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12383`

View PR using the GUI difftool: \
`$ git pr show -t 12383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12383.diff">https://git.openjdk.org/jdk/pull/12383.diff</a>

</details>
