### PR TITLE
8302464: Parallel: Remove unreachable code in callers of numa_has_static_binding

### DIFF
--- a/src/hotspot/os/posix/os_posix.inline.hpp
+++ b/src/hotspot/os/posix/os_posix.inline.hpp
@@ -35,7 +35,6 @@
 #include <netdb.h>
 
 // Aix does not have NUMA support but need these for compilation.
-inline bool os::numa_has_static_binding()   { AIX_ONLY(ShouldNotReachHere();) return true; }
 inline bool os::numa_has_group_homing()     { AIX_ONLY(ShouldNotReachHere();) return false;  }
 
 // Platform Mutex/Monitor implementation

--- a/src/hotspot/os/windows/os_windows.inline.hpp
+++ b/src/hotspot/os/windows/os_windows.inline.hpp
@@ -57,7 +57,6 @@ inline void os::map_stack_shadow_pages(address sp) {
   }
 }
 
-inline bool os::numa_has_static_binding()   { return true;   }
 inline bool os::numa_has_group_homing()     { return false;  }
 
 // Platform Mutex/Monitor implementation

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -116,47 +116,12 @@ void MutableNUMASpace::ensure_parsability() {
                  "Remaining size (" SIZE_FORMAT ") is too small to fill (based on " SIZE_FORMAT " and " SIZE_FORMAT ")",
                  words_to_fill, words_left_to_fill, CollectedHeap::filler_array_max_size());
           CollectedHeap::fill_with_object(cur_top, words_to_fill);
-          if (!os::numa_has_static_binding()) {
-            size_t touched_words = words_to_fill;
-#ifndef ASSERT
-            if (!ZapUnusedHeapArea) {
-              touched_words = MIN2((size_t)align_object_size(typeArrayOopDesc::header_size(T_INT)),
-                touched_words);
-            }
-#endif
-            MemRegion invalid;
-            HeapWord *crossing_start = align_up(cur_top, os::vm_page_size());
-            HeapWord *crossing_end = align_down(cur_top + touched_words, os::vm_page_size());
-            if (crossing_start != crossing_end) {
-              // If object header crossed a small page boundary we mark the area
-              // as invalid rounding it to a page_size().
-              HeapWord *start = MAX2(align_down(cur_top, page_size()), s->bottom());
-              HeapWord *end = MIN2(align_up(cur_top + touched_words, page_size()), s->end());
-              invalid = MemRegion(start, end);
-            }
-
-            ls->add_invalid_region(invalid);
-          }
           cur_top += words_to_fill;
           words_left_to_fill -= words_to_fill;
         }
       }
     } else {
-      if (!os::numa_has_static_binding()) {
-#ifdef ASSERT
-        MemRegion invalid(s->top(), s->end());
-        ls->add_invalid_region(invalid);
-#else
-        if (ZapUnusedHeapArea) {
-          MemRegion invalid(s->top(), s->end());
-          ls->add_invalid_region(invalid);
-        } else {
-          return;
-        }
-#endif
-      } else {
-          return;
-      }
+      return;
     }
   }
 }
@@ -278,18 +243,7 @@ void MutableNUMASpace::free_region(MemRegion mr) {
 
 // Update space layout. Perform adaptation.
 void MutableNUMASpace::update() {
-  bool should_initialize = false;
-  if (!os::numa_has_static_binding()) {
-    for (int i = 0; i < lgrp_spaces()->length(); i++) {
-      if (!lgrp_spaces()->at(i)->invalid_region().is_empty()) {
-        should_initialize = true;
-        break;
-      }
-    }
-  }
-
-  if (should_initialize ||
-      (UseAdaptiveNUMAChunkSizing && adaptation_cycles() < samples_count())) {
+  if (UseAdaptiveNUMAChunkSizing && adaptation_cycles() < samples_count()) {
     // A NUMA space is never mangled
     initialize(region(),
                SpaceDecorator::Clear,
@@ -605,31 +559,12 @@ void MutableNUMASpace::initialize(MemRegion mr,
       intersection = MemRegion(new_region.start(), new_region.start());
     }
 
-    if (!os::numa_has_static_binding()) {
-      MemRegion invalid_region = ls->invalid_region().intersection(new_region);
-      // Invalid region is a range of memory that could've possibly
-      // been allocated on the other node. That's relevant only on Solaris where
-      // there is no static memory binding.
-      if (!invalid_region.is_empty()) {
-        merge_regions(new_region, &intersection, &invalid_region);
-        free_region(invalid_region);
-        ls->set_invalid_region(MemRegion());
-      }
-    }
-
     select_tails(new_region, intersection, &bottom_region, &top_region);
 
-    if (!os::numa_has_static_binding()) {
-      // If that's a system with the first-touch policy then it's enough
-      // to free the pages.
-      free_region(bottom_region);
-      free_region(top_region);
-    } else {
-      // In a system with static binding we have to change the bias whenever
-      // we reshape the heap.
-      bias_region(bottom_region, ls->lgrp_id());
-      bias_region(top_region, ls->lgrp_id());
-    }
+    // In a system with static binding we have to change the bias whenever
+    // we reshape the heap.
+    bias_region(bottom_region, ls->lgrp_id());
+    bias_region(top_region, ls->lgrp_id());
 
     // Clear space (set top = bottom) but never mangle.
     s->initialize(new_region, SpaceDecorator::Clear, SpaceDecorator::DontMangle, MutableSpace::DontSetupPages);
@@ -664,18 +599,12 @@ void MutableNUMASpace::set_top(HeapWord* value) {
         }
       }
 
-      if (!os::numa_has_static_binding() && top < value && top < s->end()) {
-        ls->add_invalid_region(MemRegion(top, value));
-      }
       s->set_top(value);
       found_top = true;
     } else {
         if (found_top) {
-            s->set_top(s->bottom());
+          s->set_top(s->bottom());
         } else {
-          if (!os::numa_has_static_binding() && top < s->end()) {
-            ls->add_invalid_region(MemRegion(top, s->end()));
-          }
           s->set_top(s->end());
         }
     }
@@ -742,12 +671,6 @@ HeapWord* MutableNUMASpace::cas_allocate(size_t size) {
     }
   }
 
-  // Make the page allocation happen here if there is no static binding.
-  if (p != nullptr && !os::numa_has_static_binding() ) {
-    for (HeapWord *i = p; i < p + size; i += os::vm_page_size() >> LogHeapWordSize) {
-      *(int*)i = 0;
-    }
-  }
   if (p == nullptr) {
     ls->set_allocation_failed();
   }

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -489,7 +489,6 @@ class os: AllStatic {
   static void   realign_memory(char *addr, size_t bytes, size_t alignment_hint);
 
   // NUMA-specific interface
-  static bool   numa_has_static_binding();
   static bool   numa_has_group_homing();
   static void   numa_make_local(char *addr, size_t bytes, int lgrp_hint);
   static void   numa_make_global(char *addr, size_t bytes);


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302464](https://bugs.openjdk.org/browse/JDK-8302464): Parallel: Remove unreachable code in callers of numa_has_static_binding


### Reviewers
 * [Leo Korinth](https://openjdk.org/census#lkorinth) (@lkorinth - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12559/head:pull/12559` \
`$ git checkout pull/12559`

Update a local copy of the PR: \
`$ git checkout pull/12559` \
`$ git pull https://git.openjdk.org/jdk pull/12559/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12559`

View PR using the GUI difftool: \
`$ git pr show -t 12559`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12559.diff">https://git.openjdk.org/jdk/pull/12559.diff</a>

</details>
