### PR TITLE
8221580: Confusing diagnostic for assigning a static final field in a constructor

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -30,6 +30,7 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import javax.lang.model.element.Modifier;
 
@@ -390,6 +391,15 @@ public class Flags {
      */
     public static final long NON_SEALED = 1L<<63; // ClassSymbols
 
+    /**
+     * Describe modifier flags as they migh appear in source code, i.e.,
+     * separated by spaces and in the order suggested by JLS 8.1.1.
+     */
+    public static String toSource(long flags) {
+        return asModifierSet(flags).stream()
+          .map(Modifier::toString)
+          .collect(Collectors.joining(" "));
+    }
 
     /** Modifier masks.
      */

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -303,7 +303,7 @@ public class Attr extends JCTree.Visitor {
             if (v.isResourceVariable()) { //TWR resource
                 log.error(pos, Errors.TryResourceMayNotBeAssigned(v));
             } else {
-                log.error(pos, Errors.CantAssignValToVar(Flags.toSource(FINAL), v));
+                log.error(pos, Errors.CantAssignValToVar(Flags.toSource(v.flags() & (STATIC | FINAL)), v));
             }
         }
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -303,7 +303,7 @@ public class Attr extends JCTree.Visitor {
             if (v.isResourceVariable()) { //TWR resource
                 log.error(pos, Errors.TryResourceMayNotBeAssigned(v));
             } else {
-                log.error(pos, Errors.CantAssignValToFinalVar(v));
+                log.error(pos, Errors.CantAssignValToVar(Flags.toSource(FINAL), v));
             }
         }
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -333,9 +333,9 @@ compiler.misc.invalid.mref=\
 compiler.misc.static.mref.with.targs=\
     parameterized qualifier on static method reference
 
-# 0: symbol
-compiler.err.cant.assign.val.to.final.var=\
-    cannot assign a value to final variable {0}
+# 0: set of flag or string, 1: symbol
+compiler.err.cant.assign.val.to.var=\
+    cannot assign a value to {0} variable {1}
 
 compiler.err.cant.assign.val.to.this=\
     cannot assign to ''this''

--- a/test/langtools/jdk/jshell/ModifiersTest.java
+++ b/test/langtools/jdk/jshell/ModifiersTest.java
@@ -128,9 +128,9 @@ public class ModifiersTest extends KullaTesting {
         assertEval("A.y;", "18");
 
         assertDeclareFail("A.x = 18;",
-                new ExpectedDiagnostic("compiler.err.cant.assign.val.to.final.var", 0, 3, 1, -1, -1, Diagnostic.Kind.ERROR));
+                new ExpectedDiagnostic("compiler.err.cant.assign.val.to.var", 0, 3, 1, -1, -1, Diagnostic.Kind.ERROR));
         assertDeclareFail("A.y = 88;",
-                new ExpectedDiagnostic("compiler.err.cant.assign.val.to.final.var", 0, 3, 1, -1, -1, Diagnostic.Kind.ERROR));
+                new ExpectedDiagnostic("compiler.err.cant.assign.val.to.var", 0, 3, 1, -1, -1, Diagnostic.Kind.ERROR));
         assertActiveKeys();
     }
 

--- a/test/langtools/tools/javac/InnerNamedConstant_2_A.out
+++ b/test/langtools/tools/javac/InnerNamedConstant_2_A.out
@@ -1,5 +1,5 @@
 InnerNamedConstant_2.java:23:20: compiler.err.icls.cant.have.static.decl: InnerNamedConstant_2.Inner2
 InnerNamedConstant_2.java:24:29: compiler.err.icls.cant.have.static.decl: InnerNamedConstant_2.Inner2
-InnerNamedConstant_2.java:26:13: compiler.err.cant.assign.val.to.final.var: z
+InnerNamedConstant_2.java:26:13: compiler.err.cant.assign.val.to.var: final, z
 InnerNamedConstant_2.java:35:26: compiler.err.icls.cant.have.static.decl: InnerNamedConstant_2.Inner3
 4 errors

--- a/test/langtools/tools/javac/InnerNamedConstant_2_A.out
+++ b/test/langtools/tools/javac/InnerNamedConstant_2_A.out
@@ -1,5 +1,5 @@
 InnerNamedConstant_2.java:23:20: compiler.err.icls.cant.have.static.decl: InnerNamedConstant_2.Inner2
 InnerNamedConstant_2.java:24:29: compiler.err.icls.cant.have.static.decl: InnerNamedConstant_2.Inner2
-InnerNamedConstant_2.java:26:13: compiler.err.cant.assign.val.to.var: final, z
+InnerNamedConstant_2.java:26:13: compiler.err.cant.assign.val.to.var: static final, z
 InnerNamedConstant_2.java:35:26: compiler.err.icls.cant.have.static.decl: InnerNamedConstant_2.Inner3
 4 errors

--- a/test/langtools/tools/javac/InnerNamedConstant_2_B.out
+++ b/test/langtools/tools/javac/InnerNamedConstant_2_B.out
@@ -1,2 +1,2 @@
-InnerNamedConstant_2.java:26:13: compiler.err.cant.assign.val.to.var: final, z
+InnerNamedConstant_2.java:26:13: compiler.err.cant.assign.val.to.var: static final, z
 1 error

