### PR TITLE
8178806: Better exception logging in crypto code

### DIFF
--- a/src/java.base/share/classes/javax/crypto/JceSecurity.java.template
+++ b/src/java.base/share/classes/javax/crypto/JceSecurity.java.template
@@ -236,13 +236,8 @@ final class JceSecurity {
     // return whether this provider is properly signed and can be used by JCE
     static boolean canUseProvider(Provider p) {
         Exception e = getVerificationResult(p);
-        if (debug != null) {
-            if(e != null) {
-                debug.println("Provider verification result: " + e.getClass());
-                if(e.getMessage() != null) {
-                    debug.println("Exception message: " + e.getMessage());
-                }
-            }
+        if (debug != null && e != null) {
+            debug.println("Provider verification result: " + e);
         }
         return e == null;
     }

--- a/src/java.base/share/classes/javax/crypto/JceSecurity.java.template
+++ b/src/java.base/share/classes/javax/crypto/JceSecurity.java.template
@@ -235,7 +235,16 @@ final class JceSecurity {
 
     // return whether this provider is properly signed and can be used by JCE
     static boolean canUseProvider(Provider p) {
-        return getVerificationResult(p) == null;
+        Exception e = getVerificationResult(p);
+        if (debug != null) {
+            if(e != null) {
+                debug.println("Provider verification result: " + e.getClass());
+                if(e.getMessage() != null) {
+                    debug.println("Exception message: " + e.getMessage());
+                }
+            }
+        }
+        return e == null;
     }
 
     // dummy object to represent null


### PR DESCRIPTION
Updated this `template` file to not fail silently on `canUseProvider` check in debug mode to provide additional information to aid in debugging.

See: https://bugs.openjdk.org/browse/JDK-8178806

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8178806](https://bugs.openjdk.org/browse/JDK-8178806): Better exception logging in crypto code


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12504/head:pull/12504` \
`$ git checkout pull/12504`

Update a local copy of the PR: \
`$ git checkout pull/12504` \
`$ git pull https://git.openjdk.org/jdk pull/12504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12504`

View PR using the GUI difftool: \
`$ git pr show -t 12504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12504.diff">https://git.openjdk.org/jdk/pull/12504.diff</a>

</details>
