### PR TITLE
8301787: java/net/httpclient/SpecialHeadersTest failing after JDK-8301306

### DIFF
--- a/test/jdk/java/net/httpclient/SpecialHeadersTest.java
+++ b/test/jdk/java/net/httpclient/SpecialHeadersTest.java
@@ -30,7 +30,6 @@
  * @build jdk.httpclient.test.lib.common.HttpServerAdapters
  *        jdk.httpclient.test.lib.http2.Http2TestServer
  *        jdk.test.lib.net.SimpleSSLContext
- * @requests (vm.compMode != "Xcomp")
  * @run testng/othervm
  *       -Djdk.httpclient.HttpClient.log=requests,headers,errors
  *       SpecialHeadersTest

--- a/test/jdk/java/net/httpclient/SpecialHeadersTest.java
+++ b/test/jdk/java/net/httpclient/SpecialHeadersTest.java
@@ -30,6 +30,7 @@
  * @build jdk.httpclient.test.lib.common.HttpServerAdapters
  *        jdk.httpclient.test.lib.http2.Http2TestServer
  *        jdk.test.lib.net.SimpleSSLContext
+ * @requires vm.compMode != "Xcomp"
  * @run testng/othervm
  *       -Djdk.httpclient.HttpClient.log=requests,headers,errors
  *       SpecialHeadersTest

--- a/test/jdk/java/net/httpclient/SpecialHeadersTest.java
+++ b/test/jdk/java/net/httpclient/SpecialHeadersTest.java
@@ -30,7 +30,7 @@
  * @build jdk.httpclient.test.lib.common.HttpServerAdapters
  *        jdk.httpclient.test.lib.http2.Http2TestServer
  *        jdk.test.lib.net.SimpleSSLContext
- * @requires vm.compMode != "Xcomp"
+ * @requires (vm.compMode != "Xcomp")
  * @run testng/othervm
  *       -Djdk.httpclient.HttpClient.log=requests,headers,errors
  *       SpecialHeadersTest


### PR DESCRIPTION
Please find here a changeset that reverts a recent change made to java/net/httpclient/SpecialHeadersTest.java. That change is causing the test to fail in the CI with:

```
test result: Error. Parse Exception: Invalid tag: requests
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301787](https://bugs.openjdk.org/browse/JDK-8301787): java/net/httpclient/SpecialHeadersTest failing after JDK-8301306


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to [52eb9055](https://git.openjdk.org/jdk/pull/12409/files/52eb90556432469ed535c675d04e08dbd6f5b581)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12409/head:pull/12409` \
`$ git checkout pull/12409`

Update a local copy of the PR: \
`$ git checkout pull/12409` \
`$ git pull https://git.openjdk.org/jdk pull/12409/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12409`

View PR using the GUI difftool: \
`$ git pr show -t 12409`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12409.diff">https://git.openjdk.org/jdk/pull/12409.diff</a>

</details>
