### PR TITLE
8279619: [JVMCI] improve EncodedSpeculationReason

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/EncodedSpeculationReason.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/EncodedSpeculationReason.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,6 +61,7 @@ public class EncodedSpeculationReason implements SpeculationReason {
         if (encoding == null) {
             encoding = encodingSupplier.get();
             encoding.addInt(groupId);
+            encoding.addInt(groupName.hashCode());
             for (Object o : context) {
                 if (o == null) {
                     encoding.addInt(0);


### PR DESCRIPTION
This PR enhances `jdk.vm.ci.meta.EncodedSpeculationReason.encode` such that the `groupName` parameter is included in the encoding. This mitigates the possibility of 2 unrelated speculation objects having the same hash which, in turn, mitigates the possibility of missing a speculation based optimization opportunity.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279619](https://bugs.openjdk.org/browse/JDK-8279619): [JVMCI] improve EncodedSpeculationReason


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12532/head:pull/12532` \
`$ git checkout pull/12532`

Update a local copy of the PR: \
`$ git checkout pull/12532` \
`$ git pull https://git.openjdk.org/jdk pull/12532/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12532`

View PR using the GUI difftool: \
`$ git pr show -t 12532`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12532.diff">https://git.openjdk.org/jdk/pull/12532.diff</a>

</details>
