### PR TITLE
8297936: Use reachabilityFence to manage liveness in ClassUnload tests

### DIFF
--- a/test/hotspot/jtreg/runtime/ClassUnload/ConstantPoolDependsTest.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/ConstantPoolDependsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,12 +32,13 @@
  * @build jdk.test.whitebox.WhiteBox
  * @compile p2/c2.java MyDiffClassLoader.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -Xmn8m -XX:+UnlockDiagnosticVMOptions -Xlog:class+unload -XX:+WhiteBoxAPI ConstantPoolDependsTest
+ * @run main/othervm -Xbootclasspath/a:. -Xmn8m -XX:+UnlockDiagnosticVMOptions -Xlog:class+unload -Xcomp -XX:+WhiteBoxAPI ConstantPoolDependsTest
  */
 
 import jdk.test.whitebox.WhiteBox;
 import jdk.test.lib.classloader.ClassUnloadCommon;
 
+import java.lang.ref.Reference;
 public class ConstantPoolDependsTest {
     public static WhiteBox wb = WhiteBox.getWhiteBox();
     public static final String MY_TEST = "ConstantPoolDependsTest$c1c";
@@ -71,8 +72,8 @@ public class ConstantPoolDependsTest {
         ClassUnloadCommon.triggerUnloading();  // should not unload anything
         ClassUnloadCommon.failIf(!wb.isClassAlive(MY_TEST), "should not be unloaded");
         ClassUnloadCommon.failIf(!wb.isClassAlive("p2.c2"), "should not be unloaded");
-        // Unless MyTest_class is referenced here, the compiler can unload it.
-        System.out.println("Should not unload anything before here because " + MyTest_class + " is still alive.");
+        // Should not unload anything before here because MyTest_class is kept alive by the following fence.
+        Reference.reachabilityFence(MyTest_class);
     }
 
     public static void main(String args[]) throws Throwable {

--- a/test/hotspot/jtreg/runtime/ClassUnload/ConstantPoolDependsTest.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/ConstantPoolDependsTest.java
@@ -32,7 +32,7 @@
  * @build jdk.test.whitebox.WhiteBox
  * @compile p2/c2.java MyDiffClassLoader.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -Xmn8m -XX:+UnlockDiagnosticVMOptions -Xlog:class+unload -Xcomp -XX:+WhiteBoxAPI ConstantPoolDependsTest
+ * @run main/othervm -Xbootclasspath/a:. -Xmn8m -XX:+UnlockDiagnosticVMOptions -Xlog:class+unload -XX:+WhiteBoxAPI ConstantPoolDependsTest
  */
 
 import jdk.test.whitebox.WhiteBox;

--- a/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveObject.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,26 +30,25 @@
  * @library classes
  * @build jdk.test.whitebox.WhiteBox test.Empty
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -Xmn8m -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI KeepAliveObject
+ * @run main/othervm -Xbootclasspath/a:. -Xmn8m -XX:+UnlockDiagnosticVMOptions -Xcomp -XX:+WhiteBoxAPI KeepAliveObject
  */
 
 import jdk.test.whitebox.WhiteBox;
 import jdk.test.lib.classloader.ClassUnloadCommon;
 
+import java.lang.ref.Reference;
 /**
  * Test that verifies that classes are not unloaded when specific types of references are kept to them.
  */
 public class KeepAliveObject {
   private static final String className = "test.Empty";
   private static final WhiteBox wb = WhiteBox.getWhiteBox();
-  public static Object escape = null;
 
   public static void main(String... args) throws Exception {
     ClassLoader cl = ClassUnloadCommon.newClassLoader();
     Class<?> c = cl.loadClass(className);
     Object o = c.newInstance();
     cl = null; c = null;
-    escape = o;
 
     {
         boolean isAlive = wb.isClassAlive(className);
@@ -66,8 +65,8 @@ public class KeepAliveObject {
 
         ClassUnloadCommon.failIf(!isAlive, "should be alive");
     }
+    Reference.reachabilityFence(o);
     o = null;
-    escape = null;
     ClassUnloadCommon.triggerUnloading();
 
     {

--- a/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveObject.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveObject.java
@@ -30,7 +30,7 @@
  * @library classes
  * @build jdk.test.whitebox.WhiteBox test.Empty
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -Xmn8m -XX:+UnlockDiagnosticVMOptions -Xcomp -XX:+WhiteBoxAPI KeepAliveObject
+ * @run main/othervm -Xbootclasspath/a:. -Xmn8m -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI KeepAliveObject
  */
 
 import jdk.test.whitebox.WhiteBox;
@@ -65,6 +65,7 @@ public class KeepAliveObject {
 
         ClassUnloadCommon.failIf(!isAlive, "should be alive");
     }
+    // Don't let `o` get prematurely reclaimed by the GC.
     Reference.reachabilityFence(o);
     o = null;
     ClassUnloadCommon.triggerUnloading();

--- a/test/hotspot/jtreg/runtime/ClassUnload/UnloadTest.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/UnloadTest.java
@@ -30,7 +30,7 @@
  * @library classes
  * @build jdk.test.whitebox.WhiteBox test.Empty
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -Xmn8m -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:class+unload=debug -Xcomp UnloadTest
+ * @run main/othervm -Xbootclasspath/a:. -Xmn8m -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:class+unload=debug UnloadTest
  */
 import jdk.test.whitebox.WhiteBox;
 import jdk.test.lib.classloader.ClassUnloadCommon;
@@ -49,7 +49,6 @@ import java.lang.ref.Reference;
  *    and verifies the class is unloaded.
  */
 public class UnloadTest {
-    // Using a global static field to keep the object live in -Xcomp mode.
 
     public static void main(String... args) throws Exception {
         test_unload_instance_klass();
@@ -76,6 +75,7 @@ public class UnloadTest {
 
         ClassUnloadCommon.failIf(!wb.isClassAlive(className), "should still be live");
 
+        // Don't let `o` get prematurely reclaimed by the GC.
         Reference.reachabilityFence(o);
         o = null;
         ClassUnloadCommon.triggerUnloading();
@@ -105,6 +105,7 @@ public class UnloadTest {
         ClassUnloadCommon.triggerUnloading();
         ClassUnloadCommon.failIf(!wb.isClassAlive(className), "should still be live");
 
+        // Don't let `o` get prematurely reclaimed by the GC.
         Reference.reachabilityFence(o);
         o = null;
         ClassUnloadCommon.triggerUnloading();


### PR DESCRIPTION
### Description
Instead of using static instances or using an object in print to keep it alive, `java.lang.ref.Reference.reachabilityFence(Object)` is used to keep an object alive and avoid class unloading.

### Tests
linux-x64-debug, macosx-aarch64-debug, mach5 tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297936](https://bugs.openjdk.org/browse/JDK-8297936): Use reachabilityFence to manage liveness in ClassUnload tests


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12552/head:pull/12552` \
`$ git checkout pull/12552`

Update a local copy of the PR: \
`$ git checkout pull/12552` \
`$ git pull https://git.openjdk.org/jdk pull/12552/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12552`

View PR using the GUI difftool: \
`$ git pr show -t 12552`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12552.diff">https://git.openjdk.org/jdk/pull/12552.diff</a>

</details>
