### PR TITLE
8301788: AlgorithmId should keep lowercase characters from 3rd party providers

### DIFF
--- a/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
+++ b/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -597,16 +597,16 @@ public class AlgorithmId implements Serializable, DerEncoder {
                     String ostr = alias.substring(index);
                     String stdAlgName = provider.getProperty(alias);
                     if (stdAlgName != null) {
-                        stdAlgName = stdAlgName.toUpperCase(Locale.ENGLISH);
-                    }
-                    // add the name->oid and oid->name mappings if none exists
-                    if (KnownOIDs.findMatch(stdAlgName) == null) {
-                        // not override earlier entries if it exists
-                        t.putIfAbsent(stdAlgName, ostr);
-                    }
-                    if (KnownOIDs.findMatch(ostr) == null) {
-                        // not override earlier entries if it exists
-                        t.putIfAbsent(ostr, stdAlgName);
+                        String upperStdAlgName = stdAlgName.toUpperCase(Locale.ENGLISH);
+                        // add the name->oid and oid->name mappings if none exists
+                        if (KnownOIDs.findMatch(upperStdAlgName) == null) {
+                            // not override earlier entries if it exists
+                            t.putIfAbsent(upperStdAlgName, ostr);
+                        }
+                        if (KnownOIDs.findMatch(ostr) == null) {
+                            // not override earlier entries if it exists
+                            t.putIfAbsent(ostr, stdAlgName);
+                        }
                     }
                 }
             }

--- a/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
+++ b/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
@@ -600,11 +600,11 @@ public class AlgorithmId implements Serializable, DerEncoder {
                         String upperStdAlgName = stdAlgName.toUpperCase(Locale.ENGLISH);
                         // add the name->oid and oid->name mappings if none exists
                         if (KnownOIDs.findMatch(upperStdAlgName) == null) {
-                            // not override earlier entries if it exists
+                            // do not override earlier entries if it exists
                             t.putIfAbsent(upperStdAlgName, ostr);
                         }
                         if (KnownOIDs.findMatch(ostr) == null) {
-                            // not override earlier entries if it exists
+                            // do not override earlier entries if it exists
                             t.putIfAbsent(ostr, stdAlgName);
                         }
                     }

--- a/test/jdk/sun/security/x509/AlgorithmId/Uppercase.java
+++ b/test/jdk/sun/security/x509/AlgorithmId/Uppercase.java
@@ -32,7 +32,6 @@
 import jdk.test.lib.Asserts;
 import sun.security.x509.AlgorithmId;
 
-import java.security.MessageDigestSpi;
 import java.security.Provider;
 import java.security.Security;
 import java.util.Locale;

--- a/test/jdk/sun/security/x509/AlgorithmId/Uppercase.java
+++ b/test/jdk/sun/security/x509/AlgorithmId/Uppercase.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8301788
+ * @library /test/lib
+ * @summary AlgorithmId should keep lowercase characters from 3rd party providers
+ * @modules java.base/sun.security.x509
+ *          java.base/sun.security.util
+ */
+import jdk.test.lib.Asserts;
+import sun.security.x509.AlgorithmId;
+
+import java.security.MessageDigestSpi;
+import java.security.Provider;
+import java.security.Security;
+import java.util.Locale;
+
+public class Uppercase {
+
+    private static final String OID = "2.3.4.5.8301788";
+    private static final String ALG = "Oolala";
+
+    public static void main(String[] args) throws Exception {
+        Security.addProvider(new ProviderImpl());
+        Asserts.assertEQ(AlgorithmId.get(ALG).getOID().toString(), OID);
+        Asserts.assertEQ(AlgorithmId.get(ALG.toUpperCase(Locale.ROOT)).getOID().toString(), OID);
+        Asserts.assertEQ(AlgorithmId.get(OID).getName(), ALG);
+    }
+
+    public static class ProviderImpl extends Provider {
+        public ProviderImpl() {
+            super("ProviderImpl", "1.0", "ProviderImpl");
+            put("MessageDigest." + ALG, "Uppercase$MessageDigestImpl");
+            put("Alg.Alias.MessageDigest.OID." + OID, ALG);
+        }
+    }
+    public static class MessageDigestImpl extends MessageDigestSpi {
+        @Override
+        protected void engineUpdate(byte input) {
+
+        }
+
+        @Override
+        protected void engineUpdate(byte[] input, int offset, int len) {
+
+        }
+
+        @Override
+        protected byte[] engineDigest() {
+            return new byte[0];
+        }
+
+        @Override
+        protected void engineReset() {
+
+        }
+    }
+}

--- a/test/jdk/sun/security/x509/AlgorithmId/Uppercase.java
+++ b/test/jdk/sun/security/x509/AlgorithmId/Uppercase.java
@@ -52,7 +52,7 @@ public class Uppercase {
     public static class ProviderImpl extends Provider {
         public ProviderImpl() {
             super("ProviderImpl", "1.0", "ProviderImpl");
-            // It does not matter if we really provider an implementation
+            // It does not matter if we really provide an implementation
             put("MessageDigest." + ALG, "Uppercase$MessageDigestImpl");
             put("Alg.Alias.MessageDigest.OID." + OID, ALG);
         }

--- a/test/jdk/sun/security/x509/AlgorithmId/Uppercase.java
+++ b/test/jdk/sun/security/x509/AlgorithmId/Uppercase.java
@@ -52,29 +52,9 @@ public class Uppercase {
     public static class ProviderImpl extends Provider {
         public ProviderImpl() {
             super("ProviderImpl", "1.0", "ProviderImpl");
+            // It does not matter if we really provider an implementation
             put("MessageDigest." + ALG, "Uppercase$MessageDigestImpl");
             put("Alg.Alias.MessageDigest.OID." + OID, ALG);
-        }
-    }
-    public static class MessageDigestImpl extends MessageDigestSpi {
-        @Override
-        protected void engineUpdate(byte input) {
-
-        }
-
-        @Override
-        protected void engineUpdate(byte[] input, int offset, int len) {
-
-        }
-
-        @Override
-        protected byte[] engineDigest() {
-            return new byte[0];
-        }
-
-        @Override
-        protected void engineReset() {
-
         }
     }
 }


### PR DESCRIPTION
Keep the "NAME -> 1.2.3.4" mapping unchanged but modify "1.2.3.4 -> NAME" to "1.2.3.4 -> Name".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301788](https://bugs.openjdk.org/browse/JDK-8301788): AlgorithmId should keep lowercase characters from 3rd party providers


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12410/head:pull/12410` \
`$ git checkout pull/12410`

Update a local copy of the PR: \
`$ git checkout pull/12410` \
`$ git pull https://git.openjdk.org/jdk pull/12410/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12410`

View PR using the GUI difftool: \
`$ git pr show -t 12410`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12410.diff">https://git.openjdk.org/jdk/pull/12410.diff</a>

</details>
