### PR TITLE
8301876: Crash in DumpTimeClassInfo::add_verification_constraint

### DIFF
--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -1449,11 +1449,9 @@ class CloneDumpTimeClassTable: public StackObj {
     assert(_cloned_table != nullptr, "_cloned_table is nullptr");
   }
   void do_entry(InstanceKlass* k, DumpTimeClassInfo& info) {
-    if (!info.is_excluded()) {
-      bool created;
-      _cloned_table->put_if_absent(k, info, &created);
-      assert(created, "must be");
-    }
+    bool created;
+    _cloned_table->put_if_absent(k, info, &created);
+    assert(created, "must be");
   }
 };
 


### PR DESCRIPTION
When dumping the a dynamic CDS archive, we clone and restore the `SystemDictionaryShared::_dumptime_table` (see [JDK-8264735](https://bugs.openjdk.org/browse/JDK-8264735).)

The bug is that for generated classes such as ` jdk/proxy2/$Proxy16` that are excluded from the CDS dump, we incorrectly remove their `DumpTimeClassInfo` from the `_dumptime_table` clone. After the dynamic archive has finished dumping, there's a very small window of time where some Java code would be executed and cause ` jdk/proxy2/$Proxy16` to be verified. This will cause the following crash because we can't find a `DumpTimeClassInfo` for this class. 

```
DumpTimeSharedClassTable::get_info()
SystemDictionaryShared::get_info()
SystemDictionaryShared::add_verification_constraint()
VerificationType::is_reference_assignable_from()
ClassVerifier::verify_exception_handler_table()
ClassVerifier::verify_method()
ClassVerifier::verify_class()
Verifier::verify()
InstanceKlass::link_class_impl() -- for  jdk/proxy2/$Proxy16
```

The fix is simple -- always copy all  `DumpTimeClassInfo` when cloning  `_dumptime_table` .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301876](https://bugs.openjdk.org/browse/JDK-8301876): Crash in DumpTimeClassInfo::add_verification_constraint


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12467/head:pull/12467` \
`$ git checkout pull/12467`

Update a local copy of the PR: \
`$ git checkout pull/12467` \
`$ git pull https://git.openjdk.org/jdk pull/12467/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12467`

View PR using the GUI difftool: \
`$ git pr show -t 12467`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12467.diff">https://git.openjdk.org/jdk/pull/12467.diff</a>

</details>
