### PR TITLE
8302127: Remove unused arg in write_ref_field_post

### DIFF
--- a/src/hotspot/share/gc/g1/g1BarrierSet.hpp
+++ b/src/hotspot/share/gc/g1/g1BarrierSet.hpp
@@ -78,7 +78,7 @@ class G1BarrierSet: public CardTableBarrierSet {
   void write_ref_array_work(MemRegion mr) { invalidate(mr); }
 
   template <DecoratorSet decorators, typename T>
-  void write_ref_field_post(T* field, oop new_val);
+  void write_ref_field_post(T* field);
   void write_ref_field_post_slow(volatile CardValue* byte);
 
   virtual void on_thread_create(Thread* thread);

--- a/src/hotspot/share/gc/g1/g1BarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1BarrierSet.inline.hpp
@@ -68,7 +68,7 @@ inline void G1BarrierSet::write_ref_field_pre(T* field) {
 }
 
 template <DecoratorSet decorators, typename T>
-inline void G1BarrierSet::write_ref_field_post(T* field, oop new_val) {
+inline void G1BarrierSet::write_ref_field_post(T* field) {
   volatile CardValue* byte = _card_table->byte_for(field);
   if (*byte != G1CardTable::g1_young_card_val()) {
     // Take a slow path for cards in old

--- a/src/hotspot/share/gc/shared/cardTableBarrierSet.hpp
+++ b/src/hotspot/share/gc/shared/cardTableBarrierSet.hpp
@@ -80,7 +80,7 @@ protected:
   // either precise or imprecise. We make non-virtual inline variants of
   // these functions here for performance.
   template <DecoratorSet decorators, typename T>
-  void write_ref_field_post(T* field, oop newVal);
+  void write_ref_field_post(T* field);
 
   virtual void invalidate(MemRegion mr);
 

--- a/src/hotspot/share/gc/shared/cardTableBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shared/cardTableBarrierSet.inline.hpp
@@ -31,7 +31,7 @@
 #include "runtime/atomic.hpp"
 
 template <DecoratorSet decorators, typename T>
-inline void CardTableBarrierSet::write_ref_field_post(T* field, oop newVal) {
+inline void CardTableBarrierSet::write_ref_field_post(T* field) {
   volatile CardValue* byte = _card_table->byte_for(field);
   *byte = CardTable::dirty_card_val();
 }

--- a/src/hotspot/share/gc/shared/modRefBarrierSet.hpp
+++ b/src/hotspot/share/gc/shared/modRefBarrierSet.hpp
@@ -49,7 +49,7 @@ public:
   inline void write_ref_field_pre(T* addr) {}
 
   template <DecoratorSet decorators, typename T>
-  inline void write_ref_field_post(T *addr, oop new_value) {}
+  inline void write_ref_field_post(T *addr) {}
 
   // Causes all refs in "mr" to be assumed to be modified.
   virtual void invalidate(MemRegion mr) = 0;

--- a/src/hotspot/share/gc/shared/modRefBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shared/modRefBarrierSet.inline.hpp
@@ -63,7 +63,7 @@ oop_store_in_heap(T* addr, oop value) {
   BarrierSetT *bs = barrier_set_cast<BarrierSetT>(barrier_set());
   bs->template write_ref_field_pre<decorators>(addr);
   Raw::oop_store(addr, value);
-  bs->template write_ref_field_post<decorators>(addr, value);
+  bs->template write_ref_field_post<decorators>(addr);
 }
 
 template <DecoratorSet decorators, typename BarrierSetT>
@@ -74,7 +74,7 @@ oop_atomic_cmpxchg_in_heap(T* addr, oop compare_value, oop new_value) {
   bs->template write_ref_field_pre<decorators>(addr);
   oop result = Raw::oop_atomic_cmpxchg(addr, compare_value, new_value);
   if (result == compare_value) {
-    bs->template write_ref_field_post<decorators>(addr, new_value);
+    bs->template write_ref_field_post<decorators>(addr);
   }
   return result;
 }
@@ -86,7 +86,7 @@ oop_atomic_xchg_in_heap(T* addr, oop new_value) {
   BarrierSetT *bs = barrier_set_cast<BarrierSetT>(barrier_set());
   bs->template write_ref_field_pre<decorators>(addr);
   oop result = Raw::oop_atomic_xchg(addr, new_value);
-  bs->template write_ref_field_post<decorators>(addr, new_value);
+  bs->template write_ref_field_post<decorators>(addr);
   return result;
 }
 


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302127](https://bugs.openjdk.org/browse/JDK-8302127): Remove unused arg in write_ref_field_post


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12489/head:pull/12489` \
`$ git checkout pull/12489`

Update a local copy of the PR: \
`$ git checkout pull/12489` \
`$ git pull https://git.openjdk.org/jdk pull/12489/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12489`

View PR using the GUI difftool: \
`$ git pr show -t 12489`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12489.diff">https://git.openjdk.org/jdk/pull/12489.diff</a>

</details>
