### PR TITLE
JDK-7154070: in SwingSet2, switching between LaFs it's easy to lose JTable dividers

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTableUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTableUI.java
@@ -86,6 +86,8 @@ public class SynthTableUI extends BasicTableUI
     private TableCellRenderer booleanRenderer;
     private TableCellRenderer objectRenderer;
 
+    private boolean showHorizLines;
+    private boolean showVertLines;
 //
 //  The installation/uninstall procedures and support
 //
@@ -178,6 +180,8 @@ public class SynthTableUI extends BasicTableUI
             if (rowHeight != null) {
                 LookAndFeel.installProperty(table, "rowHeight", rowHeight);
             }
+            showHorizLines = table.getShowHorizontalLines();
+            showVertLines = table.getShowVerticalLines();
             boolean showGrid = style.getBoolean(context, "Table.showGrid", true);
             if (!showGrid) {
                 table.setShowGrid(false);
@@ -227,9 +231,11 @@ public class SynthTableUI extends BasicTableUI
             table.setTransferHandler(null);
         }
         SynthContext context = getContext(table, ENABLED);
-        boolean showGrid = style.getBoolean(context, "Table.showGrid", true);
-        if (!showGrid) {
-            table.setShowGrid(true);
+        if (showHorizLines) {
+            table.setShowHorizontalLines(true);
+        }
+        if (showVertLines) {
+            table.setShowVerticalLines(true);
         }
         style.uninstallDefaults(context);
         style = null;

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTableUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTableUI.java
@@ -227,6 +227,10 @@ public class SynthTableUI extends BasicTableUI
             table.setTransferHandler(null);
         }
         SynthContext context = getContext(table, ENABLED);
+        boolean showGrid = style.getBoolean(context, "Table.showGrid", true);
+        if (!showGrid) {
+            table.setShowGrid(true);
+        }
         style.uninstallDefaults(context);
         style = null;
     }

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTableUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTableUI.java
@@ -88,7 +88,6 @@ public class SynthTableUI extends BasicTableUI
 
     private boolean showHorizLines;
     private boolean showVertLines;
-    private boolean showGrid;
 //
 //  The installation/uninstall procedures and support
 //
@@ -183,10 +182,8 @@ public class SynthTableUI extends BasicTableUI
             }
             showHorizLines = table.getShowHorizontalLines();
             showVertLines = table.getShowVerticalLines();
-            showGrid = style.getBoolean(context, "Table.showGrid", true);
-            if (!showGrid) {
-                table.setShowGrid(false);
-            }
+            boolean showGrid = style.getBoolean(context, "Table.showGrid", true);
+            table.setShowGrid(showGrid);
             Dimension d = table.getIntercellSpacing();
 //            if (d == null || d instanceof UIResource) {
             if (d != null) {
@@ -232,14 +229,8 @@ public class SynthTableUI extends BasicTableUI
             table.setTransferHandler(null);
         }
         SynthContext context = getContext(table, ENABLED);
-        if (!showGrid) {
-            if (showHorizLines) {
-                table.setShowHorizontalLines(true);
-            }
-            if (showVertLines) {
-                table.setShowVerticalLines(true);
-            }
-        }
+        table.setShowHorizontalLines(showHorizLines);
+        table.setShowVerticalLines(showVertLines);
         style.uninstallDefaults(context);
         style = null;
     }

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTableUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTableUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,6 +88,7 @@ public class SynthTableUI extends BasicTableUI
 
     private boolean showHorizLines;
     private boolean showVertLines;
+    private boolean showGrid;
 //
 //  The installation/uninstall procedures and support
 //
@@ -182,7 +183,7 @@ public class SynthTableUI extends BasicTableUI
             }
             showHorizLines = table.getShowHorizontalLines();
             showVertLines = table.getShowVerticalLines();
-            boolean showGrid = style.getBoolean(context, "Table.showGrid", true);
+            showGrid = style.getBoolean(context, "Table.showGrid", true);
             if (!showGrid) {
                 table.setShowGrid(false);
             }
