### PR TITLE
8302460: System C++ Compiler for cross compiling gcc is dangerously wrong

### DIFF
--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -888,7 +888,7 @@ AC_DEFUN_ONCE([TOOLCHAIN_SETUP_BUILD_COMPILERS],
         UTIL_REQUIRE_PROGS(BUILD_CXX, clang++)
       else
         UTIL_REQUIRE_PROGS(BUILD_CC, cc gcc)
-        UTIL_REQUIRE_PROGS(BUILD_CXX, CC g++)
+        UTIL_REQUIRE_PROGS(BUILD_CXX, c++ g++)
       fi
       UTIL_LOOKUP_PROGS(BUILD_NM, nm gcc-nm)
       UTIL_LOOKUP_PROGS(BUILD_AR, ar gcc-ar lib)


### PR DESCRIPTION
Full details in linked entry, man did this give me a scare on my local branch

All C++ compilers for the build operating system are under the name c++ (when selected compiler is gcc), but when searching for BUILD_CXX the compiler given priority is an uppercase CC, and then g++, which is not correct since this simply links to the C compiler instead

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302460](https://bugs.openjdk.org/browse/JDK-8302460): System C++ Compiler for cross compiling gcc is dangerously wrong


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12558/head:pull/12558` \
`$ git checkout pull/12558`

Update a local copy of the PR: \
`$ git checkout pull/12558` \
`$ git pull https://git.openjdk.org/jdk pull/12558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12558`

View PR using the GUI difftool: \
`$ git pr show -t 12558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12558.diff">https://git.openjdk.org/jdk/pull/12558.diff</a>

</details>
