### PR TITLE
8278965: crash in SymbolTable::do_lookup

### DIFF
--- a/src/hotspot/share/classfile/placeholders.hpp
+++ b/src/hotspot/share/classfile/placeholders.hpp
@@ -25,10 +25,11 @@
 #ifndef SHARE_CLASSFILE_PLACEHOLDERS_HPP
 #define SHARE_CLASSFILE_PLACEHOLDERS_HPP
 
+#include "oops/symbol.hpp"
+
 class PlaceholderEntry;
 class Thread;
 class ClassLoaderData;
-class Symbol;
 
 // Placeholder objects. These represent classes currently
 // being loaded, as well as arrays of primitives.

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -670,7 +670,7 @@ InstanceKlass* SystemDictionary::resolve_instance_class_or_null(Symbol* name,
 
   bool super_load_in_progress  = false;
   InstanceKlass* loaded_class = nullptr;
-  Symbol* superclassname = nullptr;
+  SymbolHandle superclassname; // Keep alive while loading in parallel thread.
 
   assert(THREAD->can_call_java(),
          "can not load classes with compiler thread: class=%s, classloader=%s",

--- a/test/hotspot/gtest/classfile/test_placeholders.cpp
+++ b/test/hotspot/gtest/classfile/test_placeholders.cpp
@@ -36,7 +36,7 @@ TEST_VM(PlaceholderTable, supername) {
   JavaThread* THREAD = JavaThread::current();
   JavaThread* T2 = THREAD;
   // the thread should be in vm to use locks
-  ThreadInVMfromNative ThreadInVMfromNative(THREAD);
+  ThreadInVMfromNative tivfn(THREAD);
 
   // Assert messages assume these symbols are unique, and the refcounts start at one.
   TempNewSymbol A = SymbolTable::new_symbol("abc2_8_2023_class");

--- a/test/hotspot/gtest/classfile/test_placeholders.cpp
+++ b/test/hotspot/gtest/classfile/test_placeholders.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "precompiled.hpp"
+#include "classfile/classLoaderData.hpp"
+#include "classfile/placeholders.hpp"
+#include "classfile/symbolTable.hpp"
+#include "oops/symbol.hpp"
+#include "runtime/interfaceSupport.inline.hpp"
+#include "runtime/mutexLocker.hpp"
+#include "threadHelper.inline.hpp"
+#include "unittest.hpp"
+
+// Test that multiple threads calling handle_parallel_super_load don't underflow supername refcount.
+TEST_VM(PlaceholderTable, supername) {
+  JavaThread* THREAD = JavaThread::current();
+  JavaThread* T2 = THREAD;
+  // the thread should be in vm to use locks
+  ThreadInVMfromNative ThreadInVMfromNative(THREAD);
+
+  // Assert messages assume these symbols are unique, and the refcounts start at one.
+  TempNewSymbol A = SymbolTable::new_symbol("abc2_8_2023_class");
+  TempNewSymbol D = SymbolTable::new_symbol("def2_8_2023_class");
+  Symbol* super = SymbolTable::new_symbol("super2_8_2023_supername");
+  TempNewSymbol interf = SymbolTable::new_symbol("interface2_8_2023_supername");
+
+  ClassLoaderData* loader_data = ClassLoaderData::the_null_class_loader_data();
+
+  {
+    MutexLocker ml(THREAD, SystemDictionary_lock);
+
+    PlaceholderTable::classloadAction super_action = PlaceholderTable::LOAD_SUPER;
+    PlaceholderTable::classloadAction define_action = PlaceholderTable::DEFINE_CLASS;
+
+    // DefineClass A and D
+    PlaceholderTable::find_and_add(A, loader_data, define_action, nullptr, THREAD);
+    PlaceholderTable::find_and_add(D, loader_data, define_action, nullptr, T2);
+
+    // Load interfaces first to get supername replaced
+    PlaceholderTable::find_and_add(A, loader_data, super_action, interf, THREAD);
+    PlaceholderTable::find_and_remove(A, loader_data, super_action, THREAD);
+
+    PlaceholderTable::find_and_add(D, loader_data, super_action, interf, T2);
+    PlaceholderTable::find_and_remove(D, loader_data, super_action, T2);
+
+    ASSERT_EQ(interf->refcount(), 3) << "supername isn't replaced until super set";
+
+    // Add placeholder to the table for loading A and super, and D also loading super
+    PlaceholderTable::find_and_add(A, loader_data, super_action, super, THREAD);
+    PlaceholderTable::find_and_add(D, loader_data, super_action, super, T2);
+
+    ASSERT_EQ(interf->refcount(), 1) << "now should be one";
+
+    // Another thread comes in and finds A loading Super
+    PlaceholderEntry* placeholder = PlaceholderTable::get_entry(A, loader_data);
+    SymbolHandle supername = placeholder->supername();
+
+    // Other thread is done before handle_parallel_super_load
+    PlaceholderTable::find_and_remove(A, loader_data, super_action, THREAD);
+
+    // if THREAD drops reference to supername (loading failed or class unloaded), we're left with
+    // a supername without refcount
+    super->decrement_refcount();
+
+    // handle_parallel_super_load (same thread doesn't assert)
+    PlaceholderTable::find_and_add(A, loader_data, super_action, supername, T2);
+
+    // Refcount should be 3: one in table for class A, one in table for class D
+    // and one locally with SymbolHandle keeping it alive
+    placeholder = PlaceholderTable::get_entry(A, loader_data);
+    supername = placeholder->supername();
+    EXPECT_EQ(super->refcount(), 3) << "super class name refcount should be 3";
+
+    // Second thread's done too
+    PlaceholderTable::find_and_remove(D, loader_data, super_action, T2);
+
+    // Other threads are done.
+    PlaceholderTable::find_and_remove(A, loader_data, super_action, THREAD);
+
+    // Remove A and D define_class placeholder
+    PlaceholderTable::find_and_remove(A, loader_data, define_action, THREAD);
+    PlaceholderTable::find_and_remove(D, loader_data, define_action, T2);
+
+    placeholder = PlaceholderTable::get_entry(A, loader_data);
+    ASSERT_TRUE(placeholder == nullptr) << "placeholder should be removed";
+    placeholder = PlaceholderTable::get_entry(D, loader_data);
+    ASSERT_TRUE(placeholder == nullptr) << "placeholder should be removed";
+
+    EXPECT_EQ(super->refcount(), 1) << "super class name refcount should be 1 - kept alive in this scope";
+  }
+
+  EXPECT_EQ(A->refcount(), 1) << "first lass name refcount should be 1";
+  EXPECT_EQ(D->refcount(), 1) << "second class name refcount should be 1";
+  EXPECT_EQ(super->refcount(), 0) << "super class name refcount should be 0 - was unloaded.";
+}


### PR DESCRIPTION
Please review this small change to hold the refcount of a super class name while calling handle_parallel_super_load. Contrary to what I wrote in JDK-8298061, the refcount in the Placeholder table should never go to one.  I can reproduce this with btree012 occasionally, so this fixes this too.

The include in placeholders.hpp is required to make the gtest compiled since placeholders header file has Symbol::maybe_increment_refcount and decrement calls.

Tested with the graal test that failed, and tier1-7.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278965](https://bugs.openjdk.org/browse/JDK-8278965): crash in SymbolTable::do_lookup


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [3f2bea79](https://git.openjdk.org/jdk/pull/12491/files/3f2bea798ebc9c27fb443b42c9fcf23d00721d30)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12491/head:pull/12491` \
`$ git checkout pull/12491`

Update a local copy of the PR: \
`$ git checkout pull/12491` \
`$ git pull https://git.openjdk.org/jdk pull/12491/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12491`

View PR using the GUI difftool: \
`$ git pr show -t 12491`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12491.diff">https://git.openjdk.org/jdk/pull/12491.diff</a>

</details>