@@ -231,11 +232,13 @@ public class SynthTableUI extends BasicTableUI
             table.setTransferHandler(null);
         }
         SynthContext context = getContext(table, ENABLED);
-        if (showHorizLines) {
-            table.setShowHorizontalLines(true);
-        }
-        if (showVertLines) {
-            table.setShowVerticalLines(true);
+        if (!showGrid) {
+            if (showHorizLines) {
+                table.setShowHorizontalLines(true);
+            }
+            if (showVertLines) {
+                table.setShowVerticalLines(true);
+            }
         }
         style.uninstallDefaults(context);
         style = null;

--- a/test/jdk/javax/swing/JTable/TestJTableGridReset.java
+++ b/test/jdk/javax/swing/JTable/TestJTableGridReset.java
@@ -58,28 +58,28 @@ public class TestJTableGridReset {
             System.out.println("Testing L&F: " + laf.getClassName());
             SwingUtilities.invokeAndWait(() -> {
                 setLookAndFeel(laf);
-	        table = new JTable();
+                table = new JTable();
                 table.setShowHorizontalLines(true);
                 table.setShowVerticalLines(true);
-	    });
-	    SwingUtilities.updateComponentTreeUI(table);
+            });
+            SwingUtilities.updateComponentTreeUI(table);
             SwingUtilities.invokeAndWait(() -> {
-	        origHorizLines = table.getShowHorizontalLines();
+                origHorizLines = table.getShowHorizontalLines();
                 origVertLines = table.getShowVerticalLines();
-	    });
-	    UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
-	    SwingUtilities.updateComponentTreeUI(table);
+            });
+            UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
+            SwingUtilities.updateComponentTreeUI(table);
             SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
-	    SwingUtilities.updateComponentTreeUI(table);
+            SwingUtilities.updateComponentTreeUI(table);
             SwingUtilities.invokeAndWait(() -> {
-	        curHorizLines = table.getShowHorizontalLines();
+                curHorizLines = table.getShowHorizontalLines();
                 curVertLines = table.getShowVerticalLines();
-	    });
-	    System.out.println("origHorizLines " + origHorizLines +
+            });
+            System.out.println("origHorizLines " + origHorizLines +
                                " origVertLines " + origVertLines);
