### PR TITLE
8301243: java/net/httpclient/http2/IdleConnectionTimeoutTest.java intermittent failure

### DIFF
--- a/test/jdk/java/net/httpclient/http2/IdleConnectionTimeoutTest.java
+++ b/test/jdk/java/net/httpclient/http2/IdleConnectionTimeoutTest.java
@@ -51,14 +51,19 @@
  *                                                                   IdleConnectionTimeoutTest
  */
 
+import jdk.httpclient.test.lib.http2.BodyOutputStream;
+import jdk.httpclient.test.lib.http2.Http2TestExchangeImpl;
+import jdk.httpclient.test.lib.http2.Http2TestServerConnection;
+import jdk.internal.net.http.common.HttpHeadersBuilder;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintStream;
-import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.concurrent.CompletableFuture;
@@ -66,13 +71,15 @@ import jdk.httpclient.test.lib.http2.Http2TestServer;
 import jdk.httpclient.test.lib.http2.Http2TestExchange;
 import jdk.httpclient.test.lib.http2.Http2Handler;
 
+import javax.net.ssl.SSLSession;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.net.http.HttpClient.Version.HTTP_2;
 import static org.testng.Assert.assertEquals;
 
 public class IdleConnectionTimeoutTest {
 
-    Http2TestServer http2TestServer;
+    static Http2TestServer http2TestServer;
     URI timeoutUri;
     URI noTimeoutUri;
     final String IDLE_CONN_PROPERTY = "jdk.httpclient.keepalive.timeout.h2";
@@ -86,6 +93,7 @@ public class IdleConnectionTimeoutTest {
         http2TestServer = new Http2TestServer(false, 0);
         http2TestServer.addHandler(new ServerTimeoutHandler(), TIMEOUT_PATH);
         http2TestServer.addHandler(new ServerNoTimeoutHandler(), NO_TIMEOUT_PATH);
+        http2TestServer.setExchangeSupplier(TestExchangeSupplier::new);
 
         http2TestServer.start();
         int port = http2TestServer.getAddress().getPort();
@@ -154,40 +162,72 @@ public class IdleConnectionTimeoutTest {
 
     static class ServerTimeoutHandler implements Http2Handler {
 
-        InetSocketAddress remote;
+        boolean acceptedFirstConnection;
+        int firstConnectionHash = 0;
 
         @Override
         public void handle(Http2TestExchange exchange) throws IOException {
-            if (remote == null) {
-                remote = exchange.getRemoteAddress();
-                exchange.sendResponseHeaders(200, 0);
-            } else if (!remote.equals(exchange.getRemoteAddress())) {
-                testLog.println("ServerTimeoutHandler: New Connection was used, idleConnectionTimeoutEvent fired."
-                        + " First remote: " + remote + ", Second Remote: " + exchange.getRemoteAddress());
-                exchange.sendResponseHeaders(200, 0);
-            } else {
-                exchange.sendResponseHeaders(400, 0);
+            if (exchange instanceof TestExchangeSupplier exch) {
+                if (!acceptedFirstConnection) {
+                    firstConnectionHash = exch.getTestConnection().hashCode();
+                    acceptedFirstConnection = true;
+                    exch.sendResponseHeaders(200, 0);
+                } else {
+                    int secondConnectionHash = exch.getTestConnection().hashCode();
+                    int cmp = Integer.compare(firstConnectionHash, secondConnectionHash);
+
+                    if (cmp < 0 | cmp > 0) {
+                        testLog.println("ServerTimeoutHandler: New Connection was used, idleConnectionTimeoutEvent fired."
+                                + " First Connection Hash: " + firstConnectionHash + ", Second Connection Hash: " + secondConnectionHash);
+                        exch.sendResponseHeaders(200, 0);
+                    } else {
+                        testLog.println("ServerTimeoutHandler: Same Connection was used, idleConnectionTimeoutEvent did not fire."
+                                + " First Connection Hash: " + firstConnectionHash + ", Second Connection Hash: " + secondConnectionHash);
+                        exch.sendResponseHeaders(400, 0);
+                    }
+                }
             }
         }
     }
 
     static class ServerNoTimeoutHandler implements Http2Handler {
 
-        InetSocketAddress oldRemote;
+        boolean acceptedFirstConnection;
+        int firstConnectionHash = 0;
 
         @Override
         public void handle(Http2TestExchange exchange) throws IOException {
-            InetSocketAddress newRemote = exchange.getRemoteAddress();
-            if (oldRemote == null) {
-                oldRemote = newRemote;
-                exchange.sendResponseHeaders(200, 0);
-            } else if (oldRemote.equals(newRemote)) {
-                testLog.println("ServerNoTimeoutHandler: Same Connection was used, idleConnectionTimeoutEvent did not fire."
-                        + " First remote: " + oldRemote + ", Second Remote: " + newRemote);
-                exchange.sendResponseHeaders(200, 0);
-            } else {
-                exchange.sendResponseHeaders(400, 0);
+            if (exchange instanceof TestExchangeSupplier exch) {
+                if (!acceptedFirstConnection) {
+                    firstConnectionHash = exch.getTestConnection().hashCode();
+                    acceptedFirstConnection = true;
+                    exch.sendResponseHeaders(200, 0);
+                } else {
+                    int secondConnectionHash = exch.getTestConnection().hashCode();
+                    int cmp = Integer.compare(firstConnectionHash, secondConnectionHash);
+
+                    if (cmp == 0) {
+                        testLog.println("ServerTimeoutHandler: Same Connection was used, idleConnectionTimeoutEvent did not fire."
+                                + " First Connection Hash: " + firstConnectionHash + ", Second Connection Hash: " + secondConnectionHash);
+                        exch.sendResponseHeaders(200, 0);
+                    } else {
+                        testLog.println("ServerTimeoutHandler: Different Connection was used, idleConnectionTimeoutEvent fired."
+                                + " First Connection Hash: " + firstConnectionHash + ", Second Connection Hash: " + secondConnectionHash);
+                        exch.sendResponseHeaders(400, 0);
+                    }
+                }
             }
+        }
+    }
+
+    static class TestExchangeSupplier extends Http2TestExchangeImpl {
+
+        public TestExchangeSupplier(int streamid, String method, HttpHeaders reqheaders, HttpHeadersBuilder rspheadersBuilder, URI uri, InputStream is, SSLSession sslSession, BodyOutputStream os, Http2TestServerConnection conn, boolean pushAllowed) {
+            super(streamid, method, reqheaders, rspheadersBuilder, uri, is, sslSession, os, conn, pushAllowed);
+        }
+
+        public Http2TestServerConnection getTestConnection() {
+            return this.conn;
         }
     }
 }

--- a/test/jdk/java/net/httpclient/http2/IdleConnectionTimeoutTest.java
+++ b/test/jdk/java/net/httpclient/http2/IdleConnectionTimeoutTest.java
@@ -162,27 +162,24 @@ public class IdleConnectionTimeoutTest {
 
     static class ServerTimeoutHandler implements Http2Handler {
 
-        boolean acceptedFirstConnection;
-        int firstConnectionHash = 0;
+        volatile Object firstConnection = null;
 
         @Override
         public void handle(Http2TestExchange exchange) throws IOException {
             if (exchange instanceof TestExchangeSupplier exch) {
-                if (!acceptedFirstConnection) {
-                    firstConnectionHash = exch.getTestConnection().hashCode();
-                    acceptedFirstConnection = true;
+                if (firstConnection == null) {
+                    firstConnection = exch.getTestConnection();
                     exch.sendResponseHeaders(200, 0);
                 } else {
-                    int secondConnectionHash = exch.getTestConnection().hashCode();
-                    int cmp = Integer.compare(firstConnectionHash, secondConnectionHash);
+                    var secondConnection = exch.getTestConnection();
 
-                    if (cmp < 0 | cmp > 0) {
+                    if (firstConnection != secondConnection) {
                         testLog.println("ServerTimeoutHandler: New Connection was used, idleConnectionTimeoutEvent fired."
-                                + " First Connection Hash: " + firstConnectionHash + ", Second Connection Hash: " + secondConnectionHash);
+                                + " First Connection Hash: " + firstConnection + ", Second Connection Hash: " + secondConnection);
                         exch.sendResponseHeaders(200, 0);
                     } else {
                         testLog.println("ServerTimeoutHandler: Same Connection was used, idleConnectionTimeoutEvent did not fire."
-                                + " First Connection Hash: " + firstConnectionHash + ", Second Connection Hash: " + secondConnectionHash);
+                                + " First Connection Hash: " + firstConnection + ", Second Connection Hash: " + secondConnection);
                         exch.sendResponseHeaders(400, 0);
                     }
                 }
@@ -192,27 +189,24 @@ public class IdleConnectionTimeoutTest {
 
     static class ServerNoTimeoutHandler implements Http2Handler {
 
-        boolean acceptedFirstConnection;
-        int firstConnectionHash = 0;
+        volatile Object firstConnection = null;
 
         @Override
         public void handle(Http2TestExchange exchange) throws IOException {
             if (exchange instanceof TestExchangeSupplier exch) {
-                if (!acceptedFirstConnection) {
-                    firstConnectionHash = exch.getTestConnection().hashCode();
-                    acceptedFirstConnection = true;
+                if (firstConnection == null) {
+                    firstConnection = exch.getTestConnection();
                     exch.sendResponseHeaders(200, 0);
                 } else {
-                    int secondConnectionHash = exch.getTestConnection().hashCode();
-                    int cmp = Integer.compare(firstConnectionHash, secondConnectionHash);
+                    var secondConnection = exch.getTestConnection();
 
-                    if (cmp == 0) {
+                    if (firstConnection == secondConnection) {
                         testLog.println("ServerTimeoutHandler: Same Connection was used, idleConnectionTimeoutEvent did not fire."
-                                + " First Connection Hash: " + firstConnectionHash + ", Second Connection Hash: " + secondConnectionHash);
+                                + " First Connection Hash: " + firstConnection + ", Second Connection Hash: " + secondConnection);
                         exch.sendResponseHeaders(200, 0);
                     } else {
                         testLog.println("ServerTimeoutHandler: Different Connection was used, idleConnectionTimeoutEvent fired."
-                                + " First Connection Hash: " + firstConnectionHash + ", Second Connection Hash: " + secondConnectionHash);
+                                + " First Connection Hash: " + firstConnection + ", Second Connection Hash: " + secondConnection);
                         exch.sendResponseHeaders(400, 0);
                     }
                 }


### PR DESCRIPTION
### Description ###
Intermittent failures of this test are observed on frequent `HttpClient` test runs. The test checks that the same connection is not used twice for two seperate requests if an Idle Connection Timeout occurs by verifying that the client-side port does not use the same port. It also verifies that when an Idle Connection Timeout does not occur, the same connection is used by verifying that the port used in both requests is the same.

The issue here is that there is no guarantee that the ports used will not be the same for when an Idle Connection Timeout occurs and so the test will/does fail intermittently.

### Summary of Changes & Justification ###
Instead of comparing the post numbers of the connections used for each request in all test cases, the connections themselves are now compared with calls to `hashCode()` like so. The connection instances themselves are accessed by using a customised `ExchangeSupplier` for the `Http2TestServer`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301243](https://bugs.openjdk.org/browse/JDK-8301243): java/net/httpclient/http2/IdleConnectionTimeoutTest.java intermittent failure


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12457/head:pull/12457` \
`$ git checkout pull/12457`

Update a local copy of the PR: \
`$ git checkout pull/12457` \
`$ git pull https://git.openjdk.org/jdk pull/12457/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12457`

View PR using the GUI difftool: \
`$ git pr show -t 12457`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12457.diff">https://git.openjdk.org/jdk/pull/12457.diff</a>

</details>
