### PR TITLE
8298278: JFR: Turn MEMFLAGS into a type for use with the NativeMemoryUsage events

### DIFF
--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -723,7 +723,7 @@
 
   <Event name="NativeMemoryUsage" category="Java Virtual Machine, Memory" label="Native Memory Usage Per Type"
     description="Native memory usage for a given memory type in the JVM" period="everyChunk">
-    <Field type="string" name="type" label="Memory Type" description="Type used for the native memory allocation" />
+    <Field type="NMTType" name="type" label="Memory Type" description="Type used for the native memory allocation" />
     <Field type="ulong" contentType="bytes" name="reserved" label="Reserved Memory" description="Reserved bytes for this type" />
     <Field type="ulong" contentType="bytes" name="committed" label="Committed Memory" description="Committed bytes for this type" />
   </Event>
@@ -1376,6 +1376,10 @@
 
   <Type name="ChunkHeader" label="Chunk Header">
     <Field type="byte" array="true" name="payload" label="Payload" />
+  </Type>
+
+  <Type name="NMTType" label="Native Memory Tracking Type">
+    <Field type="string" name="name" label="Name" />
   </Type>
 
   <Relation name="JavaMonitorAddress"/>

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrType.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrType.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,7 @@
 #include "runtime/safepoint.hpp"
 #include "runtime/synchronizer.hpp"
 #include "runtime/vmOperations.hpp"
+#include "services/nmtCommon.hpp"
 #ifdef COMPILER2
 #include "opto/compile.hpp"
 #include "opto/node.hpp"
@@ -319,5 +320,14 @@ void CompilerTypeConstant::serialize(JfrCheckpointWriter& writer) {
   for (u4 i = 0; i < nof_entries; ++i) {
     writer.write_key(i);
     writer.write(compilertype2name((CompilerType)i));
+  }
+}
+
+void NMTTypeConstant::serialize(JfrCheckpointWriter& writer) {
+  writer.write_count(mt_number_of_types);
+  for (int i = 0; i < mt_number_of_types; ++i) {
+    writer.write_key(i);
+    MEMFLAGS flag = NMTUtil::index_to_flag(i);
+    writer.write(NMTUtil::flag_to_name(flag));
   }
 }

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrType.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrType.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,6 +119,11 @@ class BytecodeConstant : public JfrSerializer {
 };
 
 class CompilerTypeConstant : public JfrSerializer {
+ public:
+  void serialize(JfrCheckpointWriter& writer);
+};
+
+class NMTTypeConstant : public JfrSerializer {
  public:
   void serialize(JfrCheckpointWriter& writer);
 };

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeManager.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@
 #include "runtime/javaThread.hpp"
 #include "runtime/semaphore.hpp"
 #include "runtime/thread.inline.hpp"
+#include "services/memTracker.hpp"
 #include "utilities/macros.hpp"
 
 class JfrSerializerRegistration : public JfrCHeapObj {
@@ -237,6 +238,9 @@ bool JfrTypeManager::initialize() {
   register_static_type(TYPE_THREADSTATE, true, new ThreadStateConstant());
   register_static_type(TYPE_BYTECODE, true, new BytecodeConstant());
   register_static_type(TYPE_COMPILERTYPE, true, new CompilerTypeConstant());
+  if (MemTracker::enabled()) {
+    register_static_type(TYPE_NMTTYPE, true, new NMTTypeConstant());
+  }
   return load_thread_constants(JavaThread::current());
 }
 

--- a/src/hotspot/share/services/memJfrReporter.cpp
+++ b/src/hotspot/share/services/memJfrReporter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,10 +85,10 @@ void MemJFRReporter::send_total_event() {
   event.commit();
 }
 
-void MemJFRReporter::send_type_event(const Ticks& starttime, const char* type, size_t reserved, size_t committed) {
+void MemJFRReporter::send_type_event(const Ticks& starttime, MEMFLAGS flag, size_t reserved, size_t committed) {
   EventNativeMemoryUsage event(UNTIMED);
   event.set_starttime(starttime);
-  event.set_type(type);
+  event.set_type(NMTUtil::flag_to_index(flag));
   event.set_reserved(reserved);
   event.set_committed(committed);
   event.commit();
@@ -108,6 +108,6 @@ void MemJFRReporter::send_type_events() {
       // Skip mtNone since it is not really used.
       continue;
     }
-    send_type_event(timestamp, NMTUtil::flag_to_name(flag), usage->reserved(flag), usage->committed(flag));
+    send_type_event(timestamp, flag, usage->reserved(flag), usage->committed(flag));
   }
 }

--- a/src/hotspot/share/services/memJfrReporter.hpp
+++ b/src/hotspot/share/services/memJfrReporter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@
 // so no more synchronization is needed.
 class MemJFRReporter : public AllStatic {
 private:
-  static void send_type_event(const Ticks& starttime, const char* tag, size_t reserved, size_t committed);
+  static void send_type_event(const Ticks& starttime, MEMFLAGS flag, size_t reserved, size_t committed);
  public:
   static void send_total_event();
   static void send_type_events();


### PR DESCRIPTION
Hi,

Could I have review of change that creates a type for MEMFLAGS

Testing: tier1,tier2, jdk/jdk/jfr/*

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298278](https://bugs.openjdk.org/browse/JDK-8298278): JFR: Turn MEMFLAGS into a type for use with the NativeMemoryUsage events


### Reviewers
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12541/head:pull/12541` \
`$ git checkout pull/12541`

Update a local copy of the PR: \
`$ git checkout pull/12541` \
`$ git pull https://git.openjdk.org/jdk pull/12541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12541`

View PR using the GUI difftool: \
`$ git pr show -t 12541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12541.diff">https://git.openjdk.org/jdk/pull/12541.diff</a>

</details>
