### PR TITLE
JDK-8302455: VM.classloader_stats memory size values are wrong

### DIFF
--- a/src/hotspot/share/classfile/classLoaderStats.cpp
+++ b/src/hotspot/share/classfile/classLoaderStats.cpp
@@ -84,8 +84,10 @@ void ClassLoaderStatsClosure::do_cld(ClassLoaderData* cld) {
 
   ClassLoaderMetaspace* ms = cld->metaspace_or_null();
   if (ms != nullptr) {
-    size_t used_bytes, capacity_bytes;
-    ms->calculate_jfr_stats(&used_bytes, &capacity_bytes);
+    size_t used_words, capacity_words;
+    ms->calculate_jfr_stats(&used_words, &capacity_words);
+    size_t used_bytes = used_words * BytesPerWord;
+    size_t capacity_bytes = capacity_words * BytesPerWord;
     if(cld->has_class_mirror_holder()) {
       cls->_hidden_chunk_sz += capacity_bytes;
       cls->_hidden_block_sz += used_bytes;

--- a/src/hotspot/share/classfile/classLoaderStats.cpp
+++ b/src/hotspot/share/classfile/classLoaderStats.cpp
@@ -85,7 +85,7 @@ void ClassLoaderStatsClosure::do_cld(ClassLoaderData* cld) {
   ClassLoaderMetaspace* ms = cld->metaspace_or_null();
   if (ms != nullptr) {
     size_t used_words, capacity_words;
-    ms->calculate_jfr_stats(&used_words, &capacity_words);
+    ms->usage_numbers(&used_words, nullptr, &capacity_words);
     size_t used_bytes = used_words * BytesPerWord;
     size_t capacity_bytes = capacity_words * BytesPerWord;
     if(cld->has_class_mirror_holder()) {
@@ -99,7 +99,6 @@ void ClassLoaderStatsClosure::do_cld(ClassLoaderData* cld) {
     _total_block_sz += used_bytes;
   }
 }
-
 
 // Handles the difference in pointer width on 32 and 64 bit platforms
 #ifdef _LP64

--- a/src/hotspot/share/memory/classLoaderMetaspace.cpp
+++ b/src/hotspot/share/memory/classLoaderMetaspace.cpp
@@ -173,8 +173,10 @@ void ClassLoaderMetaspace::usage_numbers(size_t* p_used_words, size_t* p_committ
                                          size_t* p_capacity_words) const {
   size_t used_nc, comm_nc, cap_nc;
   usage_numbers(Metaspace::MetadataType::NonClassType, &used_nc, &comm_nc, &cap_nc);
-  size_t used_c, comm_c, cap_c;
-  usage_numbers(Metaspace::MetadataType::ClassType, &used_c, &comm_c, &cap_c);
+  size_t used_c = 0, comm_c = 0, cap_c = 0;
+  if (Metaspace::using_class_space()) {
+    usage_numbers(Metaspace::MetadataType::ClassType, &used_c, &comm_c, &cap_c);
+  }
   if (p_used_words != nullptr) {
     (*p_used_words) = used_nc + used_c;
   }

--- a/src/hotspot/share/memory/classLoaderMetaspace.hpp
+++ b/src/hotspot/share/memory/classLoaderMetaspace.hpp
@@ -99,11 +99,15 @@ public:
 
   DEBUG_ONLY(void verify() const;)
 
-  // This only exists for JFR and jcmd VM.classloader_stats. We may want to
-  //  change this. Capacity as a stat is of questionable use since it may
-  //  contain committed and uncommitted areas. For now we do this to maintain
-  //  backward compatibility with JFR.
-  void calculate_jfr_stats(size_t* p_used_bytes, size_t* p_capacity_bytes) const;
+  // Convenience method to get the most important usage statistics for either class
+  // or non-class space. For more detailed statistics, use add_to_statistics().
+  void usage_numbers(Metaspace::MetadataType mdType, size_t* p_used_words,
+                     size_t* p_committed_words, size_t* p_capacity_words) const;
+
+  // Convenience method to get the most important usage statistics (totals; both class- and non-class spaces)
+  // For more detailed statistics, use add_to_statistics().
+  void usage_numbers(size_t* p_used_words, size_t* p_committed_words,
+                     size_t* p_capacity_words) const;
 
 }; // end: ClassLoaderMetaspace
 

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/ClassLoaderStatsTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/ClassLoaderStatsTest.java
@@ -32,6 +32,17 @@
  * @run testng/othervm --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED ClassLoaderStatsTest
  */
 
+/*
+ * @test
+ * @summary Test of diagnostic command VM.classloader_stats (-UseCCP)
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.compiler
+ *          java.management
+ *          jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm -XX:-UseCompressedClassPointers --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED ClassLoaderStatsTest
+ */
+
 import org.testng.annotations.Test;
 import org.testng.Assert;
 

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/ClassLoaderStatsTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/ClassLoaderStatsTest.java
@@ -80,6 +80,7 @@ public class ClassLoaderStatsTest {
         }
 
         OutputAnalyzer output = executor.execute("VM.classloader_stats");
+        output.reportDiagnosticSummary();
         Iterator<String> lines = output.asLines().iterator();
         while (lines.hasNext()) {
             String line = lines.next();
@@ -91,8 +92,20 @@ public class ClassLoaderStatsTest {
                     if (!m.group(1).equals("1")) {
                         Assert.fail("Should have loaded 1 class: " + line);
                     }
-                    checkPositiveInt(m.group(2));
-                    checkPositiveInt(m.group(3));
+
+                    long capacityBytes = Long.parseLong(m.group(2)); // aka "Chunksz"
+                    long usedBytes = Long.parseLong(m.group(3)); // aka "Blocksz"
+
+                    // Minimum expected sizes: initial capacity is governed by the chunk size of the first chunk, which
+                    // depends on the arena growth policy. Since this is a normal class loader, we expect as initial chunk
+                    // size at least 4k (if UseCompressedClassPointers is off).
+                    // Minimum used size is difficult to guess but should be at least 1k.
+                    // Maximum expected sizes: We just assume a reasonable maximum. We only loaded one class, so
+                    // we should not see values > 64k.
+                    long K = 1024;
+                    if (capacityBytes < (K * 4) || usedBytes < K || capacityBytes > (64 * K) || usedBytes > (64 * K)) {
+                        throw new RuntimeException("Sizes seem off. Chunksz: " + capacityBytes + ", Blocksz: " + usedBytes);
+                    }
 
                     String next = lines.next();
                     System.out.println("DummyClassLoader next: " + next);


### PR DESCRIPTION
VM.classloader_stats shows metaspace consumption in words, but should show bytes. 

Patch fixes that, and adjusts the associated jtreg test to catch regressions like this.

I manually tested the test with the unpatched hotspot to see if the regression shows up, it does.

Tested the patch on x64 (fastdebug, release) and x86.

Note: "calculate_jfr_stats" is misnamed, actually only ever used by this dcmd, not by jfr. I will clear this up in a separate RFE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302455](https://bugs.openjdk.org/browse/JDK-8302455): VM.classloader_stats memory size values are wrong


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [2be3a810](https://git.openjdk.org/jdk/pull/12556/files/2be3a810493f91a1c5b9a4c85229bdd9a70d2304)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12556/head:pull/12556` \
`$ git checkout pull/12556`

Update a local copy of the PR: \
`$ git checkout pull/12556` \
`$ git pull https://git.openjdk.org/jdk pull/12556/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12556`

View PR using the GUI difftool: \
`$ git pr show -t 12556`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12556.diff">https://git.openjdk.org/jdk/pull/12556.diff</a>

</details>
