### PR TITLE
8302147: Speed up compiler/jvmci/compilerToVM/IterateFramesNative.java

### DIFF
--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IterateFramesNative.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IterateFramesNative.java
@@ -105,15 +105,17 @@ public class IterateFramesNative {
 
     private void test() {
         // Run enough iterations to reach compilation.
-        for (int i = 0; i < (CHECK_COMPILED ? 1 : 1000); i++) {
+        for (int i = 0; i < (CHECK_COMPILED ? 1 : 10_000); i++) {
             testNativeFrame("someString", i);
         }
 
-        // Verify that we reached compilation at some point.
-        Asserts.assertTrue(WB.isMethodCompiled(ITERATE_FRAMES_METHOD),
-            "Expected native method to be compiled: " + ITERATE_FRAMES_METHOD);
-        Asserts.assertTrue(WB.isMethodCompiled(NATIVE_METHOD),
-            "Expected native method to be compiled: " + NATIVE_METHOD);
+        if (CHECK_COMPILED) {
+            // Verify that we reached compilation at some point.
+            Asserts.assertTrue(WB.isMethodCompiled(ITERATE_FRAMES_METHOD),
+                "Expected native method to be compiled: " + ITERATE_FRAMES_METHOD);
+            Asserts.assertTrue(WB.isMethodCompiled(NATIVE_METHOD),
+                "Expected native method to be compiled: " + NATIVE_METHOD);
+        }
     }
 
     /**

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IterateFramesNative.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IterateFramesNative.java
@@ -105,9 +105,15 @@ public class IterateFramesNative {
 
     private void test() {
         // Run enough iterations to reach compilation.
-        for (int i = 0; i < (CHECK_COMPILED ? 1 : 1001); i++) {
+        for (int i = 0; i < (CHECK_COMPILED ? 1 : 1000); i++) {
             testNativeFrame("someString", i);
         }
+
+        // Verify that we reached compilation at some point.
+        Asserts.assertTrue(WB.isMethodCompiled(ITERATE_FRAMES_METHOD),
+            "Expected native method to be compiled: " + ITERATE_FRAMES_METHOD);
+        Asserts.assertTrue(WB.isMethodCompiled(NATIVE_METHOD),
+            "Expected native method to be compiled: " + NATIVE_METHOD);
     }
 
     /**
@@ -126,14 +132,6 @@ public class IterateFramesNative {
 
         Asserts.assertEQ(innerHelper.string, NATIVE_METHOD_RESOLVED.getName(),
             "Native frame not found?: " + NATIVE_METHOD_RESOLVED.getName());
-
-        // Check we reached compilation in the end.
-        if (CHECK_COMPILED || iteration >= 1000) {
-            Asserts.assertTrue(WB.isMethodCompiled(ITERATE_FRAMES_METHOD),
-                "Expected native method to be compiled: " + ITERATE_FRAMES_METHOD);
-            Asserts.assertTrue(WB.isMethodCompiled(NATIVE_METHOD),
-                "Expected native method to be compiled: " + NATIVE_METHOD);
-        }
     }
 
     private void testNativeFrameCallback(Helper helper, int iteration) {

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IterateFramesNative.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IterateFramesNative.java
@@ -104,7 +104,7 @@ public class IterateFramesNative {
     }
 
     private void test() {
-        for (int i = 0; i < 3; i++) {
+        for (int i = 0; i < (CHECK_COMPILED ? 1 : CompilerWhiteBoxTest.THRESHOLD + 1); i++) {
             testNativeFrame("someString", i);
         }
     }

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IterateFramesNative.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IterateFramesNative.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,7 +104,7 @@ public class IterateFramesNative {
     }
 
     private void test() {
-        for (int i = 0; i < CompilerWhiteBoxTest.THRESHOLD + 1; i++) {
+        for (int i = 0; i < 3; i++) {
             testNativeFrame("someString", i);
         }
     }

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IterateFramesNative.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IterateFramesNative.java
@@ -104,7 +104,8 @@ public class IterateFramesNative {
     }
 
     private void test() {
-        for (int i = 0; i < (CHECK_COMPILED ? 1 : CompilerWhiteBoxTest.THRESHOLD + 1); i++) {
+        // Run enough iterations to reach compilation.
+        for (int i = 0; i < (CHECK_COMPILED ? 1 : 1001); i++) {
             testNativeFrame("someString", i);
         }
     }
@@ -126,7 +127,8 @@ public class IterateFramesNative {
         Asserts.assertEQ(innerHelper.string, NATIVE_METHOD_RESOLVED.getName(),
             "Native frame not found?: " + NATIVE_METHOD_RESOLVED.getName());
 
-        if (CHECK_COMPILED) {
+        // Check we reached compilation in the end.
+        if (CHECK_COMPILED || iteration >= 1000) {
             Asserts.assertTrue(WB.isMethodCompiled(ITERATE_FRAMES_METHOD),
                 "Expected native method to be compiled: " + ITERATE_FRAMES_METHOD);
             Asserts.assertTrue(WB.isMethodCompiled(NATIVE_METHOD),


### PR DESCRIPTION
We have two run statements.

The `-Xbatch`  version takes `5 sec`, now `1.5-2.3`.
And the `-Xcomp`  took `19` and now takes `0.5`.

I discussed it with @woess the original author of the test. He suggested this fix.
The first run statement still works as before, the second one, which sets `-Dcompiler.jvmci.compilerToVM.IterateFramesNative.checkCompiled=true` and has `CHECK_COMPILED == true` now only runs one iteration. This should be sufficient, we see that the whitebox checks successfully that the methods were compiled.

**Update**
For `-Xbatch`, I simply reduced the iteration count. We had `CompilerWhiteBoxTest.THRESHOLD = 150_000` iterations, now I reduced it to `10_000`, which should be sufficient.

I would have liked to assert compilation in both cases, but the `-Xbatch` case does not always lead to compilation, especially when we have `-XX:-TieredCompilation`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302147](https://bugs.openjdk.org/browse/JDK-8302147): Speed up compiler/jvmci/compilerToVM/IterateFramesNative.java


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [095ee38b](https://git.openjdk.org/jdk/pull/12496/files/095ee38b4d2ab7b2b7dd974dd11745b0fd19b66d)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12496/head:pull/12496` \
`$ git checkout pull/12496`

Update a local copy of the PR: \
`$ git checkout pull/12496` \
`$ git pull https://git.openjdk.org/jdk pull/12496/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12496`

View PR using the GUI difftool: \
`$ git pr show -t 12496`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12496.diff">https://git.openjdk.org/jdk/pull/12496.diff</a>

</details>
