### PR TITLE
8302152: Speed up tests with infinite loops, sleep less

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/TestCMoveWithDeadPhi.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestCMoveWithDeadPhi.java
@@ -67,6 +67,6 @@ public class TestCMoveWithDeadPhi {
         // Give thread some time to trigger compilation
         thread.setDaemon(true);
         thread.start();
-        Thread.sleep(Utils.adjustTimeout(4000));
+        Thread.sleep(Utils.adjustTimeout(500));
     }
 }

--- a/test/hotspot/jtreg/compiler/loopopts/TestCMoveWithDeadPhi.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestCMoveWithDeadPhi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/loopopts/TestInfLoopNearUsePlacement.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInfLoopNearUsePlacement.java
@@ -67,6 +67,6 @@ public class TestInfLoopNearUsePlacement {
         thread.setDaemon(true);
         thread.start();
         // Give thread some time to trigger compilation
-        Thread.sleep(Utils.adjustTimeout(5000));
+        Thread.sleep(Utils.adjustTimeout(500));
     }
 }

--- a/test/hotspot/jtreg/compiler/loopopts/TestInfLoopNearUsePlacement.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInfLoopNearUsePlacement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopCCP.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopCCP.java
@@ -72,6 +72,6 @@ public class TestInfiniteLoopCCP {
         // Give thread some time to trigger compilation
         thread.setDaemon(true);
         thread.start();
-        Thread.sleep(Utils.adjustTimeout(4000));
+        Thread.sleep(Utils.adjustTimeout(500));
     }
 }

--- a/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopCCP.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopCCP.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopNest.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopNest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopNest.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopNest.java
@@ -65,7 +65,7 @@ public class TestInfiniteLoopNest {
         // Give thread some time to trigger compilation
         thread.setDaemon(true);
         thread.start();
-        Thread.sleep(Utils.adjustTimeout(4000));
+        Thread.sleep(Utils.adjustTimeout(500));
     }
 
     static Boolean b;

--- a/test/hotspot/jtreg/compiler/loopopts/TestStrangeControl.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestStrangeControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/loopopts/TestStrangeControl.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestStrangeControl.java
@@ -47,6 +47,6 @@ public class TestStrangeControl {
         thread.setDaemon(true);
         thread.start();
         // Give thread executing strange control loop enough time to trigger OSR compilation
-        Thread.sleep(Utils.adjustTimeout(4000));
+        Thread.sleep(Utils.adjustTimeout(1000));
     }
 }


### PR DESCRIPTION
From over `5 sec` to about `0.8 sec`.

I simply reduced the `Thread.sleep`.

I verified that the same compilations still happen.
```
~/Documents/jtreg/bin/jtreg -va -s -jdk:/home/emanuel/Documents/fork5-jdk/build/linux-x64-debug/jdk/ -javaoptions:"-XX:CompileCommand=printcompilation,compiler.loopopts.TestInfLoopNearUsePlacement::test" /home/emanuel/Documents/fork5-jdk/open/test/hotspot/jtreg/compiler/loopopts/TestInfLoopNearUsePlacement.java

    283   32 % !   3       compiler.loopopts.TestInfLoopNearUsePlacement::test @ 39 (61 bytes)
    284   33 % !   4       compiler.loopopts.TestInfLoopNearUsePlacement::test @ 39 (61 bytes)
    286   34   !   4       compiler.loopopts.TestInfLoopNearUsePlacement::test (61 bytes)
```

On the time measurement that I got initially reported, this test was flagged as especially long-running, with `17 sec`. There may well be another issue, but I hope this fix already does the trick. We will see this in a while once I get the new data.

**Update**
Did the same for 4 more tests. Always ensured that we still have all compilations.

`TestStrangeControl.java` -> reduced from `5sec` to `2sec`. Needs sleep of `1sec` to ensure we still run all compilations as before.

`TestInfiniteLoopNest.java` -> reduced from `5sec` to `1.5sec`.

`TestInfiniteLoopCCP.java` -> reduced from `4.5sec` to `0.8sec`.

`TestCMoveWithDeadPhi.java` -> reduced from `4.3sec` to `0.8sec`.

I decided to keep the sleep time rather a bit higher than strictly required. in most of these cases `100ms` would have been sufficient on my machine already.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302152](https://bugs.openjdk.org/browse/JDK-8302152): Speed up tests with infinite loops, sleep less


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [9a904a33](https://git.openjdk.org/jdk/pull/12514/files/9a904a33d419dec56b3d348e70ca0943905a6011)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12514/head:pull/12514` \
`$ git checkout pull/12514`

Update a local copy of the PR: \
`$ git checkout pull/12514` \
`$ git pull https://git.openjdk.org/jdk pull/12514/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12514`

View PR using the GUI difftool: \
`$ git pr show -t 12514`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12514.diff">https://git.openjdk.org/jdk/pull/12514.diff</a>

</details>
