### PR TITLE
8302462: [REDO] 8297487: G1 Remark: no need to keep alive oop constants of nmethods on stack

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1777,27 +1777,14 @@ public:
 
 class G1RemarkThreadsClosure : public ThreadClosure {
   G1SATBMarkQueueSet& _qset;
-  G1CMOopClosure _cm_cl;
-  MarkingCodeBlobClosure _code_cl;
 
  public:
   G1RemarkThreadsClosure(G1CollectedHeap* g1h, G1CMTask* task) :
-    _qset(G1BarrierSet::satb_mark_queue_set()),
-    _cm_cl(g1h, task),
-    _code_cl(&_cm_cl, !CodeBlobToOopClosure::FixRelocations, true /* keepalive nmethods */) {}
+    _qset(G1BarrierSet::satb_mark_queue_set()) {}
 
   void do_thread(Thread* thread) {
     // Transfer any partial buffer to the qset for completed buffer processing.
     _qset.flush_queue(G1ThreadLocalData::satb_mark_queue(thread));
-    if (thread->is_Java_thread()) {
-      // In theory it should not be necessary to explicitly walk the nmethods to find roots for concurrent marking
-      // however the liveness of oops reachable from nmethods have very complex lifecycles:
-      // * Alive if on the stack of an executing method
-      // * Weakly reachable otherwise
-      // Some objects reachable from nmethods, such as the class loader (or klass_holder) of the receiver should be
-      // live by the SATB invariant but other oops recorded in nmethods may behave differently.
-      JavaThread::cast(thread)->nmethods_do(&_code_cl);
-    }
   }
 };
 

--- a/src/hotspot/share/gc/shared/barrierSet.cpp
+++ b/src/hotspot/share/gc/shared/barrierSet.cpp
@@ -57,8 +57,11 @@ static BarrierSetNMethod* select_barrier_set_nmethod(BarrierSetNMethod* barrier_
     // The GC needs nmethod entry barriers to do concurrent GC
     return barrier_set_nmethod;
   } else {
-    // The GC needs nmethod entry barriers to deal with continuations
-    // and code cache unloading
+    // The GC needs nmethod entry barriers for code cache unloading.
+    // Concurrent GC needs them also for preserving the weakly referenced objects in
+    // the constant pool of nmethods as part of the SATB snapshot, and to deal with
+    // compiled frames contained in continuation stack chunks allocated after
+    // concurent mark start.
     return new BarrierSetNMethod();
   }
 }

--- a/src/hotspot/share/gc/shared/barrierSet.cpp
+++ b/src/hotspot/share/gc/shared/barrierSet.cpp
@@ -57,11 +57,8 @@ static BarrierSetNMethod* select_barrier_set_nmethod(BarrierSetNMethod* barrier_
     // The GC needs nmethod entry barriers to do concurrent GC
     return barrier_set_nmethod;
   } else {
-    // The GC needs nmethod entry barriers for code cache unloading.
-    // Concurrent GC needs them also for preserving the weakly referenced objects in
-    // the constant pool of nmethods as part of the SATB snapshot, and to deal with
-    // compiled frames contained in continuation stack chunks allocated after
-    // concurent mark start.
+    // The GC needs nmethod entry barriers to deal with continuations
+    // and code cache unloading
     return new BarrierSetNMethod();
   }
 }

--- a/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
@@ -99,6 +99,8 @@ bool BarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
 
   // If the nmethod is the only thing pointing to the oops, and we are using a
   // SATB GC, then it is important that this code marks them live.
+  // Also, with concurrent GC, it is possible that frames in continuation stack
+  // chunks are not visited if they are allocated after concurrent GC started.
   OopKeepAliveClosure cl;
   nm->oops_do(&cl);
 


### PR DESCRIPTION
This is a REDO of JDK-8297487 after the issues that cause the BACKOUT were resolved with [JDK-8300915](https://bugs.openjdk.org/browse/JDK-8300915)

Testing:
* The reproducer `test/langtools:tier1` was executed without crash for 12h.
* Multiple iterations of jtreg tests tiers 1-4  on standard platforms and also on ppc64le.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302462](https://bugs.openjdk.org/browse/JDK-8302462): [REDO] 8297487: G1 Remark: no need to keep alive oop constants of nmethods on stack


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [e423ed1a](https://git.openjdk.org/jdk/pull/12561/files/e423ed1ab181bfdf0fb402b1dfbab8d20bead89d)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12561/head:pull/12561` \
`$ git checkout pull/12561`

Update a local copy of the PR: \
`$ git checkout pull/12561` \
`$ git pull https://git.openjdk.org/jdk pull/12561/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12561`

View PR using the GUI difftool: \
`$ git pr show -t 12561`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12561.diff">https://git.openjdk.org/jdk/pull/12561.diff</a>

</details>
