### PR TITLE
8302203: IR framework should detect non-compilable test methods early

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/AbstractTest.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/AbstractTest.java
@@ -116,12 +116,6 @@ abstract class AbstractTest {
 
     protected void compileMethod(DeclaredTest test) {
         final Method testMethod = test.getTestMethod();
-        TestRun.check(WHITE_BOX.isMethodCompilable(testMethod, test.getCompLevel().getValue(), false),
-                      "Method " + testMethod + " not compilable at level " + test.getCompLevel()
-                      + ". Did you use compileonly without including all @Test methods?");
-        TestRun.check(WHITE_BOX.isMethodCompilable(testMethod),
-                      "Method " + testMethod + " not compilable at level " + test.getCompLevel()
-                      + ". Did you use compileonly without including all @Test methods?");
         if (TestFramework.VERBOSE) {
             System.out.println("Compile method " + testMethod + " after warm-up...");
         }
@@ -163,7 +157,10 @@ abstract class AbstractTest {
     }
 
     private void enqueueMethodForCompilation(DeclaredTest test) {
-        TestVM.enqueueForCompilation(test.getTestMethod(), test.getCompLevel());
+        final Method testMethod = test.getTestMethod();
+        TestRun.check(WHITE_BOX.isMethodCompilable(testMethod, test.getCompLevel().getValue(), false),
+                      "Method " + testMethod + " not compilable (anymore) at level " + test.getCompLevel());
+        TestVM.enqueueForCompilation(testMethod, test.getCompLevel());
     }
 
     protected void checkCompilationLevel(DeclaredTest test) {


### PR DESCRIPTION
If a test method becomes non-compilable due to compilation bailouts, the IR framework will currently try to re-enqueue the method for compilation until the 10s timeout is reached (see log in bug report). Instead, we should check if the method became non-compilable and bail out immediately.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302203](https://bugs.openjdk.org/browse/JDK-8302203): IR framework should detect non-compilable test methods early


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12510/head:pull/12510` \
`$ git checkout pull/12510`

Update a local copy of the PR: \
`$ git checkout pull/12510` \
`$ git pull https://git.openjdk.org/jdk pull/12510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12510`

View PR using the GUI difftool: \
`$ git pr show -t 12510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12510.diff">https://git.openjdk.org/jdk/pull/12510.diff</a>

</details>
