### PR TITLE
JDK-8301990: Separate Arguments::parse into two phases

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3864,7 +3864,7 @@ jint Arguments::preprocess(const JavaVMInitArgs* args, Preprocessed* preproc_arg
     return code;
   }
 
-  code = expand_vm_options_as_needed(result->initial_cmd_args.get(),
+  code = expand_vm_options_as_needed(args,
                                      &result->mod_cmd_args,
                                      &result->cur_cmd_args);
   if (code != JNI_OK) {
@@ -3948,7 +3948,7 @@ jint Arguments::parse(const Preprocessed& preproc_args) {
             hotspotrc, hotspotrc);
   }
 
-  if (args->needs_module_property_warning) {
+  if (needs_module_property_warning) {
     warning("Ignoring system property options whose names match the '-Djdk.module.*'."
             " names that are reserved for internal use.");
   }

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3785,17 +3785,17 @@ static void apply_debugger_ergo() {
 
 static const char* const hotspotrc = ".hotspotrc";
 
-class Arguments::PreprocessedImpl final : public CHeapObj<mtArguments> {
+class PreprocessedArguments final : public CHeapObj<mtArguments> {
  public:
-  PreprocessedImpl() : initial_vm_options_args(""),
-                       initial_java_tool_options_args("env_var='JAVA_TOOL_OPTIONS'"),
-                       initial_java_options_args("env_var='_JAVA_OPTIONS'"),
-                       mod_cmd_args("cmd_line_args"),
-                       mod_vm_options_args("vm_options_args"),
-                       mod_java_tool_options_args("env_var='JAVA_TOOL_OPTIONS'"),
-                       mod_java_options_args("env_var='_JAVA_OPTIONS'") {}
+  PreprocessedArguments() : initial_vm_options_args(""),
+                            initial_java_tool_options_args("env_var='JAVA_TOOL_OPTIONS'"),
+                            initial_java_options_args("env_var='_JAVA_OPTIONS'"),
+                            mod_cmd_args("cmd_line_args"),
+                            mod_vm_options_args("vm_options_args"),
+                            mod_java_tool_options_args("env_var='JAVA_TOOL_OPTIONS'"),
+                            mod_java_options_args("env_var='_JAVA_OPTIONS'") {}
 
-  NONCOPYABLE(PreprocessedImpl);
+  NONCOPYABLE(PreprocessedArguments);
 
   ScopedVMInitArgs initial_vm_options_args;
   ScopedVMInitArgs initial_java_tool_options_args;
@@ -3832,7 +3832,7 @@ jint Arguments::preprocess(const JavaVMInitArgs* args, Preprocessed* preproc_arg
 
   // If flag "-XX:Flags=flags-file" is used it will be the first option to be processed.
 
-  PreprocessedImpl* result = new PreprocessedImpl();
+  PreprocessedArguments* result = new PreprocessedArguments();
   // preproc_args will perform any required cleanup.
   preproc_args->_impl = result;
 
@@ -3925,7 +3925,7 @@ jint Arguments::preprocess(const JavaVMInitArgs* args, Preprocessed* preproc_arg
 }
 
 jint Arguments::parse(const Preprocessed& preproc_args) {
-  const PreprocessedImpl* args = preproc_args._impl;
+  const PreprocessedArguments* args = preproc_args._impl;
   assert(args != nullptr, "Arguments::parse called before successful Arguments::preprocess");
 
   // Parse JavaVMInitArgs structure passed in, as well as JAVA_TOOL_OPTIONS and _JAVA_OPTIONS

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -269,6 +269,27 @@ class Arguments : AllStatic {
     ExternalProperty
   };
 
+  // RAII style wrapper representing preprocessed arguments returned from Arguments::preprocess and
+  // accepted by Arguments::parse.
+  class Preprocessed final : public StackObj {
+   private:
+    friend class Arguments;
+
+    void* _impl = nullptr;
+
+   public:
+    Preprocessed() = default;
+
+    ~Preprocessed();
+
+    Preprocessed(const Preprocessed&) = delete;
+    Preprocessed(Preprocessed&&) = delete;
+    Preprocessed& operator=(const Preprocessed&) = delete;
+    Preprocessed& operator=(Preprocessed&&) = delete;
+
+    // Future changes will allow retrieving NativeMemoryTracking and MallocLimit.
+  };
+
  private:
 
   // a pointer to the flags file name if it is specified
@@ -483,8 +504,14 @@ class Arguments : AllStatic {
 
  public:
   static int num_archives(const char* archive_path) NOT_CDS_RETURN_(0);
-  // Parses the arguments, first phase
-  static jint parse(const JavaVMInitArgs* args);
+
+  // Preprocess the arguments, placing the results in `preproc_args` when successful. `args` must
+  // outlive `preproc_args`.
+  static jint preprocess(const JavaVMInitArgs* args, Preprocessed* preproc_args);
+
+  // Parses the already preprocessed arguments.
+  static jint parse(const Preprocessed& args);
+
   // Parse a string for a unsigned integer.  Returns true if value
   // is an unsigned integer greater than or equal to the minimum
   // parameter passed and returns the value in uintx_arg.  Returns

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -239,6 +239,9 @@ class Arguments : AllStatic {
   friend class CodeCacheExtensions;
   friend class ArgumentsTest;
   friend class LargeOptionsTest;
+
+  class PreprocessedImpl;
+
  public:
   // Operation modi
   enum Mode {
@@ -275,23 +278,20 @@ class Arguments : AllStatic {
    private:
     friend class Arguments;
 
-    void* _impl = nullptr;
+    // Actual implementation defined in source file instead of the header.
+    PreprocessedImpl* _impl = nullptr;
 
    public:
     Preprocessed() = default;
 
     ~Preprocessed();
 
-    Preprocessed(const Preprocessed&) = delete;
-    Preprocessed(Preprocessed&&) = delete;
-    Preprocessed& operator=(const Preprocessed&) = delete;
-    Preprocessed& operator=(Preprocessed&&) = delete;
+    NONCOPYABLE(Preprocessed);
 
     // Future changes will allow retrieving NativeMemoryTracking and MallocLimit.
   };
 
  private:
-
   // a pointer to the flags file name if it is specified
   static char*  _jvm_flags_file;
   // an array containing all flags specified in the .hotspotrc file

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -232,6 +232,7 @@ class AgentLibraryList {
 
 // Helper class for controlling the lifetime of JavaVMInitArgs objects.
 class ScopedVMInitArgs;
+class PreprocessedArguments;
 
 class Arguments : AllStatic {
   friend class VMStructs;
@@ -239,8 +240,6 @@ class Arguments : AllStatic {
   friend class CodeCacheExtensions;
   friend class ArgumentsTest;
   friend class LargeOptionsTest;
-
-  class PreprocessedImpl;
 
  public:
   // Operation modi
@@ -279,7 +278,7 @@ class Arguments : AllStatic {
     friend class Arguments;
 
     // Actual implementation defined in source file instead of the header.
-    PreprocessedImpl* _impl = nullptr;
+    PreprocessedArguments* _impl = nullptr;
 
    public:
     Preprocessed() = default;

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -448,10 +448,19 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   // Make sure to initialize log configuration *before* parsing arguments
   LogConfiguration::initialize(create_vm_timer.begin_time());
 
-  // Parse arguments
-  // Note: this internally calls os::init_container_support()
-  jint parse_result = Arguments::parse(args);
-  if (parse_result != JNI_OK) return parse_result;
+  {
+    Arguments::Preprocessed preproc_args;
+
+    jint preprocess_result = Arguments::preprocess(args, &preproc_args);
+    if (preprocess_result != JNI_OK) return preprocess_result;
+
+    // Do not add anything here yet. Future changes will fully separate preprocessing and parsing.
+
+    // Parse arguments
+    // Note: this internally calls os::init_container_support()
+    jint parse_result = Arguments::parse(preproc_args);
+    if (parse_result != JNI_OK) return parse_result;
+  }
 
   // Initialize NMT right after argument parsing to keep the pre-NMT-init window small.
   MemTracker::initialize();


### PR DESCRIPTION
Separate out some logic from `Arguments::parse` into a separate preceding phase, preprocessing. See JDK-8301990 and JDK-8299196 for more details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (3 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 2 [Authors](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8301990](https://bugs.openjdk.org/browse/JDK-8301990): Separate Arguments::parse into two phases


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12458/head:pull/12458` \
`$ git checkout pull/12458`

Update a local copy of the PR: \
`$ git checkout pull/12458` \
`$ git pull https://git.openjdk.org/jdk pull/12458/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12458`

View PR using the GUI difftool: \
`$ git pr show -t 12458`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12458.diff">https://git.openjdk.org/jdk/pull/12458.diff</a>

</details>
