### PR TITLE
8302215: G1: Last-ditch Full GC should do serial compaction for tail regions in per thread compaction points.

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -389,15 +389,17 @@ void G1FullCollector::phase2c_prepare_serial_compaction() {
   // Update the forwarding information for the regions in the serial
   // compaction point.
   G1FullGCCompactionPoint* cp = serial_compaction_point();
+  HeapWord* dense_prefix_top = nullptr;
   for (GrowableArrayIterator<HeapRegion*> it = cp->regions()->begin(); it != cp->regions()->end(); ++it) {
     HeapRegion* current = *it;
     if (!cp->is_initialized()) {
       // Initialize the compaction point. Nothing more is needed for the first heap region
       // since it is already prepared for compaction.
       cp->initialize(current);
+      dense_prefix_top = compaction_top(current);
     } else {
       assert(!current->is_humongous(), "Should be no humongous regions in compaction queue");
-      G1SerialRePrepareClosure re_prepare(cp, current);
+      G1SerialRePrepareClosure re_prepare(cp, current, dense_prefix_top);
       set_compaction_top(current, current->bottom());
       current->apply_to_marked_objects(mark_bitmap(), &re_prepare);
     }

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -381,9 +381,6 @@ void G1FullCollector::phase2c_prepare_serial_compaction() {
   // lowest and the highest region in the tails of the compaction points.
 
   uint start_serial = truncate_parallel_cps();
-  if (start_serial >= _heap->max_reserved_regions()) {
-    return;
-  }
 
   G1FullGCCompactionPoint* serial_cp = serial_compaction_point();
   assert(!serial_cp->is_initialized(), "sanity!");

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -395,10 +395,8 @@ void G1FullCollector::phase2c_prepare_serial_compaction() {
   for (uint i = start_serial + 1; i < _heap->max_reserved_regions(); i++) {
     if (is_compaction_target(i)) {
       HeapRegion* current = _heap->region_at(i);
-      serial_cp->add(current);
-
-      assert(!current->is_humongous(), "Should be no humongous regions in compaction queue");
       set_compaction_top(current, current->bottom());
+      serial_cp->add(current);
       current->apply_to_marked_objects(mark_bitmap(), &re_prepare);
     }
   }

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -357,6 +357,11 @@ uint G1FullCollector::truncate_parallel_cps() {
     }
   }
 
+  if (lowest_current == (uint)-1) {
+    // worker compaction points are empty
+    return lowest_current;
+  }
+
   for (uint i = 0; i < workers(); i++) {
     G1FullGCCompactionPoint* cp = compaction_point(i);
     if (cp->has_regions()) {
@@ -381,6 +386,9 @@ void G1FullCollector::phase2c_prepare_serial_compaction() {
   // lowest and the highest region in the tails of the compaction points.
 
   uint start_serial = truncate_parallel_cps();
+  if (start_serial >= _heap->max_reserved_regions()) {
+    return;
+  }
 
   G1FullGCCompactionPoint* serial_cp = serial_compaction_point();
   assert(!serial_cp->is_initialized(), "sanity!");

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -358,7 +358,8 @@ void G1FullCollector::add_regions_for_serial_compaction() {
   // For maximum compaction, we need to re-prepare all objects above the lowest
   // region among the current regions for all thread compaction points. It may
   // happen that due to the uneven distribution of objects to parallel threads, holes
-  // have been created as threads compact to different target regions.
+  // have been created as threads compact to different target regions between the
+  // lowest and the highest region in the tails of the compaction points.
   uint lowest_current_hr = (uint)-1;
   for (uint i = 0; i < workers(); i++) {
     G1FullGCCompactionPoint* cp = compaction_point(i);
@@ -377,7 +378,7 @@ void G1FullCollector::add_regions_for_serial_compaction() {
 
   // We use regions as compaction targets in the order they appear in the compaction
   // point. To get maximum compaction and reduce fragmentation, we sort the regions
-  // by hrm_idex so that we compact objects to one end of the heap.
+  // by hrm_index so that we compact objects to one end of the heap.
   serial_cp->sort_regions();
 }
 

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -385,7 +385,6 @@ void G1FullCollector::phase2c_prepare_serial_compaction() {
     return;
   }
 
-
   G1FullGCCompactionPoint* serial_cp = serial_compaction_point();
   assert(!serial_cp->is_initialized(), "sanity!");
 

--- a/src/hotspot/share/gc/g1/g1FullCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1FullCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.hpp
@@ -144,6 +144,7 @@ private:
   void phase2a_determine_worklists();
   bool phase2b_forward_oops();
   void phase2c_prepare_serial_compaction();
+  void add_regions_for_serial_compaction();
 
   void phase3_adjust_pointers();
   void phase4_do_compaction();

--- a/src/hotspot/share/gc/g1/g1FullCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.hpp
@@ -137,6 +137,8 @@ public:
   inline void set_compaction_top(HeapRegion* r, HeapWord* value);
   inline HeapWord* compaction_top(HeapRegion* r) const;
 
+  uint truncate_parallel_cps();
+
 private:
   void phase1_mark_live_objects();
   void phase2_prepare_compaction();

--- a/src/hotspot/share/gc/g1/g1FullCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.hpp
@@ -144,7 +144,6 @@ private:
   void phase2a_determine_worklists();
   bool phase2b_forward_oops();
   void phase2c_prepare_serial_compaction();
-  void add_regions_for_serial_compaction();
 
   void phase3_adjust_pointers();
   void phase4_do_compaction();

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
@@ -116,19 +116,17 @@ void G1FullGCCompactionPoint::add(HeapRegion* hr) {
   _compaction_regions->append(hr);
 }
 
-int G1FullGCCompactionPoint::compare(const uint& hrm_index, HeapRegion* const& e) {
-  return static_cast<int>(hrm_index - e->hrm_index());
+int G1FullGCCompactionPoint::compare(HeapRegion* const& hr, HeapRegion* const& e) {
+  return compare(hr->hrm_index(), e->hrm_index());
 }
 
 void G1FullGCCompactionPoint::sort_regions(){
-  regions()->sort([](HeapRegion** a, HeapRegion** b) {
-    return static_cast<int>((*a)->hrm_index() - (*b)->hrm_index());
-  });
+  regions()->sort(compare_ptr);
 }
 
 int G1FullGCCompactionPoint::find_sorted(HeapRegion* hr) {
   bool found = false;
-  int pos = _compaction_regions->find_sorted<uint, compare>(hr->hrm_index(), found);
+  int pos = _compaction_regions->find_sorted<HeapRegion*, compare>(hr, found);
   if (found) {
     return pos;
   }

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
@@ -116,38 +116,17 @@ void G1FullGCCompactionPoint::add(HeapRegion* hr) {
   _compaction_regions->append(hr);
 }
 
-int G1FullGCCompactionPoint::compare(HeapRegion* const& hr, HeapRegion* const& e) {
-  return compare(hr->hrm_index(), e->hrm_index());
-}
-
-void G1FullGCCompactionPoint::sort_regions(){
-  regions()->sort(compare_ptr);
-}
-
-int G1FullGCCompactionPoint::find_sorted(HeapRegion* hr) {
-  bool found = false;
-  int pos = _compaction_regions->find_sorted<HeapRegion*, compare>(hr, found);
-  if (found) {
-    return pos;
-  }
-  return -1;
-}
-
-void G1FullGCCompactionPoint::move_regions_with_higher_hrm_index(G1FullGCCompactionPoint* cp, uint bottom) {
+void G1FullGCCompactionPoint::remove_at_or_above(uint bottom) {
   HeapRegion* cur = current_region();
   assert(cur->hrm_index() >= bottom, "Sanity!");
 
-  HeapRegion* start = nullptr;
+  int start_index = 0;
   for (HeapRegion* r : *_compaction_regions) {
-    if (r->hrm_index() >= bottom) {
-      cp->add(r);
-      if (start == nullptr) {
-        start = r;
-      }
+    if (r->hrm_index() < bottom) {
+      start_index++;
     }
   }
 
-  int start_index = find_sorted(start);
-  assert(start_index >= 0, "Should have atleast one region");
+  assert(start_index >= 0, "Should have at least one region");
   _compaction_regions->trunc_to(start_index);
 }

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.hpp
@@ -44,6 +44,9 @@ class G1FullGCCompactionPoint : public CHeapObj<mtGC> {
   void switch_region();
   HeapRegion* next_region();
 
+  static int compare(const uint& hrm_index, HeapRegion* const& e);
+  int find_sorted(HeapRegion* hr);
+
 public:
   G1FullGCCompactionPoint(G1FullCollector* collector);
   ~G1FullGCCompactionPoint();
@@ -55,7 +58,8 @@ public:
   void forward(oop object, size_t size);
   void add(HeapRegion* hr);
 
-  HeapRegion* remove_last();
+  void move_regions_with_higher_hrm_index(G1FullGCCompactionPoint* cp, uint bottom);
+  void sort_regions();
   HeapRegion* current_region();
 
   GrowableArray<HeapRegion*>* regions();

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.hpp
@@ -44,17 +44,6 @@ class G1FullGCCompactionPoint : public CHeapObj<mtGC> {
   void switch_region();
   HeapRegion* next_region();
 
-  static int compare(uint a, uint b) {
-    return a > b ? 1 : (a < b) ? -1 : 0;
-  }
-
-  static int compare_ptr(HeapRegion** hr1, HeapRegion** hr2) {
-    return compare(*hr1, *hr2);
-  }
-
-  static int compare(HeapRegion* const& hr, HeapRegion* const& e);
-  int find_sorted(HeapRegion* hr);
-
 public:
   G1FullGCCompactionPoint(G1FullCollector* collector);
   ~G1FullGCCompactionPoint();
@@ -66,8 +55,7 @@ public:
   void forward(oop object, size_t size);
   void add(HeapRegion* hr);
 
-  void move_regions_with_higher_hrm_index(G1FullGCCompactionPoint* cp, uint bottom);
-  void sort_regions();
+  void remove_at_or_above(uint bottom);
   HeapRegion* current_region();
 
   GrowableArray<HeapRegion*>* regions();

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.hpp
@@ -44,7 +44,15 @@ class G1FullGCCompactionPoint : public CHeapObj<mtGC> {
   void switch_region();
   HeapRegion* next_region();
 
-  static int compare(const uint& hrm_index, HeapRegion* const& e);
+  static int compare(uint a, uint b) {
+    return a > b ? 1 : (a < b) ? -1 : 0;
+  }
+
+  static int compare_ptr(HeapRegion** hr1, HeapRegion** hr2) {
+    return compare(*hr1, *hr2);
+  }
+
+  static int compare(HeapRegion* const& hr, HeapRegion* const& e);
   int find_sorted(HeapRegion* hr);
 
 public:

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
@@ -121,7 +121,6 @@ class G1SerialRePrepareClosure : public StackObj {
   G1FullGCCompactionPoint* _cp;
   HeapRegion* _current;
   HeapWord* _dense_prefix_top;
-  uint _bottom_index;
 
 public:
   G1SerialRePrepareClosure(G1FullGCCompactionPoint* hrcp, HeapRegion* hr, HeapWord* dense_prefix_top) :

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
@@ -120,13 +120,14 @@ private:
 class G1SerialRePrepareClosure : public StackObj {
   G1FullGCCompactionPoint* _cp;
   HeapRegion* _current;
+  HeapWord* _dense_prefix_top;
   uint _bottom_index;
 
 public:
-  G1SerialRePrepareClosure(G1FullGCCompactionPoint* hrcp, HeapRegion* hr) :
+  G1SerialRePrepareClosure(G1FullGCCompactionPoint* hrcp, HeapRegion* hr, HeapWord* dense_prefix_top) :
     _cp(hrcp),
     _current(hr),
-    _bottom_index(hrcp->regions()->first()->hrm_index()) { }
+    _dense_prefix_top(dense_prefix_top) { }
 
   inline size_t apply(oop obj);
 };

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
@@ -119,13 +119,11 @@ private:
 // serial compaction.
 class G1SerialRePrepareClosure : public StackObj {
   G1FullGCCompactionPoint* _cp;
-  HeapRegion* _current;
   HeapWord* _dense_prefix_top;
 
 public:
-  G1SerialRePrepareClosure(G1FullGCCompactionPoint* hrcp, HeapRegion* hr, HeapWord* dense_prefix_top) :
+  G1SerialRePrepareClosure(G1FullGCCompactionPoint* hrcp, HeapWord* dense_prefix_top) :
     _cp(hrcp),
-    _current(hr),
     _dense_prefix_top(dense_prefix_top) { }
 
   inline size_t apply(oop obj);

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
@@ -120,11 +120,13 @@ private:
 class G1SerialRePrepareClosure : public StackObj {
   G1FullGCCompactionPoint* _cp;
   HeapRegion* _current;
+  uint _bottom_index;
 
 public:
   G1SerialRePrepareClosure(G1FullGCCompactionPoint* hrcp, HeapRegion* hr) :
     _cp(hrcp),
-    _current(hr) { }
+    _current(hr),
+    _bottom_index(hrcp->regions()->first()->hrm_index()) { }
 
   inline size_t apply(oop obj);
 };

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.inline.hpp
@@ -111,11 +111,9 @@ inline bool G1DetermineCompactionQueueClosure::do_heap_region(HeapRegion* hr) {
 
 inline size_t G1SerialRePrepareClosure::apply(oop obj) {
   if (obj->is_forwarded()) {
-    G1CollectedHeap* g1h = G1CollectedHeap::heap();
-    HeapRegion* target_hr = g1h->heap_region_containing(obj->forwardee());
     // We skip objects compiled into the first region or
     // into regions not part of the serial compaction point.
-    if (target_hr->hrm_index() <= _bottom_index) {
+    if (cast_from_oop<HeapWord*>(obj->forwardee()) < _dense_prefix_top) {
       return obj->size();
     }
   }

--- a/src/hotspot/share/gc/g1/g1FullGCScope.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1FullGCScope.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.cpp
@@ -43,6 +43,7 @@ G1FullGCScope::G1FullGCScope(G1MonitoringSupport* monitoring_support,
                              G1FullGCTracer* tracer) :
     _rm(),
     _explicit_gc(explicit_gc),
+    _do_maximal_compaction(do_maximal_compaction),
     _g1h(G1CollectedHeap::heap()),
     _svc_marker(SvcGCMarker::FULL),
     _timer(),

--- a/src/hotspot/share/gc/g1/g1FullGCScope.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1FullGCScope.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.hpp
@@ -48,6 +48,7 @@ public:
 class G1FullGCScope : public StackObj {
   ResourceMark            _rm;
   bool                    _explicit_gc;
+  bool                    _do_maximal_compaction;
   G1CollectedHeap*        _g1h;
   SvcGCMarker             _svc_marker;
   STWGCTimer              _timer;
@@ -68,6 +69,7 @@ public:
 
   bool is_explicit_gc();
   bool should_clear_soft_refs();
+  bool do_maximal_compaction() { return _do_maximal_compaction; }
 
   STWGCTimer* timer();
   G1FullGCTracer* tracer();


### PR DESCRIPTION
Hi all, 

Please review this change to call `G1FullCollector::phase2c_prepare_serial_compaction` when `do_maximal_compaction`. For maximum compaction, we re-prepare all objects in the "tail" regions of the per thread compaction points.

Testing: Tier 1-3.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302215](https://bugs.openjdk.org/browse/JDK-8302215): G1: Last-ditch Full GC should do serial compaction for tail regions in per thread compaction points.


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [4e7d5960](https://git.openjdk.org/jdk/pull/12529/files/4e7d5960261da372800637c7ef9ff3cbd56961cd)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to [c130f818](https://git.openjdk.org/jdk/pull/12529/files/c130f8181c2db7b9d42788dec00eca4b298921b5)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [4e7d5960](https://git.openjdk.org/jdk/pull/12529/files/4e7d5960261da372800637c7ef9ff3cbd56961cd)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12529/head:pull/12529` \
`$ git checkout pull/12529`

Update a local copy of the PR: \
`$ git checkout pull/12529` \
`$ git pull https://git.openjdk.org/jdk pull/12529/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12529`

View PR using the GUI difftool: \
`$ git pr show -t 12529`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12529.diff">https://git.openjdk.org/jdk/pull/12529.diff</a>

</details>
