### PR TITLE
8301736: jdk/incubator/concurrent/StructuredTaskScope/StructuredTaskScopeTest.java fail with -Xcomp

### DIFF
--- a/test/jdk/jdk/incubator/concurrent/StructuredTaskScope/StructuredTaskScopeTest.java
+++ b/test/jdk/jdk/incubator/concurrent/StructuredTaskScope/StructuredTaskScopeTest.java
@@ -614,7 +614,7 @@ public class StructuredTaskScopeTest {
     public void testInterruptJoinUntil1(ThreadFactory factory) throws Exception {
         try (var scope = new StructuredTaskScope(null, factory)) {
             Future<String> future = scope.fork(() -> {
-                Thread.sleep(Duration.ofMillis(1000));
+                Thread.sleep(Duration.ofSeconds(2));
                 return "foo";
             });
 

--- a/test/jdk/jdk/incubator/concurrent/StructuredTaskScope/StructuredTaskScopeTest.java
+++ b/test/jdk/jdk/incubator/concurrent/StructuredTaskScope/StructuredTaskScopeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -614,7 +614,7 @@ public class StructuredTaskScopeTest {
     public void testInterruptJoinUntil1(ThreadFactory factory) throws Exception {
         try (var scope = new StructuredTaskScope(null, factory)) {
             Future<String> future = scope.fork(() -> {
-                Thread.sleep(Duration.ofMillis(100));
+                Thread.sleep(Duration.ofMillis(1000));
                 return "foo";
             });
 


### PR DESCRIPTION
Hi all,
When `-Xcomp` be used, java thread to block for longer, then causing StructuredTaskScopeTest.java failed frequently on the AArch64 and LoongArch64 architecture.

This PR fix the issue, Please help review it.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301736](https://bugs.openjdk.org/browse/JDK-8301736): jdk/incubator/concurrent/StructuredTaskScope/StructuredTaskScopeTest.java fail with -Xcomp


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12398/head:pull/12398` \
`$ git checkout pull/12398`

Update a local copy of the PR: \
`$ git checkout pull/12398` \
`$ git pull https://git.openjdk.org/jdk pull/12398/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12398`

View PR using the GUI difftool: \
`$ git pr show -t 12398`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12398.diff">https://git.openjdk.org/jdk/pull/12398.diff</a>

</details>
