### PR TITLE
8295425: Match the default priv exp length between SunPKCS11 and other JDK providers

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyPairGenerator.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyPairGenerator.java
@@ -387,7 +387,7 @@ final class P11KeyPairGenerator extends KeyPairGeneratorSpi {
                     dhParams = (DHParameterSpec) params;
                     privateBits = dhParams.getL();
                     if (privateBits < 0) {
-                        // invalid; override with JDK defaults (or ignore?)
+                        // invalid, override with JDK defaults
                         privateBits = getDefDHPrivateExpSize(dhParams);
                     }
                 }

--- a/test/jdk/sun/security/pkcs11/KeyPairGenerator/TestDefaultDHPrivateExpSize.java
+++ b/test/jdk/sun/security/pkcs11/KeyPairGenerator/TestDefaultDHPrivateExpSize.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Provider;
+import java.security.PrivateKey;
+import javax.crypto.spec.DHParameterSpec;
+import javax.crypto.interfaces.DHPrivateKey;
+import sun.security.util.SecurityProviderConstants;
+import sun.security.provider.ParameterCache;
+
+/**
+ * @test
+ * @bug 8295425
+ * @modules java.base/sun.security.provider java.base/sun.security.util
+ * @library /test/lib ..
+ * @run main TestDefaultDHPrivateExpSize
+ * @summary This test verifies the DH private exponent size for SunPKCS11
+ *         provider.
+ */
+
+public class TestDefaultDHPrivateExpSize extends PKCS11Test {
+
+    @Override
+    public void main(Provider p) throws Exception {
+        System.out.println("Testing " + p.getName());
+
+        if (p.getService("KeyPairGenerator", "DH") == null) {
+            System.out.println("Skip, no support for DH KeyPairGenerator");
+            return;
+        }
+
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH", p);
+        // try common DH key sizes with built-in primes
+        int[] cachedSizes = { 2048, 3072, 4096, 6144, 8192 };
+        for (int ks : cachedSizes) {
+            // use keysize which uses JDK default parameters w/ JDK
+            // default lSize
+            kpg.initialize(ks);
+            int expectedL = SecurityProviderConstants.getDefDHPrivateExpSize
+                    (ParameterCache.getCachedDHParameterSpec(ks));
+            System.out.println("Test against built-in DH " + ks +
+                    "-bit parameters, expectedL = " + expectedL);
+            DHParameterSpec spec = generateAndCheck(kpg, ks, expectedL);
+
+            // use custom DH parameters w/o lSize
+            DHParameterSpec spec2 = new DHParameterSpec(spec.getP(),
+                    spec.getG());
+            kpg.initialize(spec2);
+            System.out.println("Test against user DH " + ks +
+                    "-bit parameters, expectedL = " + spec2.getL());
+
+            generateAndCheck(kpg, ks, spec2.getL());
+
+            // use custom DH parameters w/ lSize
+            expectedL += 2;
+            spec2 = new DHParameterSpec(spec.getP(), spec.getG(), expectedL);
+            kpg.initialize(spec2);
+            System.out.println("Test against user DH " + ks +
+                    "-bit parameters, expectedL = " + spec2.getL());
+            generateAndCheck(kpg, ks, expectedL);
+        }
+    }
+
+    // initialize the specified 'kpg' with 'initParam', then check
+    // the parameters associated with the generated key against 'initParam'
+    // and return the actual private exponent length.
+    private static DHParameterSpec generateAndCheck(KeyPairGenerator kpg,
+            int expKeySize, int expL) {
+
+        DHPrivateKey dhPriv = (DHPrivateKey) kpg.generateKeyPair().getPrivate();
+        DHParameterSpec generated = dhPriv.getParams();
+        // check the params associated with the key as that's what we
+        // have control over
+        if ((generated.getP().bitLength() != expKeySize) ||
+                generated.getL()!= expL) {
+            new RuntimeException("Error: size check failed, got " +
+                    generated.getP().bitLength() + " and " + generated.getL());
+        }
+
+        // Known NSS Issue/limitation: NSS ignores the supplied L value when
+        // generating the DH private key
+        int actualL = dhPriv.getX().bitLength();
+        System.out.println("INFO: actual L = " + actualL);
+        /*
+        if (expLSize != 0 && actualL != expLSize) {
+            throw new RuntimeException("ERROR: actual L mismatches, got "
+                    + actualL + " vs expect " + expLSize);
+        }
+        */
+        return generated;
+    }
+
+    public static void main(String[] args) throws Exception {
+        main(new TestDefaultDHPrivateExpSize(), args);
+    }
+}


### PR DESCRIPTION
This changes the SunPKCS11 provider to use the same default private exponent length as the value used by SunJCE provider when initializing the DH Key Pair Generator impl using key size. In addition, the generated key pair will contain the specified parameters. If the supplied parameter does not contain the optional private exponent length, then we will leave it to the underlying PKCS11 library.

Thanks in advance for the review~
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295425](https://bugs.openjdk.org/browse/JDK-8295425): Match the default priv exp length between SunPKCS11 and other JDK providers


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12466/head:pull/12466` \
`$ git checkout pull/12466`

Update a local copy of the PR: \
`$ git checkout pull/12466` \
`$ git pull https://git.openjdk.org/jdk pull/12466/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12466`

View PR using the GUI difftool: \
`$ git pr show -t 12466`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12466.diff">https://git.openjdk.org/jdk/pull/12466.diff</a>

</details>
