### PR TITLE
8293170: Improve encoding of the debuginfo nmethod section

### DIFF
--- a/src/hotspot/share/code/compressedStream.cpp
+++ b/src/hotspot/share/code/compressedStream.cpp
@@ -76,6 +76,7 @@ CompressedWriteStream::CompressedWriteStream(int initial_size) : CompressedStrea
   _buffer   = NEW_RESOURCE_ARRAY(u_char, initial_size);
   _size     = initial_size;
   _position = 0;
+  _zero_count = 0;
 }
 
 void CompressedWriteStream::grow() {

--- a/src/hotspot/share/code/compressedStream.hpp
+++ b/src/hotspot/share/code/compressedStream.hpp
@@ -115,7 +115,12 @@ class CompressedWriteStream : public CompressedStream {
   // input value is completely handled and no unsigned5 encoding required
   bool handle_zero(juint value) {
     if (value == 0) {
-      _zero_count = (_zero_count == 0xFF) ? 0 : _zero_count;
+      if (_zero_count == 0xFF) { // biggest zero chain length is 255
+        _zero_count = 1;
+        // for now, write it as an ordinary value (UNSINGED5 encodes zero int as a single byte)
+        // the new zero sequence is started if there are more than two zero values in a raw
+        return false;
+      }
       if (++_zero_count > 2) {
         _buffer[_position - 2] = 0;
         _buffer[_position - 1] = _zero_count;

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/CompressedReadStream.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/CompressedReadStream.java
@@ -103,7 +103,7 @@ public class CompressedReadStream extends CompressedStream {
 
   @Override
   public void setPosition(int position) {
-    this.position = position;
+    super.setPosition(position);
     remainingZeroes = 0;
   }
 

--- a/test/hotspot/gtest/code/test_debugInfoCompression.cpp
+++ b/test/hotspot/gtest/code/test_debugInfoCompression.cpp
@@ -51,7 +51,7 @@ public:
     // optionally: 523776 position() calls
     // optionally: 523776 bytes is written
     // 1024 int values is written
-    int expected_position = (variant == 0) ? 6982 : 
+    int expected_position = (variant == 0) ? 6982 :
                             (variant == 1) ? 525633 : 1049409;
     ASSERT_TRUE(out.position() == expected_position);
 

--- a/test/hotspot/gtest/code/test_debugInfoCompression.cpp
+++ b/test/hotspot/gtest/code/test_debugInfoCompression.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2023, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "precompiled.hpp"
+#include "memory/resourceArea.hpp"
+#include "code/debugInfo.hpp"
+#include "unittest.hpp"
+
+class CompressedSparseDataWriteStreamTest {
+public:
+  void check_read_write(int variant) {
+    ResourceMark rm;
+    DebugInfoWriteStream out(NULL, 100);
+    u_char* buf1 = out.buffer();
+
+    for (int i = 0; i < 1024; i++) {
+      for (int j = 0; j < i; j++) {
+        out.write_int(0);
+        // mix zeroes with position() calls or with other data
+        if (variant == 1) {
+          // position() call breaks zero sequence optimizaion
+          out.position();
+        } else if (variant == 2) {
+          out.write_byte((jbyte)i);
+        }
+      }
+      out.write_int(i);
+    }
+
+    // 523776 zero values is written
+    // optionally: 523776 position() calls
+    // optionally: 523776 bytes is written
+    // 1024 int values is written
+    int expected_position = (variant == 0) ? 6982 : 
+                            (variant == 1) ? 525633 : 1049409;
+    ASSERT_TRUE(out.position() == expected_position);
+
+    u_char* buf2 = out.buffer();
+    // the initial buffer is small and must be replaced with a bigger one
+    ASSERT_TRUE(buf1 != buf2);
+    CompressedReadStream in(buf2, 0);
+
+    for (int i = 0; i < 1024; i++) {
+      for (int j = 0; j < i; j++) {
+        ASSERT_TRUE(in.read_int() == 0);
+        if (variant == 2) {
+          ASSERT_TRUE(in.read_byte() == (jbyte)i);
+        }
+      }
+      ASSERT_TRUE(in.read_int() == i);
+    }
+  }
+
+  void check_read_write() {
+    ResourceMark rm;
+    DebugInfoWriteStream out(NULL, 100);
+
+    for (int i = 0; i < 1000*1000; i++) {
+      out.write_int(i);
+      out.write_bool((bool)i);
+      out.write_byte((jbyte)i);
+      out.write_signed_int((jint)i);
+      out.write_double((jdouble)i);
+      out.write_long((jlong)i);
+    }
+
+    u_char* buf = out.buffer();
+    CompressedReadStream in(buf, 0);
+
+    for (int i = 0; i < 1000*1000; i++) {
+      ASSERT_TRUE(in.read_int() == i);
+      ASSERT_TRUE(in.read_bool() == (jboolean)(bool)i);
+      ASSERT_TRUE(in.read_byte() == (jbyte)i);
+      ASSERT_TRUE(in.read_signed_int() == (jint)i);
+      ASSERT_TRUE(in.read_double() == (jdouble)i);
+      ASSERT_TRUE(in.read_long() == (jlong)i);
+    }
+  }
+
+  void check_int_encoding() {
+    ResourceMark rm;
+    DebugInfoWriteStream out(NULL, 100);
+    const u_char* buf = out.buffer();
+
+    out.write_int(0);
+    out.write_int(0);
+    out.write_int(0);
+    out.write_int(0);
+    out.write_int(0);
+    out.write_int(0);
+    out.write_int(0);
+    out.write_int(0);
+    ASSERT_TRUE(out.position() == 2 && buf[0] == 0 && buf[1] == 8);
+
+    out.set_position(0);
+    out.write_int(1);
+    ASSERT_TRUE(out.position() == 1 && buf[0] == 0x2);
+
+    out.set_position(0);
+    out.write_int(0xff);
+    ASSERT_TRUE(out.position() == 2 && buf[0] == 0xC0 && buf[1] == 0x2);
+
+    out.set_position(0);
+    out.write_int(0xffff);
+    ASSERT_TRUE(out.position() == 3 && buf[0] == 0xC0 && buf[1] == 0xfe && buf[2] == 0xD);
+
+    out.set_position(0);
+    out.write_int(0xffffffff);
+    ASSERT_TRUE(out.position() == 5 && buf[0] == 0xC0 && buf[1] == 0xfe && buf[2] == 0xFD && buf[3] == 0xFD);
+  }
+
+  void check_buffer_grow() {
+    ResourceMark rm;
+    DebugInfoWriteStream out(NULL, 100);
+    for (int i = 0; i < 99; i++) { out.write_int(1); }
+    out.write_int(0);
+    out.write_int(1);
+    out.write_int(2);
+    const u_char* buf = out.buffer();
+    ASSERT_TRUE(out.position() == 102 && buf[99] == 1 && buf[100] == 2 && buf[101] == 3);
+  }
+};
+
+TEST_VM(DebugInfo, basic_test)
+{
+  CompressedSparseDataWriteStreamTest test;
+  test.check_read_write(0);
+  test.check_read_write(1);
+  test.check_read_write(2);
+  test.check_read_write();
+  test.check_int_encoding();
+  test.check_buffer_grow();
+}

--- a/test/hotspot/jtreg/serviceability/sa/TestCompressedReadStream.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestCompressedReadStream.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2023, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import sun.jvm.hotspot.code.*;
+import sun.jvm.hotspot.debugger.*;
+
+/**
+ * @test
+ * @library /test/lib
+ * @requires vm.hasSA
+ * @modules jdk.hotspot.agent/sun.jvm.hotspot.debugger
+ *          jdk.hotspot.agent/sun.jvm.hotspot.code
+ * @run main/othervm -Xbootclasspath/a:. TestCompressedReadStream
+ */
+public class TestCompressedReadStream {
+
+    public static void testReadInt() {
+        byte data[] = { 
+            (byte)0, (byte)4, // zero zequence of four values
+            (byte)33, // UNSIGNED5(32) = 33
+            (byte)0, (byte)4  // zero zequence of four values
+        };
+        CompressedReadStream in = new CompressedReadStream(new Addr(data), 0);
+        assertEquals(in.readInt(), 0);
+        assertEquals(in.readInt(), 0);
+        assertEquals(in.readInt(), 0);
+        assertEquals(in.readInt(), 0);
+        assertEquals(in.readInt(), 32);
+        assertEquals(in.readInt(), 0);
+        assertEquals(in.readInt(), 0);
+        assertEquals(in.readInt(), 0);
+        assertEquals(in.readInt(), 0);
+
+        in.setPosition(2); // rollback and read once again
+        assertEquals(in.readInt(), 32);
+    }
+    
+    public static void main(String[] args) {
+        testReadInt();
+    }
+
+    private static void assertEquals(int a, int b) {
+        if (a != b) throw new RuntimeException("assert failed: " + a + " != " + b);
+    }
+}
+
+class DummyAddr implements sun.jvm.hotspot.debugger.Address {
+    public boolean    equals(Object arg)                { return false; }
+    public int        hashCode()                        { return 0; }
+    public long       getCIntegerAt      (long offset, long numBytes, boolean isUnsigned) { return 0; }
+    public Address    getAddressAt       (long offset)  { return null; }
+    public Address    getCompOopAddressAt (long offset) { return null; }
+    public Address    getCompKlassAddressAt (long offset) { return null; }
+    public boolean    getJBooleanAt      (long offset)  { return false; }
+    public byte       getJByteAt         (long offset)  { return 0; }
+    public char       getJCharAt         (long offset)  { return 0; }
+    public double     getJDoubleAt       (long offset)  { return 0; }
+    public float      getJFloatAt        (long offset)  { return 0; }
+    public int        getJIntAt          (long offset)  { return 0; }
+    public long       getJLongAt         (long offset)  { return 0; }
+    public short      getJShortAt        (long offset)  { return 0; }
+    public OopHandle  getOopHandleAt     (long offset)  { return null; }
+    public OopHandle  getCompOopHandleAt (long offset)  { return null; }
+    public void       setCIntegerAt      (long offset, long numBytes, long value) {}
+    public void       setAddressAt       (long offset, Address value) {}
+    public void       setJBooleanAt      (long offset, boolean value) {}
+    public void       setJByteAt         (long offset, byte value)    {}
+    public void       setJCharAt         (long offset, char value)    {}
+    public void       setJDoubleAt       (long offset, double value)  {}
+    public void       setJFloatAt        (long offset, float value)   {}
+    public void       setJIntAt          (long offset, int value)     {}
+    public void       setJLongAt         (long offset, long value)    {}
+    public void       setJShortAt        (long offset, short value)   {}
+    public void       setOopHandleAt     (long offset, OopHandle value) {}
+    public Address    addOffsetTo        (long offset)  { return null; }
+    public OopHandle  addOffsetToAsOopHandle(long offset)  { return null; }
+    public long       minus              (Address arg)  { return 0; }
+    public boolean    lessThan           (Address arg)  { return false; }
+    public boolean    lessThanOrEqual    (Address arg)  { return false; }
+    public boolean    greaterThan        (Address arg)  { return false; }
+    public boolean    greaterThanOrEqual (Address arg)  { return false; }
+    public Address    andWithMask        (long mask)    { return null; }
+    public Address    orWithMask         (long mask)    { return null; }
+    public Address    xorWithMask        (long mask)    { return null; }
+    public long       asLongValue        ()             { return 0; }
+}
+
+class Addr extends DummyAddr {
+    byte data[];
+    public Addr(byte data[]) {
+        this.data = data;
+    }
+    public long getCIntegerAt(long offset, long numBytes, boolean isUnsigned) {
+        return data[(int)offset];
+    }
+}

--- a/test/hotspot/jtreg/serviceability/sa/TestCompressedReadStream.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestCompressedReadStream.java
@@ -35,7 +35,7 @@ import sun.jvm.hotspot.debugger.*;
 public class TestCompressedReadStream {
 
     public static void testReadInt() {
-        byte data[] = { 
+        byte data[] = {
             (byte)0, (byte)4, // zero zequence of four values
             (byte)33, // UNSIGNED5(32) = 33
             (byte)0, (byte)4  // zero zequence of four values
@@ -54,7 +54,7 @@ public class TestCompressedReadStream {
         in.setPosition(2); // rollback and read once again
         assertEquals(in.readInt(), 32);
     }
-    
+
     public static void main(String[] args) {
         testReadInt();
     }


### PR DESCRIPTION
This is another pull request to replace https://github.com/openjdk/jdk/pull/10025 change which was blocked as not acceptable (see https://github.com/openjdk/jdk/pull/10025#pullrequestreview-1228216330)

The objections to change #10025 were:
- specialized algorithm for given data complicates things, makes it hard to learn, test and support
- algorithm is changed for DebugInfo, and the benefit is only for one type of data
- statistics of the debug info data can (will) change, breaking the optimization

The suggestion was:
- don't change the core algorithm, but add one on top or underneath the existing one, or reuse off-the-shelf zero-reduction schemes such as Cap'n Proto

With this change I propose a different approach. Instead of bit coding, the sequence of zeros in a data stream is encoded with a special character that normally never appears in Unsinged5 encoding, followed by a byte containing a number of zeros. In this way the updated algorithm is a pure extension of the existing encoding algorithm: data encoded without the zero-reduction trick is unpacked in the same way as before.

Currently there are several datasets affected by this change: Dependencies info, OopMap info, LineNumber info, Debug info. Only Debug info has a large number of zeros and gets a significant benefit. I experimented with the Cap'n Proto and lz4 algorithms on DebugInfo. The Unsinged5 algorithm has a better compression rate than these.

DebugInfo data size is reduced by ~20% (actually, 10-30%, depending on the application). Total nmethod size reduction is ~3%.

Performance impact: Renaisance and DaCapo benchmarks do not show any difference.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293170](https://bugs.openjdk.org/browse/JDK-8293170): Improve encoding of the debuginfo nmethod section (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12387/head:pull/12387` \
`$ git checkout pull/12387`

Update a local copy of the PR: \
`$ git checkout pull/12387` \
`$ git pull https://git.openjdk.org/jdk.git pull/12387/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12387`

View PR using the GUI difftool: \
`$ git pr show -t 12387`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12387.diff">https://git.openjdk.org/jdk/pull/12387.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12387#issuecomment-1544079749)