### PR TITLE
8296646: com/sun/jdi/JdbLastErrorTest.java test failure

### DIFF
--- a/test/jdk/com/sun/jdi/JdbLastErrorTest.java
+++ b/test/jdk/com/sun/jdi/JdbLastErrorTest.java
@@ -95,7 +95,7 @@ public class JdbLastErrorTest extends JdbTest {
         jdb.command(runCommand);
         // Good lastError should be reported in debuggee output:
         new OutputAnalyzer(getDebuggeeOutput()).shouldMatch("lastError = " + Integer.toString(TestNativeLastError.VALUE));
-	// Exception would be captured in jdb output:
+        // Exception would be captured in jdb output:
         new OutputAnalyzer(jdb.getJdbOutput()).shouldNotMatch("failed, lastError = ");
     }
 }

--- a/test/jdk/com/sun/jdi/JdbLastErrorTest.java
+++ b/test/jdk/com/sun/jdi/JdbLastErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8292302
  * @summary Test persistence of native last error value under jdb (Windows)
- * @requires (os.family == "windows") & (vm.compMode != "Xcomp") & (vm.compMode != "Xint")
+ * @requires (os.family == "windows") & (vm.compMode != "Xcomp") & (vm.compMode != "Xint") & (vm.gc != "Z")
  * @library /test/lib
  * @enablePreview
  * @run main/othervm JdbLastErrorTest
@@ -63,8 +63,9 @@ class TestNativeLastError {
         for (int i = 0; i < 10; i++) {
             setLastError.invoke(VALUE);
             int lastError = (int) getLastError.invoke();
-            System.out.println(lastError);
+            System.out.println("lastError = " + lastError);
             if (lastError != VALUE) {
+                System.err.println("iteration " + i + " gets lastError = " + lastError);
                 throw new RuntimeException("failed, lastError = " + lastError);
             }
         }
@@ -92,7 +93,9 @@ public class JdbLastErrorTest extends JdbTest {
         JdbCommand runCommand = JdbCommand.run();
         runCommand.allowExit();
         jdb.command(runCommand);
-        new OutputAnalyzer(jdb.getJdbOutput()).shouldMatch("The application exited");
+        // Good lastError should be reported in debuggee output:
+        new OutputAnalyzer(getDebuggeeOutput()).shouldMatch("lastError = " + Integer.toString(TestNativeLastError.VALUE));
+	// Exception would be captured in jdb output:
         new OutputAnalyzer(jdb.getJdbOutput()).shouldNotMatch("failed, lastError = ");
     }
 }

--- a/test/jdk/com/sun/jdi/JdbLastErrorTest.java
+++ b/test/jdk/com/sun/jdi/JdbLastErrorTest.java
@@ -65,7 +65,8 @@ class TestNativeLastError {
             int lastError = (int) getLastError.invoke();
             System.out.println("lastError = " + lastError);
             if (lastError != VALUE) {
-                System.err.println("iteration " + i + " gets lastError = " + lastError);
+                System.err.println("iteration " + i + " got lastError = " + lastError
+                                   + " (expected " + VALUE + ")");
                 throw new RuntimeException("failed, lastError = " + lastError);
             }
         }


### PR DESCRIPTION
This test fails sometimes with ZGC. It is testing using Panama to access Windows' last error value, and can of course be interrupted by VM work that changes the value, but it does generally work. Skipping the test with ZGC is reasonable as you don't really _have_ to step through this kind of Panama code with ZGC.

More rare is a failure where "The application exited" is not observed.  This test is not here to test the exit mode, and logging that failure avoids telling you whether the correct lastError value was seen.  Test should prioritise saying if the correct last error value was observed, and should check for the exception being thrown when the correct value is not seen.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296646](https://bugs.openjdk.org/browse/JDK-8296646): com/sun/jdi/JdbLastErrorTest.java  test failure


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [e37f1e73](https://git.openjdk.org/jdk/pull/12441/files/e37f1e73973df7aa58185163567a70528458d65b)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [e37f1e73](https://git.openjdk.org/jdk/pull/12441/files/e37f1e73973df7aa58185163567a70528458d65b)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [e37f1e73](https://git.openjdk.org/jdk/pull/12441/files/e37f1e73973df7aa58185163567a70528458d65b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12441/head:pull/12441` \
`$ git checkout pull/12441`

Update a local copy of the PR: \
`$ git checkout pull/12441` \
`$ git pull https://git.openjdk.org/jdk pull/12441/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12441`

View PR using the GUI difftool: \
`$ git pr show -t 12441`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12441.diff">https://git.openjdk.org/jdk/pull/12441.diff</a>

</details>
