### PR TITLE
8302158: PPC: test/jdk/jdk/internal/vm/Continuation/Fuzz.java: AssertionError: res: false shouldPin: false

### DIFF
--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -421,8 +421,12 @@ void frame::describe_pd(FrameValues& values, int frame_no) {
 #endif
 
 intptr_t *frame::initial_deoptimization_info() {
-  // unused... but returns fp() to minimize changes introduced by 7087445
-  return fp();
+  // `this` is the caller of the deoptee. We want to trimm it, if compiled, to
+  // unextended_sp. This is necessary if the deoptee frame is the bottom frame
+  // of a continuation on stack (more frames could be in a StackChunk) as it
+  // will pop its stack args. Otherwise the recursion in
+  // FreezeBase::recurse_freeze_java_frame() would not stop at the bottom frame.
+  return is_compiled_frame() ? unextended_sp() : sp();
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -421,7 +421,7 @@ void frame::describe_pd(FrameValues& values, int frame_no) {
 #endif
 
 intptr_t *frame::initial_deoptimization_info() {
-  // `this` is the caller of the deoptee. We want to trimm it, if compiled, to
+  // `this` is the caller of the deoptee. We want to trim it, if compiled, to
   // unextended_sp. This is necessary if the deoptee frame is the bottom frame
   // of a continuation on stack (more frames could be in a StackChunk) as it
   // will pop its stack args. Otherwise the recursion in

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -3091,7 +3091,8 @@ void SharedRuntime::generate_deopt_blob() {
   // stack: (caller_of_deoptee, ...).
 
   // Freezing continuation frames requires that the caller is trimmed to unextended sp if compiled.
-  // Otherwise the loaded value will be equal to the current SP (see frame::initial_deoptimization_info())
+  // If not compiled the loaded value is equal to the current SP (see frame::initial_deoptimization_info())
+  // and the frame is effectively not resized.
   Register caller_sp = R23_tmp3;
   __ ld_ptr(caller_sp, Deoptimization::UnrollBlock::initial_info_offset_in_bytes(), unroll_block_reg);
   __ resize_frame_absolute(caller_sp, R24_tmp4, R25_tmp5);
@@ -3232,7 +3233,8 @@ void SharedRuntime::generate_uncommon_trap_blob() {
 #endif
 
   // Freezing continuation frames requires that the caller is trimmed to unextended sp if compiled.
-  // Otherwise the loaded value will be equal to the current SP (see frame::initial_deoptimization_info())
+  // If not compiled the loaded value is equal to the current SP (see frame::initial_deoptimization_info())
+  // and the frame is effectively not resized.
   Register caller_sp = R23_tmp3;
   __ ld_ptr(caller_sp, Deoptimization::UnrollBlock::initial_info_offset_in_bytes(), unroll_block_reg);
   __ resize_frame_absolute(caller_sp, R24_tmp4, R25_tmp5);

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -3090,6 +3090,11 @@ void SharedRuntime::generate_deopt_blob() {
 
   // stack: (caller_of_deoptee, ...).
 
+  // Freezing continuation frames requires that the caller is trimmed to unextended sp if compiled.
+  Register caller_sp = R23_tmp3;
+  __ ld_ptr(caller_sp, Deoptimization::UnrollBlock::initial_info_offset_in_bytes(), unroll_block_reg);
+  __ resize_frame_absolute(caller_sp, R24_tmp4, R25_tmp5);
+
   // Loop through the `UnrollBlock' info and create interpreter frames.
   push_skeleton_frames(masm, true/*deopt*/,
                        unroll_block_reg,
@@ -3224,6 +3229,11 @@ void SharedRuntime::generate_uncommon_trap_blob() {
   __ cmpdi(CCR0, R22_tmp2, (unsigned)Deoptimization::Unpack_uncommon_trap);
   __ asm_assert_eq("SharedRuntime::generate_deopt_blob: expected Unpack_uncommon_trap");
 #endif
+
+  // Freezing continuation frames requires that the caller is trimmed to unextended sp if compiled.
+  Register caller_sp = R23_tmp3;
+  __ ld_ptr(caller_sp, Deoptimization::UnrollBlock::initial_info_offset_in_bytes(), unroll_block_reg);
+  __ resize_frame_absolute(caller_sp, R24_tmp4, R25_tmp5);
 
   // Allocate new interpreter frame(s) and possibly a c2i adapter
   // frame.

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -3091,6 +3091,7 @@ void SharedRuntime::generate_deopt_blob() {
   // stack: (caller_of_deoptee, ...).
 
   // Freezing continuation frames requires that the caller is trimmed to unextended sp if compiled.
+  // Otherwise the loaded value will be equal to the current SP (see frame::initial_deoptimization_info())
   Register caller_sp = R23_tmp3;
   __ ld_ptr(caller_sp, Deoptimization::UnrollBlock::initial_info_offset_in_bytes(), unroll_block_reg);
   __ resize_frame_absolute(caller_sp, R24_tmp4, R25_tmp5);
@@ -3231,6 +3232,7 @@ void SharedRuntime::generate_uncommon_trap_blob() {
 #endif
 
   // Freezing continuation frames requires that the caller is trimmed to unextended sp if compiled.
+  // Otherwise the loaded value will be equal to the current SP (see frame::initial_deoptimization_info())
   Register caller_sp = R23_tmp3;
   __ ld_ptr(caller_sp, Deoptimization::UnrollBlock::initial_info_offset_in_bytes(), unroll_block_reg);
   __ resize_frame_absolute(caller_sp, R24_tmp4, R25_tmp5);

--- a/test/jdk/jdk/internal/vm/Continuation/BasicExt.java
+++ b/test/jdk/jdk/internal/vm/Continuation/BasicExt.java
@@ -286,7 +286,7 @@ public class BasicExt {
             triggerGCAfterYield = Integer.parseInt(args[1]) == 1;
             runTests();
         } catch (Throwable t) {
-            t.printStackTrace();
+            throw t;
         }
     }
 

--- a/test/jdk/jdk/internal/vm/Continuation/BasicExt.java
+++ b/test/jdk/jdk/internal/vm/Continuation/BasicExt.java
@@ -23,7 +23,7 @@
  */
 
 /**
- * @test id=policy-1-without-gc-with-verification
+ * @test id=COMP_NONE
  * @summary Collection of basic continuation tests. CompilationPolicy controls which frames in a sequence should be compiled when calling Continuation.yield().
  * @requires vm.continuations
  * @requires vm.flavor == "server" & vm.opt.TieredCompilation != true
@@ -40,11 +40,11 @@
  *                     -XX:CompileCommand=dontinline,*::*dontjit*
  *                     -XX:CompileCommand=exclude,*::*dontjit*
  *                     -XX:CompileCommand=dontinline,java/lang/String*.*
- *                     BasicExt 1 0
+ *                     BasicExt COMP_NONE
  */
 
 /**
- * @test id=policy-2-without-gc-with-verification
+ * @test id=COMP_WINDOW_LENGTH_1
  * @summary Collection of basic continuation tests. CompilationPolicy controls which frames in a sequence should be compiled when calling Continuation.yield().
  * @requires vm.continuations
  * @requires vm.flavor == "server" & vm.opt.TieredCompilation != true
@@ -61,11 +61,11 @@
  *                     -XX:CompileCommand=dontinline,*::*dontjit*
  *                     -XX:CompileCommand=exclude,*::*dontjit*
  *                     -XX:CompileCommand=dontinline,java/lang/String*.*
- *                     BasicExt 2 0
+ *                     BasicExt COMP_WINDOW_LENGTH_1
  */
 
 /**
- * @test id=policy-3-without-gc-with-verification
+ * @test id=COMP_WINDOW_LENGTH_2
  * @summary Collection of basic continuation tests. CompilationPolicy controls which frames in a sequence should be compiled when calling Continuation.yield().
  * @requires vm.continuations
  * @requires vm.flavor == "server" & vm.opt.TieredCompilation != true
@@ -82,11 +82,11 @@
  *                     -XX:CompileCommand=dontinline,*::*dontjit*
  *                     -XX:CompileCommand=exclude,*::*dontjit*
  *                     -XX:CompileCommand=dontinline,java/lang/String*.*
- *                     BasicExt 3 0
+ *                     BasicExt COMP_WINDOW_LENGTH_2
  */
 
 /**
- * @test id=policy-4-without-gc-with-verification
+ * @test id=COMP_WINDOW_LENGTH_3
  * @summary Collection of basic continuation tests. CompilationPolicy controls which frames in a sequence should be compiled when calling Continuation.yield().
  * @requires vm.continuations
  * @requires vm.flavor == "server" & vm.opt.TieredCompilation != true
@@ -103,11 +103,11 @@
  *                     -XX:CompileCommand=dontinline,*::*dontjit*
  *                     -XX:CompileCommand=exclude,*::*dontjit*
  *                     -XX:CompileCommand=dontinline,java/lang/String*.*
- *                     BasicExt 4 0
+ *                     BasicExt COMP_WINDOW_LENGTH_3
  */
 
 /**
- * @test id=policy-5-without-gc-with-verification
+ * @test id=COMP_ALL
  * @summary Collection of basic continuation tests. CompilationPolicy controls which frames in a sequence should be compiled when calling Continuation.yield().
  * @requires vm.continuations
  * @requires vm.flavor == "server" & vm.opt.TieredCompilation != true
@@ -124,11 +124,11 @@
  *                     -XX:CompileCommand=dontinline,*::*dontjit*
  *                     -XX:CompileCommand=exclude,*::*dontjit*
  *                     -XX:CompileCommand=dontinline,java/lang/String*.*
- *                     BasicExt 5 0
+ *                     BasicExt COMP_ALL
  */
 
 /**
- * @test id=policy-1-with-gc-without-verification
+ * @test id=COMP_NONE-GC_AFTER_YIELD
  * @summary Collection of basic continuation tests. CompilationPolicy controls which frames in a sequence should be compiled when calling Continuation.yield().
  * @requires vm.continuations
  * @requires vm.flavor == "server" & vm.opt.TieredCompilation != true
@@ -145,11 +145,11 @@
  *                     -XX:CompileCommand=dontinline,*::*dontjit*
  *                     -XX:CompileCommand=exclude,*::*dontjit*
  *                     -XX:CompileCommand=dontinline,java/lang/String*.*
- *                     BasicExt 1 1
+ *                     BasicExt COMP_NONE GC_AFTER_YIELD
  */
 
 /**
- * @test id=policy-2-with-gc-without-verification
+ * @test id=COMP_WINDOW_LENGTH_1-GC_AFTER_YIELD
  * @summary Collection of basic continuation tests. CompilationPolicy controls which frames in a sequence should be compiled when calling Continuation.yield().
  * @requires vm.continuations
  * @requires vm.flavor == "server" & vm.opt.TieredCompilation != true
@@ -166,11 +166,11 @@
  *                     -XX:CompileCommand=dontinline,*::*dontjit*
  *                     -XX:CompileCommand=exclude,*::*dontjit*
  *                     -XX:CompileCommand=dontinline,java/lang/String*.*
- *                     BasicExt 2 1
+ *                     BasicExt COMP_WINDOW_LENGTH_1 GC_AFTER_YIELD
  */
 
 /**
- * @test id=policy-3-with-gc-without-verification
+ * @test id=COMP_WINDOW_LENGTH_2-GC_AFTER_YIELD
  * @summary Collection of basic continuation tests. CompilationPolicy controls which frames in a sequence should be compiled when calling Continuation.yield().
  * @requires vm.continuations
  * @requires vm.flavor == "server" & vm.opt.TieredCompilation != true
@@ -187,11 +187,11 @@
  *                     -XX:CompileCommand=dontinline,*::*dontjit*
  *                     -XX:CompileCommand=exclude,*::*dontjit*
  *                     -XX:CompileCommand=dontinline,java/lang/String*.*
- *                     BasicExt 3 1
+ *                     BasicExt COMP_WINDOW_LENGTH_2 GC_AFTER_YIELD
  */
 
 /**
- * @test id=policy-4-with-gc-without-verification
+ * @test id=COMP_WINDOW_LENGTH_3-GC_AFTER_YIELD
  * @summary Collection of basic continuation tests. CompilationPolicy controls which frames in a sequence should be compiled when calling Continuation.yield().
  * @requires vm.continuations
  * @requires vm.flavor == "server" & vm.opt.TieredCompilation != true
@@ -208,11 +208,11 @@
  *                     -XX:CompileCommand=dontinline,*::*dontjit*
  *                     -XX:CompileCommand=exclude,*::*dontjit*
  *                     -XX:CompileCommand=dontinline,java/lang/String*.*
- *                     BasicExt 4 1
+ *                     BasicExt COMP_WINDOW_LENGTH_3 GC_AFTER_YIELD
  */
 
 /**
- * @test id=policy-5-with-gc-without-verification
+ * @test id=COMP_ALL-GC_AFTER_YIELD
  * @summary Collection of basic continuation tests. CompilationPolicy controls which frames in a sequence should be compiled when calling Continuation.yield().
  * @requires vm.continuations
  * @requires vm.flavor == "server" & vm.opt.TieredCompilation != true
@@ -229,7 +229,7 @@
  *                     -XX:CompileCommand=dontinline,*::*dontjit*
  *                     -XX:CompileCommand=exclude,*::*dontjit*
  *                     -XX:CompileCommand=dontinline,java/lang/String*.*
- *                     BasicExt 5 1
+ *                     BasicExt COMP_ALL GC_AFTER_YIELD
  */
 
 import java.lang.reflect.Method;
@@ -251,12 +251,12 @@ import jdk.test.whitebox.WhiteBox;
 public class BasicExt {
     static final ContinuationScope THE_SCOPE = new ContinuationScope() {};
 
-    public static final Pattern COMP_NONE  = Pattern.compile("COMP_NONE");
-    public static final Pattern COMP_ALL   = Pattern.compile("COMP_ALL");
-    public static final Pattern CONT_METHS = Pattern.compile("^(enter|enter0|yield|yield0)$");
+    public static final Pattern PAT_COMP_NONE  = Pattern.compile("COMP_NONE");
+    public static final Pattern PAT_COMP_ALL   = Pattern.compile("COMP_ALL");
+    public static final Pattern PAT_CONT_METHS = Pattern.compile("^(enter|enter0|yield|yield0)$");
 
-    public static int compPolicySelection;
-    public static boolean triggerGCAfterYield;
+    public static CompilationPolicy compPolicySelection;
+    public static GCBehaviour gcBehaviour;
     public static int compLevel;
 
     public static final WhiteBox WB = WhiteBox.getWhiteBox();
@@ -272,6 +272,11 @@ public class BasicExt {
         EXPR_STACK_NOT_EMPTY,
     }
 
+    enum GCBehaviour {
+        GC_AFTER_YIELD,
+        NO_GC_AFTER_YIELD,
+    }
+
     public static class HandledException extends Exception { }
     public static class UnhandledException extends Error { }
 
@@ -282,8 +287,8 @@ public class BasicExt {
             // // Run tests with C1 compilations
             // compLevel = CompilerWhiteBoxTest.COMP_LEVEL_FULL_PROFILE;
 
-            compPolicySelection = Integer.parseInt(args[0]);
-            triggerGCAfterYield = Integer.parseInt(args[1]) == 1;
+            compPolicySelection = CompilationPolicy.valueOf(args[0]);
+            gcBehaviour = args.length > 0 ? GCBehaviour.valueOf(args[1]) : GCBehaviour.NO_GC_AFTER_YIELD;
             runTests();
         } catch (Throwable t) {
             throw t;
@@ -293,24 +298,12 @@ public class BasicExt {
     public static void runTests() {
         System.out.println("$$$0 Running test cases with the following settings:");
         System.out.println("compLevel=" + compLevel);
-        System.out.println("callSystemGC=" + triggerGCAfterYield);
+        System.out.println("callSystemGC=" + gcBehaviour);
         System.out.println();
 
         WB.deoptimizeAll();
 
-        boolean all = compPolicySelection == 0;
-        if (compPolicySelection == 1 || all)
-            runTests(new CompilationPolicy(7 /*warmup*/, COMP_NONE, COMP_NONE /*Cont. pattern*/));
-        if (compPolicySelection == 2 || all)
-            runTests(new CompilationPolicy(7 /*warmup*/, 1 /* length comp. window */));
-        if (compPolicySelection == 3 || all)
-            runTests(new CompilationPolicy(7 /*warmup*/, 2 /* length comp. window */));
-        if (compPolicySelection == 4 || all)
-            runTests(new CompilationPolicy(7 /*warmup*/, 3 /* length comp. window */));
-        if (compPolicySelection == 5 || all)
-            runTests(new CompilationPolicy(7 /*warmup*/, COMP_ALL, CONT_METHS /*Cont. pattern*/));
-        if (compPolicySelection >= 6)
-            throw new Error("CompilationPolicy with number " + compPolicySelection + " does not exist");
+        runTests(compPolicySelection);
     }
 
     public static void runTests(CompilationPolicy compPolicy) {
@@ -338,7 +331,12 @@ public class BasicExt {
     // are interpreted. With DEOPT_WINDOW vice versa.
     // The methods that are subject to the CompilationPolicy are set with setMethods().
     // Their order has to correspond to the stack order when calling yield().
-    public static class CompilationPolicy {
+    public static enum CompilationPolicy {
+        COMP_NONE(7 /*warmup*/, PAT_COMP_NONE, PAT_COMP_NONE /*Cont. pattern*/),
+        COMP_WINDOW_LENGTH_1(7 /*warmup*/, 1 /* length comp. window */),
+        COMP_WINDOW_LENGTH_2(7 /*warmup*/, 2 /* length comp. window */),
+        COMP_WINDOW_LENGTH_3(7 /*warmup*/, 3 /* length comp. window */),
+        COMP_ALL(7 /*warmup*/, PAT_COMP_ALL, PAT_CONT_METHS /*Cont. pattern*/);
         public int warmupIterations;
         public Pattern methodPattern;
         public Pattern contMethPattern;
@@ -353,19 +351,19 @@ public class BasicExt {
             NO_COMP_WINDOW, COMP_WINDOW, DEOPT_WINDOW
         }
 
-        public CompilationPolicy(int warmupIterations, Pattern methodPattern,
+        CompilationPolicy(int warmupIterations, Pattern methodPattern,
                                  Pattern contMethPattern) {
             this(warmupIterations, 0, methodPattern, contMethPattern,
                  CompWindowMode.NO_COMP_WINDOW);
         }
 
-        public CompilationPolicy(int warmupIterations, int windowLength,
+        CompilationPolicy(int warmupIterations, int windowLength,
                                  Pattern methodPattern, Pattern contMethPattern) {
             this(warmupIterations, windowLength, methodPattern, contMethPattern,
                  CompWindowMode.COMP_WINDOW);
         }
 
-        public CompilationPolicy(int warmupIterations, int windowLength,
+        CompilationPolicy(int warmupIterations, int windowLength,
                                  Pattern methodPattern, Pattern contMethPattern,
                                  CompWindowMode startMode) {
             this.warmupIterations = warmupIterations;
@@ -376,8 +374,8 @@ public class BasicExt {
             this.compWindowMode = startMode;
         }
 
-        public CompilationPolicy(int warmupIterations, int windowLength) {
-            this(warmupIterations, windowLength, COMP_ALL, CONT_METHS);
+        CompilationPolicy(int warmupIterations, int windowLength) {
+            this(warmupIterations, windowLength, PAT_COMP_ALL, PAT_CONT_METHS);
         }
 
         public int warmupIterations() {
@@ -518,11 +516,11 @@ public class BasicExt {
             this.compPolicy = compPolicy;
             ArrayList<Method> selectedMethods = new ArrayList<Method>();
             Pattern p = compPolicy.methodPattern;
-            if (p != COMP_NONE) {
+            if (p != PAT_COMP_NONE) {
                 Class<? extends TestCaseBase> c = getClass();
                 Method methods[] = c.getDeclaredMethods();
                 for (Method meth : methods) {
-                    if (p == COMP_ALL || p.matcher(meth.getName()).matches()) {
+                    if (p == PAT_COMP_ALL || p.matcher(meth.getName()).matches()) {
                         if (!meth.getName().contains("dontjit")) {
                             selectedMethods.add(meth);
                         }
@@ -531,7 +529,7 @@ public class BasicExt {
             }
 
             p = compPolicy.contMethPattern;
-            if (compPolicy.contMethPattern != COMP_NONE) {
+            if (compPolicy.contMethPattern != PAT_COMP_NONE) {
                 Class<?> c = Continuation.class;
                 Method methods[] = c .getDeclaredMethods();
                 for (Method meth : methods) {
@@ -584,7 +582,7 @@ public class BasicExt {
                 } catch (UnhandledException e) {
                     log_dontjit("Exc: " + e);
                 }
-                if (triggerGCAfterYield) WB.youngGC();
+                if (gcBehaviour == GCBehaviour.GC_AFTER_YIELD) WB.youngGC();
                 checkFrames_dontjit(cont);
             } while (!cont.isDone());
         }


### PR DESCRIPTION
This fixes the linked issue by trimming the caller of a frame to be deoptimized back to its `unextended_sp` iff it is compiled. The creation of the section `dead after deoptimization` shown in the attachment [yield_after_deopt_failure.log](https://bugs.openjdk.org/secure/attachment/102602/yield_after_deopt_failure.log) is prevented by this.

A new mode is added to the test BasicExt.java where all frames are deoptimized after a yield operation. The issue can be deterministically reproduced with the new mode. It's not worth to execute all test cases with the new mode though. Instead `ContinuationCompiledFramesWithStackArgs_3c4` is always executed a 2nd time in this mode.

Before this BasicExt.java was refactored for better argument processing and representation of the test modes.
Also the try-catch-clause in the main method had to be changed to rethrow the caught exception because without this the test would have succeeded.

Testing: jtreg tests tier 1-4 on standard platforms and also on ppc64le.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302158](https://bugs.openjdk.org/browse/JDK-8302158): PPC: test/jdk/jdk/internal/vm/Continuation/Fuzz.java: AssertionError: res: false shouldPin: false


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**) ⚠️ Review applies to [7ca17977](https://git.openjdk.org/jdk/pull/12557/files/7ca179771a663663fa4e0693ff0b1fe8336fff3d)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12557/head:pull/12557` \
`$ git checkout pull/12557`

Update a local copy of the PR: \
`$ git checkout pull/12557` \
`$ git pull https://git.openjdk.org/jdk pull/12557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12557`

View PR using the GUI difftool: \
`$ git pr show -t 12557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12557.diff">https://git.openjdk.org/jdk/pull/12557.diff</a>

</details>
