### PR TITLE
8301374: NullPointerException in MemberEnter.checkReceiver

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3723,8 +3723,9 @@ public class JavacParser implements Parser {
                 JCExpression pn = qualident(false);
                 if (pn.hasTag(Tag.IDENT) && ((JCIdent)pn).name != names._this) {
                     name = ((JCIdent)pn).name;
-                } else if (lambdaParameter) {
+                } else if (lambdaParameter && type == null) {
                     // we have a lambda parameter that is not an identifier this is a syntax error
+                    type = pn;
                     name = names.empty;
                     reportSyntaxError(pos, Errors.Expected(IDENTIFIER));
                 } else {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3723,6 +3723,10 @@ public class JavacParser implements Parser {
                 JCExpression pn = qualident(false);
                 if (pn.hasTag(Tag.IDENT) && ((JCIdent)pn).name != names._this) {
                     name = ((JCIdent)pn).name;
+                } else if (lambdaParameter) {
+                    // we have a lambda parameter that is not an identifier this is a syntax error
+                    name = names.empty;
+                    reportSyntaxError(pos, Errors.Expected(IDENTIFIER));
                 } else {
                     if (allowThisIdent) {
                         if ((mods.flags & Flags.VARARGS) != 0) {

--- a/test/langtools/tools/javac/lambda/8131742/T8131742.java
+++ b/test/langtools/tools/javac/lambda/8131742/T8131742.java
@@ -1,9 +1,17 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 8131742
+ * @bug 8131742 8301374
  * @summary Syntactically meaningless code accepted by javac
  * @compile/fail/ref=T8131742.out -XDrawDiagnostics T8131742.java
  */
 class T8131742 {
     static Runnable r = (__GAR BAGE__.this) -> { };
+
+    interface F {
+        void apply(E e);
+    }
+    enum E {
+        ONE
+    }
+    F f = (E.ONE) -> {};
 }

--- a/test/langtools/tools/javac/lambda/8131742/T8131742.out
+++ b/test/langtools/tools/javac/lambda/8131742/T8131742.out
@@ -1,2 +1,4 @@
 T8131742.java:8:39: compiler.err.this.as.identifier
-1 error
+T8131742.java:8:32: compiler.err.expected: token.identifier
+T8131742.java:16:12: compiler.err.expected: token.identifier
+3 errors

--- a/test/langtools/tools/javac/lambda/8131742/T8131742.out
+++ b/test/langtools/tools/javac/lambda/8131742/T8131742.out
@@ -1,4 +1,3 @@
 T8131742.java:8:39: compiler.err.this.as.identifier
-T8131742.java:8:32: compiler.err.expected: token.identifier
 T8131742.java:16:12: compiler.err.expected: token.identifier
-3 errors
+2 errors


### PR DESCRIPTION
the following incorrect code is crashing javac:
```
public class X {
  interface F {
    void apply(E e);
  }
  enum E {
    ONE
  }

  F f = (E.ONE) -> {};   // E.ONE?
}
```
there are several issues the incorrect argument to this lambda expression. The proposed solution is to issue a syntax error for the missing parameter name. IMO, this error message would be correct here and this way the compiler fails fast instead of having to deal with an erroneous lambda later on to avoid a crash like the one we have now,

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301374](https://bugs.openjdk.org/browse/JDK-8301374): NullPointerException in MemberEnter.checkReceiver


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12523/head:pull/12523` \
`$ git checkout pull/12523`

Update a local copy of the PR: \
`$ git checkout pull/12523` \
`$ git pull https://git.openjdk.org/jdk pull/12523/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12523`

View PR using the GUI difftool: \
`$ git pr show -t 12523`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12523.diff">https://git.openjdk.org/jdk/pull/12523.diff</a>

</details>
