### PR TITLE
7174305: (ch) Channels.newReader doesn't throw IllegalBlockingModeException if channel is configured non-blocking

### DIFF
--- a/test/jdk/java/nio/channels/Channels/NonBlockingReader.java
+++ b/test/jdk/java/nio/channels/Channels/NonBlockingReader.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 7174305
+ * @summary Verify that Reader returned by Channels::newReader throws
+ * IllegalBlockingMode if read from while configured non-blocking
+ */
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Pipe;
+import java.nio.channels.Pipe.SinkChannel;
+import java.nio.channels.Pipe.SourceChannel;
+import java.util.Scanner;
+
+/**
+ * This test will fail by timing out if no IllegalBlockingMode is thrown.
+ */
+public class NonBlockingReader {
+    public static void main(String[] args) throws IOException {
+        Pipe pipe = Pipe.open();
+        Pipe.SinkChannel sink = pipe.sink();
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    do {
+                        sink.write(ByteBuffer.wrap(new byte[] {'A'}));
+                        Thread.sleep(1000);
+                    } while(true);
+                } catch (IOException | InterruptedException e) {
+                    throw new AssertionError(e);
+                }
+
+            }
+        }).start();
+
+        Pipe.SourceChannel source = pipe.source();
+        source.configureBlocking(false);
+
+        Scanner scanner = new Scanner(source);
+        while(scanner.hasNextLine()) {
+            System.out.println(scanner.nextLine());
+        }
+    }
+}

--- a/test/jdk/java/nio/channels/Channels/NonBlockingReader.java
+++ b/test/jdk/java/nio/channels/Channels/NonBlockingReader.java
@@ -29,6 +29,7 @@
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.IllegalBlockingModeException;
 import java.nio.channels.Pipe;
 import java.nio.channels.Pipe.SinkChannel;
 import java.nio.channels.Pipe.SourceChannel;
@@ -61,8 +62,12 @@ public class NonBlockingReader {
         source.configureBlocking(false);
 
         Scanner scanner = new Scanner(source);
-        while(scanner.hasNextLine()) {
-            System.out.println(scanner.nextLine());
+        try {
+            while(scanner.hasNextLine()) {
+                System.out.println(scanner.nextLine());
+            }
+            throw new RuntimeException("IllegalBlockingModeException expected");
+        } catch (IllegalBlockingModeException expected) {
         }
     }
 }


### PR DESCRIPTION
Modify `sun.nio.cs.StreamDecoder::readBytes` to throw `IllegalBlockingModeException` if its channel is configured to be non-blocking.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-7174305](https://bugs.openjdk.org/browse/JDK-7174305): (ch) Channels.newReader doesn't throw IllegalBlockingModeException if channel is configured non-blocking


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12478/head:pull/12478` \
`$ git checkout pull/12478`

Update a local copy of the PR: \
`$ git checkout pull/12478` \
`$ git pull https://git.openjdk.org/jdk pull/12478/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12478`

View PR using the GUI difftool: \
`$ git pr show -t 12478`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12478.diff">https://git.openjdk.org/jdk/pull/12478.diff</a>

</details>
