### PR TITLE
8301834: Templated Buffer classes leave a lot of empty lines in the generated source

### DIFF
--- a/make/modules/java.base/gensrc/GensrcBuffer.gmk
+++ b/make/modules/java.base/gensrc/GensrcBuffer.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -161,7 +161,7 @@ define genBinOps
   $(call fixRw,$1,$4)
   $1_nbytes := $5
   $1_nbytesButOne := $6
-  $1_CMD := $(TOOL_SPP) \
+  $1_CMD := $(TOOL_SPP) -nel \
     -Dtype=$$($1_type) \
     -DType=$$($1_Type) \
     -Dfulltype=$$($1_fulltype) \
@@ -231,7 +231,7 @@ define SetupGenBuffer
 
   $$($1_DST): $$($1_DEP) $(GENSRC_BUFFER_DST)/_the.buffer.dir
 	$(RM) $$($1_OUT).tmp
-	$(TOOL_SPP) -i$$($1_SRC) -o$$($1_OUT).tmp \
+	$(TOOL_SPP) -i$$($1_SRC) -o$$($1_OUT).tmp -nel \
 	    -K$$($1_type) \
 	    -K$$($1_category) \
 	    -K$$($1_streams) \


### PR DESCRIPTION
Can I please get a review for this change which proposes to fix the issue noted in https://bugs.openjdk.org/browse/JDK-8301834?

Some classes in `java.nio` package are generated from template files, during the build. The template files are processed by a build tool implemented by a Java class `make/jdk/src/classes/build/tools/spp/Spp.java`. This template processing tool allows for an (optional) parameter called `-nel` which as per its documentation:

>  If -nel is declared then empty lines will not be substituted for lines of
>  text in the template that do not appear in the output.

Various places in the JDK build where this tool is used to generate source from template files, already use the `-nel` option to not generate the empty lines in the source files. However, the `GensrcBuffer.gmk` which generates the source for `java.nio` classes doesn't use this option. The commit in this PR adds this option when generating the `java.nio` classes.

Existing tests in `test/jdk/java/nio` continue to pass after this change. I've checked the generated content and compared it with the older versions to verify that these empty lines no longer appear in these generated classes.

Additional `tier` testing has been triggered to make sure no regression is introduced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301834](https://bugs.openjdk.org/browse/JDK-8301834): Templated Buffer classes leave a lot of empty lines in the generated source


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12431/head:pull/12431` \
`$ git checkout pull/12431`

Update a local copy of the PR: \
`$ git checkout pull/12431` \
`$ git pull https://git.openjdk.org/jdk pull/12431/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12431`

View PR using the GUI difftool: \
`$ git pr show -t 12431`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12431.diff">https://git.openjdk.org/jdk/pull/12431.diff</a>

</details>
