### PR TITLE
8301743: RISC-V: Add InlineSkippedInstructionsCounter to post-call nops

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -209,6 +209,7 @@ void MacroAssembler::post_call_nop() {
     return;
   }
   relocate(post_call_nop_Relocation::spec(), [&] {
+    InlineSkippedInstructionsCounter skipCounter(this);
     nop();
     li32(zr, 0);
   });


### PR DESCRIPTION
RISC-V part of [JDK-8300002](https://bugs.openjdk.org/browse/JDK-8300002), one line only.

(Did not observe performance impact on JMH mentioned in JDK-8300002.)

Tested hotspot tier1 (fastdebug).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301743](https://bugs.openjdk.org/browse/JDK-8301743): RISC-V: Add InlineSkippedInstructionsCounter to post-call nops


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12402/head:pull/12402` \
`$ git checkout pull/12402`

Update a local copy of the PR: \
`$ git checkout pull/12402` \
`$ git pull https://git.openjdk.org/jdk pull/12402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12402`

View PR using the GUI difftool: \
`$ git pr show -t 12402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12402.diff">https://git.openjdk.org/jdk/pull/12402.diff</a>

</details>
