### PR TITLE
8301858: Verification error when compiling switch with record patterns

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -740,7 +740,7 @@ public class TransPatterns extends TreeTranslator {
                         List<JCCaseLabel> newLabel;
                         if (hasUnconditional) {
                             newLabel = List.of(make.ConstantCaseLabel(makeNull()),
-                                               make.DefaultCaseLabel());
+                                    make.PatternCaseLabel(binding, newGuard));
                         } else {
                             newLabel = List.of(make.PatternCaseLabel(binding, newGuard));
                         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -539,10 +539,10 @@ public class TransPatterns extends TreeTranslator {
                                     pattern = parenthesized.pattern;
                                 }
                                 Assert.check(pattern.hasTag(Tag.BINDINGPATTERN));
-                                VarSymbol binding = ((JCBindingPattern) pattern).var.sym;
+                                BindingSymbol binding = (BindingSymbol) ((JCBindingPattern) pattern).var.sym;
                                 guard = makeBinary(Tag.OR,
                                                    makeBinary(Tag.EQ,
-                                                              make.Ident(binding),
+                                                              make.Ident(bindingContext.getBindingFor(binding)),
                                                               makeNull()),
                                                    guard);
                             }

--- a/test/langtools/tools/javac/patterns/DeconstructionDesugaring.java
+++ b/test/langtools/tools/javac/patterns/DeconstructionDesugaring.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8291769
+ * @bug 8291769 8301858
  * @summary Verify more complex switches work properly
  * @compile --enable-preview -source ${jdk.version} DeconstructionDesugaring.java
  * @run main/othervm --enable-preview DeconstructionDesugaring

--- a/test/langtools/tools/javac/patterns/DeconstructionDesugaring.java
+++ b/test/langtools/tools/javac/patterns/DeconstructionDesugaring.java
@@ -43,6 +43,8 @@ public class DeconstructionDesugaring {
         assertEquals(runCheckExpressionWithUnconditional(new R5(new R4(null))), 3);
         assertEquals(runCheckExpressionWithUnconditional1(new R5(new R4(null))), 2);
         assertEquals(runCheckExpressionWithUnconditional1(new R5(null)), 3);
+        assertEquals(runCheckExpressionWithUnconditionalAndParams(new R1(42)), 1);
+        assertEquals(runCheckExpressionWithUnconditionalAndParams(new R1(new Object())), 2);
     }
 
     private void test(ToIntFunction<Object> task) {
@@ -102,6 +104,17 @@ public class DeconstructionDesugaring {
             case R5(Object obj) -> 3;
         };
     }
+
+    public static int runCheckExpressionWithUnconditionalAndParams(R1 r) {
+        switch (r) {
+            case R1(Integer i):
+                return meth_I(i);
+            case R1(Object o):
+                return meth_O(o);
+        }
+    }
+    public static int meth_I(Integer i) { return 1; }
+    public static int meth_O(Object o) { return 2;}
 
     private void assertEquals(int expected, int actual) {
         if (expected != actual) {


### PR DESCRIPTION
When unrolling/translating record patterns with an unconditional case, we were translating the last/innermost case to`case null, default` skipping the initialization of a bound variable `o` in the example below:

    switch (..) {
      case R1(Object o):
                      return meth_O(o); 
    }
    => 
    switch (..) {
       case R1: 
          switch(..) {
            case null, default:
                            return meth_O(o);
          }
    }

This PR addresses that by emitting the correct label instead of default.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301858](https://bugs.openjdk.org/browse/JDK-8301858): Verification error when compiling switch with record patterns


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12438/head:pull/12438` \
`$ git checkout pull/12438`

Update a local copy of the PR: \
`$ git checkout pull/12438` \
`$ git pull https://git.openjdk.org/jdk pull/12438/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12438`

View PR using the GUI difftool: \
`$ git pr show -t 12438`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12438.diff">https://git.openjdk.org/jdk/pull/12438.diff</a>

</details>
