### PR TITLE
8302066: Counter _number_of_nmethods_with_dependencies should be atomic.

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -168,7 +168,7 @@ class CodeBlob_sizes {
 
 address CodeCache::_low_bound = 0;
 address CodeCache::_high_bound = 0;
-int CodeCache::_number_of_nmethods_with_dependencies = 0;
+volatile int CodeCache::_number_of_nmethods_with_dependencies = 0;
 ExceptionCache* volatile CodeCache::_exception_cache_purge_list = nullptr;
 
 // Initialize arrays of CodeHeap subsets
@@ -587,7 +587,7 @@ void CodeCache::free(CodeBlob* cb) {
   if (cb->is_nmethod()) {
     heap->set_nmethod_count(heap->nmethod_count() - 1);
     if (((nmethod *)cb)->has_dependencies()) {
-      _number_of_nmethods_with_dependencies--;
+      Atomic::dec(&_number_of_nmethods_with_dependencies);
     }
   }
   if (cb->is_adapter_blob()) {
@@ -622,7 +622,7 @@ void CodeCache::commit(CodeBlob* cb) {
   if (cb->is_nmethod()) {
     heap->set_nmethod_count(heap->nmethod_count() + 1);
     if (((nmethod *)cb)->has_dependencies()) {
-      _number_of_nmethods_with_dependencies++;
+      Atomic::inc(&_number_of_nmethods_with_dependencies);
     }
   }
   if (cb->is_adapter_blob()) {
@@ -1219,8 +1219,8 @@ void codeCache_init() {
 
 //------------------------------------------------------------------------------------------------
 
-int CodeCache::number_of_nmethods_with_dependencies() {
-  return _number_of_nmethods_with_dependencies;
+bool CodeCache::have_nmethods_with_dependencies() {
+  return Atomic::load_acquire(&_number_of_nmethods_with_dependencies) != 0;
 }
 
 void CodeCache::clear_inline_caches() {
@@ -1431,7 +1431,9 @@ void CodeCache::make_nmethod_deoptimized(CompiledMethod* nm) {
 void CodeCache::flush_dependents_on(InstanceKlass* dependee) {
   assert_lock_strong(Compile_lock);
 
-  if (number_of_nmethods_with_dependencies() == 0) return;
+  if (!have_nmethods_with_dependencies()) {
+    return;
+  }
 
   int marked = 0;
   if (dependee->is_linked()) {

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1219,7 +1219,7 @@ void codeCache_init() {
 
 //------------------------------------------------------------------------------------------------
 
-bool CodeCache::have_nmethods_with_dependencies() {
+bool CodeCache::has_nmethods_with_dependencies() {
   return Atomic::load_acquire(&_number_of_nmethods_with_dependencies) != 0;
 }
 
@@ -1431,7 +1431,7 @@ void CodeCache::make_nmethod_deoptimized(CompiledMethod* nm) {
 void CodeCache::flush_dependents_on(InstanceKlass* dependee) {
   assert_lock_strong(Compile_lock);
 
-  if (!have_nmethods_with_dependencies()) {
+  if (!has_nmethods_with_dependencies()) {
     return;
   }
 

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -93,9 +93,9 @@ class CodeCache : AllStatic {
   static GrowableArray<CodeHeap*>* _nmethod_heaps;
   static GrowableArray<CodeHeap*>* _allocable_heaps;
 
-  static address _low_bound;                            // Lower bound of CodeHeap addresses
-  static address _high_bound;                           // Upper bound of CodeHeap addresses
-  static int _number_of_nmethods_with_dependencies;     // Total number of nmethods with dependencies
+  static address _low_bound;                                 // Lower bound of CodeHeap addresses
+  static address _high_bound;                                // Upper bound of CodeHeap addresses
+  static volatile int _number_of_nmethods_with_dependencies; // Total number of nmethods with dependencies
 
   static uint8_t           _unloading_cycle;          // Global state for recognizing old nmethods that need to be unloaded
   static uint64_t          _gc_epoch;                 // Global state for tracking when nmethods were found to be on-stack
@@ -323,8 +323,8 @@ class CodeCache : AllStatic {
   // Support for fullspeed debugging
   static void flush_dependents_on_method(const methodHandle& dependee);
 
-  // tells how many nmethods have dependencies
-  static int number_of_nmethods_with_dependencies();
+  // tells if there are nmethods with dependencies
+  static bool have_nmethods_with_dependencies();
 
   static int get_codemem_full_count(CodeBlobType code_blob_type) {
     CodeHeap* heap = get_code_heap(code_blob_type);

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -324,7 +324,7 @@ class CodeCache : AllStatic {
   static void flush_dependents_on_method(const methodHandle& dependee);
 
   // tells if there are nmethods with dependencies
-  static bool have_nmethods_with_dependencies();
+  static bool has_nmethods_with_dependencies();
 
   static int get_codemem_full_count(CodeBlobType code_blob_type) {
     CodeHeap* heap = get_code_heap(code_blob_type);


### PR DESCRIPTION
Hi, please consider!

We increment this counter when holding CodeCache, but loads are holding Compile_lock.
Lets just make it atomic so we don't need to reason about if there is some race here.
Also we are trying to avoid 'dirty' reads in the code base. (since in theory it is subject to things like word-tearing)

Testing tier1 in progress.

Thanks, Robbin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302066](https://bugs.openjdk.org/browse/JDK-8302066): Counter _number_of_nmethods_with_dependencies should be atomic.


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12470/head:pull/12470` \
`$ git checkout pull/12470`

Update a local copy of the PR: \
`$ git checkout pull/12470` \
`$ git pull https://git.openjdk.org/jdk pull/12470/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12470`

View PR using the GUI difftool: \
`$ git pr show -t 12470`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12470.diff">https://git.openjdk.org/jdk/pull/12470.diff</a>

</details>
