### PR TITLE
5059679: name clash not reported for interface inheritance

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -2581,7 +2581,10 @@ public class Check {
                 //if (i) the signature of 'sym' is not a subsignature of m1 (seen as
                 //a member of 'site') and (ii) m1 has the same erasure as m2, issue an error
                 if (!types.isSubSignature(sym.type, types.memberType(site, m2)) &&
-                        types.hasSameArgs(m2.erasure(types), m1.erasure(types))) {
+                        (types.hasSameArgs(m2.erasure(types), m1.erasure(types)) ||
+                        types.hasSameArgs(
+                            m2.asMemberOf(site, types).erasure(types),
+                            m1.asMemberOf(site, types).erasure(types)))) {
                     sym.flags_field |= CLASH;
                     if (m1 == sym) {
                         log.error(pos, Errors.NameClashSameErasureNoOverride(

--- a/test/langtools/tools/javac/NameClash/NarrowingNameClash.java
+++ b/test/langtools/tools/javac/NameClash/NarrowingNameClash.java
@@ -1,0 +1,17 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 5059679
+ * @summary Verify proper detection of name class when parameter types narrow
+ * @compile/fail/ref=NarrowingNameClash.out -XDrawDiagnostics NarrowingNameClash.java
+ */
+
+public class NarrowingNameClash {
+
+    public interface Upper<T> {
+        void method(T param);
+    }
+
+    public interface Lower<R> extends Upper<Class<R>> {
+        void method(Class<?> param);        // erasure name clash here
+    }
+}

--- a/test/langtools/tools/javac/NameClash/NarrowingNameClash.out
+++ b/test/langtools/tools/javac/NameClash/NarrowingNameClash.out
@@ -1,0 +1,2 @@
+NarrowingNameClash.java:15:14: compiler.err.name.clash.same.erasure.no.override: method, java.lang.Class<?>, NarrowingNameClash.Lower, method, java.lang.Class<R>, NarrowingNameClash.Upper
+1 error


### PR DESCRIPTION
Consider this input:
```java
public class NarrowingNameClash {

    public interface Upper<T> {
        void method(T param);
    }

    public interface Lower<R> extends Upper<Class<R>> {
        void method(Class<?> param);        // erasure name clash here
    }
}
```
This violates §8.4.8.3 because `method(Class<R>)` and `method(Class<?>)` have the same erasure. However, the compiler is not reporting an error in this case.

Here's my understanding of the bug... (reviewer please double-check this :)

§8.4.8.3 "Requirements in Overriding and Hiding" says:

It is a compile-time error if a class or interface C has a member method m1 and there exists a method m2 declared in C or a superclass or superinterface of C, A, such that all of the following are true:

* m1 and m2 have the same name.
* m2 is accessible (§6.6) from C.
* The signature of m1 is not a subsignature (§8.4.2) of the signature of m2 as a member of the supertype of C that names A.
* The declared signature of m1 or some method m1 overrides (directly or indirectly) has the same erasure as the declared signature of m2 or some method m2 overrides (directly or indirectly).

Method `method(Class<R>)` is inherited by `Lower` from `Upper` and is therefore a member of `Lower`. Note that upon inheritance its parameter `T` is reinterpreted as `Class<R>` in the context of `Lower`'s generic parameterization.

Let C = `Lower`, A = `Upper`, m1 = `method(Class<R>)` and m2 = `method(Class<?>)`.

The compiler is comparing the erasures of `method(T)`, which is "some method m1 overrides", and m2 = `method(Class<?>)`, and these are different, so no bug is reported.

That comparison is appropriate, however, what it also needs to do is compare the erasures of m1 and m2, which are both `method(Class)`.

In a nutshell: within the context of `Lower`, the method `method(Class<R>)` inherited from `Upper`, when erased, has a different signature from its original form `method(T)` in `Upper`, when erased. The possibility of this different form was not being taken into account in the compiler.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-5059679](https://bugs.openjdk.org/browse/JDK-5059679): name clash not reported for interface inheritance


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12503/head:pull/12503` \
`$ git checkout pull/12503`

Update a local copy of the PR: \
`$ git checkout pull/12503` \
`$ git pull https://git.openjdk.org/jdk pull/12503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12503`

View PR using the GUI difftool: \
`$ git pr show -t 12503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12503.diff">https://git.openjdk.org/jdk/pull/12503.diff</a>

</details>
