### PR TITLE
8301964: Expensive fillInStackTrace operation in HttpURLConnection.getLastModified when no last-modified in response

### DIFF
--- a/src/java.base/share/classes/java/net/HttpURLConnection.java
+++ b/src/java.base/share/classes/java/net/HttpURLConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -601,12 +601,14 @@ public abstract class HttpURLConnection extends URLConnection {
     @SuppressWarnings("deprecation")
     public long getHeaderFieldDate(String name, long Default) {
         String dateString = getHeaderField(name);
-        try {
+        if (dateString != null) {
             if (!dateString.contains("GMT")) {
-                dateString = dateString+" GMT";
+                dateString = dateString + " GMT";
             }
-            return Date.parse(dateString);
-        } catch (Exception e) {
+            try {
+                return Date.parse(dateString);
+            } catch (Exception e) {
+            }
         }
         return Default;
     }

--- a/src/java.base/share/classes/java/net/HttpURLConnection.java
+++ b/src/java.base/share/classes/java/net/HttpURLConnection.java
@@ -599,7 +599,7 @@ public abstract class HttpURLConnection extends URLConnection {
     }
 
     @SuppressWarnings("deprecation")
-    public long getHeaderFieldDate(String name, long Default) {
+    public long getHeaderFieldDate(String name, long defaultValue) {
         String dateString = getHeaderField(name);
         if (dateString != null) {
             if (!dateString.contains("GMT")) {
@@ -610,7 +610,7 @@ public abstract class HttpURLConnection extends URLConnection {
             } catch (Exception e) {
             }
         }
-        return Default;
+        return defaultValue;
     }
 
 

--- a/src/java.base/share/classes/java/net/URLConnection.java
+++ b/src/java.base/share/classes/java/net/URLConnection.java
@@ -612,20 +612,20 @@ public abstract class URLConnection {
      * headers. Classes for that connection type can override this method
      * and short-circuit the parsing.
      *
-     * @param   name      the name of the header field.
-     * @param   Default   the default value.
+     * @param   name          the name of the header field.
+     * @param   defaultValue  the default value.
      * @return  the value of the named field, parsed as an integer. The
-     *          {@code Default} value is returned if the field is
+     *          {@code defaultValue} value is returned if the field is
      *          missing or malformed.
      */
-    public int getHeaderFieldInt(String name, int Default) {
+    public int getHeaderFieldInt(String name, int defaultValue) {
         final String value = getHeaderField(name);
         if (value != null) {
             try {
                 return Integer.parseInt(value);
             } catch (NumberFormatException e) { }
         }
-        return Default;
+        return defaultValue;
     }
 
     /**
@@ -636,21 +636,21 @@ public abstract class URLConnection {
      * headers. Classes for that connection type can override this method
      * and short-circuit the parsing.
      *
-     * @param   name      the name of the header field.
-     * @param   Default   the default value.
+     * @param   name          the name of the header field.
+     * @param   defaultValue  the default value.
      * @return  the value of the named field, parsed as a long. The
-     *          {@code Default} value is returned if the field is
+     *          {@code defaultValue} value is returned if the field is
      *          missing or malformed.
      * @since 1.7
      */
-    public long getHeaderFieldLong(String name, long Default) {
+    public long getHeaderFieldLong(String name, long defaultValue) {
         final String value = getHeaderField(name);
         if (value != null) {
             try {
                 return Long.parseLong(value);
             } catch (NumberFormatException e) { }
         }
-        return Default;
+        return defaultValue;
     }
 
     /**
@@ -663,21 +663,21 @@ public abstract class URLConnection {
      * headers. Classes for that connection type can override this method
      * and short-circuit the parsing.
      *
-     * @param   name     the name of the header field.
-     * @param   Default   a default value.
+     * @param   name          the name of the header field.
+     * @param   defaultValue  a default value.
      * @return  the value of the field, parsed as a date. The value of the
-     *          {@code Default} argument is returned if the field is
+     *          {@code defaultValue} argument is returned if the field is
      *          missing or malformed.
      */
     @SuppressWarnings("deprecation")
-    public long getHeaderFieldDate(String name, long Default) {
+    public long getHeaderFieldDate(String name, long defaultValue) {
         final String value = getHeaderField(name);
         if (value != null) {
             try {
                 return Date.parse(value);
             } catch (Exception e) { }
         }
-        return Default;
+        return defaultValue;
     }
 
     /**

--- a/src/java.base/share/classes/java/net/URLConnection.java
+++ b/src/java.base/share/classes/java/net/URLConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@ import java.util.Hashtable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.Date;
 import java.util.Iterator;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;

--- a/src/java.base/share/classes/sun/net/www/protocol/https/HttpsURLConnectionImpl.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/HttpsURLConnectionImpl.java
@@ -352,8 +352,8 @@ public class HttpsURLConnectionImpl
         return delegate.getResponseMessage();
     }
 
-    public long getHeaderFieldDate(String name, long Default) {
-        return delegate.getHeaderFieldDate(name, Default);
+    public long getHeaderFieldDate(String name, long defaultValue) {
+        return delegate.getHeaderFieldDate(name, defaultValue);
     }
 
     public Permission getPermission() throws IOException {
@@ -392,12 +392,12 @@ public class HttpsURLConnectionImpl
         return delegate.getLastModified();
     }
 
-    public int getHeaderFieldInt(String name, int Default) {
-        return delegate.getHeaderFieldInt(name, Default);
+    public int getHeaderFieldInt(String name, int defaultValue) {
+        return delegate.getHeaderFieldInt(name, defaultValue);
     }
 
-    public long getHeaderFieldLong(String name, long Default) {
-        return delegate.getHeaderFieldLong(name, Default);
+    public long getHeaderFieldLong(String name, long defaultValue) {
+        return delegate.getHeaderFieldLong(name, defaultValue);
     }
 
     public Object getContent() throws IOException {

--- a/src/java.base/share/classes/sun/net/www/protocol/https/HttpsURLConnectionImpl.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/HttpsURLConnectionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,6 @@ import java.util.Map;
 import java.util.List;
 import java.util.Optional;
 import sun.net.util.IPAddressUtil;
-import sun.net.www.http.HttpClient;
 
 /**
  * A class to represent an HTTP connection to a remote object.


### PR DESCRIPTION
[JDK-8297211](https://bugs.openjdk.org/browse/JDK-8297211) (#11258) missed one case with date headers: `last-modified`, `date`, `expires`. We can avoid expensive NPE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301964](https://bugs.openjdk.org/browse/JDK-8301964): Expensive fillInStackTrace operation in HttpURLConnection.getLastModified when no last-modified in response


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to [b836a2c3](https://git.openjdk.org/jdk/pull/12451/files/b836a2c3e89ec9e48ef9ca27bd50cb7c68fdd350)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [b836a2c3](https://git.openjdk.org/jdk/pull/12451/files/b836a2c3e89ec9e48ef9ca27bd50cb7c68fdd350)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12451/head:pull/12451` \
`$ git checkout pull/12451`

Update a local copy of the PR: \
`$ git checkout pull/12451` \
`$ git pull https://git.openjdk.org/jdk pull/12451/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12451`

View PR using the GUI difftool: \
`$ git pr show -t 12451`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12451.diff">https://git.openjdk.org/jdk/pull/12451.diff</a>

</details>
