### PR TITLE
8298276: JFR: Update NMT events to make use of common periodic timestamp feature

### DIFF
--- a/src/hotspot/share/jfr/periodic/jfrNativeMemoryEvent.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrNativeMemoryEvent.cpp
@@ -30,7 +30,7 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/ticks.hpp"
 
-NMTUsage* get_usage(const Ticks& timestamp) {
+static NMTUsage* get_usage(const Ticks& timestamp) {
   static Ticks last_timestamp;
   static NMTUsage* usage = nullptr;
 

--- a/src/hotspot/share/jfr/periodic/jfrNativeMemoryEvent.hpp
+++ b/src/hotspot/share/jfr/periodic/jfrNativeMemoryEvent.hpp
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef SHARE_SERVICES_MEMJFRREPORTER_HPP
-#define SHARE_SERVICES_MEMJFRREPORTER_HPP
+#ifndef SHARE_JFR_PERIODIC_JFRNATIVEMEMORYEVENT_HPP
+#define SHARE_JFR_PERIODIC_JFRNATIVEMEMORYEVENT_HPP
 
 #include "memory/allocation.hpp"
 #include "services/nmtUsage.hpp"
@@ -33,12 +33,12 @@
 // MemJFRReporter is only used by threads sending periodic JFR
 // events. These threads are synchronized at a higher level,
 // so no more synchronization is needed.
-class MemJFRReporter : public AllStatic {
+class JfrNativeMemoryEvent : public AllStatic {
 private:
   static void send_type_event(const Ticks& starttime, MEMFLAGS flag, size_t reserved, size_t committed);
  public:
-  static void send_total_event();
-  static void send_type_events();
+  static void send_total_event(const Ticks& timestamp);
+  static void send_type_events(const Ticks& timestamp);
 };
 
-#endif //SHARE_SERVICES_MEMJFRREPORTER_HPP
+#endif //SHARE_JFR_PERIODIC_JFRNATIVEMEMORYEVENT_HPP

--- a/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
@@ -41,6 +41,7 @@
 #include "jfr/periodic/jfrOSInterface.hpp"
 #include "jfr/periodic/jfrThreadCPULoadEvent.hpp"
 #include "jfr/periodic/jfrThreadDumpEvent.hpp"
+#include "jfr/periodic/jfrNativeMemoryEvent.hpp"
 #include "jfr/periodic/jfrNetworkUtilization.hpp"
 #include "jfr/recorder/jfrRecorder.hpp"
 #include "jfr/utilities/jfrThreadIterator.hpp"
@@ -63,7 +64,6 @@
 #include "runtime/vm_version.hpp"
 #include "services/classLoadingService.hpp"
 #include "services/management.hpp"
-#include "services/memJfrReporter.hpp"
 #include "services/threadService.hpp"
 #include "utilities/exceptions.hpp"
 #include "utilities/globalDefinitions.hpp"
@@ -643,9 +643,9 @@ TRACE_REQUEST_FUNC(FinalizerStatistics) {
 }
 
 TRACE_REQUEST_FUNC(NativeMemoryUsage) {
-  MemJFRReporter::send_type_events();
+  JfrNativeMemoryEvent::send_type_events(timestamp());
 }
 
 TRACE_REQUEST_FUNC(NativeMemoryUsageTotal) {
-  MemJFRReporter::send_total_event();
+  JfrNativeMemoryEvent::send_total_event(timestamp());
 }

--- a/test/jdk/jdk/jfr/event/runtime/TestNativeMemoryUsageEvents.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestNativeMemoryUsageEvents.java
@@ -134,12 +134,12 @@ public class TestNativeMemoryUsageEvents {
         for (String type : UsageEventTypes) {
             assertTrue(uniqueEventTypes.contains(type), "Events should include: " + type);
         }
-        // Verify all events have the same timestamp
+        // Verify that events only have two timestamps
         List<Instant> timestamps = events.stream()
                 .map(e -> e.getStartTime())
                 .distinct()
                 .toList();
-        assertEquals(timestamps.size(), 2, "Expected two timestamp: " + timestamps);
+        assertEquals(timestamps.size(), 2, "Expected two timestamps: " + timestamps);
     }
 
     private static void verifyHeapGrowth(List<RecordedEvent> events) throws Exception {

--- a/test/jdk/jdk/jfr/event/runtime/TestNativeMemoryUsageEvents.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestNativeMemoryUsageEvents.java
@@ -25,7 +25,9 @@ package jdk.jfr.event.runtime;
 
 import static jdk.test.lib.Asserts.assertGreaterThan;
 import static jdk.test.lib.Asserts.assertTrue;
+import static jdk.test.lib.Asserts.assertEquals;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -132,6 +134,12 @@ public class TestNativeMemoryUsageEvents {
         for (String type : UsageEventTypes) {
             assertTrue(uniqueEventTypes.contains(type), "Events should include: " + type);
         }
+        // Verify all events have the same timestamp
+        List<Instant> timestamps = events.stream()
+                .map(e -> e.getStartTime())
+                .distinct()
+                .toList();
+        assertEquals(timestamps.size(), 2, "Expected two timestamp: " + timestamps);
     }
 
     private static void verifyHeapGrowth(List<RecordedEvent> events) throws Exception {


### PR DESCRIPTION
Could I have review of a change that ensures NMT events use the same timestamp.

Testing: tier1, tier2, jdk/jdk/jfr/*

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298276](https://bugs.openjdk.org/browse/JDK-8298276): JFR: Update NMT events to make use of common periodic timestamp feature


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12564/head:pull/12564` \
`$ git checkout pull/12564`

Update a local copy of the PR: \
`$ git checkout pull/12564` \
`$ git pull https://git.openjdk.org/jdk pull/12564/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12564`

View PR using the GUI difftool: \
`$ git pr show -t 12564`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12564.diff">https://git.openjdk.org/jdk/pull/12564.diff</a>

</details>
