### PR TITLE
8301820: C4819 warnings were reported on Windows

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -427,7 +427,7 @@ else
       CFLAGS := $(CFLAGS_JDKLIB) \
           $(BUILD_LIBFREETYPE_CFLAGS), \
       EXTRA_HEADER_DIRS := $(BUILD_LIBFREETYPE_HEADER_DIRS), \
-      DISABLED_WARNINGS_microsoft := 4267 4244 4996, \
+      DISABLED_WARNINGS_microsoft := 4267 4244 4819 4996, \
       DISABLED_WARNINGS_gcc := dangling-pointer stringop-overflow, \
       LDFLAGS := $(LDFLAGS_JDKLIB) \
           $(call SET_SHARED_LIBRARY_ORIGIN), \
@@ -467,7 +467,7 @@ else
        unused-result
    HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := class-memaccess
    HARFBUZZ_DISABLED_WARNINGS_clang := missing-field-initializers range-loop-analysis
-   HARFBUZZ_DISABLED_WARNINGS_microsoft := 4267 4244
+   HARFBUZZ_DISABLED_WARNINGS_microsoft := 4267 4244 4819
 
    LIBFONTMANAGER_CFLAGS += $(HARFBUZZ_CFLAGS)
 

--- a/src/hotspot/share/utilities/elfFile.hpp
+++ b/src/hotspot/share/utilities/elfFile.hpp
@@ -797,7 +797,7 @@ class DwarfFile : public ElfFile {
       uint32_t _line;
 
       // A column number within a source line. Columns are numbered beginning at 1. The value 0 is reserved to indicate
-      // that a statement begins at the “left edge” of the line.
+      // that a statement begins at the "left edge" of the line.
       uint32_t _column;
 
       // Indicates that the current instruction is a recommended breakpoint location.


### PR DESCRIPTION
C4819 warnings were reported when I tried to build JDK on Windows with VS2022.
This PR contains changes both HotSpot and client libraries. Let me know if they should be separated.

* HotSpot
    * stubGenerator_x86_64_poly.cpp
    * elfFile.hpp
* libfontmanager
    * hb.hh
* libfreetype
    * afblue.c

I added C4819 to `DISABLED_WARNINGS_microsoft` for libfontmanager and for libfreetype because they are 3rd-party libraries.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301820](https://bugs.openjdk.org/browse/JDK-8301820): C4819 warnings were reported on Windows


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12427/head:pull/12427` \
`$ git checkout pull/12427`

Update a local copy of the PR: \
`$ git checkout pull/12427` \
`$ git pull https://git.openjdk.org/jdk pull/12427/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12427`

View PR using the GUI difftool: \
`$ git pr show -t 12427`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12427.diff">https://git.openjdk.org/jdk/pull/12427.diff</a>

</details>
