### PR TITLE
JDK-8301491: C2: java.lang.StringUTF16::indexOfChar intrinsic called with negative character argument

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1313,6 +1313,15 @@ bool LibraryCallKit::inline_string_indexOfChar(StrIntrinsicNode::ArgEnc ae) {
     return true;
   }
 
+  // Check for tgt >= 0
+  Node* tgt_cmp = _gvn.transform(new CmpINode(tgt, intcon(0)));
+  Node* tgt_bol = _gvn.transform(new BoolNode(tgt_cmp, BoolTest::ge));
+  {
+    BuildCutout unless(this, tgt_bol, PROB_MAX);
+    uncommon_trap(Deoptimization::Reason_intrinsic,
+                  Deoptimization::Action_maybe_recompile);
+  }
+
   RegionNode* region = new RegionNode(3);
   Node* phi = new PhiNode(region, TypeInt::INT);
 

--- a/test/hotspot/jtreg/compiler/intrinsics/string/TestStringIndexOfCharIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/string/TestStringIndexOfCharIntrinsics.java
@@ -26,10 +26,18 @@
 /*
  * @test
  * @bug 8301491
- * @summary Check for correct deoptimization when calling indexOfChar intrinsics with negative value.
+ * @summary Check for correct return value when calling indexOfChar intrinsics with negative value.
  * @library /test/lib
  *
- * @run main/othervm -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,java.lang.StringUTF*::indexOf* -Xcomp -XX:-TieredCompilation compiler.intrinsics.string.TestStringIndexOfCharIntrinsics
+ * @run main/othervm -XX:CompileCommand=quiet
+ *                   -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,compiler.intrinsics.string.TestStringIndexOfCharIntrinsics::testIndexOfChar*
+ *                   -XX:CompileCommand=inline,java.lang.String*::indexOf*
+ *                   -XX:+UnlockExperimentalVMOptions
+ *                   -XX:PerBytecodeTrapLimit=20000
+ *                   -XX:PerMethodTrapLimit=20000
+ *                   -XX:PerMethodSpecTrapLimit=20000
+ *                   compiler.intrinsics.string.TestStringIndexOfCharIntrinsics
  */
 
 package compiler.intrinsics.string;
@@ -47,12 +55,22 @@ public class TestStringIndexOfCharIntrinsics {
         // Test value for aarch64
         byArr[24] = 0x7;
         byArr[23] = -0x80;
-        int result = testIndexOfChar();
-        Asserts.assertEquals(result , -1, "must be -1 (character not found)");
+        // Warmup
+        for (int i = 0; i < 10000; i++) {
+            testIndexOfCharArg(i);
+            testIndexOfCharConst();
+        }
+        Asserts.assertEquals(testIndexOfCharConst() , -1, "must be -1 (character not found)");
+        Asserts.assertEquals(testIndexOfCharArg(-2147483641) , -1, "must be -1 (character not found)");
     }
 
-    static int testIndexOfChar() {
+    static int testIndexOfCharConst() {
         String s = new String(byArr);
         return s.indexOf(-2147483641);
+    }
+
+    static int testIndexOfCharArg(int ch) {
+        String s = new String(byArr);
+        return s.indexOf(ch);
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/string/TestStringIndexOfCharIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/string/TestStringIndexOfCharIntrinsics.java
@@ -33,10 +33,8 @@
  *                   -XX:-TieredCompilation
  *                   -XX:CompileCommand=compileonly,compiler.intrinsics.string.TestStringIndexOfCharIntrinsics::testIndexOfChar*
  *                   -XX:CompileCommand=inline,java.lang.String*::indexOf*
- *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:PerBytecodeTrapLimit=20000
  *                   -XX:PerMethodTrapLimit=20000
- *                   -XX:PerMethodSpecTrapLimit=20000
  *                   compiler.intrinsics.string.TestStringIndexOfCharIntrinsics
  */
 

--- a/test/hotspot/jtreg/compiler/intrinsics/string/TestStringIndexOfCharIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/string/TestStringIndexOfCharIntrinsics.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8301491
+ * @summary Check for correct deoptimization when calling indexOfChar intrinsics with negative value.
+ * @library /test/lib
+ *
+ * @run main/othervm -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,java.lang.StringUTF*::indexOf* -Xcomp -XX:-TieredCompilation compiler.intrinsics.string.TestStringIndexOfCharIntrinsics
+ */
+
+package compiler.intrinsics.string;
+
+import jdk.test.lib.Asserts;
+
+public class TestStringIndexOfCharIntrinsics {
+
+    static byte byArr[] = new byte[500];
+
+    public static void main(String[] args) {
+        for (int j = 0; j < byArr.length; j++) {
+            byArr[j] = (byte)j;
+        }
+        // Test value for aarch64
+        byArr[24] = 0x7;
+        byArr[23] = -0x80;
+        int result = testIndexOfChar();
+        Asserts.assertEquals(result , -1, "must be -1 (character not found)");
+    }
+
+    static int testIndexOfChar() {
+        String s = new String(byArr);
+        return s.indexOf(-2147483641);
+    }
+}


### PR DESCRIPTION
The `java.lang.StringUTF16::indexOfChar` is supposed to return -1 for characters with value `< 0`. Its intrinsic methods don't always do so.
https://github.com/openjdk/jdk/blob/96c50a3486e3b6cdce7f8fb409d015b289770811/src/java.base/share/classes/java/lang/StringUTF16.java#L535

The intrinsic methods expect the `int` character being passed to be `>= 0`. Unfortunately this is not enforced in the Java part (`indexOf` only checks for the upper bound):
https://github.com/openjdk/jdk/blob/96c50a3486e3b6cdce7f8fb409d015b289770811/src/java.base/share/classes/java/lang/StringUTF16.java#L430
The intrinsic methods assume that only the lower 16 bits are used (0 <=  `ch` <= 0xFFFF) and either don't care about the upper 16 bits or implicitly mask them, e.g. for aarch64:
https://github.com/openjdk/jdk/blob/96c50a3486e3b6cdce7f8fb409d015b289770811/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp#L502-L503 or avx:
https://github.com/openjdk/jdk/blob/96c50a3486e3b6cdce7f8fb409d015b289770811/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp#L3039

On the other hand, the Java method `indexOfCharUnsafe` makes this check implicitly by comparing a `char` with an `int`;
https://github.com/openjdk/jdk/blob/96c50a3486e3b6cdce7f8fb409d015b289770811/src/java.base/share/classes/java/lang/StringUTF16.java#L542-L544

As there doesn't seem to be a good reason to call `indexOfChar` with `ch < 0`, it seems reasonable to add a check in `LibraryCallKit::inline_string_indexOfChar` that triggers a deoptimization if it fails.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301491](https://bugs.openjdk.org/browse/JDK-8301491): C2: java.lang.StringUTF16::indexOfChar intrinsic called with negative character argument


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12538/head:pull/12538` \
`$ git checkout pull/12538`

Update a local copy of the PR: \
`$ git checkout pull/12538` \
`$ git pull https://git.openjdk.org/jdk pull/12538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12538`

View PR using the GUI difftool: \
`$ git pr show -t 12538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12538.diff">https://git.openjdk.org/jdk/pull/12538.diff</a>

</details>
