### PR TITLE
8302453: RISC-V: Add support for small width vector operations

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1639,12 +1639,7 @@ void C2_MacroAssembler::reduce_minmax_FD_v(FloatRegister dst,
   assert_different_registers(src2, tmp1, tmp2);
 
   Label L_done, L_NaN;
-  if (length_in_bytes != MaxVectorSize) {
-    mv(t0, length_in_bytes / type2aelembytes(is_double ? T_DOUBLE : T_FLOAT));
-    vsetvli(t0, t0, is_double ? Assembler::e64 : Assembler::e32);
-  } else {
-    vsetvli(t0, x0, is_double ? Assembler::e64 : Assembler::e32);
-  }
+  rvv_vsetvli(is_double ? T_DOUBLE : T_FLOAT, length_in_bytes);
   vfmv_s_f(tmp2, src1);
 
   is_min ? vfredmin_vs(tmp1, src2, tmp2)
@@ -1680,13 +1675,7 @@ void C2_MacroAssembler::rvv_reduce_integral(Register dst, VectorRegister tmp,
                                             BasicType bt, int opc, int length_in_bytes) {
   assert(bt == T_BYTE || bt == T_SHORT || bt == T_INT || bt == T_LONG, "unsupported element type");
 
-  Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-  if (length_in_bytes != MaxVectorSize) {
-    mv(t0, length_in_bytes / type2aelembytes(bt));
-    vsetvli(t0, t0, sew);
-  } else {
-    vsetvli(t0, x0, sew);
-  }
+  rvv_vsetvli(bt, length_in_bytes);
 
   vmv_s_x(tmp, src1);
 
@@ -1715,4 +1704,14 @@ void C2_MacroAssembler::rvv_reduce_integral(Register dst, VectorRegister tmp,
   }
 
   vmv_x_s(dst, tmp);
+}
+
+void C2_MacroAssembler::rvv_vsetvli(BasicType bt, int length_in_bytes) {
+  Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
+  if (length_in_bytes != MaxVectorSize) {
+    mv(t0, length_in_bytes / type2aelembytes(bt));
+    vsetvli(t0, t0, sew);
+  } else {
+    vsetvli(t0, x0, sew);
+  }
 }

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1706,12 +1706,12 @@ void C2_MacroAssembler::rvv_reduce_integral(Register dst, VectorRegister tmp,
   vmv_x_s(dst, tmp);
 }
 
-void C2_MacroAssembler::rvv_vsetvli(BasicType bt, int length_in_bytes) {
+void C2_MacroAssembler::rvv_vsetvli(BasicType bt, int length_in_bytes, Register tmp) {
   Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
   if (length_in_bytes != MaxVectorSize) {
-    mv(t0, length_in_bytes / type2aelembytes(bt));
-    vsetvli(t0, t0, sew);
+    mv(tmp, length_in_bytes / type2aelembytes(bt));
+    vsetvli(tmp, tmp, sew);
   } else {
-    vsetvli(t0, x0, sew);
+    vsetvli(tmp, x0, sew);
   }
 }

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1708,10 +1708,15 @@ void C2_MacroAssembler::rvv_reduce_integral(Register dst, VectorRegister tmp,
 
 void C2_MacroAssembler::rvv_vsetvli(BasicType bt, int length_in_bytes, Register tmp) {
   Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-  if (length_in_bytes != MaxVectorSize) {
-    mv(tmp, length_in_bytes / type2aelembytes(bt));
-    vsetvli(tmp, tmp, sew);
-  } else {
+  if (length_in_bytes == MaxVectorSize) {
     vsetvli(tmp, x0, sew);
+  } else {
+    int num_elements = length_in_bytes / type2aelembytes(bt);
+    if (num_elements <= 31) {
+      vsetivli(tmp, num_elements, sew);
+    } else {
+      mv(tmp, num_elements);
+      vsetvli(tmp, tmp, sew);
+    }
   }
 }

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1706,6 +1706,8 @@ void C2_MacroAssembler::rvv_reduce_integral(Register dst, VectorRegister tmp,
   vmv_x_s(dst, tmp);
 }
 
+// Set vl and vtype for full and partial vector operations.
+// (vlmul = m1, vma = mu, vta = tu, vill = false)
 void C2_MacroAssembler::rvv_vsetvli(BasicType bt, int length_in_bytes, Register tmp) {
   Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
   if (length_in_bytes == MaxVectorSize) {

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1617,10 +1617,10 @@ void C2_MacroAssembler::string_indexof_char_v(Register str1, Register cnt1,
 
 // Set dst to NaN if any NaN input.
 void C2_MacroAssembler::minmax_FD_v(VectorRegister dst, VectorRegister src1, VectorRegister src2,
-                                    bool is_double, bool is_min) {
+                                    bool is_double, bool is_min, int length_in_bytes) {
   assert_different_registers(dst, src1, src2);
 
-  vsetvli(t0, x0, is_double ? Assembler::e64 : Assembler::e32);
+  rvv_vsetvli(is_double ? T_DOUBLE : T_FLOAT, length_in_bytes);
 
   is_min ? vfmin_vv(dst, src1, src2)
          : vfmax_vv(dst, src1, src2);

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1635,11 +1635,16 @@ void C2_MacroAssembler::minmax_FD_v(VectorRegister dst, VectorRegister src1, Vec
 void C2_MacroAssembler::reduce_minmax_FD_v(FloatRegister dst,
                                            FloatRegister src1, VectorRegister src2,
                                            VectorRegister tmp1, VectorRegister tmp2,
-                                           bool is_double, bool is_min) {
+                                           bool is_double, bool is_min, int length_in_bytes) {
   assert_different_registers(src2, tmp1, tmp2);
 
   Label L_done, L_NaN;
-  vsetvli(t0, x0, is_double ? Assembler::e64 : Assembler::e32);
+  if (length_in_bytes != MaxVectorSize) {
+    mv(t0, length_in_bytes / type2aelembytes(is_double ? T_DOUBLE : T_FLOAT));
+    vsetvli(t0, t0, is_double ? Assembler::e64 : Assembler::e32);
+  } else {
+    vsetvli(t0, x0, is_double ? Assembler::e64 : Assembler::e32);
+  }
   vfmv_s_f(tmp2, src1);
 
   is_min ? vfredmin_vs(tmp1, src2, tmp2)
@@ -1672,11 +1677,16 @@ bool C2_MacroAssembler::in_scratch_emit_size() {
 
 void C2_MacroAssembler::rvv_reduce_integral(Register dst, VectorRegister tmp,
                                             Register src1, VectorRegister src2,
-                                            BasicType bt, int opc) {
+                                            BasicType bt, int opc, int length_in_bytes) {
   assert(bt == T_BYTE || bt == T_SHORT || bt == T_INT || bt == T_LONG, "unsupported element type");
 
   Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-  vsetvli(t0, x0, sew);
+  if (length_in_bytes != MaxVectorSize) {
+    mv(t0, length_in_bytes / type2aelembytes(bt));
+    vsetvli(t0, t0, sew);
+  } else {
+    vsetvli(t0, x0, sew);
+  }
 
   vmv_s_x(tmp, src1);
 

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -196,4 +196,6 @@
                           Register src1, VectorRegister src2,
                           BasicType bt, int opc, int length_in_bytes);
 
+ void rvv_vsetvli(BasicType bt, int length_in_bytes);
+
 #endif // CPU_RISCV_C2_MACROASSEMBLER_RISCV_HPP

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -185,7 +185,7 @@
 
  void minmax_FD_v(VectorRegister dst,
                   VectorRegister src1, VectorRegister src2,
-                  bool is_double, bool is_min);
+                  bool is_double, bool is_min, int length_in_bytes);
 
  void reduce_minmax_FD_v(FloatRegister dst,
                          FloatRegister src1, VectorRegister src2,

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -196,6 +196,6 @@
                           Register src1, VectorRegister src2,
                           BasicType bt, int opc, int length_in_bytes);
 
- void rvv_vsetvli(BasicType bt, int length_in_bytes);
+ void rvv_vsetvli(BasicType bt, int length_in_bytes, Register tmp = t0);
 
 #endif // CPU_RISCV_C2_MACROASSEMBLER_RISCV_HPP

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -190,10 +190,10 @@
  void reduce_minmax_FD_v(FloatRegister dst,
                          FloatRegister src1, VectorRegister src2,
                          VectorRegister tmp1, VectorRegister tmp2,
-                         bool is_double, bool is_min);
+                         bool is_double, bool is_min, int length_in_bytes);
 
  void rvv_reduce_integral(Register dst, VectorRegister tmp,
                           Register src1, VectorRegister src2,
-                          BasicType bt, int opc);
+                          BasicType bt, int opc, int length_in_bytes);
 
 #endif // CPU_RISCV_C2_MACROASSEMBLER_RISCV_HPP

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1936,14 +1936,12 @@ const int Matcher::vector_width_in_bytes(BasicType bt) {
 const int Matcher::max_vector_size(const BasicType bt) {
   return vector_width_in_bytes(bt) / type2aelembytes(bt);
 }
+
 const int Matcher::min_vector_size(const BasicType bt) {
   int max_size = max_vector_size(bt);
   // Limit the min vector size to 8 bytes.
   int size = 8 / type2aelembytes(bt);
-  if (bt == T_BYTE) {
-    // To support vector api shuffle/rearrange.
-    size = 4;
-  } else if (bt == T_BOOLEAN) {
+  if (bt == T_BOOLEAN) {
     // To support vector api load/store mask.
     size = 2;
   }

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1922,7 +1922,12 @@ const int Matcher::vector_width_in_bytes(BasicType bt) {
   if (UseRVV) {
     // The MaxVectorSize should have been set by detecting RVV max vector register size when check UseRVV.
     // MaxVectorSize == VM_Version::_initial_vector_length
-    return MaxVectorSize;
+    int size = MaxVectorSize;
+    // Minimum 2 values in vector
+    if (size < 2 * type2aelembytes(bt)) size = 0;
+    // But never < 4
+    if (size < 4) size = 0;
+    return size;
   }
   return 0;
 }
@@ -1932,7 +1937,18 @@ const int Matcher::max_vector_size(const BasicType bt) {
   return vector_width_in_bytes(bt) / type2aelembytes(bt);
 }
 const int Matcher::min_vector_size(const BasicType bt) {
-  return max_vector_size(bt);
+  int max_size = max_vector_size(bt);
+  // Limit the min vector size to 8 bytes.
+  int size = 8 / type2aelembytes(bt);
+  if (bt == T_BYTE) {
+    // To support vector api shuffle/rearrange.
+    size = 4;
+  } else if (bt == T_BOOLEAN) {
+    // To support vector api load/store mask.
+    size = 2;
+  }
+  if (size < 2) size = 2;
+  return MIN2(size, max_size);
 }
 
 // Vector ideal reg.

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -37,12 +37,7 @@ source %{
   static void loadStore(C2_MacroAssembler masm, bool is_store,
                         VectorRegister reg, BasicType bt, Register base, int length_in_bytes) {
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    if (length_in_bytes != MaxVectorSize) {
-      masm.mv(t0, length_in_bytes / type2aelembytes(bt));
-      masm.vsetvli(t0, t0, sew);
-    } else {
-      masm.vsetvli(t0, x0, sew);
-    }
+    masm.rvv_vsetvli(bt, length_in_bytes);
 
     if (is_store) {
       masm.vsex_v(reg, base, sew);
@@ -973,13 +968,7 @@ instruct reduce_addF(fRegF src1_dst, vReg src2, vReg tmp) %{
             "vfredosum.vs $tmp, $src2, $tmp\n\t"
             "vfmv.f.s $src1_dst, $tmp" %}
   ins_encode %{
-    int length_in_bytes = Matcher::vector_length_in_bytes(this, $src2);
-    if (length_in_bytes != MaxVectorSize) {
-      __ mv(t0, length_in_bytes / type2aelembytes(T_FLOAT));
-      __ vsetvli(t0, t0, Assembler::e32);
-    } else {
-      __ vsetvli(t0, x0, Assembler::e32);
-    }
+    __ rvv_vsetvli(T_FLOAT, Matcher::vector_length_in_bytes(this, $src2));
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1_dst$$FloatRegister);
     __ vfredosum_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg),
                     as_VectorRegister($tmp$$reg));
@@ -996,13 +985,7 @@ instruct reduce_addD(fRegD src1_dst, vReg src2, vReg tmp) %{
             "vfredosum.vs $tmp, $src2, $tmp\n\t"
             "vfmv.f.s $src1_dst, $tmp" %}
   ins_encode %{
-    int length_in_bytes = Matcher::vector_length_in_bytes(this, $src2);
-    if (length_in_bytes != MaxVectorSize) {
-      __ mv(t0, length_in_bytes / type2aelembytes(T_DOUBLE));
-      __ vsetvli(t0, t0, Assembler::e64);
-    } else {
-      __ vsetvli(t0, x0, Assembler::e64);
-    }
+    __ rvv_vsetvli(T_DOUBLE, Matcher::vector_length_in_bytes(this, $src2));
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1_dst$$FloatRegister);
     __ vfredosum_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg),
                     as_VectorRegister($tmp$$reg));

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -1736,7 +1736,7 @@ instruct vsqrtF(vReg dst, vReg src) %{
   ins_cost(VEC_COST);
   format %{ "vfsqrt.v $dst, $src\t#@vsqrtF" %}
   ins_encode %{
-    __ rvv_vsetvli(T_INT, Matcher::vector_length_in_bytes(this));
+    __ rvv_vsetvli(T_FLOAT, Matcher::vector_length_in_bytes(this));
     __ vfsqrt_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -1747,7 +1747,7 @@ instruct vsqrtD(vReg dst, vReg src) %{
   ins_cost(VEC_COST);
   format %{ "vfsqrt.v $dst, $src\t#@vsqrtD" %}
   ins_encode %{
-    __ rvv_vsetvli(T_LONG, Matcher::vector_length_in_bytes(this));
+    __ rvv_vsetvli(T_DOUBLE, Matcher::vector_length_in_bytes(this));
     __ vfsqrt_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -35,9 +35,15 @@ source_hpp %{
 source %{
 
   static void loadStore(C2_MacroAssembler masm, bool is_store,
-                        VectorRegister reg, BasicType bt, Register base) {
+                        VectorRegister reg, BasicType bt, Register base, int length_in_bytes) {
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    masm.vsetvli(t0, x0, sew);
+    if (length_in_bytes != MaxVectorSize) {
+      masm.mv(t0, length_in_bytes / type2aelembytes(bt));
+      masm.vsetvli(t0, t0, sew);
+    } else {
+      masm.vsetvli(t0, x0, sew);
+    }
+
     if (is_store) {
       masm.vsex_v(reg, base, sew);
     } else {
@@ -101,11 +107,11 @@ definitions %{
 instruct loadV(vReg dst, vmemA mem) %{
   match(Set dst (LoadVector mem));
   ins_cost(VEC_COST);
-  format %{ "vle $dst, $mem\t#@loadV" %}
+  format %{ "loadV $dst, $mem\t# vector (rvv)" %}
   ins_encode %{
     VectorRegister dst_reg = as_VectorRegister($dst$$reg);
     loadStore(C2_MacroAssembler(&cbuf), false, dst_reg,
-              Matcher::vector_element_basic_type(this), as_Register($mem$$base));
+              Matcher::vector_element_basic_type(this), as_Register($mem$$base), Matcher::vector_length_in_bytes(this));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -113,11 +119,11 @@ instruct loadV(vReg dst, vmemA mem) %{
 instruct storeV(vReg src, vmemA mem) %{
   match(Set mem (StoreVector mem src));
   ins_cost(VEC_COST);
-  format %{ "vse $src, $mem\t#@storeV" %}
+  format %{ "storeV $mem, $src\t# vector (rvv)" %}
   ins_encode %{
     VectorRegister src_reg = as_VectorRegister($src$$reg);
     loadStore(C2_MacroAssembler(&cbuf), true, src_reg,
-              Matcher::vector_element_basic_type(this, $src), as_Register($mem$$base));
+              Matcher::vector_element_basic_type(this, $src), as_Register($mem$$base), Matcher::vector_length_in_bytes(this, $src));
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -828,7 +828,8 @@ instruct reduce_andI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt,
+                           this->ideal_Opcode(), Matcher::vector_length_in_bytes(this, $src2));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -844,7 +845,8 @@ instruct reduce_andL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt,
+                           this->ideal_Opcode(), Matcher::vector_length_in_bytes(this, $src2));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -864,7 +866,8 @@ instruct reduce_orI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt,
+                           this->ideal_Opcode(), Matcher::vector_length_in_bytes(this, $src2));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -880,7 +883,8 @@ instruct reduce_orL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt,
+                           this->ideal_Opcode(), Matcher::vector_length_in_bytes(this, $src2));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -900,7 +904,8 @@ instruct reduce_xorI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt,
+                           this->ideal_Opcode(), Matcher::vector_length_in_bytes(this, $src2));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -916,7 +921,8 @@ instruct reduce_xorL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt,
+                           this->ideal_Opcode(), Matcher::vector_length_in_bytes(this, $src2));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -936,7 +942,8 @@ instruct reduce_addI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt,
+                           this->ideal_Opcode(), Matcher::vector_length_in_bytes(this, $src2));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -952,7 +959,8 @@ instruct reduce_addL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt,
+                           this->ideal_Opcode(), Matcher::vector_length_in_bytes(this, $src2));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -965,7 +973,13 @@ instruct reduce_addF(fRegF src1_dst, vReg src2, vReg tmp) %{
             "vfredosum.vs $tmp, $src2, $tmp\n\t"
             "vfmv.f.s $src1_dst, $tmp" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    int length_in_bytes = Matcher::vector_length_in_bytes(this, $src2);
+    if (length_in_bytes != MaxVectorSize) {
+      __ mv(t0, length_in_bytes / type2aelembytes(T_FLOAT));
+      __ vsetvli(t0, t0, Assembler::e32);
+    } else {
+      __ vsetvli(t0, x0, Assembler::e32);
+    }
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1_dst$$FloatRegister);
     __ vfredosum_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg),
                     as_VectorRegister($tmp$$reg));
@@ -982,7 +996,13 @@ instruct reduce_addD(fRegD src1_dst, vReg src2, vReg tmp) %{
             "vfredosum.vs $tmp, $src2, $tmp\n\t"
             "vfmv.f.s $src1_dst, $tmp" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    int length_in_bytes = Matcher::vector_length_in_bytes(this, $src2);
+    if (length_in_bytes != MaxVectorSize) {
+      __ mv(t0, length_in_bytes / type2aelembytes(T_DOUBLE));
+      __ vsetvli(t0, t0, Assembler::e64);
+    } else {
+      __ vsetvli(t0, x0, Assembler::e64);
+    }
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1_dst$$FloatRegister);
     __ vfredosum_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg),
                     as_VectorRegister($tmp$$reg));
@@ -1004,7 +1024,8 @@ instruct vreduce_maxI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt,
+                           this->ideal_Opcode(), Matcher::vector_length_in_bytes(this, $src2));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1018,7 +1039,8 @@ instruct vreduce_maxL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt,
+                           this->ideal_Opcode(), Matcher::vector_length_in_bytes(this, $src2));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1036,7 +1058,8 @@ instruct vreduce_minI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt,
+                           this->ideal_Opcode(), Matcher::vector_length_in_bytes(this, $src2));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1050,7 +1073,8 @@ instruct vreduce_minL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ rvv_reduce_integral($dst$$Register, as_VectorRegister($tmp$$reg),
-                           $src1$$Register, as_VectorRegister($src2$$reg), bt, this->ideal_Opcode());
+                           $src1$$Register, as_VectorRegister($src2$$reg), bt,
+                           this->ideal_Opcode(), Matcher::vector_length_in_bytes(this, $src2));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1067,7 +1091,7 @@ instruct vreduce_maxF(fRegF dst, fRegF src1, vReg src2, vReg tmp1, vReg tmp2) %{
     __ reduce_minmax_FD_v($dst$$FloatRegister,
                           $src1$$FloatRegister, as_VectorRegister($src2$$reg),
                           as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
-                          false /* is_double */, false /* is_min */);
+                          false /* is_double */, false /* is_min */, Matcher::vector_length_in_bytes(this, $src2));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1082,7 +1106,7 @@ instruct vreduce_maxD(fRegD dst, fRegD src1, vReg src2, vReg tmp1, vReg tmp2) %{
     __ reduce_minmax_FD_v($dst$$FloatRegister,
                           $src1$$FloatRegister, as_VectorRegister($src2$$reg),
                           as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
-                          true /* is_double */, false /* is_min */);
+                          true /* is_double */, false /* is_min */, Matcher::vector_length_in_bytes(this, $src2));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1099,7 +1123,7 @@ instruct vreduce_minF(fRegF dst, fRegF src1, vReg src2, vReg tmp1, vReg tmp2) %{
     __ reduce_minmax_FD_v($dst$$FloatRegister,
                           $src1$$FloatRegister, as_VectorRegister($src2$$reg),
                           as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
-                          false /* is_double */, true /* is_min */);
+                          false /* is_double */, true /* is_min */, Matcher::vector_length_in_bytes(this, $src2));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1114,7 +1138,7 @@ instruct vreduce_minD(fRegD dst, fRegD src1, vReg src2, vReg tmp1, vReg tmp2) %{
     __ reduce_minmax_FD_v($dst$$FloatRegister,
                           $src1$$FloatRegister, as_VectorRegister($src2$$reg),
                           as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
-                          true /* is_double */, true /* is_min */);
+                          true /* is_double */, true /* is_min */, Matcher::vector_length_in_bytes(this, $src2));
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -132,7 +132,7 @@ instruct vabsB(vReg dst, vReg src, vReg tmp) %{
   format %{ "vrsub.vi $tmp, 0, $src\t#@vabsB\n\t"
             "vmax.vv $dst, $tmp, $src" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e8);
+    __ rvv_vsetvli(T_BYTE, Matcher::vector_length_in_bytes(this));
     __ vrsub_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg), 0);
     __ vmax_vv(as_VectorRegister($dst$$reg), as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg));
   %}
@@ -146,7 +146,7 @@ instruct vabsS(vReg dst, vReg src, vReg tmp) %{
   format %{ "vrsub.vi $tmp, 0, $src\t#@vabsS\n\t"
             "vmax.vv $dst, $tmp, $src" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e16);
+    __ rvv_vsetvli(T_SHORT, Matcher::vector_length_in_bytes(this));
     __ vrsub_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg), 0);
     __ vmax_vv(as_VectorRegister($dst$$reg), as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg));
   %}
