### PR TITLE
8302151: BMPImageReader throws an exception reading BMP images

### DIFF
--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/bmp/BMPImageReader.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/bmp/BMPImageReader.java
@@ -592,8 +592,10 @@ public class BMPImageReader extends ImageReader implements BMPConstants {
             height = Math.abs(height);
         }
 
-        if (metadata.compression == BI_RGB) {
-            long imageDataSize = ((long)width * height * (bitsPerPixel / 8));
+        if (metadata.compression == BI_RGB &&
+            metadata.paletteSize == 0 &&
+            metadata.bitsPerPixel >= 16) {
+            long imageDataSize = (((long)width * height * bitsPerPixel) / 8);
             if (imageDataSize > (bitmapFileSize - bitmapOffset)) {
                 throw new IIOException(I18N.getString("BMPImageReader9"));
             }

--- a/test/jdk/javax/imageio/plugins/bmp/BMP1bppImageWithPaletteTest.java
+++ b/test/jdk/javax/imageio/plugins/bmp/BMP1bppImageWithPaletteTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8302151
+ * @summary Tests that we should not try to calculate bitmap image
+            size using bitmap file size when we have a color palette
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import javax.imageio.ImageIO;
+
+public class BMP1bppImageWithPaletteTest {
+
+    public static void main(String[] args) throws IOException {
+        // incomplete 1bpp BMP byte stream with color palette and
+        // invalid file size data
+        byte[] corruptedBmp = { (byte) 0x42, (byte) 0x4d, (byte) 0x0e,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0x3e, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x28, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0xa2, (byte) 0x06, (byte) 0x00, (byte) 0x00, (byte) 0xb4,
+            (byte) 0x08, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00,
+            (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0xe0, (byte) 0x57, (byte) 0x07, (byte) 0x00,
+            (byte) 0xc2, (byte) 0x1e, (byte) 0x00, (byte) 0x00, (byte) 0xc2,
+            (byte) 0x1e, (byte) 0x00, (byte) 0x00, (byte) 0x02, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff
+        };
+
+        // We expect EOFException to be thrown
+        try {
+            ImageIO.read(new ByteArrayInputStream(corruptedBmp));
+        } catch(Exception ex) {
+            if (!(ex instanceof EOFException))
+                throw ex;
+        }
+    }
+}


### PR DESCRIPTION
We have check in BMPImageReader, where we verify image data size using BMP file size and bitmap offset value.
But we can't rely on this calculation when we have color palette. Also color palette is necessary in BMP when bits per pixel is less than 16 according to BMP specification(https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapv4header).

Now extra checks are added to not perform this check when we have color palette or bpp is less than 16.

Also when bitsPerPixel was less than 8 it was getting down-casted to 0. So this is also resolved by making this check for >=16bpp and not doing (bitsPerPixel / 8)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302151](https://bugs.openjdk.org/browse/JDK-8302151): BMPImageReader throws an exception reading BMP images


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12573/head:pull/12573` \
`$ git checkout pull/12573`

Update a local copy of the PR: \
`$ git checkout pull/12573` \
`$ git pull https://git.openjdk.org/jdk pull/12573/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12573`

View PR using the GUI difftool: \
`$ git pr show -t 12573`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12573.diff">https://git.openjdk.org/jdk/pull/12573.diff</a>

</details>
