### PR TITLE
8300268 : ServerImpl allows too many idle connections when using sun.net.httpserver.maxIdleConnections

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
@@ -963,7 +963,7 @@ class ServerImpl {
     }
 
     void markIdle(HttpConnection c) {
-        Boolean close = false;
+        boolean close = false;
 
         try {
             idleConnectionLock.lock();

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
@@ -64,7 +64,6 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.Executor;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static sun.net.httpserver.Utils.isValidName;

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
@@ -63,6 +63,8 @@ import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.Executor;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static sun.net.httpserver.Utils.isValidName;
@@ -95,6 +97,7 @@ class ServerImpl {
     private final Set<HttpConnection> rspConnections;
     private List<Event> events;
     private final Object lolock = new Object();
+    private final ReentrantLock idleConnectionLock = new ReentrantLock();
     private volatile boolean finished = false;
     private volatile boolean terminating = false;
     private boolean bound = false;
@@ -410,7 +413,7 @@ class ServerImpl {
                         }
                     }
                     responseCompleted (c);
-                    if (t.close || idleConnections.size() >= MAX_IDLE_CONNECTIONS) {
+                    if (t.close) {
                         c.close();
                         allConnections.remove (c);
                     } else {
@@ -961,9 +964,24 @@ class ServerImpl {
     }
 
     void markIdle(HttpConnection c) {
-        c.idleStartTime = System.currentTimeMillis();
-        c.setState(State.IDLE);
-        idleConnections.add(c);
+        Boolean close = false;
+
+        idleConnectionLock.lock();
+        if (idleConnections.size() >= MAX_IDLE_CONNECTIONS) {
+            // closing the connection here could block
+            // instead set boolean and close outside of lock
+            close = true;
+        } else {
+            c.idleStartTime = System.currentTimeMillis();
+            c.setState(State.IDLE);
+            idleConnections.add(c);
+        }
+        idleConnectionLock.unlock();
+
+        if (close) {
+            c.close();
+            allConnections.remove(c);
+        }
     }
 
     void markNewlyAccepted(HttpConnection c) {

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
@@ -965,8 +965,8 @@ class ServerImpl {
     void markIdle(HttpConnection c) {
         boolean close = false;
 
+        idleConnectionLock.lock();
         try {
-            idleConnectionLock.lock();
             if (idleConnections.size() >= MAX_IDLE_CONNECTIONS) {
                 // closing the connection here could block
                 // instead set boolean and close outside of lock

--- a/test/jdk/com/sun/net/httpserver/bugs/8300268/MaxIdleConnectionsTest.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/8300268/MaxIdleConnectionsTest.java
@@ -33,6 +33,7 @@
  */
 
 import com.sun.net.httpserver.HttpServer;
+import jdk.test.lib.net.URIBuilder;
 import sun.net.httpserver.HttpServerAccess;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -82,7 +83,12 @@ public class MaxIdleConnectionsTest {
         final List<Future<Void>> responses = new ArrayList<>();
         try (final ExecutorService requestIssuer = Executors.newFixedThreadPool(totalConnections)) {
             for (int i = 1; i <= totalConnections; i++) {
-                final URL requestURL = new URL("http://" + host + ":" + port + "/MaxIdleConnectionTest/" + i);
+                URL requestURL = URIBuilder.newBuilder()
+                        .scheme("http")
+                        .loopback()
+                        .port(port)
+                        .path("/MaxIdleConnectionTest/" + i)
+                        .toURL();
                 final Future<Void> result = requestIssuer.submit(() -> {
                     System.out.println("Issuing request " + requestURL);
                     final URLConnection conn = requestURL.openConnection();
@@ -126,8 +132,7 @@ public class MaxIdleConnectionsTest {
         }));
 
         server.createContext("/MaxIdleConnectionTest/", (exchange) -> {
-            System.out.println("Request " + exchange.getRequestURI()
-                    + " received; handler will wait on latch");
+            System.out.println("Request " + exchange.getRequestURI() + " received");
             System.out.println("Sending response for request " + exchange.getRequestURI() + " from " + exchange.getRemoteAddress());
             reqFinishedProcessing.countDown();
             exchange.sendResponseHeaders(200, 0);

--- a/test/jdk/com/sun/net/httpserver/bugs/8300268/MaxIdleConnectionsTest.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/8300268/MaxIdleConnectionsTest.java
@@ -108,7 +108,8 @@ public class MaxIdleConnectionsTest {
         // assert that the limit set by maxIdleConnections was not exceeded
         int idleConnectionCount = HttpServerAccess.getIdleConnectionCount(server);
         System.out.println("count " + idleConnectionCount);
-        assertTrue(maxIdleConnections >= idleConnectionCount);
+        assertTrue(maxIdleConnections >= idleConnectionCount,
+                String.format("Too many idle connections: %d, limit: %d", idleConnectionCount, maxIdleConnections));
     }
 
     // Create HttpServer that will handle requests with multiple threads

--- a/test/jdk/com/sun/net/httpserver/bugs/8300268/MaxIdleConnectionsTest.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/8300268/MaxIdleConnectionsTest.java
@@ -50,7 +50,7 @@ import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class MaxIdleConnectionsTest {
@@ -105,11 +105,10 @@ public class MaxIdleConnectionsTest {
             System.out.println("Received successful response for request " + i);
         }
 
-        // assert that the expected number of idle connections has been reached
-        // meaning the extra connection was served but then closed
+        // assert that the limit set by maxIdleConnections was not exceeded
         int idleConnectionCount = HttpServerAccess.getIdleConnectionCount(server);
         System.out.println("count " + idleConnectionCount);
-        assertEquals(maxIdleConnections, idleConnectionCount);
+        assertTrue(maxIdleConnections >= idleConnectionCount);
     }
 
     // Create HttpServer that will handle requests with multiple threads

--- a/test/jdk/com/sun/net/httpserver/bugs/8300268/MaxIdleConnectionsTest.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/8300268/MaxIdleConnectionsTest.java
@@ -62,7 +62,7 @@ public class MaxIdleConnectionsTest {
     @BeforeAll
     void before() throws Exception {
         maxIdleConnections = Integer.getInteger("sun.net.httpserver.maxIdleConnections");
-        totalConnections = maxIdleConnections+1;
+        totalConnections = maxIdleConnections + 1;
         reqFinishedProcessing = new CountDownLatch(totalConnections);
         server = startServer(reqFinishedProcessing);
     }
@@ -81,10 +81,9 @@ public class MaxIdleConnectionsTest {
 
         final List<Future<Void>> responses = new ArrayList<>();
         try (final ExecutorService requestIssuer = Executors.newFixedThreadPool(totalConnections)) {
-            // issue requests
             for (int i = 1; i <= totalConnections; i++) {
                 final URL requestURL = new URL("http://" + host + ":" + port + "/MaxIdleConnectionTest/" + i);
-                final Future<Void> result = requestIssuer.submit((Callable<Void>) () -> {
+                final Future<Void> result = requestIssuer.submit(() -> {
                     System.out.println("Issuing request " + requestURL);
                     final URLConnection conn = requestURL.openConnection();
                     try (final InputStream is = conn.getInputStream()) {
@@ -94,7 +93,7 @@ public class MaxIdleConnectionsTest {
                 });
                 responses.add(result);
             }
-            // wait for all these issues requests to reach each of the handlers
+            // wait for all the requests to reach each of the handlers
             System.out.println("Waiting for all " + totalConnections + " requests to reach" +
                     " the server side request handler");
             reqFinishedProcessing.await();
@@ -109,7 +108,7 @@ public class MaxIdleConnectionsTest {
         // assert that the expected number of idle connections has been reached
         // meaning the extra connection was served but then closed
         int idleConnectionCount = HttpServerAccess.getIdleConnectionCount(server);
-        System.out.println("count "+idleConnectionCount);
+        System.out.println("count " + idleConnectionCount);
         assertEquals(maxIdleConnections, idleConnectionCount);
     }
 

--- a/test/jdk/com/sun/net/httpserver/bugs/8300268/MaxIdleConnectionsTest.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/8300268/MaxIdleConnectionsTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8300268
+ * @library /test/lib
+ * @modules jdk.httpserver/sun.net.httpserver
+ * @build jdk.httpserver/sun.net.httpserver.HttpServerAccess MaxIdleConnectionsTest
+ * @run junit/othervm -Dsun.net.httpserver.maxIdleConnections=4 MaxIdleConnectionsTest
+ */
+
+import com.sun.net.httpserver.HttpServer;
+import sun.net.httpserver.HttpServerAccess;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class MaxIdleConnectionsTest {
+
+    HttpServer server;
+    int maxIdleConnections, totalConnections;
+    CountDownLatch reqFinishedProcessing;
+
+    @BeforeAll
+    void before() throws Exception {
+        maxIdleConnections = Integer.getInteger("sun.net.httpserver.maxIdleConnections");
+        totalConnections = maxIdleConnections+1;
+        reqFinishedProcessing = new CountDownLatch(totalConnections);
+        server = startServer(reqFinishedProcessing);
+    }
+
+    @AfterAll
+    void after() throws Exception {
+        server.stop(0);
+    }
+
+    // Issue one too many requests and assert that the idle connection pool doesn't
+    // exceed maxIdleConnections
+    @Test
+    public void test() throws Exception {
+        final String host = server.getAddress().getHostString();
+        final int port = server.getAddress().getPort();
+
+        final List<Future<Void>> responses = new ArrayList<>();
+        try (final ExecutorService requestIssuer = Executors.newFixedThreadPool(totalConnections)) {
+            // issue requests
+            for (int i = 1; i <= totalConnections; i++) {
+                final URL requestURL = new URL("http://" + host + ":" + port + "/MaxIdleConnectionTest/" + i);
+                final Future<Void> result = requestIssuer.submit((Callable<Void>) () -> {
+                    System.out.println("Issuing request " + requestURL);
+                    final URLConnection conn = requestURL.openConnection();
+                    try (final InputStream is = conn.getInputStream()) {
+                        is.readAllBytes();
+                    }
+                    return null;
+                });
+                responses.add(result);
+            }
+            // wait for all these issues requests to reach each of the handlers
+            System.out.println("Waiting for all " + totalConnections + " requests to reach" +
+                    " the server side request handler");
+            reqFinishedProcessing.await();
+        }
+
+        // verify every request got served before checking idle count
+        for (int i = 0; i < totalConnections; i++) {
+            responses.get(i).get();
+            System.out.println("Received successful response for request " + i);
+        }
+
+        // assert that the expected number of idle connections has been reached
+        // meaning the extra connection was served but then closed
+        int idleConnectionCount = HttpServerAccess.getIdleConnectionCount(server);
+        System.out.println("count "+idleConnectionCount);
+        assertEquals(maxIdleConnections, idleConnectionCount);
+    }
+
+    // Create HttpServer that will handle requests with multiple threads
+    private static HttpServer startServer(final CountDownLatch reqFinishedProcessing) throws IOException {
+        final var bindAddr = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
+        final HttpServer server = HttpServer.create(bindAddr, 0);
+
+        final AtomicInteger threadId = new AtomicInteger();
+        server.setExecutor(Executors.newCachedThreadPool(r -> {
+            final Thread t = new Thread(r);
+            t.setName("http-request-handler-" + threadId.incrementAndGet());
+            t.setDaemon(true);
+            return t;
+        }));
+
+        server.createContext("/MaxIdleConnectionTest/", (exchange) -> {
+            System.out.println("Request " + exchange.getRequestURI()
+                    + " received; handler will wait on latch");
+            System.out.println("Sending response for request " + exchange.getRequestURI() + " from " + exchange.getRemoteAddress());
+            reqFinishedProcessing.countDown();
+            exchange.sendResponseHeaders(200, 0);
+            exchange.getResponseBody().close();
+        });
+
+        server.start();
+        System.out.println("Server started at address " + server.getAddress());
+        return server;
+    }
+}

--- a/test/jdk/com/sun/net/httpserver/bugs/8300268/MaxIdleConnectionsTest.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/8300268/MaxIdleConnectionsTest.java
@@ -77,7 +77,6 @@ public class MaxIdleConnectionsTest {
     // exceed maxIdleConnections
     @Test
     public void test() throws Exception {
-        final String host = server.getAddress().getHostString();
         final int port = server.getAddress().getPort();
 
         final List<Future<Void>> responses = new ArrayList<>();

--- a/test/jdk/com/sun/net/httpserver/bugs/8300268/jdk.httpserver/sun/net/httpserver/HttpServerAccess.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/8300268/jdk.httpserver/sun/net/httpserver/HttpServerAccess.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.net.httpserver;
+
+import com.sun.net.httpserver.HttpServer;
+import java.lang.reflect.Field;
+import java.util.Set;
+
+public class HttpServerAccess {
+
+   // Given a HttpServer object get the number of idleConnections it currently has
+    public static int getIdleConnectionCount(HttpServer server) throws Exception{
+        // Use reflection to get server object which is HTTPServerImpl
+        Field serverField = server.getClass().getDeclaredField("server");
+        serverField.setAccessible(true);
+
+        // Get the actual serverImpl class, then get the IdleConnection Field
+        Object serverImpl = serverField.get(server);
+        Field idleConnectionField = serverImpl.getClass().getDeclaredField("idleConnections");
+        idleConnectionField.setAccessible(true);
+
+        // Finally get the IdleConnection object which is of type Set<HttpConnection>
+        Object idleConnectionSet = idleConnectionField.get(serverImpl);
+        Set<HttpConnection> idleConnectionPool = (Set<HttpConnection>) idleConnectionSet;
+        return idleConnectionPool.size();
+    }
+}


### PR DESCRIPTION
Currently there is a race condition that can allow for too many 'idleConnections' in `ServerImpl`

This PR adds a lock to make sure only one connection can be marked Idle at a time as well as a test that consistently failed before the change but which now passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300268](https://bugs.openjdk.org/browse/JDK-8300268): ServerImpl allows too many idle connections when using sun.net.httpserver.maxIdleConnections


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer) ⚠️ Review applies to [2eae924b](https://git.openjdk.org/jdk/pull/12413/files/2eae924bc6bb3b05e02f19bad9542b3a59d896f7)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**) ⚠️ Review applies to [2eae924b](https://git.openjdk.org/jdk/pull/12413/files/2eae924bc6bb3b05e02f19bad9542b3a59d896f7)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12413/head:pull/12413` \
`$ git checkout pull/12413`

Update a local copy of the PR: \
`$ git checkout pull/12413` \
`$ git pull https://git.openjdk.org/jdk pull/12413/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12413`

View PR using the GUI difftool: \
`$ git pr show -t 12413`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12413.diff">https://git.openjdk.org/jdk/pull/12413.diff</a>

</details>
