### PR TITLE
8297539: Consolidate the uses of the int<->float union conversion trick

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020 Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -27,6 +27,7 @@
 #include "asm/assembler.inline.hpp"
 #include "asm/macroAssembler.hpp"
 #include "compiler/disassembler.hpp"
+#include "metaprogramming/primitiveConversions.hpp"
 #include "immediate_aarch64.hpp"
 #include "memory/resourceArea.hpp"
 
@@ -410,13 +411,8 @@ bool Assembler::operand_valid_for_sve_logical_immediate(unsigned elembits, uint6
 }
 
 static uint64_t doubleTo64Bits(jdouble d) {
-  union {
-    jdouble double_value;
-    uint64_t double_bits;
-  };
-
-  double_value = d;
-  return double_bits;
+    // 8297539. This matches with Template #5  of cast<To>(From).
+    return PrimitiveConversions::cast<uint64_t>(d);
 }
 
 bool Assembler::operand_valid_for_float_immediate(double imm) {
@@ -499,12 +495,9 @@ unsigned Assembler::pack(double value) {
 // Packed operands for  Floating-point Move (immediate)
 
 static float unpack(unsigned value) {
-  union {
-    unsigned ival;
-    float val;
-  };
-  ival = fp_immediate_for_encoding(value, 0);
-  return val;
+  unsigned ival = fp_immediate_for_encoding(value, 0);
+  // 8297539. This matches with Template #5 of cast<To>(From).
+  return PrimitiveConversions::cast<float>(ival);
 }
 
 address Assembler::locate_next_instruction(address inst) {

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -411,7 +411,7 @@ bool Assembler::operand_valid_for_sve_logical_immediate(unsigned elembits, uint6
 }
 
 static uint64_t doubleTo64Bits(jdouble d) {
-    // 8297539. This matches with Template #5  of cast<To>(From).
+    // This matches with Template #5  of cast<To>(From).
     return PrimitiveConversions::cast<uint64_t>(d);
 }
 
@@ -496,7 +496,7 @@ unsigned Assembler::pack(double value) {
 
 static float unpack(unsigned value) {
   unsigned ival = fp_immediate_for_encoding(value, 0);
-  // 8297539. This matches with Template #5 of cast<To>(From).
+  // This matches with Template #5 of cast<To>(From).
   return PrimitiveConversions::cast<float>(ival);
 }
 

--- a/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
@@ -413,10 +413,10 @@ uint64_t fp_immediate_for_encoding(uint32_t imm8, int is_dp)
   }
   if (is_dp) {
     double dpval = (double)fpval;
-    // 8297539. This matches with Template #5 of cast<To>(From).
+    // This matches with Template #5 of cast<To>(From).
     return PrimitiveConversions::cast<uint64_t>(dpval);
   }
-  // 8297539. This matches with Template #6 of cast<To>(From).
+  // This matches with Template #6 of cast<To>(From).
   return PrimitiveConversions::cast<uint64_t>(fpval);
 }
 
@@ -429,7 +429,7 @@ uint32_t encoding_for_fp_immediate(float immediate)
   // where n is 16+f and imm1:s, imm4:f, simm3:r
   // return the imm8 result [s:r:f]
   //
-  // 8297539. This matches with Template #5 of cast<To>(From).
+  // This matches with Template #5 of cast<To>(From).
   uint32_t val = PrimitiveConversions::cast<uint32_t>(immediate);
   uint32_t s, r, f, res;
   // sign bit is 31

--- a/src/hotspot/cpu/arm/assembler_arm.hpp
+++ b/src/hotspot/cpu/arm/assembler_arm.hpp
@@ -279,7 +279,7 @@ class VFP {
   class float_num : public fpnum {
    public:
     float_num(float v) {
-      // 8297539. This matches with Template #5 of cast<To>(From).
+      // This matches with Template #5 of cast<To>(From).
      _num_bits = PrimitiveConversions::cast<unsigned int>(v);
     }
 
@@ -295,7 +295,7 @@ class VFP {
   class double_num : public fpnum {
    public:
     double_num(double v) {
-      // 8297539. This matches with Template #5 of cast<To>(From).
+      // This matches with Template #5 of cast<To>(From).
       _num_bits = PrimitiveConversions::cast<unsigned long long>(v);
     }
 

--- a/src/hotspot/cpu/arm/assembler_arm.hpp
+++ b/src/hotspot/cpu/arm/assembler_arm.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -279,37 +279,33 @@ class VFP {
   class float_num : public fpnum {
    public:
     float_num(float v) {
-      _num.val = v;
+      // 8297539. This matches with Template #5 of cast<To>(From).
+     _num_bits = PrimitiveConversions::cast<unsigned int>(v);
     }
 
-    virtual unsigned int f_hi4() const { return (_num.bits << 9) >> (19+9); }
-    virtual bool f_lo_is_null() const { return (_num.bits & ((1 << 19) - 1)) == 0; }
-    virtual int e() const { return ((_num.bits << 1) >> (23+1)) - 127; }
-    virtual unsigned int s() const { return _num.bits >> 31; }
+    virtual unsigned int f_hi4() const { return (_num_bits << 9) >> (19+9); }
+    virtual bool f_lo_is_null() const { return (_num_bits & ((1 << 19) - 1)) == 0; }
+    virtual int e() const { return ((_num_bits << 1) >> (23+1)) - 127; }
+    virtual unsigned int s() const { return _num_bits >> 31; }
 
    private:
-    union {
-      float val;
-      unsigned int bits;
-    } _num;
+    unsigned int _num_bits;
   };
 
   class double_num : public fpnum {
    public:
     double_num(double v) {
-      _num.val = v;
+      // 8297539. This matches with Template #5 of cast<To>(From).
+      _num_bits = PrimitiveConversions::cast<unsigned long long>(v);
     }
 
-    virtual unsigned int f_hi4() const { return (_num.bits << 12) >> (48+12); }
-    virtual bool f_lo_is_null() const { return (_num.bits & ((1LL << 48) - 1)) == 0; }
-    virtual int e() const { return ((_num.bits << 1) >> (52+1)) - 1023; }
-    virtual unsigned int s() const { return _num.bits >> 63; }
+    virtual unsigned int f_hi4() const { return (_num_bits << 12) >> (48+12); }
+    virtual bool f_lo_is_null() const { return (_num_bits & ((1LL << 48) - 1)) == 0; }
+    virtual int e() const { return ((_num_bits << 1) >> (52+1)) - 1023; }
+    virtual unsigned int s() const { return _num_bits >> 63; }
 
    private:
-    union {
-      double val;
-      unsigned long long bits;
-    } _num;
+    unsigned long long _num_bits;
   };
 };
 #endif

--- a/src/hotspot/cpu/arm/macroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/macroAssembler_arm.cpp
@@ -677,7 +677,7 @@ void MacroAssembler::mov_float(FloatRegister fd, jfloat c, AsmCondition cond) {
 
   flds(fd, Address(PC), cond);
   b(skip_constant);
-  // 8297539. This matches with Template #5 of cast<To>(From).
+  // This matches with Template #5 of cast<To>(From).
   emit_int32(PrimitiveConversions::cast<jint>(c));
   bind(skip_constant);
 }
@@ -687,7 +687,7 @@ void MacroAssembler::mov_double(FloatRegister fd, jdouble c, AsmCondition cond) 
 
   fldd(fd, Address(PC), cond);
   b(skip_constant);
-  // 8297539. This matches with Template #8 of cast<To>(From).
+  // This matches with Template #8 of cast<To>(From).
   jint *accessor = PrimitiveConversions::cast<jint*>(&c);
   emit_int32(accessor[0]);
   emit_int32(accessor[1]);

--- a/src/hotspot/share/code/compressedStream.hpp
+++ b/src/hotspot/share/code/compressedStream.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 #define SHARE_CODE_COMPRESSEDSTREAM_HPP
 
 #include "memory/allocation.hpp"
+#include "utilities/globalJavaValue.hpp"
 #include "utilities/unsigned5.hpp"
 
 // Simple interface for filing out and filing in basic types

--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -165,7 +165,7 @@ class TypedMethodOptionMatcher : public MethodMatcher {
 
 // A few templated accessors instead of a full template class.
   template<> ccstr TypedMethodOptionMatcher::value<ccstr>() {
-    // 8297539. There is no Template in cast<to>(From) for this case.
+    // There is no Template in cast<to>(From) for this case.
     return (ccstr)(_u_value);
   }
 template<typename T> void TypedMethodOptionMatcher::set_value(T value) {

--- a/src/hotspot/share/gc/g1/g1GCPauseType.hpp
+++ b/src/hotspot/share/gc/g1/g1GCPauseType.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
 
 #include "utilities/debug.hpp"
 #include "utilities/enumIterator.hpp"
+#include "utilities/globalDefinitions.hpp"  // Just for definition of uint.
 
 enum class G1GCPauseType : uint {
   YoungGC,

--- a/src/hotspot/share/jfr/jni/jfrJavaCall.hpp
+++ b/src/hotspot/share/jfr/jni/jfrJavaCall.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@
 
 class JavaCallArguments;
 class JavaThread;
-class JavaValue;
 class Klass;
 class Symbol;
 

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@
 #include "logging/log.hpp"
 #include "memory/oopFactory.hpp"
 #include "memory/universe.hpp"
+#include "metaprogramming/primitiveConversions.hpp"
 #include "oops/constantPool.inline.hpp"
 #include "oops/klass.inline.hpp"
 #include "oops/method.inline.hpp"
@@ -703,21 +704,15 @@ JRT_END
 PRAGMA_DIAG_POP
 
 JRT_LEAF(void, JVMCIRuntime::log_primitive(JavaThread* thread, jchar typeChar, jlong value, jboolean newline))
-  union {
-      jlong l;
-      jdouble d;
-      jfloat f;
-  } uu;
-  uu.l = value;
   switch (typeChar) {
     case 'Z': tty->print(value == 0 ? "false" : "true"); break;
     case 'B': tty->print("%d", (jbyte) value); break;
     case 'C': tty->print("%c", (jchar) value); break;
     case 'S': tty->print("%d", (jshort) value); break;
     case 'I': tty->print("%d", (jint) value); break;
-    case 'F': tty->print("%f", uu.f); break;
+    case 'F': tty->print("%f", PrimitiveConversions::cast<jfloat>(value)); break; // 8297539. This matches with Template #6 of cast<To>(from).
     case 'J': tty->print(JLONG_FORMAT, value); break;
-    case 'D': tty->print("%lf", uu.d); break;
+    case 'D': tty->print("%lf", PrimitiveConversions::cast<jdouble>(value)); break;// 8297539. This matches with Template #5 of cast<To>(From).
     default: assert(false, "unknown typeChar"); break;
   }
   if (newline) {

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -710,9 +710,9 @@ JRT_LEAF(void, JVMCIRuntime::log_primitive(JavaThread* thread, jchar typeChar, j
     case 'C': tty->print("%c", (jchar) value); break;
     case 'S': tty->print("%d", (jshort) value); break;
     case 'I': tty->print("%d", (jint) value); break;
-    case 'F': tty->print("%f", PrimitiveConversions::cast<jfloat>(value)); break; // 8297539. This matches with Template #6 of cast<To>(from).
+    case 'F': tty->print("%f", PrimitiveConversions::cast<jfloat>(value)); break; // This matches with Template #6 of cast<To>(from).
     case 'J': tty->print(JLONG_FORMAT, value); break;
-    case 'D': tty->print("%lf", PrimitiveConversions::cast<jdouble>(value)); break;// 8297539. This matches with Template #5 of cast<To>(From).
+    case 'D': tty->print("%lf", PrimitiveConversions::cast<jdouble>(value)); break;// This matches with Template #5 of cast<To>(From).
     default: assert(false, "unknown typeChar"); break;
   }
   if (newline) {

--- a/src/hotspot/share/metaprogramming/primitiveConversions.hpp
+++ b/src/hotspot/share/metaprogramming/primitiveConversions.hpp
@@ -27,20 +27,9 @@
 
 #include "memory/allStatic.hpp"
 #include "metaprogramming/enableIf.hpp"
+#include "utilities/globalDefinitionsForConversions.hpp"
 #include <cstdint>
 #include <type_traits>
-
-// 8297539. Since the globalDefinitions.hpp is not included anymore, the
-// following required types are defined here.
-typedef float jfloat;
-typedef double jdouble;
-// uint is needed by the following include sequence:
-//   g1GCPauseType.hpp
-//     utilities/enumIterator.hpp
-//       metaprogramming/primitiveConversions.hpp (this file)
-// Since globalDefinitions.hpp is not any more included here, the uint definition is explicitly written here instead.
-typedef unsigned int uint;
-
 
 class PrimitiveConversions : public AllStatic {
 
@@ -142,7 +131,7 @@ public:
   }
 
   // integral -> floating point, floating point -> integral where sizes are not the same.
-  // 8297539. To be able to use cast for floating-point narrowing and widening cases.
+  // To be able to use cast for floating-point narrowing and widening cases.
   //
   // Template #6
   template<typename To, typename From,
@@ -156,7 +145,7 @@ public:
   }
 
   // integral <-> integral with different sizes.
-  // 8297539. To be able to use cast for integral narrowing and widening cases.
+  // To be able to use cast for integral narrowing and widening cases.
   //
   // Template #7
   template<typename To, typename From,
@@ -167,7 +156,7 @@ public:
   }
 
   // pointer to integral <-> pointer to floating point
-  // 8297539. To be able to use cast for "int* <-> float*" casts.
+  // To be able to use cast for "int* <-> float*" casts.
   //
   // Template #8
   template<typename To, typename From,

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -29,6 +29,7 @@
 #include "metaprogramming/integralConstant.hpp"
 #include "runtime/osInfo.hpp"
 #include "utilities/exceptions.hpp"
+#include "utilities/globalJavaValue.hpp"
 #include "utilities/ostream.hpp"
 #include "utilities/macros.hpp"
 #ifdef __APPLE__

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -238,7 +238,7 @@ JRT_LEAF(jfloat, SharedRuntime::frem(jfloat  x, jfloat  y))
 #ifdef _WIN64
   // 64-bit Windows on amd64 returns the wrong values for
   // infinity operands.
-  // 8297539. These casts match with Template #5 of cast<To>(From).
+  // These casts match with Template #5 of cast<To>(From).
   juint xbits_i = PrimitiveConversions::cast<juint>(x);
   juint ybits_i = PrimitiveConversions::cast<juint>(y);
   // x Mod Infinity == x unless x is infinity
@@ -255,7 +255,7 @@ JRT_END
 
 JRT_LEAF(jdouble, SharedRuntime::drem(jdouble x, jdouble y))
 #ifdef _WIN64
-  // 8297539. These casts match with Template #5 of cast<To>(From).
+  // These casts match with Template #5 of cast<To>(From).
   julong xbits_l = PrimitiveConversions::cast<julong>(x);
   julong ybits_l = PrimitiveConversions::cast<julong>(y);
   // x Mod Infinity == x unless x is infinity
@@ -448,7 +448,7 @@ JRT_END
 
 // Reference implementation at src/java.base/share/classes/java/lang/Float.java:floatToFloat16
 JRT_LEAF(jshort, SharedRuntime::f2hf(jfloat  x))
-  // 8297539. This matches with Template #5 of cast<To>(From).
+  // This matches with Template #5 of cast<To>(From).
   jint doppel = PrimitiveConversions::cast<jint>(x);
   jshort sign_bit = (jshort) ((doppel & 0x80000000) >> 16);
   if (g_isnan(x))
@@ -517,10 +517,10 @@ JRT_LEAF(jfloat, SharedRuntime::hf2f(jshort x))
     return (sign * (pow(2,-24)) * hf_significand_bits);
   } else if (hf_exp == 16) {
     if (hf_significand_bits == 0) {
-      // 8297539. This matches with Template #5 of cast<To>(From).
+      // This matches with Template #5 of cast<To>(From).
       return sign * PrimitiveConversions::cast<jfloat>(0x7f800000);
     } else {
-      // 8297539. This matches with Template #5 of cast<To>(From).
+      // This matches with Template #5 of cast<To>(From).
       return PrimitiveConversions::cast<jfloat>((hf_sign_bit << 16) | 0x7f800000 |
                                                (hf_significand_bits << significand_shift));
     }
@@ -530,7 +530,7 @@ JRT_LEAF(jfloat, SharedRuntime::hf2f(jshort x))
   jint float_exp_bits = (hf_exp + 127) << (24 - 1);
 
   // Combine sign, exponent and significand bits
-  // 8297539. This matches with Template #5 of cast<To>(From).
+  // This matches with Template #5 of cast<To>(From).
   return PrimitiveConversions::cast<jfloat>((hf_sign_bit << 16) | float_exp_bits |
                                             (hf_significand_bits << significand_shift));
 JRT_END

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,6 +46,7 @@
 #include "logging/log.hpp"
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
+#include "metaprogramming/primitiveConversions.hpp"
 #include "oops/compiledICHolder.inline.hpp"
 #include "oops/klass.hpp"
 #include "oops/method.inline.hpp"
@@ -237,12 +238,12 @@ JRT_LEAF(jfloat, SharedRuntime::frem(jfloat  x, jfloat  y))
 #ifdef _WIN64
   // 64-bit Windows on amd64 returns the wrong values for
   // infinity operands.
-  union { jfloat f; juint i; } xbits, ybits;
-  xbits.f = x;
-  ybits.f = y;
+  // 8297539. These casts match with Template #5 of cast<To>(From).
+  juint xbits_i = PrimitiveConversions::cast<juint>(x);
+  juint ybits_i = PrimitiveConversions::cast<juint>(y);
   // x Mod Infinity == x unless x is infinity
-  if (((xbits.i & float_sign_mask) != float_infinity) &&
-       ((ybits.i & float_sign_mask) == float_infinity) ) {
+  if (((xbits_i & float_sign_mask) != float_infinity) &&
+       ((ybits_i & float_sign_mask) == float_infinity) ) {
     return x;
   }
   return ((jfloat)fmod_winx64((double)x, (double)y));
@@ -254,12 +255,12 @@ JRT_END
 
 JRT_LEAF(jdouble, SharedRuntime::drem(jdouble x, jdouble y))
 #ifdef _WIN64
-  union { jdouble d; julong l; } xbits, ybits;
-  xbits.d = x;
-  ybits.d = y;
+  // 8297539. These casts match with Template #5 of cast<To>(From).
+  julong xbits_l = PrimitiveConversions::cast<julong>(x);
+  julong ybits_l = PrimitiveConversions::cast<julong>(y);
   // x Mod Infinity == x unless x is infinity
-  if (((xbits.l & double_sign_mask) != double_infinity) &&
-       ((ybits.l & double_sign_mask) == double_infinity) ) {
+  if (((xbits_l & double_sign_mask) != double_infinity) &&
+       ((ybits_l & double_sign_mask) == double_infinity) ) {
     return x;
   }
   return ((jdouble)fmod_winx64((double)x, (double)y));
@@ -447,9 +448,8 @@ JRT_END
 
 // Reference implementation at src/java.base/share/classes/java/lang/Float.java:floatToFloat16
 JRT_LEAF(jshort, SharedRuntime::f2hf(jfloat  x))
-  union {jfloat f; jint i;} bits;
-  bits.f = x;
-  jint doppel = bits.i;
+  // 8297539. This matches with Template #5 of cast<To>(From).
+  jint doppel = PrimitiveConversions::cast<jint>(x);
   jshort sign_bit = (jshort) ((doppel & 0x80000000) >> 16);
   if (g_isnan(x))
     return (jshort)(sign_bit | 0x7c00 | (doppel & 0x007fe000) >> 13 | (doppel & 0x00001ff0) >> 4 | (doppel & 0x0000000f));
@@ -500,7 +500,6 @@ JRT_END
 JRT_LEAF(jfloat, SharedRuntime::hf2f(jshort x))
   // Halffloat format has 1 signbit, 5 exponent bits and
   // 10 significand bits
-  union {jfloat f; jint i;} bits;
   jint hf_arg = (jint)x;
   jint hf_sign_bit = 0x8000 & hf_arg;
   jint hf_exp_bits = 0x7c00 & hf_arg;
@@ -518,12 +517,12 @@ JRT_LEAF(jfloat, SharedRuntime::hf2f(jshort x))
     return (sign * (pow(2,-24)) * hf_significand_bits);
   } else if (hf_exp == 16) {
     if (hf_significand_bits == 0) {
-      bits.i = 0x7f800000;
-      return sign * bits.f;
+      // 8297539. This matches with Template #5 of cast<To>(From).
+      return sign * PrimitiveConversions::cast<jfloat>(0x7f800000);
     } else {
-      bits.i = (hf_sign_bit << 16) | 0x7f800000 |
-               (hf_significand_bits << significand_shift);
-      return bits.f;
+      // 8297539. This matches with Template #5 of cast<To>(From).
+      return PrimitiveConversions::cast<jfloat>((hf_sign_bit << 16) | 0x7f800000 |
+                                               (hf_significand_bits << significand_shift));
     }
   }
 
@@ -531,10 +530,9 @@ JRT_LEAF(jfloat, SharedRuntime::hf2f(jshort x))
   jint float_exp_bits = (hf_exp + 127) << (24 - 1);
 
   // Combine sign, exponent and significand bits
-  bits.i = (hf_sign_bit << 16) | float_exp_bits |
-           (hf_significand_bits << significand_shift);
-
-  return bits.f;
+  // 8297539. This matches with Template #5 of cast<To>(From).
+  return PrimitiveConversions::cast<jfloat>((hf_sign_bit << 16) | float_exp_bits |
+                                            (hf_significand_bits << significand_shift));
 JRT_END
 
 // Exception handling across interpreter/compiler boundaries

--- a/src/hotspot/share/runtime/sharedRuntimeMath.hpp
+++ b/src/hotspot/share/runtime/sharedRuntimeMath.hpp
@@ -36,34 +36,34 @@
   #define _Lo 1
 #endif
 static inline int high(double d) {
-  // 8297539. This matches with Template #8 of cast<To>(From).
+  // This matches with Template #8 of cast<To>(From).
   int *di = PrimitiveConversions::cast<int*>(&d);
   return di[_Hi];
 }
 
 static inline int low(double d) {
-  // 8297539. This matches with Template #8 of cast<To>(From).
+  // This matches with Template #8 of cast<To>(From).
   int *di = PrimitiveConversions::cast<int*>(&d);
   return di[_Lo];
 }
 
 static inline void set_high(double* d, int high) {
-  // 8297539. This matches with Template #8 of cast<To>(From).
+  // This matches with Template #8 of cast<To>(From).
   int *di = PrimitiveConversions::cast<int*>(d);
   di[_Hi] = high;
 }
 
 static inline void set_low(double* d, int low) {
-  // 8297539. This matches with Template #8 of cast<To>(From).
+  // This matches with Template #8 of cast<To>(From).
   int *di = PrimitiveConversions::cast<int*>(d);
   di[_Lo] = low;
 }
 
 static double copysignA(double x, double y) {
-  // 8297539. This matches with Template #8 of cast<To>(From).
+  // This matches with Template #8 of cast<To>(From).
   int *di = PrimitiveConversions::cast<int*>(&x);
   di[_Hi] = (di[_Hi] & 0x7fffffff) | (high(y) & 0x80000000);
-  // 8297539. This matches with Template #8 of cast<To>(From).
+  // This matches with Template #8 of cast<To>(From).
   return *PrimitiveConversions::cast<double*>(di);
 }
 

--- a/src/hotspot/share/runtime/sharedRuntimeMath.hpp
+++ b/src/hotspot/share/runtime/sharedRuntimeMath.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,52 +26,45 @@
 #define SHARE_RUNTIME_SHAREDRUNTIMEMATH_HPP
 
 #include <math.h>
+#include "metaprogramming/primitiveConversions.hpp"
 
-// Used to access the lower/higher 32 bits of a double
-typedef union {
-    double d;
-    struct {
 #ifdef VM_LITTLE_ENDIAN
-      int lo;
-      int hi;
+  #define _Lo 0
+  #define _Hi 1
 #else
-      int hi;
-      int lo;
+  #define _Hi 0
+  #define _Lo 1
 #endif
-    } split;
-} DoubleIntConv;
-
 static inline int high(double d) {
-  DoubleIntConv x;
-  x.d = d;
-  return x.split.hi;
+  // 8297539. This matches with Template #8 of cast<To>(From).
+  int *di = PrimitiveConversions::cast<int*>(&d);
+  return di[_Hi];
 }
 
 static inline int low(double d) {
-  DoubleIntConv x;
-  x.d = d;
-  return x.split.lo;
+  // 8297539. This matches with Template #8 of cast<To>(From).
+  int *di = PrimitiveConversions::cast<int*>(&d);
+  return di[_Lo];
 }
 
 static inline void set_high(double* d, int high) {
-  DoubleIntConv conv;
-  conv.d = *d;
-  conv.split.hi = high;
-  *d = conv.d;
+  // 8297539. This matches with Template #8 of cast<To>(From).
+  int *di = PrimitiveConversions::cast<int*>(d);
+  di[_Hi] = high;
 }
 
 static inline void set_low(double* d, int low) {
-  DoubleIntConv conv;
-  conv.d = *d;
-  conv.split.lo = low;
-  *d = conv.d;
+  // 8297539. This matches with Template #8 of cast<To>(From).
+  int *di = PrimitiveConversions::cast<int*>(d);
+  di[_Lo] = low;
 }
 
 static double copysignA(double x, double y) {
-  DoubleIntConv convX;
-  convX.d = x;
-  convX.split.hi = (convX.split.hi & 0x7fffffff) | (high(y) & 0x80000000);
-  return convX.d;
+  // 8297539. This matches with Template #8 of cast<To>(From).
+  int *di = PrimitiveConversions::cast<int*>(&x);
+  di[_Hi] = (di[_Hi] & 0x7fffffff) | (high(y) & 0x80000000);
+  // 8297539. This matches with Template #8 of cast<To>(From).
+  return *PrimitiveConversions::cast<double*>(di);
 }
 
 /*

--- a/src/hotspot/share/runtime/stackValue.cpp
+++ b/src/hotspot/share/runtime/stackValue.cpp
@@ -152,7 +152,7 @@ StackValue* StackValue::create_stack_value(ScopeValue* sv, address value_addr, c
       assert( loc.is_register(), "floats always saved to stack in 1 word" );
       intptr_t value_p = (intptr_t) CONST64(0xDEADDEAFDEADDEAF);
       jfloat value_jf = (jfloat) *(jdouble*) value_addr;
-      // 8297539. This matches with Template #8 of cast<To>(From).
+      // This matches with Template #8 of cast<To>(From).
       return new StackValue(*PrimitiveConversions::cast<intptr_t*>(&value_jf)); // 64-bit high half is stack junk
     }
     case Location::int_in_long: { // Holds an int in a long register?
@@ -163,7 +163,7 @@ StackValue* StackValue::create_stack_value(ScopeValue* sv, address value_addr, c
       assert( loc.is_register(), "ints always saved to stack in 1 word" );
       intptr_t value_p = (intptr_t) CONST64(0xDEADDEAFDEADDEAF);
       jint value_ji = (jint) *(jlong*) value_addr;
-      // 8297539. This matches with Template #7 of cast<To>(From).
+      // This matches with Template #7 of cast<To>(From).
       return new StackValue(PrimitiveConversions::cast<intptr_t>(value_ji)); // 64-bit high half is stack junk
     }
 #ifdef _LP64
@@ -186,7 +186,7 @@ StackValue* StackValue::create_stack_value(ScopeValue* sv, address value_addr, c
       // Just copy all other bits straight through
       intptr_t value_p = (intptr_t) CONST64(0xDEADDEAFDEADDEAF);
       jint value_ji = *(jint*)value_addr;
-      // 8297539. This matches with Template #7 of cast<To>(From).
+      // This matches with Template #7 of cast<To>(From).
       return new StackValue(PrimitiveConversions::cast<intptr_t>(value_ji));
     }
     case Location::invalid: {
@@ -215,13 +215,13 @@ StackValue* StackValue::create_stack_value(ScopeValue* sv, address value_addr, c
     // Constant double in a single stack slot
     intptr_t value_p = (intptr_t) CONST64(0xDEADDEAFDEADDEAF);
     jdouble value_jd = ((ConstantDoubleValue *)sv)->value();
-    // 8297539. This matches with Template #5 of cast<To>(From).
+    // This matches with Template #5 of cast<To>(From).
     return new StackValue(PrimitiveConversions::cast<intptr_t>(value_jd));
   } else if (sv->is_constant_long()) {
     // Constant long in a single stack slot
     intptr_t value_p = (intptr_t) CONST64(0xDEADDEAFDEADDEAF);
     jlong value_jl = ((ConstantLongValue *)sv)->value();
-    // 8297539. This matches with Template #1 of cast<To>(From).
+    // This matches with Template #1 of cast<To>(From).
     return new StackValue(PrimitiveConversions::cast<intptr_t>(value_jl));
 #endif
   } else if (sv->is_object()) { // Scalar replaced object in compiled frame

--- a/src/hotspot/share/runtime/stackValueCollection.cpp
+++ b/src/hotspot/share/runtime/stackValueCollection.cpp
@@ -67,7 +67,7 @@ jdouble StackValueCollection::double_at(int slot) const {
   jint value_array[2] ;
   value_array[0] = at(slot+1)->get_int();
   value_array[1] = at(slot  )->get_int();
-  // 8297539. This matches with Template #8 of cast<To>(From).
+  // This matches with Template #8 of cast<To>(From).
   return *PrimitiveConversions::cast<jdouble *>(value_array);
 #endif
 }
@@ -85,7 +85,7 @@ void StackValueCollection::set_long_at(int slot, jlong value) {
 #else
   // Interpreter stack is reversed in memory:
   // low memory location is in higher java local slot.
-  // 8297539. In arm32 bit builds, no cast<To>(From) can be found by compiler.
+  // In arm32 bit builds, no cast<To>(From) can be found by compiler.
   // So it is not possible to use jint *x_array = PrimitiveConversions::cast<jint*>(&value);
   jint *x_array = (jint*)(&value);
   at(slot+1)->set_int(x_array[0]);
@@ -118,7 +118,7 @@ void StackValueCollection::set_double_at(int slot, jdouble value) {
 #else
   // Interpreter stack is reversed in memory:
   // low memory location is in higher java local slot.
-  // 8297539. This matches with Template #8 of cast<To>(From).
+  // This matches with Template #8 of cast<To>(From).
   // Note: It was expected that this cast can also be used for set_long_at() above.
   jint *x_array = PrimitiveConversions::cast<jint*>(&value);
   at(slot+1)->set_int(x_array[0]);

--- a/src/hotspot/share/utilities/globalDefinitionsForConversions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitionsForConversions.hpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_UTILITIES_GLOBALDEFINITIONSFORCONVERSIONS_HPP
+#define SHARE_UTILITIES_GLOBALDEFINITIONSFORCONVERSIONS_HPP
+
+#include "utilities/compilerWarnings.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/macros.hpp"
+
+// Get constants like JVM_T_CHAR and JVM_SIGNATURE_INT, before pulling in <jvm.h>.
+#include "classfile_constants.h"
+
+#include COMPILER_HEADER(utilities/globalDefinitions)
+
+
+#include <cstddef>
+#include <type_traits>
+#endif // SHARE_UTILITIES_GLOBALDEFINITIONSFORCONVERSIONS_HPP

--- a/src/hotspot/share/utilities/globalJavaValue.hpp
+++ b/src/hotspot/share/utilities/globalJavaValue.hpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_UTILITIES_GLOBALJAVAVALUE_HPP
+#define SHARE_UTILITIES_GLOBALJAVAVALUE_HPP
+
+
+#include "metaprogramming/primitiveConversions.hpp"
+#include "utilities/compilerWarnings.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/macros.hpp"
+
+// Get constants like JVM_T_CHAR and JVM_SIGNATURE_INT, before pulling in <jvm.h>.
+#include "classfile_constants.h"
+
+#include COMPILER_HEADER(utilities/globalDefinitions)
+
+#include <cstddef>
+#include <type_traits>
+
+// NOTE: replicated in SA in vm/agent/sun/jvm/hotspot/runtime/BasicType.java
+enum BasicType {
+// The values T_BOOLEAN..T_LONG (4..11) are derived from the JVMS.
+  T_BOOLEAN     = JVM_T_BOOLEAN,
+  T_CHAR        = JVM_T_CHAR,
+  T_FLOAT       = JVM_T_FLOAT,
+  T_DOUBLE      = JVM_T_DOUBLE,
+  T_BYTE        = JVM_T_BYTE,
+  T_SHORT       = JVM_T_SHORT,
+  T_INT         = JVM_T_INT,
+  T_LONG        = JVM_T_LONG,
+  // The remaining values are not part of any standard.
+  // T_OBJECT and T_VOID denote two more semantic choices
+  // for method return values.
+  // T_OBJECT and T_ARRAY describe signature syntax.
+  // T_ADDRESS, T_METADATA, T_NARROWOOP, T_NARROWKLASS describe
+  // internal references within the JVM as if they were Java
+  // types in their own right.
+  T_OBJECT      = 12,
+  T_ARRAY       = 13,
+  T_VOID        = 14,
+  T_ADDRESS     = 15,
+  T_NARROWOOP   = 16,
+  T_METADATA    = 17,
+  T_NARROWKLASS = 18,
+  T_CONFLICT    = 19, // for stack value type with conflicting contents
+  T_ILLEGAL     = 99
+};
+
+
+// JavaValue serves as a container for arbitrary Java values.
+class JavaValue {
+
+ public:
+  // Define it large enough to hold all possible primitive types.
+  typedef long long JavaCallValue;
+
+ private:
+  BasicType _type;
+  JavaCallValue _value;
+
+ public:
+  JavaValue(BasicType t = T_ILLEGAL) { _type = t; }
+
+  JavaValue(jfloat value) {
+    _type    = T_FLOAT;
+    // This matches with Template #6 of cast<To>(From).
+    _value = PrimitiveConversions::cast<JavaCallValue>(value);
+  }
+
+  JavaValue(jdouble value) {
+    _type    = T_DOUBLE;
+    // This matches with Template #5 of cast<To>(From).
+    _value = PrimitiveConversions::cast<JavaCallValue>(value);
+  }
+
+ jfloat get_jfloat() const    { return PrimitiveConversions::cast<jfloat>(_value);  } // Tempalte #6.
+ jdouble get_jdouble() const  { return PrimitiveConversions::cast<jdouble>(_value); } // Tempalte #5.
+ jint get_jint() const        { return PrimitiveConversions::cast<jint>(_value);    } // Tempalte #7.
+ jlong get_jlong() const      { return PrimitiveConversions::cast<jlong>(_value);   } // Tempalte #1.
+ jobject get_jobject() const {
+  #ifdef ARM32
+    // In arm32 archs, this call compiles to cast<jobject>(const JavaCallValue&) and
+    // does not match with any of the cast<To>(From) instances.
+    return *(jobject*)(&_value);
+  #else
+    return PrimitiveConversions::cast<jobject>(_value);
+  #endif
+ }
+ oopDesc* get_oop() const     {
+  #ifdef ARM32
+    // In arm32 archs, this call compiles to cast<oopDesc*>(const JavaCallValue&) and
+    // does not match with any of the cast<To>(From) instances.
+    return (oopDesc*)(&_value);
+  #else
+    // This matches with Template #4 of cast<To>(From).
+    return PrimitiveConversions::cast<oopDesc*>(_value);
+  #endif
+ }
+
+ JavaCallValue* get_value_addr() { return &_value; }
+ BasicType get_type() const { return _type; }
+
+ void set_jfloat(jfloat f)   { _value = PrimitiveConversions::cast<JavaCallValue>(f); } // Tempalte #6.
+ void set_jdouble(jdouble d) { _value = PrimitiveConversions::cast<JavaCallValue>(d); } // Tempalte #5.
+ void set_jint(jint i)       { _value = PrimitiveConversions::cast<JavaCallValue>(i); } // Tempalte #7.
+ void set_jlong(jlong l)     { _value = PrimitiveConversions::cast<JavaCallValue>(l); } // Tempalte #1.
+ void set_jobject(jobject h) {
+  #ifdef ARM32
+    // In arm32 archs, this call compiles to cast<JavaCallValue>(_jobject*&) and
+    // does not match with any of the cast<To>(From) instances.
+    _value = *(JavaCallValue*)h;
+  #else
+    _value = PrimitiveConversions::cast<JavaCallValue>(h);
+  #endif
+ }
+ void set_oop(oopDesc* o)    {
+  #ifdef ARM32
+    // In arm32 archs, this call compiles to cast<JavaCallValue>(oopDesc*&) and
+    // does not match with any of the cast<To>(From) instances.
+    _value = *(JavaCallValue*)o;
+  #else
+    _value = PrimitiveConversions::cast<JavaCallValue>(o);
+  #endif
+ }
+ void set_type(BasicType t) { _type = t; }
+
+ jboolean get_jboolean() const { return PrimitiveConversions::cast<jboolean>(PrimitiveConversions::cast<jint>(_value)); } // Tempalte #7.
+ jbyte get_jbyte() const       { return PrimitiveConversions::cast<jbyte>(PrimitiveConversions::cast<jint>(_value));    } // Tempalte #7.
+ jchar get_jchar() const       { return PrimitiveConversions::cast<jchar>(PrimitiveConversions::cast<jint>(_value));    } // Tempalte #7.
+ jshort get_jshort() const     { return PrimitiveConversions::cast<jshort>(PrimitiveConversions::cast<jint>(_value));   } // Tempalte #7.
+
+};
+
+//----------------------------------------------------------------------------------------------------
+// Special casts
+// Cast floats into same-size integers and vice-versa w/o changing bit-pattern
+
+inline jint    jint_cast    (jfloat  x)  { return PrimitiveConversions::cast<jint>(x);    } // Template #5 of cast<To>(From).
+inline jfloat  jfloat_cast  (jint    x)  { return PrimitiveConversions::cast<jfloat>(x);  } // Tempalte #5
+
+inline jlong   jlong_cast   (jdouble x)  { return PrimitiveConversions::cast<jlong>(x);   } // Tempalte #5
+inline julong  julong_cast  (jdouble x)  { return PrimitiveConversions::cast<julong>(x);  } // Tempalte #5
+inline jdouble jdouble_cast (jlong   x)  { return PrimitiveConversions::cast<jdouble>(x); } // Tempalte #5
+#endif // SHARE_UTILITIES_GLOBALJAVAVALUE_HPP


### PR DESCRIPTION
### Discussion

There are different ways of casting/converting integral types to floating point types and vice versa in the code. 
These conversions are changed to invocation of a centralised `cast<To>(From)` method in `primitiveConversions.hpp`. To make this changes build and run, some new `cast` methods are introduced and header dependencies changed. 

### Patch

- All instances of using `union` technique that are used for int<->float and long<->double type conversions are replaced by `PrimitiveConversions::cast<To>(From)` method.
  - Instances of, for example, converting `int`<->`intptr_t` are not changed.
- After this change, `JavaValue` also uses the `PrimitiveConversions::cast<To>(From)` templates. Therefore, all the `union` conversions for `int`<-> `float` and `long` <-> `double` in hotspot are now centralised in one location.
- Templates in `PrimitiveConversions` class are numbered from 1-9 and all lines of code that use `PrimitivEConversions::cast<To>(From)` have comments saying which templated `cast<To>(From)` matches. Issue number 8297539 is also in the comments to make the search/reviews more easier.
- The new 'cast<To>(From)' templates are numbered 6-9 for some instances where existing templates (1-5) did not match.
- `globalDefinitions.hpp` now includes `primitiveConversions.hpp`.
- `primitiveConversions.hpp` does NOT include `globalDefinitions.hpp` any more. Some typedef's are added to it to compensate the missing types.
- The followings are not changed:
  - `jni.hpp`
  - `ciConstant.hpp` is not changed, since uinon is not used for converting `int` <->`float` or `long` <-> `double`. There are some asserts that allow setter/getter used only for the same types.
  - `bytecodeInterpreter_zero.hpp` is not changed. Writing to and reading from the `VMJavaVal64` are always with the same type and no conversion is made.
  - union with bit fields are not changed.
  - `json.hpp` and `json.cpp` in src/hotspot/share/utilities.

### Test
mach5 tiers 1-5 passed, tiers 6-8 in progress

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297539](https://bugs.openjdk.org/browse/JDK-8297539): Consolidate the uses of the int&lt;-&gt;float union conversion trick


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12384/head:pull/12384` \
`$ git checkout pull/12384`

Update a local copy of the PR: \
`$ git checkout pull/12384` \
`$ git pull https://git.openjdk.org/jdk pull/12384/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12384`

View PR using the GUI difftool: \
`$ git pr show -t 12384`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12384.diff">https://git.openjdk.org/jdk/pull/12384.diff</a>

</details>
