### PR TITLE
8302268: Prefer ArrayList to LinkedList in XEmbeddedFramePeer

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/XEmbeddedFramePeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XEmbeddedFramePeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@ package sun.awt.X11;
 
 import java.awt.*;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 
 import sun.util.logging.PlatformLogger;
 
@@ -40,7 +40,7 @@ public class XEmbeddedFramePeer extends XFramePeer {
 
     private static final PlatformLogger xembedLog = PlatformLogger.getLogger("sun.awt.X11.xembed.XEmbeddedFramePeer");
 
-    LinkedList<AWTKeyStroke> strokes;
+    private ArrayList<AWTKeyStroke> strokes;
 
     XEmbedClientHelper embedder; // Caution - can be null if XEmbed is not supported
     public XEmbeddedFramePeer(EmbeddedFrame target) {
@@ -55,7 +55,7 @@ public class XEmbeddedFramePeer extends XFramePeer {
 
     public void preInit(XCreateWindowParams params) {
         super.preInit(params);
-        strokes = new LinkedList<AWTKeyStroke>();
+        strokes = new ArrayList<>();
         if (supportsXEmbed()) {
             embedder = new XEmbedClientHelper();
         }


### PR DESCRIPTION
There is only add/iterator/indexOf calls on this list. No removes from the head or something like this. ArrayList should be preferred as more efficient and widely used (more chances for JIT) collection

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302268](https://bugs.openjdk.org/browse/JDK-8302268): Prefer ArrayList to LinkedList in XEmbeddedFramePeer


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * @SWinxy (no known openjdk.org user name / role)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12486/head:pull/12486` \
`$ git checkout pull/12486`

Update a local copy of the PR: \
`$ git checkout pull/12486` \
`$ git pull https://git.openjdk.org/jdk pull/12486/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12486`

View PR using the GUI difftool: \
`$ git pr show -t 12486`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12486.diff">https://git.openjdk.org/jdk/pull/12486.diff</a>

</details>
