### PR TITLE
8301862: G1: Remove G1PageBasedVirtualSpace::_executable

### DIFF
--- a/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.cpp
+++ b/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.cpp
@@ -36,7 +36,8 @@
 
 G1PageBasedVirtualSpace::G1PageBasedVirtualSpace(ReservedSpace rs, size_t used_size, size_t page_size) :
   _low_boundary(NULL), _high_boundary(NULL), _tail_size(0), _page_size(0),
-  _committed(mtGC), _dirty(mtGC), _special(false), _executable(false) {
+  _committed(mtGC), _dirty(mtGC), _special(false) {
+  assert(!rs.executable(), "precondition");
   initialize_with_page_size(rs, used_size, page_size);
 }
 
@@ -59,7 +60,6 @@ void G1PageBasedVirtualSpace::initialize_with_page_size(ReservedSpace rs, size_t
   _high_boundary = _low_boundary + used_size;
 
   _special = rs.special();
-  _executable = rs.executable();
 
   _page_size = page_size;
 
@@ -79,7 +79,6 @@ G1PageBasedVirtualSpace::~G1PageBasedVirtualSpace() {
   _low_boundary           = NULL;
   _high_boundary          = NULL;
   _special                = false;
-  _executable             = false;
   _page_size              = 0;
   _tail_size              = 0;
 }
@@ -140,14 +139,14 @@ void G1PageBasedVirtualSpace::commit_preferred_pages(size_t start, size_t num_pa
   char* start_addr = page_start(start);
   size_t size = num_pages * _page_size;
 
-  os::commit_memory_or_exit(start_addr, size, _page_size, _executable, "G1 virtual space");
+  os::commit_memory_or_exit(start_addr, size, _page_size, false, "G1 virtual space");
 }
 
 void G1PageBasedVirtualSpace::commit_tail() {
   vmassert(_tail_size > 0, "The size of the tail area must be > 0 when reaching here");
 
   char* const aligned_end_address = align_down(_high_boundary, _page_size);
-  os::commit_memory_or_exit(aligned_end_address, _tail_size, os::vm_page_size(), _executable, "G1 virtual space");
+  os::commit_memory_or_exit(aligned_end_address, _tail_size, os::vm_page_size(), false, "G1 virtual space");
 }
 
 void G1PageBasedVirtualSpace::commit_internal(size_t start_page, size_t end_page) {

--- a/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.hpp
+++ b/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.hpp
@@ -71,9 +71,6 @@ class G1PageBasedVirtualSpace {
   // os::commit_memory() or os::uncommit_memory() have no function.
   bool _special;
 
-  // Indicates whether the committed space should be executable.
-  bool _executable;
-
   // Helper function for committing memory. Commit the given memory range by using
   // _page_size pages as much as possible and the remainder with small sized pages.
   void commit_internal(size_t start_page, size_t end_page);


### PR DESCRIPTION
Simple removing an effectively unused field.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301862](https://bugs.openjdk.org/browse/JDK-8301862): G1: Remove G1PageBasedVirtualSpace::_executable


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Leo Korinth](https://openjdk.org/census#lkorinth) (@lkorinth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12439/head:pull/12439` \
`$ git checkout pull/12439`

Update a local copy of the PR: \
`$ git checkout pull/12439` \
`$ git pull https://git.openjdk.org/jdk pull/12439/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12439`

View PR using the GUI difftool: \
`$ git pr show -t 12439`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12439.diff">https://git.openjdk.org/jdk/pull/12439.diff</a>

</details>
