### PR TITLE
8282379: [LOOM] vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod011 sometimes fails

### DIFF
--- a/test/hotspot/jtreg/ProblemList-svc-vthread.txt
+++ b/test/hotspot/jtreg/ProblemList-svc-vthread.txt
@@ -82,8 +82,6 @@ vmTestbase/nsk/jdb/repeat/repeat001/repeat001.java  8300707 generic-all
 ####
 ## NSK JDI tests failing with wrapper
 
-vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod011/TestDescription.java 8282379 generic-all
-
 ####
 ## The test expects an NPE to be uncaught, but nsk.share.MainWrapper
 ## introduces exception handlers.

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod011.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod011.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -209,6 +209,16 @@ public class invokemethod011 {
                 clsType.setValue(fldToExit, vm.mirrorOf(true));
 
                 invThr.join(argHandler.getWaitTime()*60000);
+                if (invThr.isAlive()) {
+                    // The join failed because the invoke never completed.
+                    log.complain("TEST FAILED: invoke never completed");
+                    tot_res = Consts.TEST_FAILED;
+                    // Do a vm.resume() to see if that helps.
+                    vm.resume();
+                    invThr.join(); // let test time out if this fails
+                    return quitDebuggee();
+                }
+
                 log.display("Thread \"" + invThr.getName() + "\" done");
 
                 // check threads status after method invocation

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod011t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod011t.java
@@ -87,11 +87,15 @@ public class invokemethod011t {
     static volatile boolean isInvoked = false;
 
     static long dummyMeth(long l) throws InterruptedException {
+        /*
+         * WARNING: Since this method is called using INVOKE_SINGLE_THREADED, we need to
+         * be careful not to do anything that might block on another thread. That includes
+         * calling Thread.sleep(), which can be a problem for virtual threads.
+         */
         invokemethod011t.log.display("dummyMeth: going to loop");
         isInvoked = true;
         while(!doExit) {
             l--; l++;
-            Thread.currentThread().sleep(0);
         }
         invokemethod011t.log.display("dummyMeth: exiting");
         isInvoked = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod011t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod011t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,7 +91,7 @@ public class invokemethod011t {
         isInvoked = true;
         while(!doExit) {
             l--; l++;
-            Thread.currentThread().sleep(400);
+            Thread.currentThread().sleep(0);
         }
         invokemethod011t.log.display("dummyMeth: exiting");
         isInvoked = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod012.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod012.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -202,6 +202,15 @@ public class invokemethod012 {
 
             clsType.setValue(fldToExit, vm.mirrorOf(true));
             invThr.join(argHandler.getWaitTime()*60000);
+            if (invThr.isAlive()) {
+                // The join failed because the invoke never completed.
+                log.complain("TEST FAILED: invoke never completed");
+                tot_res = Consts.TEST_FAILED;
+                // Do a vm.resume() to see if that helps.
+                vm.resume();
+                invThr.join(); // let test time out if this fails
+                return quitDebuggee();
+            }
             log.display("Thread \"" + invThr.getName() + "\" done");
 
             // check threads status after the method invocation

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod012t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod012t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,7 +93,7 @@ public class invokemethod012t {
         isInvoked = true;
         while(!doExit) {
             l--; l++;
-            Thread.currentThread().sleep(400);
+            Thread.currentThread().sleep(0);
         }
         invokemethod012t.log.display("dummyMeth: exiting");
         isInvoked = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod012t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod012t.java
@@ -89,11 +89,15 @@ public class invokemethod012t {
     static volatile boolean isInvoked = false;
 
     static long dummyMeth(long l) throws InterruptedException {
+        /*
+         * WARNING: Since this method is called using INVOKE_SINGLE_THREADED, we need to
+         * be careful not to do anything that might block on another thread. That includes
+         * calling Thread.sleep(), which can be a problem for virtual threads.
+         */
         invokemethod012t.log.display("dummyMeth: going to loop");
         isInvoked = true;
         while(!doExit) {
             l--; l++;
-            Thread.currentThread().sleep(0);
         }
         invokemethod012t.log.display("dummyMeth: exiting");
         isInvoked = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod013.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod013.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -204,6 +204,15 @@ public class invokemethod013 {
             // finish the invocation
             clsRef.setValue(fldToExit, vm.mirrorOf(true));
             invThr.join(argHandler.getWaitTime()*60000);
+            if (invThr.isAlive()) {
+                // The join failed because the invoke never completed.
+                log.complain("TEST FAILED: invoke never completed");
+                tot_res = Consts.TEST_FAILED;
+                // Do a vm.resume() to see if that helps.
+                vm.resume();
+                invThr.join(); // let test time out if this fails
+                return quitDebuggee();
+            }
             log.display("Thread \"" + invThr.getName() + "\" done");
 
             // check threads status after the method invocation

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod013t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod013t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,7 +92,7 @@ public class invokemethod013t {
         isInvoked = true;
         while(!doExit) {
             l--; l++;
-            Thread.currentThread().sleep(400);
+            Thread.currentThread().sleep(0);
         }
         invokemethod013t.log.display("dummyMeth: exiting");
         isInvoked = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod013t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod013t.java
@@ -88,11 +88,15 @@ public class invokemethod013t {
     static volatile boolean isInvoked = false;
 
     static long dummyMeth(long l) throws InterruptedException {
+        /*
+         * WARNING: Since this method is called using INVOKE_SINGLE_THREADED, we need to
+         * be careful not to do anything that might block on another thread. That includes
+         * calling Thread.sleep(), which can be a problem for virtual threads.
+         */
         invokemethod013t.log.display("dummyMeth: going to loop");
         isInvoked = true;
         while(!doExit) {
             l--; l++;
-            Thread.currentThread().sleep(0);
         }
         invokemethod013t.log.display("dummyMeth: exiting");
         isInvoked = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod010.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod010.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -206,6 +206,16 @@ public class invokemethod010 {
                 objRef.setValue(fldToExit, vm.mirrorOf(true));
 
                 invThr.join(argHandler.getWaitTime()*60000);
+                if (invThr.isAlive()) {
+                    // The join failed because the invoke never completed.
+                    log.complain("TEST FAILED: invoke never completed");
+                    tot_res = Consts.TEST_FAILED;
+                    // Do a vm.resume() to see if that helps.
+                    vm.resume();
+                    invThr.join(); // let test time out if this fails
+                    return quitDebuggee();
+                }
+
                 log.display("Thread \"" + invThr.getName() + "\" done");
 
                 // check threads status after method invocation

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod010t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod010t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -185,7 +185,7 @@ class invokemethod010tDummyClass {
         isInvoked = true;
         while(!doExit) {
             l--; l++;
-            Thread.currentThread().sleep(400);
+            Thread.currentThread().sleep(0);
         }
         invokemethod010t.log.display("invokemethod010tDummyClass: longMeth: exiting");
         isInvoked = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod010t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod010t.java
@@ -181,11 +181,15 @@ class invokemethod010tDummyClass {
     volatile boolean isInvoked = false;
 
     long longMeth(long l) throws InterruptedException {
+        /*
+         * WARNING: Since this method is called using INVOKE_SINGLE_THREADED, we need to
+         * be careful not to do anything that might block on another thread. That includes
+         * calling Thread.sleep(), which can be a problem for virtual threads.
+         */
         invokemethod010t.log.display("invokemethod010tDummyClass: longMeth: going to loop");
         isInvoked = true;
         while(!doExit) {
             l--; l++;
-            Thread.currentThread().sleep(0);
         }
         invokemethod010t.log.display("invokemethod010tDummyClass: longMeth: exiting");
         isInvoked = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod011.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod011.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -206,6 +206,16 @@ public class invokemethod011 {
                 objRef.setValue(fldToExit, vm.mirrorOf(true));
 
                 invThr.join(argHandler.getWaitTime()*60000);
+                if (invThr.isAlive()) {
+                    // The join failed because the invoke never completed.
+                    log.complain("TEST FAILED: invoke never completed");
+                    tot_res = Consts.TEST_FAILED;
+                    // Do a vm.resume() to see if that helps.
+                    vm.resume();
+                    invThr.join(); // let test time out if this fails
+                    return quitDebuggee();
+                }
+
                 log.display("Thread \"" + invThr.getName() + "\" done");
 
                 // check threads status after method invocation

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod011t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod011t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -185,7 +185,7 @@ class invokemethod011tDummyClass {
         isInvoked = true;
         while(!doExit) {
             l--; l++;
-            Thread.currentThread().sleep(400);
+            Thread.currentThread().sleep(0);
         }
         invokemethod011t.log.display("invokemethod011tDummyClass: longMeth: exiting");
         isInvoked = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod011t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod011t.java
@@ -181,11 +181,15 @@ class invokemethod011tDummyClass {
     volatile boolean isInvoked = false;
 
     long longMeth(long l) throws InterruptedException {
+        /*
+         * WARNING: Since this method is called using INVOKE_SINGLE_THREADED, we need to
+         * be careful not to do anything that might block on another thread. That includes
+         * calling Thread.sleep(), which can be a problem for virtual threads.
+         */
         invokemethod011t.log.display("invokemethod011tDummyClass: longMeth: going to loop");
         isInvoked = true;
         while(!doExit) {
             l--; l++;
-            Thread.currentThread().sleep(0);
         }
         invokemethod011t.log.display("invokemethod011tDummyClass: longMeth: exiting");
         isInvoked = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod012.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod012.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -206,6 +206,15 @@ public class invokemethod012 {
 
             objRef.setValue(fldToExit, vm.mirrorOf(true));
             invThr.join(argHandler.getWaitTime()*60000);
+            if (invThr.isAlive()) {
+                // The join failed because the invoke never completed.
+                log.complain("TEST FAILED: invoke never completed");
+                tot_res = Consts.TEST_FAILED;
+                // Do a vm.resume() to see if that helps.
+                vm.resume();
+                invThr.join(); // let test time out if this fails
+                return quitDebuggee();
+            }
             log.display("Thread \"" + invThr.getName() + "\" done");
 
             // check threads status after the method invocation

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod012t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod012t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -185,7 +185,7 @@ class invokemethod012tDummyClass {
         isInvoked = true;
         while(!doExit) {
             l--; l++;
-            Thread.currentThread().sleep(400);
+            Thread.currentThread().sleep(0);
         }
         invokemethod012t.log.display("invokemethod012tDummyClass: longMeth: exiting");
         isInvoked = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod012t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod012t.java
@@ -181,11 +181,15 @@ class invokemethod012tDummyClass {
     volatile boolean isInvoked = false;
 
     long longMeth(long l) throws InterruptedException {
+        /*
+         * WARNING: Since this method is called using INVOKE_SINGLE_THREADED, we need to
+         * be careful not to do anything that might block on another thread. That includes
+         * calling Thread.sleep(), which can be a problem for virtual threads.
+         */
         invokemethod012t.log.display("invokemethod012tDummyClass: longMeth: going to loop");
         isInvoked = true;
         while(!doExit) {
             l--; l++;
-            Thread.currentThread().sleep(0);
         }
         invokemethod012t.log.display("invokemethod012tDummyClass: longMeth: exiting");
         isInvoked = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod013.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod013.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -207,6 +207,15 @@ public class invokemethod013 {
 
             objRef.setValue(fldToExit, vm.mirrorOf(true));
             invThr.join(argHandler.getWaitTime()*60000);
+            if (invThr.isAlive()) {
+                // The join failed because the invoke never completed.
+                log.complain("TEST FAILED: invoke never completed");
+                tot_res = Consts.TEST_FAILED;
+                // Do a vm.resume() to see if that helps.
+                vm.resume();
+                invThr.join(); // let test time out if this fails
+                return quitDebuggee();
+            }
             log.display("Thread \"" + invThr.getName() + "\" done");
 
             // check threads status after the method invocation

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod013t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod013t.java
@@ -180,11 +180,15 @@ class invokemethod013tDummyClass {
     volatile boolean isInvoked = false;
 
     long longMeth(long l) throws InterruptedException {
+        /*
+         * WARNING: Since this method is called using INVOKE_SINGLE_THREADED, we need to
+         * be careful not to do anything that might block on another thread. That includes
+         * calling Thread.sleep(), which can be a problem for virtual threads.
+         */
         invokemethod013t.log.display("invokemethod013tDummyClass: longMeth: going to loop");
         isInvoked = true;
         while(!doExit) {
             l--; l++;
-            Thread.currentThread().sleep(0);
         }
         invokemethod013t.log.display("invokemethod013tDummyClass: longMeth: exiting");
         isInvoked = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod013t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod013t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -184,7 +184,7 @@ class invokemethod013tDummyClass {
         isInvoked = true;
         while(!doExit) {
             l--; l++;
-            Thread.currentThread().sleep(400);
+            Thread.currentThread().sleep(0);
         }
         invokemethod013t.log.display("invokemethod013tDummyClass: longMeth: exiting");
         isInvoked = false;


### PR DESCRIPTION
A number of tests that use JDI invokeMethod() support occasionally fail when run using virtual threads. The tests fail with:

```
# ERROR: TEST FAILED: wrong invocation:
# ERROR: invoking debuggee thread instance of java.lang.VirtualThread(name='invokemethod010tThr', id=272)
# ERROR: is not suspended again after the invocation 
```

Although as explained later, this is a misleading message, and does not accurately reflect why the test is failing. More on that below.

The root cause of the failure is due to these tests using JDI invokeMethod support with the  INVOKE_SINGLE_THREADED flag. This is not always going to work with virtual threads because the invoked method is doing a Thread.sleep(400), and that is at risk of blocking indefinitely if all other threads are blocked form making progress. Note that technically platform threads could fail in the same manner. However, the reason the failure only happens now with virtual threads is because the implementation of Thread.sleep() differs for virtual threads, and may require ownership of a monitor that sometimes is held by another thread.

Another issue is that the tests do not do a very good job of error handling when this happens, and give the misleading failure reason of the invoked thread not being suspended after the invoke completed. The reason it is not suspended is because the invoke has actually not completed. There was a timeout that the test did not properly note as the cause of the failure. The test (debugger side) spawns a thread to do the JDI invokeMethod with, and then waits for it with:

                invThr.join(argHandler.getWaitTime()*60000);

This join() times out, but the test assumes once it returns the invoke is complete, even though the invoked thread is actually still in the middle of the invoke. So that is the reason debuggee invokemethod thread is not currently suspended. I've fixed this by having a test check if invThr is still alive after the join. If it is, then the test is made to fail at that point, rather than continuing on and checking the debuggee threads status. The failure then becomes:

nsk.share.TestFailure: TEST FAILED: invoke never completed

At that point a vm.resume() is done to allow the invoke to complete, and the test will exit with this failure.

As for avoiding the failure in the first place (the deadlock in the debuggee during the invoke), this is really a test bug for relying on INVOKE_SINGLE_THREADED and assuming that the invoked thread won't become deadlocked. Since there is a Thread.sleep() call in the invoked method, it can't make this assumption. From the ObjectReference.invoke() spec:

"By default, all threads in the target VM are resumed while the method is being invoked if they were previously suspended by an event or by VirtualMachine.suspend() or ThreadReference.suspend(). This is done to prevent the deadlocks that will occur if any of the threads own monitors that will be needed by the invoked method."

"The resumption of other threads during the invocation can be prevented by specifying the INVOKE_SINGLE_THREADED bit flag in the options argument; however, there is no protection against or recovery from the deadlocks described above, so this option should be used with great caution."

For platform threads, sleep() doesn't require any monitors, so these tests never ran into problems before. For virtual threads however there is some synchronization done, and potential reliance on other threads not being suspended. A way around this is to always use sleep(0), which will at least attempt to yield the thread. For platform threads an actual yield is likely. For a virtual thread it will not yield in this particular case because the virtual thread is pinned to the carrier thread due to the jvmti breakpoint callback that is currently in the call chain of the invoked thread. So for virtual threads this effectively the same as sitting in a spin loop with no yielding. This is ok. CPU wasting is not a concern.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282379](https://bugs.openjdk.org/browse/JDK-8282379): [LOOM] vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod011 sometimes fails


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12420/head:pull/12420` \
`$ git checkout pull/12420`

Update a local copy of the PR: \
`$ git checkout pull/12420` \
`$ git pull https://git.openjdk.org/jdk pull/12420/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12420`

View PR using the GUI difftool: \
`$ git pr show -t 12420`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12420.diff">https://git.openjdk.org/jdk/pull/12420.diff</a>

</details>
