### PR TITLE
JDK-8302324: Inheritance tree does not show correct type parameters/arguments

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -1093,22 +1093,8 @@ public class Utils {
      *          be found.
      */
     public TypeMirror getFirstVisibleSuperClass(TypeMirror type) {
-        return getFirstVisibleSuperClass(asTypeElement(type));
-    }
-
-
-    /**
-     * Given a class, return the closest visible superclass.
-     *
-     * @param te the TypeElement to be interrogated
-     * @return the closest visible superclass.  Return null if it cannot
-     *         be found.
-     */
-    public TypeMirror getFirstVisibleSuperClass(TypeElement te) {
-        TypeMirror superType = te.getSuperclass();
-        if (isNoType(superType)) {
-            superType = getObjectType();
-        }
+        List<? extends TypeMirror> superTypes = typeUtils.directSupertypes(type);
+        TypeMirror superType = superTypes.isEmpty() ? getObjectType() : superTypes.get(0);
         TypeElement superClass = asTypeElement(superType);
         // skip "hidden" classes
         while ((superClass != null && hasHiddenTag(superClass))
@@ -1122,10 +1108,22 @@ public class Utils {
             superType = supersuperType;
             superClass = supersuperClass;
         }
-        if (typeUtils.isSameType(te.asType(), superType)) {
+        if (typeUtils.isSameType(type, superType)) {
             return null;
         }
         return superType;
+    }
+
+
+    /**
+     * Given a class, return the closest visible superclass.
+     *
+     * @param te the TypeElement to be interrogated
+     * @return the closest visible superclass.  Return null if it cannot
+     *         be found.
+     */
+    public TypeMirror getFirstVisibleSuperClass(TypeElement te) {
+        return getFirstVisibleSuperClass(te.asType());
     }
 
     /**

--- a/test/langtools/jdk/javadoc/doclet/testInheritance/TestInheritance.java
+++ b/test/langtools/jdk/javadoc/doclet/testInheritance/TestInheritance.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug      8302324
+ * @summary  Inheritance tree does not show correct type parameters/arguments
+ * @library  /tools/lib ../../lib
+ * @modules  jdk.javadoc/jdk.javadoc.internal.tool
+ * @build    toolbox.ToolBox javadoc.tester.*
+ * @run main TestInheritance
+ */
+
+import java.nio.file.Path;
+
+import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+public class TestInheritance extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        var test = new TestInheritance();
+        test.runTests();
+    }
+
+    @Test
+    public void testInheritanceGeneric(Path base) throws Exception {
+        Path src = base.resolve("src");
+        new ToolBox().writeJavaFiles(src, """
+                    package pkg;
+                    /**
+                     * Base class
+                     * @param <M> param M
+                     * @param <N> param N
+                     */
+                    public class A<M, N> { private A() { } }
+                    """,
+                """
+                    package pkg;
+                    /**
+                     * First subclass
+                     * @param <O> param O
+                     * @param <P> param P
+                     */
+                    public class B<O, P>  extends A<O, P> { private B() { } }
+                    """,
+                """
+                    package pkg;
+                    /**
+                     * Second subclass
+                     * @param <Q> param Q
+                     */
+                    public class C<Q>  extends B<String, Q>{ private C() { } }
+                    """,
+                """
+                    package pkg;
+                    /**
+                     * Second subclass
+                     * @param <R> param R
+                     * @param <S> param S
+                     */
+                    public class D<R, S>  extends B<S, B>{ private D() { } }
+                    """);
+        javadoc("-d", base.resolve("docs").toString(),
+                "-sourcepath", src.toString(),
+                "--no-platform-links",
+                "pkg");
+        checkExit(Exit.OK);
+        checkOrder("pkg/A.html", """
+                     <div class="inheritance" title="Inheritance Tree">java.lang.Object
+                     <div class="inheritance">pkg.A&lt;M,<wbr>N&gt;</div>""");
+        checkOrder("pkg/B.html", """
+                     <div class="inheritance" title="Inheritance Tree">java.lang.Object
+                     <div class="inheritance"><a href="A.html" title="class in pkg">pkg.A</a>&lt;O,<wbr>P&gt;
+                     <div class="inheritance">pkg.B&lt;O,<wbr>P&gt;</div>""");
+        checkOrder("pkg/C.html", """
+                     <div class="inheritance" title="Inheritance Tree">java.lang.Object
+                     <div class="inheritance"><a href="A.html" title="class in pkg">pkg.A</a>&lt;java.lang.String,<wbr>Q&gt;
+                     <div class="inheritance"><a href="B.html" title="class in pkg">pkg.B</a>&lt;java.lang.String,<wbr>Q&gt;
+                     <div class="inheritance">pkg.C&lt;Q&gt;</div>""");
+        checkOrder("pkg/D.html", """
+                     <div class="inheritance" title="Inheritance Tree">java.lang.Object
+                     <div class="inheritance"><a href="A.html" title="class in pkg">pkg.A</a>&lt;S,<wbr><a href="B.html" title="class in pkg">B</a>&gt;
+                     <div class="inheritance"><a href="B.html" title="class in pkg">pkg.B</a>&lt;S,<wbr><a href="B.html" title="class in pkg">B</a>&gt;
+                     <div class="inheritance">pkg.D&lt;R,<wbr>S&gt;</div>""");
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testInheritance/TestInheritance.java
+++ b/test/langtools/jdk/javadoc/doclet/testInheritance/TestInheritance.java
@@ -79,7 +79,7 @@ public class TestInheritance extends JavadocTester {
                      * @param <R> param R
                      * @param <S> param S
                      */
-                    public class D<R, S>  extends B<S, B>{ private D() { } }
+                    public class D<R, S> extends B<S, B> { private D() { } }
                     """);
         javadoc("-d", base.resolve("docs").toString(),
                 "-sourcepath", src.toString(),

--- a/test/langtools/jdk/javadoc/doclet/testInheritance/TestInheritance.java
+++ b/test/langtools/jdk/javadoc/doclet/testInheritance/TestInheritance.java
@@ -70,7 +70,7 @@ public class TestInheritance extends JavadocTester {
                      * Second subclass
                      * @param <Q> param Q
                      */
-                    public class C<Q>  extends B<String, Q>{ private C() { } }
+                    public class C<Q> extends B<String, Q> { private C() { } }
                     """,
                 """
                     package pkg;

--- a/test/langtools/jdk/javadoc/doclet/testInheritance/TestInheritance.java
+++ b/test/langtools/jdk/javadoc/doclet/testInheritance/TestInheritance.java
@@ -62,7 +62,7 @@ public class TestInheritance extends JavadocTester {
                      * @param <O> param O
                      * @param <P> param P
                      */
-                    public class B<O, P>  extends A<O, P> { private B() { } }
+                    public class B<O, P> extends A<O, P> { private B() { } }
                     """,
                 """
                     package pkg;


### PR DESCRIPTION
Please review a simple change to show the correct type parameters or arguments in the inheritance list in the class documentation header. The solution is simply to move the implementation of `Utils.getFirstVisibleSuperClass(...)` from the method with a `TypeElement` parameter to the one with a `TypeMirror` parameter, thereby preserving the type arguments.

I compared JDK API docs with and without this change, and the only change is that inheritance with generic superclasses is now rendered correctly. For instance, the inheritance list for `java.util.Properties` used to look like this:

```
java.lang.Object
    java.util.Dictionary<K,V>
        java.util.Hashtable<Object,Object>
            java.util.Properties
```
Now it is generated as follows:
```
java.lang.Object
    java.util.Dictionary<Object,Object>
        java.util.Hashtable<Object,Object>
            java.util.Properties
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302324](https://bugs.openjdk.org/browse/JDK-8302324): Inheritance tree does not show correct type parameters/arguments


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**) ⚠️ Review applies to [f2b94e2d](https://git.openjdk.org/jdk/pull/12544/files/f2b94e2d422863e41c90ce269a732e06a6b92566)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12544/head:pull/12544` \
`$ git checkout pull/12544`

Update a local copy of the PR: \
`$ git checkout pull/12544` \
`$ git pull https://git.openjdk.org/jdk pull/12544/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12544`

View PR using the GUI difftool: \
`$ git pr show -t 12544`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12544.diff">https://git.openjdk.org/jdk/pull/12544.diff</a>

</details>
