### PR TITLE
8301638: A number of nsk/jdi invokemethod tests should be converted to create virtual threads

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod012t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod012t.java
@@ -34,8 +34,8 @@ import nsk.share.jdi.*;
  */
 public class invokemethod012t {
     static Log log;
-    private invokemethod012Thr thrs[] =
-        new invokemethod012Thr[invokemethod012.THRDS_NUM-1];
+    private invokemethod012Thr thrs012[] = new invokemethod012Thr[invokemethod012.THRDS_NUM-1];
+    private Thread thrs[] = new Thread[invokemethod012.THRDS_NUM-1];
     private IOPipe pipe;
 
     public static void main(String args[]) {
@@ -109,8 +109,8 @@ public class invokemethod012t {
         Object readyObj = new Object();
 
         for (int i=0; i < invokemethod012.THRDS_NUM-1; i++) {
-            thrs[i] = new invokemethod012Thr(readyObj,
-                invokemethod012.DEBUGGEE_THRDS[i+1][0]);
+            thrs012[i] = new invokemethod012Thr(readyObj, invokemethod012.DEBUGGEE_THRDS[i+1][0]);
+            thrs[i] = JDIThreadFactory.newThread(thrs012[i]);
             thrs[i].setDaemon(true);
             log.display("Debuggee: starting thread #"
                 + i + " \"" + thrs[i].getName() + "\" ...");
@@ -133,7 +133,7 @@ public class invokemethod012t {
 
     private void killThreads(int waitTime) {
         for (int i=0; i < invokemethod012.THRDS_NUM-1 ; i++) {
-            thrs[i].doExit = true;
+            thrs012[i].doExit = true;
             try {
                 thrs[i].join(waitTime);
                 log.display("Debuggee: thread #"
@@ -149,7 +149,7 @@ public class invokemethod012t {
     * This is an auxiliary thread class used to check the flag
     * INVOKE_SINGLE_THREADED in the debugger.
     */
-    class invokemethod012Thr extends Thread {
+    class invokemethod012Thr extends NamedTask {
         volatile boolean doExit = false;
         private Object readyObj;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod010t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod010t.java
@@ -34,8 +34,8 @@ import nsk.share.jdi.*;
  */
 public class invokemethod010t {
     static Log log;
-    private invokemethod010Thr thrs[] =
-        new invokemethod010Thr[invokemethod010.THRDS_NUM-1];
+    private invokemethod010Thr thrs010[] = new invokemethod010Thr[invokemethod010.THRDS_NUM-1];
+    private Thread thrs[] = new Thread[invokemethod010.THRDS_NUM-1];
     private IOPipe pipe;
 
     public static void main(String args[]) {
@@ -87,8 +87,8 @@ public class invokemethod010t {
         Object readyObj = new Object();
 
         for (int i=0; i < invokemethod010.THRDS_NUM-1; i++) {
-            thrs[i] = new invokemethod010Thr(readyObj,
-                invokemethod010.DEBUGGEE_THRDS[i+1]);
+            thrs010[i] = new invokemethod010Thr(readyObj, invokemethod010.DEBUGGEE_THRDS[i+1]);
+            thrs[i] = JDIThreadFactory.newThread(thrs010[i]);
             thrs[i].setDaemon(true);
             log.display("Debuggee: starting thread #"
                 + i + " \"" + thrs[i].getName() + "\" ...");
@@ -111,7 +111,7 @@ public class invokemethod010t {
 
     private void killThreads(int waitTime) {
         for (int i=0; i < invokemethod010.THRDS_NUM-1 ; i++) {
-            thrs[i].doExit = true;
+            thrs010[i].doExit = true;
             try {
                 thrs[i].join(waitTime);
                 log.display("Debuggee: thread #"
@@ -127,7 +127,7 @@ public class invokemethod010t {
     * This is an auxiliary thread class used to check the flag
     * ObjectReference.INVOKE_SINGLE_THREADED in the debugger.
     */
-    class invokemethod010Thr extends Thread {
+    class invokemethod010Thr extends NamedTask {
         volatile boolean doExit = false;
         private Object readyObj;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod011t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod011t.java
@@ -34,8 +34,8 @@ import nsk.share.jdi.*;
  */
 public class invokemethod011t {
     static Log log;
-    private invokemethod011Thr thrs[] =
-        new invokemethod011Thr[invokemethod011.THRDS_NUM-1];
+    private invokemethod011Thr thrs011[] = new invokemethod011Thr[invokemethod011.THRDS_NUM-1];
+    private Thread thrs[] = new Thread[invokemethod011.THRDS_NUM-1];
     private IOPipe pipe;
 
     public static void main(String args[]) {
@@ -87,8 +87,8 @@ public class invokemethod011t {
         Object readyObj = new Object();
 
         for (int i=0; i < invokemethod011.THRDS_NUM-1; i++) {
-            thrs[i] = new invokemethod011Thr(readyObj,
-                invokemethod011.DEBUGGEE_THRDS[i+1]);
+            thrs011[i] = new invokemethod011Thr(readyObj, invokemethod011.DEBUGGEE_THRDS[i+1]);
+            thrs[i] = JDIThreadFactory.newThread(thrs011[i]);
             thrs[i].setDaemon(true);
             log.display("Debuggee: starting thread #"
                 + i + " \"" + thrs[i].getName() + "\" ...");
@@ -111,7 +111,7 @@ public class invokemethod011t {
 
     private void killThreads(int waitTime) {
         for (int i=0; i < invokemethod011.THRDS_NUM-1 ; i++) {
-            thrs[i].doExit = true;
+            thrs011[i].doExit = true;
             try {
                 thrs[i].join(waitTime);
                 log.display("Debuggee: thread #"
@@ -127,7 +127,7 @@ public class invokemethod011t {
     * This is an auxiliary thread class used to check the flag
     * ObjectReference.INVOKE_SINGLE_THREADED in the debugger.
     */
-    class invokemethod011Thr extends Thread {
+    class invokemethod011Thr extends NamedTask {
         volatile boolean doExit = false;
         private Object readyObj;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod012t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod012t.java
@@ -34,8 +34,8 @@ import nsk.share.jdi.*;
  */
 public class invokemethod012t {
     static Log log;
-    private invokemethod012Thr thrs[] =
-        new invokemethod012Thr[invokemethod012.THRDS_NUM-1];
+    private invokemethod012Thr thrs012[] = new invokemethod012Thr[invokemethod012.THRDS_NUM-1];
+    private Thread thrs[] = new Thread[invokemethod012.THRDS_NUM-1];
     private IOPipe pipe;
 
     public static void main(String args[]) {
@@ -87,8 +87,8 @@ public class invokemethod012t {
         Object readyObj = new Object();
 
         for (int i=0; i < invokemethod012.THRDS_NUM-1; i++) {
-            thrs[i] = new invokemethod012Thr(readyObj,
-                invokemethod012.DEBUGGEE_THRDS[i+1][0]);
+            thrs012[i] = new invokemethod012Thr(readyObj, invokemethod012.DEBUGGEE_THRDS[i+1][0]);
+            thrs[i] = JDIThreadFactory.newThread(thrs012[i]);
             thrs[i].setDaemon(true);
             log.display("Debuggee: starting thread #"
                 + i + " \"" + thrs[i].getName() + "\" ...");
@@ -111,7 +111,7 @@ public class invokemethod012t {
 
     private void killThreads(int waitTime) {
         for (int i=0; i < invokemethod012.THRDS_NUM-1 ; i++) {
-            thrs[i].doExit = true;
+            thrs012[i].doExit = true;
             try {
                 thrs[i].join(waitTime);
                 log.display("Debuggee: thread #"
@@ -127,7 +127,7 @@ public class invokemethod012t {
     * This is an auxiliary thread class used to check the flag
     * ObjectReference.INVOKE_SINGLE_THREADED in the debugger.
     */
-    class invokemethod012Thr extends Thread {
+    class invokemethod012Thr extends NamedTask {
         volatile boolean doExit = false;
         private Object readyObj;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod013t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ObjectReference/invokeMethod/invokemethod013t.java
@@ -34,8 +34,8 @@ import nsk.share.jdi.*;
  */
 public class invokemethod013t {
     static Log log;
-    private invokemethod013Thr thrs[] =
-        new invokemethod013Thr[invokemethod013.THRDS_NUM-1];
+    private invokemethod013Thr thrs013[] = new invokemethod013Thr[invokemethod013.THRDS_NUM-1];
+    private Thread thrs[] = new Thread[invokemethod013.THRDS_NUM-1];
     private IOPipe pipe;
 
     public static void main(String args[]) {
@@ -87,8 +87,8 @@ public class invokemethod013t {
         Object readyObj = new Object();
 
         for (int i=0; i < invokemethod013.THRDS_NUM-1; i++) {
-            thrs[i] = new invokemethod013Thr(readyObj,
-                invokemethod013.DEBUGGEE_THRDS[i+1][0]);
+            thrs013[i] = new invokemethod013Thr(readyObj, invokemethod013.DEBUGGEE_THRDS[i+1][0]);
+            thrs[i] = JDIThreadFactory.newThread(thrs013[i]);
             thrs[i].setDaemon(true);
             log.display("Debuggee: starting thread #"
                 + i + " \"" + thrs[i].getName() + "\" ...");
@@ -111,7 +111,7 @@ public class invokemethod013t {
 
     private void killThreads(int waitTime) {
         for (int i=0; i < invokemethod013.THRDS_NUM-1 ; i++) {
-            thrs[i].doExit = true;
+            thrs013[i].doExit = true;
             try {
                 thrs[i].join(waitTime);
                 log.display("Debuggee: thread #"
@@ -127,7 +127,7 @@ public class invokemethod013t {
     * This is an auxiliary thread class used to check method
     * invocation in the debugger.
     */
-    class invokemethod013Thr extends Thread {
+    class invokemethod013Thr extends NamedTask {
         volatile boolean doExit = false;
         private Object readyObj;
 


### PR DESCRIPTION
As part of the initial loom work, some nsk/jdi invokemethod tests were converted to support testing with virtual threads.  However, for some reason a few of the tests were skipped when the initial conversion was done. This PR converts the remaining tests.

The general approach is to take the Thread subclass defined by the debuggee and change it to instead extend NamedTask. Then  JDIThreadFactory.newThread(NamedTask) is used to create the Thread instance, passing the task instance in as argument. JDIThreadFactory.newThread(NamedTask) will create a virtual thread or a platform thread depending on the setting of the main.wrapper property. Tests are run with -Dmain.wrapper=Virtual to trigger using virtual threads.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301638](https://bugs.openjdk.org/browse/JDK-8301638): A number of nsk/jdi invokemethod tests should be converted to create virtual threads


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12500/head:pull/12500` \
`$ git checkout pull/12500`

Update a local copy of the PR: \
`$ git checkout pull/12500` \
`$ git pull https://git.openjdk.org/jdk pull/12500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12500`

View PR using the GUI difftool: \
`$ git pr show -t 12500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12500.diff">https://git.openjdk.org/jdk/pull/12500.diff</a>

</details>
