### PR TITLE
8208470: Type annotations on inner type that is an array component

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
@@ -50,7 +50,6 @@ import com.sun.tools.javac.code.TypeAnnotationPosition.TypePathEntryKind;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Type.ModuleType;
-import com.sun.tools.javac.code.TypeMetadata.Entry.Kind;
 import com.sun.tools.javac.comp.Annotate;
 import com.sun.tools.javac.comp.Attr;
 import com.sun.tools.javac.comp.AttrContext;
@@ -448,7 +447,7 @@ public class TypeAnnotations {
             }
 
             if (type.hasTag(TypeTag.ARRAY))
-                return rewriteArrayType((ArrayType)type, annotations, pos);
+                return rewriteArrayType(typetree, (ArrayType)type, annotations, onlyTypeAnnotations, pos);
 
             if (type.hasTag(TypeTag.TYPEVAR)) {
                 return type.annotatedType(onlyTypeAnnotations);
@@ -557,54 +556,22 @@ public class TypeAnnotations {
          *
          * SIDE EFFECT: Update position for the annotations to be {@code pos}.
          */
-        private Type rewriteArrayType(ArrayType type, List<TypeCompound> annotations, TypeAnnotationPosition pos) {
-            ArrayType tomodify = new ArrayType(type);
-            if (type.isVarargs()) {
-                tomodify = tomodify.makeVarargs();
-            }
-            ArrayType res = tomodify;
-
-            List<TypePathEntry> loc = List.nil();
-
-            // peel one and update loc
-            Type tmpType = type.elemtype;
-            loc = loc.prepend(TypePathEntry.ARRAY);
-
-            while (tmpType.hasTag(TypeTag.ARRAY)) {
-                ArrayType arr = (ArrayType)tmpType;
-
-                // Update last type with new element type
-                ArrayType tmp = new ArrayType(arr);
-                tomodify.elemtype = tmp;
-                tomodify = tmp;
-
-                tmpType = arr.elemtype;
-                loc = loc.prepend(TypePathEntry.ARRAY);
-            }
-
-            // Fix innermost element type
-            Type elemType;
-            if (tmpType.getMetadata() != null) {
-                List<TypeCompound> tcs;
-                if (tmpType.getAnnotationMirrors().isEmpty()) {
-                    tcs = annotations;
-                } else {
-                    // Special case, lets prepend
-                    tcs =  annotations.appendList(tmpType.getAnnotationMirrors());
-                }
-                elemType = tmpType.cloneWithMetadata(tmpType
-                        .getMetadata()
-                        .without(Kind.ANNOTATIONS)
-                        .combine(new TypeMetadata.Annotations(tcs)));
-            } else {
-                elemType = tmpType.cloneWithMetadata(new TypeMetadata(new TypeMetadata.Annotations(annotations)));
-            }
-            tomodify.elemtype = elemType;
+        private Type rewriteArrayType(JCTree typetree, ArrayType type, List<TypeCompound> annotations,
+                                      List<Attribute.TypeCompound> onlyTypeAnnotations, TypeAnnotationPosition pos) {
+            ArrayType res = new ArrayType(type);
 
             // Update positions
-            pos.location = loc;
+            pos.location = pos.location.append(TypePathEntry.ARRAY);
 
+            res.elemtype = typeWithAnnotations(arrayElemTypeTree(typetree), type.elemtype, annotations, onlyTypeAnnotations, pos);
             return res;
+        }
+
+        private JCTree arrayElemTypeTree(JCTree typetree) {
+            if (typetree.getKind() == JCTree.Kind.ANNOTATED_TYPE) {
+                typetree = ((JCAnnotatedType) typetree).underlyingType;
+            }
+            return ((JCArrayTypeTree) typetree).elemtype;
         }
 
         /** Return a copy of the first type that only differs by

--- a/test/langtools/tools/javac/annotations/typeAnnotations/referenceinfos/Driver.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/referenceinfos/Driver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -235,8 +235,10 @@ public class Driver {
                               || compact.contains(" class"))
                             && !compact.contains("interface")
                             && !compact.contains("enum");
-        if (isSnippet)
+        if (isSnippet) {
             sb.append("class %TEST_CLASS_NAME% {\n");
+            sb.append("class Nested {}\n");
+        }
 
         sb.append(compact);
         sb.append("\n");

--- a/test/langtools/tools/javac/annotations/typeAnnotations/referenceinfos/Fields.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/referenceinfos/Fields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,8 +21,6 @@
  * questions.
  */
 
-import static com.sun.tools.classfile.TypeAnnotation.TargetType.*;
-
 /*
  * @test
  * @bug 8042451
@@ -31,6 +29,9 @@ import static com.sun.tools.classfile.TypeAnnotation.TargetType.*;
  * @compile -g Driver.java ReferenceInfoUtil.java Fields.java
  * @run main Driver Fields
  */
+
+import static com.sun.tools.classfile.TypeAnnotation.TargetType.*;
+
 public class Fields {
     // field types
     @TADescription(annotation = "TA", type = FIELD)
@@ -61,6 +62,26 @@ public class Fields {
             genericLocation = { 0, 0, 0, 0 })
     public String fieldAsArray() {
         return "@TC String @TA [] @TB [] test;";
+    }
+
+    @TADescription(annotation = "TA", type = FIELD)
+    @TADescription(annotation = "TB", type = FIELD,
+            genericLocation = { 0, 0 })
+    @TADescription(annotation = "TC", type = FIELD,
+            genericLocation = { 0, 0, 0, 0, 1, 0})
+    public String fieldAsNestedArray1() {
+        return "@TC Nested @TA [] @TB [] test;";
+    }
+
+    @TADescription(annotation = "TA", type = FIELD)
+    @TADescription(annotation = "TB", type = FIELD,
+            genericLocation = { 0, 0 })
+    @TADescription(annotation = "TC", type = FIELD,
+            genericLocation = { 0, 0, 0, 0, 1, 0})
+    @TADescription(annotation = "TD", type = FIELD,
+            genericLocation = { 0, 0, 0, 0 })
+    public String fieldAsNestedArray2() {
+        return "@TD %TEST_CLASS_NAME%. @TC Nested @TA [] @TB [] test;";
     }
 
     @TADescription(annotation = "TA", type = FIELD)

--- a/test/langtools/tools/javac/annotations/typeAnnotations/referenceinfos/Fields.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/referenceinfos/Fields.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8042451
+ * @bug 8042451 8208470
  * @summary Test population of reference info for field
  * @modules jdk.jdeps/com.sun.tools.classfile
  * @compile -g Driver.java ReferenceInfoUtil.java Fields.java

--- a/test/langtools/tools/javac/warnings/6747671/T6747671.out
+++ b/test/langtools/tools/javac/warnings/6747671/T6747671.out
@@ -7,6 +7,6 @@ T6747671.java:29:28: compiler.warn.raw.class.use: T6747671.B, T6747671.B<X>
 T6747671.java:32:9: compiler.warn.raw.class.use: T6747671.A, T6747671<E>.A<X>
 T6747671.java:32:20: compiler.warn.raw.class.use: T6747671.A, T6747671<E>.A<X>
 T6747671.java:33:16: compiler.warn.raw.class.use: T6747671.A.Z, T6747671<E>.A<X>.Z<Y>
-T6747671.java:36:9: compiler.warn.raw.class.use: T6747671.B, T6747671.B<X>
+T6747671.java:36:9: compiler.warn.raw.class.use: @T6747671.TA T6747671.B, T6747671.B<X>
 T6747671.java:36:27: compiler.warn.raw.class.use: T6747671.B, T6747671.B<X>
 11 warnings


### PR DESCRIPTION
As stated in the bug great description by Werner D.:

Considering this example:
```
import java.lang.annotation.ElementType;
import java.lang.annotation.Retention;
import java.lang.annotation.RetentionPolicy;
import java.lang.annotation.Target;

@Retention(RetentionPolicy.RUNTIME)
@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
@interface TA {
  int value();
}

class ArrayOfInner {
  class Inner {}

  @TA(1) ArrayOfInner. @TA(2) Inner oi;
  @TA(3) ArrayOfInner. @TA(4) Inner [] oia;
  @TA(5) Inner i;
  @TA(6) Inner [] ia;
}
```
If compiled with javac 8, according to javap -v field ia has the annotation:
```
  ArrayOfInner$Inner[] ia;
    descriptor: [LArrayOfInner$Inner;
    flags: (0x0000)
    RuntimeVisibleTypeAnnotations:
      0: #10(#11=I#21): FIELD, location=[ARRAY, INNER_TYPE]
        TA(
          value=6
        )
```
if compiled with javac > 8 ia has the annotation:
```
  ArrayOfInner$Inner[] ia;
    descriptor: [LArrayOfInner$Inner;
    flags: (0x0000)
    RuntimeVisibleTypeAnnotations:
      0: #10(#11=I#21): FIELD, location=[ARRAY]
        TA(
          value=6
        )
```
Note the missing `INNER_TYPE` location. This PR is re-establishing the Java 8 behavior.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8208470](https://bugs.openjdk.org/browse/JDK-8208470): Type annotations on inner type that is an array component


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Contributors
 * Bernard Blaser `<bsrbnd@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12522/head:pull/12522` \
`$ git checkout pull/12522`

Update a local copy of the PR: \
`$ git checkout pull/12522` \
`$ git pull https://git.openjdk.org/jdk pull/12522/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12522`

View PR using the GUI difftool: \
`$ git pr show -t 12522`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12522.diff">https://git.openjdk.org/jdk/pull/12522.diff</a>

</details>
