### PR TITLE
8257967: JFR: Event for loaded agents

### DIFF
--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -1172,6 +1172,18 @@
     <Field type="ulong" name="totalFinalizersRun" label="Finalizers Run" description="Total number of finalizers run since JVM start" />
   </Event>
 
+  <Event name="LoadedAgent" category="Java Virtual Machine, Diagnostics" label="Loaded Agent"
+    thread="false" startTime="false" period="endChunk" stackTrace="false">
+    <Field type="string" name="name" label="Name" />
+    <Field type="string" name="options" label="Options" />
+    <Field type="boolean" name="java" label="Java Agent"
+      description="If the agent is implemented using java.lang.instrument" />
+    <Field type="boolean" name="dynamic" label="Dynamically Loaded"
+      description="If the agent was loaded after startup using the attach mechanism" />
+    <Field type="long" contentType="epochmillis" name="loadStart" label="Load Start" />
+    <Field type="long" contentType="nanos" name="loadDuration" label="Load Duration" />
+  </Event>
+
   <Type name="DeoptimizationReason" label="Deoptimization Reason">
     <Field type="string" name="reason" label="Reason" />
   </Type>

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -1181,7 +1181,7 @@
     <Field type="boolean" name="dynamic" label="Dynamically Loaded"
       description="If the agent was loaded after startup using the attach mechanism" />
     <Field type="long" contentType="epochmillis" name="loadTime" label="Load Time"
-     description="Timestamp taken at JVM startup or when loaded by attach mechanism"/>
+     description="Timestamp taken at JVM startup or when agent is loaded by the attach mechanism"/>
   </Event>
 
   <Type name="DeoptimizationReason" label="Deoptimization Reason">

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -1181,7 +1181,7 @@
     <Field type="boolean" name="dynamic" label="Dynamically Loaded"
       description="If the agent was loaded after startup using the attach mechanism" />
     <Field type="long" contentType="epochmillis" name="loadTime" label="Load Time"
-     description="Timestamp taken before Agent_OnLoad was called"/>
+     description="Timestamp taken at JVM startup or before Agent_OnAttach was called"/>
   </Event>
 
   <Type name="DeoptimizationReason" label="Deoptimization Reason">

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -1180,8 +1180,8 @@
       description="If the agent is implemented using java.lang.instrument" />
     <Field type="boolean" name="dynamic" label="Dynamically Loaded"
       description="If the agent was loaded after startup using the attach mechanism" />
-    <Field type="long" contentType="epochmillis" name="loadStart" label="Load Start" />
-    <Field type="long" contentType="nanos" name="loadDuration" label="Load Duration" />
+    <Field type="long" contentType="epochmillis" name="loadTime" label="Load Time"
+     description="Timestamp taken before Agent_OnLoad was called"/>
   </Event>
 
   <Type name="DeoptimizationReason" label="Deoptimization Reason">

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -1181,7 +1181,7 @@
     <Field type="boolean" name="dynamic" label="Dynamically Loaded"
       description="If the agent was loaded after startup using the attach mechanism" />
     <Field type="long" contentType="epochmillis" name="loadTime" label="Load Time"
-     description="Timestamp taken at JVM startup or before Agent_OnAttach was called"/>
+     description="Timestamp taken at JVM startup or when loaded by attach mechanism"/>
   </Event>
 
   <Type name="DeoptimizationReason" label="Deoptimization Reason">

