### PR TITLE
8301380: jdk/jfr/api/consumer/streaming/TestCrossProcessStreaming.java

### DIFF
--- a/src/hotspot/share/jfr/utilities/jfrThreadIterator.cpp
+++ b/src/hotspot/share/jfr/utilities/jfrThreadIterator.cpp
@@ -38,6 +38,9 @@ static bool java_thread_inclusion_predicate(JavaThread* jt, bool live_only) {
   if (live_only && jt->thread_state() == _thread_new) {
     return false;
   }
+  if (jt->is_attaching_via_jni()) {
+    return false;
+  }
   return thread_inclusion_predicate(jt);
 }
 

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -3465,7 +3465,7 @@ struct JNINativeInterface_* jni_functions_nocheck() {
 
 static void post_thread_start_event(const JavaThread* jt) {
   assert(jt != nullptr, "invariant");
-  // We hoist the read for the thread id to ensure the thread is assigned an id (lazily assignment)..
+  // We hoist the read for the thread id to ensure the thread is assigned an id (lazy assignment).
   const traceid thread_id = JFR_JVM_THREAD_ID(jt);
   EventThreadStart event;
   if (event.should_commit()) {

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -3836,6 +3836,9 @@ static jint attach_current_thread(JavaVM *vm, void **penv, void *_args, bool dae
     return JNI_ERR;
   }
 
+  // Please keep this inside the _attaching_via_jni section.
+  post_thread_start_event(thread);
+
   // mark the thread as no longer attaching
   // this uses a fence to push the change through so we don't have
   // to regrab the threads_lock
@@ -3849,8 +3852,6 @@ static jint attach_current_thread(JavaVM *vm, void **penv, void *_args, bool dae
   if (JvmtiExport::should_post_thread_life()) {
     JvmtiExport::post_thread_start(thread);
   }
-
-  post_thread_start_event(thread);
 
   *(JNIEnv**)penv = thread->jni_environment();
 

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -3465,9 +3465,11 @@ struct JNINativeInterface_* jni_functions_nocheck() {
 
 static void post_thread_start_event(const JavaThread* jt) {
   assert(jt != nullptr, "invariant");
+  // We hoist the read for the thread id to ensure the thread is assigned an id (lazily assignment)..
+  const traceid thread_id = JFR_JVM_THREAD_ID(jt);
   EventThreadStart event;
   if (event.should_commit()) {
-    event.set_thread(JFR_JVM_THREAD_ID(jt));
+    event.set_thread(thread_id);
     event.set_parentThread((traceid)0);
 #if INCLUDE_JFR
     if (EventThreadStart::is_stacktrace_enabled()) {


### PR DESCRIPTION
Greetings,

please help review this small adjustment to close the gap where iterated threads that attach via jni are left without a valid JFR thread id. For details, please see the JIRA issue.

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301380](https://bugs.openjdk.org/browse/JDK-8301380): jdk/jfr/api/consumer/streaming/TestCrossProcessStreaming.java


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12388/head:pull/12388` \
`$ git checkout pull/12388`

Update a local copy of the PR: \
`$ git checkout pull/12388` \
`$ git pull https://git.openjdk.org/jdk pull/12388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12388`

View PR using the GUI difftool: \
`$ git pr show -t 12388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12388.diff">https://git.openjdk.org/jdk/pull/12388.diff</a>

</details>
