### PR TITLE
8302047: G1: Remove unused G1RegionToSpaceMapper::_region_granularity

### DIFF
--- a/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp
+++ b/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp
@@ -43,7 +43,6 @@ G1RegionToSpaceMapper::G1RegionToSpaceMapper(ReservedSpace rs,
                                              MEMFLAGS type) :
   _listener(NULL),
   _storage(rs, used_size, page_size),
-  _region_granularity(region_granularity),
   _region_commit_map(rs.size() * commit_factor / region_granularity, mtGC),
   _memory_type(type) {
   guarantee(is_power_of_2(page_size), "must be");

--- a/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.hpp
+++ b/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.hpp
@@ -49,7 +49,6 @@ class G1RegionToSpaceMapper : public CHeapObj<mtGC> {
   // Backing storage.
   G1PageBasedVirtualSpace _storage;
 
-  size_t _region_granularity;
   // Mapping management
   CHeapBitMap _region_commit_map;
 


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302047](https://bugs.openjdk.org/browse/JDK-8302047): G1: Remove unused G1RegionToSpaceMapper::_region_granularity


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12469/head:pull/12469` \
`$ git checkout pull/12469`

Update a local copy of the PR: \
`$ git checkout pull/12469` \
`$ git pull https://git.openjdk.org/jdk pull/12469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12469`

View PR using the GUI difftool: \
`$ git pr show -t 12469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12469.diff">https://git.openjdk.org/jdk/pull/12469.diff</a>

</details>
