### PR TITLE
JDK-8301396: Port fdlibm expm1 to Java

### DIFF
--- a/src/java.base/share/classes/java/lang/FdLibm.java
+++ b/src/java.base/share/classes/java/lang/FdLibm.java
@@ -985,4 +985,213 @@ class FdLibm {
             }
         }
     }
+
+    /* expm1(x)
+     * Returns exp(x)-1, the exponential of x minus 1.
+     *
+     * Method
+     *   1. Argument reduction:
+     *      Given x, find r and integer k such that
+     *
+     *               x = k*ln2 + r,  |r| <= 0.5*ln2 ~ 0.34658
+     *
+     *      Here a correction term c will be computed to compensate
+     *      the error in r when rounded to a floating-point number.
+     *
+     *   2. Approximating expm1(r) by a special rational function on
+     *      the interval [0,0.34658]:
+     *      Since
+     *          r*(exp(r)+1)/(exp(r)-1) = 2+ r^2/6 - r^4/360 + ...
+     *      we define R1(r*r) by
+     *          r*(exp(r)+1)/(exp(r)-1) = 2+ r^2/6 * R1(r*r)
+     *      That is,
+     *          R1(r**2) = 6/r *((exp(r)+1)/(exp(r)-1) - 2/r)
+     *                   = 6/r * ( 1 + 2.0*(1/(exp(r)-1) - 1/r))
+     *                   = 1 - r^2/60 + r^4/2520 - r^6/100800 + ...
+     *      We use a special Reme algorithm on [0,0.347] to generate
+     *      a polynomial of degree 5 in r*r to approximate R1. The
+     *      maximum error of this polynomial approximation is bounded
+     *      by 2**-61. In other words,
+     *          R1(z) ~ 1.0 + Q1*z + Q2*z**2 + Q3*z**3 + Q4*z**4 + Q5*z**5
+     *      where   Q1  =  -1.6666666666666567384E-2,
+     *              Q2  =   3.9682539681370365873E-4,
+     *              Q3  =  -9.9206344733435987357E-6,
+     *              Q4  =   2.5051361420808517002E-7,
+     *              Q5  =  -6.2843505682382617102E-9;
+     *      (where z=r*r, and the values of Q1 to Q5 are listed below)
+     *      with error bounded by
+     *          |                  5           |     -61
+     *          | 1.0+Q1*z+...+Q5*z   -  R1(z) | <= 2
+     *          |                              |
+     *
+     *      expm1(r) = exp(r)-1 is then computed by the following
+     *      specific way which minimize the accumulation rounding error:
+     *                             2     3
+     *                            r     r    [ 3 - (R1 + R1*r/2)  ]
+     *            expm1(r) = r + --- + --- * [--------------------]
+     *                            2     2    [ 6 - r*(3 - R1*r/2) ]
+     *
+     *      To compensate the error in the argument reduction, we use
+     *              expm1(r+c) = expm1(r) + c + expm1(r)*c
+     *                         ~ expm1(r) + c + r*c
+     *      Thus c+r*c will be added in as the correction terms for
+     *      expm1(r+c). Now rearrange the term to avoid optimization
+     *      screw up:
+     *                      (      2                                    2 )
+     *                      ({  ( r    [ R1 -  (3 - R1*r/2) ]  )  }    r  )
+     *       expm1(r+c)~r - ({r*(--- * [--------------------]-c)-c} - --- )
+     *                      ({  ( 2    [ 6 - r*(3 - R1*r/2) ]  )  }    2  )
+     *                      (                                             )
+     *
+     *                 = r - E
+     *   3. Scale back to obtain expm1(x):
+     *      From step 1, we have
+     *         expm1(x) = either 2^k*[expm1(r)+1] - 1
+     *                  = or     2^k*[expm1(r) + (1-2^-k)]
+     *   4. Implementation notes:
+     *      (A). To save one multiplication, we scale the coefficient Qi
+     *           to Qi*2^i, and replace z by (x^2)/2.
+     *      (B). To achieve maximum accuracy, we compute expm1(x) by
+     *        (i)   if x < -56*ln2, return -1.0, (raise inexact if x!=inf)
+     *        (ii)  if k=0, return r-E
+     *        (iii) if k=-1, return 0.5*(r-E)-0.5
+     *        (iv)  if k=1 if r < -0.25, return 2*((r+0.5)- E)
+     *                     else          return  1.0+2.0*(r-E);
+     *        (v)   if (k<-2||k>56) return 2^k(1-(E-r)) - 1 (or exp(x)-1)
+     *        (vi)  if k <= 20, return 2^k((1-2^-k)-(E-r)), else
+     *        (vii) return 2^k(1-((E+2^-k)-r))
+     *
+     * Special cases:
+     *      expm1(INF) is INF, expm1(NaN) is NaN;
+     *      expm1(-INF) is -1, and
+     *      for finite argument, only expm1(0)=0 is exact.
+     *
+     * Accuracy:
+     *      according to an error analysis, the error is always less than
+     *      1 ulp (unit in the last place).
+     *
+     * Misc. info.
+     *      For IEEE double
+     *          if x >  7.09782712893383973096e+02 then expm1(x) overflow
+     *
+     * Constants:
+     * The hexadecimal values are the intended ones for the following
+     * constants. The decimal values may be used, provided that the
+     * compiler will convert from decimal to binary accurately enough
+     * to produce the hexadecimal values shown.
+     */
+    static class Expm1 {
+        private static final double one         =  1.0;
+        private static final double huge        =  1.0e+300;
+        private static final double tiny        =  1.0e-300;
+        private static final double o_threshold =  0x1.62e42fefa39efp9;   //  7.09782712893383973096e+02
+        private static final double ln2_hi      =  0x1.62e42feep-1;       //  6.93147180369123816490e-01
+        private static final double ln2_lo      =  0x1.a39ef35793c76p-33; //  1.90821492927058770002e-10
+        private static final double invln2      =  0x1.71547652b82fep0;   //  1.44269504088896338700e+00
+        /* scaled coefficients related to expm1 */
+        private static final double Q1          = -0x1.11111111110f4p-5;  // -3.33333333333331316428e-02
+        private static final double Q2          =  0x1.a01a019fe5585p-10; //  1.58730158725481460165e-03
+        private static final double Q3          = -0x1.4ce199eaadbb7p-14; // -7.93650757867487942473e-05
+        private static final double Q4          =  0x1.0cfca86e65239p-18; //  4.00821782732936239552e-06
+        private static final double Q5          = -0x1.afdb76e09c32dp-23; // -2.01099218183624371326e-07
+
+        static double compute(double x) {
+            double y, hi, lo, c=0, t, e, hxs, hfx, r1;
+            int k, xsb;
+            /*unsigned*/ int hx;
+
+            hx  = __HI(x);  /* high word of x */
+            xsb = hx & 0x8000_0000;            /* sign bit of x */
+            y = Math.abs(x);
+            hx &= 0x7fff_ffff;               /* high word of |x| */
+
+            /* filter out huge and non-finite argument */
+            if (hx >= 0x4043_687A) {                  /* if |x| >= 56*ln2 */
+                if (hx >= 0x4086_2E42) {              /* if |x| >= 709.78... */
+                    if (hx >= 0x7ff_00000) {
+                        if (((hx & 0xf_ffff) | __LO(x)) != 0) {
+                            return x + x;     /* NaN */
+                        } else {
+                            return (xsb == 0)? x : -1.0; /* exp(+-inf)={inf,-1} */
+                        }
+                    }
+                    if (x > o_threshold) {
+                        return huge*huge; /* overflow */
+                    }
+                }
+                if (xsb != 0) { /* x < -56*ln2, return -1.0 with inexact */
+                    if (x + tiny < 0.0) {         /* raise inexact */
+                        return tiny - one;        /* return -1 */
+                    }
+                }
+            }
+
+            /* argument reduction */
+            if (hx > 0x3fd6_2e42) {           /* if  |x| > 0.5 ln2 */
+                if (hx < 0x3FF0_A2B2) {       /* and |x| < 1.5 ln2 */
+                    if (xsb == 0) {
+                        hi = x - ln2_hi;
+                        lo =  ln2_lo;
+                        k =  1;}
+                    else {
+                        hi = x + ln2_hi;
+                        lo = -ln2_lo;
+                        k = -1;
+                    }
+                } else {
+                    k  = (int)(invln2*x + ((xsb == 0) ? 0.5 : -0.5));
+                    t  = k;
+                    hi = x - t*ln2_hi;      /* t*ln2_hi is exact here */
+                    lo = t*ln2_lo;
+                }
+                x  = hi - lo;
+                c  = (hi - x) - lo;
+            } else if (hx < 0x3c90_0000) {      /* when |x|<2**-54, return x */
+                t = huge + x; /* return x with inexact flags when x != 0 */
+                return x - (t - (huge + x));
+            } else {
+                k = 0;
+            }
+
+            /* x is now in primary range */
+            hfx = 0.5*x;
+            hxs = x*hfx;
+            r1 = one + hxs*(Q1 + hxs*(Q2 + hxs*(Q3 + hxs*(Q4 + hxs*Q5))));
+            t  = 3.0 - r1*hfx;
+            e  = hxs *((r1 - t)/(6.0 - x*t));
+            if (k == 0) {
+                return x - (x*e - hxs);          /* c is 0 */
+            } else {
+                e  = (x*(e - c) - c);
+                e -= hxs;
+                if (k == -1) {
+                    return 0.5*(x - e) - 0.5;
+                }
+                if (k == 1) {
+                    if(x < -0.25) {
+                        return -2.0*(e - (x + 0.5));
+                    } else {
+                        return  one + 2.0*(x - e);
+                    }
+                }
+                if (k <= -2 || k > 56) {   /* suffice to return exp(x) - 1 */
+                    y = one - (e - x);
+                    y = __HI(y, __HI(y) + (k << 20));     /* add k to y's exponent */
+                    return y - one;
+                }
+                t = one;
+                if (k < 20) {
+                    t = __HI(t, 0x3ff0_0000 - (0x2_00000 >> k));  /* t=1-2^-k */
+                    y = t - ( e - x);
+                    y = __HI(y, __HI(y) + (k << 20));     /* add k to y's exponent */
+                } else {
+                    t = __HI(t, ((0x3ff - k) << 20));     /* 2^-k */
+                    y = x - (e + t);
+                    y += one;
+                    y = __HI(y, __HI(y) + (k << 20));     /* add k to y's exponent */
+                }
+            }
+            return y;
+        }
+    }
 }

