### PR TITLE
8298293: NMT: os::realloc() should verify that flags do not change between reallocations

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -694,7 +694,7 @@ void* os::realloc(void *memblock, size_t size, MEMFLAGS memflags, const NativeCa
 
   // Special handling for NMT preinit phase before arguments are parsed
   void* rc = nullptr;
-  if (NMTPreInit::handle_realloc(&rc, memblock, size)) {
+  if (NMTPreInit::handle_realloc(&rc, memblock, size, memflags)) {
     return rc;
   }
 
@@ -727,6 +727,8 @@ void* os::realloc(void *memblock, size_t size, MEMFLAGS memflags, const NativeCa
     // Perform integrity checks on and mark the old block as dead *before* calling the real realloc(3) since it
     // may invalidate the old block, including its header.
     MallocHeader* header = MallocHeader::resolve_checked(memblock);
+    assert(memflags == header->flags(), "weird NMT flags mismatch (new:\"%s\" != old:\"%s\")\n",
+           NMTUtil::flag_to_name(memflags), NMTUtil::flag_to_name(header->flags()));
     const MallocHeader::FreeInfo free_info = header->free_info();
     header->mark_block_as_dead();
 

--- a/src/hotspot/share/services/nmtPreInit.cpp
+++ b/src/hotspot/share/services/nmtPreInit.cpp
@@ -172,8 +172,8 @@ void NMTPreInit::create_table() {
 }
 
 // Allocate with os::malloc (hidden to prevent having to include os.hpp)
-void* NMTPreInit::do_os_malloc(size_t size) {
-  return os::malloc(size, mtNMT);
+void* NMTPreInit::do_os_malloc(size_t size, MEMFLAGS memflags) {
+  return os::malloc(size, memflags);
 }
 
 // Switches from NMT pre-init state to NMT post-init state;

--- a/src/hotspot/share/services/nmtPreInit.hpp
+++ b/src/hotspot/share/services/nmtPreInit.hpp
@@ -248,7 +248,7 @@ class NMTPreInit : public AllStatic {
   }
 
   // Just a wrapper for os::malloc to avoid including os.hpp here.
-  static void* do_os_malloc(size_t size);
+  static void* do_os_malloc(size_t size, MEMFLAGS memflags);
 
 public:
 
@@ -276,7 +276,7 @@ public:
   // Called from os::realloc.
   // Returns true if reallocation was handled here; in that case,
   // *rc contains the return address.
-  static bool handle_realloc(void** rc, void* old_p, size_t new_size) {
+  static bool handle_realloc(void** rc, void* old_p, size_t new_size, MEMFLAGS memflags) {
     if (old_p == nullptr) {                  // realloc(null, n)
       return handle_malloc(rc, new_size);
     }
@@ -305,7 +305,7 @@ public:
       //   and confusing us.
       const NMTPreInitAllocation* a = find_in_map(old_p);
       if (a != nullptr) { // this was originally a pre-init allocation
-        void* p_new = do_os_malloc(new_size);
+        void* p_new = do_os_malloc(new_size, memflags);
         ::memcpy(p_new, a->payload(), MIN2(a->size, new_size));
         (*rc) = p_new;
         return true;


### PR DESCRIPTION
Please review this enhancement, which adds `assert` to make sure that we are not changing the NMT flags when calling `os::realloc()`

We also fix a bug, which the `assert` caught.

Passes Mach5 tier1,2,3,4,5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298293](https://bugs.openjdk.org/browse/JDK-8298293): NMT: os::realloc() should verify that flags do not change between reallocations


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12422/head:pull/12422` \
`$ git checkout pull/12422`

Update a local copy of the PR: \
`$ git checkout pull/12422` \
`$ git pull https://git.openjdk.org/jdk pull/12422/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12422`

View PR using the GUI difftool: \
`$ git pr show -t 12422`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12422.diff">https://git.openjdk.org/jdk/pull/12422.diff</a>

</details>
