### PR TITLE
8207017: Type annotations on anonymous classes in initializer blocks not written to class file

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
@@ -1364,8 +1364,7 @@ public class TypeAnnotations {
                     newattrs.append(new Attribute.TypeCompound(old.type, old.values, pos));
                 }
             }
-
-            sym.owner.appendUniqueTypeAttributes(newattrs.toList());
+            appendTypeAnnotationsToOwner(sym, newattrs.toList());
         }
 
         @Override


### PR DESCRIPTION
Javac is not writing type annotations applied to anonymous classes inside of instance or static initializers. Basically for code like:

```
import java.lang.annotation.*;

class X {

    @Retention(RetentionPolicy.RUNTIME)
    @Target(ElementType.TYPE_USE)
    public @interface TA {
        String value() default "empty";
    }

    {
        class Local {}
        new @TA("LocalInstanceInitializerAnnonymous") Local() {};
    }

    static {
        class Local {}
        new @TA("LocalStaticAnnonymous") Local() {};
    }
}
```
not type annotations are generated as attributes of methods <init> or <clinit>. This PR is fixing this issue. The annotations are currently generated if the anonymous class is declared inside an instance or static method. The issue is only with initializers,

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8207017](https://bugs.openjdk.org/browse/JDK-8207017): Type annotations on anonymous classes in initializer blocks not written to class file


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12519/head:pull/12519` \
`$ git checkout pull/12519`

Update a local copy of the PR: \
`$ git checkout pull/12519` \
`$ git pull https://git.openjdk.org/jdk pull/12519/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12519`

View PR using the GUI difftool: \
`$ git pr show -t 12519`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12519.diff">https://git.openjdk.org/jdk/pull/12519.diff</a>

</details>
