### PR TITLE
8301992: Embed SymbolTable CHT node

### DIFF
--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -126,38 +126,68 @@ static uintx hash_shared_symbol(const char* s, int len) {
 #endif
 
 class SymbolTableConfig : public AllStatic {
-private:
+
 public:
-  typedef Symbol* Value;  // value of the Node in the hashtable
+  typedef Symbol Value;  // value of the Node in the hashtable
 
   static uintx get_hash(Value const& value, bool* is_dead) {
-    *is_dead = (value->refcount() == 0);
+    *is_dead = (value.refcount() == 0);
     if (*is_dead) {
       return 0;
     } else {
-      return hash_symbol((const char*)value->bytes(), value->utf8_length(), _alt_hash);
+      return hash_symbol((const char*)value.bytes(), value.utf8_length(), _alt_hash);
     }
   }
   // We use default allocation/deallocation but counted
   static void* allocate_node(void* context, size_t size, Value const& value) {
     SymbolTable::item_added();
-    return AllocateHeap(size, mtSymbol);
+    return allocate_node_impl(size, value);
   }
-  static void free_node(void* context, void* memory, Value const& value) {
+  static void free_node(void* context, void* memory, Value & value) {
     // We get here because #1 some threads lost a race to insert a newly created Symbol
     // or #2 we're cleaning up unused symbol.
     // If #1, then the symbol can be either permanent,
     // or regular newly created one (refcount==1)
     // If #2, then the symbol is dead (refcount==0)
-    assert(value->is_permanent() || (value->refcount() == 1) || (value->refcount() == 0),
-           "refcount %d", value->refcount());
-    if (value->refcount() == 1) {
-      value->decrement_refcount();
-      assert(value->refcount() == 0, "expected dead symbol");
+    assert(value.is_permanent() || (value.refcount() == 1) || (value.refcount() == 0),
+           "refcount %d", value.refcount());
+    if (value.refcount() == 1) {
+      value.decrement_refcount();
+      assert(value.refcount() == 0, "expected dead symbol");
     }
-    SymbolTable::delete_symbol(value);
-    FreeHeap(memory);
-    SymbolTable::item_removed();
+    if (value.refcount() != PERM_REFCOUNT) {
+      FreeHeap(memory);
+      SymbolTable::item_removed();
+    }
+  }
+
+private:
+  static void* allocate_node_impl(size_t size, Value const& value) {
+    size_t alloc_size = size + value.byte_size() + value.effective_length();
+#if INCLUDE_CDS
+    if (DumpSharedSpaces) {
+      MutexLocker ml(DumpRegion_lock, Mutex::_no_safepoint_check_flag);
+      // To get deterministic output from -Xshare:dump, we ensure that Symbols are allocated in
+      // increasing addresses. When the symbols are copied into the archive, we preserve their
+      // relative address order (sorted, see ArchiveBuilder::gather_klasses_and_symbols).
+      //
+      // We cannot use arena because arena chunks are allocated by the OS. As a result, for example,
+      // the archived symbol of "java/lang/Object" may sometimes be lower than "java/lang/String", and
+      // sometimes be higher. This would cause non-deterministic contents in the archive.
+      DEBUG_ONLY(static void* last = 0);
+      void* p = (void*)MetaspaceShared::symbol_space_alloc(alloc_size);
+      assert(p > last, "must increase monotonically");
+      DEBUG_ONLY(last = p);
+      return p;
+    }
+#endif
+    if (value.refcount() != PERM_REFCOUNT) {
+      return AllocateHeap(alloc_size, mtSymbol);
+    } else {
+      // Allocate to global arena
+      MutexLocker ml(SymbolArena_lock, Mutex::_no_safepoint_check_flag); // Protect arena
+      return SymbolTable::arena()->Amalloc(alloc_size);
+    }
   }
 };
 
@@ -173,20 +203,6 @@ void SymbolTable::create_table ()  {
     _arena = new (mtSymbol) Arena(mtSymbol);
   } else {
     _arena = new (mtSymbol) Arena(mtSymbol, symbol_alloc_arena_size);
-  }
-}
-
-void SymbolTable::delete_symbol(Symbol* sym) {
-  if (sym->is_permanent()) {
-    MutexLocker ml(SymbolArena_lock, Mutex::_no_safepoint_check_flag); // Protect arena
-    // Deleting permanent symbol should not occur very often (insert race condition),
-    // so log it.
-    log_trace_symboltable_helper(sym, "Freeing permanent symbol");
-    if (!arena()->Afree(sym, sym->size())) {
-      log_trace_symboltable_helper(sym, "Leaked permanent symbol");
-    }
-  } else {
-    delete sym;
   }
 }
 
@@ -217,39 +233,13 @@ void SymbolTable::trigger_cleanup() {
   Service_lock->notify_all();
 }
 
-Symbol* SymbolTable::allocate_symbol(const char* name, int len, bool c_heap) {
-  assert (len <= Symbol::max_length(), "should be checked by caller");
-
-  Symbol* sym;
-  if (DumpSharedSpaces) {
-    // TODO: Special handling of Symbol allocation for DumpSharedSpaces will be removed
-    // in JDK-8250989
-    c_heap = false;
-  }
-  if (c_heap) {
-    // refcount starts as 1
-    sym = new (len) Symbol((const u1*)name, len, 1);
-    assert(sym != nullptr, "new should call vm_exit_out_of_memory if C_HEAP is exhausted");
-  } else if (DumpSharedSpaces) {
-    // See comments inside Symbol::operator new(size_t, int)
-    sym = new (len) Symbol((const u1*)name, len, PERM_REFCOUNT);
-    assert(sym != nullptr, "new should call vm_exit_out_of_memory if failed to allocate symbol during DumpSharedSpaces");
-  } else {
-    // Allocate to global arena
-    MutexLocker ml(SymbolArena_lock, Mutex::_no_safepoint_check_flag); // Protect arena
-    sym = new (len, arena()) Symbol((const u1*)name, len, PERM_REFCOUNT);
-  }
-  return sym;
-}
-
 class SymbolsDo : StackObj {
   SymbolClosure *_cl;
 public:
   SymbolsDo(SymbolClosure *cl) : _cl(cl) {}
-  bool operator()(Symbol** value) {
+  bool operator()(Symbol* value) {
     assert(value != nullptr, "expected valid value");
-    assert(*value != nullptr, "value should point to a symbol");
-    _cl->do_symbol(value);
+    _cl->do_symbol(&value);
     return true;
   };
 };
@@ -365,10 +355,9 @@ public:
   uintx get_hash() const {
     return _hash;
   }
-  bool equals(Symbol** value, bool* is_dead) {
+  bool equals(Symbol* value, bool* is_dead) {
     assert(value != nullptr, "expected valid value");
-    assert(*value != nullptr, "value should point to a symbol");
-    Symbol *sym = *value;
+    Symbol *sym = value;
     if (sym->equals(_str, _len)) {
       if (sym->try_increment_refcount()) {
         // something is referencing this symbol now.
@@ -389,10 +378,9 @@ class SymbolTableGet : public StackObj {
   Symbol* _return;
 public:
   SymbolTableGet() : _return(nullptr) {}
-  void operator()(Symbol** value) {
+  void operator()(Symbol* value) {
     assert(value != nullptr, "expected valid value");
-    assert(*value != nullptr, "value should point to a symbol");
-    _return = *value;
+    _return = value;
   }
   Symbol* get_res_sym() const {
     return _return;
@@ -472,18 +460,31 @@ Symbol* SymbolTable::do_add_if_needed(const char* name, int len, uintx hash, boo
   SymbolTableGet stg;
   bool clean_hint = false;
   bool rehash_warning = false;
-  Symbol* sym = nullptr;
   Thread* current = Thread::current();
+  Symbol* sym;
+
+  ResourceMark rm(current);
+  const int alloc_size = Symbol::byte_size(len);
+  u1* u1_buf = NEW_RESOURCE_ARRAY(u1, alloc_size);
+  Symbol* tmp = ::new ((void*)u1_buf) Symbol((const u1*)name, len, (heap && !DumpSharedSpaces) ? 1 : PERM_REFCOUNT);
 
   do {
-    // Callers have looked up the symbol once, insert the symbol.
-    sym = allocate_symbol(name, len, heap);
-    if (_local_table->insert(current, lookup, sym, &rehash_warning, &clean_hint)) {
-      break;
+    if (_local_table->insert(current, lookup, *tmp, &rehash_warning, &clean_hint)) {
+      if (_local_table->get(current, lookup, stg, &rehash_warning)) {
+        sym = stg.get_res_sym();
+        // The get adds one to ref count, but we inserted with our ref already included.
+        // Therefore decrement with one.
+        if (sym->refcount() != PERM_REFCOUNT) {
+          sym->decrement_refcount();
+        }
+        break;
+      }
     }
+
     // In case another thread did a concurrent add, return value already in the table.
     // This could fail if the symbol got deleted concurrently, so loop back until success.
     if (_local_table->get(current, lookup, stg, &rehash_warning)) {
+      // The lookup added a refcount, which is ours.
       sym = stg.get_res_sym();
       break;
     }
@@ -515,10 +516,9 @@ Symbol* SymbolTable::new_permanent_symbol(const char* name) {
 }
 
 struct SizeFunc : StackObj {
-  size_t operator()(Symbol** value) {
+  size_t operator()(Symbol* value) {
     assert(value != nullptr, "expected valid value");
-    assert(*value != nullptr, "value should point to a symbol");
-    return (*value)->size() * HeapWordSize;
+    return (value)->size() * HeapWordSize;
   };
 };
 
@@ -545,10 +545,9 @@ void SymbolTable::print_table_statistics(outputStream* st) {
 // Verification
 class VerifySymbols : StackObj {
 public:
-  bool operator()(Symbol** value) {
+  bool operator()(Symbol* value) {
     guarantee(value != nullptr, "expected valid value");
-    guarantee(*value != nullptr, "value should point to a symbol");
-    Symbol* sym = *value;
+    Symbol* sym = value;
     guarantee(sym->equals((const char*)sym->bytes(), sym->utf8_length()),
               "symbol must be internally consistent");
     return true;
@@ -577,10 +576,9 @@ class DumpSymbol : StackObj {
   outputStream* _st;
 public:
   DumpSymbol(Thread* thr, outputStream* st) : _thr(thr), _st(st) {}
-  bool operator()(Symbol** value) {
+  bool operator()(Symbol* value) {
     assert(value != nullptr, "expected valid value");
-    assert(*value != nullptr, "value should point to a symbol");
-    print_symbol(_st, *value);
+    print_symbol(_st, value);
     return true;
   };
 };
@@ -695,10 +693,9 @@ void SymbolTable::grow(JavaThread* jt) {
 struct SymbolTableDoDelete : StackObj {
   size_t _deleted;
   SymbolTableDoDelete() : _deleted(0) {}
-  void operator()(Symbol** value) {
+  void operator()(Symbol* value) {
     assert(value != nullptr, "expected valid value");
-    assert(*value != nullptr, "value should point to a symbol");
-    Symbol *sym = *value;
+    Symbol *sym = value;
     assert(sym->refcount() == 0, "refcount");
     _deleted++;
   }
@@ -707,11 +704,10 @@ struct SymbolTableDoDelete : StackObj {
 struct SymbolTableDeleteCheck : StackObj {
   size_t _processed;
   SymbolTableDeleteCheck() : _processed(0) {}
-  bool operator()(Symbol** value) {
+  bool operator()(Symbol* value) {
     assert(value != nullptr, "expected valid value");
-    assert(*value != nullptr, "value should point to a symbol");
     _processed++;
-    Symbol *sym = *value;
+    Symbol *sym = value;
     return (sym->refcount() == 0);
   }
 };
@@ -849,10 +845,9 @@ public:
       sizes[i] = 0;
     }
   }
-  bool operator()(Symbol** value) {
+  bool operator()(Symbol* value) {
     assert(value != nullptr, "expected valid value");
-    assert(*value != nullptr, "value should point to a symbol");
-    Symbol* sym = *value;
+    Symbol* sym = value;
     size_t size = sym->size();
     size_t len = sym->utf8_length();
     if (len < results_length) {

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -151,6 +151,12 @@ public:
     // If #2, then the symbol is dead (refcount==0)
     assert(value.is_permanent() || (value.refcount() == 1) || (value.refcount() == 0),
            "refcount %d", value.refcount());
+#if INCLUDE_CDS
+    if (DumpSharedSpaces) {
+      // no deallocation is needed
+      return;
+    }
+#endif
     if (value.refcount() == 1) {
       value.decrement_refcount();
       assert(value.refcount() == 0, "expected dead symbol");

--- a/src/hotspot/share/classfile/symbolTable.hpp
+++ b/src/hotspot/share/classfile/symbolTable.hpp
@@ -74,7 +74,6 @@ class SymbolTable : public AllStatic {
   static void mark_has_items_to_clean();
   static bool has_items_to_clean();
 
-  static Symbol* allocate_symbol(const char* name, int len, bool c_heap); // Assumes no characters larger than 0x7F
   static Symbol* do_lookup(const char* name, int len, uintx hash);
   static Symbol* do_add_if_needed(const char* name, int len, uintx hash, bool is_permanent);
 

--- a/src/hotspot/share/classfile/symbolTable.hpp
+++ b/src/hotspot/share/classfile/symbolTable.hpp
@@ -59,7 +59,6 @@ class SymbolTable : public AllStatic {
   // Set if one bucket is out of balance due to hash algorithm deficiency
   static volatile bool _needs_rehashing;
 
-  static void delete_symbol(Symbol* sym);
   static void grow(JavaThread* jt);
   static void clean_dead_entries(JavaThread* jt);
 

--- a/src/hotspot/share/classfile/symbolTable.hpp
+++ b/src/hotspot/share/classfile/symbolTable.hpp
@@ -76,7 +76,7 @@ class SymbolTable : public AllStatic {
 
   static Symbol* allocate_symbol(const char* name, int len, bool c_heap); // Assumes no characters larger than 0x7F
   static Symbol* do_lookup(const char* name, int len, uintx hash);
-  static Symbol* do_add_if_needed(const char* name, int len, uintx hash, bool heap);
+  static Symbol* do_add_if_needed(const char* name, int len, uintx hash, bool is_permanent);
 
   // lookup only, won't add. Also calculate hash. Used by the ClassfileParser.
   static Symbol* lookup_only(const char* name, int len, unsigned int& hash);

--- a/src/hotspot/share/oops/symbol.cpp
+++ b/src/hotspot/share/oops/symbol.cpp
@@ -65,38 +65,10 @@ Symbol::Symbol(const u1* name, int length, int refcount) {
   memcpy(_body, name, length);
 }
 
-void* Symbol::operator new(size_t sz, int len) throw() {
-#if INCLUDE_CDS
- if (DumpSharedSpaces) {
-   MutexLocker ml(DumpRegion_lock, Mutex::_no_safepoint_check_flag);
-   // To get deterministic output from -Xshare:dump, we ensure that Symbols are allocated in
-   // increasing addresses. When the symbols are copied into the archive, we preserve their
-   // relative address order (sorted, see ArchiveBuilder::gather_klasses_and_symbols).
-   //
-   // We cannot use arena because arena chunks are allocated by the OS. As a result, for example,
-   // the archived symbol of "java/lang/Object" may sometimes be lower than "java/lang/String", and
-   // sometimes be higher. This would cause non-deterministic contents in the archive.
-   DEBUG_ONLY(static void* last = 0);
-   void* p = (void*)MetaspaceShared::symbol_space_alloc(size(len)*wordSize);
-   assert(p > last, "must increase monotonically");
-   DEBUG_ONLY(last = p);
-   return p;
- }
-#endif
-  int alloc_size = size(len)*wordSize;
-  address res = (address) AllocateHeap(alloc_size, mtSymbol);
-  return res;
-}
-
-void* Symbol::operator new(size_t sz, int len, Arena* arena) throw() {
-  int alloc_size = size(len)*wordSize;
-  address res = (address)arena->AmallocWords(alloc_size);
-  return res;
-}
-
-void Symbol::operator delete(void *p) {
-  assert(((Symbol*)p)->refcount() == 0, "should not call this");
-  FreeHeap(p);
+Symbol::Symbol(const Symbol& s1) {
+  _hash_and_refcount = s1._hash_and_refcount;
+  _length = s1._length;
+  memcpy(_body, s1._body, _length);
 }
 
 #if INCLUDE_CDS

--- a/src/hotspot/share/oops/symbol.cpp
+++ b/src/hotspot/share/oops/symbol.cpp
@@ -65,6 +65,7 @@ Symbol::Symbol(const u1* name, int length, int refcount) {
   memcpy(_body, name, length);
 }
 
+// This copies the symbol when it is added to the ConcurrentHashTable.
 Symbol::Symbol(const Symbol& s1) {
   _hash_and_refcount = s1._hash_and_refcount;
   _length = s1._length;

--- a/src/hotspot/share/oops/symbol.hpp
+++ b/src/hotspot/share/oops/symbol.hpp
@@ -131,10 +131,6 @@ class Symbol : public MetaspaceObj {
   }
 
   Symbol(const u1* name, int length, int refcount);
-  void* operator new(size_t size, int len) throw();
-  void* operator new(size_t size, int len, Arena* arena) throw();
-
-  void  operator delete(void* p);
 
   static short extract_hash(uint32_t value)   { return (short)(value >> 16); }
   static int extract_refcount(uint32_t value) { return value & 0xffff; }
@@ -143,11 +139,15 @@ class Symbol : public MetaspaceObj {
   int length() const   { return _length; }
 
  public:
+  Symbol(const Symbol& s1);
+
   // Low-level access (used with care, since not GC-safe)
   const u1* base() const { return &_body[0]; }
 
-  int size()                { return size(utf8_length()); }
-  int byte_size()           { return byte_size(utf8_length()); }
+  int size()      const     { return size(utf8_length()); }
+  int byte_size() const     { return byte_size(utf8_length()); };
+  // length without the _body
+  size_t effective_length() const { return (size_t)byte_size() - sizeof(Symbol); }
 
   // Symbols should be stored in the read-only region of CDS archive.
   static bool is_read_only_by_default() { return true; }


### PR DESCRIPTION
Please review this patch for embedding the Symbol inside a ConcurrentHashTable Node instead of having a pointer to a Symbol. This eliminates malloc/free for each Symbol.

This patch is co-authored by @robehn.

Passed tiers 1 - 4 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301992](https://bugs.openjdk.org/browse/JDK-8301992): Embed SymbolTable CHT node


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [b22eb3b0](https://git.openjdk.org/jdk/pull/12562/files/b22eb3b03450c6b2c964f0b160912439dccd80a6)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Contributors
 * Robbin Ehn `<rehn@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12562/head:pull/12562` \
`$ git checkout pull/12562`

Update a local copy of the PR: \
`$ git checkout pull/12562` \
`$ git pull https://git.openjdk.org/jdk pull/12562/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12562`

View PR using the GUI difftool: \
`$ git pr show -t 12562`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12562.diff">https://git.openjdk.org/jdk/pull/12562.diff</a>

</details>
