### PR TITLE
8301853: C4819 warnings were reported in HotSpot on Windows

### DIFF
--- a/src/hotspot/share/utilities/elfFile.hpp
+++ b/src/hotspot/share/utilities/elfFile.hpp
@@ -797,7 +797,7 @@ class DwarfFile : public ElfFile {
       uint32_t _line;
 
       // A column number within a source line. Columns are numbered beginning at 1. The value 0 is reserved to indicate
-      // that a statement begins at the “left edge” of the line.
+      // that a statement begins at the "left edge" of the line.
       uint32_t _column;
 
       // Indicates that the current instruction is a recommended breakpoint location.


### PR DESCRIPTION
This is subtask of #12427 .

I have seen C4819 warning in stubGenerator_x86_64_poly.cpp and elfFile.hpp in HotSpot on Windows (CP932: Japanese locale)

```
d:\github-forked\jdk\src\hotspot\cpu\x86\stubGenerator_x86_64_poly.cpp(1): error C2220: 次の警告はエラーとして処理されます
d:\github-forked\jdk\src\hotspot\cpu\x86\stubGenerator_x86_64_poly.cpp(1): warning C4819: ファイルは、現在のコード ページ (932) で表示できない文字を含んでいます。データの損失を防ぐために、ファイルを Unicode 形式で保存してください。
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301853](https://bugs.openjdk.org/browse/JDK-8301853): C4819 warnings were reported in HotSpot on Windows


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12435/head:pull/12435` \
`$ git checkout pull/12435`

Update a local copy of the PR: \
`$ git checkout pull/12435` \
`$ git pull https://git.openjdk.org/jdk pull/12435/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12435`

View PR using the GUI difftool: \
`$ git pr show -t 12435`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12435.diff">https://git.openjdk.org/jdk/pull/12435.diff</a>

</details>
