### PR TITLE
7093691: Nimbus LAF: disabled JComboBox using renderer has bad font color

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/DefaultListCellRenderer.java
+++ b/src/java.desktop/share/classes/javax/swing/DefaultListCellRenderer.java
@@ -25,15 +25,14 @@
 
 package javax.swing;
 
-import javax.swing.*;
-import javax.swing.event.*;
-import javax.swing.border.*;
-
-import java.awt.Component;
 import java.awt.Color;
+import java.awt.Component;
 import java.awt.Rectangle;
-
 import java.io.Serializable;
+
+import javax.swing.border.Border;
+import javax.swing.border.EmptyBorder;
+
 import sun.swing.DefaultLookup;
 import sun.swing.SwingUtilities2;
 
@@ -157,7 +156,10 @@ public class DefaultListCellRenderer extends JLabel
             setText((value == null) ? "" : value.toString());
         }
 
-        setEnabled(list.isEnabled());
+        if (list.getName() == null || !list.getName().equals("ComboBox.list")) {
+            setEnabled(list.isEnabled());
+        }
+
         setFont(list.getFont());
 
         Border border = null;

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthComboBoxUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthComboBoxUI.java
@@ -39,6 +39,7 @@ import java.beans.PropertyChangeListener;
 
 import javax.swing.ComboBoxEditor;
 import javax.swing.DefaultButtonModel;
+import javax.swing.DefaultListCellRenderer;
 import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -107,6 +108,8 @@ public class SynthComboBoxUI extends BasicComboBoxUI implements
      * Handler for repainting combo when editor component gains/looses focus
      */
     private EditorFocusHandler editorFocusHandler;
