### PR TITLE
JDK-8301749: Tracking malloc pooled memory size

### DIFF
--- a/src/hotspot/os/linux/mallocInfoDcmd.cpp
+++ b/src/hotspot/os/linux/mallocInfoDcmd.cpp
@@ -30,7 +30,7 @@
 
 #include <malloc.h>
 
-constexpr const char* malloc_info_unavailable = "Error: malloc_info(3) not available.";
+constexpr const char* malloc_info_unavailable = "Error: malloc_info(3) not available.\n";
 
 void MallocInfoDcmd::execute(DCmdSource source, TRAPS) {
 #ifdef __GLIBC__
@@ -38,16 +38,16 @@ void MallocInfoDcmd::execute(DCmdSource source, TRAPS) {
   size_t size;
   ALLOW_C_FUNCTION(::open_memstream, FILE* stream = ::open_memstream(&buf, &size);)
   if (stream == nullptr) {
-    _output->print("Error: Could not call malloc_info(3)");
+    _output->print("Error: Could not call malloc_info(3)\n");
     return;
   }
 
   int err = os::Linux::malloc_info(stream);
   if (err == 0) {
     ALLOW_C_FUNCTION(::fflush, fflush(stream);)
-      _output->print_raw(buf);
+    _output->print_raw(buf);
   } else if (err == -1) {
-    _output->print("Error: %s", os::strerror(errno));
+    _output->print("Error: %s\n", os::strerror(errno));
   } else if (err == -2) {
     _output->print(malloc_info_unavailable);
   } else {
@@ -56,6 +56,6 @@ void MallocInfoDcmd::execute(DCmdSource source, TRAPS) {
   ALLOW_C_FUNCTION(::fclose, ::fclose(stream);)
   ALLOW_C_FUNCTION(::free, ::free(buf);)
 #else
-    _output->print(malloc_info_unavailable);
+  _output->print(malloc_info_unavailable);
 #endif // __GLIBC__
 }

--- a/src/hotspot/os/linux/mallocInfoDcmd.cpp
+++ b/src/hotspot/os/linux/mallocInfoDcmd.cpp
@@ -30,7 +30,7 @@
 
 #include <malloc.h>
 
-constexpr const char* malloc_info_unavailable = "Error: malloc_info not available.";
+constexpr const char* malloc_info_unavailable = "Error: malloc_info(3) not available.";
 
 void MallocInfoDcmd::execute(DCmdSource source, TRAPS) {
 #ifdef __GLIBC__
@@ -38,7 +38,7 @@ void MallocInfoDcmd::execute(DCmdSource source, TRAPS) {
   size_t size;
   ALLOW_C_FUNCTION(::open_memstream, FILE* stream = ::open_memstream(&buf, &size);)
   if (stream == nullptr) {
-    _output->print("Error: Could not call malloc_info");
+    _output->print("Error: Could not call malloc_info(3)");
     return;
   }
 

--- a/src/hotspot/os/linux/mallocInfoDcmd.cpp
+++ b/src/hotspot/os/linux/mallocInfoDcmd.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "runtime/os.inline.hpp"
+#include "mallocInfoDcmd.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/ostream.hpp"
+
+#include <malloc.h>
+
+void MallocInfoDcmd::execute(DCmdSource source, TRAPS) {
+#ifdef LINUX
+  char* buf;
+  size_t size;
+  ALLOW_C_FUNCTION(::open_memstream, FILE* stream = ::open_memstream(&buf, &size);)
+  if (!os::Linux::malloc_info(stream)) {
+    ALLOW_C_FUNCTION(::fflush, fflush(stream);)
+    _output->print_raw(buf);
+  }
+  ALLOW_C_FUNCTION(::fclose, ::fclose(stream);)
+  ALLOW_C_FUNCTION(::free, ::free(buf);)
+#else
+    // Nothing.
+#endif // LINUX
+}

--- a/src/hotspot/os/linux/mallocInfoDcmd.cpp
+++ b/src/hotspot/os/linux/mallocInfoDcmd.cpp
@@ -57,6 +57,6 @@ void MallocInfoDcmd::execute(DCmdSource source, TRAPS) {
   ALLOW_C_FUNCTION(::fclose, ::fclose(stream);)
   ALLOW_C_FUNCTION(::free, ::free(buf);)
 #else
-  _output->print(malloc_info_unavailable);
+  _output->print_cr(malloc_info_unavailable);
 #endif // __GLIBC__
 }

--- a/src/hotspot/os/linux/mallocInfoDcmd.cpp
+++ b/src/hotspot/os/linux/mallocInfoDcmd.cpp
@@ -30,7 +30,7 @@
 
 #include <malloc.h>
 
-constexpr const char* malloc_info_unavailable = "Error: malloc_info(3) not available.\n";
+constexpr const char* malloc_info_unavailable = "Error: malloc_info(3) not available.";
 
 void MallocInfoDcmd::execute(DCmdSource source, TRAPS) {
 #ifdef __GLIBC__
@@ -38,7 +38,7 @@ void MallocInfoDcmd::execute(DCmdSource source, TRAPS) {
   size_t size;
   ALLOW_C_FUNCTION(::open_memstream, FILE* stream = ::open_memstream(&buf, &size);)
   if (stream == nullptr) {
-    _output->print("Error: Could not call malloc_info(3)\n");
+    _output->print_cr("Error: Could not call malloc_info(3)");
     return;
   }
 
@@ -46,10 +46,11 @@ void MallocInfoDcmd::execute(DCmdSource source, TRAPS) {
   if (err == 0) {
     ALLOW_C_FUNCTION(::fflush, fflush(stream);)
     _output->print_raw(buf);
+    _output->cr();
   } else if (err == -1) {
-    _output->print("Error: %s\n", os::strerror(errno));
+    _output->print_cr("Error: %s", os::strerror(errno));
   } else if (err == -2) {
-    _output->print(malloc_info_unavailable);
+    _output->print_cr(malloc_info_unavailable);
   } else {
     ShouldNotReachHere();
   }

--- a/src/hotspot/os/linux/mallocInfoDcmd.hpp
+++ b/src/hotspot/os/linux/mallocInfoDcmd.hpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_LINUX_MALLOCINFODCMD_HPP
+#define OS_LINUX_MALLOCINFODCMD_HPP
+
+#include "services/diagnosticCommand.hpp"
+
+class outputStream;
+
+class MallocInfoDcmd : public DCmd {
+public:
+  MallocInfoDcmd(outputStream* output, bool heap) : DCmd(output, heap) {}
+  static const char* name() {
+    return "System.malloc_info";
+  }
+  static const char* description() {
+    return "Prints the malloc information if available. Otherwise, prints nothing.";
+  }
+  static const char* impact() {
+    return "Low";
+  }
+  static const JavaPermission permission() {
+    JavaPermission p = { "java.lang.management.ManagementPermission", "monitor", nullptr };
+    return p;
+  }
+  void execute(DCmdSource source, TRAPS) override;
+};
+
+#endif // OS_LINUX_MALLOCINFODCMD_HPP

--- a/src/hotspot/os/linux/mallocInfoDcmd.hpp
+++ b/src/hotspot/os/linux/mallocInfoDcmd.hpp
@@ -33,10 +33,10 @@ class MallocInfoDcmd : public DCmd {
 public:
   MallocInfoDcmd(outputStream* output, bool heap) : DCmd(output, heap) {}
   static const char* name() {
-    return "System.malloc_info";
+    return "System.native_heap_info";
   }
   static const char* description() {
-    return "Prints the malloc information if available. Otherwise, prints nothing.";
+    return "Attempts to output information regarding native heap usage through malloc_info(3). If unsuccessful outputs \"Error: \" and a reason.";
   }
   static const char* impact() {
     return "Low";

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -114,6 +114,9 @@
 # include <malloc.h>
 #endif
 
+// Forward (re-)declare malloc_info in order to support Alpine Linux.
+int __attribute__((weak)) malloc_info(int options, FILE *stream);
+
 #ifndef _GNU_SOURCE
   #define _GNU_SOURCE
   #include <sched.h>
@@ -215,6 +218,13 @@ static bool suppress_primordial_thread_resolution = false;
 
 julong os::available_memory() {
   return Linux::available_memory();
+}
+
+int os::Linux::malloc_info(FILE* stream) {
+  if (::malloc_info) {
+    return ::malloc_info(0, stream);
+  }
+  return 0;
 }
 
 julong os::Linux::available_memory() {

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -193,10 +193,6 @@ class os::Linux {
 
   // none present
 
-  // Calls out to GNU extension malloc_info if available
-  // otherwise does nothing and returns 0.
-  static int malloc_info(FILE* stream);
-
  private:
   static void numa_init();
 
@@ -428,6 +424,10 @@ class os::Linux {
     size_t keepcost;
   };
   static void get_mallinfo(glibc_mallinfo* out, bool* might_have_wrapped);
+
+  // Calls out to GNU extension malloc_info if available
+  // otherwise does nothing and returns -2.
+  static int malloc_info(FILE* stream);
 #endif // GLIBC
 };
 

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -193,6 +193,10 @@ class os::Linux {
 
   // none present
 
+  // Calls out to GNU extension malloc_info if available
+  // otherwise does nothing and returns 0.
+  static int malloc_info(FILE* stream);
+
  private:
   static void numa_init();
 

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -63,6 +63,7 @@
 #include "utilities/macros.hpp"
 #ifdef LINUX
 #include "trimCHeapDCmd.hpp"
+#include "mallocInfoDcmd.hpp"
 #endif
 
 static void loadAgentModule(TRAPS) {
@@ -126,6 +127,7 @@ void DCmdRegistrant::register_dcmds(){
 #ifdef LINUX
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<PerfMapDCmd>(full_export, true, false));
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<TrimCLibcHeapDCmd>(full_export, true, false));
+  DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<MallocInfoDcmd>(full_export, true, false));
 #endif // LINUX
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<CodeHeapAnalyticsDCmd>(full_export, true, false));
 

--- a/src/jdk.jcmd/share/man/jcmd.1
+++ b/src/jdk.jcmd/share/man/jcmd.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JCMD" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JCMD" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -773,6 +773,15 @@ Stops the remote management agent.
 .RS
 .PP
 Impact: Low --- no impact
+.RE
+.TP
+\f[V]System.native_heap_info\f[R] (Linux only)
+Prints information about native heap usage through malloc_info(3).
+.RS
+.PP
+Impact: Low
+.PP
+Permission: \f[V]java.lang.management.ManagementPermission(monitor)\f[R]
 .RE
 .TP
 \f[V]System.trim_native_heap\f[R] (Linux only)

--- a/src/jdk.jcmd/share/man/jcmd.1
+++ b/src/jdk.jcmd/share/man/jcmd.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JCMD" "1" "2023" "JDK 21" "JDK Commands"
+.TH "JCMD" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/MallocInfoTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/MallocInfoTest.java
@@ -28,7 +28,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 /*
  * @test
- * @summary Test of diagnostic command VM.trim_libc_heap
+ * @summary Test of diagnostic command System.native_heap_info
  * @library /test/lib
  * @requires (os.family=="linux") & !vm.musl
  * @modules java.base/jdk.internal.misc
@@ -39,7 +39,7 @@ import jdk.test.lib.process.OutputAnalyzer;
  */
 public class MallocInfoTest {
     public void run(CommandExecutor executor) {
-        OutputAnalyzer output = executor.execute("System.malloc_info");
+        OutputAnalyzer output = executor.execute("System.native_heap_info");
         output.reportDiagnosticSummary();
         output.shouldNotMatch(".*Error.*");
         output.shouldMatch(".*<malloc version=.*");

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/MallocInfoTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/MallocInfoTest.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import jdk.test.lib.Platform;
 import org.testng.annotations.Test;
 import jdk.test.lib.dcmd.CommandExecutor;
 import jdk.test.lib.dcmd.JMXExecutor;
@@ -30,7 +31,7 @@ import jdk.test.lib.process.OutputAnalyzer;
  * @test
  * @summary Test of diagnostic command System.native_heap_info
  * @library /test/lib
- * @requires (os.family=="linux") & !vm.musl
+ * @requires (os.family=="linux")
  * @modules java.base/jdk.internal.misc
  *          java.compiler
  *          java.management
@@ -40,8 +41,12 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class MallocInfoTest {
     public void run(CommandExecutor executor) {
         OutputAnalyzer output = executor.execute("System.native_heap_info");
-        output.shouldNotContain("Error: ");
-        output.shouldContain("<malloc version=");
+        if (!Platform.isMusl()) {
+            output.shouldNotContain("Error: ");
+            output.shouldContain("<malloc version=");
+        } else {
+            output.shouldContain("Error: malloc_info(3) not available.");
+        }
         output.reportDiagnosticSummary();
     }
 

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/MallocInfoTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/MallocInfoTest.java
@@ -40,9 +40,9 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class MallocInfoTest {
     public void run(CommandExecutor executor) {
         OutputAnalyzer output = executor.execute("System.native_heap_info");
+        output.shouldNotContain("Error: ");
+        output.shouldContain("<malloc version=");
         output.reportDiagnosticSummary();
-        output.shouldNotMatch(".*Error.*");
-        output.shouldMatch(".*<malloc version=.*");
     }
 
     @Test

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/MallocInfoTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/MallocInfoTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+import jdk.test.lib.dcmd.CommandExecutor;
+import jdk.test.lib.dcmd.JMXExecutor;
+import jdk.test.lib.process.OutputAnalyzer;
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.trim_libc_heap
+ * @library /test/lib
+ * @requires (os.family=="linux") & !vm.musl
+ * @modules java.base/jdk.internal.misc
+ *          java.compiler
+ *          java.management
+ *          jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng MallocInfoTest
+ */
+public class MallocInfoTest {
+    public void run(CommandExecutor executor) {
+        OutputAnalyzer output = executor.execute("System.malloc_info");
+        output.reportDiagnosticSummary();
+        output.shouldNotMatch(".*Error.*");
+        output.shouldMatch(".*<malloc version=.*");
+    }
+
+    @Test
+    public void jmx() {
+        run(new JMXExecutor());
+    }
+}


### PR DESCRIPTION
This PR implements `os::malloc_info` by calling into glibc's `malloc_info` and provides a JCmd for asking the JVM to call `malloc_info` and print out the results. The user can make an informed decision regarding heap trimming by parsing the output of the JCmd. I wanted to avoid parsing the XML inside of the JVM , as this functionality may turn out to be "good enough". A future enhancement would be for the JVM to make this informed decision by parsing the output. Another may be to present this with other data, for example in NMT.

@tstuefe, I think you'd be interested in this PR as it builds upon your `trim_native_heap` functionality.

I'm using weak symbols (as per ELF) in order to compile this for both GLibc and Musl.

The original bug description is this:

>Memory not allocated via NMT and uncommitted memory contributes to a discrepancy between NMT and RSS.
It can be hard to distinguish between these cases.
If the VM can determine the amount of pooled memory by malloc it would help with both determining if a trim_native_memory is needed, or there are some allocations happening outside of NMT.
>
>It would be good if the VM can summarize the malloc pooled memory by using e.g. malloc_info(3).
>
>We can thus more precise account for RSS value.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8302128](https://bugs.openjdk.org/browse/JDK-8302128) to be approved

### Issues
 * [JDK-8301749](https://bugs.openjdk.org/browse/JDK-8301749): Tracking malloc pooled memory size
 * [JDK-8302128](https://bugs.openjdk.org/browse/JDK-8302128): Tracking malloc pooled memory size (**CSR**)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [5d93207c](https://git.openjdk.org/jdk/pull/12455/files/5d93207c34a5e355c07796ae7217d2225bdd5098)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12455/head:pull/12455` \
`$ git checkout pull/12455`

Update a local copy of the PR: \
`$ git checkout pull/12455` \
`$ git pull https://git.openjdk.org/jdk pull/12455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12455`

View PR using the GUI difftool: \
`$ git pr show -t 12455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12455.diff">https://git.openjdk.org/jdk/pull/12455.diff</a>

</details>
