### PR TITLE
8295344: Harden runtime/StackGuardPages/TestStackGuardPages.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -96,7 +96,6 @@ runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
 runtime/vthread/RedefineClass.java 8297286 generic-all
 runtime/vthread/TestObjectAllocationSampleEvent.java 8297286 generic-all
-runtime/StackGuardPages/TestStackGuardPages.java 8293452 linux-all
 
 applications/jcstress/copy.java 8229852 linux-all
 

--- a/test/hotspot/jtreg/runtime/StackGuardPages/TestStackGuardPages.java
+++ b/test/hotspot/jtreg/runtime/StackGuardPages/TestStackGuardPages.java
@@ -40,13 +40,25 @@ public class TestStackGuardPages {
         ProcessBuilder pb = ProcessTools.createNativeTestProcessBuilder("invoke",
                                                                         "test_java_overflow");
         pb.environment().put("CLASSPATH", Utils.TEST_CLASS_PATH);
-        new OutputAnalyzer(pb.start())
-            .shouldHaveExitValue(0);
+        OutputAnalyzer output = ProcessTools.executeProcess(pb);
+        output.shouldHaveExitValue(0);
+
+        pb = ProcessTools.createNativeTestProcessBuilder("invoke",
+                                                         "test_java_overflow_initial");
+        pb.environment().put("CLASSPATH", Utils.TEST_CLASS_PATH);
+        output = ProcessTools.executeProcess(pb);
+        output.shouldHaveExitValue(0);
 
         pb = ProcessTools.createNativeTestProcessBuilder("invoke", "test_native_overflow");
         pb.environment().put("CLASSPATH", Utils.TEST_CLASS_PATH);
-        new OutputAnalyzer(pb.start())
-            .shouldHaveExitValue(0);
+        output = ProcessTools.executeProcess(pb);
+        output.shouldHaveExitValue(0);
+
+        pb = ProcessTools.createNativeTestProcessBuilder("invoke", "test_native_overflow_initial");
+        pb.environment().put("CLASSPATH", Utils.TEST_CLASS_PATH);
+        output = ProcessTools.executeProcess(pb);
+        output.shouldHaveExitValue(0);
+
     }
 }
 

--- a/test/hotspot/jtreg/runtime/StackGuardPages/TestStackGuardPagesNative.java
+++ b/test/hotspot/jtreg/runtime/StackGuardPages/TestStackGuardPagesNative.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,31 +23,30 @@
 
 /*
  * @test
- * @summary Stack guard pages should be installed correctly and removed when thread is detached
+ * @summary Stack guard pages should be installed correctly and removed when thread is detached for native threads
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @requires os.family == "linux"
  * @compile DoOverflow.java
- * @run main/native TestStackGuardPages
+ * @run main/native TestStackGuardPagesNative
  */
 import jdk.test.lib.Utils;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 
 
