### PR TITLE
8301838: PPC: continuation yield intrinsic: exception check not needed if yield succeeded

### DIFF
--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -1980,7 +1980,7 @@ static void gen_continuation_yield(MacroAssembler* masm,
 
   Label L_pinned;
 
-  __ cmpdi(CCR0, R3_RET, 0);
+  __ cmpwi(CCR0, R3_RET, 0);
   __ bne(CCR0, L_pinned);
 
   // yield succeeded

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -1983,10 +1983,18 @@ static void gen_continuation_yield(MacroAssembler* masm,
   __ cmpdi(CCR0, R3_RET, 0);
   __ bne(CCR0, L_pinned);
 
+  // yield succeeded
+
   // Pop frames of continuation including this stub's frame
   __ ld_ptr(R1_SP, JavaThread::cont_entry_offset(), R16_thread);
   // The frame pushed by gen_continuation_enter is on top now again
   continuation_enter_cleanup(masm);
+
+  // Pop frame and return
+  __ pop_frame();
+  __ ld(R0, _abi0(lr), R1_SP); // Return pc
+  __ mtlr(R0);
+  __ blr();
 
   __ bind(L_pinned); // pinned -- return to caller
 

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -1991,31 +1991,27 @@ static void gen_continuation_yield(MacroAssembler* masm,
   continuation_enter_cleanup(masm);
 
   // Pop frame and return
+  Label L_return;
+  __ bind(L_return);
   __ pop_frame();
   __ ld(R0, _abi0(lr), R1_SP); // Return pc
   __ mtlr(R0);
   __ blr();
 
-  __ bind(L_pinned); // pinned -- return to caller
+  // yield failed - continuation is pinned
+
+  __ bind(L_pinned);
 
   // handle pending exception thrown by freeze
-  Label ok;
   __ ld(tmp, in_bytes(JavaThread::pending_exception_offset()), R16_thread);
   __ cmpdi(CCR0, tmp, 0);
-  __ beq(CCR0, ok);
+  __ beq(CCR0, L_return); // return if no exception is pending
   __ pop_frame();
   __ ld(R0, _abi0(lr), R1_SP); // Return pc
   __ mtlr(R0);
   __ load_const_optimized(tmp, StubRoutines::forward_exception_entry(), R0);
   __ mtctr(tmp);
   __ bctr();
-  __ bind(ok);
-
-  // Pop frame and return
-  __ pop_frame();
-  __ ld(R0, _abi0(lr), R1_SP); // Return pc
-  __ mtlr(R0);
-  __ blr();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
This small enhancement let's the continuation yield intrinsic return if the yield succeeded.
Doing so is ok because there will never be a pending exception if the yield succeeded.

All continuation tests succeeded.

GHA: some cross compiles failed because packages could not be downloaded. I tried to restart these but that didn't work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301838](https://bugs.openjdk.org/browse/JDK-8301838): PPC: continuation yield intrinsic: exception check not needed if yield succeeded


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12450/head:pull/12450` \
`$ git checkout pull/12450`

Update a local copy of the PR: \
`$ git checkout pull/12450` \
`$ git pull https://git.openjdk.org/jdk pull/12450/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12450`

View PR using the GUI difftool: \
`$ git pr show -t 12450`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12450.diff">https://git.openjdk.org/jdk/pull/12450.diff</a>

</details>
