### PR TITLE
8302117: IgnoreUnrecognizedVMOptions flag causes failure in ArchiveHeapTestClass

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchiveHeapTestClass.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchiveHeapTestClass.java
@@ -173,7 +173,7 @@ public class ArchiveHeapTestClass {
     static void testProductBuild() throws Exception {
         OutputAnalyzer output;
 
-        output = dumpHelloOnly("-XX:ArchiveHeapTestClass=NoSuchClass");
+        output = dumpHelloOnly("-XX:-IgnoreUnrecognizedVMOptions", "-XX:ArchiveHeapTestClass=NoSuchClass");
         mustFail(output, "VM option 'ArchiveHeapTestClass' is develop and is available only in debug version of VM.");
     }
 }


### PR DESCRIPTION
with IgnoreUnrecognizedVMOptions, product build doesn't throws the expected error. Fixing it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302117](https://bugs.openjdk.org/browse/JDK-8302117): IgnoreUnrecognizedVMOptions flag causes failure in ArchiveHeapTestClass


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12483/head:pull/12483` \
`$ git checkout pull/12483`

Update a local copy of the PR: \
`$ git checkout pull/12483` \
`$ git pull https://git.openjdk.org/jdk pull/12483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12483`

View PR using the GUI difftool: \
`$ git pr show -t 12483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12483.diff">https://git.openjdk.org/jdk/pull/12483.diff</a>

</details>
