### PR TITLE
8302226 failure_handler native.core should wait for coredump to finish on linux

### DIFF
--- a/test/failure_handler/src/share/conf/linux.properties
+++ b/test/failure_handler/src/share/conf/linux.properties
@@ -54,8 +54,11 @@ native.stack.args.delimiter=\0
 native.stack.params.repeat=6
 
 # has to be the last command
-native.core.app=kill
-native.core.args=-ABRT %p
+native.core.app=bash
+# The below trick was found on https://stackoverflow.com/a/41613532
+native.core.args=-c\0kill -ABRT %p && tail --pid=%p -f /dev/null
+native.core.args.delimiter=\0
+native.core.timeout=600000
 
 cores=native.gdb
 native.gdb.app=gdb


### PR DESCRIPTION
Update open/test/failure_handler/src/share/conf/linux.properties to handle core dumps more correctly.