### PR TITLE
8301798: [BACKOUT] jdb ThreadStartRequest and ThreadDeathRequest should use SUSPEND_NONE instead of SUSPEND_ALL

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/VMConnection.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/VMConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,6 @@ package com.sun.tools.example.debug.tty;
 
 import com.sun.jdi.*;
 import com.sun.jdi.connect.*;
-import com.sun.jdi.request.EventRequest;
 import com.sun.jdi.request.EventRequestManager;
 import com.sun.jdi.request.ThreadStartRequest;
 import com.sun.jdi.request.ThreadDeathRequest;
@@ -470,8 +469,6 @@ class VMConnection {
 
         ThreadStartRequest tsr = erm.createThreadStartRequest();
         ThreadDeathRequest tdr = erm.createThreadDeathRequest();
-        tsr.setSuspendPolicy(EventRequest.SUSPEND_NONE);
-        tdr.setSuspendPolicy(EventRequest.SUSPEND_NONE);
         if (!trackVthreads) {
             tsr.addPlatformThreadsOnlyFilter();
             tdr.addPlatformThreadsOnlyFilter();


### PR DESCRIPTION
Backing out the following due to numerous failing tests. There will be no redo. The original change was an enhancement, not a bug fix.

[JDK-8300811](https://bugs.openjdk.org/browse/JDK-8300811) jdb ThreadStartRequest and ThreadDeathRequest should use SUSPEND_NONE instead of SUSPEND_ALL

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301798](https://bugs.openjdk.org/browse/JDK-8301798): [BACKOUT] jdb ThreadStartRequest and ThreadDeathRequest should use SUSPEND_NONE instead of SUSPEND_ALL


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12416/head:pull/12416` \
`$ git checkout pull/12416`

Update a local copy of the PR: \
`$ git checkout pull/12416` \
`$ git pull https://git.openjdk.org/jdk pull/12416/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12416`

View PR using the GUI difftool: \
`$ git pr show -t 12416`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12416.diff">https://git.openjdk.org/jdk/pull/12416.diff</a>

</details>