-	    System.out.println("curHorizLines " + curHorizLines +
+            System.out.println("curHorizLines " + curHorizLines +
                                 " curVertLines " + curVertLines);
-	    if (origHorizLines != curHorizLines ||
+            if (origHorizLines != curHorizLines ||
                 origVertLines != curVertLines) {
                 throw new RuntimeException("Horizontal/Vertical grid lines not restored");
             }

--- a/test/jdk/javax/swing/JTable/TestJTableGridReset.java
+++ b/test/jdk/javax/swing/JTable/TestJTableGridReset.java
@@ -61,17 +61,15 @@ public class TestJTableGridReset {
                 table = new JTable();
                 table.setShowHorizontalLines(true);
                 table.setShowVerticalLines(true);
-            });
-            SwingUtilities.updateComponentTreeUI(table);
-            SwingUtilities.invokeAndWait(() -> {
+                SwingUtilities.updateComponentTreeUI(table);
                 origHorizLines = table.getShowHorizontalLines();
                 origVertLines = table.getShowVerticalLines();
             });
             UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
-            SwingUtilities.updateComponentTreeUI(table);
-            SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
-            SwingUtilities.updateComponentTreeUI(table);
             SwingUtilities.invokeAndWait(() -> {
+                SwingUtilities.updateComponentTreeUI(table);
+                setLookAndFeel(laf);
+                SwingUtilities.updateComponentTreeUI(table);
                 curHorizLines = table.getShowHorizontalLines();
                 curVertLines = table.getShowVerticalLines();
             });

--- a/test/jdk/javax/swing/JTable/TestJTableGridReset.java
+++ b/test/jdk/javax/swing/JTable/TestJTableGridReset.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 7154070
+ * @key headful
+ * @summary  Verifies if switching between LaFs JTable dividers setting are not lost
+ * @run main TestJTableGridReset
+ */
+
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+public class TestJTableGridReset {
+
+    private static JTable table;
+    private static volatile boolean origHorizLines;
+    private static volatile boolean origVertLines;
+    private static volatile boolean curHorizLines;
+    private static volatile boolean curVertLines;
+
+    private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
+        try {
+            UIManager.setLookAndFeel(laf.getClassName());
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.out.println("Unsupported L&F: " + laf.getClassName());
+        } catch (ClassNotFoundException | InstantiationException
+                | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        for (UIManager.LookAndFeelInfo laf :
+                 UIManager.getInstalledLookAndFeels()) {
+            System.out.println("Testing L&F: " + laf.getClassName());
+            SwingUtilities.invokeAndWait(() -> {
+                setLookAndFeel(laf);
+	        table = new JTable();
+                table.setShowHorizontalLines(true);
+                table.setShowVerticalLines(true);
+	    });
+	    SwingUtilities.updateComponentTreeUI(table);
+            SwingUtilities.invokeAndWait(() -> {
+	        origHorizLines = table.getShowHorizontalLines();
+                origVertLines = table.getShowVerticalLines();
+	    });
+	    UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
+	    SwingUtilities.updateComponentTreeUI(table);
+            SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
+	    SwingUtilities.updateComponentTreeUI(table);
+            SwingUtilities.invokeAndWait(() -> {
+	        curHorizLines = table.getShowHorizontalLines();
+                curVertLines = table.getShowVerticalLines();
+	    });
+	    System.out.println("origHorizLines " + origHorizLines +
+                               " origVertLines " + origVertLines);
+	    System.out.println("curHorizLines " + curHorizLines +
+                                " curVertLines " + curVertLines);
+	    if (origHorizLines != curHorizLines ||
+                origVertLines != curVertLines) {
+                throw new RuntimeException("Horizontal/Vertical grid lines not restored");
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
In SwingSet2 in TableDemo, we can see grid dividers in Metal L&F but 
if we Switch to the Nimbus LaF which has no grid dividers by default and then if we switch to Java (Metal): it will show no dividers.

Issue is Nimbus call JTable.showGrid(false) in installDefaults but fail to reset in uninstallDefaults which is now rectified.

No regression test is added as it can be verified by SwingSet2 Tabledemo..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-7154070](https://bugs.openjdk.org/browse/JDK-7154070): in SwingSet2, switching between LaFs it's easy to lose JTable dividers
 * [JDK-6788475](https://bugs.openjdk.org/browse/JDK-6788475): Changing to Nimbus LAF and back doesn't reset look and feel of JTable completely


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer) ⚠️ Review applies to [c1d64881](https://git.openjdk.org/jdk/pull/12385/files/c1d6488125f0d89c2232d87392c372748cf405fb)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer) ⚠️ Review applies to [c1d64881](https://git.openjdk.org/jdk/pull/12385/files/c1d6488125f0d89c2232d87392c372748cf405fb)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer) ⚠️ Review applies to [1a456cc7](https://git.openjdk.org/jdk/pull/12385/files/1a456cc75f723032691d7034d2f500b52c550a79)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**) ⚠️ Review applies to [1a456cc7](https://git.openjdk.org/jdk/pull/12385/files/1a456cc75f723032691d7034d2f500b52c550a79)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12385/head:pull/12385` \
`$ git checkout pull/12385`

Update a local copy of the PR: \
`$ git checkout pull/12385` \
`$ git pull https://git.openjdk.org/jdk pull/12385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12385`

View PR using the GUI difftool: \
`$ git pr show -t 12385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12385.diff">https://git.openjdk.org/jdk/pull/12385.diff</a>

</details>
