### PR TITLE
8302172: [JVMCI] HotSpotResolvedJavaMethodImpl.canBeInlined must respect ForceInline

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl.java
@@ -577,6 +577,9 @@ final class HotSpotResolvedJavaMethodImpl extends HotSpotMethod implements HotSp
 
     @Override
     public boolean canBeInlined() {
+        if (isForceInline()) {
+            return true;
+        }
         if (hasNeverInlineDirective()) {
             return false;
         }


### PR DESCRIPTION
The implementation of `HotSpotResolvedJavaMethodImpl.canBeInlined` must return true for a method annotated with `@ForceInline`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302172](https://bugs.openjdk.org/browse/JDK-8302172): [JVMCI] HotSpotResolvedJavaMethodImpl.canBeInlined must respect ForceInline


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12501/head:pull/12501` \
`$ git checkout pull/12501`

Update a local copy of the PR: \
`$ git checkout pull/12501` \
`$ git pull https://git.openjdk.org/jdk pull/12501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12501`

View PR using the GUI difftool: \
`$ git pr show -t 12501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12501.diff">https://git.openjdk.org/jdk/pull/12501.diff</a>

</details>
