### PR TITLE
7167356: (javac) investigate failing tests in JavacParserTest

### DIFF
--- a/test/langtools/tools/javac/parser/JavacParserTest.java
+++ b/test/langtools/tools/javac/parser/JavacParserTest.java
@@ -866,11 +866,7 @@ public class JavacParserTest extends TestCase {
                 + expectedValues, values, expectedValues);
     }
 
-    /*
-     * The following tests do not work just yet with nb-javac nor javac,
-     * they need further investigation, see CR: 7167356
-     */
-
+    @Test
     void testPositionBrokenSource126732a() throws IOException {
         String[] commands = new String[]{
             "return Runnable()",
@@ -910,6 +906,7 @@ public class JavacParserTest extends TestCase {
         }
     }
 
+    @Test
     void testPositionBrokenSource126732b() throws IOException {
         String[] commands = new String[]{
             "break",
@@ -951,6 +948,7 @@ public class JavacParserTest extends TestCase {
         }
     }
 
+    @Test
     void testStartPositionEnumConstantInit() throws IOException {
 
         String code = "package t; enum Test { AAA; }";
@@ -964,7 +962,7 @@ public class JavacParserTest extends TestCase {
         int start = (int) t.getSourcePositions().getStartPosition(cut,
                 enumAAA.getInitializer());
 
-        assertEquals("testStartPositionEnumConstantInit", -1, start);
+        assertEquals("testStartPositionEnumConstantInit", 23, start);
     }
 
     @Test


### PR DESCRIPTION
This bug, created back in 2012, notes that three of the unit `@Test`s in `parser/JavacParserTest.java` are disabled because the functionality they verify was not yet implemented correctly at that time.

That was a long time ago, and since then the functionality has been fixed and the tests are now working properly, so they can be enabled at long last.

The third test also needs to be adjusted in order to succeed. It was (for some reason) expecting that an `enum` constant's source position would be reported as offset -1, instead of its actual source position (in this case, 23).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-7167356](https://bugs.openjdk.org/browse/JDK-7167356): (javac) investigate failing tests in JavacParserTest


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12444/head:pull/12444` \
`$ git checkout pull/12444`

Update a local copy of the PR: \
`$ git checkout pull/12444` \
`$ git pull https://git.openjdk.org/jdk pull/12444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12444`

View PR using the GUI difftool: \
`$ git pr show -t 12444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12444.diff">https://git.openjdk.org/jdk/pull/12444.diff</a>

</details>
