### PR TITLE
JDK-8301983: Refactor MEMFLAGS and AllocFailStrategy

### DIFF
--- a/src/hotspot/share/gc/g1/g1BatchedTask.hpp
+++ b/src/hotspot/share/gc/g1/g1BatchedTask.hpp
@@ -29,7 +29,7 @@
 #include "gc/shared/workerThread.hpp"
 #include "memory/allocation.hpp"
 
-template <typename E, MEMFLAGS F>
+template <typename E, MemoryType F>
 class GrowableArrayCHeap;
 
 // G1AbstractSubTask represents a task to be performed either within a

--- a/src/hotspot/share/gc/g1/g1MonotonicArena.cpp
+++ b/src/hotspot/share/gc/g1/g1MonotonicArena.cpp
@@ -29,7 +29,7 @@
 #include "runtime/vmOperations.hpp"
 #include "utilities/globalCounter.inline.hpp"
 
-G1MonotonicArena::Segment::Segment(uint slot_size, uint num_slots, Segment* next, MEMFLAGS flag) :
+G1MonotonicArena::Segment::Segment(uint slot_size, uint num_slots, Segment* next, MemoryType flag) :
   _slot_size(slot_size),
   _num_slots(num_slots),
   _next(next),
@@ -41,7 +41,7 @@ G1MonotonicArena::Segment::Segment(uint slot_size, uint num_slots, Segment* next
 G1MonotonicArena::Segment* G1MonotonicArena::Segment::create_segment(uint slot_size,
                                                                      uint num_slots,
                                                                      Segment* next,
-                                                                     MEMFLAGS mem_flag) {
+                                                                     MemoryType mem_flag) {
   size_t block_size = size_in_bytes(slot_size, num_slots);
   char* alloc_block = NEW_C_HEAP_ARRAY(char, block_size, mem_flag);
   return new (alloc_block) Segment(slot_size, num_slots, next, mem_flag);

--- a/src/hotspot/share/gc/g1/g1MonotonicArena.hpp
+++ b/src/hotspot/share/gc/g1/g1MonotonicArena.hpp
@@ -120,7 +120,7 @@ class G1MonotonicArena::Segment {
   // to _num_slots (can be larger because we atomically increment this value and
   // check only afterwards if the allocation has been successful).
   uint volatile _next_allocate;
-  const MEMFLAGS _mem_flag;
+  const MemoryType _mem_flag;
 
   char* _bottom;  // Actual data.
   // Do not add class member variables beyond this point
@@ -136,7 +136,7 @@ class G1MonotonicArena::Segment {
 
   NONCOPYABLE(Segment);
 
-  Segment(uint slot_size, uint num_slots, Segment* next, MEMFLAGS flag);
+  Segment(uint slot_size, uint num_slots, Segment* next, MemoryType flag);
   ~Segment() = default;
 public:
   Segment* volatile* next_addr() { return &_next; }
@@ -173,7 +173,7 @@ public:
     return header_size() + payload_size(slot_size, num_slots);
   }
 
-  static Segment* create_segment(uint slot_size, uint num_slots, Segment* next, MEMFLAGS mem_flag);
+  static Segment* create_segment(uint slot_size, uint num_slots, Segment* next, MemoryType mem_flag);
   static void delete_segment(Segment* segment);
 
   // Copies the contents of this segment into the destination.
@@ -222,7 +222,7 @@ public:
 class G1MonotonicArena::AllocOptions {
 
 protected:
-  const MEMFLAGS _mem_flag;
+  const MemoryType _mem_flag;
   const uint _slot_size;
   const uint _initial_num_slots;
   // Defines a limit to the number of slots in the segment
@@ -230,7 +230,7 @@ protected:
   const uint _slot_alignment;
 
 public:
-  AllocOptions(MEMFLAGS mem_flag, uint slot_size, uint initial_num_slots, uint max_num_slots, uint alignment) :
+  AllocOptions(MemoryType mem_flag, uint slot_size, uint initial_num_slots, uint max_num_slots, uint alignment) :
     _mem_flag(mem_flag),
     _slot_size(align_up(slot_size, alignment)),
     _initial_num_slots(initial_num_slots),
@@ -250,7 +250,7 @@ public:
 
   uint slot_alignment() const { return _slot_alignment; }
 
-  MEMFLAGS mem_flag() const {return _mem_flag; }
+  MemoryType mem_flag() const {return _mem_flag; }
 };
 
 #endif //SHARE_GC_G1_MONOTONICARENA_HPP

--- a/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp
+++ b/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp
@@ -40,7 +40,7 @@ G1RegionToSpaceMapper::G1RegionToSpaceMapper(ReservedSpace rs,
                                              size_t page_size,
                                              size_t region_granularity,
                                              size_t commit_factor,
-                                             MEMFLAGS type) :
+                                             MemoryType type) :
   _listener(NULL),
   _storage(rs, used_size, page_size),
   _region_granularity(region_granularity),
@@ -73,7 +73,7 @@ class G1RegionsLargerThanCommitSizeMapper : public G1RegionToSpaceMapper {
                                       size_t page_size,
                                       size_t alloc_granularity,
                                       size_t commit_factor,
-                                      MEMFLAGS type) :
+                                      MemoryType type) :
     G1RegionToSpaceMapper(rs, actual_size, page_size, alloc_granularity, commit_factor, type),
     _pages_per_region(alloc_granularity / (page_size * commit_factor)) {
 
@@ -165,7 +165,7 @@ class G1RegionsSmallerThanCommitSizeMapper : public G1RegionToSpaceMapper {
                                        size_t page_size,
                                        size_t alloc_granularity,
                                        size_t commit_factor,
-                                       MEMFLAGS type) :
+                                       MemoryType type) :
     G1RegionToSpaceMapper(rs, actual_size, page_size, alloc_granularity, commit_factor, type),
     _regions_per_page((page_size * commit_factor) / alloc_granularity),
     _lock(Mutex::service-3, "G1Mapper_lock") {
@@ -264,7 +264,7 @@ G1RegionToSpaceMapper* G1RegionToSpaceMapper::create_mapper(ReservedSpace rs,
                                                             size_t page_size,
                                                             size_t region_granularity,
                                                             size_t commit_factor,
-                                                            MEMFLAGS type) {
+                                                            MemoryType type) {
   if (region_granularity >= (page_size * commit_factor)) {
     return new G1RegionsLargerThanCommitSizeMapper(rs, actual_size, page_size, region_granularity, commit_factor, type);
   } else {

--- a/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.hpp
+++ b/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.hpp
@@ -53,9 +53,9 @@ class G1RegionToSpaceMapper : public CHeapObj<mtGC> {
   // Mapping management
   CHeapBitMap _region_commit_map;
 
-  MEMFLAGS _memory_type;
+  MemoryType _memory_type;
 
-  G1RegionToSpaceMapper(ReservedSpace rs, size_t used_size, size_t page_size, size_t region_granularity, size_t commit_factor, MEMFLAGS type);
+  G1RegionToSpaceMapper(ReservedSpace rs, size_t used_size, size_t page_size, size_t region_granularity, size_t commit_factor, MemoryType type);
 
   void fire_on_commit(uint start_idx, size_t num_regions, bool zero_filled);
  public:
@@ -86,7 +86,7 @@ class G1RegionToSpaceMapper : public CHeapObj<mtGC> {
                                               size_t page_size,
                                               size_t region_granularity,
                                               size_t byte_translation_factor,
-                                              MEMFLAGS type);
+                                              MemoryType type);
 };
 
 #endif // SHARE_GC_G1_G1REGIONTOSPACEMAPPER_HPP

--- a/src/hotspot/share/gc/shared/oopStorage.hpp
+++ b/src/hotspot/share/gc/shared/oopStorage.hpp
@@ -74,7 +74,7 @@ class outputStream;
 
 class OopStorage : public CHeapObjBase {
 public:
-  static OopStorage* create(const char* name, MEMFLAGS memflags);
+  static OopStorage* create(const char* name, MemoryType mt);
   ~OopStorage();
 
   // These count and usage accessors are racy unless at a safepoint.
@@ -90,7 +90,7 @@ public:
   size_t total_memory_usage() const;
 
   // The memory type for allocations.
-  MEMFLAGS memflags() const;
+  MemoryType memory_type() const;
 
   enum EntryStatus {
     INVALID_ENTRY,
@@ -274,13 +274,13 @@ private:
   mutable int _concurrent_iteration_count;
 
   // The memory type for allocations.
-  MEMFLAGS _memflags;
+  MemoryType _memory_type;
 
   // Flag indicating this storage object is a candidate for empty block deletion.
   volatile bool _needs_cleanup;
 
   // Clients construct via "create" factory function.
-  OopStorage(const char* name, MEMFLAGS memflags);
+  OopStorage(const char* name, MemoryType mt);
   NONCOPYABLE(OopStorage);
 
   bool try_add_block();

--- a/src/hotspot/share/gc/shared/oopStorage.inline.hpp
+++ b/src/hotspot/share/gc/shared/oopStorage.inline.hpp
@@ -60,8 +60,8 @@ class OopStorage::ActiveArray {
 
 public:
   static ActiveArray* create(size_t size,
-                             MEMFLAGS memflags = mtGC,
-                             AllocFailType alloc_fail = AllocFailStrategy::EXIT_OOM);
+                             MemoryType mt = mtGC,
+                             AllocationFailureStrategy alloc_fail = AllocationFailureStrategy::EXIT_OOM);
   static void destroy(ActiveArray* ba);
 
   inline Block* at(size_t i) const;

--- a/src/hotspot/share/gc/shared/oopStorageSet.cpp
+++ b/src/hotspot/share/gc/shared/oopStorageSet.cpp
@@ -31,18 +31,18 @@
 
 OopStorage* OopStorageSet::_storages[all_count] = {};
 
-OopStorage* OopStorageSet::create_strong(const char* name, MEMFLAGS memflags) {
+OopStorage* OopStorageSet::create_strong(const char* name, MemoryType mt) {
   static uint registered_strong = 0;
   assert(registered_strong < strong_count, "More registered strong storages than slots");
-  OopStorage* storage = OopStorage::create(name, memflags);
+  OopStorage* storage = OopStorage::create(name, mt);
   _storages[strong_start + registered_strong++] = storage;
   return storage;
 }
 
-OopStorage* OopStorageSet::create_weak(const char* name, MEMFLAGS memflags) {
+OopStorage* OopStorageSet::create_weak(const char* name, MemoryType mt) {
   static uint registered_weak = 0;
   assert(registered_weak < weak_count, "More registered strong storages than slots");
-  OopStorage* storage = OopStorage::create(name, memflags);
+  OopStorage* storage = OopStorage::create(name, mt);
   _storages[weak_start + registered_weak++] = storage;
   return storage;
 }

--- a/src/hotspot/share/gc/shared/oopStorageSet.hpp
+++ b/src/hotspot/share/gc/shared/oopStorageSet.hpp
@@ -79,8 +79,8 @@ public:
   static OopStorage* storage(WeakId id) { return get_storage(id); }
   static OopStorage* storage(Id id) { return get_storage(id); }
 
-  static OopStorage* create_strong(const char* name, MEMFLAGS memflags);
-  static OopStorage* create_weak(const char* name, MEMFLAGS memflags);
+  static OopStorage* create_strong(const char* name, MemoryType mt);
+  static OopStorage* create_weak(const char* name, MemoryType mt);
 
   // Support iteration over the storage objects.
   template<typename StorageId> class Range;

--- a/src/hotspot/share/gc/shared/taskqueue.hpp
+++ b/src/hotspot/share/gc/shared/taskqueue.hpp
@@ -116,7 +116,7 @@ void TaskQueueStats::reset() {
 
 // TaskQueueSuper collects functionality common to all GenericTaskQueue instances.
 
-template <unsigned int N, MEMFLAGS F>
+template <unsigned int N, MemoryType F>
 class TaskQueueSuper: public CHeapObj<F> {
 protected:
   // Internal type for indexing the queue; also used for the tag.
@@ -324,7 +324,7 @@ public:
 // practice of parallel programming (PPoPP 2013), 69-80
 //
 
-template <class E, MEMFLAGS F, unsigned int N = TASKQUEUE_SIZE>
+template <class E, MemoryType F, unsigned int N = TASKQUEUE_SIZE>
 class GenericTaskQueue: public TaskQueueSuper<N, F> {
 protected:
   typedef typename TaskQueueSuper<N, F>::Age Age;
@@ -428,7 +428,7 @@ public:
 // Note that size() is not hidden--it returns the number of elements in the
 // TaskQueue, and does not include the size of the overflow stack.  This
 // simplifies replacement of GenericTaskQueues with OverflowTaskQueues.
-template<class E, MEMFLAGS F, unsigned int N = TASKQUEUE_SIZE>
+template<class E, MemoryType F, unsigned int N = TASKQUEUE_SIZE>
 class OverflowTaskQueue: public GenericTaskQueue<E, F, N>
 {
 public:
@@ -467,10 +467,10 @@ public:
   virtual uint tasks() const = 0;
 };
 
-template <MEMFLAGS F> class TaskQueueSetSuperImpl: public CHeapObj<F>, public TaskQueueSetSuper {
+template <MemoryType F> class TaskQueueSetSuperImpl: public CHeapObj<F>, public TaskQueueSetSuper {
 };
 
-template<class T, MEMFLAGS F>
+template<class T, MemoryType F>
 class GenericTaskQueueSet: public TaskQueueSetSuperImpl<F> {
 public:
   typedef typename T::element_type E;
@@ -518,20 +518,20 @@ public:
 #endif // TASKQUEUE_STATS
 };
 
-template<class T, MEMFLAGS F> void
+template<class T, MemoryType F> void
 GenericTaskQueueSet<T, F>::register_queue(uint i, T* q) {
   assert(i < _n, "index out of range.");
   _queues[i] = q;
 }
 
-template<class T, MEMFLAGS F> T*
+template<class T, MemoryType F> T*
 GenericTaskQueueSet<T, F>::queue(uint i) {
   assert(i < _n, "index out of range.");
   return _queues[i];
 }
 
 #ifdef ASSERT
-template<class T, MEMFLAGS F>
+template<class T, MemoryType F>
 void GenericTaskQueueSet<T, F>::assert_empty() const {
   for (uint j = 0; j < _n; j++) {
     _queues[j]->assert_empty();
@@ -539,7 +539,7 @@ void GenericTaskQueueSet<T, F>::assert_empty() const {
 }
 #endif // ASSERT
 
-template<class T, MEMFLAGS F>
+template<class T, MemoryType F>
 uint GenericTaskQueueSet<T, F>::tasks() const {
   uint n = 0;
   for (uint j = 0; j < _n; j++) {

--- a/src/hotspot/share/gc/shared/taskqueue.inline.hpp
+++ b/src/hotspot/share/gc/shared/taskqueue.inline.hpp
@@ -38,7 +38,7 @@
 #include "utilities/ostream.hpp"
 #include "utilities/stack.inline.hpp"
 
-template <class T, MEMFLAGS F>
+template <class T, MemoryType F>
 inline GenericTaskQueueSet<T, F>::GenericTaskQueueSet(uint n) : _n(n) {
   typedef T* GenericTaskQueuePtr;
   _queues = NEW_C_HEAP_ARRAY(GenericTaskQueuePtr, n, F);
@@ -47,20 +47,20 @@ inline GenericTaskQueueSet<T, F>::GenericTaskQueueSet(uint n) : _n(n) {
   }
 }
 
-template <class T, MEMFLAGS F>
+template <class T, MemoryType F>
 inline GenericTaskQueueSet<T, F>::~GenericTaskQueueSet() {
   FREE_C_HEAP_ARRAY(T*, _queues);
 }
 
 #if TASKQUEUE_STATS
-template<class T, MEMFLAGS F>
+template<class T, MemoryType F>
 void GenericTaskQueueSet<T, F>::print_taskqueue_stats_hdr(outputStream* const st, const char* label) {
   st->print_cr("GC Task Stats %s", label);
   st->print("thr "); TaskQueueStats::print_header(1, st); st->cr();
   st->print("--- "); TaskQueueStats::print_header(2, st); st->cr();
 }
 
-template<class T, MEMFLAGS F>
+template<class T, MemoryType F>
 void GenericTaskQueueSet<T, F>::print_taskqueue_stats(outputStream* const st, const char* label) {
   print_taskqueue_stats_hdr(st, label);
 
@@ -75,7 +75,7 @@ void GenericTaskQueueSet<T, F>::print_taskqueue_stats(outputStream* const st, co
   DEBUG_ONLY(totals.verify());
 }
 
-template<class T, MEMFLAGS F>
+template<class T, MemoryType F>
 void GenericTaskQueueSet<T, F>::reset_taskqueue_stats() {
   const uint n = size();
   for (uint i = 0; i < n; ++i) {
@@ -83,7 +83,7 @@ void GenericTaskQueueSet<T, F>::reset_taskqueue_stats() {
   }
 }
 
-template <class T, MEMFLAGS F>
+template <class T, MemoryType F>
 inline void GenericTaskQueueSet<T, F>::print_and_reset_taskqueue_stats(const char* label) {
   if (!log_is_enabled(Trace, gc, task, stats)) {
     return;
@@ -97,18 +97,18 @@ inline void GenericTaskQueueSet<T, F>::print_and_reset_taskqueue_stats(const cha
 }
 #endif // TASKQUEUE_STATS
 
-template<class E, MEMFLAGS F, unsigned int N>
+template<class E, MemoryType F, unsigned int N>
 inline GenericTaskQueue<E, F, N>::GenericTaskQueue() :
   _elems(ArrayAllocator<E>::allocate(N, F)),
   _last_stolen_queue_id(InvalidQueueId),
   _seed(17 /* random number */) {}
 
-template<class E, MEMFLAGS F, unsigned int N>
+template<class E, MemoryType F, unsigned int N>
 inline GenericTaskQueue<E, F, N>::~GenericTaskQueue() {
   ArrayAllocator<E>::free(_elems, N);
 }
 
-template<class E, MEMFLAGS F, unsigned int N> inline bool
+template<class E, MemoryType F, unsigned int N> inline bool
 GenericTaskQueue<E, F, N>::push(E t) {
   uint localBot = bottom_relaxed();
   assert(localBot < N, "_bottom out of range.");
@@ -134,7 +134,7 @@ GenericTaskQueue<E, F, N>::push(E t) {
   return false;                 // Queue is full.
 }
 
-template <class E, MEMFLAGS F, unsigned int N>
+template <class E, MemoryType F, unsigned int N>
 inline bool OverflowTaskQueue<E, F, N>::push(E t) {
   if (!taskqueue_t::push(t)) {
     overflow_stack()->push(t);
@@ -143,7 +143,7 @@ inline bool OverflowTaskQueue<E, F, N>::push(E t) {
   return true;
 }
 
-template <class E, MEMFLAGS F, unsigned int N>
+template <class E, MemoryType F, unsigned int N>
 inline bool OverflowTaskQueue<E, F, N>::try_push_to_taskqueue(E t) {
   return taskqueue_t::push(t);
 }
@@ -154,7 +154,7 @@ inline bool OverflowTaskQueue<E, F, N>::try_push_to_taskqueue(E t) {
 // whenever the queue goes empty which it will do here if this thread
 // gets the last task or in pop_global() if the queue wraps (top == 0
 // and pop_global() succeeds, see pop_global()).
-template<class E, MEMFLAGS F, unsigned int N>
+template<class E, MemoryType F, unsigned int N>
 bool GenericTaskQueue<E, F, N>::pop_local_slow(uint localBot, Age oldAge) {
   // This queue was observed to contain exactly one element; either this
   // thread will claim it, or a competing "pop_global".  In either case,
@@ -187,7 +187,7 @@ bool GenericTaskQueue<E, F, N>::pop_local_slow(uint localBot, Age oldAge) {
   return false;
 }
 
-template<class E, MEMFLAGS F, unsigned int N> inline bool
+template<class E, MemoryType F, unsigned int N> inline bool
 GenericTaskQueue<E, F, N>::pop_local(E& t, uint threshold) {
   uint localBot = bottom_relaxed();
   // This value cannot be N-1.  That can only occur as a result of
@@ -224,7 +224,7 @@ GenericTaskQueue<E, F, N>::pop_local(E& t, uint threshold) {
   }
 }
 
-template <class E, MEMFLAGS F, unsigned int N>
+template <class E, MemoryType F, unsigned int N>
 bool OverflowTaskQueue<E, F, N>::pop_overflow(E& t)
 {
   if (overflow_empty()) return false;
@@ -253,7 +253,7 @@ bool OverflowTaskQueue<E, F, N>::pop_overflow(E& t)
 // (3) Owner starts a push, writing elems[bottom].  At the same time, Thief
 // reads elems[oldAge.top].  The owner's bottom == the thief's oldAge.top.
 // (4) Thief will discard the read value, because its cmpxchg of age will fail.
-template<class E, MEMFLAGS F, unsigned int N>
+template<class E, MemoryType F, unsigned int N>
 typename GenericTaskQueue<E, F, N>::PopResult GenericTaskQueue<E, F, N>::pop_global(E& t) {
   Age oldAge = age_relaxed();
 
@@ -311,12 +311,12 @@ inline int randomParkAndMiller(int *seed0) {
   return seed;
 }
 
-template<class E, MEMFLAGS F, unsigned int N>
+template<class E, MemoryType F, unsigned int N>
 int GenericTaskQueue<E, F, N>::next_random_queue_id() {
   return randomParkAndMiller(&_seed);
 }
 
-template<class T, MEMFLAGS F>
+template<class T, MemoryType F>
 typename GenericTaskQueueSet<T, F>::PopResult GenericTaskQueueSet<T, F>::steal_best_of_2(uint queue_num, E& t) {
   T* const local_queue = queue(queue_num);
   if (_n > 2) {
@@ -372,7 +372,7 @@ typename GenericTaskQueueSet<T, F>::PopResult GenericTaskQueueSet<T, F>::steal_b
   }
 }
 
-template<class T, MEMFLAGS F>
+template<class T, MemoryType F>
 bool GenericTaskQueueSet<T, F>::steal(uint queue_num, E& t) {
   uint const num_retries = 2 * _n;
 
@@ -394,7 +394,7 @@ bool GenericTaskQueueSet<T, F>::steal(uint queue_num, E& t) {
   return false;
 }
 
-template<class E, MEMFLAGS F, unsigned int N>
+template<class E, MemoryType F, unsigned int N>
 template<class Fn>
 inline void GenericTaskQueue<E, F, N>::iterate(Fn fn) {
   uint iters = size();

--- a/src/hotspot/share/gc/shenandoah/shenandoahTaskqueue.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahTaskqueue.hpp
@@ -34,7 +34,7 @@
 #include "runtime/mutex.hpp"
 #include "utilities/debug.hpp"
 
-template<class E, MEMFLAGS F, unsigned int N = TASKQUEUE_SIZE>
+template<class E, MemoryType F, unsigned int N = TASKQUEUE_SIZE>
 class BufferedOverflowTaskQueue: public OverflowTaskQueue<E, F, N>
 {
 public:
@@ -299,7 +299,7 @@ public:
 typedef BufferedOverflowTaskQueue<ShenandoahMarkTask, mtGC> ShenandoahBufferedOverflowTaskQueue;
 typedef Padded<ShenandoahBufferedOverflowTaskQueue> ShenandoahObjToScanQueue;
 
-template <class T, MEMFLAGS F>
+template <class T, MemoryType F>
 class ParallelClaimableQueueSet: public GenericTaskQueueSet<T, F> {
 private:
   shenandoah_padding(0);
@@ -329,7 +329,7 @@ public:
   debug_only(uint get_reserved() const { return (uint)_reserved; })
 };
 
-template <class T, MEMFLAGS F>
+template <class T, MemoryType F>
 T* ParallelClaimableQueueSet<T, F>::claim_next() {
   jint size = (jint)GenericTaskQueueSet<T, F>::size();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahTaskqueue.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahTaskqueue.inline.hpp
@@ -30,7 +30,7 @@
 #include "gc/shared/taskqueue.inline.hpp"
 #include "utilities/stack.inline.hpp"
 
-template <class E, MEMFLAGS F, unsigned int N>
+template <class E, MemoryType F, unsigned int N>
 bool BufferedOverflowTaskQueue<E, F, N>::pop(E &t) {
   if (!_buf_empty) {
     t = _elem;
@@ -45,7 +45,7 @@ bool BufferedOverflowTaskQueue<E, F, N>::pop(E &t) {
   return taskqueue_t::pop_overflow(t);
 }
 
-template <class E, MEMFLAGS F, unsigned int N>
+template <class E, MemoryType F, unsigned int N>
 inline bool BufferedOverflowTaskQueue<E, F, N>::push(E t) {
   if (_buf_empty) {
     _elem = t;
@@ -58,7 +58,7 @@ inline bool BufferedOverflowTaskQueue<E, F, N>::push(E t) {
   return true;
 }
 
-template <class E, MEMFLAGS F, unsigned int N>
+template <class E, MemoryType F, unsigned int N>
 void BufferedOverflowTaskQueue<E, F, N>::clear() {
     _buf_empty = true;
     taskqueue_t::set_empty();

--- a/src/hotspot/share/jfr/utilities/jfrAllocation.cpp
+++ b/src/hotspot/share/jfr/utilities/jfrAllocation.cpp
@@ -124,7 +124,7 @@ void JfrCHeapObj::operator delete[](void* p, size_t size) {
 }
 
 char* JfrCHeapObj::realloc_array(char* old, size_t size) {
-  char* const memory = ReallocateHeap(old, size, mtTracing, AllocFailStrategy::RETURN_NULL);
+  char* const memory = ReallocateHeap(old, size, mtTracing, AllocationFailureStrategy::RETURN_NULL);
   hook_memory_allocation(memory, size);
   return memory;
 }
@@ -135,5 +135,5 @@ void JfrCHeapObj::free(void* p, size_t size) {
 }
 
 char* JfrCHeapObj::allocate_array_noinline(size_t elements, size_t element_size) {
-  return AllocateHeap(elements * element_size, mtTracing, CALLER_PC, AllocFailStrategy::RETURN_NULL);
+  return AllocateHeap(elements * element_size, mtTracing, CALLER_PC, AllocationFailureStrategy::RETURN_NULL);
 }

--- a/src/hotspot/share/memory/allocation.cpp
+++ b/src/hotspot/share/memory/allocation.cpp
@@ -36,28 +36,28 @@
 
 // allocate using malloc; will fail if no memory available
 char* AllocateHeap(size_t size,
-                   MEMFLAGS flags,
+                   MemoryType flags,
                    const NativeCallStack& stack,
-                   AllocFailType alloc_failmode /* = AllocFailStrategy::EXIT_OOM*/) {
+                   AllocationFailureStrategy alloc_failmode /* = AllocationFailureStrategy::EXIT_OOM*/) {
   char* p = (char*) os::malloc(size, flags, stack);
-  if (p == nullptr && alloc_failmode == AllocFailStrategy::EXIT_OOM) {
+  if (p == nullptr && alloc_failmode == AllocationFailureStrategy::EXIT_OOM) {
     vm_exit_out_of_memory(size, OOM_MALLOC_ERROR, "AllocateHeap");
   }
   return p;
 }
 
 char* AllocateHeap(size_t size,
-                   MEMFLAGS flags,
-                   AllocFailType alloc_failmode /* = AllocFailStrategy::EXIT_OOM*/) {
+                   MemoryType flags,
+                   AllocationFailureStrategy alloc_failmode /* = AllocationFailureStrategy::EXIT_OOM*/) {
   return AllocateHeap(size, flags, CALLER_PC, alloc_failmode);
 }
 
 char* ReallocateHeap(char *old,
                      size_t size,
-                     MEMFLAGS flag,
-                     AllocFailType alloc_failmode) {
+                     MemoryType flag,
+                     AllocationFailureStrategy alloc_failmode) {
   char* p = (char*) os::realloc(old, size, flag, CALLER_PC);
-  if (p == nullptr && alloc_failmode == AllocFailStrategy::EXIT_OOM) {
+  if (p == nullptr && alloc_failmode == AllocationFailureStrategy::EXIT_OOM) {
     vm_exit_out_of_memory(size, OOM_MALLOC_ERROR, "ReallocateHeap");
   }
   return p;
@@ -122,16 +122,16 @@ void* AnyObj::operator new(size_t size, Arena *arena) throw() {
   return res;
 }
 
-void* AnyObj::operator new(size_t size, MEMFLAGS flags) throw() {
+void* AnyObj::operator new(size_t size, MemoryType flags) throw() {
   address res = (address)AllocateHeap(size, flags, CALLER_PC);
   DEBUG_ONLY(set_allocation_type(res, C_HEAP);)
   return res;
 }
 
 void* AnyObj::operator new(size_t size, const std::nothrow_t&  nothrow_constant,
-    MEMFLAGS flags) throw() {
+    MemoryType flags) throw() {
   // should only call this with std::nothrow, use other operator new() otherwise
-    address res = (address)AllocateHeap(size, flags, CALLER_PC, AllocFailStrategy::RETURN_NULL);
+    address res = (address)AllocateHeap(size, flags, CALLER_PC, AllocationFailureStrategy::RETURN_NULL);
     DEBUG_ONLY(if (res!= nullptr) set_allocation_type(res, C_HEAP);)
   return res;
 }

--- a/src/hotspot/share/memory/allocation.inline.hpp
+++ b/src/hotspot/share/memory/allocation.inline.hpp
@@ -55,7 +55,7 @@ size_t MmapArrayAllocator<E>::size_for(size_t length) {
 }
 
 template <class E>
-E* MmapArrayAllocator<E>::allocate_or_null(size_t length, MEMFLAGS flags) {
+E* MmapArrayAllocator<E>::allocate_or_null(size_t length, MemoryType flags) {
   size_t size = size_for(length);
 
   char* addr = os::reserve_memory(size, !ExecMem, flags);
@@ -72,7 +72,7 @@ E* MmapArrayAllocator<E>::allocate_or_null(size_t length, MEMFLAGS flags) {
 }
 
 template <class E>
-E* MmapArrayAllocator<E>::allocate(size_t length, MEMFLAGS flags) {
+E* MmapArrayAllocator<E>::allocate(size_t length, MemoryType flags) {
   size_t size = size_for(length);
 
   char* addr = os::reserve_memory(size, !ExecMem, flags);
@@ -97,12 +97,12 @@ size_t MallocArrayAllocator<E>::size_for(size_t length) {
 }
 
 template <class E>
-E* MallocArrayAllocator<E>::allocate(size_t length, MEMFLAGS flags) {
+E* MallocArrayAllocator<E>::allocate(size_t length, MemoryType flags) {
   return (E*)AllocateHeap(size_for(length), flags);
 }
 
 template <class E>
-E* MallocArrayAllocator<E>::reallocate(E* addr, size_t new_length, MEMFLAGS flags) {
+E* MallocArrayAllocator<E>::reallocate(E* addr, size_t new_length, MemoryType flags) {
   return (E*)ReallocateHeap((char*)addr, size_for(new_length), flags);
 }
 
@@ -117,17 +117,17 @@ bool ArrayAllocator<E>::should_use_malloc(size_t length) {
 }
 
 template <class E>
-E* ArrayAllocator<E>::allocate_malloc(size_t length, MEMFLAGS flags) {
+E* ArrayAllocator<E>::allocate_malloc(size_t length, MemoryType flags) {
   return MallocArrayAllocator<E>::allocate(length, flags);
 }
 
 template <class E>
-E* ArrayAllocator<E>::allocate_mmap(size_t length, MEMFLAGS flags) {
+E* ArrayAllocator<E>::allocate_mmap(size_t length, MemoryType flags) {
   return MmapArrayAllocator<E>::allocate(length, flags);
 }
 
 template <class E>
-E* ArrayAllocator<E>::allocate(size_t length, MEMFLAGS flags) {
+E* ArrayAllocator<E>::allocate(size_t length, MemoryType flags) {
   if (should_use_malloc(length)) {
     return allocate_malloc(length, flags);
   }
@@ -136,12 +136,12 @@ E* ArrayAllocator<E>::allocate(size_t length, MEMFLAGS flags) {
 }
 
 template <class E>
-E* ArrayAllocator<E>::reallocate_malloc(E* addr, size_t new_length, MEMFLAGS flags) {
+E* ArrayAllocator<E>::reallocate_malloc(E* addr, size_t new_length, MemoryType flags) {
   return MallocArrayAllocator<E>::reallocate(addr, new_length, flags);
 }
 
 template <class E>
-E* ArrayAllocator<E>::reallocate(E* old_addr, size_t old_length, size_t new_length, MEMFLAGS flags) {
+E* ArrayAllocator<E>::reallocate(E* old_addr, size_t old_length, size_t new_length, MemoryType flags) {
   if (should_use_malloc(old_length) && should_use_malloc(new_length)) {
     return reallocate_malloc(old_addr, new_length, flags);
   }

--- a/src/hotspot/share/memory/allocationFailureStrategy.hpp
+++ b/src/hotspot/share/memory/allocationFailureStrategy.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,34 +22,12 @@
  *
  */
 
-#ifndef SHARE_SERVICES_ALLOCATIONSITE_HPP
-#define SHARE_SERVICES_ALLOCATIONSITE_HPP
+#ifndef SHARE_MEMORY_ALLOCATION_FAILURE_STRATEGY_HPP
+#define SHARE_MEMORY_ALLOCATION_FAILURE_STRATEGY_HPP
 
-#include "memory/allocation.hpp"
-#include "utilities/nativeCallStack.hpp"
-
-// Allocation site represents a code path that makes a memory
-// allocation
-class AllocationSite {
- private:
-  const NativeCallStack  _call_stack;
-  const MemoryType         _flag;
- public:
-  AllocationSite(const NativeCallStack& stack, MemoryType flag) : _call_stack(stack), _flag(flag) { }
-
-  bool equals(const NativeCallStack& stack) const {
-    return _call_stack.equals(stack);
-  }
-
-  bool equals(const AllocationSite& other) const {
-    return other.equals(_call_stack);
-  }
-
-  const NativeCallStack* call_stack() const {
-    return &_call_stack;
-  }
-
-  MemoryType flag() const { return _flag; }
+enum class AllocationFailureStrategy {
+  EXIT_OOM,
+  RETURN_NULL,
 };
 
-#endif // SHARE_SERVICES_ALLOCATIONSITE_HPP
+#endif // SHARE_MEMORY_ALLOCATION_FAILURE_STRATEGY_HPP

--- a/src/hotspot/share/memory/heapInspection.cpp
+++ b/src/hotspot/share/memory/heapInspection.cpp
@@ -173,7 +173,7 @@ KlassInfoTable::KlassInfoTable(bool add_all_classes) {
   _ref = (HeapWord*) Universe::boolArrayKlassObj();
   _buckets =
     (KlassInfoBucket*)  AllocateHeap(sizeof(KlassInfoBucket) * _num_buckets,
-       mtInternal, CURRENT_PC, AllocFailStrategy::RETURN_NULL);
+       mtInternal, CURRENT_PC, AllocationFailureStrategy::RETURN_NULL);
   if (_buckets != nullptr) {
     for (int index = 0; index < _num_buckets; index++) {
       _buckets[index].initialize();

--- a/src/hotspot/share/memory/memRegion.cpp
+++ b/src/hotspot/share/memory/memRegion.cpp
@@ -102,7 +102,7 @@ MemRegion MemRegion::minus(const MemRegion mr2) const {
   return MemRegion();
 }
 
-MemRegion* MemRegion::create_array(size_t length, MEMFLAGS flags) {
+MemRegion* MemRegion::create_array(size_t length, MemoryType flags) {
   MemRegion* result = NEW_C_HEAP_ARRAY(MemRegion, length, flags);
   for (size_t i = 0; i < length; i++) {
     ::new (&result[i]) MemRegion();

--- a/src/hotspot/share/memory/memRegion.hpp
+++ b/src/hotspot/share/memory/memRegion.hpp
@@ -94,7 +94,7 @@ public:
   bool is_empty() const { return word_size() == 0; }
 
   // Creates and initializes an array of MemRegions of the given length.
-  static MemRegion* create_array(size_t length, MEMFLAGS flags);
+  static MemRegion* create_array(size_t length, MemoryType flags);
   static void destroy_array(MemRegion* array, size_t length);
 };
 

--- a/src/hotspot/share/memory/padded.hpp
+++ b/src/hotspot/share/memory/padded.hpp
@@ -89,7 +89,7 @@ class PaddedEnd : public PaddedEndImpl<T, PADDED_END_SIZE(T, alignment)> {
 
 // Helper class to create an array of PaddedEnd<T> objects. All elements will
 // start at a multiple of alignment and the size will be aligned to alignment.
-template <class T, MEMFLAGS flags, size_t alignment = DEFAULT_CACHE_LINE_SIZE>
+template <class T, MemoryType flags, size_t alignment = DEFAULT_CACHE_LINE_SIZE>
 class PaddedArray {
  public:
   // Creates an aligned padded array.
@@ -100,7 +100,7 @@ class PaddedArray {
 // Helper class to create an array of references to arrays of primitive types
 // Both the array of references and the data arrays are aligned to the given
 // alignment. The allocated memory is zero-filled.
-template <class T, MEMFLAGS flags, size_t alignment = DEFAULT_CACHE_LINE_SIZE>
+template <class T, MemoryType flags, size_t alignment = DEFAULT_CACHE_LINE_SIZE>
 class Padded2DArray {
  public:
   // Creates an aligned padded 2D array.
@@ -112,7 +112,7 @@ class Padded2DArray {
 
 // Helper class to create an array of T objects. The array as a whole will
 // start at a multiple of alignment and its size will be aligned to alignment.
-template <class T, MEMFLAGS flags, size_t alignment = DEFAULT_CACHE_LINE_SIZE>
+template <class T, MemoryType flags, size_t alignment = DEFAULT_CACHE_LINE_SIZE>
 class PaddedPrimitiveArray {
  public:
   static T* create_unfreeable(size_t length);

--- a/src/hotspot/share/memory/padded.inline.hpp
+++ b/src/hotspot/share/memory/padded.inline.hpp
@@ -34,7 +34,7 @@
 
 // Creates an aligned padded array.
 // The memory can't be deleted since the raw memory chunk is not returned.
-template <class T, MEMFLAGS flags, size_t alignment>
+template <class T, MemoryType flags, size_t alignment>
 PaddedEnd<T>* PaddedArray<T, flags, alignment>::create_unfreeable(uint length) {
   // Check that the PaddedEnd class works as intended.
   STATIC_ASSERT(is_aligned(sizeof(PaddedEnd<T>), alignment));
@@ -53,7 +53,7 @@ PaddedEnd<T>* PaddedArray<T, flags, alignment>::create_unfreeable(uint length) {
   return aligned_padded_array;
 }
 
-template <class T, MEMFLAGS flags, size_t alignment>
+template <class T, MemoryType flags, size_t alignment>
 T** Padded2DArray<T, flags, alignment>::create_unfreeable(uint rows, uint columns, size_t* allocation_size) {
   // Calculate and align the size of the first dimension's table.
   size_t table_size = align_up(rows * sizeof(T*), alignment);
@@ -81,13 +81,13 @@ T** Padded2DArray<T, flags, alignment>::create_unfreeable(uint rows, uint column
   return result;
 }
 
-template <class T, MEMFLAGS flags, size_t alignment>
+template <class T, MemoryType flags, size_t alignment>
 T* PaddedPrimitiveArray<T, flags, alignment>::create_unfreeable(size_t length) {
   void* temp;
   return create(length, &temp);
 }
 
-template <class T, MEMFLAGS flags, size_t alignment>
+template <class T, MemoryType flags, size_t alignment>
 T* PaddedPrimitiveArray<T, flags, alignment>::create(size_t length, void** alloc_base) {
   // Allocate a chunk of memory large enough to allow for some alignment.
   void* chunk = AllocateHeap(length * sizeof(T) + alignment, flags);

--- a/src/hotspot/share/memory/resourceArea.cpp
+++ b/src/hotspot/share/memory/resourceArea.cpp
@@ -30,7 +30,7 @@
 #include "services/memTracker.hpp"
 #include "utilities/vmError.hpp"
 
-void ResourceArea::bias_to(MEMFLAGS new_flags) {
+void ResourceArea::bias_to(MemoryType new_flags) {
   if (new_flags != _flags) {
     size_t size = size_in_bytes();
     MemTracker::record_arena_size_change(-ssize_t(size), _flags);
@@ -63,14 +63,14 @@ void ResourceArea::verify_has_resource_mark() {
 // The following routines are declared in allocation.hpp and used everywhere:
 
 // Allocation in thread-local resource area
-extern char* resource_allocate_bytes(size_t size, AllocFailType alloc_failmode) {
+extern char* resource_allocate_bytes(size_t size, AllocationFailureStrategy alloc_failmode) {
   return Thread::current()->resource_area()->allocate_bytes(size, alloc_failmode);
 }
-extern char* resource_allocate_bytes(Thread* thread, size_t size, AllocFailType alloc_failmode) {
+extern char* resource_allocate_bytes(Thread* thread, size_t size, AllocationFailureStrategy alloc_failmode) {
   return thread->resource_area()->allocate_bytes(size, alloc_failmode);
 }
 
-extern char* resource_reallocate_bytes( char *old, size_t old_size, size_t new_size, AllocFailType alloc_failmode){
+extern char* resource_reallocate_bytes( char *old, size_t old_size, size_t new_size, AllocationFailureStrategy alloc_failmode){
   return (char*)Thread::current()->resource_area()->Arealloc(old, old_size, new_size, alloc_failmode);
 }
 

--- a/src/hotspot/share/memory/resourceArea.hpp
+++ b/src/hotspot/share/memory/resourceArea.hpp
@@ -50,17 +50,17 @@ class ResourceArea: public Arena {
 #endif // ASSERT
 
 public:
-  ResourceArea(MEMFLAGS flags = mtThread) :
+  ResourceArea(MemoryType flags = mtThread) :
     Arena(flags) DEBUG_ONLY(COMMA _nesting(0)) {}
 
-  ResourceArea(size_t init_size, MEMFLAGS flags = mtThread) :
+  ResourceArea(size_t init_size, MemoryType flags = mtThread) :
     Arena(flags, init_size) DEBUG_ONLY(COMMA _nesting(0)) {}
 
-  char* allocate_bytes(size_t size, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
+  char* allocate_bytes(size_t size, AllocationFailureStrategy alloc_failmode = AllocationFailureStrategy::EXIT_OOM);
 
   // Bias this resource area to specific memory type
   // (by default, ResourceArea is tagged as mtThread, per-thread general purpose storage)
-  void bias_to(MEMFLAGS flags);
+  void bias_to(MemoryType flags);
 
   DEBUG_ONLY(int nesting() const { return _nesting; })
 

--- a/src/hotspot/share/memory/resourceArea.inline.hpp
+++ b/src/hotspot/share/memory/resourceArea.inline.hpp
@@ -29,7 +29,7 @@
 
 #include "services/memTracker.hpp"
 
-inline char* ResourceArea::allocate_bytes(size_t size, AllocFailType alloc_failmode) {
+inline char* ResourceArea::allocate_bytes(size_t size, AllocationFailureStrategy alloc_failmode) {
 #ifdef ASSERT
   verify_has_resource_mark();
 #endif // ASSERT

--- a/src/hotspot/share/memory/types.cpp
+++ b/src/hotspot/share/memory/types.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include "precompiled.hpp"
 #include "memory/types.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"

--- a/src/hotspot/share/memory/types.cpp
+++ b/src/hotspot/share/memory/types.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "memory/types.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+struct MemoryTypeInfo final {
+  const char* const name;
+  const char* const human_readable;
+};
+
+static const MemoryTypeInfo _memory_type_infos[] = {
+#define MEMORY_TYPE_INFO(type, human_readable) { #type, human_readable },
+  MEMORY_TYPES_DO(MEMORY_TYPE_INFO)
+#undef MEMORY_TYPE_INFO
+};
+
+STATIC_ASSERT(MemoryTypes::count() == ARRAY_SIZE(_memory_type_infos));
+
+const char* MemoryTypes::name(MemoryType mt) {
+  assert(is_valid(mt), "invalid memory type (%d)", mt);
+  return _memory_type_infos[static_cast<int>(mt)].human_readable;
+}
+
+MemoryType MemoryTypes::from_string(const char* s) {
+  if ((s[0] == 'm' || s[0] == 'M') && (s[1] == 't' || s[1] == 'T')) {
+    s += 2;
+  }
+  for (int index = 0; index < count(); index++) {
+    const MemoryTypeInfo& info = _memory_type_infos[index];
+    if (strcasecmp(info.human_readable, s) == 0 || strcasecmp(info.name, s) == 0) {
+      return from_index(index);
+    }
+  }
+  return mtNone;
+}

--- a/src/hotspot/share/memory/types.cpp
+++ b/src/hotspot/share/memory/types.cpp
@@ -40,7 +40,7 @@ static const MemoryTypeInfo _memory_type_infos[] = {
 STATIC_ASSERT(MemoryTypes::count() == ARRAY_SIZE(_memory_type_infos));
 
 const char* MemoryTypes::name(MemoryType mt) {
-  assert(is_valid(mt), "invalid memory type (%d)", mt);
+  assert(is_valid(mt), "invalid memory type (%d)", static_cast<int>(mt));
   return _memory_type_infos[static_cast<int>(mt)].human_readable;
 }
 

--- a/src/hotspot/share/memory/types.hpp
+++ b/src/hotspot/share/memory/types.hpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_MEMORY_TYPES_HPP
+#define SHARE_MEMORY_TYPES_HPP
+
+#include "memory/allStatic.hpp"
+#include "utilities/debug.hpp"
+
+#include <cstdint>
+
+#define MEMORY_TYPES_DO(f)                                                         \
+  /* Memory type by sub systems. It occupies lower byte. */                        \
+  f(JavaHeap,       "Java Heap")   /* Java heap                                 */ \
+  f(Class,          "Class")       /* Java classes                              */ \
+  f(Thread,         "Thread")      /* thread objects                            */ \
+  f(ThreadStack,    "Thread Stack")                                                \
+  f(Code,           "Code")        /* generated code                            */ \
+  f(GC,             "GC")                                                          \
+  f(GCCardSet,      "GCCardSet")   /* G1 card set remembered set                */ \
+  f(Compiler,       "Compiler")                                                    \
+  f(JVMCI,          "JVMCI")                                                       \
+  f(Internal,       "Internal")    /* memory used by VM, but does not belong to */ \
+                                   /* any of above categories, and not used by  */ \
+                                   /* NMT                                       */ \
+  f(Other,          "Other")       /* memory not used by VM                     */ \
+  f(Symbol,         "Symbol")                                                      \
+  f(NMT,            "Native Memory Tracking")  /* memory used by NMT            */ \
+  f(ClassShared,    "Shared class space")      /* class data sharing            */ \
+  f(Chunk,          "Arena Chunk") /* chunk that holds content of arenas        */ \
+  f(Test,           "Test")        /* Test type for verifying NMT               */ \
+  f(Tracing,        "Tracing")                                                     \
+  f(Logging,        "Logging")                                                     \
+  f(Statistics,     "Statistics")                                                  \
+  f(Arguments,      "Arguments")                                                   \
+  f(Module,         "Module")                                                      \
+  f(Safepoint,      "Safepoint")                                                   \
+  f(Synchronizer,   "Synchronization")                                             \
+  f(Serviceability, "Serviceability")                                              \
+  f(Metaspace,      "Metaspace")                                                   \
+  f(StringDedup,    "String Deduplication")                                        \
+  f(ObjectMonitor,  "Object Monitors")                                             \
+  f(None,           "Unknown")
+
+/*
+ * Memory types.
+ */
+enum class MemoryType : uint8_t {
+#define MEMORY_TYPE_DECLARE_ENUM(type, human_readable) type,
+  MEMORY_TYPES_DO(MEMORY_TYPE_DECLARE_ENUM)
+#undef MEMORY_TYPE_DECLARE_ENUM
+};
+
+// Extra insurance that MemoryType truly has the same size as uint8_t.
+STATIC_ASSERT(sizeof(MemoryType) == sizeof(uint8_t));
+
+// Generate short aliases for the enum values. E.g. mtGC instead of MemoryType::GC.
+#define MEMORY_TYPE_SHORTNAME(type, human_readable) \
+  constexpr MemoryType mt##type = MemoryType::type;
+MEMORY_TYPES_DO(MEMORY_TYPE_SHORTNAME)
+#undef MEMORY_TYPE_SHORTNAME
+
+class MemoryTypes final : public AllStatic {
+ public:
+  static constexpr int count() {
+#define MEMORY_TYPE_COUNT(type, human_readable) + 1
+    return 0 MEMORY_TYPES_DO(MEMORY_TYPE_COUNT);
+#undef MEMORY_TYPE_COUNT
+  }
+
+  static const char* name(MemoryType mt);
+
+  static constexpr bool is_index_valid(int index) {
+    return index >= 0 && index < count();
+  }
+
+  static constexpr bool is_valid(MemoryType mt) {
+    return is_index_valid(static_cast<int>(mt));
+  }
+
+  static inline MemoryType from_index(int index) {
+    assert(is_index_valid(index), "invalid memory type index (%d)", index);
+    return static_cast<MemoryType>(index);
+  }
+
+  static inline int to_index(MemoryType mt) {
+    assert(is_valid(index), "invalid memory type (%d)", mt);
+    return static_cast<int>(mt);
+  }
+
+  static MemoryType from_string(const char* s);
+};
+
+// Legacy constant.
+constexpr int mt_number_of_types = MemoryTypes::count();
+
+#endif // SHARE_MEMORY_TYPES_HPP

--- a/src/hotspot/share/memory/types.hpp
+++ b/src/hotspot/share/memory/types.hpp
@@ -105,7 +105,7 @@ class MemoryTypes final : public AllStatic {
   }
 
   static inline int to_index(MemoryType mt) {
-    assert(is_valid(mt), "invalid memory type (%d)", mt);
+    assert(is_valid(mt), "invalid memory type (%d)", static_cast<int>(mt));
     return static_cast<int>(mt);
   }
 

--- a/src/hotspot/share/memory/types.hpp
+++ b/src/hotspot/share/memory/types.hpp
@@ -105,7 +105,7 @@ class MemoryTypes final : public AllStatic {
   }
 
   static inline int to_index(MemoryType mt) {
-    assert(is_valid(index), "invalid memory type (%d)", mt);
+    assert(is_valid(mt), "invalid memory type (%d)", mt);
     return static_cast<int>(mt);
   }
 

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -674,7 +674,7 @@ JNI_ENTRY(jobject, jni_NewGlobalRef(JNIEnv *env, jobject ref))
   HOTSPOT_JNI_NEWGLOBALREF_ENTRY(env, ref);
 
   Handle ref_handle(thread, JNIHandles::resolve(ref));
-  jobject ret = JNIHandles::make_global(ref_handle, AllocFailStrategy::RETURN_NULL);
+  jobject ret = JNIHandles::make_global(ref_handle, AllocationFailureStrategy::RETURN_NULL);
 
   HOTSPOT_JNI_NEWGLOBALREF_RETURN(ret);
   return ret;
@@ -711,7 +711,7 @@ JNI_ENTRY(jobject, jni_NewLocalRef(JNIEnv *env, jobject ref))
   HOTSPOT_JNI_NEWLOCALREF_ENTRY(env, ref);
 
   jobject ret = JNIHandles::make_local(THREAD, JNIHandles::resolve(ref),
-                                       AllocFailStrategy::RETURN_NULL);
+                                       AllocationFailureStrategy::RETURN_NULL);
 
   HOTSPOT_JNI_NEWLOCALREF_RETURN(ret);
   return ret;
@@ -2232,7 +2232,7 @@ JNI_ENTRY(const char*, jni_GetStringUTFChars(JNIEnv *env, jstring string, jboole
   if (s_value != nullptr) {
     size_t length = java_lang_String::utf8_length(java_string, s_value);
     /* JNI Specification states return null on OOM */
-    result = AllocateHeap(length + 1, mtInternal, AllocFailStrategy::RETURN_NULL);
+    result = AllocateHeap(length + 1, mtInternal, AllocationFailureStrategy::RETURN_NULL);
     if (result != nullptr) {
       java_lang_String::as_utf8_string(java_string, s_value, result, (int) length + 1);
       if (isCopy != nullptr) {
@@ -2874,7 +2874,7 @@ JNI_END
 JNI_ENTRY(jweak, jni_NewWeakGlobalRef(JNIEnv *env, jobject ref))
   HOTSPOT_JNI_NEWWEAKGLOBALREF_ENTRY(env, ref);
   Handle ref_handle(thread, JNIHandles::resolve(ref));
-  jweak ret = JNIHandles::make_weak_global(ref_handle, AllocFailStrategy::RETURN_NULL);
+  jweak ret = JNIHandles::make_weak_global(ref_handle, AllocationFailureStrategy::RETURN_NULL);
   if (ret == nullptr) {
     THROW_OOP_(Universe::out_of_memory_error_c_heap(), nullptr);
   }

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -4040,7 +4040,7 @@ JvmtiEnv::SetSystemProperty(const char* property, const char* value_ptr) {
   for (SystemProperty* p = Arguments::system_properties(); p != nullptr; p = p->next()) {
     if (strcmp(property, p->key()) == 0) {
       if (p->writeable()) {
-        if (p->set_value(value_ptr, AllocFailStrategy::RETURN_NULL)) {
+        if (p->set_value(value_ptr, AllocationFailureStrategy::RETURN_NULL)) {
           return JVMTI_ERROR_NONE;
         } else {
           return JVMTI_ERROR_OUT_OF_MEMORY;

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -661,7 +661,7 @@ WB_END
 WB_ENTRY(jlong, WB_NMTMallocWithPseudoStackAndType(JNIEnv* env, jobject o, jlong size, jint pseudo_stack, jint type))
   address pc = (address)(size_t)pseudo_stack;
   NativeCallStack stack(&pc, 1);
-  return (jlong)(uintptr_t)os::malloc(size, (MEMFLAGS)type, stack);
+  return (jlong)(uintptr_t)os::malloc(size, (MemoryType)type, stack);
 WB_END
 
 // Free the memory allocated by NMTAllocTest

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -128,10 +128,10 @@ char* Arguments::_ext_dirs = nullptr;
 // True if -Xshare:auto option was specified.
 static bool xshare_auto_cmd_line = false;
 
-bool PathString::set_value(const char *value, AllocFailType alloc_failmode) {
+bool PathString::set_value(const char *value, AllocationFailureStrategy alloc_failmode) {
   char* new_value = AllocateHeap(strlen(value)+1, mtArguments, alloc_failmode);
   if (new_value == nullptr) {
-    assert(alloc_failmode == AllocFailStrategy::RETURN_NULL, "must be");
+    assert(alloc_failmode == AllocationFailureStrategy::RETURN_NULL, "must be");
     return false;
   }
   if (_value != nullptr) {
@@ -4288,7 +4288,7 @@ void Arguments::parse_single_category_limit(char* expression, size_t limits[mt_n
     vm_exit_during_initialization("MallocLimit: colon missing", expression);
   }
   *colon = '\0';
-  MEMFLAGS f = NMTUtil::string_to_flag(expression);
+  MemoryType f = NMTUtil::string_to_flag(expression);
   if (f == mtNone) {
     vm_exit_during_initialization("MallocLimit: invalid nmt category", expression);
   }

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -69,8 +69,8 @@ class PathString : public CHeapObj<mtArguments> {
  public:
   char* value() const { return _value; }
 
-  // return false iff OOM && alloc_failmode == AllocFailStrategy::RETURN_NULL
-  bool set_value(const char *value, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
+  // return false iff OOM && alloc_failmode == AllocationFailureStrategy::RETURN_NULL
+  bool set_value(const char *value, AllocationFailureStrategy alloc_failmode = AllocationFailureStrategy::EXIT_OOM);
   void append_value(const char *value);
 
   PathString(const char* value);

--- a/src/hotspot/share/runtime/jniHandles.hpp
+++ b/src/hotspot/share/runtime/jniHandles.hpp
@@ -94,17 +94,17 @@ public:
   // Local handles
   static jobject make_local(oop obj);
   static jobject make_local(JavaThread* thread, oop obj,  // Faster version when current thread is known
-                            AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
+                            AllocationFailureStrategy alloc_failmode = AllocationFailureStrategy::EXIT_OOM);
   inline static void destroy_local(jobject handle);
 
   // Global handles
   static jobject make_global(Handle  obj,
-                             AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
+                             AllocationFailureStrategy alloc_failmode = AllocationFailureStrategy::EXIT_OOM);
   static void destroy_global(jobject handle);
 
   // Weak global handles
   static jweak make_weak_global(Handle obj,
-                                AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
+                                AllocationFailureStrategy alloc_failmode = AllocationFailureStrategy::EXIT_OOM);
   static void destroy_weak_global(jweak handle);
   static bool is_weak_global_cleared(jweak handle); // Test jweak without resolution
 
@@ -167,10 +167,10 @@ class JNIHandleBlock : public CHeapObj<mtInternal> {
 
  public:
   // Handle allocation
-  jobject allocate_handle(JavaThread* caller, oop obj, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
+  jobject allocate_handle(JavaThread* caller, oop obj, AllocationFailureStrategy alloc_failmode = AllocationFailureStrategy::EXIT_OOM);
 
   // Block allocation and block free list management
-  static JNIHandleBlock* allocate_block(JavaThread* thread = nullptr, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
+  static JNIHandleBlock* allocate_block(JavaThread* thread = nullptr, AllocationFailureStrategy alloc_failmode = AllocationFailureStrategy::EXIT_OOM);
   static void release_block(JNIHandleBlock* block, JavaThread* thread = nullptr);
 
   // JNI PushLocalFrame/PopLocalFrame support

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -416,7 +416,7 @@ class os: AllStatic {
   inline static size_t cds_core_region_alignment();
 
   // Reserves virtual memory.
-  static char*  reserve_memory(size_t bytes, bool executable = false, MEMFLAGS flags = mtNone);
+  static char*  reserve_memory(size_t bytes, bool executable = false, MemoryType flags = mtNone);
 
   // Reserves virtual memory that starts at an address that is aligned to 'alignment'.
   static char*  reserve_memory_aligned(size_t size, size_t alignment, bool executable = false);
@@ -480,7 +480,7 @@ class os: AllStatic {
 
   static char*  map_memory(int fd, const char* file_name, size_t file_offset,
                            char *addr, size_t bytes, bool read_only = false,
-                           bool allow_exec = false, MEMFLAGS flags = mtNone);
+                           bool allow_exec = false, MemoryType flags = mtNone);
   static char*  remap_memory(int fd, const char* file_name, size_t file_offset,
                              char *addr, size_t bytes, bool read_only,
                              bool allow_exec);
@@ -862,16 +862,16 @@ class os: AllStatic {
   static int get_native_stack(address* stack, int size, int toSkip = 0);
 
   // General allocation (must be MT-safe)
-  static void* malloc  (size_t size, MEMFLAGS flags, const NativeCallStack& stack);
-  static void* malloc  (size_t size, MEMFLAGS flags);
-  static void* realloc (void *memblock, size_t size, MEMFLAGS flag, const NativeCallStack& stack);
-  static void* realloc (void *memblock, size_t size, MEMFLAGS flag);
+  static void* malloc  (size_t size, MemoryType flags, const NativeCallStack& stack);
+  static void* malloc  (size_t size, MemoryType flags);
+  static void* realloc (void *memblock, size_t size, MemoryType flag, const NativeCallStack& stack);
+  static void* realloc (void *memblock, size_t size, MemoryType flag);
 
   // handles null pointers
   static void  free    (void *memblock);
-  static char* strdup(const char *, MEMFLAGS flags = mtInternal);  // Like strdup
+  static char* strdup(const char *, MemoryType flags = mtInternal);  // Like strdup
   // Like strdup, but exit VM when strdup() returns null
-  static char* strdup_check_oom(const char*, MEMFLAGS flags = mtInternal);
+  static char* strdup_check_oom(const char*, MemoryType flags = mtInternal);
 
   // SocketInterface (ex HPI SocketInterface )
   static int socket_close(int fd);

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -63,7 +63,7 @@
 class ObjectMonitorsHashtable::PtrList :
   public LinkedListImpl<ObjectMonitor*,
                         AnyObj::C_HEAP, mtThread,
-                        AllocFailStrategy::RETURN_NULL> {};
+                        AllocationFailureStrategy::RETURN_NULL> {};
 
 class CleanupObjectMonitorsHashtable: StackObj {
  public:

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -58,9 +58,9 @@ THREAD_LOCAL Thread* Thread::_thr_current = nullptr;
 #endif
 
 // ======= Thread ========
-void* Thread::allocate(size_t size, bool throw_excpt, MEMFLAGS flags) {
+void* Thread::allocate(size_t size, bool throw_excpt, MemoryType flags) {
   return throw_excpt ? AllocateHeap(size, flags, CURRENT_PC)
-                       : AllocateHeap(size, flags, CURRENT_PC, AllocFailStrategy::RETURN_NULL);
+                       : AllocateHeap(size, flags, CURRENT_PC, AllocationFailureStrategy::RETURN_NULL);
 }
 
 void Thread::operator delete(void* p) {

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -206,7 +206,7 @@ class Thread: public ThreadShadow {
   void  operator delete(void* p);
 
  protected:
-  static void* allocate(size_t size, bool throw_excpt, MEMFLAGS flags = mtThread);
+  static void* allocate(size_t size, bool throw_excpt, MemoryType flags = mtThread);
 
  private:
   DEBUG_ONLY(bool _suspendible_thread;)

--- a/src/hotspot/share/services/mallocHeader.hpp
+++ b/src/hotspot/share/services/mallocHeader.hpp
@@ -92,7 +92,7 @@ class MallocHeader {
   NOT_LP64(uint32_t _alt_canary);
   const size_t _size;
   const uint32_t _mst_marker;
-  const MEMFLAGS _flags;
+  const MemoryType _flags;
   const uint8_t _unused;
   uint16_t _canary;
 
@@ -121,14 +121,14 @@ public:
   // Contains all of the necessary data to to deaccount block with NMT.
   struct FreeInfo {
     const size_t size;
-    const MEMFLAGS flags;
+    const MemoryType flags;
     const uint32_t mst_marker;
   };
 
-  inline MallocHeader(size_t size, MEMFLAGS flags, uint32_t mst_marker);
+  inline MallocHeader(size_t size, MemoryType flags, uint32_t mst_marker);
 
   inline size_t   size()  const { return _size; }
-  inline MEMFLAGS flags() const { return _flags; }
+  inline MemoryType flags() const { return _flags; }
   inline uint32_t mst_marker() const { return _mst_marker; }
   bool get_stack(NativeCallStack& stack) const;
 

--- a/src/hotspot/share/services/mallocHeader.inline.hpp
+++ b/src/hotspot/share/services/mallocHeader.inline.hpp
@@ -34,7 +34,7 @@
 #include "utilities/macros.hpp"
 #include "utilities/nativeCallStack.hpp"
 
-inline MallocHeader::MallocHeader(size_t size, MEMFLAGS flags, uint32_t mst_marker)
+inline MallocHeader::MallocHeader(size_t size, MemoryType flags, uint32_t mst_marker)
   : _size(size), _mst_marker(mst_marker), _flags(flags),
     _unused(0), _canary(_header_canary_life_mark)
 {

--- a/src/hotspot/share/services/mallocSiteTable.cpp
+++ b/src/hotspot/share/services/mallocSiteTable.cpp
@@ -112,7 +112,7 @@ bool MallocSiteTable::walk(MallocSiteWalker* walker) {
  *    2. Overflow hash bucket.
  *  Under any of above circumstances, caller should handle the situation.
  */
-MallocSite* MallocSiteTable::lookup_or_add(const NativeCallStack& key, uint32_t* marker, MEMFLAGS flags) {
+MallocSite* MallocSiteTable::lookup_or_add(const NativeCallStack& key, uint32_t* marker, MemoryType flags) {
   assert(flags != mtNone, "Should have a real memory type");
   const unsigned int hash = key.calculate_hash();
   const unsigned int index = hash_to_index(hash);
@@ -178,9 +178,9 @@ MallocSite* MallocSiteTable::malloc_site(uint32_t marker) {
 // Allocates MallocSiteHashtableEntry object. Special call stack
 // (pre-installed allocation site) has to be used to avoid infinite
 // recursion.
-MallocSiteHashtableEntry* MallocSiteTable::new_entry(const NativeCallStack& key, MEMFLAGS flags) {
+MallocSiteHashtableEntry* MallocSiteTable::new_entry(const NativeCallStack& key, MemoryType flags) {
   void* p = AllocateHeap(sizeof(MallocSiteHashtableEntry), mtNMT,
-    *hash_entry_allocation_stack(), AllocFailStrategy::RETURN_NULL);
+    *hash_entry_allocation_stack(), AllocationFailureStrategy::RETURN_NULL);
   return ::new (p) MallocSiteHashtableEntry(key, flags);
 }
 

--- a/src/hotspot/share/services/mallocSiteTable.hpp
+++ b/src/hotspot/share/services/mallocSiteTable.hpp
@@ -38,7 +38,7 @@
 class MallocSite : public AllocationSite {
   MemoryCounter _c;
  public:
-  MallocSite(const NativeCallStack& stack, MEMFLAGS flags) :
+  MallocSite(const NativeCallStack& stack, MemoryType flags) :
     AllocationSite(stack, flags) {}
 
   void allocate(size_t size)      { _c.allocate(size);   }
@@ -63,7 +63,7 @@ class MallocSiteHashtableEntry : public CHeapObj<mtNMT> {
 
  public:
 
-  MallocSiteHashtableEntry(NativeCallStack stack, MEMFLAGS flags):
+  MallocSiteHashtableEntry(NativeCallStack stack, MemoryType flags):
     _malloc_site(stack, flags), _hash(stack.calculate_hash()), _next(nullptr) {
     assert(flags != mtNone, "Expect a real memory type");
   }
@@ -147,7 +147,7 @@ class MallocSiteTable : AllStatic {
   //  1. out of memory
   //  2. overflow hash bucket
   static inline bool allocation_at(const NativeCallStack& stack, size_t size,
-      uint32_t* marker, MEMFLAGS flags) {
+      uint32_t* marker, MemoryType flags) {
     MallocSite* site = lookup_or_add(stack, marker, flags);
     if (site != nullptr) site->allocate(size);
     return site != nullptr;
@@ -170,9 +170,9 @@ class MallocSiteTable : AllStatic {
   static void print_tuning_statistics(outputStream* st);
 
  private:
-  static MallocSiteHashtableEntry* new_entry(const NativeCallStack& key, MEMFLAGS flags);
+  static MallocSiteHashtableEntry* new_entry(const NativeCallStack& key, MemoryType flags);
 
-  static MallocSite* lookup_or_add(const NativeCallStack& key, uint32_t* marker, MEMFLAGS flags);
+  static MallocSite* lookup_or_add(const NativeCallStack& key, uint32_t* marker, MemoryType flags);
   static MallocSite* malloc_site(uint32_t marker);
   static bool walk(MallocSiteWalker* walker);
 

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -96,7 +96,7 @@ void MallocMemorySummary::initialize_limit_handling() {
       size_t catlim = _limits_per_category[i];
       if (catlim > 0) {
         log_info(nmt)("MallocLimit: category \"%s\" limit: " SIZE_FORMAT "%s",
-                      NMTUtil::flag_to_name((MEMFLAGS)i),
+                      NMTUtil::flag_to_name((MemoryType)i),
                       byte_size_in_proper_unit(catlim),
                       proper_unit_for_byte_size(catlim));
       }
@@ -112,7 +112,7 @@ void MallocMemorySummary::total_limit_reached(size_t size, size_t limit) {
   }
 }
 
-void MallocMemorySummary::category_limit_reached(size_t size, size_t limit, MEMFLAGS flag) {
+void MallocMemorySummary::category_limit_reached(size_t size, size_t limit, MemoryType flag) {
   // Assert in both debug and release, but allow error reporting to malloc beyond limits.
   if (!VMError::is_error_reported()) {
     fatal("MallocLimit: category \"%s\" reached limit (size: " SIZE_FORMAT ", limit: " SIZE_FORMAT ") ",
@@ -128,7 +128,7 @@ void MallocMemorySummary::print_limits(outputStream* st) {
     for (int i = 0; i < mt_number_of_types; i ++) {
       if (_limits_per_category[i] > 0) {
         st->print("%s%s:" SIZE_FORMAT, (first ? "MallocLimit: " : ", "),
-                  NMTUtil::flag_to_name((MEMFLAGS)i), _limits_per_category[i]);
+                  NMTUtil::flag_to_name((MemoryType)i), _limits_per_category[i]);
         first = false;
       }
     }
@@ -147,7 +147,7 @@ bool MallocTracker::initialize(NMT_TrackingLevel level) {
 }
 
 // Record a malloc memory allocation
-void* MallocTracker::record_malloc(void* malloc_base, size_t size, MEMFLAGS flags,
+void* MallocTracker::record_malloc(void* malloc_base, size_t size, MemoryType flags,
   const NativeCallStack& stack)
 {
   assert(MemTracker::enabled(), "precondition");

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -153,12 +153,12 @@ class MallocMemorySnapshot : public ResourceObj {
 
 
  public:
-  inline MallocMemory* by_type(MEMFLAGS flags) {
+  inline MallocMemory* by_type(MemoryType flags) {
     int index = NMTUtil::flag_to_index(flags);
     return &_malloc[index];
   }
 
-  inline const MallocMemory* by_type(MEMFLAGS flags) const {
+  inline const MallocMemory* by_type(MemoryType flags) const {
     int index = NMTUtil::flag_to_index(flags);
     return &_malloc[index];
   }
@@ -215,9 +215,9 @@ class MallocMemorySummary : AllStatic {
 
   static void initialize_limit_handling();
   static void total_limit_reached(size_t size, size_t limit);
-  static void category_limit_reached(size_t size, size_t limit, MEMFLAGS flag);
+  static void category_limit_reached(size_t size, size_t limit, MemoryType flag);
 
-  static void check_limits_after_allocation(MEMFLAGS flag) {
+  static void check_limits_after_allocation(MemoryType flag) {
     // We can only either have a total limit or category specific limits,
     // not both.
     if (_total_limit != 0) {
@@ -240,26 +240,26 @@ class MallocMemorySummary : AllStatic {
  public:
    static void initialize();
 
-   static inline void record_malloc(size_t size, MEMFLAGS flag) {
+   static inline void record_malloc(size_t size, MemoryType flag) {
      as_snapshot()->by_type(flag)->record_malloc(size);
      as_snapshot()->_all_mallocs.allocate(size);
      check_limits_after_allocation(flag);
    }
 
-   static inline void record_free(size_t size, MEMFLAGS flag) {
+   static inline void record_free(size_t size, MemoryType flag) {
      as_snapshot()->by_type(flag)->record_free(size);
      as_snapshot()->_all_mallocs.deallocate(size);
    }
 
-   static inline void record_new_arena(MEMFLAGS flag) {
+   static inline void record_new_arena(MemoryType flag) {
      as_snapshot()->by_type(flag)->record_new_arena();
    }
 
-   static inline void record_arena_free(MEMFLAGS flag) {
+   static inline void record_arena_free(MemoryType flag) {
      as_snapshot()->by_type(flag)->record_arena_free();
    }
 
-   static inline void record_arena_size_change(ssize_t size, MEMFLAGS flag) {
+   static inline void record_arena_size_change(ssize_t size, MemoryType flag) {
      as_snapshot()->by_type(flag)->record_arena_size_change(size);
      check_limits_after_allocation(flag);
    }
@@ -300,7 +300,7 @@ class MallocTracker : AllStatic {
   //
 
   // Record  malloc on specified memory block
-  static void* record_malloc(void* malloc_base, size_t size, MEMFLAGS flags,
+  static void* record_malloc(void* malloc_base, size_t size, MemoryType flags,
     const NativeCallStack& stack);
 
   // Given a block returned by os::malloc() or os::realloc():
@@ -309,15 +309,15 @@ class MallocTracker : AllStatic {
   // Given the free info from a block, de-account block from NMT.
   static void deaccount(MallocHeader::FreeInfo free_info);
 
-  static inline void record_new_arena(MEMFLAGS flags) {
+  static inline void record_new_arena(MemoryType flags) {
     MallocMemorySummary::record_new_arena(flags);
   }
 
-  static inline void record_arena_free(MEMFLAGS flags) {
+  static inline void record_arena_free(MemoryType flags) {
     MallocMemorySummary::record_arena_free(flags);
   }
 
-  static inline void record_arena_size_change(ssize_t size, MEMFLAGS flags) {
+  static inline void record_arena_size_change(ssize_t size, MemoryType flags) {
     MallocMemorySummary::record_arena_size_change(size, flags);
   }
 

--- a/src/hotspot/share/services/memBaseline.hpp
+++ b/src/hotspot/share/services/memBaseline.hpp
@@ -143,12 +143,12 @@ class MemBaseline {
     return bl->_malloc_memory_snapshot.malloc_overhead();
   }
 
-  MallocMemory* malloc_memory(MEMFLAGS flag) {
+  MallocMemory* malloc_memory(MemoryType flag) {
     assert(baseline_type() != Not_baselined, "Not yet baselined");
     return _malloc_memory_snapshot.by_type(flag);
   }
 
-  VirtualMemory* virtual_memory(MEMFLAGS flag) {
+  VirtualMemory* virtual_memory(MemoryType flag) {
     assert(baseline_type() != Not_baselined, "Not yet baselined");
     return _virtual_memory_snapshot.by_type(flag);
   }

--- a/src/hotspot/share/services/memJfrReporter.cpp
+++ b/src/hotspot/share/services/memJfrReporter.cpp
@@ -103,7 +103,7 @@ void MemJFRReporter::send_type_events() {
   Ticks timestamp = MemJFRCurrentUsage::get_timestamp();
 
   for (int index = 0; index < mt_number_of_types; index ++) {
-    MEMFLAGS flag = NMTUtil::index_to_flag(index);
+    MemoryType flag = NMTUtil::index_to_flag(index);
     if (flag == mtNone) {
       // Skip mtNone since it is not really used.
       continue;

--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -56,7 +56,7 @@ void MemReporterBase::print_total(size_t reserved, size_t committed) const {
     amount_in_current_scale(reserved), scale, amount_in_current_scale(committed), scale);
 }
 
-void MemReporterBase::print_malloc(const MemoryCounter* c, MEMFLAGS flag) const {
+void MemReporterBase::print_malloc(const MemoryCounter* c, MemoryType flag) const {
   const char* scale = current_scale();
   outputStream* out = output();
   const char* alloc_type = (flag == mtThreadStack) ? "" : "malloc=";
@@ -166,7 +166,7 @@ void MemSummaryReporter::report() {
 
   // Summary by memory type
   for (int index = 0; index < mt_number_of_types; index ++) {
-    MEMFLAGS flag = NMTUtil::index_to_flag(index);
+    MemoryType flag = NMTUtil::index_to_flag(index);
     // thread stack is reported as part of thread category
     if (flag == mtThreadStack) continue;
     MallocMemory* malloc_memory = _malloc_snapshot->by_type(flag);
@@ -176,7 +176,7 @@ void MemSummaryReporter::report() {
   }
 }
 
-void MemSummaryReporter::report_summary_of_type(MEMFLAGS flag,
+void MemSummaryReporter::report_summary_of_type(MemoryType flag,
   MallocMemory*  malloc_memory, VirtualMemory* virtual_memory) {
 
   size_t reserved_amount  = reserved_total (malloc_memory, virtual_memory);
@@ -327,7 +327,7 @@ int MemDetailReporter::report_malloc_sites() {
     const NativeCallStack* stack = malloc_site->call_stack();
     stack->print_on(out);
     out->print("%29s", " ");
-    MEMFLAGS flag = malloc_site->flag();
+    MemoryType flag = malloc_site->flag();
     assert(NMTUtil::flag_is_valid(flag) && flag != mtNone,
       "Must have a valid memory type");
     print_malloc(malloc_site->counter(), flag);
@@ -359,7 +359,7 @@ int MemDetailReporter::report_virtual_memory_allocation_sites()  {
     stack->print_on(out);
     out->print("%28s (", " ");
     print_total(virtual_memory_site->reserved(), virtual_memory_site->committed());
-    MEMFLAGS flag = virtual_memory_site->flag();
+    MemoryType flag = virtual_memory_site->flag();
     if (flag != mtNone) {
       out->print(" Type=%s", NMTUtil::flag_to_name(flag));
     }
@@ -449,7 +449,7 @@ void MemSummaryDiffReporter::report_diff() {
 
   // Summary diff by memory type
   for (int index = 0; index < mt_number_of_types; index ++) {
-    MEMFLAGS flag = NMTUtil::index_to_flag(index);
+    MemoryType flag = NMTUtil::index_to_flag(index);
     // thread stack is reported as part of thread category
     if (flag == mtThreadStack) continue;
     diff_summary_of_type(flag,
@@ -463,7 +463,7 @@ void MemSummaryDiffReporter::report_diff() {
 }
 
 void MemSummaryDiffReporter::print_malloc_diff(size_t current_amount, size_t current_count,
-    size_t early_amount, size_t early_count, MEMFLAGS flags) const {
+    size_t early_amount, size_t early_count, MemoryType flags) const {
   const char* scale = current_scale();
   outputStream* out = output();
   const char* alloc_type = (flags == mtThread) ? "" : "malloc=";
@@ -521,7 +521,7 @@ void MemSummaryDiffReporter::print_virtual_memory_diff(size_t current_reserved, 
 }
 
 
-void MemSummaryDiffReporter::diff_summary_of_type(MEMFLAGS flag,
+void MemSummaryDiffReporter::diff_summary_of_type(MemoryType flag,
   const MallocMemory* early_malloc, const VirtualMemory* early_vm,
   const MetaspaceCombinedStats& early_ms,
   const MallocMemory* current_malloc, const VirtualMemory* current_vm,
@@ -814,7 +814,7 @@ void MemDetailDiffReporter::diff_malloc_site(const MallocSite* early,
 }
 
 void MemDetailDiffReporter::diff_malloc_site(const NativeCallStack* stack, size_t current_size,
-  size_t current_count, size_t early_size, size_t early_count, MEMFLAGS flags) const {
+  size_t current_count, size_t early_size, size_t early_count, MemoryType flags) const {
   outputStream* out = output();
 
   assert(stack != nullptr, "null stack");
@@ -849,7 +849,7 @@ void MemDetailDiffReporter::diff_virtual_memory_site(const VirtualMemoryAllocati
 }
 
 void MemDetailDiffReporter::diff_virtual_memory_site(const NativeCallStack* stack, size_t current_reserved,
-  size_t current_committed, size_t early_reserved, size_t early_committed, MEMFLAGS flag) const  {
+  size_t current_committed, size_t early_reserved, size_t early_committed, MemoryType flag) const  {
   outputStream* out = output();
 
   // no change

--- a/src/hotspot/share/services/memReporter.hpp
+++ b/src/hotspot/share/services/memReporter.hpp
@@ -108,7 +108,7 @@ class MemReporterBase : public StackObj {
 
   // Print summary total, malloc and virtual memory
   void print_total(size_t reserved, size_t committed) const;
-  void print_malloc(const MemoryCounter* c, MEMFLAGS flag = mtNone) const;
+  void print_malloc(const MemoryCounter* c, MemoryType flag = mtNone) const;
   void print_virtual_memory(size_t reserved, size_t committed) const;
 
   void print_malloc_line(const MemoryCounter* c) const;
@@ -142,7 +142,7 @@ class MemSummaryReporter : public MemReporterBase {
   virtual void report();
  private:
   // Report summary for each memory type
-  void report_summary_of_type(MEMFLAGS type, MallocMemory* malloc_memory,
+  void report_summary_of_type(MemoryType type, MallocMemory* malloc_memory,
     VirtualMemory* virtual_memory);
 
   void report_metadata(Metaspace::MetadataType type) const;
@@ -204,7 +204,7 @@ class MemSummaryDiffReporter : public MemReporterBase {
 
  private:
   // report the comparison of each memory type
-  void diff_summary_of_type(MEMFLAGS type,
+  void diff_summary_of_type(MemoryType type,
     const MallocMemory* early_malloc, const VirtualMemory* early_vm,
     const MetaspaceCombinedStats& early_ms,
     const MallocMemory* current_malloc, const VirtualMemory* current_vm,
@@ -212,7 +212,7 @@ class MemSummaryDiffReporter : public MemReporterBase {
 
  protected:
   void print_malloc_diff(size_t current_amount, size_t current_count,
-    size_t early_amount, size_t early_count, MEMFLAGS flags) const;
+    size_t early_amount, size_t early_count, MemoryType flags) const;
   void print_virtual_memory_diff(size_t current_reserved, size_t current_committed,
     size_t early_reserved, size_t early_committed) const;
   void print_arena_diff(size_t current_amount, size_t current_count,
@@ -260,9 +260,9 @@ class MemDetailDiffReporter : public MemSummaryDiffReporter {
                                 const VirtualMemoryAllocationSite* current)  const;
 
   void diff_malloc_site(const NativeCallStack* stack, size_t current_size,
-    size_t currrent_count, size_t early_size, size_t early_count, MEMFLAGS flags) const;
+    size_t currrent_count, size_t early_size, size_t early_count, MemoryType flags) const;
   void diff_virtual_memory_site(const NativeCallStack* stack, size_t current_reserved,
-    size_t current_committed, size_t early_reserved, size_t early_committed, MEMFLAGS flag) const;
+    size_t current_committed, size_t early_reserved, size_t early_committed, MemoryType flag) const;
 };
 
 #endif // SHARE_SERVICES_MEMREPORTER_HPP

--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -93,7 +93,7 @@ class MemTracker : AllStatic {
     return enabled() ? MallocTracker::overhead_per_malloc : 0;
   }
 
-  static inline void* record_malloc(void* mem_base, size_t size, MEMFLAGS flag,
+  static inline void* record_malloc(void* mem_base, size_t size, MemoryType flag,
     const NativeCallStack& stack) {
     assert(mem_base != nullptr, "caller should handle null");
     if (enabled()) {
@@ -117,20 +117,20 @@ class MemTracker : AllStatic {
   }
 
   // Record creation of an arena
-  static inline void record_new_arena(MEMFLAGS flag) {
+  static inline void record_new_arena(MemoryType flag) {
     if (!enabled()) return;
     MallocTracker::record_new_arena(flag);
   }
 
   // Record destruction of an arena
-  static inline void record_arena_free(MEMFLAGS flag) {
+  static inline void record_arena_free(MemoryType flag) {
     if (!enabled()) return;
     MallocTracker::record_arena_free(flag);
   }
 
   // Record arena size change. Arena size is the size of all arena
   // chunks that are backing up the arena.
-  static inline void record_arena_size_change(ssize_t diff, MEMFLAGS flag) {
+  static inline void record_arena_size_change(ssize_t diff, MemoryType flag) {
     if (!enabled()) return;
     MallocTracker::record_arena_size_change(diff, flag);
   }
@@ -139,7 +139,7 @@ class MemTracker : AllStatic {
   //  (we do not do any reservations before that).
 
   static inline void record_virtual_memory_reserve(void* addr, size_t size, const NativeCallStack& stack,
-    MEMFLAGS flag = mtNone) {
+    MemoryType flag = mtNone) {
     assert_post_init();
     if (!enabled()) return;
     if (addr != nullptr) {
@@ -149,7 +149,7 @@ class MemTracker : AllStatic {
   }
 
   static inline void record_virtual_memory_reserve_and_commit(void* addr, size_t size,
-    const NativeCallStack& stack, MEMFLAGS flag = mtNone) {
+    const NativeCallStack& stack, MemoryType flag = mtNone) {
     assert_post_init();
     if (!enabled()) return;
     if (addr != nullptr) {
@@ -184,7 +184,7 @@ class MemTracker : AllStatic {
     }
   }
 
-  static inline void record_virtual_memory_type(void* addr, MEMFLAGS flag) {
+  static inline void record_virtual_memory_type(void* addr, MemoryType flag) {
     assert_post_init();
     if (!enabled()) return;
     if (addr != nullptr) {

--- a/src/hotspot/share/services/nmtCommon.cpp
+++ b/src/hotspot/share/services/nmtCommon.cpp
@@ -29,13 +29,6 @@ STATIC_ASSERT(NMT_off > NMT_unknown);
 STATIC_ASSERT(NMT_summary > NMT_off);
 STATIC_ASSERT(NMT_detail > NMT_summary);
 
-#define MEMORY_TYPE_DECLARE_NAME(type, human_readable) \
-  { #type, human_readable },
-
-NMTUtil::S NMTUtil::_strings[] = {
-  MEMORY_TYPES_DO(MEMORY_TYPE_DECLARE_NAME)
-};
-
 const char* NMTUtil::scale_name(size_t scale) {
   switch(scale) {
     case 1: return "";
@@ -85,17 +78,4 @@ NMT_TrackingLevel NMTUtil::parse_tracking_level(const char* s) {
     }
   }
   return NMT_unknown;
-}
-
-MEMFLAGS NMTUtil::string_to_flag(const char* s) {
-  for (int i = 0; i < mt_number_of_types; i ++) {
-    assert(::strlen(_strings[i].enum_s) > 2, "Sanity"); // should always start with "mt"
-    if (::strcasecmp(_strings[i].human_readable, s) == 0 ||
-        ::strcasecmp(_strings[i].enum_s, s) == 0 ||
-        ::strcasecmp(_strings[i].enum_s + 2, s) == 0) // "mtXXX" -> match also "XXX" or "xxx"
-    {
-      return (MEMFLAGS)i;
-    }
-  }
-  return mtNone;
 }

--- a/src/hotspot/share/services/nmtCommon.hpp
+++ b/src/hotspot/share/services/nmtCommon.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_SERVICES_NMTCOMMON_HPP
 #define SHARE_SERVICES_NMTCOMMON_HPP
 
-#include "memory/allocation.hpp" // for MEMFLAGS only
+#include "memory/types.hpp"
 #include "utilities/align.hpp"
 #include "utilities/globalDefinitions.hpp"
 
@@ -74,32 +74,29 @@ const int NMT_TrackingStackDepth = 4;
 // A few common utilities for native memory tracking
 class NMTUtil : AllStatic {
  public:
-  // Check if index is a valid MEMFLAGS enum value (including mtNone)
+  // Check if index is a valid MemoryType enum value (including mtNone)
   static inline bool flag_index_is_valid(int index) {
-    return index >= 0 && index < mt_number_of_types;
+    return MemoryTypes::is_index_valid(index);
   }
 
-  // Check if flag value is a valid MEMFLAGS enum value (including mtNone)
-  static inline bool flag_is_valid(MEMFLAGS flag) {
-    const int index = static_cast<int>(flag);
-    return flag_index_is_valid(index);
+  // Check if flag value is a valid MemoryType enum value (including mtNone)
+  static inline bool flag_is_valid(MemoryType flag) {
+    return MemoryTypes::is_valid(flag);
   }
 
   // Map memory type to index
-  static inline int flag_to_index(MEMFLAGS flag) {
-    assert(flag_is_valid(flag), "Invalid flag (%u)", (unsigned)flag);
-    return static_cast<int>(flag);
+  static inline int flag_to_index(MemoryType flag) {
+    return MemoryTypes::to_index(flag);
   }
 
   // Map memory type to human readable name
-  static const char* flag_to_name(MEMFLAGS flag) {
-    return _strings[flag_to_index(flag)].human_readable;
+  static const char* flag_to_name(MemoryType flag) {
+    return MemoryTypes::name(flag);
   }
 
   // Map an index to memory type
-  static MEMFLAGS index_to_flag(int index) {
-    assert(flag_index_is_valid(index), "Invalid flag index (%d)", index);
-    return static_cast<MEMFLAGS>(index);
+  static MemoryType index_to_flag(int index) {
+    return MemoryTypes::from_index(index);
   }
 
   // Memory size scale
@@ -118,17 +115,12 @@ class NMTUtil : AllStatic {
   // Given a string, return associated flag. mtNone if name is invalid.
   // String can be either the human readable name or the
   // stringified enum (with or without leading "mt". In all cases, case is ignored.
-  static MEMFLAGS string_to_flag(const char* name);
+  static MemoryType string_to_flag(const char* name) {
+    return MemoryTypes::from_string(name);
+  }
 
   // Returns textual representation of a tracking level.
   static const char* tracking_level_to_string(NMT_TrackingLevel level);
-
- private:
-  struct S {
-    const char* enum_s; // e.g. "mtNMT"
-    const char* human_readable; // e.g. "Native Memory Tracking"
-  };
-  static S _strings[mt_number_of_types];
 };
 
 

--- a/src/hotspot/share/services/nmtUsage.cpp
+++ b/src/hotspot/share/services/nmtUsage.cpp
@@ -60,7 +60,7 @@ void NMTUsage::update_malloc_usage() {
 
   size_t total_arena_size = 0;
   for (int i = 0; i < mt_number_of_types; i++) {
-    MEMFLAGS flag = NMTUtil::index_to_flag(i);
+    MemoryType flag = NMTUtil::index_to_flag(i);
     const MallocMemory* mm = ms->by_type(flag);
     _malloc_by_type[i] = mm->malloc_size() + mm->arena_size();
     total_arena_size +=  mm->arena_size();
@@ -84,7 +84,7 @@ void NMTUsage::update_vm_usage() {
   _vm_total.committed = 0;
   _vm_total.reserved = 0;
   for (int i = 0; i < mt_number_of_types; i++) {
-    MEMFLAGS flag = NMTUtil::index_to_flag(i);
+    MemoryType flag = NMTUtil::index_to_flag(i);
     const VirtualMemory* vm = vms->by_type(flag);
 
     _vm_by_type[i].reserved = vm->reserved();
@@ -118,12 +118,12 @@ size_t NMTUsage::total_committed() const {
   return _malloc_total + _vm_total.committed;
 }
 
-size_t NMTUsage::reserved(MEMFLAGS flag) const {
+size_t NMTUsage::reserved(MemoryType flag) const {
   int index = NMTUtil::flag_to_index(flag);
   return _malloc_by_type[index] + _vm_by_type[index].reserved;
 }
 
-size_t NMTUsage::committed(MEMFLAGS flag) const {
+size_t NMTUsage::committed(MemoryType flag) const {
   int index = NMTUtil::flag_to_index(flag);
   return _malloc_by_type[index] + _vm_by_type[index].committed;
 }

--- a/src/hotspot/share/services/nmtUsage.hpp
+++ b/src/hotspot/share/services/nmtUsage.hpp
@@ -61,8 +61,8 @@ public:
 
   size_t total_reserved() const;
   size_t total_committed() const;
-  size_t reserved(MEMFLAGS flag) const;
-  size_t committed(MEMFLAGS flag) const;
+  size_t reserved(MemoryType flag) const;
+  size_t committed(MemoryType flag) const;
 };
 
 #endif // SHARE_SERVICES_NMTUSAGE_HPP

--- a/src/hotspot/share/services/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.cpp
@@ -288,7 +288,7 @@ size_t ReservedMemoryRegion::committed_size() const {
   return committed;
 }
 
-void ReservedMemoryRegion::set_flag(MEMFLAGS f) {
+void ReservedMemoryRegion::set_flag(MemoryType f) {
   assert((flag() == mtNone || flag() == f),
          "Overwrite memory type for region [" INTPTR_FORMAT "-" INTPTR_FORMAT "), %u->%u.",
          p2i(base()), p2i(end()), (unsigned)flag(), (unsigned)f);
@@ -331,7 +331,7 @@ bool VirtualMemoryTracker::initialize(NMT_TrackingLevel level) {
 }
 
 bool VirtualMemoryTracker::add_reserved_region(address base_addr, size_t size,
-    const NativeCallStack& stack, MEMFLAGS flag) {
+    const NativeCallStack& stack, MemoryType flag) {
   assert(base_addr != nullptr, "Invalid address");
   assert(size > 0, "Invalid size");
   assert(_reserved_regions != nullptr, "Sanity check");
@@ -406,7 +406,7 @@ bool VirtualMemoryTracker::add_reserved_region(address base_addr, size_t size,
   }
 }
 
-void VirtualMemoryTracker::set_reserved_region_type(address addr, MEMFLAGS flag) {
+void VirtualMemoryTracker::set_reserved_region_type(address addr, MemoryType flag) {
   assert(addr != nullptr, "Invalid address");
   assert(_reserved_regions != nullptr, "Sanity check");
 
@@ -560,7 +560,7 @@ bool VirtualMemoryTracker::split_reserved_region(address addr, size_t size, size
   assert(reserved_rgn->committed_size() == 0, "Splitting committed region?");
 
   NativeCallStack original_stack = *reserved_rgn->call_stack();
-  MEMFLAGS original_flags = reserved_rgn->flag();
+  MemoryType original_flags = reserved_rgn->flag();
 
   const char* name = reserved_rgn->flag_name();
   remove_released_region(reserved_rgn);

--- a/src/hotspot/share/services/virtualMemoryTracker.hpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.hpp
@@ -70,7 +70,7 @@ class VirtualMemory {
 class VirtualMemoryAllocationSite : public AllocationSite {
   VirtualMemory _c;
  public:
-  VirtualMemoryAllocationSite(const NativeCallStack& stack, MEMFLAGS flag) :
+  VirtualMemoryAllocationSite(const NativeCallStack& stack, MemoryType flag) :
     AllocationSite(stack, flag) { }
 
   inline void reserve_memory(size_t sz)  { _c.reserve_memory(sz);  }
@@ -92,12 +92,12 @@ class VirtualMemorySnapshot : public ResourceObj {
   VirtualMemory  _virtual_memory[mt_number_of_types];
 
  public:
-  inline VirtualMemory* by_type(MEMFLAGS flag) {
+  inline VirtualMemory* by_type(MemoryType flag) {
     int index = NMTUtil::flag_to_index(flag);
     return &_virtual_memory[index];
   }
 
-  inline const VirtualMemory* by_type(MEMFLAGS flag) const {
+  inline const VirtualMemory* by_type(MemoryType flag) const {
     int index = NMTUtil::flag_to_index(flag);
     return &_virtual_memory[index];
   }
@@ -129,19 +129,19 @@ class VirtualMemorySummary : AllStatic {
  public:
   static void initialize();
 
-  static inline void record_reserved_memory(size_t size, MEMFLAGS flag) {
+  static inline void record_reserved_memory(size_t size, MemoryType flag) {
     as_snapshot()->by_type(flag)->reserve_memory(size);
   }
 
-  static inline void record_committed_memory(size_t size, MEMFLAGS flag) {
+  static inline void record_committed_memory(size_t size, MemoryType flag) {
     as_snapshot()->by_type(flag)->commit_memory(size);
   }
 
-  static inline void record_uncommitted_memory(size_t size, MEMFLAGS flag) {
+  static inline void record_uncommitted_memory(size_t size, MemoryType flag) {
     as_snapshot()->by_type(flag)->uncommit_memory(size);
   }
 
-  static inline void record_released_memory(size_t size, MEMFLAGS flag) {
+  static inline void record_released_memory(size_t size, MemoryType flag) {
     as_snapshot()->by_type(flag)->release_memory(size);
   }
 
@@ -149,12 +149,12 @@ class VirtualMemorySummary : AllStatic {
   // Virtual memory can be reserved before it is associated with a memory type, and tagged
   // as 'unknown'. Once the memory is tagged, the virtual memory will be moved from 'unknown'
   // type to specified memory type.
-  static inline void move_reserved_memory(MEMFLAGS from, MEMFLAGS to, size_t size) {
+  static inline void move_reserved_memory(MemoryType from, MemoryType to, size_t size) {
     as_snapshot()->by_type(from)->release_memory(size);
     as_snapshot()->by_type(to)->reserve_memory(size);
   }
 
-  static inline void move_committed_memory(MEMFLAGS from, MEMFLAGS to, size_t size) {
+  static inline void move_committed_memory(MemoryType from, MemoryType to, size_t size) {
     as_snapshot()->by_type(from)->uncommit_memory(size);
     as_snapshot()->by_type(to)->commit_memory(size);
   }
@@ -288,11 +288,11 @@ class ReservedMemoryRegion : public VirtualMemoryRegion {
     _committed_regions;
 
   NativeCallStack  _stack;
-  MEMFLAGS         _flag;
+  MemoryType         _flag;
 
  public:
   ReservedMemoryRegion(address base, size_t size, const NativeCallStack& stack,
-    MEMFLAGS flag = mtNone) :
+    MemoryType flag = mtNone) :
     VirtualMemoryRegion(base, size), _stack(stack), _flag(flag) { }
 
 
@@ -308,8 +308,8 @@ class ReservedMemoryRegion : public VirtualMemoryRegion {
   inline void  set_call_stack(const NativeCallStack& stack) { _stack = stack; }
   inline const NativeCallStack* call_stack() const          { return &_stack;  }
 
-  void  set_flag(MEMFLAGS flag);
-  inline MEMFLAGS flag() const            { return _flag;  }
+  void  set_flag(MemoryType flag);
+  inline MemoryType flag() const            { return _flag;  }
 
   // uncommitted thread stack bottom, above guard pages if there is any.
   address thread_stack_uncommitted_bottom() const;
@@ -374,13 +374,13 @@ class VirtualMemoryTracker : AllStatic {
  public:
   static bool initialize(NMT_TrackingLevel level);
 
-  static bool add_reserved_region (address base_addr, size_t size, const NativeCallStack& stack, MEMFLAGS flag = mtNone);
+  static bool add_reserved_region (address base_addr, size_t size, const NativeCallStack& stack, MemoryType flag = mtNone);
 
   static bool add_committed_region      (address base_addr, size_t size, const NativeCallStack& stack);
   static bool remove_uncommitted_region (address base_addr, size_t size);
   static bool remove_released_region    (address base_addr, size_t size);
   static bool remove_released_region    (ReservedMemoryRegion* rgn);
-  static void set_reserved_region_type  (address addr, MEMFLAGS flag);
+  static void set_reserved_region_type  (address addr, MemoryType flag);
 
   // Given an existing memory mapping registered with NMT, split the mapping in
   //  two. The newly created two mappings will be registered under the call

--- a/src/hotspot/share/utilities/bitMap.cpp
+++ b/src/hotspot/share/utilities/bitMap.cpp
@@ -125,7 +125,7 @@ bm_word_t* ResourceBitMap::reallocate(bm_word_t* old_map, size_t old_size_in_wor
   return pseudo_reallocate(*this, old_map, old_size_in_words, new_size_in_words);
 }
 
-CHeapBitMap::CHeapBitMap(idx_t size_in_bits, MEMFLAGS flags, bool clear)
+CHeapBitMap::CHeapBitMap(idx_t size_in_bits, MemoryType flags, bool clear)
   : GrowableBitMap<CHeapBitMap>(), _flags(flags) {
   initialize(size_in_bits, clear);
 }

--- a/src/hotspot/share/utilities/bitMap.hpp
+++ b/src/hotspot/share/utilities/bitMap.hpp
@@ -391,15 +391,15 @@ class ResourceBitMap : public GrowableBitMap<ResourceBitMap> {
 // A BitMap with storage in the CHeap.
 class CHeapBitMap : public GrowableBitMap<CHeapBitMap> {
   // NMT memory type
-  const MEMFLAGS _flags;
+  const MemoryType _flags;
 
   // Don't allow copy or assignment, to prevent the
   // allocated memory from leaking out to other instances.
   NONCOPYABLE(CHeapBitMap);
 
  public:
-  explicit CHeapBitMap(MEMFLAGS flags) : GrowableBitMap(0, false), _flags(flags) {}
-  CHeapBitMap(idx_t size_in_bits, MEMFLAGS flags, bool clear = true);
+  explicit CHeapBitMap(MemoryType flags) : GrowableBitMap(0, false), _flags(flags) {}
+  CHeapBitMap(idx_t size_in_bits, MemoryType flags, bool clear = true);
   ~CHeapBitMap();
 
   bm_word_t* allocate(idx_t size_in_words) const;

--- a/src/hotspot/share/utilities/chunkedList.hpp
+++ b/src/hotspot/share/utilities/chunkedList.hpp
@@ -28,7 +28,7 @@
 #include "memory/allocation.hpp"
 #include "utilities/debug.hpp"
 
-template <class T, MEMFLAGS F> class ChunkedList : public CHeapObj<F> {
+template <class T, MemoryType F> class ChunkedList : public CHeapObj<F> {
   template <class U> friend class TestChunkedList;
 
   static const size_t BufferSize = 64;

--- a/src/hotspot/share/utilities/concurrentHashTable.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.hpp
@@ -39,7 +39,7 @@
 class Thread;
 class Mutex;
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 class ConcurrentHashTable : public CHeapObj<F> {
   typedef typename CONFIG::Value VALUE;
  private:
@@ -60,7 +60,7 @@ class ConcurrentHashTable : public CHeapObj<F> {
   TableStatistics statistics_calculate(Thread* thread, VALUE_SIZE_FUNC& vs_f);
 
   // This is the internal node structure.
-  // Only constructed with placement new from memory allocated with MEMFLAGS of
+  // Only constructed with placement new from memory allocated with MemoryType of
   // the InternalTable or user-defined memory.
   class Node {
    private:
@@ -92,7 +92,7 @@ class ConcurrentHashTable : public CHeapObj<F> {
     void print_value_on(outputStream* st) const {};
   };
 
-  // Only constructed with placement new from an array allocated with MEMFLAGS
+  // Only constructed with placement new from an array allocated with MemoryType
   // of InternalTable.
   class Bucket {
    private:

--- a/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
@@ -58,7 +58,7 @@ static void* const POISON_PTR = (void*)0xffbadbac;
 #endif
 
 // Node
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline typename ConcurrentHashTable<CONFIG, F>::Node*
 ConcurrentHashTable<CONFIG, F>::
   Node::next() const
@@ -67,7 +67,7 @@ ConcurrentHashTable<CONFIG, F>::
 }
 
 // Bucket
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline typename ConcurrentHashTable<CONFIG, F>::Node*
 ConcurrentHashTable<CONFIG, F>::
   Bucket::first_raw() const
@@ -75,7 +75,7 @@ ConcurrentHashTable<CONFIG, F>::
   return Atomic::load_acquire(&_first);
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline void ConcurrentHashTable<CONFIG, F>::
   Bucket::release_assign_node_ptr(
     typename ConcurrentHashTable<CONFIG, F>::Node* const volatile * dst,
@@ -87,7 +87,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
   Atomic::release_store(tmp, clear_set_state(node, *dst));
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline typename ConcurrentHashTable<CONFIG, F>::Node*
 ConcurrentHashTable<CONFIG, F>::
   Bucket::first() const
@@ -96,21 +96,21 @@ ConcurrentHashTable<CONFIG, F>::
   return clear_state(Atomic::load_acquire(&_first));
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline bool ConcurrentHashTable<CONFIG, F>::
   Bucket::have_redirect() const
 {
   return is_state(first_raw(), STATE_REDIRECT_BIT);
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline bool ConcurrentHashTable<CONFIG, F>::
   Bucket::is_locked() const
 {
   return is_state(first_raw(), STATE_LOCK_BIT);
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline void ConcurrentHashTable<CONFIG, F>::
   Bucket::lock()
 {
@@ -128,7 +128,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
   }
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline void ConcurrentHashTable<CONFIG, F>::
   Bucket::release_assign_last_node_next(
      typename ConcurrentHashTable<CONFIG, F>::Node* node)
@@ -141,7 +141,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
   release_assign_node_ptr(ret, node);
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline bool ConcurrentHashTable<CONFIG, F>::
   Bucket::cas_first(typename ConcurrentHashTable<CONFIG, F>::Node* node,
                     typename ConcurrentHashTable<CONFIG, F>::Node* expect
@@ -156,7 +156,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   return false;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline bool ConcurrentHashTable<CONFIG, F>::
   Bucket::trylock()
 {
@@ -171,7 +171,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   return false;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline void ConcurrentHashTable<CONFIG, F>::
   Bucket::unlock()
 {
@@ -181,7 +181,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
   Atomic::release_store(&_first, clear_state(first()));
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline void ConcurrentHashTable<CONFIG, F>::
   Bucket::redirect()
 {
@@ -190,7 +190,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
 }
 
 // InternalTable
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline ConcurrentHashTable<CONFIG, F>::
   InternalTable::InternalTable(size_t log2_size)
     : _log2_size(log2_size), _size(((size_t)1ul) << _log2_size),
@@ -206,7 +206,7 @@ inline ConcurrentHashTable<CONFIG, F>::
   }
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline ConcurrentHashTable<CONFIG, F>::
   InternalTable::~InternalTable()
 {
@@ -214,7 +214,7 @@ inline ConcurrentHashTable<CONFIG, F>::
 }
 
 // ScopedCS
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline ConcurrentHashTable<CONFIG, F>::
   ScopedCS::ScopedCS(Thread* thread, ConcurrentHashTable<CONFIG, F>* cht)
     : _thread(thread),
@@ -227,14 +227,14 @@ inline ConcurrentHashTable<CONFIG, F>::
   }
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline ConcurrentHashTable<CONFIG, F>::
   ScopedCS::~ScopedCS()
 {
   GlobalCounter::critical_section_end(_thread, _cs_context);
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 template <typename LOOKUP_FUNC>
 inline typename CONFIG::Value* ConcurrentHashTable<CONFIG, F>::
   MultiGetHandle::get(LOOKUP_FUNC& lookup_f, bool* grow_hint)
@@ -243,7 +243,7 @@ inline typename CONFIG::Value* ConcurrentHashTable<CONFIG, F>::
 }
 
 // HaveDeletables
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 template <typename EVALUATE_FUNC>
 inline bool ConcurrentHashTable<CONFIG, F>::
   HaveDeletables<true, EVALUATE_FUNC>::have_deletable(Bucket* bucket,
@@ -271,7 +271,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   return false;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 template <bool b, typename EVALUATE_FUNC>
 inline bool ConcurrentHashTable<CONFIG, F>::
   HaveDeletables<b, EVALUATE_FUNC>::have_deletable(Bucket* bucket,
@@ -287,7 +287,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
 }
 
 // ConcurrentHashTable
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline void ConcurrentHashTable<CONFIG, F>::
   write_synchonize_on_visible_epoch(Thread* thread)
 {
@@ -304,7 +304,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
   GlobalCounter::write_synchronize();
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline bool ConcurrentHashTable<CONFIG, F>::
   try_resize_lock(Thread* locker)
 {
@@ -323,7 +323,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   return true;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline void ConcurrentHashTable<CONFIG, F>::
   lock_resize_lock(Thread* locker)
 {
@@ -348,7 +348,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
   _invisible_epoch = 0;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline void ConcurrentHashTable<CONFIG, F>::
   unlock_resize_lock(Thread* locker)
 {
@@ -358,7 +358,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
   _resize_lock->unlock();
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline void ConcurrentHashTable<CONFIG, F>::
   free_nodes()
 {
@@ -374,7 +374,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
   }
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline typename ConcurrentHashTable<CONFIG, F>::InternalTable*
 ConcurrentHashTable<CONFIG, F>::
   get_table() const
@@ -382,7 +382,7 @@ ConcurrentHashTable<CONFIG, F>::
   return Atomic::load_acquire(&_table);
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline typename ConcurrentHashTable<CONFIG, F>::InternalTable*
 ConcurrentHashTable<CONFIG, F>::
   get_new_table() const
@@ -390,7 +390,7 @@ ConcurrentHashTable<CONFIG, F>::
   return Atomic::load_acquire(&_new_table);
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline typename ConcurrentHashTable<CONFIG, F>::InternalTable*
 ConcurrentHashTable<CONFIG, F>::
   set_table_from_new()
@@ -406,7 +406,7 @@ ConcurrentHashTable<CONFIG, F>::
   return old_table;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline void ConcurrentHashTable<CONFIG, F>::
   internal_grow_range(Thread* thread, size_t start, size_t stop)
 {
@@ -446,7 +446,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
   }
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 template <typename LOOKUP_FUNC, typename DELETE_FUNC>
 inline bool ConcurrentHashTable<CONFIG, F>::
   internal_remove(Thread* thread, LOOKUP_FUNC& lookup_f, DELETE_FUNC& delete_f)
@@ -479,7 +479,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   return true;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 template <typename EVALUATE_FUNC, typename DELETE_FUNC>
 inline void ConcurrentHashTable<CONFIG, F>::
   do_bulk_delete_locked_for(Thread* thread, size_t start_idx, size_t stop_idx,
@@ -534,7 +534,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
   GlobalCounter::critical_section_end(thread, cs_context);
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 template <typename LOOKUP_FUNC>
 inline void ConcurrentHashTable<CONFIG, F>::
   delete_in_bucket(Thread* thread, Bucket* bucket, LOOKUP_FUNC& lookup_f)
@@ -571,7 +571,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
   }
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline typename ConcurrentHashTable<CONFIG, F>::Bucket*
 ConcurrentHashTable<CONFIG, F>::
   get_bucket(uintx hash) const
@@ -585,7 +585,7 @@ ConcurrentHashTable<CONFIG, F>::
   return bucket;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline typename ConcurrentHashTable<CONFIG, F>::Bucket*
 ConcurrentHashTable<CONFIG, F>::
   get_bucket_locked(Thread* thread, const uintx hash)
@@ -616,7 +616,7 @@ ConcurrentHashTable<CONFIG, F>::
 }
 
 // Always called within critical section
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 template <typename LOOKUP_FUNC>
 typename ConcurrentHashTable<CONFIG, F>::Node*
 ConcurrentHashTable<CONFIG, F>::
@@ -642,7 +642,7 @@ ConcurrentHashTable<CONFIG, F>::
   return node;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline bool ConcurrentHashTable<CONFIG, F>::
   unzip_bucket(Thread* thread, InternalTable* old_table,
                InternalTable* new_table, size_t even_index, size_t odd_index)
@@ -700,7 +700,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   return true;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline bool ConcurrentHashTable<CONFIG, F>::
   internal_shrink_prolog(Thread* thread, size_t log2_size)
 {
@@ -717,7 +717,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   return true;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline void ConcurrentHashTable<CONFIG, F>::
   internal_shrink_epilog(Thread* thread)
 {
@@ -736,7 +736,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
   delete old_table;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline void ConcurrentHashTable<CONFIG, F>::
   internal_shrink_range(Thread* thread, size_t start, size_t stop)
 {
@@ -773,7 +773,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
   }
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline bool ConcurrentHashTable<CONFIG, F>::
   internal_shrink(Thread* thread, size_t log2_size)
 {
@@ -788,7 +788,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   return true;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline void ConcurrentHashTable<CONFIG, F>::
   internal_reset(size_t log2_size)
 {
@@ -802,7 +802,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
   Atomic::release_store(&_table, table);
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline bool ConcurrentHashTable<CONFIG, F>::
   internal_grow_prolog(Thread* thread, size_t log2_size)
 {
@@ -828,7 +828,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   return true;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline void ConcurrentHashTable<CONFIG, F>::
   internal_grow_epilog(Thread* thread)
 {
@@ -846,7 +846,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
   delete old_table;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline bool ConcurrentHashTable<CONFIG, F>::
   internal_grow(Thread* thread, size_t log2_size)
 {
@@ -862,7 +862,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
 }
 
 // Always called within critical section
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 template <typename LOOKUP_FUNC>
 inline typename CONFIG::Value* ConcurrentHashTable<CONFIG, F>::
   internal_get(Thread* thread, LOOKUP_FUNC& lookup_f, bool* grow_hint)
@@ -883,7 +883,7 @@ inline typename CONFIG::Value* ConcurrentHashTable<CONFIG, F>::
   return ret;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 template <typename LOOKUP_FUNC, typename FOUND_FUNC>
 inline bool ConcurrentHashTable<CONFIG, F>::
   internal_insert_get(Thread* thread, LOOKUP_FUNC& lookup_f, const VALUE& value,
@@ -950,7 +950,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   return ret;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 template <typename FUNC>
 inline bool ConcurrentHashTable<CONFIG, F>::
   visit_nodes(Bucket* bucket, FUNC& visitor_f)
@@ -966,7 +966,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   return true;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 template <typename FUNC>
 inline void ConcurrentHashTable<CONFIG, F>::
   do_scan_locked(Thread* thread, FUNC& scan_f)
@@ -983,7 +983,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
   } /* ends critical section */
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 template <typename EVALUATE_FUNC>
 inline size_t ConcurrentHashTable<CONFIG, F>::
   delete_check_nodes(Bucket* bucket, EVALUATE_FUNC& eval_f,
@@ -1014,7 +1014,7 @@ inline size_t ConcurrentHashTable<CONFIG, F>::
 }
 
 // Constructor
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline ConcurrentHashTable<CONFIG, F>::
 ConcurrentHashTable(size_t log2size, size_t log2size_limit, size_t grow_hint, bool enable_statistics, void* context)
     : _context(context), _new_table(nullptr), _log2_size_limit(log2size_limit),
@@ -1034,7 +1034,7 @@ ConcurrentHashTable(size_t log2size, size_t log2size_limit, size_t grow_hint, bo
   _size_limit_reached = _table->_log2_size == _log2_size_limit;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline ConcurrentHashTable<CONFIG, F>::
   ~ConcurrentHashTable()
 {
@@ -1044,7 +1044,7 @@ inline ConcurrentHashTable<CONFIG, F>::
   delete _stats_rate;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline size_t ConcurrentHashTable<CONFIG, F>::
   get_mem_size(Thread* thread)
 {
@@ -1052,7 +1052,7 @@ inline size_t ConcurrentHashTable<CONFIG, F>::
   return sizeof(*this) + _table->get_mem_size();
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline size_t ConcurrentHashTable<CONFIG, F>::
   get_size_log2(Thread* thread)
 {
@@ -1060,7 +1060,7 @@ inline size_t ConcurrentHashTable<CONFIG, F>::
   return _table->_log2_size;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline bool ConcurrentHashTable<CONFIG, F>::
   shrink(Thread* thread, size_t size_limit_log2)
 {
@@ -1069,7 +1069,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   return ret;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline void ConcurrentHashTable<CONFIG, F>::
   unsafe_reset(size_t size_log2)
 {
@@ -1077,7 +1077,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
   internal_reset(tmp);
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline bool ConcurrentHashTable<CONFIG, F>::
   grow(Thread* thread, size_t size_limit_log2)
 {
@@ -1085,7 +1085,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   return internal_grow(thread, tmp);
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 template <typename LOOKUP_FUNC, typename FOUND_FUNC>
 inline bool ConcurrentHashTable<CONFIG, F>::
   get(Thread* thread, LOOKUP_FUNC& lookup_f, FOUND_FUNC& found_f, bool* grow_hint)
@@ -1100,7 +1100,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   return ret;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline bool ConcurrentHashTable<CONFIG, F>::
   unsafe_insert(const VALUE& value) {
   bool dead_hash = false;
@@ -1120,7 +1120,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   return true;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 template <typename SCAN_FUNC>
 inline bool ConcurrentHashTable<CONFIG, F>::
   try_scan(Thread* thread, SCAN_FUNC& scan_f)
@@ -1133,7 +1133,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   return true;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 template <typename SCAN_FUNC>
 inline void ConcurrentHashTable<CONFIG, F>::
   do_scan(Thread* thread, SCAN_FUNC& scan_f)
@@ -1147,7 +1147,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
   assert(_resize_lock_owner != thread, "Re-size lock held");
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 template <typename SCAN_FUNC>
 inline void ConcurrentHashTable<CONFIG, F>::
   do_safepoint_scan(SCAN_FUNC& scan_f)
@@ -1171,7 +1171,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
   do_scan_for_range(scan_f, 0, table->_size, table);
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 template <typename FUNC>
 inline bool ConcurrentHashTable<CONFIG, F>::
   do_scan_for_range(FUNC& scan_f, size_t start_idx, size_t stop_idx, InternalTable* table)
@@ -1196,7 +1196,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   return true;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 template <typename EVALUATE_FUNC, typename DELETE_FUNC>
 inline bool ConcurrentHashTable<CONFIG, F>::
   try_bulk_delete(Thread* thread, EVALUATE_FUNC& eval_f, DELETE_FUNC& del_f)
@@ -1210,7 +1210,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   return true;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 template <typename EVALUATE_FUNC, typename DELETE_FUNC>
 inline void ConcurrentHashTable<CONFIG, F>::
   bulk_delete(Thread* thread, EVALUATE_FUNC& eval_f, DELETE_FUNC& del_f)
@@ -1222,7 +1222,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
   unlock_resize_lock(thread);
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 template <typename VALUE_SIZE_FUNC>
 inline TableStatistics ConcurrentHashTable<CONFIG, F>::
   statistics_calculate(Thread* thread, VALUE_SIZE_FUNC& vs_f)
@@ -1253,7 +1253,7 @@ inline TableStatistics ConcurrentHashTable<CONFIG, F>::
   }
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 template <typename VALUE_SIZE_FUNC>
 inline TableStatistics ConcurrentHashTable<CONFIG, F>::
   statistics_get(Thread* thread, VALUE_SIZE_FUNC& vs_f, TableStatistics old)
@@ -1268,7 +1268,7 @@ inline TableStatistics ConcurrentHashTable<CONFIG, F>::
   return ts;
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 template <typename VALUE_SIZE_FUNC>
 inline void ConcurrentHashTable<CONFIG, F>::
   statistics_to(Thread* thread, VALUE_SIZE_FUNC& vs_f,
@@ -1285,7 +1285,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
   ts.print(st, table_name);
 }
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 inline bool ConcurrentHashTable<CONFIG, F>::
   try_move_nodes_to(Thread* thread, ConcurrentHashTable<CONFIG, F>* to_cht)
 {

--- a/src/hotspot/share/utilities/concurrentHashTableTasks.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTableTasks.inline.hpp
@@ -35,7 +35,7 @@
 // operations, which they are serialized with each other.
 
 // Base class for pause and/or parallel bulk operations.
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 class ConcurrentHashTable<CONFIG, F>::BucketsOperation {
  protected:
   ConcurrentHashTable<CONFIG, F>* _cht;
@@ -146,7 +146,7 @@ public:
 };
 
 // For doing pausable/parallel bulk delete.
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 class ConcurrentHashTable<CONFIG, F>::BulkDeleteTask :
   public BucketsOperation
 {
@@ -190,7 +190,7 @@ class ConcurrentHashTable<CONFIG, F>::BulkDeleteTask :
   }
 };
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 class ConcurrentHashTable<CONFIG, F>::GrowTask :
   public BucketsOperation
 {
@@ -229,7 +229,7 @@ class ConcurrentHashTable<CONFIG, F>::GrowTask :
   }
 };
 
-template <typename CONFIG, MEMFLAGS F>
+template <typename CONFIG, MemoryType F>
 class ConcurrentHashTable<CONFIG, F>::ScanTask :
   public BucketsOperation
 {

--- a/src/hotspot/share/utilities/growableArray.cpp
+++ b/src/hotspot/share/utilities/growableArray.cpp
@@ -42,13 +42,13 @@ void* GrowableArrayArenaAllocator::allocate(int max, int element_size, Arena* ar
   return arena->Amalloc(byte_size);
 }
 
-void* GrowableArrayCHeapAllocator::allocate(int max, int element_size, MEMFLAGS memflags) {
+void* GrowableArrayCHeapAllocator::allocate(int max, int element_size, MemoryType mt) {
   assert(max >= 0, "integer overflow");
   size_t byte_size = element_size * (size_t) max;
 
   // memory type has to be specified for C heap allocation
-  assert(memflags != mtNone, "memory type not specified for C heap object");
-  return (void*)AllocateHeap(byte_size, memflags);
+  assert(mt != mtNone, "memory type not specified for C heap object");
+  return (void*)AllocateHeap(byte_size, mt);
 }
 
 void GrowableArrayCHeapAllocator::deallocate(void* elements) {

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -591,7 +591,7 @@ class GrowableArrayMetadata {
 
   // CHeap allocation
   static uintptr_t bits(MemoryType mt) {
-    assert(MemoryType != mtNone, "Must provide a proper MemoryType");
+    assert(mt != mtNone, "Must provide a proper MemoryType");
     return (uintptr_t(mt) << 1) | 1;
   }
 

--- a/src/hotspot/share/utilities/linkedlist.hpp
+++ b/src/hotspot/share/utilities/linkedlist.hpp
@@ -138,7 +138,7 @@ template <class E> class LinkedList : public AnyObj {
 // A linked list implementation.
 // The linked list can be allocated in various type of memory: C heap, arena and resource area, etc.
 template <class E, AnyObj::allocation_type T = AnyObj::C_HEAP,
-  MEMFLAGS F = mtNMT, AllocFailType alloc_failmode = AllocFailStrategy::RETURN_NULL>
+  MemoryType F = mtNMT, AllocationFailureStrategy alloc_failmode = AllocationFailureStrategy::RETURN_NULL>
   class LinkedListImpl : public LinkedList<E> {
  protected:
   Arena*                 _arena;
@@ -335,13 +335,13 @@ template <class E, AnyObj::allocation_type T = AnyObj::C_HEAP,
          return new(_arena) LinkedListNode<E>(e);
        }
        case AnyObj::RESOURCE_AREA:
-         if (alloc_failmode == AllocFailStrategy::RETURN_NULL) {
+         if (alloc_failmode == AllocationFailureStrategy::RETURN_NULL) {
            return new(std::nothrow) LinkedListNode<E>(e);
          } else {
            return new LinkedListNode<E>(e);
          }
        case AnyObj::C_HEAP: {
-         if (alloc_failmode == AllocFailStrategy::RETURN_NULL) {
+         if (alloc_failmode == AllocationFailureStrategy::RETURN_NULL) {
            return new(std::nothrow, F) LinkedListNode<E>(e);
          } else {
            return new(F) LinkedListNode<E>(e);
@@ -365,7 +365,7 @@ template <class E, AnyObj::allocation_type T = AnyObj::C_HEAP,
 // function
 template <class E, int (*FUNC)(const E&, const E&),
   AnyObj::allocation_type T = AnyObj::C_HEAP,
-  MEMFLAGS F = mtNMT, AllocFailType alloc_failmode = AllocFailStrategy::RETURN_NULL>
+  MemoryType F = mtNMT, AllocationFailureStrategy alloc_failmode = AllocationFailureStrategy::RETURN_NULL>
   class SortedLinkedList : public LinkedListImpl<E, T, F, alloc_failmode> {
  public:
   SortedLinkedList() { }

--- a/src/hotspot/share/utilities/objectBitSet.hpp
+++ b/src/hotspot/share/utilities/objectBitSet.hpp
@@ -39,7 +39,7 @@ class MemRegion;
  * allocated on-demand only, in fragments covering 64M heap ranges. Fragments are never deleted
  * during the lifetime of the ObjectBitSet. The underlying memory is allocated from C-Heap.
  */
-template<MEMFLAGS F>
+template<MemoryType F>
 class ObjectBitSet : public CHeapObj<F> {
   const static size_t _bitmap_granularity_shift = 26; // 64M
   const static size_t _bitmap_granularity_size = (size_t)1 << _bitmap_granularity_shift;
@@ -81,7 +81,7 @@ class ObjectBitSet : public CHeapObj<F> {
   }
 };
 
-template<MEMFLAGS F>
+template<MemoryType F>
 class ObjectBitSet<F>::BitMapFragment : public CHeapObj<F> {
   CHeapBitMap _bits;
   BitMapFragment* _next;

--- a/src/hotspot/share/utilities/objectBitSet.inline.hpp
+++ b/src/hotspot/share/utilities/objectBitSet.inline.hpp
@@ -30,13 +30,13 @@
 #include "memory/memRegion.hpp"
 #include "utilities/bitMap.inline.hpp"
 
-template<MEMFLAGS F>
+template<MemoryType F>
 ObjectBitSet<F>::BitMapFragment::BitMapFragment(uintptr_t granule, BitMapFragment* next) :
         _bits(_bitmap_granularity_size >> LogMinObjAlignmentInBytes, F, true /* clear */),
         _next(next) {
 }
 
-template<MEMFLAGS F>
+template<MemoryType F>
 ObjectBitSet<F>::ObjectBitSet() :
         _bitmap_fragments(32, 8*K),
         _fragment_list(nullptr),
@@ -44,7 +44,7 @@ ObjectBitSet<F>::ObjectBitSet() :
         _last_fragment_granule(UINTPTR_MAX) {
 }
 
-template<MEMFLAGS F>
+template<MemoryType F>
 ObjectBitSet<F>::~ObjectBitSet() {
   BitMapFragment* current = _fragment_list;
   while (current != nullptr) {
@@ -56,12 +56,12 @@ ObjectBitSet<F>::~ObjectBitSet() {
   // ResizeableResourceHashtableStorage deletes the table.
 }
 
-template<MEMFLAGS F>
+template<MemoryType F>
 inline BitMap::idx_t ObjectBitSet<F>::addr_to_bit(uintptr_t addr) const {
   return (addr & _bitmap_granularity_mask) >> LogMinObjAlignmentInBytes;
 }
 
-template<MEMFLAGS F>
+template<MemoryType F>
 inline CHeapBitMap* ObjectBitSet<F>::get_fragment_bits(uintptr_t addr) {
   uintptr_t granule = addr >> _bitmap_granularity_shift;
   if (granule == _last_fragment_granule) {
@@ -86,14 +86,14 @@ inline CHeapBitMap* ObjectBitSet<F>::get_fragment_bits(uintptr_t addr) {
   return bits;
 }
 
-template<MEMFLAGS F>
+template<MemoryType F>
 inline void ObjectBitSet<F>::mark_obj(uintptr_t addr) {
   CHeapBitMap* bits = get_fragment_bits(addr);
   const BitMap::idx_t bit = addr_to_bit(addr);
   bits->set_bit(bit);
 }
 
-template<MEMFLAGS F>
+template<MemoryType F>
 inline bool ObjectBitSet<F>::is_marked(uintptr_t addr) {
   CHeapBitMap* bits = get_fragment_bits(addr);
   const BitMap::idx_t bit = addr_to_bit(addr);

--- a/src/hotspot/share/utilities/resizeableResourceHash.hpp
+++ b/src/hotspot/share/utilities/resizeableResourceHash.hpp
@@ -30,7 +30,7 @@
 template<
     typename K, typename V,
     AnyObj::allocation_type ALLOC_TYPE,
-    MEMFLAGS MEM_TYPE>
+    MemoryType MEM_TYPE>
 class ResizeableResourceHashtableStorage : public AnyObj {
   using Node = ResourceHashtableNode<K, V>;
 
@@ -72,7 +72,7 @@ protected:
 template<
     typename K, typename V,
     AnyObj::allocation_type ALLOC_TYPE = AnyObj::RESOURCE_AREA,
-    MEMFLAGS MEM_TYPE = mtInternal,
+    MemoryType MEM_TYPE = mtInternal,
     unsigned (*HASH)  (K const&)           = primitive_hash<K>,
     bool     (*EQUALS)(K const&, K const&) = primitive_equals<K>
     >

--- a/src/hotspot/share/utilities/resourceHash.hpp
+++ b/src/hotspot/share/utilities/resourceHash.hpp
@@ -52,7 +52,7 @@ template<
     class STORAGE,
     typename K, typename V,
     AnyObj::allocation_type ALLOC_TYPE,
-    MEMFLAGS MEM_TYPE,
+    MemoryType MEM_TYPE,
     unsigned (*HASH)  (K const&),
     bool     (*EQUALS)(K const&, K const&)
     >
@@ -333,7 +333,7 @@ template<
     typename K, typename V,
     unsigned SIZE = 256,
     AnyObj::allocation_type ALLOC_TYPE = AnyObj::RESOURCE_AREA,
-    MEMFLAGS MEM_TYPE = mtInternal,
+    MemoryType MEM_TYPE = mtInternal,
     unsigned (*HASH)  (K const&)           = primitive_hash<K>,
     bool     (*EQUALS)(K const&, K const&) = primitive_equals<K>
     >

--- a/src/hotspot/share/utilities/stack.hpp
+++ b/src/hotspot/share/utilities/stack.hpp
@@ -51,11 +51,11 @@
 // implementation in class Stack assumes that alloc() will terminate the process
 // if the allocation fails.
 
-template <class E, MEMFLAGS F> class StackIterator;
+template <class E, MemoryType F> class StackIterator;
 
 // StackBase holds common data/methods that don't depend on the element type,
 // factored out to reduce template code duplication.
-template <MEMFLAGS F> class StackBase
+template <MemoryType F> class StackBase
 {
 public:
   size_t segment_size()   const { return _seg_size; } // Elements per segment.
@@ -85,7 +85,7 @@ protected:
   size_t       _cache_size;     // Number of segments in the cache.
 };
 
-template <class E, MEMFLAGS F>
+template <class E, MemoryType F>
 class Stack:  public StackBase<F>
 {
 public:
@@ -160,7 +160,7 @@ private:
   E* _cache;      // Segment cache to avoid ping-ponging.
 };
 
-template <class E, MEMFLAGS F>
+template <class E, MemoryType F>
 class StackIterator: public StackObj
 {
 public:

--- a/test/hotspot/gtest/nmt/test_nmt_cornercases.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_cornercases.cpp
@@ -32,7 +32,7 @@
 #include "unittest.hpp"
 
 // Check NMT header for integrity, as well as expected type and size.
-static void check_expected_malloc_header(const void* payload, MEMFLAGS type, size_t size) {
+static void check_expected_malloc_header(const void* payload, MemoryType type, size_t size) {
   const MallocHeader* hdr = MallocHeader::resolve_checked(payload);
   EXPECT_EQ(hdr->size(), size);
   EXPECT_EQ(hdr->flags(), type);

--- a/test/hotspot/gtest/nmt/test_nmt_totals.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_totals.cpp
@@ -90,7 +90,7 @@ TEST_VM(NMTNumbers, totals) {
   for (int i = 0; i < NUM_ALLOCS; i ++) {
     // spread over categories
     int category = i % (mt_number_of_types - 1);
-    p[i] = NEW_C_HEAP_ARRAY(char, ALLOC_SIZE, (MEMFLAGS)category);
+    p[i] = NEW_C_HEAP_ARRAY(char, ALLOC_SIZE, (MemoryType)category);
   }
 
   const totals_t t2 = get_totals();

--- a/test/hotspot/gtest/utilities/test_growableArray.cpp
+++ b/test/hotspot/gtest/utilities/test_growableArray.cpp
@@ -35,7 +35,7 @@ struct WithEmbeddedArray {
   // Arena allocated data array
   WithEmbeddedArray(Arena* arena, int initial_max) : _a(arena, initial_max, 0, 0) {}
   // CHeap allocated data array
-  WithEmbeddedArray(int initial_max, MEMFLAGS memflags) : _a(initial_max, memflags) {
+  WithEmbeddedArray(int initial_max, MemoryType memflags) : _a(initial_max, memflags) {
     assert(memflags != mtNone, "test requirement");
   }
   WithEmbeddedArray(const GrowableArray<int>& other) : _a(other) {}

--- a/test/hotspot/gtest/utilities/test_resourceHash.cpp
+++ b/test/hotspot/gtest/utilities/test_resourceHash.cpp
@@ -35,7 +35,7 @@ class CommonResourceHashtableTest : public ::testing::Test {
  protected:
   typedef void* K;
   typedef uintx V;
-  const static MEMFLAGS MEM_TYPE = mtInternal;
+  const static MemoryType MEM_TYPE = mtInternal;
 
   static unsigned identity_hash(const K& k) {
     return (unsigned) (uintptr_t) k;


### PR DESCRIPTION
- Rename `MEMFLAGS` to `MemoryType`. `MEMFLAGS` is highly misleading as flags typically can be combined.
- Update `MemoryType` to have enumeration names that follow the style guide, no `mt` prefix.
- Create aliases for old `mtXXX` names.
- Remove `mt_number_of_types` from the enumeration.
- Shift implementation of utilities related to `MEMFLAGS` from `NMTUtil` to `MemoryTypes`. Handle missing `mt` prefix during parsing.
- `NMTUtil` references are not updated to avoid increasing patch size.
- Merge `AllocFailStrategy` and `AllocFailType` into `AllocationFailureStrategy`.
- Move `MemoryType` and `AllocationFailureStrategy` to their own respective headers.

This change does not update variable verbiage. That should be something done over time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301983](https://bugs.openjdk.org/browse/JDK-8301983): Refactor MEMFLAGS and AllocFailStrategy


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12454/head:pull/12454` \
`$ git checkout pull/12454`

Update a local copy of the PR: \
`$ git checkout pull/12454` \
`$ git pull https://git.openjdk.org/jdk pull/12454/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12454`

View PR using the GUI difftool: \
`$ git pr show -t 12454`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12454.diff">https://git.openjdk.org/jdk/pull/12454.diff</a>

</details>
