### PR TITLE
8298478: (fs) Path.of should allow input to include long path prefix

### DIFF
--- a/src/java.base/windows/classes/sun/nio/fs/WindowsPathParser.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsPathParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,12 +86,26 @@ class WindowsPathParser {
     }
 
     /**
+     * Removes the long path "\\?\" or "\\?\UNC" prefix. If the input
+     * has neither of these, the parameter is returned unchanged.
+     */
+    private static String removePrefix(String input) {
+        if (input.startsWith("\\\\?\\UNC")) {
+            return "\\" + input.substring(7);
+        } else if(input.startsWith("\\\\?\\")) {
+            return input.substring(4);
+        }
+        return input;
+    }
+
+    /**
      * Parses the given input as a Windows path.
      *
      * @param   requireToNormalize
      *          Indicates if the path requires to be normalized
      */
     private static Result parse(String input, boolean requireToNormalize) {
+        input = removePrefix(input);
         String root = "";
         WindowsPathType type = null;
 

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsPathParser.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsPathParser.java
@@ -161,7 +161,7 @@ class WindowsPathParser {
             }
         }
 
-        if (type != expectedType) {
+        if (expectedType != null && type != expectedType) {
             if (expectedType == WindowsPathType.ABSOLUTE) { // long path prefix
                 throw new InvalidPathException(input, "Long path prefix can only be used with an absolute path");
             } else if (expectedType == WindowsPathType.UNC) { // long UNC path prefix

--- a/test/jdk/java/nio/file/Path/PathOps.java
+++ b/test/jdk/java/nio/file/Path/PathOps.java
@@ -1455,11 +1455,15 @@ public class PathOps {
         // long UNC path prefixes
         test("\\\\?\\UNC\\server\\share\\dir\\file.dat")      // UNC
             .string("\\\\server\\share\\dir\\file.dat");
-        test("\\\\?\\UNC\\server\\share\\C:\\mnt\\file.dat")  // absolute
+        test("\\\\?\\UNC\\server\\share\\C:\\file.dat")       // absolute
+            .invalid();
+        test("\\\\?\\UNC\\file.dat")                          // relative
             .invalid();
         test("\\\\?\\UNC\\server\\share\\C:file.dat")         // drive-relative
             .invalid();
         test("\\\\?\\UNC")                                    // empty
+            .invalid();
+        test("\\\\?\\UNC\\")                                    // empty
             .invalid();
     }
 

--- a/test/jdk/java/nio/file/Path/PathOps.java
+++ b/test/jdk/java/nio/file/Path/PathOps.java
@@ -1463,7 +1463,7 @@ public class PathOps {
             .invalid();
         test("\\\\?\\UNC")                                    // empty
             .invalid();
-        test("\\\\?\\UNC\\")                                    // empty
+        test("\\\\?\\UNC\\")                                  // empty
             .invalid();
     }
 

--- a/test/jdk/java/nio/file/Path/PathOps.java
+++ b/test/jdk/java/nio/file/Path/PathOps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4313887 6838333 6925932 7006126 8037945 8072495 8140449 8254876
+ * @bug 4313887 6838333 6925932 7006126 8037945 8072495 8140449 8254876 8298478
  * @summary Unit test for java.nio.file.Path path operations
  */
 
@@ -1437,6 +1437,12 @@ public class PathOps {
         int h2 = test("c:\\FOO").path().hashCode();
         if (h1 != h2)
             throw new RuntimeException("PathOps failed");
+
+        // lnog path prefixes
+        test("\\\\?\\C:\\mnt\\file.dat")
+            .string("C:\\mnt\\file.dat");
+        test("\\\\?\\UNC\\server\\share\\dir\\file.dat")
+            .string("\\\\server\\share\\dir\\file.dat");
     }
 
     static void doUnixTests() {

--- a/test/jdk/java/nio/file/Path/PathOps.java
+++ b/test/jdk/java/nio/file/Path/PathOps.java
@@ -1438,11 +1438,29 @@ public class PathOps {
         if (h1 != h2)
             throw new RuntimeException("PathOps failed");
 
-        // lnog path prefixes
-        test("\\\\?\\C:\\mnt\\file.dat")
+        // long path prefixes
+        test("\\\\?\\C:\\mnt\\file.dat")  // absolute
             .string("C:\\mnt\\file.dat");
-        test("\\\\?\\UNC\\server\\share\\dir\\file.dat")
+        test("\\\\?\\\\\\server\\share\\dir\\file.dat")  // UNC
+            .invalid();
+        test("\\\\?\\file.dat")           // relative
+            .invalid();
+        test("\\\\?\\\\file.dat")         // directory-relative
+            .invalid();
+        test("\\\\?\\C:file.dat")         // drive-relative
+            .invalid();
+        test("\\\\?\\")                   // empty
+            .invalid();
+
+        // long UNC path prefixes
+        test("\\\\?\\UNC\\server\\share\\dir\\file.dat")      // UNC
             .string("\\\\server\\share\\dir\\file.dat");
+        test("\\\\?\\UNC\\server\\share\\C:\\mnt\\file.dat")  // absolute
+            .invalid();
+        test("\\\\?\\UNC\\server\\share\\C:file.dat")         // drive-relative
+            .invalid();
+        test("\\\\?\\UNC")                                    // empty
+            .invalid();
     }
 
     static void doUnixTests() {


### PR DESCRIPTION
Remove the long path `\\?\` or `\\?\UNC` prefix before creating the `WindowsPath` instance..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8302016](https://bugs.openjdk.org/browse/JDK-8302016) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8298478](https://bugs.openjdk.org/browse/JDK-8298478): (fs) Path.of should allow input to include long path prefix
 * [JDK-8302016](https://bugs.openjdk.org/browse/JDK-8302016): (fs) Path.of should allow input to include long path prefix (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12423/head:pull/12423` \
`$ git checkout pull/12423`

Update a local copy of the PR: \
`$ git checkout pull/12423` \
`$ git pull https://git.openjdk.org/jdk pull/12423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12423`

View PR using the GUI difftool: \
`$ git pr show -t 12423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12423.diff">https://git.openjdk.org/jdk/pull/12423.diff</a>

</details>