@@ -160,7 +160,7 @@ instruct vabsI(vReg dst, vReg src, vReg tmp) %{
   format %{ "vrsub.vi $tmp, 0, $src\t#@vabsI\n\t"
             "vmax.vv $dst, $tmp, $src" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_INT, Matcher::vector_length_in_bytes(this));
     __ vrsub_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg), 0);
     __ vmax_vv(as_VectorRegister($dst$$reg), as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg));
   %}
@@ -174,7 +174,7 @@ instruct vabsL(vReg dst, vReg src, vReg tmp) %{
   format %{ "vrsub.vi $tmp, 0, $src\t#@vabsL\n\t"
             "vmax.vv $dst, $tmp, $src" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_LONG, Matcher::vector_length_in_bytes(this));
     __ vrsub_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg), 0);
     __ vmax_vv(as_VectorRegister($dst$$reg), as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg));
   %}
@@ -186,7 +186,7 @@ instruct vabsF(vReg dst, vReg src) %{
   ins_cost(VEC_COST);
   format %{ "vfsgnjx.vv $dst, $src, $src, vm\t#@vabsF" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_FLOAT, Matcher::vector_length_in_bytes(this));
     __ vfsgnjx_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -197,7 +197,7 @@ instruct vabsD(vReg dst, vReg src) %{
   ins_cost(VEC_COST);
   format %{ "vfsgnjx.vv $dst, $src, $src, vm\t#@vabsD" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_DOUBLE, Matcher::vector_length_in_bytes(this));
     __ vfsgnjx_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -210,7 +210,7 @@ instruct vaddB(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vadd.vv $dst, $src1, $src2\t#@vaddB" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e8);
+    __ rvv_vsetvli(T_BYTE, Matcher::vector_length_in_bytes(this));
     __ vadd_vv(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_VectorRegister($src2$$reg));
@@ -223,7 +223,7 @@ instruct vaddS(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vadd.vv $dst, $src1, $src2\t#@vaddS" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e16);
+    __ rvv_vsetvli(T_SHORT, Matcher::vector_length_in_bytes(this));
     __ vadd_vv(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_VectorRegister($src2$$reg));
@@ -236,7 +236,7 @@ instruct vaddI(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vadd.vv $dst, $src1, $src2\t#@vaddI" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_INT, Matcher::vector_length_in_bytes(this));
     __ vadd_vv(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_VectorRegister($src2$$reg));
@@ -249,7 +249,7 @@ instruct vaddL(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vadd.vv $dst, $src1, $src2\t#@vaddL" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_LONG, Matcher::vector_length_in_bytes(this));
     __ vadd_vv(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_VectorRegister($src2$$reg));
@@ -262,7 +262,7 @@ instruct vaddF(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vfadd.vv $dst, $src1, $src2\t#@vaddF" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_FLOAT, Matcher::vector_length_in_bytes(this));
     __ vfadd_vv(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
@@ -275,7 +275,7 @@ instruct vaddD(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vfadd.vv $dst, $src1, $src2\t#@vaddD" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_DOUBLE, Matcher::vector_length_in_bytes(this));
     __ vfadd_vv(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
@@ -290,7 +290,7 @@ instruct vand(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vand.vv  $dst, $src1, $src2\t#@vand" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_LONG, Matcher::vector_length_in_bytes(this));
     __ vand_vv(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_VectorRegister($src2$$reg));
@@ -305,7 +305,7 @@ instruct vor(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vor.vv  $dst, $src1, $src2\t#@vor" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_LONG, Matcher::vector_length_in_bytes(this));
     __ vor_vv(as_VectorRegister($dst$$reg),
               as_VectorRegister($src1$$reg),
               as_VectorRegister($src2$$reg));
@@ -320,7 +320,7 @@ instruct vxor(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vxor.vv  $dst, $src1, $src2\t#@vxor" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_LONG, Matcher::vector_length_in_bytes(this));
     __ vxor_vv(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_VectorRegister($src2$$reg));
@@ -335,7 +335,7 @@ instruct vdivF(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vfdiv.vv  $dst, $src1, $src2\t#@vdivF" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_FLOAT, Matcher::vector_length_in_bytes(this));
     __ vfdiv_vv(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
@@ -348,7 +348,7 @@ instruct vdivD(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vfdiv.vv  $dst, $src1, $src2\t#@vdivD" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_DOUBLE, Matcher::vector_length_in_bytes(this));
     __ vfdiv_vv(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
@@ -366,8 +366,7 @@ instruct vmax(vReg dst, vReg src1, vReg src2) %{
   format %{ "vmax.vv $dst, $src1, $src2\t#@vmax" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli(t0, x0, sew);
+    __ rvv_vsetvli(bt, Matcher::vector_length_in_bytes(this));
     __ vmax_vv(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg));
   %}
@@ -382,8 +381,7 @@ instruct vmin(vReg dst, vReg src1, vReg src2) %{
   format %{ "vmin.vv $dst, $src1, $src2\t#@vmin" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli(t0, x0, sew);
+    __ rvv_vsetvli(bt, Matcher::vector_length_in_bytes(this));
     __ vmin_vv(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg));
   %}
@@ -401,7 +399,7 @@ instruct vmaxF(vReg dst, vReg src1, vReg src2) %{
   ins_encode %{
     __ minmax_FD_v(as_VectorRegister($dst$$reg),
                    as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
-                   false /* is_double */, false /* is_min */);
+                   false /* is_double */, false /* is_min */, Matcher::vector_length_in_bytes(this));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -415,7 +413,7 @@ instruct vmaxD(vReg dst, vReg src1, vReg src2) %{
   ins_encode %{
     __ minmax_FD_v(as_VectorRegister($dst$$reg),
                    as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
-                   true /* is_double */, false /* is_min */);
+                   true /* is_double */, false /* is_min */, Matcher::vector_length_in_bytes(this));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -429,7 +427,7 @@ instruct vminF(vReg dst, vReg src1, vReg src2) %{
   ins_encode %{
     __ minmax_FD_v(as_VectorRegister($dst$$reg),
                    as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
-                   false /* is_double */, true /* is_min */);
+                   false /* is_double */, true /* is_min */, Matcher::vector_length_in_bytes(this));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -443,7 +441,7 @@ instruct vminD(vReg dst, vReg src1, vReg src2) %{
   ins_encode %{
     __ minmax_FD_v(as_VectorRegister($dst$$reg),
                    as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
-                   true /* is_double */, true /* is_min */);
+                   true /* is_double */, true /* is_min */, Matcher::vector_length_in_bytes(this));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -457,7 +455,7 @@ instruct vfmlaF(vReg dst_src1, vReg src2, vReg src3) %{
   ins_cost(VEC_COST);
   format %{ "vfmacc.vv $dst_src1, $src2, $src3\t#@vfmlaF" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_FLOAT, Matcher::vector_length_in_bytes(this));
     __ vfmacc_vv(as_VectorRegister($dst_src1$$reg),
                  as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -471,7 +469,7 @@ instruct vfmlaD(vReg dst_src1, vReg src2, vReg src3) %{
   ins_cost(VEC_COST);
   format %{ "vfmacc.vv $dst_src1, $src2, $src3\t#@vfmlaD" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_DOUBLE, Matcher::vector_length_in_bytes(this));
     __ vfmacc_vv(as_VectorRegister($dst_src1$$reg),
                  as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -489,7 +487,7 @@ instruct vfmlsF(vReg dst_src1, vReg src2, vReg src3) %{
   ins_cost(VEC_COST);
   format %{ "vfnmsac.vv $dst_src1, $src2, $src3\t#@vfmlsF" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_FLOAT, Matcher::vector_length_in_bytes(this));
     __ vfnmsac_vv(as_VectorRegister($dst_src1$$reg),
                   as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -505,7 +503,7 @@ instruct vfmlsD(vReg dst_src1, vReg src2, vReg src3) %{
   ins_cost(VEC_COST);
   format %{ "vfnmsac.vv $dst_src1, $src2, $src3\t#@vfmlsD" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_DOUBLE, Matcher::vector_length_in_bytes(this));
     __ vfnmsac_vv(as_VectorRegister($dst_src1$$reg),
                   as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -523,7 +521,7 @@ instruct vfnmlaF(vReg dst_src1, vReg src2, vReg src3) %{
   ins_cost(VEC_COST);
   format %{ "vfnmacc.vv $dst_src1, $src2, $src3\t#@vfnmlaF" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_FLOAT, Matcher::vector_length_in_bytes(this));
     __ vfnmacc_vv(as_VectorRegister($dst_src1$$reg),
                   as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -539,7 +537,7 @@ instruct vfnmlaD(vReg dst_src1, vReg src2, vReg src3) %{
   ins_cost(VEC_COST);
   format %{ "vfnmacc.vv $dst_src1, $src2, $src3\t#@vfnmlaD" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_DOUBLE, Matcher::vector_length_in_bytes(this));
     __ vfnmacc_vv(as_VectorRegister($dst_src1$$reg),
                   as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -555,7 +553,7 @@ instruct vfnmlsF(vReg dst_src1, vReg src2, vReg src3) %{
   ins_cost(VEC_COST);
   format %{ "vfmsac.vv $dst_src1, $src2, $src3\t#@vfnmlsF" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_FLOAT, Matcher::vector_length_in_bytes(this));
     __ vfmsac_vv(as_VectorRegister($dst_src1$$reg),
                  as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -569,7 +567,7 @@ instruct vfnmlsD(vReg dst_src1, vReg src2, vReg src3) %{
   ins_cost(VEC_COST);
   format %{ "vfmsac.vv $dst_src1, $src2, $src3\t#@vfnmlsD" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_DOUBLE, Matcher::vector_length_in_bytes(this));
     __ vfmsac_vv(as_VectorRegister($dst_src1$$reg),
                  as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -584,7 +582,7 @@ instruct vmlaB(vReg dst_src1, vReg src2, vReg src3) %{
   ins_cost(VEC_COST);
   format %{ "vmacc.vv $dst_src1, src2, src3\t#@vmlaB" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e8);
+    __ rvv_vsetvli(T_BYTE, Matcher::vector_length_in_bytes(this));
     __ vmacc_vv(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -597,7 +595,7 @@ instruct vmlaS(vReg dst_src1, vReg src2, vReg src3) %{
   ins_cost(VEC_COST);
   format %{ "vmacc.vv $dst_src1, src2, src3\t#@vmlaS" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e16);
+    __ rvv_vsetvli(T_SHORT, Matcher::vector_length_in_bytes(this));
     __ vmacc_vv(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -610,7 +608,7 @@ instruct vmlaI(vReg dst_src1, vReg src2, vReg src3) %{
   ins_cost(VEC_COST);
   format %{ "vmacc.vv $dst_src1, src2, src3\t#@vmlaI" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_INT, Matcher::vector_length_in_bytes(this));
     __ vmacc_vv(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -623,7 +621,7 @@ instruct vmlaL(vReg dst_src1, vReg src2, vReg src3) %{
   ins_cost(VEC_COST);
   format %{ "vmacc.vv $dst_src1, src2, src3\t#@vmlaL" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_LONG, Matcher::vector_length_in_bytes(this));
     __ vmacc_vv(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -638,7 +636,7 @@ instruct vmlsB(vReg dst_src1, vReg src2, vReg src3) %{
   ins_cost(VEC_COST);
   format %{ "vnmsac.vv $dst_src1, src2, src3\t#@vmlsB" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e8);
+    __ rvv_vsetvli(T_BYTE, Matcher::vector_length_in_bytes(this));
     __ vnmsac_vv(as_VectorRegister($dst_src1$$reg),
                  as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -651,7 +649,7 @@ instruct vmlsS(vReg dst_src1, vReg src2, vReg src3) %{
   ins_cost(VEC_COST);
   format %{ "vnmsac.vv $dst_src1, src2, src3\t#@vmlsS" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e16);
+    __ rvv_vsetvli(T_SHORT, Matcher::vector_length_in_bytes(this));
     __ vnmsac_vv(as_VectorRegister($dst_src1$$reg),
                  as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -664,7 +662,7 @@ instruct vmlsI(vReg dst_src1, vReg src2, vReg src3) %{
   ins_cost(VEC_COST);
   format %{ "vnmsac.vv $dst_src1, src2, src3\t#@vmlsI" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_INT, Matcher::vector_length_in_bytes(this));
     __ vnmsac_vv(as_VectorRegister($dst_src1$$reg),
                  as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -677,7 +675,7 @@ instruct vmlsL(vReg dst_src1, vReg src2, vReg src3) %{
   ins_cost(VEC_COST);
   format %{ "vnmsac.vv $dst_src1, src2, src3\t#@vmlsL" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_LONG, Matcher::vector_length_in_bytes(this));
     __ vnmsac_vv(as_VectorRegister($dst_src1$$reg),
                  as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -691,7 +689,7 @@ instruct vmulB(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vmul.vv $dst, $src1, $src2\t#@vmulB" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e8);
+    __ rvv_vsetvli(T_BYTE, Matcher::vector_length_in_bytes(this));
     __ vmul_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                as_VectorRegister($src2$$reg));
   %}
@@ -703,7 +701,7 @@ instruct vmulS(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vmul.vv $dst, $src1, $src2\t#@vmulS" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e16);
+    __ rvv_vsetvli(T_SHORT, Matcher::vector_length_in_bytes(this));
     __ vmul_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                as_VectorRegister($src2$$reg));
   %}
@@ -715,7 +713,7 @@ instruct vmulI(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vmul.vv $dst, $src1, $src2\t#@vmulI" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_INT, Matcher::vector_length_in_bytes(this));
     __ vmul_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                as_VectorRegister($src2$$reg));
   %}
@@ -727,7 +725,7 @@ instruct vmulL(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vmul.vv $dst, $src1, $src2\t#@vmulL" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_LONG, Matcher::vector_length_in_bytes(this));
     __ vmul_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                as_VectorRegister($src2$$reg));
   %}
@@ -739,7 +737,7 @@ instruct vmulF(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vfmul.vv $dst, $src1, $src2\t#@vmulF" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_FLOAT, Matcher::vector_length_in_bytes(this));
     __ vfmul_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
   %}
@@ -751,7 +749,7 @@ instruct vmulD(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vfmul.vv $dst, $src1, $src2\t#@vmulD" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_DOUBLE, Matcher::vector_length_in_bytes(this));
     __ vfmul_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
   %}
@@ -766,8 +764,7 @@ instruct vnegI(vReg dst, vReg src) %{
   format %{ "vrsub.vx $dst, $src, $src\t#@vnegI" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli(t0, x0, sew);
+    __ rvv_vsetvli(bt, Matcher::vector_length_in_bytes(this));
     __ vneg_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -778,7 +775,7 @@ instruct vnegL(vReg dst, vReg src) %{
   ins_cost(VEC_COST);
   format %{ "vrsub.vx $dst, $src, $src\t#@vnegL" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_LONG, Matcher::vector_length_in_bytes(this));
     __ vneg_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -791,7 +788,7 @@ instruct vnegF(vReg dst, vReg src) %{
   ins_cost(VEC_COST);
   format %{ "vfsgnjn.vv $dst, $src, $src\t#@vnegF" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_FLOAT, Matcher::vector_length_in_bytes(this));
     __ vfneg_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -802,7 +799,7 @@ instruct vnegD(vReg dst, vReg src) %{
   ins_cost(VEC_COST);
   format %{ "vfsgnjn.vv $dst, $src, $src\t#@vnegD" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_DOUBLE, Matcher::vector_length_in_bytes(this));
     __ vfneg_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -1161,7 +1158,7 @@ instruct replicateB(vReg dst, iRegIorL2I src) %{
   ins_cost(VEC_COST);
   format %{ "vmv.v.x  $dst, $src\t#@replicateB" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e8);
+    __ rvv_vsetvli(T_BYTE, Matcher::vector_length_in_bytes(this));
     __ vmv_v_x(as_VectorRegister($dst$$reg), as_Register($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -1172,7 +1169,7 @@ instruct replicateS(vReg dst, iRegIorL2I src) %{
   ins_cost(VEC_COST);
   format %{ "vmv.v.x  $dst, $src\t#@replicateS" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e16);
+    __ rvv_vsetvli(T_SHORT, Matcher::vector_length_in_bytes(this));
     __ vmv_v_x(as_VectorRegister($dst$$reg), as_Register($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -1183,7 +1180,7 @@ instruct replicateI(vReg dst, iRegIorL2I src) %{
   ins_cost(VEC_COST);
   format %{ "vmv.v.x  $dst, $src\t#@replicateI" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_INT, Matcher::vector_length_in_bytes(this));
     __ vmv_v_x(as_VectorRegister($dst$$reg), as_Register($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -1194,7 +1191,7 @@ instruct replicateL(vReg dst, iRegL src) %{
   ins_cost(VEC_COST);
   format %{ "vmv.v.x  $dst, $src\t#@replicateL" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_LONG, Matcher::vector_length_in_bytes(this));
     __ vmv_v_x(as_VectorRegister($dst$$reg), as_Register($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -1205,7 +1202,7 @@ instruct replicateB_imm5(vReg dst, immI5 con) %{
   ins_cost(VEC_COST);
   format %{ "vmv.v.i  $dst, $con\t#@replicateB_imm5" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e8);
+    __ rvv_vsetvli(T_BYTE, Matcher::vector_length_in_bytes(this));
     __ vmv_v_i(as_VectorRegister($dst$$reg), $con$$constant);
   %}
   ins_pipe(pipe_slow);
@@ -1216,7 +1213,7 @@ instruct replicateS_imm5(vReg dst, immI5 con) %{
   ins_cost(VEC_COST);
   format %{ "vmv.v.i  $dst, $con\t#@replicateS_imm5" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e16);
+    __ rvv_vsetvli(T_SHORT, Matcher::vector_length_in_bytes(this));
     __ vmv_v_i(as_VectorRegister($dst$$reg), $con$$constant);
   %}
   ins_pipe(pipe_slow);
@@ -1227,7 +1224,7 @@ instruct replicateI_imm5(vReg dst, immI5 con) %{
   ins_cost(VEC_COST);
   format %{ "vmv.v.i  $dst, $con\t#@replicateI_imm5" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_INT, Matcher::vector_length_in_bytes(this));
     __ vmv_v_i(as_VectorRegister($dst$$reg), $con$$constant);
   %}
   ins_pipe(pipe_slow);
@@ -1238,7 +1235,7 @@ instruct replicateL_imm5(vReg dst, immL5 con) %{
   ins_cost(VEC_COST);
   format %{ "vmv.v.i  $dst, $con\t#@replicateL_imm5" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_LONG, Matcher::vector_length_in_bytes(this));
     __ vmv_v_i(as_VectorRegister($dst$$reg), $con$$constant);
   %}
   ins_pipe(pipe_slow);
@@ -1249,7 +1246,7 @@ instruct replicateF(vReg dst, fRegF src) %{
   ins_cost(VEC_COST);
   format %{ "vfmv.v.f  $dst, $src\t#@replicateF" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_FLOAT, Matcher::vector_length_in_bytes(this));
     __ vfmv_v_f(as_VectorRegister($dst$$reg), $src$$FloatRegister);
   %}
   ins_pipe(pipe_slow);
@@ -1260,7 +1257,7 @@ instruct replicateD(vReg dst, fRegD src) %{
   ins_cost(VEC_COST);
   format %{ "vfmv.v.f  $dst, $src\t#@replicateD" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_DOUBLE, Matcher::vector_length_in_bytes(this));
     __ vfmv_v_f(as_VectorRegister($dst$$reg), $src$$FloatRegister);
   %}
   ins_pipe(pipe_slow);
@@ -1277,7 +1274,7 @@ instruct vasrB(vReg dst, vReg src, vReg shift) %{
             "vmnot.m v0, v0\n\t"
             "vsra.vv $dst, $src, $shift, Assembler::v0_t" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e8);
+    __ rvv_vsetvli(T_BYTE, Matcher::vector_length_in_bytes(this));
     // if shift > BitsPerByte - 1, clear the low BitsPerByte - 1 bits
     __ vmsgtu_vi(v0, as_VectorRegister($shift$$reg), BitsPerByte - 1);
     __ vsra_vi(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -1299,7 +1296,7 @@ instruct vasrS(vReg dst, vReg src, vReg shift) %{
             "vmnot.m v0, v0\n\t"
             "vsra.vv $dst, $src, $shift, Assembler::v0_t" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e16);
+    __ rvv_vsetvli(T_SHORT, Matcher::vector_length_in_bytes(this));
     // if shift > BitsPerShort - 1, clear the low BitsPerShort - 1 bits
     __ vmsgtu_vi(v0, as_VectorRegister($shift$$reg), BitsPerShort - 1);
     __ vsra_vi(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -1317,7 +1314,7 @@ instruct vasrI(vReg dst, vReg src, vReg shift) %{
   ins_cost(VEC_COST);
   format %{ "vsra.vv $dst, $src, $shift\t#@vasrI" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_INT, Matcher::vector_length_in_bytes(this));
     __ vsra_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                as_VectorRegister($shift$$reg));
   %}
@@ -1329,7 +1326,7 @@ instruct vasrL(vReg dst, vReg src, vReg shift) %{
   ins_cost(VEC_COST);
   format %{ "vsra.vv $dst, $src, $shift\t#@vasrL" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_LONG, Matcher::vector_length_in_bytes(this));
     __ vsra_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
          as_VectorRegister($shift$$reg));
   %}
@@ -1345,7 +1342,7 @@ instruct vlslB(vReg dst, vReg src, vReg shift) %{
             "vmnot.m v0, v0\n\t"
             "vsll.vv $dst, $src, $shift, Assembler::v0_t" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e8);
+    __ rvv_vsetvli(T_BYTE, Matcher::vector_length_in_bytes(this));
     // if shift > BitsPerByte - 1, clear the element
     __ vmsgtu_vi(v0, as_VectorRegister($shift$$reg), BitsPerByte - 1);
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -1367,7 +1364,7 @@ instruct vlslS(vReg dst, vReg src, vReg shift) %{
             "vmnot.m v0, v0\n\t"
             "vsll.vv $dst, $src, $shift, Assembler::v0_t" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e16);
+    __ rvv_vsetvli(T_SHORT, Matcher::vector_length_in_bytes(this));
     // if shift > BitsPerShort - 1, clear the element
     __ vmsgtu_vi(v0, as_VectorRegister($shift$$reg), BitsPerShort - 1);
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -1385,7 +1382,7 @@ instruct vlslI(vReg dst, vReg src, vReg shift) %{
   ins_cost(VEC_COST);
   format %{ "vsll.vv $dst, $src, $shift\t#@vlslI" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_INT, Matcher::vector_length_in_bytes(this));
     __ vsll_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                as_VectorRegister($shift$$reg));
   %}
@@ -1397,7 +1394,7 @@ instruct vlslL(vReg dst, vReg src, vReg shift) %{
   ins_cost(VEC_COST);
   format %{ "vsll.vv $dst, $src, $shift\t# vector (D)" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_LONG, Matcher::vector_length_in_bytes(this));
     __ vsll_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                as_VectorRegister($shift$$reg));
   %}
@@ -1413,7 +1410,7 @@ instruct vlsrB(vReg dst, vReg src, vReg shift) %{
             "vmnot.m v0, v0, v0\n\t"
             "vsll.vv $dst, $src, $shift, Assembler::v0_t" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e8);
+    __ rvv_vsetvli(T_BYTE, Matcher::vector_length_in_bytes(this));
     // if shift > BitsPerByte - 1, clear the element
     __ vmsgtu_vi(v0, as_VectorRegister($shift$$reg), BitsPerByte - 1);
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -1435,7 +1432,7 @@ instruct vlsrS(vReg dst, vReg src, vReg shift) %{
             "vmnot.m v0, v0\n\t"
             "vsll.vv $dst, $src, $shift, Assembler::v0_t" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e16);
+    __ rvv_vsetvli(T_SHORT, Matcher::vector_length_in_bytes(this));
     // if shift > BitsPerShort - 1, clear the element
     __ vmsgtu_vi(v0, as_VectorRegister($shift$$reg), BitsPerShort - 1);
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -1454,7 +1451,7 @@ instruct vlsrI(vReg dst, vReg src, vReg shift) %{
   ins_cost(VEC_COST);
   format %{ "vsrl.vv $dst, $src, $shift\t#@vlsrI" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_INT, Matcher::vector_length_in_bytes(this));
     __ vsrl_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                as_VectorRegister($shift$$reg));
   %}
@@ -1467,7 +1464,7 @@ instruct vlsrL(vReg dst, vReg src, vReg shift) %{
   ins_cost(VEC_COST);
   format %{ "vsrl.vv $dst, $src, $shift\t#@vlsrL" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_LONG, Matcher::vector_length_in_bytes(this));
     __ vsrl_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                as_VectorRegister($shift$$reg));
   %}
@@ -1480,7 +1477,7 @@ instruct vasrB_imm(vReg dst, vReg src, immI shift) %{
   format %{ "vsra.vi $dst, $src, $shift\t#@vasrB_imm" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli(t0, x0, Assembler::e8);
+    __ rvv_vsetvli(T_BYTE, Matcher::vector_length_in_bytes(this));
     if (con == 0) {
       __ vor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                 as_VectorRegister($src$$reg));
@@ -1498,7 +1495,7 @@ instruct vasrS_imm(vReg dst, vReg src, immI shift) %{
   format %{ "vsra.vi $dst, $src, $shift\t#@vasrS_imm" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli(t0, x0, Assembler::e16);
+    __ rvv_vsetvli(T_SHORT, Matcher::vector_length_in_bytes(this));
     if (con == 0) {
       __ vor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                 as_VectorRegister($src$$reg));
@@ -1516,7 +1513,7 @@ instruct vasrI_imm(vReg dst, vReg src, immI shift) %{
   format %{ "vsrl.vi $dst, $src, $shift\t#@vasrI_imm" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_INT, Matcher::vector_length_in_bytes(this));
     if (con == 0) {
       __ vor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                 as_VectorRegister($src$$reg));
@@ -1534,7 +1531,7 @@ instruct vasrL_imm(vReg dst, vReg src, immI shift) %{
   format %{ "vsrl.vi $dst, $src, $shift\t#@vasrL_imm" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_LONG, Matcher::vector_length_in_bytes(this));
     if (con == 0) {
       __ vor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                 as_VectorRegister($src$$reg));
@@ -1551,7 +1548,7 @@ instruct vlsrB_imm(vReg dst, vReg src, immI shift) %{
   format %{ "vsrl.vi $dst, $src, $shift\t#@vlsrB_imm" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli(t0, x0, Assembler::e8);
+    __ rvv_vsetvli(T_BYTE, Matcher::vector_length_in_bytes(this));
     if (con == 0) {
       __ vor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                 as_VectorRegister($src$$reg));
@@ -1573,7 +1570,7 @@ instruct vlsrS_imm(vReg dst, vReg src, immI shift) %{
   format %{ "vsrl.vi $dst, $src, $shift\t#@vlsrS_imm" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli(t0, x0, Assembler::e16);
+    __ rvv_vsetvli(T_SHORT, Matcher::vector_length_in_bytes(this));
     if (con == 0) {
       __ vor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                 as_VectorRegister($src$$reg));
@@ -1595,7 +1592,7 @@ instruct vlsrI_imm(vReg dst, vReg src, immI shift) %{
   format %{ "vsrl.vi $dst, $src, $shift\t#@vlsrI_imm" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_INT, Matcher::vector_length_in_bytes(this));
     if (con == 0) {
       __ vor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                 as_VectorRegister($src$$reg));
@@ -1613,7 +1610,7 @@ instruct vlsrL_imm(vReg dst, vReg src, immI shift) %{
   format %{ "vsrl.vi $dst, $src, $shift\t#@vlsrL_imm" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_LONG, Matcher::vector_length_in_bytes(this));
     if (con == 0) {
       __ vor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                 as_VectorRegister($src$$reg));
@@ -1630,7 +1627,7 @@ instruct vlslB_imm(vReg dst, vReg src, immI shift) %{
   format %{ "vsll.vi $dst, $src, $shift\t#@vlslB_imm" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli(t0, x0, Assembler::e8);
+    __ rvv_vsetvli(T_BYTE, Matcher::vector_length_in_bytes(this));
     if (con >= BitsPerByte) {
       __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                  as_VectorRegister($src$$reg));
@@ -1647,7 +1644,7 @@ instruct vlslS_imm(vReg dst, vReg src, immI shift) %{
   format %{ "vsll.vi $dst, $src, $shift\t#@vlslS_imm" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli(t0, x0, Assembler::e16);
+    __ rvv_vsetvli(T_SHORT, Matcher::vector_length_in_bytes(this));
     if (con >= BitsPerShort) {
       __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                  as_VectorRegister($src$$reg));
@@ -1664,7 +1661,7 @@ instruct vlslI_imm(vReg dst, vReg src, immI shift) %{
   format %{ "vsll.vi $dst, $src, $shift\t#@vlslI_imm" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_INT, Matcher::vector_length_in_bytes(this));
     __ vsll_vi(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), con);
   %}
   ins_pipe(pipe_slow);
@@ -1677,7 +1674,7 @@ instruct vlslL_imm(vReg dst, vReg src, immI shift) %{
   format %{ "vsll.vi $dst, $src, $shift\t#@vlslL_imm" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_LONG, Matcher::vector_length_in_bytes(this));
     __ vsll_vi(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), con);
   %}
   ins_pipe(pipe_slow);
@@ -1689,7 +1686,7 @@ instruct vshiftcntB(vReg dst, iRegIorL2I cnt) %{
   match(Set dst (RShiftCntV cnt));
   format %{ "vmv.v.x $dst, $cnt\t#@vshiftcntB" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e8);
+    __ rvv_vsetvli(T_BYTE, Matcher::vector_length_in_bytes(this));
     __ vmv_v_x(as_VectorRegister($dst$$reg), as_Register($cnt$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -1702,7 +1699,7 @@ instruct vshiftcntS(vReg dst, iRegIorL2I cnt) %{
   match(Set dst (RShiftCntV cnt));
   format %{ "vmv.v.x $dst, $cnt\t#@vshiftcntS" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e16);
+    __ rvv_vsetvli(T_SHORT, Matcher::vector_length_in_bytes(this));
     __ vmv_v_x(as_VectorRegister($dst$$reg), as_Register($cnt$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -1714,7 +1711,7 @@ instruct vshiftcntI(vReg dst, iRegIorL2I cnt) %{
   match(Set dst (RShiftCntV cnt));
   format %{ "vmv.v.x $dst, $cnt\t#@vshiftcntI" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_INT, Matcher::vector_length_in_bytes(this));
     __ vmv_v_x(as_VectorRegister($dst$$reg), as_Register($cnt$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -1726,7 +1723,7 @@ instruct vshiftcntL(vReg dst, iRegIorL2I cnt) %{
   match(Set dst (RShiftCntV cnt));
   format %{ "vmv.v.x $dst, $cnt\t#@vshiftcntL" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_LONG, Matcher::vector_length_in_bytes(this));
     __ vmv_v_x(as_VectorRegister($dst$$reg), as_Register($cnt$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -1739,7 +1736,7 @@ instruct vsqrtF(vReg dst, vReg src) %{
   ins_cost(VEC_COST);
   format %{ "vfsqrt.v $dst, $src\t#@vsqrtF" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_INT, Matcher::vector_length_in_bytes(this));
     __ vfsqrt_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -1750,7 +1747,7 @@ instruct vsqrtD(vReg dst, vReg src) %{
   ins_cost(VEC_COST);
   format %{ "vfsqrt.v $dst, $src\t#@vsqrtD" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_LONG, Matcher::vector_length_in_bytes(this));
     __ vfsqrt_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -1763,7 +1760,7 @@ instruct vsubB(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vsub.vv $dst, $src1, $src2\t#@vsubB" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e8);
+    __ rvv_vsetvli(T_BYTE, Matcher::vector_length_in_bytes(this));
     __ vsub_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                as_VectorRegister($src2$$reg));
   %}
@@ -1775,7 +1772,7 @@ instruct vsubS(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vsub.vv $dst, $src1, $src2\t#@vsubS" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e16);
+    __ rvv_vsetvli(T_SHORT, Matcher::vector_length_in_bytes(this));
     __ vsub_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                as_VectorRegister($src2$$reg));
   %}
@@ -1787,7 +1784,7 @@ instruct vsubI(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vsub.vv $dst, $src1, $src2\t#@vsubI" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_INT, Matcher::vector_length_in_bytes(this));
     __ vsub_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                as_VectorRegister($src2$$reg));
   %}
@@ -1799,7 +1796,7 @@ instruct vsubL(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vsub.vv $dst, $src1, $src2\t#@vsubL" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_LONG, Matcher::vector_length_in_bytes(this));
     __ vsub_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                as_VectorRegister($src2$$reg));
   %}
@@ -1811,7 +1808,7 @@ instruct vsubF(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vfsub.vv $dst, $src1, $src2\t@vsubF" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
+    __ rvv_vsetvli(T_FLOAT, Matcher::vector_length_in_bytes(this));
     __ vfsub_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
   %}
@@ -1823,7 +1820,7 @@ instruct vsubD(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vfsub.vv $dst, $src1, $src2\t#@vsubD" %}
   ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e64);
+    __ rvv_vsetvli(T_DOUBLE, Matcher::vector_length_in_bytes(this));
     __ vfsub_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
   %}
@@ -2097,8 +2094,7 @@ instruct vloadcon(vReg dst, immI0 src) %{
   format %{ "vloadcon $dst\t# generate iota indices" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli(t0, x0, sew);
+    __ rvv_vsetvli(bt, Matcher::vector_length_in_bytes(this));
     __ vid_v(as_VectorRegister($dst$$reg));
     if (is_floating_point_type(bt)) {
       __ vfcvt_f_x_v(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg));


### PR DESCRIPTION
HI,

   We have added support for small width vector operations, please take a look and have some reviews. Thanks a lot.

Add256Test case:
```
import jdk.incubator.vector.IntVector;
import jdk.incubator.vector.VectorSpecies;

public class Add256Test {
    static final VectorSpecies<Integer> SPECIES = IntVector.SPECIES_256;

    static final int SIZE = 1024;
    static int[] a = new int[SIZE];
    static int[] b = new int[SIZE];
    static int[] c = new int[SIZE];

    static {
        for (int i = 0; i < SIZE; i++) {
            a[i] = 1;
            b[i] = 2;
        }
    }

    static void workload() {
        for (int i = 0; i < a.length; i += SPECIES.length()) {
            IntVector av = IntVector.fromArray(SPECIES, a, i);
            IntVector bv = IntVector.fromArray(SPECIES, b, i);
            av.add(bv).intoArray(c,i);
        }
    }

    public static void main(String args[]) {
        for (int i = 0; i < 30_0000; i++) {
            workload();
        }
    }
}


```
Add128Test case:
```
import jdk.incubator.vector.IntVector;
import jdk.incubator.vector.VectorSpecies;

public class Add128Test {
    static final VectorSpecies<Integer> SPECIES = IntVector.SPECIES_128;

    static final int SIZE = 1024;
    static int[] a = new int[SIZE];
    static int[] b = new int[SIZE];
    static int[] c = new int[SIZE];

    static {
        for (int i = 0; i < SIZE; i++) {
            a[i] = 1;
            b[i] = 2;
        }
    }

    static void workload() {
        for (int i = 0; i < a.length; i += SPECIES.length()) {
            IntVector av = IntVector.fromArray(SPECIES, a, i);
            IntVector bv = IntVector.fromArray(SPECIES, b, i);
            av.add(bv).intoArray(c,i);
        }
    }

    public static void main(String args[]) {
        for (int i = 0; i < 30_0000; i++) {
            workload();
        }
    }
}
```
These two test cases are reduced from existing jtreg vector tests Int256VectorTests.java [1] and Int128VectorTests.java [2].
Note that the use of incubated Java features requires additional startup parameters to expose the module, in this case --add-modules jdk.incubator.vector, for example: `javac --add-modules jdk.incubator.vector Add128Test.java`
Before this fix, only the compilation log of Add256Test test cases used RVV-related instructions, after the fix, the compilation log of Add128Test test cases will also use RVV-related instructions.
The compiled log fragment of the Add128Test test case after the fix is as follows:
```
----------------------- MetaData before Compile_id = 464 ------------------------
{method}
 - this oop:          0x0000004057701c60
 - method holder:     'Add128Test'
 - constants:         0x0000004057701848 constant pool [64] {0x0000004057701848} for 'Add128Test' cache=0x0000004057702000
 - access:            0xc1000008  static 
 - name:              'workload'
 - signature:         '()V'
....

------------------------ OptoAssembly for Compile_id = 464 -----------------------
#
#  void ( rawptr:BotPTR )
#
000     N192: #	out( B1 ) <- BLOCK HEAD IS JUNK  Freq: 1
000     BREAKPOINT
        nop 	# 7 bytes pad for loops and calls
....

0d0     B8: #	out( B9 ) <- in( B12 ) top-of-loop Freq: 253.388
0d0     add R28, R12, R28	# ptr, #@addP_reg_reg
0d2     addi  R28, R28, #16	# ptr, #@addP_reg_imm
0d4     storeV [R28], V1	# vector (rvv)
0de     ld  R28, [R23, #960]	# ptr, #@loadP
0e2     addiw  R19, R19, #4	#@addI_reg_imm
....
100     addi  R31, R31, #16	# ptr, #@addP_reg_imm
102     loadV V2, [R30]	# vector (rvv)
10c     bgeu  R19, R29, B16	#@cmpU_branch  P=0.000001 C=-1.000000

110     B12: #	out( B8 B13 ) <- in( B11 )  Freq: 253.389
110     loadV V1, [R31]	# vector (rvv)
11a     vadd.vv V1, V2, V1	#@vaddI
122     bltu  R19, R8, B8	#@cmpU_branch  P=0.999999 C=-1.000000
```

#### The first part modifies Matcher::max_vector_size, Matcher::min_vector_size
In the process of using qemu to open RVV test vector api, currently if you set RVV vlen and java vector api's VectorSpecies are not equal, the instruction set related to RVV will not be used, and the scalar simulation implementation is used. For example, if RVV vlen = 256, the java program will execute normally when the VectorSpecies of the java vector api is SPECIES_256, as in the Add256Test case, and if you look at the java compilation log, the compilation log will also show that the current program does use the RVV-related instruction set. However, when RVV vlen = 256 and the VectorSpecies of the java vector api is SPECIES_64 or SPECIES_128, as in the Add128Test case, the java program executes normally, but no RVV-related instructions are generated in the compilation log. The reason for this is that Matcher::vector_size_supported function returns false during vectorization compilation, and thus no vectorization compilation is performed. This function is implemented as follows.
```
  static const bool vector_size_supported(const BasicType bt, int size) {
    return (Matcher::max_vector_size(bt) >= size &&
            Matcher::min_vector_size(bt) <= size);
  }
```
The maximum and minimum values are implemented in the individual architecture AD files, and the current RISC-V implementation is as follows.
```
// Vector width in bytes.
const int Matcher::vector_width_in_bytes(BasicType bt) {
  if (UseRVV) {
    // The MaxVectorSize should have been set by detecting RVV max vector register size when check UseRVV.
    // MaxVectorSize == VM_Version::_initial_vector_length
    return MaxVectorSize;
  }
  return 0;
}
// Limits on vector size (number of elements) loaded into vector.
const int Matcher::max_vector_size(const BasicType bt) {
  return vector_width_in_bytes(bt) / type2aelembytes(bt);
}
const int Matcher::min_vector_size(const BasicType bt) {
  return max_vector_size(bt);
}
```
In the above implementation, we can see that Matcher::max_vector_size, Matcher::min_vector_size are calculated to the maximum value (i.e. the maximum number of elements of that type that can be processed by the current vector register at one time). When RVV vlen and java vector api's VectorSpecies are not equal, the number of elements processed is not the maximum, so Matcher::vector_size_supported returns false during vectorization compilation, resulting in no vectorization compilation and no use of RVV instruction set optimization.

##### The second part modifies LoadVector, StoreVector node implementation
java vector api of VectorSpecies actually indicates a vectorization operation memory size, before the operation need to load the data from memory to the register, after the operation need to store the data in the register to memory. However, the current RISC-V operation on vector register data loading and storage is based on the maximum register width, assuming RVV vlen = 256, for loading, it means that all 256 bits of data are loaded into the vector register, for storage, it means that all 256 bits of data in the register are stored in memory, if the java vector api VectorSpecies is SPECIES_128, if the actual data that needs to be stored at this time is 128 bits, then it stores 128 more bits of data, which also destroys other data.

[1] https://github.com/openjdk/jdk/blob/master/test/jdk/jdk/incubator/vector/Int256VectorTests.java
[2] https://github.com/openjdk/jdk/blob/master/test/jdk/jdk/incubator/vector/Int128VectorTests.java
### Testing:
Let me share some of the testing results carried out on qemu with UseRVV:
- [x] Tier1 tests (release)
- [x] Tier2 tests (release)
- [x] Tier3 tests (release)
- [x] test/jdk/jdk/incubator/vector (fastdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302453](https://bugs.openjdk.org/browse/JDK-8302453): RISC-V: Add support for small width vector operations


### Reviewers
 * [Yanhong Zhu](https://openjdk.org/census#yzhu) (@yhzhu20 - Author) ⚠️ Review applies to [9e315673](https://git.openjdk.org/jdk/pull/12553/files/9e3156733f9840c958f2f77af1248201aefb3671)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Contributors
 * Dingli Zhang `<dingli@iscas.ac.cn>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12553/head:pull/12553` \
`$ git checkout pull/12553`

Update a local copy of the PR: \
`$ git checkout pull/12553` \
`$ git pull https://git.openjdk.org/jdk pull/12553/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12553`

View PR using the GUI difftool: \
`$ git pr show -t 12553`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12553.diff">https://git.openjdk.org/jdk/pull/12553.diff</a>

</details>
