### PR TITLE
8180387: com.sun.source.util.JavacTask should have a protected constructor.

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/source/util/JavacTask.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/JavacTask.java
@@ -53,7 +53,7 @@ public abstract class JavacTask implements CompilationTask {
     /**
      * Constructor for subclasses to call.
      */
-    public JavacTask() {}
+    protected JavacTask() {}
 
     /**
      * Returns the {@code JavacTask} for a {@code ProcessingEnvironment}.


### PR DESCRIPTION
Standard practice is for constructors in `abstract` classes to be `protected` rather than `public` because they can't be used except from subclasses.

[JDK-8180387](https://bugs.openjdk.org/browse/JDK-8180387) was filed to address a particular instance of this phenomenon in the class `com.sun.source.util.JavacTask`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8180387](https://bugs.openjdk.org/browse/JDK-8180387): com.sun.source.util.JavacTask should have a protected constructor.


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12462/head:pull/12462` \
`$ git checkout pull/12462`

Update a local copy of the PR: \
`$ git checkout pull/12462` \
`$ git pull https://git.openjdk.org/jdk pull/12462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12462`

View PR using the GUI difftool: \
`$ git pr show -t 12462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12462.diff">https://git.openjdk.org/jdk/pull/12462.diff</a>

</details>
