### PR TITLE
8301854: C4819 warnings were reported in libfreetype on Windows

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -427,7 +427,7 @@ else
       CFLAGS := $(CFLAGS_JDKLIB) \
           $(BUILD_LIBFREETYPE_CFLAGS), \
       EXTRA_HEADER_DIRS := $(BUILD_LIBFREETYPE_HEADER_DIRS), \
-      DISABLED_WARNINGS_microsoft := 4267 4244 4996, \
+      DISABLED_WARNINGS_microsoft := 4267 4244 4819 4996, \
       DISABLED_WARNINGS_gcc := dangling-pointer stringop-overflow, \
       LDFLAGS := $(LDFLAGS_JDKLIB) \
           $(call SET_SHARED_LIBRARY_ORIGIN), \


### PR DESCRIPTION
This is subtask of https://github.com/openjdk/jdk/pull/12427 .

I have seen C4819 warning in libfreetype files on Windows (CP932: Japanese locale)

```
d:\github-forked\jdk\src\java.desktop\share\native\libfreetype\src\autofit\afscript.h(1): warning C4819: ファイルは、現在のコード ページ (932) で表示できない文字を含んでいます。データの損失を防ぐために、ファイルを Unicode 形式で保存してください。
```

I added C4819 to DISABLED_WARNINGS_microsoft for libfontmanager and for libfreetype because they are 3rd-party libraries.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301854](https://bugs.openjdk.org/browse/JDK-8301854): C4819 warnings were reported in libfreetype on Windows


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12436/head:pull/12436` \
`$ git checkout pull/12436`

Update a local copy of the PR: \
`$ git checkout pull/12436` \
`$ git pull https://git.openjdk.org/jdk pull/12436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12436`

View PR using the GUI difftool: \
`$ git pr show -t 12436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12436.diff">https://git.openjdk.org/jdk/pull/12436.diff</a>

</details>
