### PR TITLE
8299970: Speed up compiler/arraycopy/TestArrayCopyConjoint.java

### DIFF
--- a/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyConjoint.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyConjoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyConjoint.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyConjoint.java
@@ -232,8 +232,7 @@ public class TestArrayCopyConjoint {
 
       setup();
 
-      try {
-        for (int i = 0 ; i < 1000000 ; i++ ) {
+      for (int i = 0 ; i < 30_000 ; i++ ) {
           int index = r.nextInt(2048);
           testByte(lengths[i % lengths.length], index , index+2);
           reinit(byte.class);
@@ -262,10 +261,6 @@ public class TestArrayCopyConjoint {
           reinit(long.class);
           testLong_constant_LT64B (index , index+2);
           reinit(long.class);
-        }
-        System.out.println("PASS : " + validate_ctr);
-      } catch (Exception e) {
-        System.out.println(e.getMessage());
       }
     }
 }

--- a/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyDisjoint.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyDisjoint.java
@@ -202,27 +202,22 @@ public class TestArrayCopyDisjoint {
 
       setup();
 
-      try {
-        for (int i = 0 ; i < 1000000 ; i++ ) {
-          testByte(lengths[i % lengths.length], r.nextInt(2048) , r.nextInt(2048));
-          testByte_constant_LT32B (r.nextInt(2048) , r.nextInt(2048));
-          testByte_constant_LT64B (r.nextInt(2048) , r.nextInt(2048));
+      for (int i = 0 ; i < 30_000 ; i++ ) {
+        testByte(lengths[i % lengths.length], r.nextInt(2048) , r.nextInt(2048));
+        testByte_constant_LT32B (r.nextInt(2048) , r.nextInt(2048));
+        testByte_constant_LT64B (r.nextInt(2048) , r.nextInt(2048));
 
-          testChar(lengths[i % lengths.length] >> 1, r.nextInt(2048) , r.nextInt(2048));
-          testChar_constant_LT32B (r.nextInt(2048) , r.nextInt(2048));
-          testChar_constant_LT64B (r.nextInt(2048) , r.nextInt(2048));
+        testChar(lengths[i % lengths.length] >> 1, r.nextInt(2048) , r.nextInt(2048));
+        testChar_constant_LT32B (r.nextInt(2048) , r.nextInt(2048));
+        testChar_constant_LT64B (r.nextInt(2048) , r.nextInt(2048));
 
-          testInt(lengths[i % lengths.length]  >> 2, r.nextInt(2048) , r.nextInt(2048));
-          testInt_constant_LT32B (r.nextInt(2048) , r.nextInt(2048));
-          testInt_constant_LT64B (r.nextInt(2048) , r.nextInt(2048));
+        testInt(lengths[i % lengths.length]  >> 2, r.nextInt(2048) , r.nextInt(2048));
+        testInt_constant_LT32B (r.nextInt(2048) , r.nextInt(2048));
+        testInt_constant_LT64B (r.nextInt(2048) , r.nextInt(2048));
 
-          testLong(lengths[i % lengths.length] >> 3, r.nextInt(2048) , r.nextInt(2048));
-          testLong_constant_LT32B (r.nextInt(2048) , r.nextInt(2048));
-          testLong_constant_LT64B (r.nextInt(2048) , r.nextInt(2048));
-        }
-        System.out.println("PASS : " + validate_ctr);
-      } catch (Exception e) {
-         System.out.println(e.getMessage());
+        testLong(lengths[i % lengths.length] >> 3, r.nextInt(2048) , r.nextInt(2048));
+        testLong_constant_LT32B (r.nextInt(2048) , r.nextInt(2048));
+        testLong_constant_LT64B (r.nextInt(2048) , r.nextInt(2048));
       }
     }
 }


### PR DESCRIPTION
I lowered the iteration count from `1000_000` (million) down to `30_000` (30k). I also removed a `try-catch` statement that seems to serve no purpose, but may actually prevent us from detecting failures of the test.

Per `@run` statement, I got the runtime down from about `4-4.5 sec` to `1-1.3 sec` (3-4x speedup).

**Details**
I ran the test with `-XX:+PrintCompilation -XX:+PrintInlining -XX:-TieredCompilation -XX:CICompilerCount=1 -Xbatch`, and then analyzed the output with this `cat txt.txt  | sed -n -e "s/.*java.lang.System::\(\w*\).*intrinsic.*/\1/p" | sort | uniq -c`, which gives me the count for the `arraycopy` intrinsification. For `1000_000` and `30_000` iterations I got `336` intrinisifications, so I am not losing any. I also tried to lower the iterations further down to `10_000`, but that did only marginally lower the runtime, to `1 sec`, but with much less intrinsifications, only `144`. So I decided to stay at `30k`.

If this fix does not turn out to be sufficient, we can try an IR test, and trigger compilation of the test methods after a much smaller iteration count for warmup (after all we want to make sure intrinsification happens), and then verify that the intrinsic is in the IR.

**Update**
I applied the same changes to `compiler/arraycopy/TestArrayCopyDisjoint.java`, verified that no intrinsification was lost. Marginal speedup from `1 sec` down to `0.7 sec` per run statement.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299970](https://bugs.openjdk.org/browse/JDK-8299970): Speed up compiler/arraycopy/TestArrayCopyConjoint.java


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [48cbd4c2](https://git.openjdk.org/jdk/pull/12475/files/48cbd4c2ca70e45ca35acab895223927faa610c9)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12475/head:pull/12475` \
`$ git checkout pull/12475`

Update a local copy of the PR: \
`$ git checkout pull/12475` \
`$ git pull https://git.openjdk.org/jdk pull/12475/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12475`

View PR using the GUI difftool: \
`$ git pr show -t 12475`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12475.diff">https://git.openjdk.org/jdk/pull/12475.diff</a>

</details>
