### PR TITLE
8301942: java/net/httpclient/DigestEchoClientSSL.java fail with -Xcomp

### DIFF
--- a/test/jdk/java/net/httpclient/DigestEchoClient.java
+++ b/test/jdk/java/net/httpclient/DigestEchoClient.java
@@ -507,7 +507,7 @@ public class DigestEchoClient {
                 System.gc();
                 if (queue.remove(100) == ref) break;
             }
-            var error = TRACKER.checkShutdown(500);
+            var error = TRACKER.checkShutdown(900);
             if (error != null) throw error;
         }
         System.out.println("OK");


### PR DESCRIPTION
This test failed with VM_OPTIONS=-Xcomp and CONF=fastdebug on the LOONGARCH64 architecture.

java.lang.AssertionError: WARNING: tracker for HttpClientImpl(1) has outstanding operations:
    Pending HTTP Requests: 0
    Pending HTTP/1.1 operations: 0
    Pending HTTP/2 streams: 0
    Pending WebSocket operations: 0
    Pending TCP connections: 1
    Total pending operations: 0
    Facade referenced: false
    Selector alive: true
Found 0 client still active, with 0 operations still pending out of 1 tracked clients.


This PR fix the issue, Please help review it.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301942](https://bugs.openjdk.org/browse/JDK-8301942): java/net/httpclient/DigestEchoClientSSL.java fail with -Xcomp


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12449/head:pull/12449` \
`$ git checkout pull/12449`

Update a local copy of the PR: \
`$ git checkout pull/12449` \
`$ git pull https://git.openjdk.org/jdk pull/12449/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12449`

View PR using the GUI difftool: \
`$ git pr show -t 12449`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12449.diff">https://git.openjdk.org/jdk/pull/12449.diff</a>

</details>
