### PR TITLE
8302603: Use Set.of in java.nio.charset.Charset

### DIFF
--- a/src/java.base/share/classes/java/nio/charset/Charset.java
+++ b/src/java.base/share/classes/java/nio/charset/Charset.java
@@ -38,7 +38,6 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
@@ -714,13 +713,8 @@ public abstract class Charset
      * @return  An immutable set of this charset's aliases
      */
     public final Set<String> aliases() {
-        if (aliasSet != null)
-            return aliasSet;
-        int n = aliases.length;
-        HashSet<String> hs = HashSet.newHashSet(n);
-        for (int i = 0; i < n; i++)
-            hs.add(aliases[i]);
-        aliasSet = Collections.unmodifiableSet(hs);
+        if (aliasSet == null)
+            aliasSet = Set.of(aliases);
         return aliasSet;
     }
 

--- a/src/java.base/share/classes/java/nio/charset/Charset.java
+++ b/src/java.base/share/classes/java/nio/charset/Charset.java
@@ -666,7 +666,7 @@ public abstract class Charset
 
     private final String name;          // tickles a bug in oldjavac
     private final String[] aliases;     // tickles a bug in oldjavac
-    private Set<String> aliasSet = null;
+    private Set<String> aliasSet;
 
     /**
      * Initializes a new charset with the given canonical name and alias
@@ -713,9 +713,12 @@ public abstract class Charset
      * @return  An immutable set of this charset's aliases
      */
     public final Set<String> aliases() {
-        if (aliasSet == null)
-            aliasSet = Set.of(aliases);
-        return aliasSet;
+        Set<String> as = this.aliasSet;
+        if (as == null) {
+            as = Set.of(aliases);
+            this.aliasSet = as;
+        }
+        return as;
     }
 
     /**

--- a/src/java.base/share/classes/java/nio/charset/Charset.java
+++ b/src/java.base/share/classes/java/nio/charset/Charset.java
@@ -713,12 +713,12 @@ public abstract class Charset
      * @return  An immutable set of this charset's aliases
      */
     public final Set<String> aliases() {
-        Set<String> as = this.aliasSet;
-        if (as == null) {
-            as = Set.of(aliases);
-            this.aliasSet = as;
+        Set<String> set = this.aliasSet;
+        if (set == null) {
+            set = Set.of(aliases);
+            this.aliasSet = set;
         }
-        return as;
+        return set;
     }
 
     /**


### PR DESCRIPTION
A small patch, using `Set.of` instead of `Collections.unmodifiableSet()` of `Charset#aliasSet`.

The alias should not be null, and the aliasSet is an immutable copy, so it is safe to use `Set.of`.

I have investigated all charsets, most of charsets have no more than 4 aliases, and the maximum is only 17.

In this case, the performance difference between immutable sets and HashSet can be ignored, and the memory footprint of immutable sets is smaller.

I need someone to help me open an Issue on JBS. Thank you very much.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302603](https://bugs.openjdk.org/browse/JDK-8302603): Use Set.of in java.nio.charset.Charset


### Reviewers
 * [Sergey Tsypanov](https://openjdk.org/census#stsypanov) (@stsypanov - Author) ⚠️ Review applies to [f28a3f1b](https://git.openjdk.org/jdk/pull/12570/files/f28a3f1b156e72a0460803246cb636e494878189)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12570/head:pull/12570` \
`$ git checkout pull/12570`

Update a local copy of the PR: \
`$ git checkout pull/12570` \
`$ git pull https://git.openjdk.org/jdk pull/12570/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12570`

View PR using the GUI difftool: \
`$ git pr show -t 12570`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12570.diff">https://git.openjdk.org/jdk/pull/12570.diff</a>

</details>