--- a/src/java.base/share/classes/java/lang/FdLibm.java
+++ b/src/java.base/share/classes/java/lang/FdLibm.java
@@ -1088,7 +1088,7 @@ class FdLibm {
         private static final double ln2_hi      =  0x1.62e42feep-1;       //  6.93147180369123816490e-01
         private static final double ln2_lo      =  0x1.a39ef35793c76p-33; //  1.90821492927058770002e-10
         private static final double invln2      =  0x1.71547652b82fep0;   //  1.44269504088896338700e+00
-        /* scaled coefficients related to expm1 */
+        // scaled coefficients related to expm1
         private static final double Q1          = -0x1.11111111110f4p-5;  // -3.33333333333331316428e-02
         private static final double Q2          =  0x1.a01a019fe5585p-10; //  1.58730158725481460165e-03
         private static final double Q3          = -0x1.4ce199eaadbb7p-14; // -7.93650757867487942473e-05
@@ -1100,40 +1100,40 @@ class FdLibm {
             int k, xsb;
             /*unsigned*/ int hx;
 
-            hx  = __HI(x);  /* high word of x */
-            xsb = hx & 0x8000_0000;            /* sign bit of x */
+            hx  = __HI(x);  // high word of x
+            xsb = hx & 0x8000_0000;          // sign bit of x
             y = Math.abs(x);
-            hx &= 0x7fff_ffff;               /* high word of |x| */
+            hx &= 0x7fff_ffff;               // high word of |x|
 
-            /* filter out huge and non-finite argument */
-            if (hx >= 0x4043_687A) {                  /* if |x| >= 56*ln2 */
-                if (hx >= 0x4086_2E42) {              /* if |x| >= 709.78... */
+            // filter out huge and non-finite argument
+            if (hx >= 0x4043_687A) {                  // if |x| >= 56*ln2
+                if (hx >= 0x4086_2E42) {              // if |x| >= 709.78...
                     if (hx >= 0x7ff_00000) {
                         if (((hx & 0xf_ffff) | __LO(x)) != 0) {
-                            return x + x;     /* NaN */
+                            return x + x;     // NaN
                         } else {
-                            return (xsb == 0)? x : -1.0; /* exp(+-inf)={inf,-1} */
+                            return (xsb == 0)? x : -1.0; // exp(+-inf)={inf,-1}
                         }
                     }
                     if (x > o_threshold) {
-                        return huge*huge; /* overflow */
+                        return huge*huge; // overflow
                     }
                 }
-                if (xsb != 0) { /* x < -56*ln2, return -1.0 with inexact */
-                    if (x + tiny < 0.0) {         /* raise inexact */
-                        return tiny - one;        /* return -1 */
+                if (xsb != 0) { // x < -56*ln2, return -1.0 with inexact
+                    if (x + tiny < 0.0) {         // raise inexact
+                        return tiny - one;        // return -1
                     }
                 }
             }
 
-            /* argument reduction */
-            if (hx > 0x3fd6_2e42) {           /* if  |x| > 0.5 ln2 */
-                if (hx < 0x3FF0_A2B2) {       /* and |x| < 1.5 ln2 */
+            // argument reduction
+            if (hx > 0x3fd6_2e42) {         // if  |x| > 0.5 ln2
+                if (hx < 0x3FF0_A2B2) {     // and |x| < 1.5 ln2
                     if (xsb == 0) {
                         hi = x - ln2_hi;
-                        lo =  ln2_lo;
-                        k =  1;}
-                    else {
+                        lo = ln2_lo;
+                        k =  1;
+                    } else {
                         hi = x + ln2_hi;
                         lo = -ln2_lo;
                         k = -1;
@@ -1141,26 +1141,26 @@ class FdLibm {
                 } else {
                     k  = (int)(invln2*x + ((xsb == 0) ? 0.5 : -0.5));
                     t  = k;
-                    hi = x - t*ln2_hi;      /* t*ln2_hi is exact here */
+                    hi = x - t*ln2_hi;      // t*ln2_hi is exact here
                     lo = t*ln2_lo;
                 }
                 x  = hi - lo;
                 c  = (hi - x) - lo;
-            } else if (hx < 0x3c90_0000) {      /* when |x|<2**-54, return x */
-                t = huge + x; /* return x with inexact flags when x != 0 */
+            } else if (hx < 0x3c90_0000) {  // when |x| < 2**-54, return x
+                t = huge + x; // return x with inexact flags when x != 0
                 return x - (t - (huge + x));
             } else {
                 k = 0;
             }
 
-            /* x is now in primary range */
+            // x is now in primary range
             hfx = 0.5*x;
             hxs = x*hfx;
             r1 = one + hxs*(Q1 + hxs*(Q2 + hxs*(Q3 + hxs*(Q4 + hxs*Q5))));
             t  = 3.0 - r1*hfx;
             e  = hxs *((r1 - t)/(6.0 - x*t));
             if (k == 0) {
-                return x - (x*e - hxs);          /* c is 0 */
+                return x - (x*e - hxs);          // c is 0
             } else {
                 e  = (x*(e - c) - c);
                 e -= hxs;
@@ -1168,27 +1168,27 @@ class FdLibm {
                     return 0.5*(x - e) - 0.5;
                 }
                 if (k == 1) {
-                    if(x < -0.25) {
+                    if (x < -0.25) {
                         return -2.0*(e - (x + 0.5));
                     } else {
-                        return  one + 2.0*(x - e);
+                        return one + 2.0*(x - e);
                     }
                 }
-                if (k <= -2 || k > 56) {   /* suffice to return exp(x) - 1 */
+                if (k <= -2 || k > 56) {   // suffice to return exp(x) - 1
                     y = one - (e - x);
-                    y = __HI(y, __HI(y) + (k << 20));     /* add k to y's exponent */
+                    y = __HI(y, __HI(y) + (k << 20));     // add k to y's exponent
                     return y - one;
                 }
                 t = one;
                 if (k < 20) {
-                    t = __HI(t, 0x3ff0_0000 - (0x2_00000 >> k));  /* t=1-2^-k */
+                    t = __HI(t, 0x3ff0_0000 - (0x2_00000 >> k));  // t = 1-2^-k
                     y = t - ( e - x);
-                    y = __HI(y, __HI(y) + (k << 20));     /* add k to y's exponent */
+                    y = __HI(y, __HI(y) + (k << 20));     // add k to y's exponent
                 } else {
-                    t = __HI(t, ((0x3ff - k) << 20));     /* 2^-k */
+                    t = __HI(t, ((0x3ff - k) << 20));     // 2^-k
                     y = x - (e + t);
                     y += one;
-                    y = __HI(y, __HI(y) + (k << 20));     /* add k to y's exponent */
+                    y = __HI(y, __HI(y) + (k << 20));     // add k to y's exponent
                 }
             }
             return y;

--- a/src/java.base/share/classes/java/lang/StrictMath.java
+++ b/src/java.base/share/classes/java/lang/StrictMath.java
@@ -2093,7 +2093,9 @@ public final class StrictMath {
      * @return  the value <i>e</i><sup>{@code x}</sup>&nbsp;-&nbsp;1.
      * @since 1.5
      */
-    public static native double expm1(double x);
+    public static double expm1(double x) {
+        return FdLibm.Expm1.compute(x);
+    }
 
     /**
      * Returns the natural logarithm of the sum of the argument and 1.

--- a/test/jdk/java/lang/StrictMath/Expm1Tests.java
+++ b/test/jdk/java/lang/StrictMath/Expm1Tests.java
@@ -77,41 +77,41 @@ public class Expm1Tests {
         failures += testRange(x, Math.ulp(x), 1000);
 
         // ... and just below subnormal threshold ...
-         x =  Math.nextDown(Double.MIN_NORMAL);
-         failures += testRange(x, -Math.ulp(x), 1000);
+        x = Math.nextDown(Double.MIN_NORMAL);
+        failures += testRange(x, -Math.ulp(x), 1000);
 
         // ... and near 1.0 ...
-         failures += testRangeMidpoint(1.0, Math.ulp(x), 2000);
-         // (Note: probes every-other value less than 1.0 due to
-         // change in the size of an ulp at 1.0.
+        failures += testRangeMidpoint(1.0, Math.ulp(x), 2000);
+        // (Note: probes every-other value less than 1.0 due to
+        // change in the size of an ulp at 1.0.
 
-         // Probe near decision points in the FDLIBM algorithm.
-         double LN2 = StrictMath.log(2.0);
-         double[] decisionPoints = {
-               7.09782712893383973096e+02, // overflow threshold
-               56.0 * LN2,
-              -56.0 * LN2,
-               0.5 * LN2,
-              -0.5 * LN2,
-               1.5 * LN2,
-              -1.5 * LN2,
-               0x1.0p-54,
-              -0x1.0p-54,
-         };
+        // Probe near decision points in the FDLIBM algorithm.
+        double LN2 = StrictMath.log(2.0);
+        double[] decisionPoints = {
+             7.09782712893383973096e+02, // overflow threshold
+             56.0 * LN2,
+            -56.0 * LN2,
+             0.5 * LN2,
+            -0.5 * LN2,
+             1.5 * LN2,
+            -1.5 * LN2,
+             0x1.0p-54,
+            -0x1.0p-54,
+        };
 
-         for (double testPoint : decisionPoints) {
-             failures += testRangeMidpoint(testPoint, Math.ulp(testPoint), 1000);
-         }
+        for (double testPoint : decisionPoints) {
+            failures += testRangeMidpoint(testPoint, Math.ulp(testPoint), 1000);
+        }
 
-         x = Tests.createRandomDouble(random);
+        x = Tests.createRandomDouble(random);
 
-         // Make the increment twice the ulp value in case the random
-         // value is near an exponent threshold. Don't worry about test
-         // elements overflowing to infinity if the starting value is
-         // near Double.MAX_VALUE.
-         failures += testRange(x, 2.0 * Math.ulp(x), 1000);
+        // Make the increment twice the ulp value in case the random
+        // value is near an exponent threshold. Don't worry about test
+        // elements overflowing to infinity if the starting value is
+        // near Double.MAX_VALUE.
+        failures += testRange(x, 2.0 * Math.ulp(x), 1000);
 
-         return failures;
+        return failures;
     }
 
     private static int testRange(double start, double increment, int count) {

--- a/test/jdk/java/lang/StrictMath/FdlibmTranslit.java
+++ b/test/jdk/java/lang/StrictMath/FdlibmTranslit.java
@@ -86,6 +86,10 @@ public class FdlibmTranslit {
         return Log1p.compute(x);
     }
 
+    public static double expm1(double x) {
+        return Expm1.compute(x);
+    }
+
     /**
      * cbrt(x)
      * Return cube root of x
@@ -609,6 +613,199 @@ public class FdlibmTranslit {
             R = z*(Lp1+z*(Lp2+z*(Lp3+z*(Lp4+z*(Lp5+z*(Lp6+z*Lp7))))));
             if(k==0) return f-(hfsq-s*(hfsq+R)); else
                 return k*ln2_hi-((hfsq-(s*(hfsq+R)+(k*ln2_lo+c)))-f);
+        }
+    }
+
+    /* expm1(x)
+     * Returns exp(x)-1, the exponential of x minus 1.
+     *
+     * Method
+     *   1. Argument reduction:
+     *      Given x, find r and integer k such that
+     *
+     *               x = k*ln2 + r,  |r| <= 0.5*ln2 ~ 0.34658
+     *
+     *      Here a correction term c will be computed to compensate
+     *      the error in r when rounded to a floating-point number.
+     *
+     *   2. Approximating expm1(r) by a special rational function on
+     *      the interval [0,0.34658]:
+     *      Since
+     *          r*(exp(r)+1)/(exp(r)-1) = 2+ r^2/6 - r^4/360 + ...
+     *      we define R1(r*r) by
+     *          r*(exp(r)+1)/(exp(r)-1) = 2+ r^2/6 * R1(r*r)
+     *      That is,
+     *          R1(r**2) = 6/r *((exp(r)+1)/(exp(r)-1) - 2/r)
+     *                   = 6/r * ( 1 + 2.0*(1/(exp(r)-1) - 1/r))
+     *                   = 1 - r^2/60 + r^4/2520 - r^6/100800 + ...
+     *      We use a special Reme algorithm on [0,0.347] to generate
+     *      a polynomial of degree 5 in r*r to approximate R1. The
+     *      maximum error of this polynomial approximation is bounded
+     *      by 2**-61. In other words,
+     *          R1(z) ~ 1.0 + Q1*z + Q2*z**2 + Q3*z**3 + Q4*z**4 + Q5*z**5
+     *      where   Q1  =  -1.6666666666666567384E-2,
+     *              Q2  =   3.9682539681370365873E-4,
+     *              Q3  =  -9.9206344733435987357E-6,
+     *              Q4  =   2.5051361420808517002E-7,
+     *              Q5  =  -6.2843505682382617102E-9;
+     *      (where z=r*r, and the values of Q1 to Q5 are listed below)
+     *      with error bounded by
+     *          |                  5           |     -61
+     *          | 1.0+Q1*z+...+Q5*z   -  R1(z) | <= 2
+     *          |                              |
+     *
+     *      expm1(r) = exp(r)-1 is then computed by the following
+     *      specific way which minimize the accumulation rounding error:
+     *                             2     3
+     *                            r     r    [ 3 - (R1 + R1*r/2)  ]
+     *            expm1(r) = r + --- + --- * [--------------------]
+     *                            2     2    [ 6 - r*(3 - R1*r/2) ]
+     *
+     *      To compensate the error in the argument reduction, we use
+     *              expm1(r+c) = expm1(r) + c + expm1(r)*c
+     *                         ~ expm1(r) + c + r*c
+     *      Thus c+r*c will be added in as the correction terms for
+     *      expm1(r+c). Now rearrange the term to avoid optimization
+     *      screw up:
+     *                      (      2                                    2 )
+     *                      ({  ( r    [ R1 -  (3 - R1*r/2) ]  )  }    r  )
+     *       expm1(r+c)~r - ({r*(--- * [--------------------]-c)-c} - --- )
+     *                      ({  ( 2    [ 6 - r*(3 - R1*r/2) ]  )  }    2  )
+     *                      (                                             )
+     *
+     *                 = r - E
+     *   3. Scale back to obtain expm1(x):
+     *      From step 1, we have
+     *         expm1(x) = either 2^k*[expm1(r)+1] - 1
+     *                  = or     2^k*[expm1(r) + (1-2^-k)]
+     *   4. Implementation notes:
+     *      (A). To save one multiplication, we scale the coefficient Qi
+     *           to Qi*2^i, and replace z by (x^2)/2.
+     *      (B). To achieve maximum accuracy, we compute expm1(x) by
+     *        (i)   if x < -56*ln2, return -1.0, (raise inexact if x!=inf)
+     *        (ii)  if k=0, return r-E
+     *        (iii) if k=-1, return 0.5*(r-E)-0.5
+     *        (iv)  if k=1 if r < -0.25, return 2*((r+0.5)- E)
+     *                     else          return  1.0+2.0*(r-E);
+     *        (v)   if (k<-2||k>56) return 2^k(1-(E-r)) - 1 (or exp(x)-1)
+     *        (vi)  if k <= 20, return 2^k((1-2^-k)-(E-r)), else
+     *        (vii) return 2^k(1-((E+2^-k)-r))
+     *
+     * Special cases:
+     *      expm1(INF) is INF, expm1(NaN) is NaN;
+     *      expm1(-INF) is -1, and
+     *      for finite argument, only expm1(0)=0 is exact.
+     *
+     * Accuracy:
+     *      according to an error analysis, the error is always less than
+     *      1 ulp (unit in the last place).
+     *
+     * Misc. info.
+     *      For IEEE double
+     *          if x >  7.09782712893383973096e+02 then expm1(x) overflow
+     *
+     * Constants:
+     * The hexadecimal values are the intended ones for the following
+     * constants. The decimal values may be used, provided that the
+     * compiler will convert from decimal to binary accurately enough
+     * to produce the hexadecimal values shown.
+     */
+    static class Expm1 {
+        private static final double one             = 1.0;
+        private static final double huge            = 1.0e+300;
+        private static final double tiny            = 1.0e-300;
+        private static final double o_threshold     = 7.09782712893383973096e+02; /* 0x40862E42, 0xFEFA39EF */
+        private static final double ln2_hi          = 6.93147180369123816490e-01; /* 0x3fe62e42, 0xfee00000 */
+        private static final double ln2_lo          = 1.90821492927058770002e-10; /* 0x3dea39ef, 0x35793c76 */
+        private static final double invln2          = 1.44269504088896338700e+00; /* 0x3ff71547, 0x652b82fe */
+        /* scaled coefficients related to expm1 */
+        private static final double Q1  =  -3.33333333333331316428e-02; /* BFA11111 111110F4 */
+        private static final double Q2  =   1.58730158725481460165e-03; /* 3F5A01A0 19FE5585 */
+        private static final double Q3  =  -7.93650757867487942473e-05; /* BF14CE19 9EAADBB7 */
+        private static final double Q4  =   4.00821782732936239552e-06; /* 3ED0CFCA 86E65239 */
+        private static final double Q5  =  -2.01099218183624371326e-07; /* BE8AFDB7 6E09C32D */
+
+        static double compute(double x) {
+            double y,hi,lo,c=0,t,e,hxs,hfx,r1;
+            int k,xsb;
+            /*unsigned*/ int hx;
+
+            hx  = __HI(x);  /* high word of x */
+            xsb = hx&0x80000000;            /* sign bit of x */
+            if(xsb==0) y=x; else y= -x;     /* y = |x| */
+            hx &= 0x7fffffff;               /* high word of |x| */
+
+            /* filter out huge and non-finite argument */
+            if(hx >= 0x4043687A) {                  /* if |x|>=56*ln2 */
+                if(hx >= 0x40862E42) {              /* if |x|>=709.78... */
+                    if(hx>=0x7ff00000) {
+                        if(((hx&0xfffff)|__LO(x))!=0)
+                            return x+x;     /* NaN */
+                        else return (xsb==0)? x:-1.0;/* exp(+-inf)={inf,-1} */
+                    }
+                    if(x > o_threshold) return huge*huge; /* overflow */
+                }
+                if(xsb!=0) { /* x < -56*ln2, return -1.0 with inexact */
+                    if(x+tiny<0.0)          /* raise inexact */
+                        return tiny-one;        /* return -1 */
+                }
+            }
+
+            /* argument reduction */
+            if(hx > 0x3fd62e42) {           /* if  |x| > 0.5 ln2 */
+                if(hx < 0x3FF0A2B2) {       /* and |x| < 1.5 ln2 */
+                    if(xsb==0)
+                        {hi = x - ln2_hi; lo =  ln2_lo;  k =  1;}
+                    else
+                        {hi = x + ln2_hi; lo = -ln2_lo;  k = -1;}
+                } else {
+                    k  = (int)(invln2*x+((xsb==0)?0.5:-0.5));
+                    t  = k;
+                    hi = x - t*ln2_hi;      /* t*ln2_hi is exact here */
+                    lo = t*ln2_lo;
+                }
+                x  = hi - lo;
+                c  = (hi-x)-lo;
+            }
+            else if(hx < 0x3c900000) {      /* when |x|<2**-54, return x */
+                t = huge+x; /* return x with inexact flags when x!=0 */
+                return x - (t-(huge+x));
+            }
+            else k = 0;
+
+            /* x is now in primary range */
+            hfx = 0.5*x;
+            hxs = x*hfx;
+            r1 = one+hxs*(Q1+hxs*(Q2+hxs*(Q3+hxs*(Q4+hxs*Q5))));
+            t  = 3.0-r1*hfx;
+            e  = hxs*((r1-t)/(6.0 - x*t));
+            if(k==0) return x - (x*e-hxs);          /* c is 0 */
+            else {
+                e  = (x*(e-c)-c);
+                e -= hxs;
+                if(k== -1) return 0.5*(x-e)-0.5;
+                if(k==1) {
+                    if(x < -0.25) return -2.0*(e-(x+0.5));
+                    else          return  one+2.0*(x-e);
+                }
+                if (k <= -2 || k>56) {   /* suffice to return exp(x)-1 */
+                    y = one-(e-x);
+                    y = __HI(y,  __HI(y) + (k<<20));     /* add k to y's exponent */
+                    return y-one;
+                }
+                t = one;
+                if(k<20) {
+                    t = __HI(t, 0x3ff00000 - (0x200000>>k));  /* t=1-2^-k */
+                    y = t-(e-x);
+                    y = __HI(y, __HI(y) + (k<<20));     /* add k to y's exponent */
+                } else {
+                    t = __HI(t, ((0x3ff-k)<<20));     /* 2^-k */
+                    y = x-(e+t);
+                    y += one;
+                    y = __HI(y, __HI(y) + (k<<20));     /* add k to y's exponent */
+                }
+            }
+            return y;
         }
     }
 }


### PR DESCRIPTION
Next on the FDLIBM C -> Java port, expm1.
Coming soon, hyperbolic transcendentals (sinh, cosh, tanh)!

For expm1, the C vs transliteration port show the usual kind of differences, beside formatting of the constants, the use of the __HI macro on the left-hand side needs to be replaced by a method call and an assignment, as seen below:

```
< 
< #include "fdlibm.h"
< 
< #ifdef __STDC__
< static const double
< #else
< static double
< #endif
< one             = 1.0,
< huge            = 1.0e+300,
< tiny            = 1.0e-300,
< o_threshold     = 7.09782712893383973096e+02,/* 0x40862E42, 0xFEFA39EF */
< ln2_hi          = 6.93147180369123816490e-01,/* 0x3fe62e42, 0xfee00000 */
< ln2_lo          = 1.90821492927058770002e-10,/* 0x3dea39ef, 0x35793c76 */
< invln2          = 1.44269504088896338700e+00,/* 0x3ff71547, 0x652b82fe */
---
>     static class Expm1 {
>         private static final double one             = 1.0;
>         private static final double huge            = 1.0e+300;
>         private static final double tiny            = 1.0e-300;
>         private static final double o_threshold     = 7.09782712893383973096e+02; /* 0x40862E42, 0xFEFA39EF */
>         private static final double ln2_hi          = 6.93147180369123816490e-01; /* 0x3fe62e42, 0xfee00000 */
>         private static final double ln2_lo          = 1.90821492927058770002e-10; /* 0x3dea39ef, 0x35793c76 */
>         private static final double invln2          = 1.44269504088896338700e+00; /* 0x3ff71547, 0x652b82fe */
111,115c104,108
< Q1  =  -3.33333333333331316428e-02, /* BFA11111 111110F4 */
< Q2  =   1.58730158725481460165e-03, /* 3F5A01A0 19FE5585 */
< Q3  =  -7.93650757867487942473e-05, /* BF14CE19 9EAADBB7 */
< Q4  =   4.00821782732936239552e-06, /* 3ED0CFCA 86E65239 */
< Q5  =  -2.01099218183624371326e-07; /* BE8AFDB7 6E09C32D */
---
>         private static final double Q1  =  -3.33333333333331316428e-02; /* BFA11111 111110F4 */
>         private static final double Q2  =   1.58730158725481460165e-03; /* 3F5A01A0 19FE5585 */
>         private static final double Q3  =  -7.93650757867487942473e-05; /* BF14CE19 9EAADBB7 */
>         private static final double Q4  =   4.00821782732936239552e-06; /* 3ED0CFCA 86E65239 */
>         private static final double Q5  =  -2.01099218183624371326e-07; /* BE8AFDB7 6E09C32D */
117,123c110
< #ifdef __STDC__
<         double expm1(double x)
< #else
<         double expm1(x)
<         double x;
< #endif
< {
---
>         static double compute(double x) {
126c113
<         unsigned hx;
---
>             /*unsigned*/ int hx;
157c144
<                 k  = invln2*x+((xsb==0)?0.5:-0.5);
---
>                     k  = (int)(invln2*x+((xsb==0)?0.5:-0.5));
188c175
<                 __HI(y) += (k<<20);     /* add k to y's exponent */
---
>                     y = __HI(y,  __HI(y) + (k<<20));     /* add k to y's exponent */
193c180
<                 __HI(t) = 0x3ff00000 - (0x200000>>k);  /* t=1-2^-k */
---
>                     t = __HI(t, 0x3ff00000 - (0x200000>>k));  /* t=1-2^-k */
195c182
<                 __HI(y) += (k<<20);     /* add k to y's exponent */
---
>                     y = __HI(y, __HI(y) + (k<<20));     /* add k to y's exponent */
197c184
<                 __HI(t)  = ((0x3ff-k)<<20);     /* 2^-k */
---
>                     t = __HI(t, ((0x3ff-k)<<20));     /* 2^-k */
200c187
<                 __HI(y) += (k<<20);     /* add k to y's exponent */
---
>                     y = __HI(y, __HI(y) + (k<<20));     /* add k to y's exponent */
205c192
< 
---
>     }
```

When comparing the transliteration port and the more idiomatic port, there were no surprising or notable differences:

```
$ diff -w Expm1.translit.java Expm1.fdlibm.java  
99,102c99,102
<         private static final double o_threshold     = 7.09782712893383973096e+02; /* 0x40862E42, 0xFEFA39EF */
<         private static final double ln2_hi          = 6.93147180369123816490e-01; /* 0x3fe62e42, 0xfee00000 */
<         private static final double ln2_lo          = 1.90821492927058770002e-10; /* 0x3dea39ef, 0x35793c76 */
<         private static final double invln2          = 1.44269504088896338700e+00; /* 0x3ff71547, 0x652b82fe */
---
>         private static final double o_threshold =  0x1.62e42fefa39efp9;   //  7.09782712893383973096e+02
>         private static final double ln2_hi      =  0x1.62e42feep-1;       //  6.93147180369123816490e-01
>         private static final double ln2_lo      =  0x1.a39ef35793c76p-33; //  1.90821492927058770002e-10
>         private static final double invln2      =  0x1.71547652b82fep0;   //  1.44269504088896338700e+00
104,108c104,108
<         private static final double Q1  =  -3.33333333333331316428e-02; /* BFA11111 111110F4 */
<         private static final double Q2  =   1.58730158725481460165e-03; /* 3F5A01A0 19FE5585 */
<         private static final double Q3  =  -7.93650757867487942473e-05; /* BF14CE19 9EAADBB7 */
<         private static final double Q4  =   4.00821782732936239552e-06; /* 3ED0CFCA 86E65239 */
<         private static final double Q5  =  -2.01099218183624371326e-07; /* BE8AFDB7 6E09C32D */
---
>         private static final double Q1          = -0x1.11111111110f4p-5;  // -3.33333333333331316428e-02
>         private static final double Q2          =  0x1.a01a019fe5585p-10; //  1.58730158725481460165e-03
>         private static final double Q3          = -0x1.4ce199eaadbb7p-14; // -7.93650757867487942473e-05
>         private static final double Q4          =  0x1.0cfca86e65239p-18; //  4.00821782732936239552e-06
>         private static final double Q5          = -0x1.afdb76e09c32dp-23; // -2.01099218183624371326e-07
116,118c116,118
<             xsb = hx&0x80000000;            /* sign bit of x */
<             if(xsb==0) y=x; else y= -x;     /* y = |x| */
<             hx &= 0x7fffffff;               /* high word of |x| */
---
>             xsb = hx & 0x8000_0000;            /* sign bit of x */
>             y = Math.abs(x);
>             hx &= 0x7fff_ffff;               /* high word of |x| */
121,124c121,124
<             if(hx >= 0x4043687A) {                  /* if |x|>=56*ln2 */
<                 if(hx >= 0x40862E42) {              /* if |x|>=709.78... */
<                     if(hx>=0x7ff00000) {
<                         if(((hx&0xfffff)|__LO(x))!=0)
---
>             if (hx >= 0x4043_687A) {                  /* if |x| >= 56*ln2 */
>                 if (hx >= 0x4086_2E42) {              /* if |x| >= 709.78... */
>                     if (hx >= 0x7ff_00000) {
>                         if (((hx & 0xf_ffff) | __LO(x)) != 0) {
126c126,131
<                         else return (xsb==0)? x:-1.0;/* exp(+-inf)={inf,-1} */
---
>                         } else {
>                             return (xsb == 0)? x : -1.0; /* exp(+-inf)={inf,-1} */
>                         }
>                     }
>                     if (x > o_threshold) {
>                         return huge*huge; /* overflow */
128d132
<                     if(x > o_threshold) return huge*huge; /* overflow */
131c135
<                     if(x+tiny<0.0)          /* raise inexact */
---
>                     if (x + tiny < 0.0) {         /* raise inexact */
134a139
>             }
137,142c142,152
<             if(hx > 0x3fd62e42) {           /* if  |x| > 0.5 ln2 */
<                 if(hx < 0x3FF0A2B2) {       /* and |x| < 1.5 ln2 */
<                     if(xsb==0)
<                         {hi = x - ln2_hi; lo =  ln2_lo;  k =  1;}
<                     else
<                         {hi = x + ln2_hi; lo = -ln2_lo;  k = -1;}
---
>             if (hx > 0x3fd6_2e42) {           /* if  |x| > 0.5 ln2 */
>                 if (hx < 0x3FF0_A2B2) {       /* and |x| < 1.5 ln2 */
>                     if (xsb == 0) {
>                         hi = x - ln2_hi;
>                         lo =  ln2_lo;
>                         k =  1;}
>                     else {
>                         hi = x + ln2_hi;
>                         lo = -ln2_lo;
>                         k = -1;
>                     }
151,152c161
<             }
<             else if(hx < 0x3c900000) {      /* when |x|<2**-54, return x */
---
>             } else if (hx < 0x3c90_0000) {      /* when |x|<2**-54, return x */
154a164,165
>             } else {
>                 k = 0;
156d166
<             else k = 0;
164,165c174,176
<             if(k==0) return x - (x*e-hxs);          /* c is 0 */
<             else {
---
>             if (k == 0) {
>                 return x - (x*e - hxs);          /* c is 0 */
>             } else {
168c179,181
<                 if(k== -1) return 0.5*(x-e)-0.5;
---
>                 if (k == -1) {
>                     return 0.5*(x - e) - 0.5;
>                 }
170,171c183,187
<                     if(x < -0.25) return -2.0*(e-(x+0.5));
<                     else          return  one+2.0*(x-e);
---
>                     if(x < -0.25) {
>                         return -2.0*(e - (x + 0.5));
>                     } else {
>                         return  one + 2.0*(x - e);
>                     }
180c196
<                     t = __HI(t, 0x3ff00000 - (0x200000>>k));  /* t=1-2^-k */
---
>                     t = __HI(t, 0x3ff0_0000 - (0x2_00000 >> k));  /* t=1-2^-k */
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301396](https://bugs.openjdk.org/browse/JDK-8301396): Port fdlibm expm1 to Java


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12394/head:pull/12394` \
`$ git checkout pull/12394`

Update a local copy of the PR: \
`$ git checkout pull/12394` \
`$ git pull https://git.openjdk.org/jdk pull/12394/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12394`

View PR using the GUI difftool: \
`$ git pr show -t 12394`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12394.diff">https://git.openjdk.org/jdk/pull/12394.diff</a>

</details>
