### PR TITLE
8301740: RISC-V: Address::uses() should check address mode

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -267,7 +267,7 @@ class Address {
   }
 
   bool uses(Register reg) const {
-    return base() == reg;
+    return _mode != literal && base() == reg;
   }
 
   const address target() const {


### PR DESCRIPTION
Follow up [JDK-8299733](https://bugs.openjdk.org/browse/JDK-8299733). Although RISC-V does not trigger the same issue at the moment, we should better deal with this as well.

We have only three addressing mode in RISC-V and I think switch statement is not needed. If we get another literal type, we can update here together with many places that would need to be updated at the same time. I think it's enough to just test for non-literal so far.

## Testing:

- all tier1 on unmatched board without new failures

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301740](https://bugs.openjdk.org/browse/JDK-8301740): RISC-V: Address::uses() should check address mode


### Reviewers
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12401/head:pull/12401` \
`$ git checkout pull/12401`

Update a local copy of the PR: \
`$ git checkout pull/12401` \
`$ git pull https://git.openjdk.org/jdk pull/12401/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12401`

View PR using the GUI difftool: \
`$ git pr show -t 12401`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12401.diff">https://git.openjdk.org/jdk/pull/12401.diff</a>

</details>