-public class TestStackGuardPages {
+public class TestStackGuardPagesNative {
     public static void main(String args[]) throws Exception {
-        ProcessBuilder pb = ProcessTools.createNativeTestProcessBuilder("invoke",
-                                                                        "test_java_overflow");
+
+        ProcessBuilder pb = ProcessTools.createNativeTestProcessBuilder("invoke", "test_native_overflow");
         pb.environment().put("CLASSPATH", Utils.TEST_CLASS_PATH);
         OutputAnalyzer output = ProcessTools.executeProcess(pb);
         output.shouldHaveExitValue(0);
 
-        pb = ProcessTools.createNativeTestProcessBuilder("invoke",
-                                                         "test_java_overflow_initial");
+        pb = ProcessTools.createNativeTestProcessBuilder("invoke", "test_native_overflow_initial");
         pb.environment().put("CLASSPATH", Utils.TEST_CLASS_PATH);
         output = ProcessTools.executeProcess(pb);
         output.shouldHaveExitValue(0);
+
     }
 }
-

--- a/test/hotspot/jtreg/runtime/StackGuardPages/exeinvoke.c
+++ b/test/hotspot/jtreg/runtime/StackGuardPages/exeinvoke.c
@@ -231,6 +231,16 @@ void usage() {
   fprintf(stderr, "       invoke test_native_overflow_initial\n");
 }
 
+void init_thread_or_die(pthread_t *thr, pthread_attr_t *thread_attr) {
+  size_t stack_size = get_java_stacksize();
+  if (pthread_attr_init(thread_attr) != 0 ||
+      pthread_attr_setstacksize(thread_attr, stack_size) != 0) {
+    printf("Failed to set stacksize. Exiting test.\n");
+    exit(0);
+  }
+
+}
+
 
 int main (int argc, const char** argv) {
   JavaVMInitArgs vm_args;
@@ -271,15 +281,8 @@ int main (int argc, const char** argv) {
     exit(7);
   }
 
-  size_t stack_size = get_java_stacksize();
   pthread_t thr;
   pthread_attr_t thread_attr;
-
-  if (pthread_attr_init(&thread_attr) != 0 ||
-      pthread_attr_setstacksize(&thread_attr, stack_size) != 0) {
-    printf("Failed to set stacksize. Exiting test.\n");
-    exit(0);
-  }
 
   if (argc < 2) {
     fprintf(stderr, "No test selected");
@@ -297,6 +300,7 @@ int main (int argc, const char** argv) {
   }
 
   if (strcmp(argv[1], "test_java_overflow") == 0) {
+    init_thread_or_die(&thr, &thread_attr);
     printf("\nTesting JAVA_OVERFLOW\n");
     printf("Testing stack guard page behaviour for other thread\n");
 
@@ -317,6 +321,7 @@ int main (int argc, const char** argv) {
   }
 
   if (strcmp(argv[1], "test_native_overflow") == 0) {
+    init_thread_or_die(&thr, &thread_attr);
     printf("\nTesting NATIVE_OVERFLOW\n");
     printf("Testing stack guard page behaviour for other thread\n");
 

--- a/test/hotspot/jtreg/runtime/StackGuardPages/exeinvoke.c
+++ b/test/hotspot/jtreg/runtime/StackGuardPages/exeinvoke.c
@@ -159,11 +159,11 @@ void *run_java_overflow (void *p) {
 }
 
 void do_overflow(){
-  volatile int *p;
+  volatile void *p;
   if (_kp_rec_count == 0 || _rec_count < _kp_rec_count) {
     for(;;) {
       _rec_count++;
-      p = (int*)alloca(sizeof(int));
+      p = alloca(128);
     }
   }
 }
@@ -238,7 +238,6 @@ void init_thread_or_die(pthread_t *thr, pthread_attr_t *thread_attr) {
     printf("Failed to set stacksize. Exiting test.\n");
     exit(0);
   }
-
 }
 
 

--- a/test/hotspot/jtreg/runtime/StackGuardPages/exeinvoke.c
+++ b/test/hotspot/jtreg/runtime/StackGuardPages/exeinvoke.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -124,8 +124,6 @@ void call_method_on_jvm(const char* method) {
   jmethodID method_id;
   int res;
 
-  printf("run_native_overflow %ld\n", (long) gettid());
-
   res = (*_jvm)->AttachCurrentThread(_jvm, (void **)&env, NULL);
   if (res != JNI_OK) {
     fprintf(stderr, "Test ERROR. Can't attach to current thread\n");
@@ -174,6 +172,7 @@ void *run_native_overflow(void *p) {
   // Test that stack guard page is correctly set for initial and non initial thread
   // and correctly removed for the initial thread
   volatile int res;
+  printf("run_native_overflow %ld\n", (long) gettid());
   call_method_on_jvm("printAlive");
 
   // Initialize statics used in do_overflow
@@ -187,8 +186,6 @@ void *run_native_overflow(void *p) {
 
   if (_last_si_code == SEGV_ACCERR) {
     printf("Test PASSED. Got access violation accessing guard page at %d\n", _rec_count);
-    // Use _y in side-effect to ensure that compiler doesn't optimize it away
-    printf("You can ignore this value: %d", _peek_value);
   }
 
   res = (*_jvm)->DetachCurrentThread(_jvm);

--- a/test/hotspot/jtreg/runtime/StackGuardPages/exeinvoke.c
+++ b/test/hotspot/jtreg/runtime/StackGuardPages/exeinvoke.c
@@ -275,8 +275,8 @@ int main (int argc, const char** argv) {
   pthread_t thr;
   pthread_attr_t thread_attr;
 
-  if (!pthread_attr_init(&thread_attr) ||
-      !pthread_attr_setstacksize(&thread_attr, stack_size)) {
+  if (pthread_attr_init(&thread_attr) != 0 ||
+      pthread_attr_setstacksize(&thread_attr, stack_size) != 0) {
     printf("Failed to set stacksize. Exiting test.\n");
     exit(0);
   }

--- a/test/hotspot/jtreg/runtime/StackGuardPages/exeinvoke.c
+++ b/test/hotspot/jtreg/runtime/StackGuardPages/exeinvoke.c
@@ -138,7 +138,7 @@ void call_method_on_jvm(const char* method) {
 
   method_id = (*env)->GetStaticMethodID(env, class_id, method, "()V");
   if (method_id == NULL) {
-    fprintf(stderr, "Test ERROR. Can't find method DoOverflow.printAlive\n");
+    fprintf(stderr, "Test ERROR. Can't find method DoOverflow.%s\n", method);
     exit(7);
   }
 


### PR DESCRIPTION
There are multiple ways which the stack guard pages tests can be hardened:
- Rewritten the Java part of the test using ProcessTools.executeProcess(ProcessBuilder pb) which will make stdout/stderr be consistently logged and debugging much easier.
- Split up initial/other thread into 2 tests
- Split up Java thread tests and native thread tests into two separate files
- Check more error conditions in the C code
- Instead of recursing and creating stack frames, just `alloca()` and poke until we hit a `SIGSEGV`.

The goal is that this will help us out with  [JDK-8293452](https://bugs.openjdk.org/browse/JDK-8293452).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295344](https://bugs.openjdk.org/browse/JDK-8295344): Harden runtime/StackGuardPages/TestStackGuardPages.java


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12386/head:pull/12386` \
`$ git checkout pull/12386`

Update a local copy of the PR: \
`$ git checkout pull/12386` \
`$ git pull https://git.openjdk.org/jdk pull/12386/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12386`

View PR using the GUI difftool: \
`$ git pr show -t 12386`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12386.diff">https://git.openjdk.org/jdk/pull/12386.diff</a>

</details>
