### PR TITLE
8301701 : java/net/DatagramSocket/DatagramSocketMulticasting.java should be hardened

### DIFF
--- a/test/jdk/java/net/DatagramSocket/DatagramSocketMulticasting.java
+++ b/test/jdk/java/net/DatagramSocket/DatagramSocketMulticasting.java
@@ -320,7 +320,7 @@ public class DatagramSocketMulticasting {
         for (int i = 1; i <= MAX_TRIES; i++) {
             p = new DatagramPacket(new byte[1024], 100);
             s.receive(p);
-            String messageReceived = new String(p.getData(), 0, p.getLength());
+            String messageReceived = new String(p.getData(), 0, p.getLength(), "UTF-8");
 
             System.out.format(
                     "TestSendReceive iteration [%s], Received DatagramPacket [%s] from [%s]%n",
@@ -367,7 +367,7 @@ public class DatagramSocketMulticasting {
                 if (Arrays.equals(p.getData(), p.getOffset(), p.getLength(), message, 0, message.length)) {
                     throw new RuntimeException("message shouldn't have been received");
                 } else {
-                    String messageReceived = new String(p.getData(), 0, p.getLength());
+                    String messageReceived = new String(p.getData(), 0, p.getLength(), "UTF-8");
                     System.out.format("Received unexpected message %s from %s%n",
                             messageReceived, p.getSocketAddress());
                 }

--- a/test/jdk/java/net/DatagramSocket/DatagramSocketMulticasting.java
+++ b/test/jdk/java/net/DatagramSocket/DatagramSocketMulticasting.java
@@ -257,12 +257,12 @@ public class DatagramSocketMulticasting {
      */
     static void testTimeToLive(DatagramSocket s) throws IOException {
         // should be 1 by default
-        assertEquals(s.getOption(IP_MULTICAST_TTL), 1);
+        assertEquals(1, s.getOption(IP_MULTICAST_TTL));
 
         // setOption(IP_MULTICAST_TTL)
         for (int ttl = 0; ttl <= 2; ttl++) {
             s.setOption(IP_MULTICAST_TTL, ttl);
-            assertEquals(s.getOption(IP_MULTICAST_TTL), ttl);
+            assertEquals(ttl, s.getOption(IP_MULTICAST_TTL));
         }
 
         // bad values for IP_MULTICAST_TTL
@@ -333,7 +333,7 @@ public class DatagramSocketMulticasting {
                 break;
             }
 
-            assertNotEquals(i, MAX_TRIES, "testSendReceive: too many retries");
+            assertNotEquals(MAX_TRIES, i, "testSendReceive: too many retries");
         }
     }
 

--- a/test/jdk/java/net/DatagramSocket/DatagramSocketMulticasting.java
+++ b/test/jdk/java/net/DatagramSocket/DatagramSocketMulticasting.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
 
 import jdk.test.lib.NetworkConfiguration;
 import jdk.test.lib.net.IPSupport;
+import jtreg.SkippedException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -59,11 +60,8 @@ import static java.net.StandardSocketOptions.IP_MULTICAST_TTL;
 import static java.net.StandardSocketOptions.SO_REUSEADDR;
 import static jdk.test.lib.NetworkConfiguration.isSameInterface;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class DatagramSocketMulticasting {
@@ -72,7 +70,7 @@ public class DatagramSocketMulticasting {
 
     @Test
     public void main() throws IOException {
-        IPSupport.throwSkippedExceptionIfNonOperational();
+        assumeTrue(IPSupport.currentConfigurationIsValid(), "Invalid networking configuration");
 
         // IPv4 and IPv6 interfaces that support multicasting
         NetworkConfiguration config = NetworkConfiguration.probe();
@@ -143,13 +141,13 @@ public class DatagramSocketMulticasting {
         System.out.format("testJoinGroup2: local socket address: %s%n", s.getLocalSocketAddress());
 
         // check network interface not set
-        assertEquals(s.getOption(IP_MULTICAST_IF), null);
+        assertNull(s.getOption(IP_MULTICAST_IF));
 
         // join on default interface
         s.joinGroup(new InetSocketAddress(group, 0), null);
 
         // join should not change the outgoing multicast interface
-        assertEquals(s.getOption(IP_MULTICAST_IF), null);
+        assertNull(s.getOption(IP_MULTICAST_IF));
 
         // already a member (exception not specified)
         assertThrows(SocketException.class,
@@ -166,7 +164,7 @@ public class DatagramSocketMulticasting {
         s.joinGroup(new InetSocketAddress(group, 0), ni);
 
         // join should not change the outgoing multicast interface
-        assertEquals(s.getOption(IP_MULTICAST_IF), null);
+        assertNull(s.getOption(IP_MULTICAST_IF));
 
         // already a member (exception not specified)
         assertThrows(SocketException.class,
@@ -243,7 +241,7 @@ public class DatagramSocketMulticasting {
     static void testNetworkInterface(DatagramSocket s,
                                      NetworkInterface ni) throws IOException {
         // default value
-        assertEquals(s.getOption(IP_MULTICAST_IF), null);
+        assertNull(s.getOption(IP_MULTICAST_IF));
 
         // setOption(IP_MULTICAST_IF)
         s.setOption(IP_MULTICAST_IF, ni);
@@ -309,7 +307,7 @@ public class DatagramSocketMulticasting {
         System.out.println("testSendReceive");
 
         // outgoing multicast interface needs to be set
-        assertNotEquals(s.getOption(IP_MULTICAST_IF), null);
+        assertNotNull(s.getOption(IP_MULTICAST_IF));
 
         SocketAddress target = new InetSocketAddress(group, s.getLocalPort());
         byte[] message = "testSendReceive".getBytes("UTF-8");
@@ -343,7 +341,7 @@ public class DatagramSocketMulticasting {
         System.out.println("testSendNoReceive");
 
         // outgoing multicast interface needs to be set
-        assertNotEquals(s.getOption(IP_MULTICAST_IF), null);
+        assertNotNull(s.getOption(IP_MULTICAST_IF));
 
         SocketAddress target = new InetSocketAddress(group, s.getLocalPort());
         long nano = System.nanoTime();

--- a/test/jdk/java/net/DatagramSocket/DatagramSocketMulticasting.java
+++ b/test/jdk/java/net/DatagramSocket/DatagramSocketMulticasting.java
@@ -322,10 +322,14 @@ public class DatagramSocketMulticasting {
             s.receive(p);
             String messageReceived = new String(p.getData(), 0, p.getLength());
 
-            System.out.println(String.format("TestSendReceive iteration [%s], Received DatagramPacket [%s] from [%s]", i, messageReceived, s.getLocalSocketAddress()));
+            System.out.format(
+                    "TestSendReceive iteration [%s], Received DatagramPacket [%s] from [%s]%n",
+                    i, messageReceived, s.getLocalSocketAddress());
+
             if (s.getLocalPort() == p.getPort()) {
                 assertEquals(message, messageReceived,
-                        String.format("expected message %s, instead received %s%n", message, messageReceived));
+                        String.format("expected message %s, instead received %s%n",
+                                message, messageReceived));
                 break;
             }
 
@@ -364,7 +368,8 @@ public class DatagramSocketMulticasting {
                     throw new RuntimeException("message shouldn't have been received");
                 } else {
                     String messageReceived = new String(p.getData(), 0, p.getLength());
-                    System.out.format("Received unexpected message %s from %s%n", messageReceived,p.getSocketAddress());
+                    System.out.format("Received unexpected message %s from %s%n",
+                            messageReceived, p.getSocketAddress());
                 }
             } catch (SocketTimeoutException expected) {
                 break;


### PR DESCRIPTION
Updated `DatagramSocketMulticasting` to use Junit and also hardened the test to avoid occasional interference from other tests.

- Test now uses Junit Assertions, in general if the assertion used had been `assertTrue(foo==bar)` I replaced it with `assertEquals(foo,bar)` though there are some cases where I used `assertTrue` or `assertFalse`
- `testSendReceive` now retries up to 3 times if a message from an unexpected port is received
- Both `testSendReceive` and `testSendNoReceive` both have messages that use the methods name instead of just "hello"

Ran tiers 1-3 of tests as well as running this updated test to make sure it was stable

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301701](https://bugs.openjdk.org/browse/JDK-8301701): java/net/DatagramSocket/DatagramSocketMulticasting.java should be hardened


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12513/head:pull/12513` \
`$ git checkout pull/12513`

Update a local copy of the PR: \
`$ git checkout pull/12513` \
`$ git pull https://git.openjdk.org/jdk pull/12513/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12513`

View PR using the GUI difftool: \
`$ git pr show -t 12513`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12513.diff">https://git.openjdk.org/jdk/pull/12513.diff</a>

</details>
