### PR TITLE
8040793: vmTestbase/nsk/monitoring/stress/lowmem fails on calling isCollectionUsageThresholdExceeded()

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -228,6 +228,10 @@ void DefNewGeneration::compute_space_boundaries(uintx minimum_eden_size,
   uintx size = _virtual_space.committed_size();
   uintx survivor_size = compute_survivor_size(size, SpaceAlignment);
   uintx eden_size = size - (2*survivor_size);
+  if (eden_size > max_eden_size()) {
+    eden_size = max_eden_size();
+    survivor_size = (size - eden_size)/2;
+  }
   assert(eden_size > 0 && survivor_size <= eden_size, "just checking");
 
   if (eden_size < minimum_eden_size) {


### PR DESCRIPTION
Fix a simple bug in Serial eden-resize logic by clamping it by its max value.

Test: observed two failures with 100 iterations of `vmTestbase/nsk/monitoring/stress/lowmem` before and no failures for 500 iterations afterwards.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8040793](https://bugs.openjdk.org/browse/JDK-8040793): vmTestbase/nsk/monitoring/stress/lowmem fails on calling isCollectionUsageThresholdExceeded()


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12516/head:pull/12516` \
`$ git checkout pull/12516`

Update a local copy of the PR: \
`$ git checkout pull/12516` \
`$ git pull https://git.openjdk.org/jdk pull/12516/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12516`

View PR using the GUI difftool: \
`$ git pr show -t 12516`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12516.diff">https://git.openjdk.org/jdk/pull/12516.diff</a>

</details>
