### PR TITLE
8301768: G1: Remove unimplemented HeapRegionRemSet::split_card

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegionRemSet.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.hpp
@@ -55,9 +55,6 @@ class HeapRegionRemSet : public CHeapObj<mtGC> {
   // Cached value of heap base address.
   static HeapWord* _heap_base_address;
 
-  // Split the given address into region of that card and the card within that
-  // region.
-  inline void split_card(OopOrNarrowOopStar from, uint& card_region, uint& card_within_region) const;
   void clear_fcc();
 
 public:


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301768](https://bugs.openjdk.org/browse/JDK-8301768): G1: Remove unimplemented HeapRegionRemSet::split_card


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12408/head:pull/12408` \
`$ git checkout pull/12408`

Update a local copy of the PR: \
`$ git checkout pull/12408` \
`$ git pull https://git.openjdk.org/jdk pull/12408/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12408`

View PR using the GUI difftool: \
`$ git pr show -t 12408`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12408.diff">https://git.openjdk.org/jdk/pull/12408.diff</a>

</details>
