### PR TITLE
8301855: C4819 warnings were reported in harfbuzz on Windows

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -467,7 +467,7 @@ else
        unused-result
    HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := class-memaccess
    HARFBUZZ_DISABLED_WARNINGS_clang := missing-field-initializers range-loop-analysis
-   HARFBUZZ_DISABLED_WARNINGS_microsoft := 4267 4244
+   HARFBUZZ_DISABLED_WARNINGS_microsoft := 4267 4244 4819
 
    LIBFONTMANAGER_CFLAGS += $(HARFBUZZ_CFLAGS)
 


### PR DESCRIPTION
This is subtask of https://github.com/openjdk/jdk/pull/12427 .

I have seen C4819 warning in harfbuzz files on Windows (CP932: Japanese locale)

```
d:\github-forked\jdk\src\java.desktop\share\native\libharfbuzz\hb.hh(1): error C2220: 次の警告はエラーとして処理されます
d:\github-forked\jdk\src\java.desktop\share\native\libharfbuzz\hb.hh(1): warning C4819: ファイルは、現在のコード ページ (932) で表示できない文字を含んでいます。データの損失を防ぐために、ファイルを Unicode 形式で保存してください。
```

I added C4819 to DISABLED_WARNINGS_microsoft for libfontmanager and for libfreetype because they are 3rd-party libraries.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301855](https://bugs.openjdk.org/browse/JDK-8301855): C4819 warnings were reported in harfbuzz on Windows


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12437/head:pull/12437` \
`$ git checkout pull/12437`

Update a local copy of the PR: \
`$ git checkout pull/12437` \
`$ git pull https://git.openjdk.org/jdk pull/12437/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12437`

View PR using the GUI difftool: \
`$ git pr show -t 12437`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12437.diff">https://git.openjdk.org/jdk/pull/12437.diff</a>

</details>
