### PR TITLE
8302109: Trivial fixes to btree tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree002/btree002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree002/btree002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
  * VM Testbase keywords: [stress, sysdict, stressopt, nonconcurrent]
  * VM Testbase readme:
  * DESCRIPTION
- *     Single thread loads a tree of classes with signle loader.
+ *     Single thread loads a tree of classes with single loader.
  *     The test is deemed failed if loading attempt fails.
  *     The test repeats until the given number of iterations,
  *     or until EndOfMemoryError.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree005/btree005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree005/btree005.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
  * VM Testbase keywords: [stress, sysdict, stressopt, nonconcurrent]
  * VM Testbase readme:
  * DESCRIPTION
- *     Multiple threads load a tree of classes with signle loader.
+ *     Multiple threads load a tree of classes with single loader.
  *     The test is deemed failed if loading attempt fails.
  *     The test repeats until the given number of iterations,
  *     or until EndOfMemoryError.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree008/btree008.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree008/btree008.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
  * VM Testbase keywords: [stress, sysdict, stressopt, nonconcurrent]
  * VM Testbase readme:
  * DESCRIPTION
- *     Single thread loads a tree of classes with signle loader.
+ *     Single thread loads a tree of classes with single loader.
  *     Then, memory stress is induced to unload the classes.
  *     The test is deemed failed if loading attempt fails;
  *     or if the tested VM crashes.
@@ -51,5 +51,6 @@
  *      -jarpath btree.jar${path.separator}fats.jar
  *      -useSingleLoader
  *      -stressHeap
+ *      -t 1
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree011/btree011.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree011/btree011.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
  * VM Testbase keywords: [stress, sysdict, stressopt, nonconcurrent]
  * VM Testbase readme:
  * DESCRIPTION
- *     Multiple threads load a tree of classes with signle loader.
+ *     Multiple threads load a tree of classes with single loader.
  *     Then, memory stress is induced to unload the classes.
  *     The test is deemed failed if loading attempt fails;
  *     or if the tested VM crashes.


### PR DESCRIPTION
Please review this trivial change.  One of the btree tests claimed to be single threaded but didn't pass -t1 so was the same as btree011.  Ran tier7 that runs these tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302109](https://bugs.openjdk.org/browse/JDK-8302109): Trivial fixes to btree tests


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12490/head:pull/12490` \
`$ git checkout pull/12490`

Update a local copy of the PR: \
`$ git checkout pull/12490` \
`$ git pull https://git.openjdk.org/jdk pull/12490/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12490`

View PR using the GUI difftool: \
`$ git pr show -t 12490`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12490.diff">https://git.openjdk.org/jdk/pull/12490.diff</a>

</details>
