### PR TITLE
8302267: [jittester] Improve separation of test generation and execution

### DIFF
--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/Automatic.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/Automatic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,12 +24,6 @@
 package jdk.test.lib.jittester;
 
 import jdk.test.lib.util.Pair;
-import jdk.test.lib.jittester.factories.IRNodeBuilder;
-import jdk.test.lib.jittester.types.TypeKlass;
-import jdk.test.lib.jittester.utils.FixedTrees;
-import jdk.test.lib.jittester.utils.OptionResolver;
-import jdk.test.lib.jittester.utils.OptionResolver.Option;
-import jdk.test.lib.jittester.utils.PseudoRandom;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -38,56 +32,6 @@ import java.util.function.Function;
 
 public class Automatic {
     public static final int MINUTES_TO_WAIT = Integer.getInteger("jdk.test.lib.jittester", 3);
-
-    private static Pair<IRNode, IRNode> generateIRTree(String name) {
-        SymbolTable.removeAll();
-        TypeList.removeAll();
-
-        IRNodeBuilder builder = new IRNodeBuilder()
-                .setPrefix(name)
-                .setName(name)
-                .setLevel(0);
-
-        Long complexityLimit = ProductionParams.complexityLimit.value();
-        IRNode privateClasses = null;
-        if (!ProductionParams.disableClasses.value()) {
-            long privateClassComlexity = (long) (complexityLimit * PseudoRandom.random());
-            try {
-                privateClasses = builder.setComplexityLimit(privateClassComlexity)
-                        .getClassDefinitionBlockFactory()
-                        .produce();
-            } catch (ProductionFailedException ex) {
-                ex.printStackTrace(System.out);
-            }
-        }
-        long mainClassComplexity = (long) (complexityLimit * PseudoRandom.random());
-        IRNode mainClass = null;
-        try {
-            mainClass = builder.setComplexityLimit(mainClassComplexity)
-                    .getMainKlassFactory()
-                    .produce();
-            TypeKlass aClass = new TypeKlass(name);
-            mainClass.getChild(1).addChild(FixedTrees.generateMainOrExecuteMethod(aClass, true));
-            mainClass.getChild(1).addChild(FixedTrees.generateMainOrExecuteMethod(aClass, false));
-        } catch (ProductionFailedException ex) {
-            ex.printStackTrace(System.out);
-        }
-        return new Pair<>(mainClass, privateClasses);
-    }
-
-    private static void initializeTestGenerator(String[] params) {
-        OptionResolver parser = new OptionResolver();
-        Option<String> propertyFileOpt = parser.addStringOption('p', "property-file",
-                "conf/default.properties", "File to read properties from");
-        ProductionParams.register(parser);
-        parser.parse(params, propertyFileOpt);
-        PseudoRandom.reset(ProductionParams.seed.value());
-        TypesParser.parseTypesAndMethods(ProductionParams.classesFile.value(),
-                ProductionParams.excludeMethodsFile.value());
-        if (ProductionParams.specificSeed.isSet()) {
-            PseudoRandom.setCurrentSeed(ProductionParams.specificSeed.value());
-        }
-    }
 
     private static List<TestsGenerator> getTestGenerators() {
         List<TestsGenerator> result = new ArrayList<>();
@@ -108,7 +52,7 @@ public class Automatic {
     }
 
     public static void main(String[] args) {
-        initializeTestGenerator(args);
+        IRTreeGenerator.initializeFromCmdlineArgs(args);
         int counter = 0;
         System.out.printf("Generating %d tests...%n",  ProductionParams.numberOfTests.value());
         System.out.printf(" %13s | %8s | %8s | %8s |%n", "start time", "count", "generat",
@@ -119,7 +63,7 @@ public class Automatic {
             double start = System.currentTimeMillis();
             System.out.print("[" + LocalTime.now() + "] |");
             String name = "Test_" + counter;
-            Pair<IRNode, IRNode> irTree = generateIRTree(name);
+            Pair<IRNode, IRNode> irTree = IRTreeGenerator.generateIRTree(name);
             System.out.printf(" %8d |", counter);
             long maxWaitTime = TimeUnit.MINUTES.toMillis(MINUTES_TO_WAIT);
             double generationTime = System.currentTimeMillis() - start;

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ByteCodeGenerator.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ByteCodeGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,20 +30,22 @@ import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.function.Function;
 
 /**
  * Generates class files from IRTree
  */
-class ByteCodeGenerator extends TestsGenerator {
-    private static final String DEFAULT_SUFFIX = "bytecode_tests";
+public class ByteCodeGenerator extends TestsGenerator {
+    public static final String DEFAULT_SUFFIX = "bytecode_tests";
 
-    ByteCodeGenerator() {
-        super(DEFAULT_SUFFIX, s -> new String[0], "-Xcomp");
+    protected final HeaderFormatter headerFormatter;
+
+    protected ByteCodeGenerator() {
+        this(new HeaderFormatter.Builder().build());
     }
 
-    ByteCodeGenerator(String suffix, Function<String, String[]> preRunActions, String jtDriverOptions) {
-        super(suffix, preRunActions, jtDriverOptions);
+    protected ByteCodeGenerator(HeaderFormatter headerFormatter) {
+        super(DEFAULT_SUFFIX);
+        this.headerFormatter = headerFormatter;
     }
 
     @Override
@@ -56,10 +58,10 @@ class ByteCodeGenerator extends TestsGenerator {
 
     private void generateSeparateJtregHeader(IRNode mainClass) {
         String mainClassName = mainClass.getName();
-        writeFile(generatorDir, mainClassName + ".java", getJtregHeader(mainClassName));
+        writeFile(generatorDir, mainClassName + ".java", headerFormatter.getJtregHeader(mainClassName));
     }
 
-    private void generateClassFiles(IRNode mainClass, IRNode privateClasses) {
+    protected void generateClassFiles(IRNode mainClass, IRNode privateClasses) {
         String mainClassName = mainClass.getName();
         ensureExisting(generatorDir);
         try {

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ErrorTolerance.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ErrorTolerance.java
@@ -50,6 +50,8 @@ public class ErrorTolerance {
 
     private static final Predicate<String> OOME = Pattern.compile(
             "Exception in thread \".*\" java.lang.OutOfMemoryError.*").asPredicate();
+    private static final Predicate<String> SOE = Pattern.compile(
+            ".*StackOverFlowError.*").asPredicate();
 
     private static boolean isIntrinsicCandidate(String line) {
         return PATTERNS.stream()
@@ -64,10 +66,6 @@ public class ErrorTolerance {
             while (goldIt.hasNext() && runIt.hasNext()) {
                 String goldLine = goldIt.next();
                 String runLine = runIt.next();
-
-                if (OOME.test(goldLine)) {
-                    return;     // OOMEs are simply ignored.
-                }
 
                 // Skipping intrinsics in 'run'
                 while (isIntrinsicCandidate(goldLine) &&
@@ -94,5 +92,9 @@ public class ErrorTolerance {
         } catch (IOException e) {
             throw new Error("Could not compare files: '" + comparisonNames);
         }
+    }
+
+    public static boolean isReliable(Stream<String> gold) {
+        return !gold.anyMatch(line -> OOME.test(line) || SOE.test(line));
     }
 }

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ErrorTolerance.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ErrorTolerance.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib.jittester;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import jdk.test.lib.Asserts;
+
+/**
+  * Compares reference output to the one that's being verified.
+  *
+  * The class can tolerate some errors (like OutOfMemoryError),
+  * as their nature is unpredictable and ignore missing intrinsics in
+  * compiled code stack traces.
+  */
+public class ErrorTolerance {
+
+    // Put the most annoying intrinsics here
+    private static final List<Predicate<String>> PATTERNS = List.of(
+        Pattern.compile(".*at java.base.*misc.Unsafe.allocateUninitializedArray0.*").asPredicate()
+    );
+
+    private static final Predicate<String> OOME = Pattern.compile(
+            "Exception in thread \".*\" java.lang.OutOfMemoryError.*").asPredicate();
+
+    private static boolean isIntrinsicCandidate(String line) {
+        return PATTERNS.stream()
+                       .map(pattern -> pattern.test(line))
+                       .reduce(false, (acc, match) -> acc | match);
+    }
+
+    public static void assertIsAcceptable(String message, Stream<String> gold, Stream<String> run) {
+            Iterator<String> goldIt = gold.iterator();
+            Iterator<String> runIt = run.iterator();
+
+            while (goldIt.hasNext() && runIt.hasNext()) {
+                String goldLine = goldIt.next();
+                String runLine = runIt.next();
+
+                if (OOME.test(goldLine)) {
+                    return;     // OOMEs are simply ignored.
+                }
+
+                // Skipping intrinsics in 'run'
+                while (isIntrinsicCandidate(goldLine) &&
+                       !runLine.equals(goldLine) &&
+                       goldIt.hasNext()) {
+                    goldLine = goldIt.next();
+                }
+
+                if (!goldLine.equals(runLine)) {
+                    String fullMessage = "While " + message + ":\n" +
+                                         "Expected: " + goldLine + "\n" +
+                                         "Actual  : " + runLine + "\n";
+                    Asserts.fail(fullMessage);
+                }
+            }
+            Asserts.assertEquals(goldIt.hasNext(), runIt.hasNext(), message + ": files are different");
+    }
+
+    public static void assertIsAcceptable(Path gold, Path run) {
+        String comparisonNames = "'" + gold + "' and '" + run + "'";
+        try {
+            assertIsAcceptable("comparing files " + comparisonNames,
+                    Files.lines(gold), Files.lines(run));
+        } catch (IOException e) {
+            throw new Error("Could not compare files: '" + comparisonNames);
+        }
+    }
+}

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/HeaderFormatter.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/HeaderFormatter.java
@@ -39,6 +39,7 @@ public final class HeaderFormatter {
         private String jtDriverOptions = "-Xcomp";
         private String libraries = "/ ../";
         private boolean printJitTesterHierarchy = true;
+        private boolean buildPrinter = true;
 
         public Builder preRunActions(Function<String, String[]> from) {
             preRunActions = from;
@@ -60,6 +61,11 @@ public final class HeaderFormatter {
             return this;
         }
 
+        public Builder buildPrinter(boolean from) {
+            buildPrinter = false;
+            return this;
+        }
+
         public HeaderFormatter build() {
             return new HeaderFormatter(this);
         }
@@ -76,14 +82,14 @@ public final class HeaderFormatter {
         header.append("/*\n * @test\n * @summary ")
               .append(synopsis)
               .append(" \n * @library " + builder.libraries + "\n");
-        header.append(" * @run build jdk.test.lib.jittester.jtreg.JitTesterDriver "
-                        + "jdk.test.lib.jittester.jtreg.Printer\n");
-        for (String action : builder.preRunActions.apply(mainClassName)) {
+       header.append(" * @run build jdk.test.lib.jittester.jtreg.JitTesterDriver"
+                        + (builder.buildPrinter ? " jdk.test.lib.jittester.jtreg.Printer\n" : "\n"));
+       for (String action : builder.preRunActions.apply(mainClassName)) {
             header.append(" * ")
                   .append(action)
                   .append("\n");
         }
-        header.append(" * @run driver jdk.test.lib.jittester.jtreg.JitTesterDriver ")
+        header.append(" * @run driver/timeout=180 jdk.test.lib.jittester.jtreg.JitTesterDriver ")
               .append(DISABLE_WARNINGS)
               .append(" ")
               .append(builder.jtDriverOptions)

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/HeaderFormatter.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/HeaderFormatter.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib.jittester;
+
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import jdk.test.lib.jittester.types.TypeKlass;
+import jdk.test.lib.jittester.utils.PseudoRandom;
+
+public final class HeaderFormatter {
+    public static final String DISABLE_WARNINGS = "-XX:-PrintWarnings";
+
+    private final Builder builder;
+
+    public static class Builder {
+        private Function<String, String[]>  preRunActions = s -> new String[0];
+        private String jtDriverOptions = "-Xcomp";
+        private String libraries = "/ ../";
+        private boolean printJitTesterHierarchy = true;
+
+        public Builder preRunActions(Function<String, String[]> from) {
+            preRunActions = from;
+            return this;
+        }
+
+        public Builder jtDriverOptions(String from) {
+            jtDriverOptions = from;
+            return this;
+        }
+
+        public Builder libraries(String from) {
+            libraries = from;
+            return this;
+        }
+
+        public Builder printJitTesterHierarchy(boolean from) {
+            printJitTesterHierarchy = from;
+            return this;
+        }
+
+        public HeaderFormatter build() {
+            return new HeaderFormatter(this);
+        }
+    }
+
+    private HeaderFormatter(Builder builder) {
+        this.builder = builder;
+    }
+
+    public  String getJtregHeader(String mainClassName) {
+        String synopsis = "seed = '" + ProductionParams.seed.value() + "'"
+                + ", specificSeed = '" + PseudoRandom.getCurrentSeed() + "'";
+        StringBuilder header = new StringBuilder();
+        header.append("/*\n * @test\n * @summary ")
+              .append(synopsis)
+              .append(" \n * @library " + builder.libraries + "\n");
+        header.append(" * @run build jdk.test.lib.jittester.jtreg.JitTesterDriver "
+                        + "jdk.test.lib.jittester.jtreg.Printer\n");
+        for (String action : builder.preRunActions.apply(mainClassName)) {
+            header.append(" * ")
+                  .append(action)
+                  .append("\n");
+        }
+        header.append(" * @run driver jdk.test.lib.jittester.jtreg.JitTesterDriver ")
+              .append(DISABLE_WARNINGS)
+              .append(" ")
+              .append(builder.jtDriverOptions)
+              .append(" ")
+              .append(mainClassName)
+              .append("\n */\n\n");
+        if (ProductionParams.printHierarchy.value() && builder.printJitTesterHierarchy) {
+            header.append("/*\n")
+                  .append(printHierarchy())
+                  .append("*/\n");
+        }
+        return header.toString();
+    }
+
+    private static String printHierarchy() {
+        return TypeList.getAll()
+                .stream()
+                .filter(t -> t instanceof TypeKlass)
+                .map(t -> typeDescription((TypeKlass) t))
+                .collect(Collectors.joining("\n", "CLASS HIERARCHY:\n", "\n"));
+    }
+
+    private static String typeDescription(TypeKlass type) {
+        StringBuilder result = new StringBuilder();
+        String parents = type.getParentsNames().stream().collect(Collectors.joining(","));
+        result.append(type.isAbstract() ? "abstract " : "")
+              .append(type.isFinal() ? "final " : "")
+              .append(type.isInterface() ? "interface " : "class ")
+              .append(type.getName())
+              .append(parents.isEmpty() ? "" : ": " + parents);
+        return result.toString();
+    }
+
+}

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/IRTreeGenerator.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/IRTreeGenerator.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib.jittester;
+
+import java.util.concurrent.locks.ReentrantLock;
+
+import jdk.test.lib.util.Pair;
+
+import jdk.test.lib.jittester.factories.IRNodeBuilder;
+import jdk.test.lib.jittester.types.TypeKlass;
+import jdk.test.lib.jittester.utils.FixedTrees;
+import jdk.test.lib.jittester.utils.OptionResolver;
+import jdk.test.lib.jittester.utils.OptionResolver.Option;
+import jdk.test.lib.jittester.utils.PseudoRandom;
+
+public class IRTreeGenerator {
+    private static final ReentrantLock LOCK = new ReentrantLock();
+
+    public static boolean tryLock() {
+        return LOCK.tryLock();
+    }
+
+    public static void unlock() {
+        LOCK.unlock();
+    }
+
+    public static Pair<IRNode, IRNode> generateIRTree(String name) {
+        ProductionLimiter.resetTimer();
+        //NB: SymbolTable is a widely-used singleton, hence all the locking.
+        SymbolTable.removeAll();
+        TypeList.removeAll();
+
+        IRNodeBuilder builder = new IRNodeBuilder()
+                .setPrefix(name)
+                .setName(name)
+                .setLevel(0);
+
+        Long complexityLimit = ProductionParams.complexityLimit.value();
+        IRNode privateClasses = null;
+        if (!ProductionParams.disableClasses.value()) {
+            long privateClassComlexity = (long) (complexityLimit * PseudoRandom.random());
+            try {
+                privateClasses = builder.setComplexityLimit(privateClassComlexity)
+                        .getClassDefinitionBlockFactory()
+                        .produce();
+            } catch (ProductionFailedException ex) {
+                ex.printStackTrace(System.out);
+            }
+        }
+        long mainClassComplexity = (long) (complexityLimit * PseudoRandom.random());
+        IRNode mainClass = null;
+        try {
+            mainClass = builder.setComplexityLimit(mainClassComplexity)
+                    .getMainKlassFactory()
+                    .produce();
+            TypeKlass aClass = new TypeKlass(name);
+            mainClass.getChild(1).addChild(FixedTrees.generateMainOrExecuteMethod(aClass, true));
+            mainClass.getChild(1).addChild(FixedTrees.generateMainOrExecuteMethod(aClass, false));
+        } catch (ProductionFailedException ex) {
+            ex.printStackTrace(System.out);
+        }
+        return new Pair<IRNode, IRNode>(mainClass, privateClasses);
+    }
+
+    public static void initializeFromCmdlineArgs(String[] args) {
+        OptionResolver parser = new OptionResolver();
+        Option<String> propertyFileOpt = parser.addStringOption('p', "property-file",
+                "conf/default.properties", "File to read properties from");
+        ProductionParams.register(parser);
+        parser.parse(args, propertyFileOpt);
+        PseudoRandom.reset(ProductionParams.seed.value());
+        TypesParser.parseTypesAndMethods(ProductionParams.classesFile.value(),
+                ProductionParams.excludeMethodsFile.value());
+        if (ProductionParams.specificSeed.isSet()) {
+            PseudoRandom.setCurrentSeed(ProductionParams.specificSeed.value());
+        }
+    }
+
+}

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/Phase.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/Phase.java
@@ -27,7 +27,7 @@ public enum Phase {
     GENERATE(300, "generate"),
     COMPILE(300, "javac"),
     GOLD_RUN(70, "gold"),
-    RUN(90, "run"),
+    RUN(120, "run"),
     IGNORE(10, "ignore");
 
     public final int timeoutSeconds;

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/Phase.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/Phase.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib.jittester;
+
+public enum Phase {
+    GENERATE(300, "generate"),
+    COMPILE(300, "javac"),
+    GOLD_RUN(70, "gold"),
+    RUN(90, "run"),
+    IGNORE(10, "ignore");
+
+    public final int timeoutSeconds;
+    public final String suffix;
+
+    private Phase(int timeoutSeconds, String suffix) {
+        this.timeoutSeconds = timeoutSeconds;
+        this.suffix = suffix;
+    }
+}

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ProcessRunner.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ProcessRunner.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib.jittester;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.BufferedWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+public class ProcessRunner {
+
+    private static boolean waitForProcess(Process process, long timeoutSeconds) {
+        long now = System.currentTimeMillis();
+        long end = now + timeoutSeconds * 1000;
+        do {
+            try {
+                if (process.waitFor(end - now, TimeUnit.MILLISECONDS)) {
+                    return true;
+                }
+            } catch (InterruptedException ignored) {
+            }
+            now = System.currentTimeMillis();
+        } while (process.isAlive() && (now < end));
+
+        process.destroyForcibly();
+        return false;
+    }
+
+    private static String escapeString(String src) {
+        StringBuilder sb = new StringBuilder();
+
+        src.chars().forEachOrdered(code -> {
+            if  ((code >= 32) && (code <= 126) && (code != 92) || (code == 9)) {
+                // From space to ~ and tabs, excluding \ which is needed for escapes
+                sb.append((char) code);
+            } else {
+                // All unreadable, encoding-dependent and \ are escaped
+                sb.append("\\u" + String.format("%04X", code));
+            }
+        });
+
+        return sb.toString();
+    }
+
+    private static void escapeRawFileContents(String name) throws IOException {
+        Path rawPath = Path.of(name + ".utf8");
+        Path escPath = Path.of(name);
+
+        try (BufferedWriter writer = Files.newBufferedWriter(
+                    escPath, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+                Stream<String> lines = Files.lines(rawPath)) {
+            lines.map(ProcessRunner::escapeString).forEachOrdered(line -> {
+                try {
+                    writer.write(line);
+                    writer.newLine();
+                } catch (IOException e) {
+                    throw new Error("Can't write file " + escPath);
+                }
+            });
+            writer.flush();
+        }
+    }
+
+    public static int runProcess(ProcessBuilder pb, String name, Phase phase)
+            throws IOException, InterruptedException {
+        final String nameAndPhase = name + "." + phase.suffix;
+        pb.redirectError(new File(nameAndPhase + ".err.utf8"));
+        pb.redirectOutput(new File(nameAndPhase + ".out.utf8"));
+        Process process = pb.start();
+
+        int result = -1;
+        if (waitForProcess(process, phase.timeoutSeconds)) {
+            try (FileWriter file = new FileWriter(nameAndPhase + ".exit")) {
+                file.write(Integer.toString(process.exitValue()));
+            }
+            result = process.exitValue();
+        } else {
+            try (FileWriter file = new FileWriter(nameAndPhase + ".exit")) {
+                file.write("TIMEOUT");
+            }
+        }
+
+        if (phase == Phase.RUN || phase == Phase.GOLD_RUN) {
+            escapeRawFileContents(nameAndPhase + ".err");
+            escapeRawFileContents(nameAndPhase + ".out");
+        }
+
+        return result;
+    }
+
+}

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ProductionParams.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ProductionParams.java
@@ -29,6 +29,7 @@ import jdk.test.lib.jittester.utils.OptionResolver.Option;
 public class ProductionParams {
 
     public static Option<Integer> productionLimit = null;
+    public static Option<Integer> productionLimitSeconds = null;
     public static Option<Integer> dataMemberLimit = null;
     public static Option<Integer> statementLimit = null;
     public static Option<Integer> testStatementLimit = null;
@@ -71,6 +72,7 @@ public class ProductionParams {
     // workaraound: to reduce chance throwing ArrayIndexOutOfBoundsException
     public static Option<Integer> chanceExpressionIndex = null;
     public static Option<String> testbaseDir = null;
+    public static Option<String> tempDir = null;
     public static Option<Integer> numberOfTests = null;
     public static Option<String> seed = null;
     public static Option<Long> specificSeed = null;
@@ -81,6 +83,7 @@ public class ProductionParams {
 
     public static void register(OptionResolver optionResolver) {
         productionLimit = optionResolver.addIntegerOption('l', "production-limit", 100, "Limit on steps in the production of an expression");
+        productionLimitSeconds = optionResolver.addIntegerOption("production-limit-seconds", 600, "Limit the time a test generation may take");
         dataMemberLimit = optionResolver.addIntegerOption('v', "data-member-limit", 10, "Upper limit on data members");
         statementLimit = optionResolver.addIntegerOption('s', "statement-limit", 30, "Upper limit on statements in function");
         testStatementLimit = optionResolver.addIntegerOption('e', "test-statement-limit", 300, "Upper limit on statements in test() function");
@@ -122,6 +125,7 @@ public class ProductionParams {
         enableFinalizers = optionResolver.addBooleanOption("enable-finalizers", "Enable finalizers (for stress testing)");
         chanceExpressionIndex = optionResolver.addIntegerOption("chance-expression-index", 0, "A non negative decimal integer used to restrict chane of generating expression in array index while creating or accessing by index");
         testbaseDir = optionResolver.addStringOption("testbase-dir", ".", "Testbase dir");
+        tempDir = optionResolver.addStringOption("temp-dir", ".", "Temp dir path");
         numberOfTests = optionResolver.addIntegerOption('n', "number-of-tests", 0, "Number of test classes to generate");
         seed = optionResolver.addStringOption("seed", "", "Random seed");
         specificSeed = optionResolver.addLongOption('z', "specificSeed", 0L, "A seed to be set for specific test generation(regular seed still needed for initialization)");

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/TempDir.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/TempDir.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib.jittester;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+
+public class TempDir {
+    public final Path path;
+
+    public TempDir(String suffix) {
+        try {
+            if (ProductionParams.tempDir.isSet()) {
+                Path tmpRoot = Path.of(ProductionParams.tempDir.value());
+                TestsGenerator.ensureExisting(tmpRoot);
+                path = Files.createTempDirectory(tmpRoot, suffix).toAbsolutePath();
+            } else {
+                path = Files.createTempDirectory(suffix).toAbsolutePath();
+                Runtime.getRuntime().addShutdownHook(new Thread(this::delete));
+            }
+        } catch (IOException e) {
+            throw new Error("Can't create a tmp dir for " + suffix, e);
+        }
+
+        System.out.println("DBG: Temp folder created: '" + path + "'");
+    }
+
+    private void delete() {
+        var deleteVisitor = new SimpleFileVisitor<Path>() {
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
+                deleteOrError(dir);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                deleteOrError(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            private void deleteOrError(Path what) {
+                try {
+                    Files.delete(what);
+                } catch (IOException e) {
+                    throw new Error("Could not delete '" + what + "'", e);
+                }
+            }
+        };
+
+        try {
+            Files.walkFileTree(path, deleteVisitor);
+        } catch (IOException e) {
+            throw new Error("Could not delete '" + path + "'", e);
+        }
+    }
+}

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/jtreg/JitTesterDriver.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/jtreg/JitTesterDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,17 +25,19 @@ package jdk.test.lib.jittester.jtreg;
 
 import jdk.test.lib.Asserts;
 import jdk.test.lib.Utils;
-import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import java.util.Iterator;
 import java.util.stream.Stream;
+
+import jdk.test.lib.jittester.ErrorTolerance;
+import jdk.test.lib.jittester.Phase;
+import jdk.test.lib.jittester.ProcessRunner;
 
 public class JitTesterDriver {
 
@@ -45,42 +47,40 @@ public class JitTesterDriver {
                     "[TESTBUG]: wrong number of argument : " + args.length
                     + ". Expected at least 1 argument -- jit-tester test name.");
         }
-        OutputAnalyzer oa;
+
+        String name = args[args.length - 1];
+        Path testDir = Paths.get(Utils.TEST_SRC);
+
         try {
             ProcessBuilder pb = ProcessTools.createTestJvm(args);
-            oa = new OutputAnalyzer(pb.start());
+            ProcessRunner.runProcess(pb, name, Phase.RUN);
+
+            // Verification
+            String goldExitValue = streamFile(testDir, name, Phase.GOLD_RUN, "exit").findFirst().get();
+            if (!goldExitValue.equals("TIMEOUT")) {
+                String anlzExitValue = streamFile(Path.of("."), name, Phase.RUN, "exit").findFirst().get();
+                Asserts.assertEQ(anlzExitValue, goldExitValue);
+
+                ErrorTolerance.assertIsAcceptable(
+                    Paths.get(Utils.TEST_SRC).resolve(name + "." + Phase.GOLD_RUN.suffix + ".err"),
+                    Paths.get(".").resolve(name + "." + Phase.RUN.suffix + ".err"));
+
+                ErrorTolerance.assertIsAcceptable(
+                    Paths.get(Utils.TEST_SRC).resolve(name + "." + Phase.GOLD_RUN.suffix + ".out"),
+                    Paths.get(".").resolve(name + "." + Phase.RUN.suffix + ".out"));
+            }
         } catch (Exception e) {
             throw new Error("Unexpected exception on test jvm start :" + e, e);
         }
-
-        String name = args[args.length - 1];
-        Pattern splitOut = Pattern.compile("\\n"); // tests use \n only in stdout
-        Pattern splitErr = Pattern.compile("\\r?\\n"); // can handle both \r\n and \n
-        Path testDir = Paths.get(Utils.TEST_SRC);
-        String goldOut = formatOutput(streamGoldFile(testDir, name, "out"));
-        String anlzOut = formatOutput(Arrays.stream(splitOut.split(oa.getStdout())));
-        Asserts.assertEQ(anlzOut, goldOut, "Actual stdout isn't equal to golden one");
-        String goldErr = formatOutput(streamGoldFile(testDir, name, "err"));
-        String anlzErr = formatOutput(Arrays.stream(splitErr.split(oa.getStderr())));
-        Asserts.assertEQ(anlzErr, goldErr, "Actual stderr isn't equal to golden one");
-
-        int exitValue = Integer.parseInt(streamGoldFile(testDir, name, "exit").findFirst().get());
-        oa.shouldHaveExitValue(exitValue);
     }
 
-    private static String formatOutput(Stream<String> stream) {
-        String result = stream.collect(Collectors.joining(Utils.NEW_LINE));
-        if (result.length() > 0) {
-            result += Utils.NEW_LINE;
-        }
-        return result;
-    }
-
-    private static Stream<String> streamGoldFile(Path dir, String name, String suffix) {
+    private static Stream<String> streamFile(Path dir, String name, Phase phase, String kind) {
+        String fullName = name + "." + phase.suffix + "." + kind;
         try {
-            return Files.lines(dir.resolve(name + ".gold." + suffix));
+            return Files.lines(dir.resolve(fullName), Charset.forName("UTF-8"));
         } catch (IOException e) {
-            throw new Error(String.format("Can't read golden %s for %s : %s", suffix, name, e), e);
+            throw new Error(String.format("Can't read file: %s", fullName), e);
         }
     }
+
 }

--- a/test/lib-test/jdk/test/lib/jittester/ErrorToleranceTest.java
+++ b/test/lib-test/jdk/test/lib/jittester/ErrorToleranceTest.java
@@ -211,7 +211,62 @@ public class ErrorToleranceTest {
             "Correct line 2"
         };
 
-        ErrorTolerance.assertIsAcceptable("", Arrays.stream(run), Arrays.stream(gold));
+        ErrorTolerance.assertIsAcceptable("", Arrays.stream(gold), Arrays.stream(run));
+    }
+
+    @Test
+    public void goldHaveStackOverflowWhileRunDoesnt() {
+        String[] gold = new String[] {
+            "[Fuzzer] End of execution.",
+            "[Fuzzer] Field field_0: 0",
+            "[Fuzzer] StackOverFlowError caught.",
+            "[Fuzzer] Field traceCount: 2238",
+        };
+
+        String[] run = new String[] {
+            "[Fuzzer] traceID27",
+            "[Fuzzer] Field field_0: 0",
+            "[Fuzzer] Field traceCount: 7919",
+            "[Fuzzer] traceID2",
+            "[Fuzzer] Field field_0: 0",
+            "[Fuzzer] Field traceCount: 15838",
+            "[Fuzzer] traceID0",
+            "[Fuzzer] Field field_0: 0",
+            "[Fuzzer] Field traceCount: 23757",
+            "[Fuzzer] traceID28",
+            "[Fuzzer] Field field_0: 0",
+            "[Fuzzer] Field traceCount: 31676",
+            "[Fuzzer] traceID27",
+            "[Fuzzer] Field field_0: 0",
+            "[Fuzzer] Field traceCount: 39595",
+            "[Fuzzer] traceID2",
+            "[Fuzzer] Field field_0: 0",
+            "[Fuzzer] Field traceCount: 47514",
+            "[Fuzzer] traceID0",
+            "[Fuzzer] Field field_0: 0",
+            "[Fuzzer] Field traceCount: 55433",
+            "[Fuzzer] traceID28",
+            "[Fuzzer] Field field_0: 0",
+            "[Fuzzer] Field traceCount: 63352",
+            "[Fuzzer] traceID27",
+            "[Fuzzer] Field field_0: 0",
+            "[Fuzzer] Field traceCount: 71271",
+            "[Fuzzer] traceID2",
+            "[Fuzzer] Field field_0: 0",
+            "[Fuzzer] Field traceCount: 79190",
+            "[Fuzzer] traceID0",
+            "[Fuzzer] Field field_0: 0",
+            "[Fuzzer] Field traceCount: 87109",
+            "[Fuzzer] traceID28",
+            "[Fuzzer] Field field_0: 0",
+            "[Fuzzer] Field traceCount: 95028",
+            "[Fuzzer] traceID27",
+            "[Fuzzer] Field field_0: 0",
+            "[Fuzzer] Field traceCount: 102947",
+            "[Fuzzer] trace max reached, exit.",
+        };
+
+        ErrorTolerance.assertIsAcceptable("", Arrays.stream(gold), Arrays.stream(run));
     }
 
 }

--- a/test/lib-test/jdk/test/lib/jittester/ErrorToleranceTest.java
+++ b/test/lib-test/jdk/test/lib/jittester/ErrorToleranceTest.java
@@ -38,16 +38,16 @@ public class ErrorToleranceTest {
     public void allowsForIdenticalStacks() {
         String[] gold = new String[] {
             "Exception in thread \"main\" java.lang.SomeException: Java heap space",
-            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
-            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
-            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+            "    at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
+            "    at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "    at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
         };
 
         String[] run = new String[] {
             "Exception in thread \"main\" java.lang.SomeException: Java heap space",
-            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
-            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
-            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+            "    at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
+            "    at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "    at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
         };
 
         ErrorTolerance.assertIsAcceptable("", Arrays.stream(gold), Arrays.stream(run));
@@ -57,17 +57,17 @@ public class ErrorToleranceTest {
     public void signalsDifferentStacks() {
         String[] gold = new String[] {
             "Exception in thread \"main\" java.lang.SomeException: Java heap space",
-            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
-            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
-            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+            "    at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
+            "    at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "    at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
         };
 
         String[] run = new String[] {
             "Exception in thread \"main\" java.lang.SomeException: Java heap space",
-            "	at wrong.module/some.WrongObject.method(WrongObject.java:10)",
-            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
-            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
-            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+            "    at wrong.module/some.WrongObject.method(WrongObject.java:10)",
+            "    at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
+            "    at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "    at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
         };
 
         ErrorTolerance.assertIsAcceptable("", Arrays.stream(gold), Arrays.stream(run));
@@ -77,16 +77,16 @@ public class ErrorToleranceTest {
     public void skipsIntrinsicCandidateFrames() {
         String[] gold = new String[] {
             "Exception in thread \"main\" java.lang.SomeException: Java heap space",
-            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
+            "    at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
             //        ^^^^ An intrinsic candidate ^^^^
-            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
-            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+            "    at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "    at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
         };
 
         String[] run = new String[] {
             "Exception in thread \"main\" java.lang.SomeException: Java heap space",
-            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
-            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+            "    at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "    at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
         };
 
         ErrorTolerance.assertIsAcceptable("", Arrays.stream(gold), Arrays.stream(run));
@@ -96,16 +96,16 @@ public class ErrorToleranceTest {
     public void doesNotSkipIntrinsicCandidateFramesInGold() {
         String[] gold = new String[] {
             "Exception in thread \"main\" java.lang.SomeException: Java heap space",
-            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
-            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+            "    at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "    at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
         };
 
         String[] run = new String[] {
             "Exception in thread \"main\" java.lang.SomeException: Java heap space",
-            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
+            "    at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
             //        ^^^^ An intrinsic candidate ^^^^
-            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
-            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+            "    at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "    at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
         };
 
         ErrorTolerance.assertIsAcceptable("", Arrays.stream(gold), Arrays.stream(run));
@@ -115,16 +115,16 @@ public class ErrorToleranceTest {
     public void intrinsicCandidateDoesNotPreventChecks() {
         String[] gold = new String[] {
             "Exception in thread \"main\" java.lang.SomeException: Java heap space",
-            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
+            "    at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
             //        ^^^^ An intrinsic candidate ^^^^
-            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
-            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+            "    at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "    at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
         };
 
         String[] run = new String[] {
             "Exception in thread \"main\" java.lang.SomeException: Java heap space",
-            "	at erroneous.module/some.WrongClazz.wrongMethod(WrongClazz.java:13)",
-            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+            "    at erroneous.module/some.WrongClazz.wrongMethod(WrongClazz.java:13)",
+            "    at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
         };
 
         ErrorTolerance.assertIsAcceptable("", Arrays.stream(gold), Arrays.stream(run));
@@ -134,16 +134,16 @@ public class ErrorToleranceTest {
     public void checksTheWholeStack1() {
         String[] gold = new String[] {
             "Exception in thread \"main\" java.lang.SomeException: Java heap space",
-            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
-            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)",
-            "	at java.base/java.lang.StringConcatHelper.simpleConcat(StringConcatHelper.java:365)",
-            "	at java.base/java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(DirectMethodHandle$Holder)"
+            "    at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "    at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)",
+            "    at java.base/java.lang.StringConcatHelper.simpleConcat(StringConcatHelper.java:365)",
+            "    at java.base/java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(DirectMethodHandle$Holder)"
         };
 
         String[] run = new String[] {
             "Exception in thread \"main\" java.lang.SomeException: Java heap space",
-            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
-            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+            "    at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "    at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
         };
 
         ErrorTolerance.assertIsAcceptable("", Arrays.stream(gold), Arrays.stream(run));
@@ -153,16 +153,16 @@ public class ErrorToleranceTest {
     public void checksTheWholeStack2() {
         String[] gold = new String[] {
             "Exception in thread \"main\" java.lang.SomeException: Java heap space",
-            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
-            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)",
-            "	at java.base/java.lang.StringConcatHelper.simpleConcat(StringConcatHelper.java:365)",
-            "	at java.base/java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(DirectMethodHandle$Holder)"
+            "    at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "    at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)",
+            "    at java.base/java.lang.StringConcatHelper.simpleConcat(StringConcatHelper.java:365)",
+            "    at java.base/java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(DirectMethodHandle$Holder)"
         };
 
         String[] run = new String[] {
             "Exception in thread \"main\" java.lang.SomeException: Java heap space",
-            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
-            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+            "    at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "    at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
         };
 
         ErrorTolerance.assertIsAcceptable("", Arrays.stream(run), Arrays.stream(gold));
@@ -174,24 +174,24 @@ public class ErrorToleranceTest {
 
         String[] gold = new String[] {
             "Exception in thread \"main\" java.lang.OutOfMemoryError: Java heap space",
-            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
-            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
-            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)",
-            "	at java.base/java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(DirectMethodHandle$Holder)",
-            "	at java.base/java.lang.invoke.LambdaForm$MH/0x00000008000c9000.invoke(LambdaForm$MH)",
-            "	at java.base/java.lang.invoke.Invokers$Holder.linkToTargetMethod(Invokers$Holder)",
-            "	at Test_221.method_float_float_192(Test_221.java:1706)",
-            "	at Test_221.mainTest(Test_221.java:1952)",
-            "	at Test_221.main(Test_221.java:1968)"
+            "    at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
+            "    at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "    at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)",
+            "    at java.base/java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(DirectMethodHandle$Holder)",
+            "    at java.base/java.lang.invoke.LambdaForm$MH/0x00000008000c9000.invoke(LambdaForm$MH)",
+            "    at java.base/java.lang.invoke.Invokers$Holder.linkToTargetMethod(Invokers$Holder)",
+            "    at Test_221.method_float_float_192(Test_221.java:1706)",
+            "    at Test_221.mainTest(Test_221.java:1952)",
+            "    at Test_221.main(Test_221.java:1968)"
         };
 
         String[] run = new String[] {
             "Exception in thread \"main\" java.lang.OutOfMemoryError: Overflow: String length out of range",
-            "	        at java.base/java.lang.StringConcatHelper.checkOverflow(StringConcatHelper.java:57)",
-            "	        at java.base/java.lang.StringConcatHelper.mix(StringConcatHelper.java:116)",
-            "	        at Test_221.method_float_float_192(Test_221.java:1706)",
-            "	        at Test_221.mainTest(Test_221.java:1952)",
-            "	        at Test_221.main(Test_221.java:1968)"
+            "    at java.base/java.lang.StringConcatHelper.checkOverflow(StringConcatHelper.java:57)",
+            "    at java.base/java.lang.StringConcatHelper.mix(StringConcatHelper.java:116)",
+            "    at Test_221.method_float_float_192(Test_221.java:1706)",
+            "    at Test_221.mainTest(Test_221.java:1952)",
+            "    at Test_221.main(Test_221.java:1968)"
         };
 
         ErrorTolerance.assertIsAcceptable("", Arrays.stream(run), Arrays.stream(gold));

--- a/test/lib-test/jdk/test/lib/jittester/ErrorToleranceTest.java
+++ b/test/lib-test/jdk/test/lib/jittester/ErrorToleranceTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib.jittester;
+
+import java.util.Arrays;
+import org.testng.annotations.Test;
+
+/*
+ * @test
+ * @summary Check error reporting and tolerating mechanics
+ * @library /test/lib /test/hotspot/jtreg/testlibrary/jittester/src
+ * @run testng jdk.test.lib.jittester.ErrorToleranceTest
+ */
+public class ErrorToleranceTest {
+
+    @Test
+    public void allowsForIdenticalStacks() {
+        String[] gold = new String[] {
+            "Exception in thread \"main\" java.lang.SomeException: Java heap space",
+            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
+            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+        };
+
+        String[] run = new String[] {
+            "Exception in thread \"main\" java.lang.SomeException: Java heap space",
+            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
+            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+        };
+
+        ErrorTolerance.assertIsAcceptable("", Arrays.stream(gold), Arrays.stream(run));
+    }
+
+    @Test(expectedExceptions = { java.lang.RuntimeException.class })
+    public void signalsDifferentStacks() {
+        String[] gold = new String[] {
+            "Exception in thread \"main\" java.lang.SomeException: Java heap space",
+            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
+            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+        };
+
+        String[] run = new String[] {
+            "Exception in thread \"main\" java.lang.SomeException: Java heap space",
+            "	at wrong.module/some.WrongObject.method(WrongObject.java:10)",
+            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
+            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+        };
+
+        ErrorTolerance.assertIsAcceptable("", Arrays.stream(gold), Arrays.stream(run));
+    }
+
+    @Test
+    public void skipsIntrinsicCandidateFrames() {
+        String[] gold = new String[] {
+            "Exception in thread \"main\" java.lang.SomeException: Java heap space",
+            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
+            //        ^^^^ An intrinsic candidate ^^^^
+            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+        };
+
+        String[] run = new String[] {
+            "Exception in thread \"main\" java.lang.SomeException: Java heap space",
+            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+        };
+
+        ErrorTolerance.assertIsAcceptable("", Arrays.stream(gold), Arrays.stream(run));
+    }
+
+    @Test(expectedExceptions = { java.lang.RuntimeException.class })
+    public void doesNotSkipIntrinsicCandidateFramesInGold() {
+        String[] gold = new String[] {
+            "Exception in thread \"main\" java.lang.SomeException: Java heap space",
+            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+        };
+
+        String[] run = new String[] {
+            "Exception in thread \"main\" java.lang.SomeException: Java heap space",
+            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
+            //        ^^^^ An intrinsic candidate ^^^^
+            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+        };
+
+        ErrorTolerance.assertIsAcceptable("", Arrays.stream(gold), Arrays.stream(run));
+    }
+
+    @Test(expectedExceptions = { java.lang.RuntimeException.class })
+    public void intrinsicCandidateDoesNotPreventChecks() {
+        String[] gold = new String[] {
+            "Exception in thread \"main\" java.lang.SomeException: Java heap space",
+            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
+            //        ^^^^ An intrinsic candidate ^^^^
+            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+        };
+
+        String[] run = new String[] {
+            "Exception in thread \"main\" java.lang.SomeException: Java heap space",
+            "	at erroneous.module/some.WrongClazz.wrongMethod(WrongClazz.java:13)",
+            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+        };
+
+        ErrorTolerance.assertIsAcceptable("", Arrays.stream(gold), Arrays.stream(run));
+    }
+
+    @Test(expectedExceptions = { java.lang.RuntimeException.class })
+    public void checksTheWholeStack1() {
+        String[] gold = new String[] {
+            "Exception in thread \"main\" java.lang.SomeException: Java heap space",
+            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)",
+            "	at java.base/java.lang.StringConcatHelper.simpleConcat(StringConcatHelper.java:365)",
+            "	at java.base/java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(DirectMethodHandle$Holder)"
+        };
+
+        String[] run = new String[] {
+            "Exception in thread \"main\" java.lang.SomeException: Java heap space",
+            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+        };
+
+        ErrorTolerance.assertIsAcceptable("", Arrays.stream(gold), Arrays.stream(run));
+    }
+
+    @Test(expectedExceptions = { java.lang.RuntimeException.class })
+    public void checksTheWholeStack2() {
+        String[] gold = new String[] {
+            "Exception in thread \"main\" java.lang.SomeException: Java heap space",
+            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)",
+            "	at java.base/java.lang.StringConcatHelper.simpleConcat(StringConcatHelper.java:365)",
+            "	at java.base/java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(DirectMethodHandle$Holder)"
+        };
+
+        String[] run = new String[] {
+            "Exception in thread \"main\" java.lang.SomeException: Java heap space",
+            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)"
+        };
+
+        ErrorTolerance.assertIsAcceptable("", Arrays.stream(run), Arrays.stream(gold));
+    }
+
+    @Test
+    public void ignoresDifferencesWithOOME() {
+        //OOME is too difficult to verify reliably, so we should just ignore such stack traces
+
+        String[] gold = new String[] {
+            "Exception in thread \"main\" java.lang.OutOfMemoryError: Java heap space",
+            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray0(Unsafe.java:1387)",
+            "	at java.base/jdk.internal.misc.Unsafe.allocateUninitializedArray(Unsafe.java:1380)",
+            "	at java.base/java.lang.StringConcatHelper.newArray(StringConcatHelper.java:441)",
+            "	at java.base/java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(DirectMethodHandle$Holder)",
+            "	at java.base/java.lang.invoke.LambdaForm$MH/0x00000008000c9000.invoke(LambdaForm$MH)",
+            "	at java.base/java.lang.invoke.Invokers$Holder.linkToTargetMethod(Invokers$Holder)",
+            "	at Test_221.method_float_float_192(Test_221.java:1706)",
+            "	at Test_221.mainTest(Test_221.java:1952)",
+            "	at Test_221.main(Test_221.java:1968)"
+        };
+
+        String[] run = new String[] {
+            "Exception in thread \"main\" java.lang.OutOfMemoryError: Overflow: String length out of range",
+            "	        at java.base/java.lang.StringConcatHelper.checkOverflow(StringConcatHelper.java:57)",
+            "	        at java.base/java.lang.StringConcatHelper.mix(StringConcatHelper.java:116)",
+            "	        at Test_221.method_float_float_192(Test_221.java:1706)",
+            "	        at Test_221.mainTest(Test_221.java:1952)",
+            "	        at Test_221.main(Test_221.java:1968)"
+        };
+
+        ErrorTolerance.assertIsAcceptable("", Arrays.stream(run), Arrays.stream(gold));
+    }
+
+    @Test(expectedExceptions = { java.lang.RuntimeException.class })
+    public void reportsFilesThatDiffer() {
+        String[] gold = new String[] {
+            "Correct line 1",
+            "The line that zigs sometimes",
+            "Correct line 2"
+        };
+
+        String[] run = new String[] {
+            "Correct line 1",
+            "The line that zags sometimes",
+            "Correct line 2"
+        };
+
+        ErrorTolerance.assertIsAcceptable("", Arrays.stream(run), Arrays.stream(gold));
+    }
+
+}


### PR DESCRIPTION
Please review a set of improvements that should improve working with other fuzzing generators and usage of JitTesterDriver with tests generated not by the JITTester:

- Provide better separation of individual test generation from java file writing, compiling, executing, etc.;
- Introduce distinct Phases of the generation process (Generation, Compilation, GoldRun and VerificationRun);
- Extract JItTesterDriver headers generation so that it would be possible to provide other header generators;
- Introduce error tolerance to not get distracted by OOMEs, intrinsics missing in the compiled code, etc.;
- Make it possible to specify time limit for an individual test generation;
- Give better control over temp/workdir creation and cleaning;
- Unify external process running;
- Introduce UTF-8 support in external processes' output and human-readable escaping of it;

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302267](https://bugs.openjdk.org/browse/JDK-8302267): [jittester] Improve separation of test generation and execution


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12527/head:pull/12527` \
`$ git checkout pull/12527`

Update a local copy of the PR: \
`$ git checkout pull/12527` \
`$ git pull https://git.openjdk.org/jdk.git pull/12527/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12527`

View PR using the GUI difftool: \
`$ git pr show -t 12527`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12527.diff">https://git.openjdk.org/jdk/pull/12527.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12527#issuecomment-1428394556)