### PR TITLE
8301717: Remove obsolete jib profiles

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -813,24 +813,6 @@ var getJibProfilesProfiles = function (input, common, data) {
         }
     });
 
-    // Define the reference implementation profiles. These are basically the same
-    // as the open profiles, but upload artifacts to a different location.
-    common.main_profile_names.forEach(function (name) {
-        var riName = name + "-ri";
-        var riDebugName = riName + common.debug_suffix;
-        var openName = name + common.open_suffix;
-        var openDebugName = openName + common.debug_suffix;
-        profiles[riName] = clone(profiles[openName]);
-        profiles[riDebugName] = clone(profiles[openDebugName]);
-        // Rewrite all remote dirs to "bundles/openjdk/BCL/..."
-        for (artifactName in profiles[riName].artifacts) {
-            var artifact = profiles[riName].artifacts[artifactName];
-            artifact.remote = replaceAll(
-                "\/GPL\/", "/BCL/",
-                (artifact.remote != null ? artifact.remote : artifact.local));
-        }
-    });
-
     // For open profiles, the non-debug jdk bundles, need an "open" prefix on the
     // remote bundle names, forming the word "openjdk". See JDK-8188789.
     common.main_profile_names.forEach(function (name) {


### PR DESCRIPTION
This patch removes some now obsolete jib profiles configurations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301717](https://bugs.openjdk.org/browse/JDK-8301717): Remove obsolete jib profiles


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12395/head:pull/12395` \
`$ git checkout pull/12395`

Update a local copy of the PR: \
`$ git checkout pull/12395` \
`$ git pull https://git.openjdk.org/jdk pull/12395/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12395`

View PR using the GUI difftool: \
`$ git pr show -t 12395`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12395.diff">https://git.openjdk.org/jdk/pull/12395.diff</a>

</details>
