### PR TITLE
8302225: SunJCE Provider doesn't validate key sizes when using 'constrained' transforms for AES/KW and AES/KWP

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/KeyWrapCipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/KeyWrapCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -296,6 +296,12 @@ abstract class KeyWrapCipher extends CipherSpi {
         if (keyBytes == null) {
             throw new InvalidKeyException("Null key");
         }
+
+        if (fixedKeySize != -1 && fixedKeySize != keyBytes.length) {
+            throw new InvalidKeyException("Invalid key length: " +
+                    keyBytes.length + " bytes, should be " + fixedKeySize);
+        }
+
         this.opmode = opmode;
         boolean decrypting = (opmode == Cipher.DECRYPT_MODE ||
                 opmode == Cipher.UNWRAP_MODE);

--- a/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/TestKeySizeCheck.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/TestKeySizeCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8248268
+ * @bug 8248268 8302225
  * @summary Verify cipher key size restriction is enforced properly with IKE
  * @run main TestKeySizeCheck
  */
@@ -42,6 +42,8 @@ public class TestKeySizeCheck {
             BYTES_32[i] = (byte) i;
         }
     }
+
+    private static final int[] AES_KEYSIZES = { 128, 192, 256 };
 
     private static SecretKey getKey(int sizeInBytes) {
         if (sizeInBytes <= BYTES_32.length) {
@@ -64,7 +66,7 @@ public class TestKeySizeCheck {
         int[] modes = { Cipher.ENCRYPT_MODE, Cipher.WRAP_MODE };
         for (int ks : invalidKeySizes) {
             System.out.println("keysize: " + ks);
-            SecretKey key = getKey(ks);
+            SecretKey key = getKey(ks >> 3);
 
             for (int m : modes) {
                 try {
@@ -72,9 +74,23 @@ public class TestKeySizeCheck {
                     throw new RuntimeException("Expected IKE not thrown for "
                             + getModeStr(m));
                 } catch (InvalidKeyException ike) {
-                    System.out.println(" => expected IKE thrown for "
-                            + getModeStr(m));
+                    System.out.println(getModeStr(m) + " => got expected IKE");
                 }
+            }
+        }
+
+        // now test against the valid key size(s) and make sure they work
+        int underscoreIdx = algo.indexOf("_");
+        int[] validKeySizes = (algo.indexOf("_") == -1 ?
+            AES_KEYSIZES : new int[] { Integer.parseInt(algo.substring
+                    (underscoreIdx + 1, underscoreIdx + 4)) });
+        for (int ks : validKeySizes) {
+            System.out.println("keysize: " + ks);
+            SecretKey key = getKey(ks >> 3);
+
+            for (int m : modes) {
+                c.init(m, key);
+                System.out.println(getModeStr(m) + " => ok");
             }
         }
     }


### PR DESCRIPTION
Due to an error in the existing regression test, this bug remain undiscovered until now. Added the key size check to the KeyWrapCipher class and fixed the regression test.

Please help review this trivial fix.

Thanks in advance,
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302225](https://bugs.openjdk.org/browse/JDK-8302225): SunJCE Provider doesn't validate key sizes when using 'constrained' transforms for AES/KW and AES/KWP


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12569/head:pull/12569` \
`$ git checkout pull/12569`

Update a local copy of the PR: \
`$ git checkout pull/12569` \
`$ git pull https://git.openjdk.org/jdk pull/12569/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12569`

View PR using the GUI difftool: \
`$ git pr show -t 12569`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12569.diff">https://git.openjdk.org/jdk/pull/12569.diff</a>

</details>
