### PR TITLE
8302125: Make G1 full gc abort the VM after failing VerifyDuringGC verification

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
@@ -127,7 +127,7 @@ void G1FullGCMarker::follow_array_chunk(objArrayOop array, int index) {
     _verify_closure.set_containing_obj(array);
     array->oop_iterate_range(&_verify_closure, beg_index, end_index);
     if (_verify_closure.failures()) {
-      assert(false, "Failed");
+      fatal("there should not have been any failures");
     }
   }
 }
@@ -148,7 +148,7 @@ inline void G1FullGCMarker::follow_object(oop obj) {
       obj->oop_iterate(&_verify_closure);
       if (_verify_closure.failures()) {
         log_warning(gc, verify)("Failed after %d", _verify_closure._cc);
-        assert(false, "Failed");
+        fatal("there should not have been any failures");
       }
     }
   }


### PR DESCRIPTION
Hi all,

  can I get reviews for this small fix that makes the VM fail if there has been a verification failure via VerifyDuringGC during full gc in product mode?

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302125](https://bugs.openjdk.org/browse/JDK-8302125): Make G1 full gc abort the VM after failing VerifyDuringGC verification


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12487/head:pull/12487` \
`$ git checkout pull/12487`

Update a local copy of the PR: \
`$ git checkout pull/12487` \
`$ git pull https://git.openjdk.org/jdk pull/12487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12487`

View PR using the GUI difftool: \
`$ git pr show -t 12487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12487.diff">https://git.openjdk.org/jdk/pull/12487.diff</a>

</details>
