### PR TITLE
8302163: Speed up various String comparison methods with ArraysSupport.mismatch

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -2140,13 +2140,13 @@ public final class String
         byte[] ov = other.value;
         byte coder = coder();
         if (coder == other.coder()) {
-            if (coder == LATIN1) {
-                return ArraysSupport.mismatch(tv, toffset,
-                        ov, ooffset, len) < 0;
-            } else {
-                return ArraysSupport.mismatch(tv, toffset << UTF16,
-                        ov, ooffset << UTF16, len << UTF16) < 0;
+            if (coder == UTF16) {
+                toffset <<= UTF16;
+                ooffset <<= UTF16;
+                len <<= UTF16;
             }
+            return ArraysSupport.mismatch(tv, toffset,
+                    ov, ooffset, len) < 0;
         } else {
             if (coder == LATIN1) {
                 while (len-- > 0) {

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -2267,7 +2267,9 @@ public final class String
         int pc = pa.length;
         byte coder = coder();
         if (coder == prefix.coder()) {
-            toffset <<= coder;
+            if (coder == UTF16) {
+                toffset <<= UTF16;
+            }
             return ArraysSupport.mismatch(ta, toffset,
                     pa, 0, pc) < 0;
         } else {

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -109,12 +109,8 @@ final class StringLatin1 {
 
     public static int compareTo(byte[] value, byte[] other, int len1, int len2) {
         int lim = Math.min(len1, len2);
-        for (int k = 0; k < lim; k++) {
-            if (value[k] != other[k]) {
-                return getChar(value, k) - getChar(other, k);
-            }
-        }
-        return len1 - len2;
+        int k = ArraysSupport.mismatch(value, other, lim);
+        return (k < 0) ? len1 - len2 : getChar(value, k) - getChar(other, k);
     }
 
     @IntrinsicCandidate

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -299,12 +299,12 @@ final class StringUTF16 {
 
     private static int compareValues(byte[] value, byte[] other, int len1, int len2) {
         int lim = Math.min(len1, len2);
-        for (int k = 0; k < lim; k++) {
+        int k = ArraysSupport.mismatch(value, other, lim << 1);
+        if (k >= 0) {
+            k >>= 1;
             char c1 = getChar(value, k);
             char c2 = getChar(other, k);
-            if (c1 != c2) {
-                return c1 - c2;
-            }
+            return c1 - c2;
         }
         return len1 - len2;
     }

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -299,12 +299,12 @@ final class StringUTF16 {
 
     private static int compareValues(byte[] value, byte[] other, int len1, int len2) {
         int lim = Math.min(len1, len2);
-        int k = ArraysSupport.mismatch(value, other, lim << 1);
-        if (k >= 0) {
-            k >>= 1;
+        for (int k = 0; k < lim; k++) {
             char c1 = getChar(value, k);
             char c2 = getChar(other, k);
-            return c1 - c2;
+            if (c1 != c2) {
+                return c1 - c2;
+            }
         }
         return len1 - len2;
     }

--- a/test/micro/org/openjdk/bench/java/lang/StringBuilders.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringBuilders.java
@@ -51,7 +51,9 @@ public class StringBuilders {
     private String[] str3p9p8;
     private String[] str22p40p31;
     private StringBuilder sbLatin1;
+    private StringBuilder sbLatin2;
     private StringBuilder sbUtf16;
+    private StringBuilder sbUtf17;
 
     @Setup
     public void setup() {
@@ -64,7 +66,9 @@ public class StringBuilders {
         str3p9p8 = new String[]{"123", "123456789", "12345678"};
         str22p40p31 = new String[]{"1234567890123456789012", "1234567890123456789012345678901234567890", "1234567890123456789012345678901"};
         sbLatin1 = new StringBuilder("Latin1 string");
+        sbLatin2 = new StringBuilder("Latin1 string");
         sbUtf16 = new StringBuilder("UTF-\uFF11\uFF16 string");
+        sbUtf17 = new StringBuilder("UTF-\uFF11\uFF16 string");
     }
 
     @Benchmark
@@ -250,6 +254,15 @@ public class StringBuilders {
         return result.toString();
     }
 
+    @Benchmark
+    public int compareToLatin1() {
+        return sbLatin1.compareTo(sbLatin2);
+    }
+
+    @Benchmark
+    public int compareToUTF16() {
+        return sbUtf16.compareTo(sbUtf17);
+    }
 
     @Benchmark
     public String toStringCharWithMixed8() {

--- a/test/micro/org/openjdk/bench/java/lang/StringComparisons.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringComparisons.java
@@ -23,13 +23,12 @@
 package org.openjdk.bench.java.lang;
 
 import org.openjdk.jmh.annotations.*;
-import org.openjdk.jmh.infra.Blackhole;
 
 import java.util.concurrent.TimeUnit;
 
 /*
- * This benchmark naively explores String::startsWith and other String comparison
- * methods performance
+ * This benchmark naively explores String::startsWith and other String
+ * comparison methods
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -39,31 +38,44 @@ import java.util.concurrent.TimeUnit;
 @Fork(value = 3)
 public class StringComparisons {
 
-    public String longString = new String("jkljayeiksdhsdkjkdjkldfnbmnbdgfaddfflsdhbdkj");
-    public String equallyLongString = new String("jkljayeiksdhsdkjkdjkldfnbmnbdgfaddfflsdhbdkj");
+    @Param({"6", "15", "1024"})
+    public int size;
 
-    public String longerString = new String("jkljayeiksdhsdkjkdjkldfnbmnbdgfaddfflsdhbdkj_");
+    @Param({"true", "false"})
+    public boolean utf16;
 
-    public String endsWithA= new String("jkljayeiksdhsdkjkdjkldfnbmnbdgfaddfflsdhbdkjA");
-    public String endsWithB= new String("jkljayeiksdhsdkjkdjkldfnbmnbdgfaddfflsdhbdkjB");
+    public String string;
+    public String equalString;
 
-    @Benchmark
-    public void startsWith(Blackhole blackhole) {
-        blackhole.consume(longerString.startsWith(longString));
+    public String endsWithA;
+    public String endsWithB;
+
+    @Setup
+    public void setup() {
+        String c = utf16 ? "\uff11" : "c";
+        string = c.repeat(size);
+        equalString = c.repeat(size);
+        endsWithA = c.repeat(size).concat("A");
+        endsWithB = c.repeat(size).concat("B");
     }
 
     @Benchmark
-    public void compareTo(Blackhole blackhole) {
-        blackhole.consume(endsWithA.compareTo(endsWithB));
+    public boolean startsWith() {
+        return endsWithA.startsWith(string);
     }
 
     @Benchmark
-    public void regionMatches(Blackhole blackhole) {
-        blackhole.consume(endsWithA.regionMatches( 0, endsWithB, 0, endsWithB.length()));
+    public int compareTo() {
+        return endsWithA.compareTo(endsWithB);
     }
 
     @Benchmark
-    public void stringEquals(Blackhole blackhole) {
-        blackhole.consume(endsWithA.equals( equallyLongString));
+    public boolean regionMatches() {
+        return endsWithA.regionMatches(0, endsWithB, 0, endsWithB.length());
+    }
+
+    @Benchmark
+    public boolean stringEquals() {
+        return endsWithA.equals(endsWithB);
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/StringComparisons.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringComparisons.java
@@ -46,9 +46,9 @@ public class StringComparisons {
 
     public String string;
     public String equalString;
-
     public String endsWithA;
     public String endsWithB;
+    public String startsWithA;
 
     @Setup
     public void setup() {
@@ -57,6 +57,7 @@ public class StringComparisons {
         equalString = c.repeat(size);
         endsWithA = c.repeat(size).concat("A");
         endsWithB = c.repeat(size).concat("B");
+        startsWithA = "A" + (c.repeat(size));
     }
 
     @Benchmark
@@ -65,8 +66,8 @@ public class StringComparisons {
     }
 
     @Benchmark
-    public int compareTo() {
-        return endsWithA.compareTo(endsWithB);
+    public boolean endsWith() {
+        return startsWithA.endsWith(string);
     }
 
     @Benchmark
@@ -75,7 +76,12 @@ public class StringComparisons {
     }
 
     @Benchmark
-    public boolean stringEquals() {
-        return endsWithA.equals(endsWithB);
+    public boolean regionMatchesRange() {
+        return startsWithA.regionMatches(1, endsWithB, 0, endsWithB.length() - 1);
+    }
+
+    @Benchmark
+    public boolean regionMatchesCI() {
+        return endsWithA.regionMatches(true, 0, endsWithB, 0, endsWithB.length());
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/StringComparisons.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringComparisons.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+/*
+ * This benchmark naively explores String::startsWith and other String comparison
+ * methods performance
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 3)
+public class StringComparisons {
+
+    public String longString = new String("jkljayeiksdhsdkjkdjkldfnbmnbdgfaddfflsdhbdkj");
+    public String equallyLongString = new String("jkljayeiksdhsdkjkdjkldfnbmnbdgfaddfflsdhbdkj");
+
+    public String longerString = new String("jkljayeiksdhsdkjkdjkldfnbmnbdgfaddfflsdhbdkj_");
+
+    public String endsWithA= new String("jkljayeiksdhsdkjkdjkldfnbmnbdgfaddfflsdhbdkjA");
+    public String endsWithB= new String("jkljayeiksdhsdkjkdjkldfnbmnbdgfaddfflsdhbdkjB");
+
+    @Benchmark
+    public void startsWith(Blackhole blackhole) {
+        blackhole.consume(longerString.startsWith(longString));
+    }
+
+    @Benchmark
+    public void compareTo(Blackhole blackhole) {
+        blackhole.consume(endsWithA.compareTo(endsWithB));
+    }
+
+    @Benchmark
+    public void regionMatches(Blackhole blackhole) {
+        blackhole.consume(endsWithA.regionMatches( 0, endsWithB, 0, endsWithB.length()));
+    }
+
+    @Benchmark
+    public void stringEquals(Blackhole blackhole) {
+        blackhole.consume(endsWithA.equals( equallyLongString));
+    }
+}

--- a/test/micro/org/openjdk/bench/java/lang/StringOther.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringOther.java
@@ -100,4 +100,11 @@ public class StringOther {
         bh.consume(str2.regionMatches(true, 16, str1UP, 0, 8));
         bh.consume(str3.regionMatches(true, 6, str4, 1, 2));
     }
+
+    @Benchmark
+    public void regionMatchesLatin1CaseSensitive(Blackhole bh) {
+        bh.consume(str1.regionMatches(false, 0, str2, 0, str1.length()));
+        bh.consume(str2.regionMatches(false, 16, str1UP, 0, 8));
+        bh.consume(str3.regionMatches(false, 6, str4, 1, 2));
+    }
 }

--- a/test/micro/org/openjdk/bench/java/lang/StringOther.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringOther.java
@@ -49,17 +49,9 @@ public class StringOther {
     private String testString;
     private Random rnd;
 
-    private String str1, str2, str3, str4;
-    private String str1UP;
-
     @Setup
     public void setup() {
         testString = "Idealism is what precedes experience; cynicism is what follows.";
-        str1 = "vm-guld vm-guld vm-guld";
-        str1UP = str1.toUpperCase(Locale.ROOT);
-        str2 = "vm-guld vm-guld vm-guldx";
-        str3 = "vm-guld vm-guld vm-guldx";
-        str4 = "adadaskasdjierudks";
         rnd = new Random();
     }
 
@@ -68,15 +60,6 @@ public class StringOther {
         for (int i = 0; i < testString.length(); i++) {
             bh.consume(testString.charAt(i));
         }
-    }
-
-    @Benchmark
-    public int compareTo() {
-        int total = 0;
-        total += str1.compareTo(str2);
-        total += str2.compareTo(str3);
-        total += str3.compareTo(str4);
-        return total;
     }
 
     /**
@@ -94,17 +77,4 @@ public class StringOther {
         return String.valueOf(rnd.nextInt()).intern();
     }
 
-    @Benchmark
-    public void regionMatchesLatin1(Blackhole bh) {
-        bh.consume(str1.regionMatches(true, 0, str2, 0, str1.length()));
-        bh.consume(str2.regionMatches(true, 16, str1UP, 0, 8));
-        bh.consume(str3.regionMatches(true, 6, str4, 1, 2));
-    }
-
-    @Benchmark
-    public void regionMatchesLatin1CaseSensitive(Blackhole bh) {
-        bh.consume(str1.regionMatches(false, 0, str2, 0, str1.length()));
-        bh.consume(str2.regionMatches(false, 16, str1UP, 0, 8));
-        bh.consume(str3.regionMatches(false, 6, str4, 1, 2));
-    }
 }


### PR DESCRIPTION
We can improve various String methods such as `startsWith`, `endsWith` and `regionMatches` by leveraging the intrinsified mismatch methods in `ArraysSupport`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302163](https://bugs.openjdk.org/browse/JDK-8302163): Speed up various String comparison methods with ArraysSupport.mismatch


### Reviewers
 * [Sergey Tsypanov](https://openjdk.org/census#stsypanov) (@stsypanov - Author) ⚠️ Review applies to [6cac333d](https://git.openjdk.org/jdk/pull/12528/files/6cac333d8f9f34e16168447c60f28a6b0d31623f)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to [6cac333d](https://git.openjdk.org/jdk/pull/12528/files/6cac333d8f9f34e16168447c60f28a6b0d31623f)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12528/head:pull/12528` \
`$ git checkout pull/12528`

Update a local copy of the PR: \
`$ git checkout pull/12528` \
`$ git pull https://git.openjdk.org/jdk pull/12528/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12528`

View PR using the GUI difftool: \
`$ git pr show -t 12528`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12528.diff">https://git.openjdk.org/jdk/pull/12528.diff</a>

</details>
