### PR TITLE
8302043: [AIX] Safefetch fails for bad_addressN and bad_address32

### DIFF
--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -188,8 +188,11 @@ public:
   DEBUG_ONLY(static void controlled_crash(int how);)
 
   // Non-null address guaranteed to generate a SEGV mapping error on read, for test purposes.
-  static constexpr intptr_t segfault_address = (1 * K) AIX_ONLY(+ (4 * K));
-
+#ifdef AIX
+  static constexpr intptr_t segfault_address = -1;
+#else
+  static constexpr intptr_t segfault_address = (1*K);
+#endif //AIX
   // Max value for the ErrorLogPrintCodeLimit flag.
   static const int max_error_log_print_code = 10;
 

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -189,7 +189,7 @@ public:
 
   // Non-null address guaranteed to generate a SEGV mapping error on read, for test purposes.
   static constexpr intptr_t segfault_address = AIX_ONLY(-1) NOT_AIX(1 * K);
-  
+
   // Max value for the ErrorLogPrintCodeLimit flag.
   static const int max_error_log_print_code = 10;
 

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -188,11 +188,8 @@ public:
   DEBUG_ONLY(static void controlled_crash(int how);)
 
   // Non-null address guaranteed to generate a SEGV mapping error on read, for test purposes.
-#ifdef AIX
-  static constexpr intptr_t segfault_address = -1;
-#else
-  static constexpr intptr_t segfault_address = (1*K);
-#endif //AIX
+  static constexpr intptr_t segfault_address = AIX_ONLY(-1) NOT_AIX(1 * K);
+  
   // Max value for the ErrorLogPrintCodeLimit flag.
   static const int max_error_log_print_code = 10;
 

--- a/test/hotspot/gtest/runtime/test_safefetch.cpp
+++ b/test/hotspot/gtest/runtime/test_safefetch.cpp
@@ -38,8 +38,8 @@
 static const intptr_t patternN = LP64_ONLY(0xABCDABCDABCDABCDULL) NOT_LP64(0xABCDABCD);
 static const int pattern32 = 0xABCDABCD;
 
-static intptr_t* const  bad_addressN = (intptr_t*) VMError::segfault_address;
-static int* const       bad_address32 = (int*) VMError::segfault_address;
+static intptr_t* const bad_addressN = (intptr_t*) NOT_AIX(VMError::segfault_address) AIX_ONLY(-1);
+static int* const    bad_address32 = (int*) NOT_AIX(VMError::segfault_address) AIX_ONLY(-1);
 
 static intptr_t dataN[3] =  { 0, patternN, 0 };
 static int data32[3] = { 0, pattern32, 0 };

--- a/test/hotspot/gtest/runtime/test_safefetch.cpp
+++ b/test/hotspot/gtest/runtime/test_safefetch.cpp
@@ -38,8 +38,8 @@
 static const intptr_t patternN = LP64_ONLY(0xABCDABCDABCDABCDULL) NOT_LP64(0xABCDABCD);
 static const int pattern32 = 0xABCDABCD;
 
-static intptr_t* const bad_addressN = (intptr_t*) NOT_AIX(VMError::segfault_address) AIX_ONLY(-1);
-static int* const    bad_address32 = (int*) NOT_AIX(VMError::segfault_address) AIX_ONLY(-1);
+static intptr_t* const bad_addressN = (intptr_t*) VMError::segfault_address;
+static int* const    bad_address32 = (int*) VMError::segfault_address;
 
 static intptr_t dataN[3] =  { 0, patternN, 0 };
 static int data32[3] = { 0, pattern32, 0 };

--- a/test/hotspot/gtest/runtime/test_safefetch.cpp
+++ b/test/hotspot/gtest/runtime/test_safefetch.cpp
@@ -38,8 +38,8 @@
 static const intptr_t patternN = LP64_ONLY(0xABCDABCDABCDABCDULL) NOT_LP64(0xABCDABCD);
 static const int pattern32 = 0xABCDABCD;
 
-static intptr_t* const bad_addressN = (intptr_t*) VMError::segfault_address;
-static int* const    bad_address32 = (int*) VMError::segfault_address;
+static intptr_t* const  bad_addressN = (intptr_t*) VMError::segfault_address;
+static int* const       bad_address32 = (int*) VMError::segfault_address;
 
 static intptr_t dataN[3] =  { 0, patternN, 0 };
 static int data32[3] = { 0, pattern32, 0 };


### PR DESCRIPTION
On AIX, reading from lower range addresses like 5120(5K) does not cause a segmentation fault, though writing to them does. Hence the safefetch tests don't run as expected on AIX. This is solved by setting bad_addressN and bad_address32 to -1 for AIX. 
These tests under NMTGtests.java also passes :
gtest/NMTGtests.java#nmt-detail
gtest/NMTGtests.java#nmt-summary
gtest/NMTGtests.java#nmt-off

Reported issue: [JDK-8302043](https://bugs.openjdk.org/browse/JDK-8302043)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302043](https://bugs.openjdk.org/browse/JDK-8302043): [AIX] Safefetch fails for bad_addressN and bad_address32


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12468/head:pull/12468` \
`$ git checkout pull/12468`

Update a local copy of the PR: \
`$ git checkout pull/12468` \
`$ git pull https://git.openjdk.org/jdk pull/12468/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12468`

View PR using the GUI difftool: \
`$ git pr show -t 12468`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12468.diff">https://git.openjdk.org/jdk/pull/12468.diff</a>

</details>
