### PR TITLE
8302121: Parallel: Remove unused arg in PSCardTable::inline_write_ref_field_gc

### DIFF
--- a/src/hotspot/share/gc/parallel/psCardTable.hpp
+++ b/src/hotspot/share/gc/parallel/psCardTable.hpp
@@ -81,7 +81,7 @@ class PSCardTable: public CardTable {
   static bool card_is_verify(int value)     { return value == verify_card; }
 
   // Card marking
-  void inline_write_ref_field_gc(void* field, oop new_val) {
+  void inline_write_ref_field_gc(void* field) {
     CardValue* byte = byte_for(field);
     *byte = youngergen_card;
   }

--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -317,7 +317,7 @@ inline void PSPromotionManager::copy_and_push_safe_barrier(T* p) {
 
   if (!PSScavenge::is_obj_in_young((HeapWord*)p) &&
        PSScavenge::is_obj_in_young(new_obj)) {
-    PSScavenge::card_table()->inline_write_ref_field_gc(p, new_obj);
+    PSScavenge::card_table()->inline_write_ref_field_gc(p);
   }
 }
 


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302121](https://bugs.openjdk.org/browse/JDK-8302121): Parallel: Remove unused arg in PSCardTable::inline_write_ref_field_gc


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12485/head:pull/12485` \
`$ git checkout pull/12485`

Update a local copy of the PR: \
`$ git checkout pull/12485` \
`$ git pull https://git.openjdk.org/jdk pull/12485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12485`

View PR using the GUI difftool: \
`$ git pr show -t 12485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12485.diff">https://git.openjdk.org/jdk/pull/12485.diff</a>

</details>
