### PR TITLE
JDK-8291735: methods_do() always run at exit

### DIFF
--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -114,7 +114,7 @@ void collect_profiled_methods(Method* m) {
 }
 
 void print_method_profiling_data() {
-  if (ProfileInterpreter COMPILER1_PRESENT(|| C1UpdateMethodData) &&
+  if ((ProfileInterpreter COMPILER1_PRESENT(|| C1UpdateMethodData)) &&
      (PrintMethodData || CompilerOracle::should_print_methods())) {
     ResourceMark rm;
     collected_profiled_methods = new GrowableArray<Method*>(1024);


### PR DESCRIPTION
`SystemDictionary::methods_do` is always executed because we miss parenthesis around the first `or`. `&&` binds stronger than `||` and therefore the condition become true if `ProfileInterpreter` is true. 

Fixed by adding the missing parenthesis.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291735](https://bugs.openjdk.org/browse/JDK-8291735): methods_do() always run at exit


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12389/head:pull/12389` \
`$ git checkout pull/12389`

Update a local copy of the PR: \
`$ git checkout pull/12389` \
`$ git pull https://git.openjdk.org/jdk pull/12389/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12389`

View PR using the GUI difftool: \
`$ git pr show -t 12389`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12389.diff">https://git.openjdk.org/jdk/pull/12389.diff</a>

</details>
