### PR TITLE
8301737: java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java fail with -Xcomp

### DIFF
--- a/test/jdk/java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java
+++ b/test/jdk/java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java
@@ -38,7 +38,7 @@ import org.testng.annotations.Test;
 
 /*
  * @test
- * @run testng/othervm -Dsun.net.httpserver.idleInterval=50000 FilterUROTest
+ * @run testng/othervm -XX:ReservedCodeCacheSize=512m FilterUROTest
  * @summary Check that objects are exported with ObjectInputFilters via UnicastRemoteObject
  */
 public class FilterUROTest {

--- a/test/jdk/java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java
+++ b/test/jdk/java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java
@@ -38,6 +38,14 @@ import org.testng.annotations.Test;
 
 /*
  * @test
+ * @bug 8301737
+ * @requires os.arch != "loongarch64"
+ * @run testng/othervm FilterUROTest
+ * @summary Check that objects are exported with ObjectInputFilters via UnicastRemoteObject
+ */
+/*
+ * @test
+ * @requires os.arch == "loongarch64"
  * @run testng/othervm -XX:ReservedCodeCacheSize=512m FilterUROTest
  * @summary Check that objects are exported with ObjectInputFilters via UnicastRemoteObject
  */

--- a/test/jdk/java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java
+++ b/test/jdk/java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java
@@ -38,19 +38,12 @@ import org.testng.annotations.Test;
 
 /*
  * @test
- * @bug 8301737
- * @requires os.arch != "loongarch64"
  * @run testng/othervm FilterUROTest
- * @summary Check that objects are exported with ObjectInputFilters via UnicastRemoteObject
- */
-/*
- * @test
- * @requires os.arch == "loongarch64"
- * @run testng/othervm -XX:ReservedCodeCacheSize=512m FilterUROTest
  * @summary Check that objects are exported with ObjectInputFilters via UnicastRemoteObject
  */
 public class FilterUROTest {
 
+    private static RemoteImpl impl;
     /**
      * Data to test serialFilter call counts.
      * - name
@@ -78,7 +71,7 @@ public class FilterUROTest {
     @Test(dataProvider = "bindData")
     public void useExportObject(String name, Object obj, int expectedFilterCount) throws RemoteException {
         try {
-            RemoteImpl impl = RemoteImpl.create();
+            impl = RemoteImpl.create();
             Echo client = (Echo) UnicastRemoteObject
                     .exportObject(impl, 0, impl.checker);
             int count = client.filterCount(obj);
@@ -105,7 +98,7 @@ public class FilterUROTest {
     @Test(dataProvider = "bindData")
     public void useExportObject2(String name, Object obj, int expectedFilterCount) throws RemoteException {
         try {
-            RemoteImpl impl = RemoteImpl.create();
+            impl = RemoteImpl.create();
             Echo client = (Echo) UnicastRemoteObject
                     .exportObject(impl, 0, null, null, impl.checker);
             int count = client.filterCount(obj);

--- a/test/jdk/java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java
+++ b/test/jdk/java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java
@@ -31,6 +31,7 @@ import java.rmi.UnmarshalException;
 import java.rmi.server.UnicastRemoteObject;
 
 import java.util.Objects;
+import java.lang.ref.Reference;
 
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -43,7 +44,6 @@ import org.testng.annotations.Test;
  */
 public class FilterUROTest {
 
-    private static RemoteImpl impl;
     /**
      * Data to test serialFilter call counts.
      * - name
@@ -71,12 +71,13 @@ public class FilterUROTest {
     @Test(dataProvider = "bindData")
     public void useExportObject(String name, Object obj, int expectedFilterCount) throws RemoteException {
         try {
-            impl = RemoteImpl.create();
+            RemoteImpl impl = RemoteImpl.create();
             Echo client = (Echo) UnicastRemoteObject
                     .exportObject(impl, 0, impl.checker);
             int count = client.filterCount(obj);
             System.out.printf("count: %d, obj: %s%n", count, obj);
             Assert.assertEquals(count, expectedFilterCount, "wrong number of filter calls");
+	    Reference.reachabilityFence(impl);
         } catch (RemoteException rex) {
             if (expectedFilterCount == -1 &&
                     UnmarshalException.class.equals(rex.getCause().getClass()) &&
@@ -98,12 +99,13 @@ public class FilterUROTest {
     @Test(dataProvider = "bindData")
     public void useExportObject2(String name, Object obj, int expectedFilterCount) throws RemoteException {
         try {
-            impl = RemoteImpl.create();
+            RemoteImpl impl = RemoteImpl.create();
             Echo client = (Echo) UnicastRemoteObject
                     .exportObject(impl, 0, null, null, impl.checker);
             int count = client.filterCount(obj);
             System.out.printf("count: %d, obj: %s%n", count, obj);
             Assert.assertEquals(count, expectedFilterCount, "wrong number of filter calls");
+	    Reference.reachabilityFence(impl);
         } catch (RemoteException rex) {
             if (expectedFilterCount == -1 &&
                     UnmarshalException.class.equals(rex.getCause().getClass()) &&

--- a/test/jdk/java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java
+++ b/test/jdk/java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java
@@ -38,7 +38,7 @@ import org.testng.annotations.Test;
 
 /*
  * @test
- * @run testng/othervm FilterUROTest
+ * @run testng/othervm -Dsun.net.httpserver.idleInterval=50000 FilterUROTest
  * @summary Check that objects are exported with ObjectInputFilters via UnicastRemoteObject
  */
 public class FilterUROTest {

--- a/test/jdk/java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java
+++ b/test/jdk/java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java
@@ -77,7 +77,7 @@ public class FilterUROTest {
             int count = client.filterCount(obj);
             System.out.printf("count: %d, obj: %s%n", count, obj);
             Assert.assertEquals(count, expectedFilterCount, "wrong number of filter calls");
-	    Reference.reachabilityFence(impl);
+            Reference.reachabilityFence(impl);
         } catch (RemoteException rex) {
             if (expectedFilterCount == -1 &&
                     UnmarshalException.class.equals(rex.getCause().getClass()) &&
@@ -105,7 +105,7 @@ public class FilterUROTest {
             int count = client.filterCount(obj);
             System.out.printf("count: %d, obj: %s%n", count, obj);
             Assert.assertEquals(count, expectedFilterCount, "wrong number of filter calls");
-	    Reference.reachabilityFence(impl);
+            Reference.reachabilityFence(impl);
         } catch (RemoteException rex) {
             if (expectedFilterCount == -1 &&
                     UnmarshalException.class.equals(rex.getCause().getClass()) &&


### PR DESCRIPTION
Hi all,
When -Xcomp be used, this testcase will use more codecaches, causing the GC to be triggered early, then causing this test failed on LoongArch64 architecture.

This PR fix the issue, Please help review it.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301737](https://bugs.openjdk.org/browse/JDK-8301737): java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java fail with -Xcomp


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12399/head:pull/12399` \
`$ git checkout pull/12399`

Update a local copy of the PR: \
`$ git checkout pull/12399` \
`$ git pull https://git.openjdk.org/jdk pull/12399/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12399`

View PR using the GUI difftool: \
`$ git pr show -t 12399`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12399.diff">https://git.openjdk.org/jdk/pull/12399.diff</a>

</details>