--- a/test/langtools/tools/javac/InnerNamedConstant_2_B.out
+++ b/test/langtools/tools/javac/InnerNamedConstant_2_B.out
@@ -1,2 +1,2 @@
-InnerNamedConstant_2.java:26:13: compiler.err.cant.assign.val.to.final.var: z
+InnerNamedConstant_2.java:26:13: compiler.err.cant.assign.val.to.var: final, z
 1 error

--- a/test/langtools/tools/javac/StoreClass.out
+++ b/test/langtools/tools/javac/StoreClass.out
@@ -1,3 +1,3 @@
-StoreClass.java:12:19: compiler.err.cant.assign.val.to.var: final, class
-StoreClass.java:13:12: compiler.err.cant.assign.val.to.var: final, class
+StoreClass.java:12:19: compiler.err.cant.assign.val.to.var: static final, class
+StoreClass.java:13:12: compiler.err.cant.assign.val.to.var: static final, class
 2 errors

--- a/test/langtools/tools/javac/StoreClass.out
+++ b/test/langtools/tools/javac/StoreClass.out
@@ -1,3 +1,3 @@
-StoreClass.java:12:19: compiler.err.cant.assign.val.to.final.var: class
-StoreClass.java:13:12: compiler.err.cant.assign.val.to.final.var: class
+StoreClass.java:12:19: compiler.err.cant.assign.val.to.var: final, class
+StoreClass.java:13:12: compiler.err.cant.assign.val.to.var: final, class
 2 errors

--- a/test/langtools/tools/javac/TryWithResources/BadTwr.out
+++ b/test/langtools/tools/javac/TryWithResources/BadTwr.out
@@ -1,5 +1,5 @@
 BadTwr.java:12:46: compiler.err.already.defined: kindname.variable, r1, kindname.method, meth(java.lang.String...)
 BadTwr.java:17:20: compiler.err.already.defined: kindname.variable, args, kindname.method, meth(java.lang.String...)
-BadTwr.java:20:13: compiler.err.cant.assign.val.to.final.var: thatsIt
+BadTwr.java:20:13: compiler.err.cant.assign.val.to.var: final, thatsIt
 BadTwr.java:25:24: compiler.err.already.defined: kindname.variable, name, kindname.method, meth(java.lang.String...)
 4 errors

--- a/test/langtools/tools/javac/diags/examples/CantAssignToFinal.java
+++ b/test/langtools/tools/javac/diags/examples/CantAssignToFinal.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-// key: compiler.err.cant.assign.val.to.final.var
+// key: compiler.err.cant.assign.val.to.var
 
 class CantAssignToFinal {
     final int i = 0;

--- a/test/langtools/tools/javac/patterns/BindingsTest2.out
+++ b/test/langtools/tools/javac/patterns/BindingsTest2.out
@@ -46,7 +46,7 @@ BindingsTest2.java:212:13: compiler.err.cant.resolve.location: kindname.variable
 BindingsTest2.java:221:17: compiler.err.cant.resolve.location: kindname.variable, s, , , (compiler.misc.location: kindname.class, BindingsTest2, null)
 BindingsTest2.java:231:17: compiler.err.cant.resolve.location: kindname.variable, s, , , (compiler.misc.location: kindname.class, BindingsTest2, null)
 BindingsTest2.java:241:17: compiler.err.cant.resolve.location: kindname.variable, s, , , (compiler.misc.location: kindname.class, BindingsTest2, null)
-BindingsTest2.java:247:17: compiler.err.cant.assign.val.to.final.var: s
+BindingsTest2.java:247:17: compiler.err.cant.assign.val.to.var: final, s
 BindingsTest2.java:135:17: compiler.err.unreachable.stmt
 BindingsTest2.java:160:17: compiler.err.unreachable.stmt
 BindingsTest2.java:185:17: compiler.err.unreachable.stmt

--- a/test/langtools/tools/javac/records/RecordCompilationTests.java
+++ b/test/langtools/tools/javac/records/RecordCompilationTests.java
@@ -2028,7 +2028,7 @@ public class RecordCompilationTests extends CompilationTestCase {
     }
 
     public void testNoAssigmentInsideCompactRecord() {
-        assertFail("compiler.err.cant.assign.val.to.final.var",
+        assertFail("compiler.err.cant.assign.val.to.var",
                 """
                 record R(int i) {
                     R {
@@ -2037,7 +2037,7 @@ public class RecordCompilationTests extends CompilationTestCase {
                 }
                 """
         );
-        assertFail("compiler.err.cant.assign.val.to.final.var",
+        assertFail("compiler.err.cant.assign.val.to.var",
                 """
                 record R(int i) {
                     R {


### PR DESCRIPTION
When a program attempts to assign a value to a final field, javac reports `cannot assign a value to final variable x`.

If the field is `static`, the exact same error message is used, which can be confusing, because no mention is made of the field's `static`ness.

This change does two things:
* Refactor the error message so that arbitrary modifiers can be included, instead of hard-wiring `final`
* Include both `static final` in the error message in the case of `static final` variables.

So for a `static final` field the error is now `cannot assign a value to static final variable x`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8221580](https://bugs.openjdk.org/browse/JDK-8221580): Confusing diagnostic for assigning a static final field in a constructor


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12411/head:pull/12411` \
`$ git checkout pull/12411`

Update a local copy of the PR: \
`$ git checkout pull/12411` \
`$ git pull https://git.openjdk.org/jdk pull/12411/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12411`

View PR using the GUI difftool: \
`$ git pr show -t 12411`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12411.diff">https://git.openjdk.org/jdk/pull/12411.diff</a>

</details>
