### PR TITLE
JDK-8302335: IGV: Bytecode not showing

### DIFF
--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputMethod.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputMethod.java
@@ -111,7 +111,7 @@ public class InputMethod extends Properties.Entity {
 
     public void setBytecodes(String text) {
         Pattern instruction = Pattern.compile("\\s*(\\d+)\\s*:?\\s*(\\w+)\\s*(.*)(?://(.*))?");
-        Pattern isInfo = Pattern.compile("(\\s*)(\\d+)(\\s+)(bci:)(.+)");
+        Pattern isInfo = Pattern.compile("(\\s*)(\\d+)(\\s*)(bci:)(.+)");
         String[] strings = text.split("\n");
         int oldBci = -1;
         for (String s : strings) {

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputMethod.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputMethod.java
@@ -111,7 +111,7 @@ public class InputMethod extends Properties.Entity {
 
     public void setBytecodes(String text) {
         Pattern instruction = Pattern.compile("\\s*(\\d+)\\s*:?\\s*(\\w+)\\s*(.*)(?://(.*))?");
-        Pattern isInfo = Pattern.compile("\\s*(\\d+)\\s{2,}+(.+)");
+        Pattern isInfo = Pattern.compile("(\\s*)(\\d+)(\\s+)(bci:)(.+)");
         String[] strings = text.split("\n");
         int oldBci = -1;
         for (String s : strings) {

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputMethod.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputMethod.java
@@ -111,10 +111,11 @@ public class InputMethod extends Properties.Entity {
 
     public void setBytecodes(String text) {
         Pattern instruction = Pattern.compile("\\s*(\\d+)\\s*:?\\s*(\\w+)\\s*(.*)(?://(.*))?");
+        Pattern isInfo = Pattern.compile("\\s*(\\d+)\\s{2,}+(.+)");
         String[] strings = text.split("\n");
         int oldBci = -1;
         for (String s : strings) {
-            if (s.startsWith(" ")) {
+            if (isInfo.matcher(s).matches()) {
                 // indented lines are extra textual information
                 continue;
             }


### PR DESCRIPTION
Currently, IGV does not show the bytecode of a graph in the "Bytecode" window although the bytecode is present in the XML file.

# Solution

Following is the `<bytecodes>` block of the XML file
```
<bytecodes>
<![CDATA[
   0 iconst_3
   1 istore_1
   2 bipush 9
   4 istore_2
   5 iload_2
   6 ifle 34
  0   bci: 6    BranchData          taken(0) displacement(112) not taken(0)
   9 iconst_2
  10 istore_3
  11 iload_3
  12 iload_2
  13 if_icmpge 28
  32  bci: 13   BranchData          taken(0) displacement(56)  not taken(0)
  16 iload_1
  17 istore_1
  18 iconst_1
  19 iload_3
  20 irem
  21 istore_1
  22 iinc #3 1
  25 goto 11
  64  bci: 25   JumpData            taken(0) displacement(-32)
  28 iinc #2 -1
  31 goto 5
  88  bci: 31   JumpData            taken(0) displacement(-88)
  34 return
]]>
</bytecodes>
```
The problem was that during paring IGV skipped all lines that started with an empty space: This just skipped all bytecodes. We only want to skip bytecode like `  0   bci: 6    BranchData          taken(0) displacement(112) not taken(0)` . Meaning: whitespace - number - exactly two white spaces - and then arbitrary text.

<img width="283" alt="bytecode" src="https://user-images.githubusercontent.com/71546117/218495199-2b02a79c-3065-404c-af57-3f8a603ac499.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302335](https://bugs.openjdk.org/browse/JDK-8302335): IGV: Bytecode not showing


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Xin Liu](https://openjdk.org/census#xliu) (@navyxliu - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12537/head:pull/12537` \
`$ git checkout pull/12537`

Update a local copy of the PR: \
`$ git checkout pull/12537` \
`$ git pull https://git.openjdk.org/jdk pull/12537/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12537`

View PR using the GUI difftool: \
`$ git pr show -t 12537`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12537.diff">https://git.openjdk.org/jdk/pull/12537.diff</a>

</details>
