### PR TITLE
8302337: JDK crashes if lib/modules contains non-zero byte containing ATTRIBUTE_END

### DIFF
--- a/src/java.base/share/native/libjimage/imageFile.cpp
+++ b/src/java.base/share/native/libjimage/imageFile.cpp
@@ -130,6 +130,9 @@ void ImageLocation::set_data(u1* data) {
         // Extract kind from header byte.
         u1 kind = attribute_kind(byte);
         assert(kind < ATTRIBUTE_COUNT && "invalid image location attribute");
+        if (kind == ATTRIBUTE_END) {
+            break;
+        }
         // Extract length of data (in bytes).
         u1 n = attribute_length(byte);
         // Read value (most significant first.)


### PR DESCRIPTION
The `jimage` location attributes are terminated with `ATTRIBUTE_END`-kinds. However,
the byte containing `ATTRIBUTE_END` (most significant 5 bits, represent `kind`), might
be non-zero in the lower 3 bits (values up to `0x07` represent `ATTRIBUTE_END`). The JDK code
handles this case correctly in [`ImageLocation.decompress()`](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/jdk/internal/jimage/ImageLocation.java#L69..L71). However, the `libjimage`
code in `java.base` doesn't. That can lead to segfaults reading random bytes and offsets.

I propose to break the loop if `ATTRIBUTE_END` is being encountered so that reading stops.

Testing:
 - [x] `test/jdk/tools/jimage` and `test/jdk/jdk/internal/jimage` tests.
 - [x] Manual testing with a patched JDK to write non-zero bytes containing `ATTRIBUTE_END` into the jimage. Segfaults before, runs fine after.
 - [x] GHA.

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302337](https://bugs.openjdk.org/browse/JDK-8302337): JDK crashes if lib/modules contains non-zero byte containing ATTRIBUTE_END


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Jim Laskey](https://openjdk.org/census#jlaskey) (@JimLaskey - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12539/head:pull/12539` \
`$ git checkout pull/12539`

Update a local copy of the PR: \
`$ git checkout pull/12539` \
`$ git pull https://git.openjdk.org/jdk pull/12539/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12539`

View PR using the GUI difftool: \
`$ git pr show -t 12539`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12539.diff">https://git.openjdk.org/jdk/pull/12539.diff</a>

</details>