--- a/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
@@ -272,11 +272,12 @@ TRACE_REQUEST_FUNC(SystemProcess) {
 TRACE_REQUEST_FUNC(LoadedAgent) {
   MutexLocker m(JfrAgentList_lock, Mutex::_no_safepoint_check_flag);
   for (AgentLibrary* a = Arguments::agents(); a != nullptr; a = a->next()) {
-    assert (a->start_time_epoch_ms() != 0, "agent not timed");
-    EventLoadedAgent event;
+    assert (a->load_time_epoch_ms() != 0, "agent not loaded");
+    EventLoadedAgent event(UNTIMED);
+    event.set_starttime(timestamp());
+    event.set_endtime(timestamp());
     event.set_dynamic(a->is_dynamic());
-    event.set_loadStart(a->start_time_epoch_ms());
-    event.set_loadDuration(a->duration_ns());
+    event.set_loadTime(a->load_time_epoch_ms());
     if (a->is_instrument_lib()) {
       event.set_java(true);
       event.set_name(a->instrument_name());

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -2937,15 +2937,6 @@ jint JvmtiExport::load_agent_library(const char *agent, const char *absParam,
   char buffer[JVM_MAXPATHLEN];
   void* library = nullptr;
   jint result = JNI_ERR;
-  if (options != nullptr) {
-    printf("\n options:\n");
-    char* h = (char*)options;
-    while (*h != '\0') {
-      unsigned char ch = (unsigned char)*h;
-      printf("%u\n", (unsigned int)ch);
-      h++;
-    }
-  }
   const char *on_attach_symbols[] = AGENT_ONATTACH_SYMBOLS;
   size_t num_symbol_entries = ARRAY_SIZE(on_attach_symbols);
 

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -2996,7 +2996,7 @@ jint JvmtiExport::load_agent_library(const char *agent, const char *absParam,
         JvmtiJavaThreadEventTransition jet(THREAD);
 
         agent_lib->start_timing();
-        result = (*on_attach_entry)(&main_vm, (char*)options, NULL);
+        result = (*on_attach_entry)(&main_vm, (char*)options, nullptr);
         agent_lib->end_timing();
 
         // Agent_OnAttach may have used JNI

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -2943,7 +2943,7 @@ jint JvmtiExport::load_agent_library(const char *agent, const char *absParam,
   // The abs parameter should be "true" or "false"
   bool is_absolute_path = (absParam != nullptr) && (strcmp(absParam,"true")==0);
 
-  bool instrument = strcmp("instrument", agent) == 0;
+  bool instrument = agent != nullptr && strcmp("instrument", agent) == 0;
   // Initially marked as invalid. It will be set to valid if we can find the agent
   AgentLibrary *agent_lib = new AgentLibrary(agent, options, is_absolute_path, nullptr, true, instrument);
 

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -2937,6 +2937,15 @@ jint JvmtiExport::load_agent_library(const char *agent, const char *absParam,
   char buffer[JVM_MAXPATHLEN];
   void* library = nullptr;
   jint result = JNI_ERR;
+  if (options != nullptr) {
+    printf("\n options:\n");
+    char* h = (char*)options;
+    while (*h != '\0') {
+      unsigned char ch = (unsigned char)*h;
+      printf("%u\n", (unsigned int)ch);
+      h++;
+    }
+  }
   const char *on_attach_symbols[] = AGENT_ONATTACH_SYMBOLS;
   size_t num_symbol_entries = ARRAY_SIZE(on_attach_symbols);
 

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -2995,9 +2995,8 @@ jint JvmtiExport::load_agent_library(const char *agent, const char *absParam,
         JvmtiThreadEventMark jem(THREAD);
         JvmtiJavaThreadEventTransition jet(THREAD);
 
-        agent_lib->start_timing();
+        agent_lib->set_load_time();
         result = (*on_attach_entry)(&main_vm, (char*)options, nullptr);
-        agent_lib->end_timing();
 
         // Agent_OnAttach may have used JNI
         if (THREAD->is_pending_jni_exception_check()) {

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -2943,8 +2943,9 @@ jint JvmtiExport::load_agent_library(const char *agent, const char *absParam,
   // The abs parameter should be "true" or "false"
   bool is_absolute_path = (absParam != nullptr) && (strcmp(absParam,"true")==0);
 
+  bool instrument = strcmp("instrument", agent) == 0;
   // Initially marked as invalid. It will be set to valid if we can find the agent
-  AgentLibrary *agent_lib = new AgentLibrary(agent, options, is_absolute_path, nullptr);
+  AgentLibrary *agent_lib = new AgentLibrary(agent, options, is_absolute_path, nullptr, true, instrument);
 
   // Check for statically linked in agent. If not found then if the path is
   // absolute we attempt to load the library. Otherwise we try to load it
@@ -2994,7 +2995,9 @@ jint JvmtiExport::load_agent_library(const char *agent, const char *absParam,
         JvmtiThreadEventMark jem(THREAD);
         JvmtiJavaThreadEventTransition jet(THREAD);
 
-        result = (*on_attach_entry)(&main_vm, (char*)options, nullptr);
+        agent_lib->start_timing();
+        result = (*on_attach_entry)(&main_vm, (char*)options, NULL);
+        agent_lib->end_timing();
 
         // Agent_OnAttach may have used JNI
         if (THREAD->is_pending_jni_exception_check()) {

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -50,6 +50,7 @@
 #include "runtime/flags/jvmFlagLimit.hpp"
 #include "runtime/globals_extension.hpp"
 #include "runtime/java.hpp"
+#include "runtime/mutexLocker.hpp"
 #include "runtime/os.hpp"
 #include "runtime/safepoint.hpp"
 #include "runtime/safepointMechanism.hpp"

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -232,9 +232,7 @@ AgentLibrary::AgentLibrary(const char* name, const char* options,
   _is_static_lib = false;
   _is_instrument_lib = instrument_lib;
   _is_dynamic = is_dynamic;
-  _start_seconds = 0;
-  _start_nanos = 0;
-  _duration_ns = 0;
+  _load_time_epoch_ms = 0;
   _instrument_lib_options = nullptr;
   _instrument_lib_name = nullptr;
   if (_is_instrument_lib && _options != nullptr) {
@@ -254,19 +252,11 @@ AgentLibrary::AgentLibrary(const char* name, const char* options,
   }
 }
 
-void AgentLibrary::start_timing() {
+void AgentLibrary::set_load_time() {
   // Ticks not initialized, use os::javaTimeSystemUTC
-  os::javaTimeSystemUTC(_start_seconds, _start_nanos);
-}
-
-void AgentLibrary::end_timing() {
-  assert(_start_seconds != 0, "invariant");
-  jlong end_seconds, end_nanos;
-  os::javaTimeSystemUTC(end_seconds, end_nanos);
-  jlong s = end_seconds - _start_seconds;
-  jlong n = end_nanos - _start_nanos;
-  _duration_ns = 1000000000 * s + n;
-  _start_time_epoch_ms = _start_seconds * 1000 + _start_nanos / 1000000;
+  jlong seconds, nanos;
+  os::javaTimeSystemUTC(seconds, nanos);
+  _load_time_epoch_ms = seconds * 1000 + nanos / 1000000;
 }
 
 // Check if head of 'option' matches 'name', and sets 'tail' to the remaining

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -253,10 +253,8 @@ AgentLibrary::AgentLibrary(const char* name, const char* options,
 }
 
 void AgentLibrary::set_load_time() {
-  // Ticks not initialized, use os::javaTimeSystemUTC
-  jlong seconds, nanos;
-  os::javaTimeSystemUTC(seconds, nanos);
-  _load_time_epoch_ms = seconds * 1000 + nanos / 1000000;
+  // Using epoch millis since Ticks system is not initialized this early.
+  _load_time_epoch_ms = os::javaTimeMillis();
 }
 
 // Check if head of 'option' matches 'name', and sets 'tail' to the remaining

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -242,12 +242,12 @@ AgentLibrary::AgentLibrary(const char* name, const char* options,
       size_t name_length = p - options;
       size_t option_length = length - name_length - 1;
       _instrument_lib_name = AllocateHeap(name_length + 1, mtArguments);
-      snprintf(_instrument_lib_name, name_length + 1, "%s", options);
+      jio_snprintf(_instrument_lib_name, name_length + 1, "%s", options);
       _instrument_lib_options = AllocateHeap(option_length + 1, mtArguments);
-      snprintf(_instrument_lib_options, option_length + 1, "%s", p + 1);
+      jio_snprintf(_instrument_lib_options, option_length + 1, "%s", p + 1);
     } else {
       _instrument_lib_name = AllocateHeap(length + 1, mtArguments);
-      snprintf(_instrument_lib_name, length + 1, "%s", options);
+      jio_snprintf(_instrument_lib_name, length + 1, "%s", options);
     }
   }
 }

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -160,10 +160,7 @@ public:
   char*           _instrument_lib_name;
   char*           _instrument_lib_options;
   bool            _is_dynamic;
-  jlong           _start_seconds;
-  jlong           _start_nanos;
-  jlong           _start_time_epoch_ms;
-  jlong           _duration_ns;
+  jlong           _load_time_epoch_ms;
   AgentState      _state;
   AgentLibrary*   _next;
 
@@ -183,10 +180,8 @@ public:
   void set_static_lib(bool is_static_lib)   { _is_static_lib = is_static_lib; }
   bool valid()                              { return (_state == agent_valid); }
   void set_valid()                          { _state = agent_valid; }
-  jlong start_time_epoch_ms() const         { return _start_time_epoch_ms; }
-  jlong duration_ns() const                 { return _duration_ns; }
-  void start_timing();
-  void end_timing();
+  jlong load_time_epoch_ms() const          { return _load_time_epoch_ms; }
+  void set_load_time();
 
   // Constructor
   AgentLibrary(const char* name, const char* options, bool is_absolute_path,

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -157,6 +157,13 @@ public:
   bool            _is_absolute_path;
   bool            _is_static_lib;
   bool            _is_instrument_lib;
+  char*           _instrument_lib_name;
+  char*           _instrument_lib_options;
+  bool            _is_dynamic;
+  jlong           _start_seconds;
+  jlong           _start_nanos;
+  jlong           _start_time_epoch_ms;
+  jlong           _duration_ns;
   AgentState      _state;
   AgentLibrary*   _next;
 
@@ -170,13 +177,20 @@ public:
   AgentLibrary* next() const                { return _next; }
   bool is_static_lib() const                { return _is_static_lib; }
   bool is_instrument_lib() const            { return _is_instrument_lib; }
+  char* instrument_name() const             { return _instrument_lib_name; }
+  char* instrument_options() const          { return _instrument_lib_options; }
+  bool is_dynamic() const                   { return _is_dynamic; }
   void set_static_lib(bool is_static_lib)   { _is_static_lib = is_static_lib; }
   bool valid()                              { return (_state == agent_valid); }
   void set_valid()                          { _state = agent_valid; }
+  jlong start_time_epoch_ms() const         { return _start_time_epoch_ms; }
+  jlong duration_ns() const                 { return _duration_ns; }
+  void start_timing();
+  void end_timing();
 
   // Constructor
   AgentLibrary(const char* name, const char* options, bool is_absolute_path,
-               void* os_lib, bool instrument_lib=false);
+               void* os_lib, bool dynamic, bool instrument_lib);
 };
 
 // maintain an order of entry list of AgentLibrary

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -127,6 +127,7 @@ Mutex*   JfrStacktrace_lock           = nullptr;
 Monitor* JfrMsg_lock                  = nullptr;
 Mutex*   JfrBuffer_lock               = nullptr;
 Monitor* JfrThreadSampler_lock        = nullptr;
+Mutex*   JfrAgentList_lock            = nullptr;
 #endif
 
 #ifndef SUPPORTS_NATIVE_CX8
@@ -308,6 +309,7 @@ void mutex_init() {
   def(JfrMsg_lock                  , PaddedMonitor, nosafepoint-3);
   def(JfrStacktrace_lock           , PaddedMutex  , stackwatermark-1);
   def(JfrThreadSampler_lock        , PaddedMonitor, nosafepoint);
+  def(JfrAgentList_lock            , PaddedMutex, nosafepoint);
 #endif
 
 #ifndef SUPPORTS_NATIVE_CX8

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -133,7 +133,7 @@ extern Mutex*   JfrStacktrace_lock;              // used to guard access to the 
 extern Monitor* JfrMsg_lock;                     // protects JFR messaging
 extern Mutex*   JfrBuffer_lock;                  // protects JFR buffer operations
 extern Monitor* JfrThreadSampler_lock;           // used to suspend/resume JFR thread sampler
-extern Mutex*   JfrAgentList_lock;               // protects list of AgentLibraries
+extern Mutex*   JfrAgentList_lock;               // protects AgentLibraryList
 #endif
 
 #ifndef SUPPORTS_NATIVE_CX8

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -133,6 +133,7 @@ extern Mutex*   JfrStacktrace_lock;              // used to guard access to the 
 extern Monitor* JfrMsg_lock;                     // protects JFR messaging
 extern Mutex*   JfrBuffer_lock;                  // protects JFR buffer operations
 extern Monitor* JfrThreadSampler_lock;           // used to suspend/resume JFR thread sampler
+extern Mutex*   JfrAgentList_lock;               // protects list of AgentLibraries
 #endif
 
 #ifndef SUPPORTS_NATIVE_CX8

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -949,7 +949,9 @@ void Threads::create_vm_init_agents() {
 
     if (on_load_entry != nullptr) {
       // Invoke the Agent_OnLoad function
+      agent->start_timing();
       jint err = (*on_load_entry)(&main_vm, agent->options(), nullptr);
+      agent->end_timing();
       if (err != JNI_OK) {
         vm_exit_during_initialization("agent library failed to init", agent->name());
       }
@@ -1003,7 +1005,9 @@ void Threads::create_vm_init_libraries() {
       JavaThread* thread = JavaThread::current();
       ThreadToNativeFromVM ttn(thread);
       HandleMark hm(thread);
+      agent->start_timing();
       jint err = (*on_load_entry)(&main_vm, agent->options(), nullptr);
+      agent->end_timing();
       if (err != JNI_OK) {
         vm_exit_during_initialization("-Xrun library failed to init", agent->name());
       }

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -949,9 +949,8 @@ void Threads::create_vm_init_agents() {
 
     if (on_load_entry != nullptr) {
       // Invoke the Agent_OnLoad function
-      agent->start_timing();
+      agent->set_load_time();
       jint err = (*on_load_entry)(&main_vm, agent->options(), nullptr);
-      agent->end_timing();
       if (err != JNI_OK) {
         vm_exit_during_initialization("agent library failed to init", agent->name());
       }
@@ -1005,9 +1004,8 @@ void Threads::create_vm_init_libraries() {
       JavaThread* thread = JavaThread::current();
       ThreadToNativeFromVM ttn(thread);
       HandleMark hm(thread);
-      agent->start_timing();
+      agent->set_load_time();
       jint err = (*on_load_entry)(&main_vm, agent->options(), nullptr);
-      agent->end_timing();
       if (err != JNI_OK) {
         vm_exit_during_initialization("-Xrun library failed to init", agent->name());
       }

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -858,6 +858,11 @@
       <setting name="period">endChunk</setting>
     </event>
 
+    <event name="jdk.LoadedAgent">
+      <setting name="enabled">true</setting>
+      <setting name="period">endChunk</setting>
+    </event>
+
 
 
 

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -858,6 +858,11 @@
       <setting name="period">endChunk</setting>
     </event>
 
+    <event name="jdk.LoadedAgent">
+      <setting name="enabled">true</setting>
+      <setting name="period">endChunk</setting>
+    </event>
+
 
 
 

--- a/test/jdk/jdk/jfr/event/runtime/JavaAgent.java
+++ b/test/jdk/jdk/jfr/event/runtime/JavaAgent.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.event.runtime;
+
+import java.lang.instrument.Instrumentation;
+
+public class JavaAgent {
+
+    public static void agentmain(String agentArgs, Instrumentation inst) throws Exception {
+        System.out.println("agentmain: " + agentArgs);
+    }
+
+    public static void premain(String agentArgs, Instrumentation inst) throws Exception {
+        System.out.println("premain: " + agentArgs);
+    }
+}

--- a/test/jdk/jdk/jfr/event/runtime/TestAgentEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestAgentEvent.java
@@ -58,11 +58,11 @@ import jdk.test.lib.jfr.TestClassLoader;
  * @run main/othervm -javaagent:JavaAgent.jar=foo=bar
  *      jdk.jfr.event.runtime.TestAgentEvent
  *      testJavaStatic
- *      
+ *
  * @run main/othervm -Djdk.attach.allowAttachSelf=true
  *      jdk.jfr.event.runtime.TestAgentEvent
  *      testJavaDynamic
- *      
+ *
  * @run main/othervm -agentlib:jdwp=transport=dt_socket,server=y,address=any,onjcmd=y
  *      jdk.jfr.event.runtime.TestAgentEvent
  *      testNativeStatic

--- a/test/jdk/jdk/jfr/event/runtime/TestAgentEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestAgentEvent.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.event.runtime;
+
+import java.lang.reflect.Method;
+import java.security.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import com.sun.tools.attach.VirtualMachine;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedClass;
+import jdk.jfr.consumer.RecordedClassLoader;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.Event;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.jfr.EventNames;
+import jdk.test.lib.jfr.Events;
+import jdk.test.lib.jfr.TestClassLoader;
+
+/**
+ * @test
+ * @key jfr
+ * @summary Tests Agent Loaded event by starting native and Java agents
+ * @requires vm.hasJFR
+ *
+ * @library /test/lib
+ * @modules java.instrument
+ *
+ * @build jdk.jfr.event.runtime.JavaAgent
+ *
+ * @run driver jdk.test.lib.util.JavaAgentBuilder
+ *      jdk.jfr.event.runtime.JavaAgent
+ *      JavaAgent.jar
+ *
+ * @run main/othervm -javaagent:JavaAgent.jar=foo=bar
+ *      jdk.jfr.event.runtime.TestAgentEvent
+ *      testJavaStatic
+ *      
+ * @run main/othervm -Djdk.attach.allowAttachSelf=true
+ *      jdk.jfr.event.runtime.TestAgentEvent
+ *      testJavaDynamic
+ *      
+ * @run main/othervm -agentlib:jdwp=transport=dt_socket,server=y,address=any,onjcmd=y
+ *      jdk.jfr.event.runtime.TestAgentEvent
+ *      testNativeStatic
+ */
+public final class TestAgentEvent {
+    private static final String JAVA_AGENT_JAR = "JavaAgent.jar";
+    private final static String EVENT_NAME = "jdk.LoadedAgent";
+
+    public static void main(String[] args) throws Throwable {
+        String testMethod = args[0];
+        Method m = TestAgentEvent.class.getDeclaredMethod(testMethod, new Class[0]);
+        if (m == null) {
+            throw new Exception("Unknown test method: " + testMethod);
+        }
+        m.invoke(null, new Object[0]);
+    }
+
+    private static void testJavaStatic() throws Throwable {
+        try (Recording r = new Recording()) {
+            r.enable(EVENT_NAME);
+            r.start();
+            List<RecordedEvent> events = Events.fromRecording(r);
+            RecordedEvent e = events.get(0);
+            System.out.println(e);
+            Events.assertField(e, "name").equal(JAVA_AGENT_JAR);
+            Events.assertField(e, "options").equal("foo=bar");
+            Events.assertField(e, "java").equal(true);
+            Events.assertField(e, "dynamic").equal(false);
+        }
+    }
+
+    private static void testNativeStatic() throws Throwable {
+        try (Recording r = new Recording()) {
+            r.enable(EVENT_NAME);
+            r.start();
+            List<RecordedEvent> events = Events.fromRecording(r);
+            RecordedEvent e = events.get(0);
+            System.out.println(e);
+            Events.assertField(e, "name").equal("jdwp");
+            Events.assertField(e, "options").equal("transport=dt_socket,server=y,address=any,onjcmd=y");
+            Events.assertField(e, "dynamic").equal(false);
+            Events.assertField(e, "java").equals(false);
+        }
+    }
+
+    private static void testJavaDynamic() throws Throwable {
+        try (Recording r = new Recording()) {
+            r.enable(EVENT_NAME);
+            r.start();
+            long pid = ProcessHandle.current().pid();
+            VirtualMachine vm = VirtualMachine.attach(Long.toString(pid));
+            vm.loadAgent(JAVA_AGENT_JAR, "bar=baz");
+            vm.detach();
+            vm = VirtualMachine.attach(Long.toString(pid));
+            vm.loadAgent(JAVA_AGENT_JAR); // options = null
+            vm.detach();
+            vm = VirtualMachine.attach(Long.toString(pid));
+            String smiley = "\uD83D\uDE00";
+            vm.loadAgent(JAVA_AGENT_JAR, "");
+            vm.loadAgent(JAVA_AGENT_JAR, "=");
+            vm.loadAgent(JAVA_AGENT_JAR, smiley);
+            vm.detach();
+            r.stop();
+            List<RecordedEvent> events = Events.fromRecording(r);
+            for (RecordedEvent e : events) {
+                System.out.println(e);
+                Instant loadStart = e.getInstant("loadStart");
+                if (loadStart.isBefore(r.getStartTime())) {
+                    throw new Exception("Expected agent to be loaded after recording start");
+                }
+                if (loadStart.isAfter(r.getStopTime())) {
+                    throw new Exception("Expected agent to be loaded before recording stop");
+                }
+                Duration duration = e.getDuration("loadDuration");
+                if (duration.isNegative()) {
+                    throw new Exception("Expected duration to be positive value");
+                }
+                if (duration.toSeconds() > 3600) {
+                    throw new Exception("Expected duration to be less than 1 hour");
+                }
+                Events.assertField(e, "name").equal(JAVA_AGENT_JAR);
+                Events.assertField(e, "dynamic").equal(true);
+                Events.assertField(e, "java").equal(true);
+            }
+            Events.assertField(events.get(0), "options").equal("bar=baz");
+            Events.assertField(events.get(1), "options").equal(null);
+            Events.assertField(events.get(2), "options").equal("");
+            Events.assertField(events.get(3), "options").equal("=");
+            Events.assertField(events.get(4), "options").equal(smiley);
+        }
+    }
+}

--- a/test/jdk/jdk/jfr/event/runtime/TestLoadedAgentEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestLoadedAgentEvent.java
@@ -69,7 +69,7 @@ import jdk.test.lib.jfr.TestClassLoader;
  */
 public final class TestLoadedAgentEvent {
     private static final String JAVA_AGENT_JAR = "JavaAgent.jar";
-    private final static String EVENT_NAME = "jdk.LoadedAgent";
+    private static final String EVENT_NAME = "jdk.LoadedAgent";
 
     public static void main(String[] args) throws Throwable {
         String testMethod = args[0];
@@ -85,6 +85,7 @@ public final class TestLoadedAgentEvent {
             r.enable(EVENT_NAME);
             r.start();
             List<RecordedEvent> events = Events.fromRecording(r);
+            Events.hasEvents(events);
             RecordedEvent e = events.get(0);
             System.out.println(e);
             Events.assertField(e, "name").equal(JAVA_AGENT_JAR);
@@ -99,6 +100,7 @@ public final class TestLoadedAgentEvent {
             r.enable(EVENT_NAME);
             r.start();
             List<RecordedEvent> events = Events.fromRecording(r);
+            Events.hasEvents(events);
             RecordedEvent e = events.get(0);
             System.out.println(e);
             Events.assertField(e, "name").equal("jdwp");
@@ -127,6 +129,7 @@ public final class TestLoadedAgentEvent {
             vm.detach();
             r.stop();
             List<RecordedEvent> events = Events.fromRecording(r);
+            Events.hasEvents(events);
             for (RecordedEvent e : events) {
                 System.out.println(e);
                 Instant loadStart = e.getInstant("loadStart");

--- a/test/jdk/jdk/jfr/event/runtime/TestLoadedAgentEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestLoadedAgentEvent.java
@@ -128,21 +128,21 @@ public final class TestLoadedAgentEvent {
             r.stop();
             List<RecordedEvent> events = Events.fromRecording(r);
             Events.hasEvents(events);
+            Instant endTime = events.get(0).getEndTime();
             for (RecordedEvent e : events) {
                 System.out.println(e);
-                Instant loadStart = e.getInstant("loadStart");
-                if (loadStart.isBefore(r.getStartTime())) {
+                if (!e.getEndTime().equals(endTime)) {
+                    throw new Exception("Expected all events to have the same end time");
+                }
+                if (!e.getStartTime().equals(endTime)) {
+                    throw new Exception("Expected start and end time to be the same");
+                }
+                Instant loadTime = e.getInstant("loadTime");
+                if (loadTime.isBefore(r.getStartTime())) {
                     throw new Exception("Expected agent to be loaded after recording start");
                 }
-                if (loadStart.isAfter(r.getStopTime())) {
+                if (loadTime.isAfter(r.getStopTime())) {
                     throw new Exception("Expected agent to be loaded before recording stop");
-                }
-                Duration duration = e.getDuration("loadDuration");
-                if (duration.isNegative()) {
-                    throw new Exception("Expected duration to be positive value");
-                }
-                if (duration.toSeconds() > 3600) {
-                    throw new Exception("Expected duration to be less than 1 hour");
                 }
                 Events.assertField(e, "name").equal(JAVA_AGENT_JAR);
                 Events.assertField(e, "dynamic").equal(true);

--- a/test/jdk/jdk/jfr/event/runtime/TestLoadedAgentEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestLoadedAgentEvent.java
@@ -122,10 +122,8 @@ public final class TestLoadedAgentEvent {
             vm.loadAgent(JAVA_AGENT_JAR); // options = null
             vm.detach();
             vm = VirtualMachine.attach(Long.toString(pid));
-            String smiley = "\uD83D\uDE00";
             vm.loadAgent(JAVA_AGENT_JAR, "");
             vm.loadAgent(JAVA_AGENT_JAR, "=");
-            vm.loadAgent(JAVA_AGENT_JAR, smiley);
             vm.detach();
             r.stop();
             List<RecordedEvent> events = Events.fromRecording(r);
@@ -154,7 +152,6 @@ public final class TestLoadedAgentEvent {
             Events.assertField(events.get(1), "options").equal(null);
             Events.assertField(events.get(2), "options").equal("");
             Events.assertField(events.get(3), "options").equal("=");
-            Events.assertField(events.get(4), "options").equal(smiley);
         }
     }
 }

--- a/test/jdk/jdk/jfr/event/runtime/TestLoadedAgentEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestLoadedAgentEvent.java
@@ -43,7 +43,7 @@ import jdk.test.lib.jfr.TestClassLoader;
 /**
  * @test
  * @key jfr
- * @summary Tests Agent Loaded event by starting native and Java agents
+ * @summary Tests Loaded Agent event by starting native and Java agents
  * @requires vm.hasJFR
  *
  * @library /test/lib
@@ -56,24 +56,24 @@ import jdk.test.lib.jfr.TestClassLoader;
  *      JavaAgent.jar
  *
  * @run main/othervm -javaagent:JavaAgent.jar=foo=bar
- *      jdk.jfr.event.runtime.TestAgentEvent
+ *      jdk.jfr.event.runtime.TestLoadedAgentEvent
  *      testJavaStatic
  *
  * @run main/othervm -Djdk.attach.allowAttachSelf=true
- *      jdk.jfr.event.runtime.TestAgentEvent
+ *      jdk.jfr.event.runtime.TestLoadedAgentEvent
  *      testJavaDynamic
  *
  * @run main/othervm -agentlib:jdwp=transport=dt_socket,server=y,address=any,onjcmd=y
- *      jdk.jfr.event.runtime.TestAgentEvent
+ *      jdk.jfr.event.runtime.TestLoadedAgentEvent
  *      testNativeStatic
  */
-public final class TestAgentEvent {
+public final class TestLoadedAgentEvent {
     private static final String JAVA_AGENT_JAR = "JavaAgent.jar";
     private final static String EVENT_NAME = "jdk.LoadedAgent";
 
     public static void main(String[] args) throws Throwable {
         String testMethod = args[0];
-        Method m = TestAgentEvent.class.getDeclaredMethod(testMethod, new Class[0]);
+        Method m = TestLoadedAgentEvent.class.getDeclaredMethod(testMethod, new Class[0]);
         if (m == null) {
             throw new Exception("Unknown test method: " + testMethod);
         }

--- a/test/lib/jdk/test/lib/jfr/EventNames.java
+++ b/test/lib/jdk/test/lib/jfr/EventNames.java
@@ -88,6 +88,7 @@ public class EventNames {
     public static final String FinalizerStatistics = PREFIX + "FinalizerStatistics";
     public static final String NativeMemoryUsage = PREFIX + "NativeMemoryUsage";
     public static final String NativeMemoryUsageTotal = PREFIX + "NativeMemoryUsageTotal";
+    public static final String Agent = PREFIX + "LoadedAgent";
 
     // This event is hard to test
     public static final String ReservedStackActivation = PREFIX + "ReservedStackActivation";


### PR DESCRIPTION
Could I have a review of an event for native and Java agents. 

Testing: 
- tier1
- tier2
- jdk/jdk/jfr/*
- 100 * TestLoadedAgent.java

Rationale for event fields:
- name: to identify problematic third party agents
- options: to identify problematic options, such as too generic filters or conflicting port numbers, that could impact application behavior
- dynamic: if an agent was loaded by a user using jcmd, which could explain why problem only occur on some server instances
- java: if the agent is native, it could explain crashes
- loadTime: to understand if application problem correlates with the time the agent was loaded

Alternatives:
- I considered making a non-periodic event that is emitted when the agent is loaded, but agents loaded at startup are then unlikely to make it into the recording.
- If it is a JPLIS agent, the jar name is used instead of "instrument". This is likely what users expect when using VirtualMachine::loadAgent(name, options) API or -javaagent:name=options
- I considered making all accesses to the agentLibrary list protected by a mutex, but it could potentially lead to deadlocks when non-JFR code iterates over the list. I think this is better fixed as a separate issue, if deemed necessary. So far so good. JFR iterates the list at every chunk rotation and not from the attach thread, so the risk for an unsafe access is real and synchronization is needed.
- When a JPLIS agent was loaded by attach, it wasn't detected properly, so I added a name check so I could pass true to the constructor and make TestLoadedAgent pass. It would possible to make all detection of JPLIS using the name "instrument" and not rely on a boolean in the constructor, but I deemed it outside the scope for the enhancement.
- I considered using Ticks::now() instead of os::javaTimeMillis() as time source, but TSC is not initialized this early. It could perhaps be fixed by moving the initialization earlier, but it might have other side effects, and is better done outside this enhancement. 


Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8257967](https://bugs.openjdk.org/browse/JDK-8257967)

### Issue
 * [JDK-8257967](https://bugs.openjdk.org/browse/JDK-8257967): JFR: Events for loaded agents ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12460/head:pull/12460` \
`$ git checkout pull/12460`

Update a local copy of the PR: \
`$ git checkout pull/12460` \
`$ git pull https://git.openjdk.org/jdk.git pull/12460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12460`

View PR using the GUI difftool: \
`$ git pr show -t 12460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12460.diff">https://git.openjdk.org/jdk/pull/12460.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12460#issuecomment-1425659052)