### PR TITLE
6595142: (spec) ByteArrayInputStream treats bytes, not characters

### DIFF
--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -96,7 +96,7 @@ public class BufferedInputStream extends FilterInputStream {
 
     /**
      * The current position in the buffer. This is the index of the next
-     * character to be read from the {@code buf} array.
+     * byte to be read from the {@code buf} array.
      * <p>
      * This value is always in the range {@code 0}
      * through {@code count}. If it is less
@@ -297,7 +297,7 @@ public class BufferedInputStream extends FilterInputStream {
     }
 
     /**
-     * Read characters into a portion of an array, reading from the underlying
+     * Read bytes into a portion of an array, reading from the underlying
      * stream at most once if necessary.
      */
     private int read1(byte[] b, int off, int len) throws IOException {

--- a/src/java.base/share/classes/java/io/ByteArrayInputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayInputStream.java
@@ -56,7 +56,7 @@ public class ByteArrayInputStream extends InputStream {
     protected byte[] buf;
 
     /**
-     * The index of the next character to read from the input stream buffer.
+     * The index of the next byte to read from the input stream buffer.
      * This value should always be nonnegative
      * and not larger than the value of {@code count}.
      * The next byte to be read from the input stream buffer
@@ -80,7 +80,7 @@ public class ByteArrayInputStream extends InputStream {
     protected int mark = 0;
 
     /**
-     * The index one greater than the last valid character in the input
+     * The index one greater than the last valid byte in the input
      * stream buffer.
      * This value should always be nonnegative
      * and not larger than the length of {@code buf}.

--- a/src/java.base/share/classes/java/io/SequenceInputStream.java
+++ b/src/java.base/share/classes/java/io/SequenceInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -134,7 +134,7 @@ public class SequenceInputStream extends InputStream {
      * {@inheritDoc}
      * <p>
      * This method
-     * tries to read one character from the current substream. If it
+     * tries to read one byte from the current substream. If it
      * reaches the end of the stream, it calls the {@code close}
      * method of the current substream and begins reading from the next
      * substream.
@@ -163,7 +163,7 @@ public class SequenceInputStream extends InputStream {
      * <p>
      * The {@code read} method of {@code SequenceInputStream}
      * tries to read the data from the current substream. If it fails to
-     * read any characters because the substream has reached the end of
+     * read any bytes because the substream has reached the end of
      * the stream, it calls the {@code close} method of the current
      * substream and begins reading from the next substream.
      *


### PR DESCRIPTION
Replace the two occurrences of `character` with `byte`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6595142](https://bugs.openjdk.org/browse/JDK-6595142): (spec) ByteArrayInputStream treats bytes, not characters


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12505/head:pull/12505` \
`$ git checkout pull/12505`

Update a local copy of the PR: \
`$ git checkout pull/12505` \
`$ git pull https://git.openjdk.org/jdk pull/12505/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12505`

View PR using the GUI difftool: \
`$ git pr show -t 12505`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12505.diff">https://git.openjdk.org/jdk/pull/12505.diff</a>

</details>
