### PR TITLE
8302204: Optimize BigDecimal.divide

### DIFF
--- a/src/java.base/share/classes/java/math/BigDecimal.java
+++ b/src/java.base/share/classes/java/math/BigDecimal.java
@@ -4946,20 +4946,21 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
         int scaleStep;
         while (intVal.compareMagnitude(BigInteger.TEN) >= 0
                 && scale > preferredScale) {
-            if (intVal.testBit(0))
-                break; // odd number cannot end in 0
-            scaleStep = checkScale(intVal, Math.max(((long)scale - preferredScale) / 2, 1));
-            qr = intVal.divideAndRemainder(bigTenToThe(scaleStep));
-            if (qr[1].signum() != 0) {
-                if (scaleStep == 1) {
-                    break;
-                } else {
-                    preferredScale = scale - scaleStep;
+            scaleStep = checkScale(intVal, Math.max(((long) scale - preferredScale) / 2, 1));
+            if (intVal.getLowestSetBit() >= scaleStep) {
+                // intVal can be divided by pow(10, scaleStep) only if intVal has more trailing zeros than scaleStep
+                qr = intVal.divideAndRemainder(bigTenToThe(scaleStep));
+                if (qr[1].signum() == 0) {
+                    intVal = qr[0];
+                    scale = checkScale(intVal, (long) scale - scaleStep); // could Overflow
                     continue;
                 }
             }
-            intVal = qr[0];
-            scale = checkScale(intVal, (long) scale - scaleStep); // could Overflow
+            if (scaleStep == 1) {
+                break;
+            } else {
+                preferredScale = scale - scaleStep;
+            }
         }
         return valueOf(intVal, scale, 0);
     }


### PR DESCRIPTION
[JDK-8269667](https://bugs.openjdk.org/browse/JDK-8269667) has uncovered the poor performance of BigDecimal.divide under certain circumstance.

We confront similar situations when benchmarking Spark3 on TPC-DS test kit. According to the flame-graph below, it is StripZeros that spends most of the time of BigDecimal.divide. Hence we propose this patch to optimize stripping zeros.
![图片 1](https://user-images.githubusercontent.com/39413832/218062061-53cd0220-776e-4b72-8b9a-6b0f11707986.png)

Currently, createAndStripZerosToMatchScale() is performed linearly. That is, the target value is parsed from back to front, each time stripping out single ‘0’. To optimize, we can adopt the method of binary search. That is, each time we try to strip out ${scale/2} ‘0’s. 

The performance looks good. Therotically, time complexity of our method is O(log n), while the current one is O(n). In practice, benchmarks on Spark3 show that 1/3 less time (102s->68s) is spent on TPC-DS query4. We also runs Jtreg and JCK to check correctness, and it seems fine.

More about environment: 
we run Spark3.3.0 on Openjdk11, but it seems jdk version doesn’t have much impact on BigDecimal. Spark cluster consists of a main node and 2 core nodes, each has 4cores, 16g memory and 4x500GB storage.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302204](https://bugs.openjdk.org/browse/JDK-8302204): Optimize BigDecimal.divide (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12509/head:pull/12509` \
`$ git checkout pull/12509`

Update a local copy of the PR: \
`$ git checkout pull/12509` \
`$ git pull https://git.openjdk.org/jdk.git pull/12509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12509`

View PR using the GUI difftool: \
`$ git pr show -t 12509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12509.diff">https://git.openjdk.org/jdk/pull/12509.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12509#issuecomment-1425556195)