### PR TITLE
8301753: AppendFile needs to add a new line to be compatible with old make

### DIFF
--- a/make/common/MakeIO.gmk
+++ b/make/common/MakeIO.gmk
@@ -268,5 +268,5 @@ ifeq ($(HAS_FILE_FUNCTION), true)
 else
   # Use printf to get consistent behavior on all platforms.
   AppendFile = \
-      $(shell $(PRINTF) "%s" $(call ShellQuote, $1) >> $2)
+      $(shell $(PRINTF) "%s\n" $(call ShellQuote, $1) >> $2)
 endif


### PR DESCRIPTION
The newline is added to be compatible with old make 3.81 which is still used on MacOSX.
Fixed actually by dnsimon.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8301753](https://bugs.openjdk.org/browse/JDK-8301753)

### Issue
 * [JDK-8301753](https://bugs.openjdk.org/browse/JDK-8301753): AppendFile/WriteFile has differences between make 3.81 and 4+ ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - Committer)


### Contributors
 * Doug Simon `<dnsimon@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12461/head:pull/12461` \
`$ git checkout pull/12461`

Update a local copy of the PR: \
`$ git checkout pull/12461` \
`$ git pull https://git.openjdk.org/jdk.git pull/12461/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12461`

View PR using the GUI difftool: \
`$ git pr show -t 12461`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12461.diff">https://git.openjdk.org/jdk/pull/12461.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12461#issuecomment-1421450354)