### PR TITLE
8068253: MethodHandleInfo does not provide the referenced class

### DIFF
--- a/src/hotspot/share/prims/methodHandles.cpp
+++ b/src/hotspot/share/prims/methodHandles.cpp
@@ -339,7 +339,8 @@ oop MethodHandles::init_method_MemberName(Handle mname, CallInfo& info) {
   java_lang_invoke_MemberName::set_flags  (mname_oop, flags);
   java_lang_invoke_MemberName::set_method (mname_oop, resolved_method());
   java_lang_invoke_MemberName::set_vmindex(mname_oop, vmindex);   // vtable/itable index
-  java_lang_invoke_MemberName::set_clazz  (mname_oop, m_klass->java_mirror());
+  if (java_lang_invoke_MemberName::clazz(mname_oop) == NULL)
+    java_lang_invoke_MemberName::set_clazz  (mname_oop, m_klass->java_mirror());
   // Note:  name and type can be lazily computed by resolve_MemberName,
   // if Java code needs them as resolved String and MethodType objects.
   // If relevant, the vtable or itable value is stored as vmindex.
@@ -360,7 +361,8 @@ oop MethodHandles::init_field_MemberName(Handle mname, fieldDescriptor& fd, bool
   java_lang_invoke_MemberName::set_flags  (mname_oop, flags);
   java_lang_invoke_MemberName::set_method (mname_oop, NULL);
   java_lang_invoke_MemberName::set_vmindex(mname_oop, vmindex);
-  java_lang_invoke_MemberName::set_clazz  (mname_oop, ik->java_mirror());
+  if (java_lang_invoke_MemberName::clazz(mname_oop) == NULL)
+    java_lang_invoke_MemberName::set_clazz  (mname_oop, ik->java_mirror());
 
   oop type = field_signature_type_or_null(fd.signature());
   oop name = field_name_or_null(fd.name());

--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -963,7 +963,7 @@ final class MemberName implements Member, Cloneable {
                 if (m == null && speculativeResolve) {
                     return null;
                 }
-                m.checkForTypeAlias(m.getDeclaringClass());
+                m.checkForTypeAlias(m.getDeclaringClass()); // TODO: did we break this?
                 m.resolution = null;
             } catch (ClassNotFoundException | LinkageError ex) {
                 // JVM reports that the "bytecode behavior" would get an error

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -3985,37 +3985,6 @@ return mh1;
                 checkSecurityManager(refc, method);
             assert(!method.isMethodHandleInvoke());
 
-            if (refKind == REF_invokeSpecial &&
-                refc != lookupClass() &&
-                !refc.isInterface() &&
-                refc != lookupClass().getSuperclass() &&
-                refc.isAssignableFrom(lookupClass())) {
-                assert(!method.getName().equals("<init>"));  // not this code path
-
-                // Per JVMS 6.5, desc. of invokespecial instruction:
-                // If the method is in a superclass of the LC,
-                // and if our original search was above LC.super,
-                // repeat the search (symbolic lookup) from LC.super
-                // and continue with the direct superclass of that class,
-                // and so forth, until a match is found or no further superclasses exist.
-                // FIXME: MemberName.resolve should handle this instead.
-                Class<?> refcAsSuper = lookupClass();
-                MemberName m2;
-                do {
-                    refcAsSuper = refcAsSuper.getSuperclass();
-                    m2 = new MemberName(refcAsSuper,
-                                        method.getName(),
-                                        method.getMethodType(),
-                                        REF_invokeSpecial);
-                    m2 = IMPL_NAMES.resolveOrNull(refKind, m2, lookupClassOrNull(), allowedModes);
-                } while (m2 == null &&         // no method is found yet
-                         refc != refcAsSuper); // search up to refc
-                if (m2 == null)  throw new InternalError(method.toString());
-                method = m2;
-                refc = refcAsSuper;
-                // redo basic checks
-                checkMethod(refKind, refc, method);
-            }
             DirectMethodHandle dmh = DirectMethodHandle.make(refKind, refc, method, lookupClass());
             MethodHandle mh = dmh;
             // Optionally narrow the receiver argument to lookupClass using restrictReceiver.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -755,14 +755,6 @@ public class LambdaToMethod extends TreeTranslator {
         String functionalInterfaceClass = classSig(targetType);
         String functionalInterfaceMethodName = samSym.getSimpleName().toString();
         String functionalInterfaceMethodSignature = typeSig(types.erasure(samSym.type));
-        Symbol baseMethod = refSym.baseSymbol();
-        Symbol origMethod = baseMethod.baseSymbol();
-        if (baseMethod != origMethod && origMethod.owner == syms.objectType.tsym) {
-            //the implementation method is a java.lang.Object method transferred to an
-            //interface that does not declare it. Runtime will refer to this method as to
-            //a java.lang.Object method, so do the same:
-            refSym = ((MethodSymbol) origMethod).asHandle();
-        }
         String implClass = classSig(types.erasure(refSym.owner.type));
         String implMethodName = refSym.getQualifiedName().toString();
         String implMethodSignature = typeSig(types.erasure(refSym.type));

--- a/test/jdk/java/lang/invoke/8068253/Classes.java
+++ b/test/jdk/java/lang/invoke/8068253/Classes.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.invoke.MethodHandles;
+
+abstract class A {
+    int x1;
+    static int x2;
+    static final int x3 = 0;
+    static void m1() {}
+    void m3() {}
+    abstract void m4();
+    private void m7() {}
+    void m8() {}
+    static MethodHandles.Lookup lookup() { return MethodHandles.lookup(); }
+}
+abstract class B extends A {
+    int x1;
+    static int x2;
+    static final int x3 = 0;
+    static MethodHandles.Lookup lookup() { return MethodHandles.lookup(); }
+    void m8() {}
+}
+class C extends B {
+    void m4() {}
+    private void m7() {}
+    static MethodHandles.Lookup lookup() { return MethodHandles.lookup(); }
+}
+
+interface I {
+    int x4 = 0;
+    static void m2() {}
+    void m5();
+    default void m6() {}
+    static MethodHandles.Lookup lookup() { return MethodHandles.lookup(); }
+}
+interface J {
+    int x4 = 0;
+    void m5();
+    static MethodHandles.Lookup lookup() { return MethodHandles.lookup(); }
+}
+interface K extends I {
+    static MethodHandles.Lookup lookup() { return MethodHandles.lookup(); }
+}
+
+abstract class G implements I, J {
+    static MethodHandles.Lookup lookup() { return MethodHandles.lookup(); }
+}
+class H implements J, I {
+    public void m5() {}
+    static MethodHandles.Lookup lookup() { return MethodHandles.lookup(); }
+}

--- a/test/jdk/java/lang/invoke/8068253/Test8068253.java
+++ b/test/jdk/java/lang/invoke/8068253/Test8068253.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+ 
+ import java.lang.invoke.*;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.MethodTypeDesc;
+import static java.lang.invoke.MethodHandleInfo.*;
+
+
+/* @test
+ * @bug 8068253
+ * @compile Classes.java
+ * @run main Test8068253
+*/
+public class Test8068253 {
+    
+    public static void main(String... args) {
+        test();
+    }
+    
+    @SuppressWarnings("auxiliaryclass")
+    static void test() {
+        resolve(REF_invokeStatic, "A", "m1", "()V");
+        resolve(REF_invokeStatic, "B", "m1", "()V");
+        resolve(REF_invokeStatic, "I", "m2", "()V");
+        failResolve(REF_invokeStatic, "G", "m2", "()V");
+        
+        resolve(REF_invokeVirtual, "A", "m3", "()V");
+        resolve(REF_invokeVirtual, "B", "m3", "()V");
+        resolve(REF_invokeVirtual, "C", "m3", "()V");
+        resolve(REF_invokeVirtual, "A", "m4", "()V");
+        resolve(REF_invokeVirtual, "B", "m4", "()V");
+        resolve(REF_invokeVirtual, "C", "m4", "()V");
+
+        resolve(REF_invokeVirtual, "G", "m5", "()V");
+        resolve(REF_invokeVirtual, "H", "m5", "()V");
+        resolve(REF_invokeVirtual, "G", "m6", "()V");
+        resolve(REF_invokeVirtual, "H", "m6", "()V");
+
+        resolve(REF_invokeVirtual, "A", "toString", "()Ljava/lang/String;");
+        resolve(REF_invokeVirtual, "B", "toString", "()Ljava/lang/String;");
+        resolve(REF_invokeVirtual, "C", "toString", "()Ljava/lang/String;");
+        resolve(REF_invokeVirtual, "G", "toString", "()Ljava/lang/String;");
+        resolve(REF_invokeVirtual, "H", "toString", "()Ljava/lang/String;");
+        resolve(REF_invokeVirtual, "[LA;", "toString", "()Ljava/lang/String;");
+
+        resolve(REF_invokeInterface, "I", "m5", "()V");
+        resolve(REF_invokeInterface, "K", "m5", "()V");
+        resolve(REF_invokeInterface, "I", "m6", "()V");
+        resolve(REF_invokeInterface, "K", "m6", "()V");
+        resolve(REF_invokeInterface, "I", "toString", "()Ljava/lang/String;");
+        resolve(REF_invokeInterface, "K", "toString", "()Ljava/lang/String;");
+        
+        resolve(A.lookup(), REF_invokeSpecial, "A", "m3", "()V");
+        resolve(A.lookup(), REF_invokeSpecial, "A", "m7", "()V");
+        resolve(A.lookup(), REF_invokeSpecial, "A", "toString", "()Ljava/lang/String;");
+
+        resolve(B.lookup(), REF_invokeSpecial, "B", "m3", "()V");
+        resolve(B.lookup(), REF_invokeSpecial, "A", "m3", "()V");
+        failResolve(B.lookup(), REF_invokeSpecial, "B", "m7", "()V");
+        failResolve(B.lookup(), REF_invokeSpecial, "A", "m7", "()V");
+        resolve(B.lookup(), REF_invokeSpecial, "B", "toString", "()Ljava/lang/String;");
+        resolve(B.lookup(), REF_invokeSpecial, "A", "toString", "()Ljava/lang/String;");
+
+        resolve(C.lookup(), REF_invokeSpecial, "C", "m3", "()V");
+        resolve(C.lookup(), REF_invokeSpecial, "B", "m3", "()V");
+        resolve(C.lookup(), REF_invokeSpecial, "A", "m3", "()V");
+        resolve(C.lookup(), REF_invokeSpecial, "C", "m7", "()V");
+        failResolve(C.lookup(), REF_invokeSpecial, "B", "m7", "()V");
+        failResolve(C.lookup(), REF_invokeSpecial, "A", "m7", "()V");
+        resolve(C.lookup(), REF_invokeSpecial, "C", "m4", "()V");
+        failResolve(C.lookup(), REF_invokeSpecial, "B", "m4", "()V");
+        failResolve(C.lookup(), REF_invokeSpecial, "A", "m4", "()V");
+        resolve(C.lookup(), REF_invokeSpecial, "C", "m8", "()V");
+        resolve(C.lookup(), REF_invokeSpecial, "B", "m8", "()V");
+        resolve(C.lookup(), REF_invokeSpecial, "A", "m8", "()V");
+        resolve(C.lookup(), REF_invokeSpecial, "C", "toString", "()Ljava/lang/String;");
+        resolve(C.lookup(), REF_invokeSpecial, "B", "toString", "()Ljava/lang/String;");
+        resolve(C.lookup(), REF_invokeSpecial, "A", "toString", "()Ljava/lang/String;");
+
+        failResolve(I.lookup(), REF_invokeSpecial, "I", "m5", "()V");
+        resolve(I.lookup(), REF_invokeSpecial, "I", "m6", "()V");
+        resolve(I.lookup(), REF_invokeSpecial, "I", "toString", "()Ljava/lang/String;");
+        //resolve(I.lookup(), REF_invokeSpecial, "java.lang.Object", "toString", "()Ljava/lang/String;"); // bug: JDK-8301721
+
+        resolve(K.lookup(), REF_invokeSpecial, "K", "m5", "()V");
+        failResolve(K.lookup(), REF_invokeSpecial, "I", "m5", "()V");
+        resolve(K.lookup(), REF_invokeSpecial, "K", "m6", "()V");
+        resolve(K.lookup(), REF_invokeSpecial, "I", "m6", "()V");
+        resolve(K.lookup(), REF_invokeSpecial, "K", "toString", "()Ljava/lang/String;");
+        resolve(K.lookup(), REF_invokeSpecial, "I", "toString", "()Ljava/lang/String;");
+
+        resolve(H.lookup(), REF_invokeSpecial, "H", "m5", "()V");
+        failResolve(H.lookup(), REF_invokeSpecial, "I", "m5", "()V");
+        resolve(H.lookup(), REF_invokeSpecial, "H", "m6", "()V");
+        resolve(H.lookup(), REF_invokeSpecial, "I", "m6", "()V");
+        resolve(H.lookup(), REF_invokeSpecial, "H", "toString", "()Ljava/lang/String;");
+        resolve(H.lookup(), REF_invokeSpecial, "I", "toString", "()Ljava/lang/String;");
+        
+        resolve(REF_newInvokeSpecial, "A", "<init>", "()V"); // abstract, should fail?
+        resolve(REF_newInvokeSpecial, "B", "<init>", "()V"); // abstract, should fail?
+        resolve(REF_newInvokeSpecial, "C", "<init>", "()V");
+        failResolve(REF_newInvokeSpecial, "I", "<init>", "()V");
+
+        resolve(REF_getField, "A", "x1", "I");
+        resolve(REF_getField, "B", "x1", "I");
+        resolve(REF_getField, "C", "x1", "I");
+        resolve(REF_putField, "A", "x1", "I");
+        resolve(REF_putField, "B", "x1", "I");
+        resolve(REF_putField, "C", "x1", "I");
+        
+        resolve(REF_getStatic, "A", "x2", "I");
+        resolve(REF_getStatic, "B", "x2", "I");
+        resolve(REF_getStatic, "C", "x2", "I");
+        resolve(REF_putStatic, "A", "x2", "I");
+        resolve(REF_putStatic, "B", "x2", "I");
+        resolve(REF_putStatic, "C", "x2", "I");
+        
+        resolve(REF_getStatic, "A", "x3", "I");
+        resolve(REF_getStatic, "B", "x3", "I");
+        resolve(REF_getStatic, "C", "x3", "I");
+        failResolve(REF_putStatic, "A", "x3", "I");
+        failResolve(REF_putStatic, "B", "x3", "I");
+        failResolve(REF_putStatic, "C", "x3", "I");
+
+        resolve(REF_getStatic, "I", "x4", "I");
+        resolve(REF_getStatic, "J", "x4", "I");
+        resolve(REF_getStatic, "K", "x4", "I");
+        resolve(REF_getStatic, "G", "x4", "I");
+        resolve(REF_getStatic, "H", "x4", "I");
+        failResolve(REF_putStatic, "I", "x4", "I");
+        failResolve(REF_putStatic, "J", "x4", "I");
+        failResolve(REF_putStatic, "K", "x4", "I");
+        failResolve(REF_putStatic, "G", "x4", "I");
+        failResolve(REF_putStatic, "H", "x4", "I");
+    }
+
+    static MethodHandles.Lookup lookup = MethodHandles.lookup();
+    
+    static void resolve(int kind, String type, String name, String descriptor) {
+        resolve(lookup, kind, type, name, descriptor);
+    }
+
+    static void resolve(MethodHandles.Lookup lookup, int kind, String type,
+                    String name, String descriptor) {
+        MHQuery initial = new MHQuery(lookup, kind, type, name, descriptor);
+        try {
+            MHQuery resolved = initial.resolvedQuery();
+            if (!initial.equals(resolved))
+                throw new AssertionError("Incorrect resolution: " + initial + " --> " + resolved);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Can't resolve " + initial);
+            //e.printStackTrace(System.out);
+        }
+    }
+
+    static void failResolve(int kind, String type, String name, String descriptor) {
+        failResolve(lookup, kind, type, name, descriptor);
+    }
+
+    static void failResolve(MethodHandles.Lookup lookup, int kind, String type,
+                    String name, String descriptor) {
+        MHQuery initial = new MHQuery(lookup, kind, type, name, descriptor);
+        try {
+            MHQuery resolved = initial.resolvedQuery();
+            throw new AssertionError("Resolution succeeded: " + initial + " --> " + resolved);
+        } catch (ReflectiveOperationException e) {
+            // expected
+        }
+    }
+
+
+    /**
+     * Support class encoding a lookup query, equivalent to a
+     * CONSTANT_MethodHandle in a class file
+     */
+    public record MHQuery(MethodHandles.Lookup lookup, int kind,
+                          String type, String name, String descriptor) {
+
+        public String kindString() {
+            return MethodHandleInfo.referenceKindToString(kind);
+        }
+
+        public Class<?> referencedType() throws ReflectiveOperationException {
+            if (type.startsWith("[")) {
+                return (Class<?>) ClassDesc.ofDescriptor(type)
+                                           .resolveConstantDesc(lookup);
+            } else {
+                return (Class<?>) ClassDesc.of(type)
+                                           .resolveConstantDesc(lookup);
+            }
+        }
+        
+        public Class<?> fieldType() throws ReflectiveOperationException {
+            return (Class<?>) ClassDesc.ofDescriptor(descriptor)
+                                       .resolveConstantDesc(lookup);
+        }
+        
+        public MethodType methodType() throws ReflectiveOperationException {
+            return (MethodType) MethodTypeDesc.ofDescriptor(descriptor)
+                                              .resolveConstantDesc(lookup);
+        }
+        
+        public MethodHandle resolve() throws ReflectiveOperationException {
+            Class<?> reft = referencedType();
+            return switch (kind) {
+                case 1 -> lookup.findGetter(reft, name, fieldType());
+                case 2 -> lookup.findStaticGetter(reft, name, fieldType());
+                case 3 -> lookup.findSetter(reft, name, fieldType());
+                case 4 -> lookup.findStaticSetter(reft, name, fieldType());
+                case 5 -> {
+                    if (reft.isInterface()) throw badType();
+                    yield lookup.findVirtual(reft, name, methodType());
+                }
+                case 6 -> lookup.findStatic(reft, name, methodType());
+                case 7 -> lookup.findSpecial(reft, name, methodType(), lookup.lookupClass());
+                case 8 -> {
+                    if (!name.equals("<init>")) throw badName();
+                    yield lookup.findConstructor(reft, methodType());
+                }
+                case 9 -> {
+                    if (!reft.isInterface()) throw badType();
+                    yield lookup.findVirtual(reft, name, methodType());
+                }
+                default -> throw badKind();
+            };
+        }
+        
+        /** Map a direct method handle back to a lookup query */
+        public MHQuery resolvedQuery() throws ReflectiveOperationException {
+            MethodHandleInfo info = lookup.revealDirect(resolve());
+            int kind2 = info.getReferenceKind();
+            String type2 = info.getDeclaringClass().getName();
+            String name2 = info.getName();
+            MethodType mt = info.getMethodType();
+            String descriptor2 = switch (info.getReferenceKind()) {
+                case 1 -> mt.returnType().descriptorString();
+                case 2 -> mt.returnType().descriptorString();
+                case 3 -> mt.parameterType(0).descriptorString();
+                case 4 -> mt.parameterType(0).descriptorString();
+                default -> mt.descriptorString();
+            };
+            return new MHQuery(lookup, kind2, type2, name2, descriptor2);
+        }
+        
+        public String toString() {
+            return String.format("%s %s.%s:%s", kindString(), type, name, descriptor);
+        }
+
+        private ReflectiveOperationException badKind() {
+            return new ReflectiveOperationException("unexpected kind: " + kind);
+        }
+        
+        private ReflectiveOperationException badType() {
+            return new ReflectiveOperationException("unexpected type: " + type);
+        }
+
+        private ReflectiveOperationException badName() {
+            return new ReflectiveOperationException("unexpected name: " + name);
+        }
+    }
+
+}


### PR DESCRIPTION
Re-interpreting `MethodHandleInfo.getDeclaringClass`, as implemented via `MemberName`, to represent the _original_ class rather than the _resolved_ class. This supports the expectation that a `findVirtual` (etc.) followed by a `revealDirect` should allow you to recreate your original query. A number of bugs have been observed because that round trip is (surprisingly) lossy, and their fixes are blocked by this issue.

Concretely, the behavior change is to no longer overwrite a `MemberName`'s declaring class at resolution time, leaving in place the original requested class (if one is already set).

In JVM terms, there is a "referenced class" and  "declaring class", and this change preserves the "referenced class", no longer surfacing the "declaring class". The `getDeclaringClass` method name is a bit unfortunate. But in other contexts, "declaring class" just means "class that has the member", and the distinction between direct declaration and inheritance is not important.

I believe this change is safe for legacy clients because:
- The new MethodHandleInfo behavior still gives you the information you need to locate the same member
- Most (maybe all) use cases should not care at all whether they're interacting with a truly declared member or an inherited member
- The metadata in a MemberName doesn't seem to be that important internally—the underlying JVM behavior is encoded elsewhere

Only one tier 1 test failed, a javac test for behavior that was specifically put in place to work around MethodHandleInfo's limitations (see JDK-8282080). This PR rolls that back.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8068253](https://bugs.openjdk.org/browse/JDK-8068253): MethodHandleInfo does not provide the referenced class


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12476/head:pull/12476` \
`$ git checkout pull/12476`

Update a local copy of the PR: \
`$ git checkout pull/12476` \
`$ git pull https://git.openjdk.org/jdk pull/12476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12476`

View PR using the GUI difftool: \
`$ git pr show -t 12476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12476.diff">https://git.openjdk.org/jdk/pull/12476.diff</a>

</details>
