### PR TITLE
8301700: Increase the default TLS Diffie-Hellman group size from 1024-bit to 2048-bit

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/DHKeyExchange.java
+++ b/src/java.base/share/classes/sun/security/ssl/DHKeyExchange.java
@@ -326,45 +326,36 @@ final class DHKeyExchange {
             }
 
             /*
-             * 768 bits ephemeral DH private keys were used to be used in
+             * 768 bit ephemeral DH private keys used to be used in
              * ServerKeyExchange except that exportable ciphers max out at 512
-             * bits modulus values. We still adhere to this behavior in legacy
+             * bit modulus values. We still adhere to this behavior in legacy
              * mode (system property "jdk.tls.ephemeralDHKeySize" is defined
              * as "legacy").
              *
-             * Old JDK (JDK 7 and previous) releases don't support DH keys
-             * bigger than 1024 bits. We have to consider the compatibility
-             * requirement. 1024 bits DH key is always used for non-exportable
-             * cipher suites in default mode (system property
+             * Only very old JDK releases don't support DH keys bigger than
+             * 1024 bits (JDK 1.5 and 6u/7u releases prior to adding support
+             * for DH keys > 1024 bits - see JDK-8062834). A 2048 bit
+             * DH key is always used for non-exportable cipher suites in
+             * default mode (when the system property
              * "jdk.tls.ephemeralDHKeySize" is not defined).
-             *
-             * However, if applications want stronger strength, setting
-             * system property "jdk.tls.ephemeralDHKeySize" to "matched"
-             * is a workaround to use ephemeral DH key which size matches the
-             * corresponding authentication key. For example, if the public key
-             * size of an authentication certificate is 2048 bits, then the
-             * ephemeral DH key size should be 2048 bits accordingly unless
-             * the cipher suite is exportable.  This key sizing scheme keeps
-             * the cryptographic strength consistent between authentication
-             * keys and key-exchange keys.
              *
              * Applications may also want to customize the ephemeral DH key
              * size to a fixed length for non-exportable cipher suites. This
-             * can be approached by setting system property
+             * can be done by setting the system property
              * "jdk.tls.ephemeralDHKeySize" to a valid positive integer between
              * 1024 and 8192 bits, inclusive.
              *
-             * Note that the minimum acceptable key size is 1024 bits except
-             * exportable cipher suites or legacy mode.
+             * Note that the minimum acceptable key size is 2048 bits except
+             * for exportable cipher suites or legacy mode.
              *
              * Note that per RFC 2246, the key size limit of DH is 512 bits for
              * exportable cipher suites.  Because of the weakness, exportable
              * cipher suites are deprecated since TLS v1.1 and they are not
              * enabled by default in Oracle provider. The legacy behavior is
-             * reserved and 512 bits DH key is always used for exportable
+             * preserved and a 512 bit DH key is always used for exportable
              * cipher suites.
              */
-            int keySize = exportable ? 512 : 1024;           // default mode
+            int keySize = exportable ? 512 : 2048;           // default mode
             if (!exportable) {
                 if (useLegacyEphemeralDHKeys) {          // legacy mode
                     keySize = 768;
@@ -390,7 +381,7 @@ final class DHKeyExchange {
                         // limit in the future when the compatibility and
                         // interoperability impact is limited.
                         keySize = ks <= 1024 ? 1024 : 2048;
-                    } // Otherwise, anonymous cipher suites, 1024-bit is used.
+                    } // Otherwise, anonymous cipher suites, 2048-bit is used.
                 } else if (customizedDHKeySize > 0) {    // customized mode
                     keySize = customizedDHKeySize;
                 }

