### PR TITLE
JDK-8302129: Make MetaspaceReclaimPolicy a diagnostic switch

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1423,7 +1423,7 @@ const int ObjectAlignmentInBytes = 8;
           "Force the class space to be allocated at this address or "       \
           "fails VM initialization (requires -Xshare=off.")                 \
                                                                             \
-  product(ccstr, MetaspaceReclaimPolicy, "balanced",                        \
+  product(ccstr, MetaspaceReclaimPolicy, "balanced", DIAGNOSTIC,            \
           "options: balanced, aggressive, none")                            \
                                                                             \
   product(bool, PrintMetaspaceStatisticsAtExit, false, DIAGNOSTIC,          \

--- a/test/hotspot/jtreg/gtest/MetaspaceGtests.java
+++ b/test/hotspot/jtreg/gtest/MetaspaceGtests.java
@@ -37,7 +37,7 @@
  *          java.xml
  * @requires vm.debug
  * @requires vm.flagless
- * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:MetaspaceReclaimPolicy=none -XX:VerifyMetaspaceInterval=3
+ * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:+UnlockDiagnosticVMOptions -XX:MetaspaceReclaimPolicy=none -XX:VerifyMetaspaceInterval=3
  */
 
 /* @test id=reclaim-none-ndebug
@@ -48,7 +48,7 @@
  *          java.xml
  * @requires vm.debug == false
  * @requires vm.flagless
- * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:MetaspaceReclaimPolicy=none
+ * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:+UnlockDiagnosticVMOptions -XX:MetaspaceReclaimPolicy=none
  */
 
 
@@ -62,7 +62,7 @@
  *          java.xml
  * @requires vm.debug
  * @requires vm.flagless
- * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:MetaspaceReclaimPolicy=aggressive -XX:VerifyMetaspaceInterval=3
+ * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:+UnlockDiagnosticVMOptions -XX:MetaspaceReclaimPolicy=aggressive -XX:VerifyMetaspaceInterval=3
  */
 
 /* @test id=reclaim-aggressive-ndebug
@@ -73,7 +73,7 @@
  *          java.xml
  * @requires vm.debug == false
  * @requires vm.flagless
- * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:MetaspaceReclaimPolicy=aggressive
+ * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:+UnlockDiagnosticVMOptions -XX:MetaspaceReclaimPolicy=aggressive
  */
 
 
@@ -99,5 +99,5 @@
  *          java.xml
  * @requires vm.bits == 64
  * @requires vm.flagless
- * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:MetaspaceReclaimPolicy=balanced -XX:-UseCompressedClassPointers
+ * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:+UnlockDiagnosticVMOptions -XX:MetaspaceReclaimPolicy=balanced -XX:-UseCompressedClassPointers
  */

--- a/test/hotspot/jtreg/runtime/Metaspace/PrintMetaspaceDcmd.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/PrintMetaspaceDcmd.java
@@ -43,7 +43,7 @@ import jdk.test.lib.JDKToolFinder;
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm -Dwith-compressed-class-space -XX:MaxMetaspaceSize=201M -Xmx100M -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:MetaspaceReclaimPolicy=none PrintMetaspaceDcmd
+ * @run main/othervm -Dwith-compressed-class-space -XX:MaxMetaspaceSize=201M -Xmx100M -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:+UnlockDiagnosticVMOptions -XX:MetaspaceReclaimPolicy=none PrintMetaspaceDcmd
  */
 
 /*
@@ -53,7 +53,7 @@ import jdk.test.lib.JDKToolFinder;
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm -Dwith-compressed-class-space -XX:MaxMetaspaceSize=201M -Xmx100M -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:MetaspaceReclaimPolicy=aggressive PrintMetaspaceDcmd
+ * @run main/othervm -Dwith-compressed-class-space -XX:MaxMetaspaceSize=201M -Xmx100M -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:+UnlockDiagnosticVMOptions -XX:MetaspaceReclaimPolicy=aggressive PrintMetaspaceDcmd
  */
 
 /*


### PR DESCRIPTION
See associated CSR for background and motivation: https://bugs.openjdk.org/browse/JDK-8302130 .

This patch is technically trivial. CSR is approved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8302130](https://bugs.openjdk.org/browse/JDK-8302130) to be approved

### Issues
 * [JDK-8302129](https://bugs.openjdk.org/browse/JDK-8302129): Make MetaspaceReclaimPolicy a diagnostic switch
 * [JDK-8302130](https://bugs.openjdk.org/browse/JDK-8302130): Make MetaspaceReclaimPolicy a diagnostic switch (**CSR**)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12540/head:pull/12540` \
`$ git checkout pull/12540`

Update a local copy of the PR: \
`$ git checkout pull/12540` \
`$ git pull https://git.openjdk.org/jdk pull/12540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12540`

View PR using the GUI difftool: \
`$ git pr show -t 12540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12540.diff">https://git.openjdk.org/jdk/pull/12540.diff</a>

</details>