+
+    private DlcrEnabledHandler dlcrEnabledHandler;
 
     /**
      * If true, then the cell renderer will be forced to be non-opaque when
@@ -187,6 +190,7 @@ public class SynthComboBoxUI extends BasicComboBoxUI implements
         comboBox.addPropertyChangeListener(this);
         comboBox.addMouseListener(buttonHandler);
         editorFocusHandler = new EditorFocusHandler(comboBox);
+        dlcrEnabledHandler = new DlcrEnabledHandler(comboBox);
         super.installListeners();
     }
 
@@ -219,6 +223,7 @@ public class SynthComboBoxUI extends BasicComboBoxUI implements
     @Override
     protected void uninstallListeners() {
         editorFocusHandler.unregister();
+        dlcrEnabledHandler.unregister();
         comboBox.removePropertyChangeListener(this);
         comboBox.removeMouseListener(buttonHandler);
         buttonHandler.pressed = false;
@@ -818,6 +823,38 @@ public class SynthComboBoxUI extends BasicComboBoxUI implements
                     if (editorComponent != null){
                         editorComponent.addFocusListener(this);
                     }
+                }
+            }
+        }
+    }
+
+    /**
+     * Handler for updating combobox enabled status when renderer enabled
+     * status changes
+     */
+    private static class DlcrEnabledHandler implements PropertyChangeListener {
+        private JComboBox<?> comboBox;
+
+        private DlcrEnabledHandler(JComboBox<?> comboBox) {
+            this.comboBox = comboBox;
+            comboBox.addPropertyChangeListener("enabled",this);
+        }
+
+        public void unregister() {
+            comboBox.removePropertyChangeListener("enabled", this);
+        }
+
+        /**
+         * Called when the combos enabled status changes
+         *
+         * @param evt A PropertyChangeEvent object describing the event source
+         *            and the property that has changed.
+         */
+        public void propertyChange(PropertyChangeEvent evt) {
+            if (evt.getPropertyName().equals("enabled")) {
+                if (comboBox.getRenderer() instanceof DefaultListCellRenderer) {
+                    ((DefaultListCellRenderer) comboBox.getRenderer())
+                            .setEnabled((boolean) evt.getNewValue());
                 }
             }
         }

--- a/test/jdk/javax/swing/JComboBox/DisabledComboBoxFontTest.java
+++ b/test/jdk/javax/swing/JComboBox/DisabledComboBoxFontTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 7093691
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Tests if Nimbus JComboBox has correct font
+ * @run main/manual DisabledComboBoxFontTest
+ */
+
+import java.awt.FlowLayout;
+import java.awt.event.ActionListener;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.DefaultListCellRenderer;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UIManager.LookAndFeelInfo;
+
+public class DisabledComboBoxFontTest {
+    private static final String instructionsText = "Pass if you can see two " +
+            "editable JComboBoxes and two JLists displayed correctly when " +
+            "enabled and disabled. Fail if they don't. Toggle UI enabled " +
+            "status with the button on the right of the frame.";
+
+    private static JFrame frame;
+    private static boolean hasNimbus;
+
+    public static void createAndShowGUI() throws InterruptedException,
+            InvocationTargetException {
+        SwingUtilities.invokeAndWait(() -> {
+
+            JComboBox combo = new JComboBox();
+            combo.addItem("Simple JComboBox");
+            combo.addItem("Simple JComboBox2");
+            combo.setEnabled(false);
+
+            JComboBox customCombo = new JComboBox();
+            customCombo.setRenderer(new DefaultListCellRenderer());
+            customCombo.addItem("JComboBox with DefaultListCellRenderer");
+            customCombo.addItem("JComboBox with DefaultListCellRenderer2");
+            customCombo.setEnabled(false);
+
+            String[] s = {"one", "two", "three"};
+            JList list = new JList(s);
+            list.setEnabled(false);
+            JList list2 = new JList(s);
+            list2.setCellRenderer(new DefaultListCellRenderer());
+            list2.setEnabled(false);
+
+            JButton btn = new JButton("Enable/Disable");
+            ActionListener actionListener = event -> {
+                combo.setEnabled(!combo.isEnabled());
+                customCombo.setEnabled(!customCombo.isEnabled());
+                list.setEnabled(!list.isEnabled());
+                list2.setEnabled(!list2.isEnabled());
+                String str = event.getActionCommand();
+                System.out.println("Clicked = " + str + " " + customCombo.isEnabled());
+            };
+            btn.addActionListener(actionListener);
+
+            FlowLayout layout = new FlowLayout(FlowLayout.LEADING);
+            JPanel panel = new JPanel(layout);
+            panel.add(combo);
+            panel.add(customCombo);
+            panel.add(list);
+            panel.add(list2);
+            panel.add(btn);
+            System.out.println("RENDERER1: " + combo.getRenderer());
+            System.out.println("RENDERER2: " + customCombo.getRenderer());
+            System.out.println("RENDERER3: " + list.getCellRenderer());
+            System.out.println("RENDERER4: " + list2.getCellRenderer());
+
+            frame = new JFrame();
+            frame.getContentPane().add(panel);
+            frame.pack();
+            frame.setLocationRelativeTo(null);
+
+            PassFailJFrame.addTestWindow(frame);
+            PassFailJFrame.positionTestWindow(frame,
+                    PassFailJFrame.Position.HORIZONTAL);
+
+            frame.setVisible(true);
+        });
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        hasNimbus = false;
+
+        for (LookAndFeelInfo info : UIManager.getInstalledLookAndFeels()) {
+            if ("Nimbus".equals(info.getName())) {
+                System.out.println("LF: " + info.getClassName());
+                UIManager.setLookAndFeel(info.getClassName());
+                hasNimbus = true;
+            }
+        }
+
+        if (!hasNimbus) {
+            System.err.println("Nimbus L&F not found");
+            return;
+        }
+
+        PassFailJFrame pfjFrame = new PassFailJFrame("Disabled Nimbus "
+                + "CustomComboBox Test Instructions", instructionsText, 5);
+
+        createAndShowGUI();
+
+        pfjFrame.awaitAndCheck();
+    }
+}


### PR DESCRIPTION
Before the fix, a JComboBox in Nimbus L&F would have normal black text even when the JComboBox was disabled if SynthComboBoxRenderer was replaced with a DefaultListCellRenderer. This text should be greyed out like in other L&F's. When looking into the defaults for Nimbus L&F files for attributes and states of a JComboBox, it confirm that the intention for disabled JComboBoxes is nimbusDisabledText (which is grey text).

SynthComboBoxes have an additional check in its default SynthComboBoxRenderer that enables/disables the renderer itself. The SynthComboBoxRenderer inherits its enabled state from the parent ComboBox. Since the renderer with DefaultListCellRenderer is in a separate class without a reference to the comboBox, a listener was added to SynthComboBoxUI.

An additional issue occurred in DefaultListCellRenderer because the renderer overrode the listener's re-assigned enabled state. In testing, setting the enabled state in DefaultListCellRenderer is redundant for all L&F's and is not needed here. However, instead of removing it altogether, a conditional was added specifically to allow ComboBoxes to skip setting enabled state here.

After the fix, the Nimbus JComboBox with DLCR set matches the appearance of a normal Nimbus JComboBox. I can enable/disable the JComboBoxes in the test, and the UI elements behave and appear as expected.