### PR TITLE
8301988: VerifyLiveClosure::verify_liveness asserts on bad pointers outside heap

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -214,7 +214,7 @@ inline bool G1CollectedHeap::requires_barriers(stackChunkOop obj) const {
 }
 
 inline bool G1CollectedHeap::is_obj_filler(const oop obj) {
-  Klass* k = obj->klass();
+  Klass* k = obj->klass_raw();
   return k == Universe::fillerArrayKlassObj() || k == vmClasses::FillerObject_klass();
 }
 

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -510,38 +510,40 @@ public:
   template <class T>
   void verify_liveness(T* p) {
     T heap_oop = RawAccess<>::oop_load(p);
-    Log(gc, verify) log;
-    if (!CompressedOops::is_null(heap_oop)) {
-      oop obj = CompressedOops::decode_raw_not_null(heap_oop);
-      bool failed = false;
-      bool is_in_heap = _g1h->is_in(obj);
-      if (!is_in_heap || _g1h->is_obj_dead_cond(obj, _vo)) {
-        MutexLocker x(ParGCRareEvent_lock, Mutex::_no_safepoint_check_flag);
+    if (CompressedOops::is_null(heap_oop)) {
+      return;
+    }
 
-        if (!_failures) {
-          log.error("----------");
-        }
-        ResourceMark rm;
+    oop obj = CompressedOops::decode_raw_not_null(heap_oop);
+    bool failed = false;
+    bool is_in_heap = _g1h->is_in(obj);
+    if (!is_in_heap || _g1h->is_obj_dead_cond(obj, _vo)) {
+      MutexLocker x(ParGCRareEvent_lock, Mutex::_no_safepoint_check_flag);
 
-        HeapRegion* from = _g1h->heap_region_containing(p);
-        log.error("Field " PTR_FORMAT " of live obj " PTR_FORMAT " in region " HR_FORMAT,
-                  p2i(p), p2i(_containing_obj), HR_FORMAT_PARAMS(from));
-        LogStream ls(log.error());
-        print_object(&ls, _containing_obj);
-
-        if (!is_in_heap) {
-          log.error("points to address " PTR_FORMAT " outside of heap", p2i(obj));
-        } else {
-          HeapRegion* to = _g1h->heap_region_containing(obj);
-          log.error("points to dead obj " PTR_FORMAT " in region " HR_FORMAT " remset %s",
-                    p2i(obj), HR_FORMAT_PARAMS(to), to->rem_set()->get_state_str());
-          print_object(&ls, obj);
-        }
+      Log(gc, verify) log;
+      if (!_failures) {
         log.error("----------");
-        _failures = true;
-        failed = true;
-        _n_failures++;
       }
+      ResourceMark rm;
+
+      HeapRegion* from = _g1h->heap_region_containing(p);
+      log.error("Field " PTR_FORMAT " of live obj " PTR_FORMAT " in region " HR_FORMAT,
+                p2i(p), p2i(_containing_obj), HR_FORMAT_PARAMS(from));
+      LogStream ls(log.error());
+      print_object(&ls, _containing_obj);
+
+      if (!is_in_heap) {
+        log.error("points to address " PTR_FORMAT " outside of heap", p2i(obj));
+      } else {
+        HeapRegion* to = _g1h->heap_region_containing(obj);
+        log.error("points to dead obj " PTR_FORMAT " in region " HR_FORMAT " remset %s",
+                  p2i(obj), HR_FORMAT_PARAMS(to), to->rem_set()->get_state_str());
+        print_object(&ls, obj);
+      }
+      log.error("----------");
+      _failures = true;
+      failed = true;
+      _n_failures++;
     }
   }
 };

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -512,7 +512,7 @@ public:
     T heap_oop = RawAccess<>::oop_load(p);
     Log(gc, verify) log;
     if (!CompressedOops::is_null(heap_oop)) {
-      oop obj = CompressedOops::decode_not_null(heap_oop);
+      oop obj = CompressedOops::decode_raw_not_null(heap_oop);
       bool failed = false;
       bool is_in_heap = _g1h->is_in(obj);
       if (!is_in_heap || _g1h->is_obj_dead_cond(obj, _vo)) {
@@ -522,24 +522,19 @@ public:
           log.error("----------");
         }
         ResourceMark rm;
+
+        HeapRegion* from = _g1h->heap_region_containing(p);
+        log.error("Field " PTR_FORMAT " of live obj " PTR_FORMAT " in region " HR_FORMAT,
+                  p2i(p), p2i(_containing_obj), HR_FORMAT_PARAMS(from));
+        LogStream ls(log.error());
+        print_object(&ls, _containing_obj);
+
         if (!is_in_heap) {
-          HeapRegion* from = _g1h->heap_region_containing(p);
-          log.error("Field " PTR_FORMAT " of live obj " PTR_FORMAT " in region " HR_FORMAT,
-                    p2i(p), p2i(_containing_obj), HR_FORMAT_PARAMS(from));
-          LogStream ls(log.error());
-          print_object(&ls, _containing_obj);
-          HeapRegion* const to = _g1h->heap_region_containing(obj);
-          log.error("points to obj " PTR_FORMAT " in region " HR_FORMAT " remset %s",
-                    p2i(obj), HR_FORMAT_PARAMS(to), to->rem_set()->get_state_str());
+          log.error("points to address " PTR_FORMAT " outside of heap", p2i(obj));
         } else {
-          HeapRegion* from = _g1h->heap_region_containing(p);
           HeapRegion* to = _g1h->heap_region_containing(obj);
-          log.error("Field " PTR_FORMAT " of live obj " PTR_FORMAT " in region " HR_FORMAT,
-                    p2i(p), p2i(_containing_obj), HR_FORMAT_PARAMS(from));
-          LogStream ls(log.error());
-          print_object(&ls, _containing_obj);
-          log.error("points to dead obj " PTR_FORMAT " in region " HR_FORMAT,
-                    p2i(obj), HR_FORMAT_PARAMS(to));
+          log.error("points to dead obj " PTR_FORMAT " in region " HR_FORMAT " remset %s",
+                    p2i(obj), HR_FORMAT_PARAMS(to), to->rem_set()->get_state_str());
           print_object(&ls, obj);
         }
         log.error("----------");

--- a/src/hotspot/share/oops/compressedOops.hpp
+++ b/src/hotspot/share/oops/compressedOops.hpp
@@ -127,6 +127,7 @@ public:
   static inline narrowOop encode(oop v);
 
   // No conversions needed for these overloads
+  static inline oop decode_raw_not_null(oop v);
   static inline oop decode_not_null(oop v);
   static inline oop decode(oop v);
   static inline narrowOop encode_not_null(narrowOop v);

--- a/src/hotspot/share/oops/compressedOops.inline.hpp
+++ b/src/hotspot/share/oops/compressedOops.inline.hpp
@@ -78,6 +78,11 @@ inline narrowOop CompressedOops::encode(oop v) {
   return is_null(v) ? narrowOop::null : encode_not_null(v);
 }
 
+inline oop CompressedOops::decode_raw_not_null(oop v) {
+  assert(v != nullptr, "object is null");
+  return v;
+}
+
 inline oop CompressedOops::decode_not_null(oop v) {
   assert(Universe::is_in_heap(v), "object not in heap " PTR_FORMAT, p2i(v));
   return v;

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -85,6 +85,8 @@ class oopDesc {
   inline Klass* klass() const;
   inline Klass* klass_or_null() const;
   inline Klass* klass_or_null_acquire() const;
+  // Get the raw value without any checks.
+  inline Klass* klass_raw() const;
 
   void set_narrow_klass(narrowKlass nk) NOT_CDS_JAVA_HEAP_RETURN;
   inline void set_klass(Klass* k);

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -107,6 +107,14 @@ Klass* oopDesc::klass_or_null_acquire() const {
   }
 }
 
+Klass* oopDesc::klass_raw() const {
+  if (UseCompressedClassPointers) {
+    return CompressedKlassPointers::decode_raw(_metadata._compressed_klass);
+  } else {
+    return _metadata._klass;
+  }
+}
+
 void oopDesc::set_klass(Klass* k) {
   assert(Universe::is_bootstrapping() || (k != NULL && k->is_klass()), "incorrect Klass");
   if (UseCompressedClassPointers) {


### PR DESCRIPTION
Hi all,

  can I have reviews for this change to liveness verification that fixes some unwanted asserts because

 - it uses decode_not_null which will assert if the given oop address is not in the heap, making the remainder of the verification useless in that case
- if the referenced object is not in the heap, we try to get its heap region too when printing, which also fails some assertions
- in the innermost if lots of code is duplicated in both cases 

The first two issues are really annoying (there is another one when the `Klass` is garbage when calling `is_obj_dead_cond`, but I'll try to improve that separately).

Testing: local compilation/testing, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301988](https://bugs.openjdk.org/browse/JDK-8301988): VerifyLiveClosure::verify_liveness asserts on bad pointers outside heap


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [b2c41af7](https://git.openjdk.org/jdk/pull/12456/files/b2c41af7ebd035a463b73cd2f5b02605d7fe6d83)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [b8182317](https://git.openjdk.org/jdk/pull/12456/files/b8182317f7cf5f89f2aaf996d8906dea97bdcebf)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12456/head:pull/12456` \
`$ git checkout pull/12456`

Update a local copy of the PR: \
`$ git checkout pull/12456` \
`$ git pull https://git.openjdk.org/jdk pull/12456/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12456`

View PR using the GUI difftool: \
`$ git pr show -t 12456`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12456.diff">https://git.openjdk.org/jdk/pull/12456.diff</a>

</details>
