### PR TITLE
8286510: Tests under dynamicArchive/methodHandles should check for loading of lambda proxy classes

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/CDSMHTest_generate.sh
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/CDSMHTest_generate.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ do
     fname="$i$name_suffix"
     cat << EOF > $fname
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,6 +94,9 @@ public class $i extends DynamicArchiveTestBase {
     private static final String ps = System.getProperty("path.separator");
     private static final String testPackageName = "test.java.lang.invoke";
     private static final String testClassName = "$i";
+    private static final String loggingOpts = "-Xlog:cds,cds+dynamic=debug,class+load=trace";
+    private static final String lambdaLoadedFromArchive =
+        ".class.load. test.java.lang.invoke.$i[$][$]Lambda[$].*/0x.*source:.*shared.*objects.*file.*(top)";
 
     static void testImpl() throws Exception {
         String topArchiveName = getNewArchiveName();
@@ -104,10 +107,20 @@ public class $i extends DynamicArchiveTestBase {
             Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "-showversion";
 
         String junitJar = Path.of(Test.class.getProtectionDomain().getCodeSource().getLocation().toURI()).toString();
+        String jars = appJar + ps + junitJar;
+        String className = testPackageName + "." + testClassName;
 
-        dumpAndRun(topArchiveName, "-Xlog:cds,cds+dynamic=debug,class+load=trace",
-            "-cp", appJar + ps + junitJar, verifyOpt,
-            mainClass, testPackageName + "." + testClassName);
+        dump(topArchiveName, loggingOpts, "-cp", jars, verifyOpt, mainClass, className)
+            .assertNormalExit(output -> {
+                    output.shouldContain("Written dynamic archive 0x");
+                });
+
+        run(topArchiveName, loggingOpts, "-cp", jars, verifyOpt, mainClass, className)
+            .assertNormalExit(output -> {
+                    output.shouldMatch(lambdaLoadedFromArchive)
+                          .shouldHaveExitValue(0);
+                });
+
     }
 }
 EOF

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesAsCollectorTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesAsCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,6 +62,9 @@ public class MethodHandlesAsCollectorTest extends DynamicArchiveTestBase {
     private static final String ps = System.getProperty("path.separator");
     private static final String testPackageName = "test.java.lang.invoke";
     private static final String testClassName = "MethodHandlesAsCollectorTest";
+    private static final String loggingOpts = "-Xlog:cds,cds+dynamic=debug,class+load=trace";
+    private static final String lambdaLoadedFromArchive =
+        ".class.load. test.java.lang.invoke.MethodHandlesAsCollectorTest[$][$]Lambda[$].*/0x.*source:.*shared.*objects.*file.*(top)";
 
     static void testImpl() throws Exception {
         String topArchiveName = getNewArchiveName();
@@ -72,9 +75,19 @@ public class MethodHandlesAsCollectorTest extends DynamicArchiveTestBase {
             Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "-showversion";
 
         String junitJar = Path.of(Test.class.getProtectionDomain().getCodeSource().getLocation().toURI()).toString();
+        String jars = appJar + ps + junitJar;
+        String className = testPackageName + "." + testClassName;
 
-        dumpAndRun(topArchiveName, "-Xlog:cds,cds+dynamic=debug,class+load=trace",
-            "-cp", appJar + ps + junitJar, verifyOpt,
-            mainClass, testPackageName + "." + testClassName);
+        dump(topArchiveName, loggingOpts, "-cp", jars, verifyOpt, mainClass, className)
+            .assertNormalExit(output -> {
+                    output.shouldContain("Written dynamic archive 0x");
+                });
+
+        run(topArchiveName, loggingOpts, "-cp", jars, verifyOpt, mainClass, className)
+            .assertNormalExit(output -> {
+                    output.shouldMatch(lambdaLoadedFromArchive)
+                          .shouldHaveExitValue(0);
+                });
+
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesCastFailureTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesCastFailureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,6 +62,9 @@ public class MethodHandlesCastFailureTest extends DynamicArchiveTestBase {
     private static final String ps = System.getProperty("path.separator");
     private static final String testPackageName = "test.java.lang.invoke";
     private static final String testClassName = "MethodHandlesCastFailureTest";
+    private static final String loggingOpts = "-Xlog:cds,cds+dynamic=debug,class+load=trace";
+    private static final String lambdaLoadedFromArchive =
+        ".class.load. test.java.lang.invoke.MethodHandlesCastFailureTest[$][$]Lambda[$].*/0x.*source:.*shared.*objects.*file.*(top)";
 
     static void testImpl() throws Exception {
         String topArchiveName = getNewArchiveName();
@@ -72,9 +75,19 @@ public class MethodHandlesCastFailureTest extends DynamicArchiveTestBase {
             Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "-showversion";
 
         String junitJar = Path.of(Test.class.getProtectionDomain().getCodeSource().getLocation().toURI()).toString();
+        String jars = appJar + ps + junitJar;
+        String className = testPackageName + "." + testClassName;
 
-        dumpAndRun(topArchiveName, "-Xlog:cds,cds+dynamic=debug,class+load=trace",
-            "-cp", appJar + ps + junitJar, verifyOpt,
-            mainClass, testPackageName + "." + testClassName);
+        dump(topArchiveName, loggingOpts, "-cp", jars, verifyOpt, mainClass, className)
+            .assertNormalExit(output -> {
+                    output.shouldContain("Written dynamic archive 0x");
+                });
+
+        run(topArchiveName, loggingOpts, "-cp", jars, verifyOpt, mainClass, className)
+            .assertNormalExit(output -> {
+                    output.shouldMatch(lambdaLoadedFromArchive)
+                          .shouldHaveExitValue(0);
+                });
+
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesGeneralTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesGeneralTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,6 +62,9 @@ public class MethodHandlesGeneralTest extends DynamicArchiveTestBase {
     private static final String ps = System.getProperty("path.separator");
     private static final String testPackageName = "test.java.lang.invoke";
     private static final String testClassName = "MethodHandlesGeneralTest";
+    private static final String loggingOpts = "-Xlog:cds,cds+dynamic=debug,class+load=trace";
+    private static final String lambdaLoadedFromArchive =
+        ".class.load. test.java.lang.invoke.MethodHandlesGeneralTest[$][$]Lambda[$].*/0x.*source:.*shared.*objects.*file.*(top)";
 
     static void testImpl() throws Exception {
         String topArchiveName = getNewArchiveName();
@@ -72,9 +75,19 @@ public class MethodHandlesGeneralTest extends DynamicArchiveTestBase {
             Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "-showversion";
 
         String junitJar = Path.of(Test.class.getProtectionDomain().getCodeSource().getLocation().toURI()).toString();
+        String jars = appJar + ps + junitJar;
+        String className = testPackageName + "." + testClassName;
 
-        dumpAndRun(topArchiveName, "-Xlog:cds,cds+dynamic=debug,class+load=trace",
-            "-cp", appJar + ps + junitJar, verifyOpt,
-            mainClass, testPackageName + "." + testClassName);
+        dump(topArchiveName, loggingOpts, "-cp", jars, verifyOpt, mainClass, className)
+            .assertNormalExit(output -> {
+                    output.shouldContain("Written dynamic archive 0x");
+                });
+
+        run(topArchiveName, loggingOpts, "-cp", jars, verifyOpt, mainClass, className)
+            .assertNormalExit(output -> {
+                    output.shouldMatch(lambdaLoadedFromArchive)
+                          .shouldHaveExitValue(0);
+                });
+
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesInvokersTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesInvokersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,6 +62,9 @@ public class MethodHandlesInvokersTest extends DynamicArchiveTestBase {
     private static final String ps = System.getProperty("path.separator");
     private static final String testPackageName = "test.java.lang.invoke";
     private static final String testClassName = "MethodHandlesInvokersTest";
+    private static final String loggingOpts = "-Xlog:cds,cds+dynamic=debug,class+load=trace";
+    private static final String lambdaLoadedFromArchive =
+        ".class.load. test.java.lang.invoke.MethodHandlesInvokersTest[$][$]Lambda[$].*/0x.*source:.*shared.*objects.*file.*(top)";
 
     static void testImpl() throws Exception {
         String topArchiveName = getNewArchiveName();
@@ -72,9 +75,19 @@ public class MethodHandlesInvokersTest extends DynamicArchiveTestBase {
             Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "-showversion";
 
         String junitJar = Path.of(Test.class.getProtectionDomain().getCodeSource().getLocation().toURI()).toString();
+        String jars = appJar + ps + junitJar;
+        String className = testPackageName + "." + testClassName;
 
-        dumpAndRun(topArchiveName, "-Xlog:cds,cds+dynamic=debug,class+load=trace",
-            "-cp", appJar + ps + junitJar, verifyOpt,
-            mainClass, testPackageName + "." + testClassName);
+        dump(topArchiveName, loggingOpts, "-cp", jars, verifyOpt, mainClass, className)
+            .assertNormalExit(output -> {
+                    output.shouldContain("Written dynamic archive 0x");
+                });
+
+        run(topArchiveName, loggingOpts, "-cp", jars, verifyOpt, mainClass, className)
+            .assertNormalExit(output -> {
+                    output.shouldMatch(lambdaLoadedFromArchive)
+                          .shouldHaveExitValue(0);
+                });
+
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesPermuteArgumentsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesPermuteArgumentsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,6 +62,9 @@ public class MethodHandlesPermuteArgumentsTest extends DynamicArchiveTestBase {
     private static final String ps = System.getProperty("path.separator");
     private static final String testPackageName = "test.java.lang.invoke";
     private static final String testClassName = "MethodHandlesPermuteArgumentsTest";
+    private static final String loggingOpts = "-Xlog:cds,cds+dynamic=debug,class+load=trace";
+    private static final String lambdaLoadedFromArchive =
+        ".class.load. test.java.lang.invoke.MethodHandlesPermuteArgumentsTest[$][$]Lambda[$].*/0x.*source:.*shared.*objects.*file.*(top)";
 
     static void testImpl() throws Exception {
         String topArchiveName = getNewArchiveName();
@@ -72,9 +75,19 @@ public class MethodHandlesPermuteArgumentsTest extends DynamicArchiveTestBase {
             Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "-showversion";
 
         String junitJar = Path.of(Test.class.getProtectionDomain().getCodeSource().getLocation().toURI()).toString();
+        String jars = appJar + ps + junitJar;
+        String className = testPackageName + "." + testClassName;
 
-        dumpAndRun(topArchiveName, "-Xlog:cds,cds+dynamic=debug,class+load=trace",
-            "-cp", appJar + ps + junitJar, verifyOpt,
-            mainClass, testPackageName + "." + testClassName);
+        dump(topArchiveName, loggingOpts, "-cp", jars, verifyOpt, mainClass, className)
+            .assertNormalExit(output -> {
+                    output.shouldContain("Written dynamic archive 0x");
+                });
+
+        run(topArchiveName, loggingOpts, "-cp", jars, verifyOpt, mainClass, className)
+            .assertNormalExit(output -> {
+                    output.shouldMatch(lambdaLoadedFromArchive)
+                          .shouldHaveExitValue(0);
+                });
+
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesSpreadArgumentsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesSpreadArgumentsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,6 +62,9 @@ public class MethodHandlesSpreadArgumentsTest extends DynamicArchiveTestBase {
     private static final String ps = System.getProperty("path.separator");
     private static final String testPackageName = "test.java.lang.invoke";
     private static final String testClassName = "MethodHandlesSpreadArgumentsTest";
+    private static final String loggingOpts = "-Xlog:cds,cds+dynamic=debug,class+load=trace";
+    private static final String lambdaLoadedFromArchive =
+        ".class.load. test.java.lang.invoke.MethodHandlesSpreadArgumentsTest[$][$]Lambda[$].*/0x.*source:.*shared.*objects.*file.*(top)";
 
     static void testImpl() throws Exception {
         String topArchiveName = getNewArchiveName();
@@ -72,9 +75,19 @@ public class MethodHandlesSpreadArgumentsTest extends DynamicArchiveTestBase {
             Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "-showversion";
 
         String junitJar = Path.of(Test.class.getProtectionDomain().getCodeSource().getLocation().toURI()).toString();
+        String jars = appJar + ps + junitJar;
+        String className = testPackageName + "." + testClassName;
 
-        dumpAndRun(topArchiveName, "-Xlog:cds,cds+dynamic=debug,class+load=trace",
-            "-cp", appJar + ps + junitJar, verifyOpt,
-            mainClass, testPackageName + "." + testClassName);
+        dump(topArchiveName, loggingOpts, "-cp", jars, verifyOpt, mainClass, className)
+            .assertNormalExit(output -> {
+                    output.shouldContain("Written dynamic archive 0x");
+                });
+
+        run(topArchiveName, loggingOpts, "-cp", jars, verifyOpt, mainClass, className)
+            .assertNormalExit(output -> {
+                    output.shouldMatch(lambdaLoadedFromArchive)
+                          .shouldHaveExitValue(0);
+                });
+
     }
 }


### PR DESCRIPTION
Fixing the tests under `runtime/cds/appcds/dynamicArchive/methodHandles` - adding a check for loading of lambda proxy classes from the CDS dynamic archive.

Tested locally on linux-x64 and passed tiers 1-3 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286510](https://bugs.openjdk.org/browse/JDK-8286510): Tests under dynamicArchive/methodHandles should check for loading of lambda proxy classes


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12414/head:pull/12414` \
`$ git checkout pull/12414`

Update a local copy of the PR: \
`$ git checkout pull/12414` \
`$ git pull https://git.openjdk.org/jdk pull/12414/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12414`

View PR using the GUI difftool: \
`$ git pr show -t 12414`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12414.diff">https://git.openjdk.org/jdk/pull/12414.diff</a>

</details>
