### PR TITLE
8302069: javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java update

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -523,8 +523,6 @@ javax/management/MBeanServer/OldMBeanServerTest.java            8030957 aix-all
 
 javax/management/monitor/DerivedGaugeMonitorTest.java           8042211 generic-all
 
-javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java 8042215 generic-all
-
 javax/management/remote/mandatory/connection/RMIConnector_NPETest.java 8267887 generic-all
 
 ############################################################################

--- a/test/jdk/javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java
+++ b/test/jdk/javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,10 @@ public class NotifReconnectDeadlockTest {
         JMXServiceURL addr = server.getAddress();
         JMXConnector client = JMXConnectorFactory.connect(addr, env);
 
-        Thread.sleep(100); // let pass the first client open notif if there is
+        // Sleeping here was an attempt to avoid seeing an initial notification.
+        // This does not work, but does not matter.
+        // Thread.sleep(100);
+
         client.getMBeanServerConnection().addNotificationListener(oname,
                                                                   listener,
                                                                   null,
@@ -100,12 +103,13 @@ public class NotifReconnectDeadlockTest {
 
         synchronized(lock) {
             while(clientState == null && System.currentTimeMillis() < end) {
+                System.out.println("Calling sendNotifications");
                 mbs.invoke(oname, "sendNotifications",
                            new Object[] {new Notification("MyType", "", 0)},
                            new String[] {"javax.management.Notification"});
 
                 try {
-                    lock.wait(10);
+                    lock.wait(1000); // sleep as no point in constant notifications
                 } catch (Exception e) {}
             }
         }
@@ -143,10 +147,10 @@ public class NotifReconnectDeadlockTest {
     private final static NotificationListener listener = new NotificationListener() {
             public void handleNotification(Notification n, Object hb) {
 
-                // treat the client notif to know the end
+                System.out.println("handleNotification: " + n);
                 if (n instanceof JMXConnectionNotification) {
                     if (!JMXConnectionNotification.NOTIFS_LOST.equals(n.getType())) {
-
+                        // Expected: [type=jmx.remote.connection.opened][message=Reconnected to server]
                         clientState = n.getType();
                         System.out.println(
                            ">>> The client state has been changed to: "+clientState);
@@ -159,7 +163,7 @@ public class NotifReconnectDeadlockTest {
                     return;
                 }
 
-                System.out.println(">>> Do sleep to make reconnection.");
+                System.out.println(">>> sleeping in NotificationListener to force reconnection.");
                 synchronized(lock) {
                     try {
                         lock.wait(listenerSleep);
@@ -170,9 +174,11 @@ public class NotifReconnectDeadlockTest {
             }
         };
 
-    private static final long serverTimeout = 1000;
+    // serverTimeout increased to avoid occasional problems with initial connect.
+    // Not using Utils.adjustTimeout to avoid accidentally making it too long.
+    private static final long serverTimeout = 2000;
     private static final long listenerSleep = serverTimeout*6;
 
-    private static String clientState = null;
+    private volatile static String clientState = null;
     private static final int[] lock = new int[0];
 }


### PR DESCRIPTION
NotifReconnectDeadlockTest.java has been problemlisted for a long time (although 8042215 is the wrong bug id).

The originally reported problem ("No reconnection happened") cannot be reproduced, although there are occasional failures when the test is run.

Those failures are more like the connection failures fixed in similar tests (e.g. JDK-8227337), where:
java.rmi.NoSuchObjectException: no such object in table
..is reported, a startup issue, before the notification work, a failure to connect:
at java.management/javax.management.remote.JMXConnectorFactory.connect(JMXConnectorFactory.java:270)
at NotifReconnectDeadlockTest.main(NotifReconnectDeadlockTest.java:88)

We should do something similar here, but not such that it affects the deadlock timing.  Increase serverTimeout, it needs a longer timeout to permit the initial connect to work reliably (fails occasionally, particularly but not exclusively on Windows debug builds).  Not using the test library timeout scaling here as the timeout has to be kept fairly short, to let the test intentionally block the notification handler and try to cause the original issue.

Additional prints to make the test logs hopefully easier to follow, and tried to clarify a few comments that made no sense to me.

Passing on many runs on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302069](https://bugs.openjdk.org/browse/JDK-8302069): javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java update


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12472/head:pull/12472` \
`$ git checkout pull/12472`

Update a local copy of the PR: \
`$ git checkout pull/12472` \
`$ git pull https://git.openjdk.org/jdk pull/12472/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12472`

View PR using the GUI difftool: \
`$ git pr show -t 12472`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12472.diff">https://git.openjdk.org/jdk/pull/12472.diff</a>

</details>
