### PR TITLE
JDK-8302102: Disable ASan for SafeFetch and os::print_hex_dump

### DIFF
--- a/src/hotspot/os/posix/safefetch_sigjmp.cpp
+++ b/src/hotspot/os/posix/safefetch_sigjmp.cpp
@@ -26,6 +26,7 @@
 #include "precompiled.hpp"
 
 #include "runtime/safefetch.hpp"
+#include "sanitizers/address.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 
@@ -63,7 +64,7 @@ bool handle_safefetch(int sig, address ignored1, void* ignored2) {
 }
 
 template <class T>
-static bool _SafeFetchXX_internal(const T *adr, T* result) {
+ATTRIBUTE_NO_SANITIZE_ADDRESS static bool _SafeFetchXX_internal(const T *adr, T* result) {
 
   T n = 0;
 

--- a/src/hotspot/os/posix/safefetch_sigjmp.cpp
+++ b/src/hotspot/os/posix/safefetch_sigjmp.cpp
@@ -64,7 +64,7 @@ bool handle_safefetch(int sig, address ignored1, void* ignored2) {
 }
 
 template <class T>
-ATTRIBUTE_NO_SANITIZE_ADDRESS static bool _SafeFetchXX_internal(const T *adr, T* result) {
+ATTRIBUTE_NO_ASAN static bool _SafeFetchXX_internal(const T *adr, T* result) {
 
   T n = 0;
 

--- a/src/hotspot/os/windows/safefetch_windows.hpp
+++ b/src/hotspot/os/windows/safefetch_windows.hpp
@@ -32,7 +32,7 @@
 // On windows, we use structured exception handling to implement SafeFetch
 
 template <class T>
-ATTRIBUTE_NO_SANITIZE_ADDRESS inline T SafeFetchXX(const T* adr, T errValue) {
+ATTRIBUTE_NO_ASAN inline T SafeFetchXX(const T* adr, T errValue) {
   T v = 0;
   __try {
     v = *adr;

--- a/src/hotspot/os/windows/safefetch_windows.hpp
+++ b/src/hotspot/os/windows/safefetch_windows.hpp
@@ -32,7 +32,7 @@
 // On windows, we use structured exception handling to implement SafeFetch
 
 template <class T>
-ATTRIBUTE_NO_SANITIZE_ADDRESS static inline T SafeFetchXX(const T* adr, T errValue) {
+ATTRIBUTE_NO_SANITIZE_ADDRESS inline T SafeFetchXX(const T* adr, T errValue) {
   T v = 0;
   __try {
     v = *adr;

--- a/src/hotspot/os/windows/safefetch_windows.hpp
+++ b/src/hotspot/os/windows/safefetch_windows.hpp
@@ -26,12 +26,13 @@
 #ifndef OS_WINDOWS_SAFEFETCH_WINDOWS_HPP
 #define OS_WINDOWS_SAFEFETCH_WINDOWS_HPP
 
+#include "sanitizers/address.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 // On windows, we use structured exception handling to implement SafeFetch
 
 template <class T>
-inline T SafeFetchXX(const T* adr, T errValue) {
+ATTRIBUTE_NO_SANITIZE_ADDRESS static inline T SafeFetchXX(const T* adr, T errValue) {
   T v = 0;
   __try {
     v = *adr;

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -941,8 +941,8 @@ bool os::print_function_and_library_name(outputStream* st,
   return have_function_name || have_library_name;
 }
 
-ATTRIBUTE_NO_SANITIZE_ADDRESS static void print_hex_readable_pointer(outputStream* st, address p,
-                                                                     int unitsize) {
+ATTRIBUTE_NO_ASAN static void print_hex_readable_pointer(outputStream* st, address p,
+                                                         int unitsize) {
   switch (unitsize) {
     case 1: st->print("%02x", *(u1*)p); break;
     case 2: st->print("%04x", *(u2*)p); break;

--- a/src/hotspot/share/sanitizers/address.hpp
+++ b/src/hotspot/share/sanitizers/address.hpp
@@ -29,6 +29,25 @@
 #include <sanitizer/asan_interface.h>
 #endif
 
+// ATTRIBUTE_NO_SANITIZE_ADDRESS
+//
+// Function attribute which informs the compiler to not instrument memory accesses in the function.
+// Useful if the function is known to do something dangerous, such as reading previous stack frames
+// or reading arbitrary regions of memory when dumping during a crash.
+#ifdef ADDRESS_SANITIZER
+#if defined(TARGET_COMPILER_gcc)
+// GCC-like, including Clang.
+#define ATTRIBUTE_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
+#elif defined(TARGET_COMPILER_visCPP)
+// Microsoft Visual C++
+#define ATTRIBUTE_NO_SANITIZE_ADDRESS __declspec(no_sanitize_address)
+#endif
+#endif
+
+#ifndef ATTRIBUTE_NO_SANITIZE_ADDRESS
+#define ATTRIBUTE_NO_SANITIZE_ADDRESS
+#endif
+
 // ASAN_POISON_MEMORY_REGION()/ASAN_UNPOISON_MEMORY_REGION()
 //
 // Poisons/unpoisons the specified memory region. When ASan is available this is the macro of the

--- a/src/hotspot/share/sanitizers/address.hpp
+++ b/src/hotspot/share/sanitizers/address.hpp
@@ -29,7 +29,7 @@
 #include <sanitizer/asan_interface.h>
 #endif
 
-// ATTRIBUTE_NO_SANITIZE_ADDRESS
+// ATTRIBUTE_NO_ASAN
 //
 // Function attribute which informs the compiler to not instrument memory accesses in the function.
 // Useful if the function is known to do something dangerous, such as reading previous stack frames
@@ -37,15 +37,15 @@
 #ifdef ADDRESS_SANITIZER
 #if defined(TARGET_COMPILER_gcc)
 // GCC-like, including Clang.
-#define ATTRIBUTE_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
+#define ATTRIBUTE_NO_ASAN __attribute__((no_sanitize_address))
 #elif defined(TARGET_COMPILER_visCPP)
 // Microsoft Visual C++
-#define ATTRIBUTE_NO_SANITIZE_ADDRESS __declspec(no_sanitize_address)
+#define ATTRIBUTE_NO_ASAN __declspec(no_sanitize_address)
 #endif
 #endif
 
-#ifndef ATTRIBUTE_NO_SANITIZE_ADDRESS
-#define ATTRIBUTE_NO_SANITIZE_ADDRESS
+#ifndef ATTRIBUTE_NO_ASAN
+#define ATTRIBUTE_NO_ASAN
 #endif
 
 // ASAN_POISON_MEMORY_REGION()/ASAN_UNPOISON_MEMORY_REGION()


### PR DESCRIPTION
Disable ASan instrumentation for non-assembly versions of SafeFetch and os::print_hex_dump.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302102](https://bugs.openjdk.org/browse/JDK-8302102): Disable ASan for SafeFetch and os::print_hex_dump


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [a4524758](https://git.openjdk.org/jdk/pull/12477/files/a452475849d1674e58b88f46914cdbfec3089939)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12477/head:pull/12477` \
`$ git checkout pull/12477`

Update a local copy of the PR: \
`$ git checkout pull/12477` \
`$ git pull https://git.openjdk.org/jdk pull/12477/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12477`

View PR using the GUI difftool: \
`$ git pr show -t 12477`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12477.diff">https://git.openjdk.org/jdk/pull/12477.diff</a>

</details>
