### PR TITLE
8300177 : URISyntaxException fields can be final

### DIFF
--- a/src/java.base/share/classes/java/net/URISyntaxException.java
+++ b/src/java.base/share/classes/java/net/URISyntaxException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,13 +44,13 @@ public class URISyntaxException
     /**
      * The input string.
      */
-    private String input;
+    private final String input;
 
     /**
      * The index at which the parse error occurred,
      * or {@code -1} if the index is not known.
      */
-    private int index;
+    private final int index;
 
     /**
      * Constructs an instance from the given input string, reason, and error


### PR DESCRIPTION
Made the two fields `input` and `index` final, this didn't need any test changes as far as I could tell so this PR is longer than the diff

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300177](https://bugs.openjdk.org/browse/JDK-8300177): URISyntaxException fields can be final


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12415/head:pull/12415` \
`$ git checkout pull/12415`

Update a local copy of the PR: \
`$ git checkout pull/12415` \
`$ git pull https://git.openjdk.org/jdk pull/12415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12415`

View PR using the GUI difftool: \
`$ git pr show -t 12415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12415.diff">https://git.openjdk.org/jdk/pull/12415.diff</a>

</details>
