### PR TITLE
8302067: [AIX] AIX build error on os_aix_ppc.cpp

### DIFF
--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
@@ -141,7 +141,7 @@ frame os::fetch_compiled_frame_from_context(const void* ucVoid) {
 }
 
 frame os::get_sender_for_C_frame(frame* fr) {
-  if (*fr->sp() == nullptr) {
+  if (*fr->sp() == (intptr_t) nullptr) {
     // fr is the last C frame
     return frame(nullptr, nullptr);
   }


### PR DESCRIPTION
AIX build error on os_aix_ppc.cpp due to comparison between intptr_t with nullptr_t  can be resolved by type casting . The obtained error:
```
/home/hotspot/openjdk/jdk/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp error: invalid operands to binary expression ('intptr_t' (aka 'long') and 'nullptr_t')
 if (*fr->sp() == nullptr) {
   ~~~~~~~~~ ^ ~~~~~~~
```

The reported issue : [JDK-8302067](https://bugs.openjdk.org/browse/JDK-8302067)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302067](https://bugs.openjdk.org/browse/JDK-8302067): [AIX] AIX build error on os_aix_ppc.cpp


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12482/head:pull/12482` \
`$ git checkout pull/12482`

Update a local copy of the PR: \
`$ git checkout pull/12482` \
`$ git pull https://git.openjdk.org/jdk pull/12482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12482`

View PR using the GUI difftool: \
`$ git pr show -t 12482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12482.diff">https://git.openjdk.org/jdk/pull/12482.diff</a>

</details>