--- a/test/jdk/sun/security/ssl/DHKeyExchange/DHEKeySizing.java
+++ b/test/jdk/sun/security/ssl/DHKeyExchange/DHEKeySizing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
 
 /*
  * @test
- * @bug 6956398
+ * @bug 6956398 8301700
  * @summary make ephemeral DH key match the length of the certificate key
  * @run main/othervm -Djdk.tls.client.enableSessionTicketExtension=false
  *      DHEKeySizing TLS_DHE_RSA_WITH_AES_128_CBC_SHA  false 1643 267
@@ -54,7 +54,7 @@
  *
  * @run main/othervm -Djsse.enableFFDHE=false
  *      -Djdk.tls.client.enableSessionTicketExtension=false
- *      DHEKeySizing TLS_DHE_RSA_WITH_AES_128_CBC_SHA  false 1387 139
+ *      DHEKeySizing TLS_DHE_RSA_WITH_AES_128_CBC_SHA  false 1643 267
  * @run main/othervm -Djsse.enableFFDHE=false
  *      -Djdk.tls.ephemeralDHKeySize=legacy
  *      -Djdk.tls.client.enableSessionTicketExtension=false
@@ -70,7 +70,7 @@
  *
  * @run main/othervm -Djsse.enableFFDHE=false
  *      -Djdk.tls.client.enableSessionTicketExtension=false
- *      DHEKeySizing SSL_DH_anon_WITH_RC4_128_MD5  false 361 139
+ *      DHEKeySizing SSL_DH_anon_WITH_RC4_128_MD5  false 617 267
  * @run main/othervm -Djsse.enableFFDHE=false
  *      -Djdk.tls.client.enableSessionTicketExtension=false
  *      -Djdk.tls.ephemeralDHKeySize=legacy
@@ -78,7 +78,7 @@
  * @run main/othervm -Djsse.enableFFDHE=false
  *      -Djdk.tls.client.enableSessionTicketExtension=false
  *      -Djdk.tls.ephemeralDHKeySize=matched
- *      DHEKeySizing SSL_DH_anon_WITH_RC4_128_MD5  false 361 139
+ *      DHEKeySizing SSL_DH_anon_WITH_RC4_128_MD5  false 617 267
  * @run main/othervm -Djsse.enableFFDHE=false
  *      -Djdk.tls.client.enableSessionTicketExtension=false
  *      -Djdk.tls.ephemeralDHKeySize=1024
@@ -106,7 +106,7 @@
  *        } dh_public;
  *    } ClientDiffieHellmanPublic;
  *
- * Fomr above structures, it is clear that if the DH key size increasing 128
+ * From the above structures, it is clear that if the DH key size increases 128
  * bits (16 bytes), the ServerHello series messages increases 48 bytes
  * (becuase dh_p, dh_g and dh_Ys each increase 16 bytes) and ClientKeyExchange
  * increases 16 bytes (because of the size increasing of dh_Yc).
@@ -117,7 +117,7 @@
  *   512-bit  |          1259 bytes  |           75 bytes |        233 bytes
  *   768-bit  |          1323 bytes  |          107 bytes |        297 bytes
  *  1024-bit  |          1387 bytes  |          139 bytes |        361 bytes
- *  2048-bit  |          1643 bytes  |          267 bytes |        361 bytes
+ *  2048-bit  |          1643 bytes  |          267 bytes |        617 bytes
  */
 
 import javax.net.ssl.*;


### PR DESCRIPTION
Please review this change to increase the default Diffie-Hellman group size used in the key exchange method of TLS_DHE cipher suites from 1024-bit to 2048-bit. This issue does not affect TLS 1.3 as the minimum DH group size is 2048 bits..

See the CSR for more details on the rationale for this change and the expected compatibility risk (low).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8302100](https://bugs.openjdk.org/browse/JDK-8302100) to be approved

### Issues
 * [JDK-8301700](https://bugs.openjdk.org/browse/JDK-8301700): Increase the default TLS Diffie-Hellman group size from 1024-bit to 2048-bit
 * [JDK-8302100](https://bugs.openjdk.org/browse/JDK-8302100): Increase the default TLS Diffie-Hellman group size from 1024-bit to 2048-bit (**CSR**)


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12502/head:pull/12502` \
`$ git checkout pull/12502`

Update a local copy of the PR: \
`$ git checkout pull/12502` \
`$ git pull https://git.openjdk.org/jdk pull/12502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12502`

View PR using the GUI difftool: \
`$ git pr show -t 12502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12502.diff">https://git.openjdk.org/jdk/pull/12502.diff</a>

</details>
