### PR TITLE
8302514: Misleading error generated when empty class file encountered

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -62,6 +62,7 @@ import com.sun.tools.javac.main.Option;
 import com.sun.tools.javac.resources.CompilerProperties.Fragments;
 import com.sun.tools.javac.resources.CompilerProperties.Warnings;
 import com.sun.tools.javac.util.*;
+import com.sun.tools.javac.util.ByteBuffer.UnderflowException;
 import com.sun.tools.javac.util.DefinedBy.Api;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
 
@@ -329,7 +330,12 @@ public class ClassReader {
     /** Read a character.
      */
     char nextChar() {
-        char res = buf.getChar(bp);
+        char res;
+        try {
+            res = buf.getChar(bp);
+        } catch (UnderflowException e) {
+            throw badClassFile("bad.class.truncated.at.offset", Integer.toString(e.getLength()));
+        }
         bp += 2;
         return res;
     }
@@ -337,13 +343,22 @@ public class ClassReader {
     /** Read a byte.
      */
     int nextByte() {
-        return buf.getByte(bp++) & 0xFF;
+        try {
+            return buf.getByte(bp++) & 0xFF;
+        } catch (UnderflowException e) {
+            throw badClassFile("bad.class.truncated.at.offset", Integer.toString(e.getLength()));
+        }
     }
 
     /** Read an integer.
      */
     int nextInt() {
-        int res = buf.getInt(bp);
+        int res;
+        try {
+            res = buf.getInt(bp);
+        } catch (UnderflowException e) {
+            throw badClassFile("bad.class.truncated.at.offset", Integer.toString(e.getLength()));
+        }
         bp += 4;
         return res;
     }
@@ -1482,7 +1497,12 @@ public class ClassReader {
     /** Read parameter annotations.
      */
     void readParameterAnnotations(Symbol meth) {
-        int numParameters = buf.getByte(bp++) & 0xFF;
+        int numParameters;
+        try {
+            numParameters = buf.getByte(bp++) & 0xFF;
+        } catch (UnderflowException e) {
+            throw badClassFile("bad.class.truncated.at.offset", Integer.toString(e.getLength()));
+        }
         if (parameterAnnotations == null) {
             parameterAnnotations = new ParameterAnnotations[numParameters];
         } else if (parameterAnnotations.length != numParameters) {
@@ -1771,7 +1791,12 @@ public class ClassReader {
     }
 
     Attribute readAttributeValue() {
-        char c = (char) buf.getByte(bp++);
+        char c;
+        try {
+            c = (char)buf.getByte(bp++);
+        } catch (UnderflowException e) {
+            throw badClassFile("bad.class.truncated.at.offset", Integer.toString(e.getLength()));
+        }
         switch (c) {
         case 'B':
             return new Attribute.Constant(syms.byteType, poolReader.getConstant(nextChar()));

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ModuleNameReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ModuleNameReader.java
@@ -25,6 +25,7 @@
 package com.sun.tools.javac.jvm;
 
 import com.sun.tools.javac.util.ByteBuffer;
+import com.sun.tools.javac.util.ByteBuffer.UnderflowException;
 import com.sun.tools.javac.util.Convert;
 import com.sun.tools.javac.util.Name.NameMapper;
 
@@ -132,16 +133,26 @@ public class ModuleNameReader {
 
     /** Read a character.
      */
-    char nextChar() {
-        char res = buf.getChar(bp);
+    char nextChar() throws BadClassFile {
+        char res;
+        try {
+            res = buf.getChar(bp);
+        } catch (UnderflowException e) {
+            throw new BadClassFile("class file truncated at offset " + e.getLength());
+        }
         bp += 2;
         return res;
     }
 
     /** Read an integer.
      */
-    int nextInt() {
-        int res = buf.getInt(bp);
+    int nextInt() throws BadClassFile {
+        int res;
+        try {
+            res = buf.getInt(bp);
+        } catch (UnderflowException e) {
+            throw new BadClassFile("class file truncated at offset " + e.getLength());
+        }
         bp += 4;
         return res;
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -2431,6 +2431,9 @@ compiler.misc.bad.const.pool.tag.at=\
 compiler.misc.unexpected.const.pool.tag.at=\
     unexpected constant pool tag: {0} at {1}
 
+compiler.misc.bad.class.truncated.at.offset=\
+    class file truncated at offset {0}
+
 compiler.misc.bad.signature=\
     bad signature: {0}
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/ArrayUtils.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/ArrayUtils.java
@@ -35,13 +35,11 @@ import java.lang.reflect.Array;
 public class ArrayUtils {
 
     private static int calculateNewLength(int currentLength, int maxIndex) {
-        if (currentLength == 0)
-            currentLength++;                    // avoid infinite loop
         if (maxIndex == Integer.MAX_VALUE)
             maxIndex--;                         // avoid negative overflow
         while (currentLength < maxIndex + 1) {
             currentLength = currentLength * 2;
-            if (currentLength < 0) {            // avoid negative overflow
+            if (currentLength <= 0) {           // avoid infinite loop and negative overflow
                 currentLength = maxIndex + 1;
                 break;
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/ArrayUtils.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/ArrayUtils.java
@@ -35,12 +35,32 @@ import java.lang.reflect.Array;
 public class ArrayUtils {
 
     private static int calculateNewLength(int currentLength, int maxIndex) {
-        while (currentLength < maxIndex + 1)
+        if (currentLength == 0)
+            currentLength++;                    // avoid infinite loop
+        if (maxIndex == Integer.MAX_VALUE)
+            maxIndex--;                         // avoid negative overflow
+        while (currentLength < maxIndex + 1) {
             currentLength = currentLength * 2;
+            if (currentLength < 0) {            // avoid negative overflow
+                currentLength = maxIndex + 1;
+                break;
+            }
+        }
         return currentLength;
     }
 
+    /**
+     * Ensure the given array has length at least {@code maxIndex + 1}.
+     *
+     * @param array original array
+     * @param maxIndex exclusive lower bound for desired length
+     * @return possibly reallocated array of length at least {@code maxIndex + 1}
+     * @throws NullPointerException if {@code array} is null
+     * @throws IllegalArgumentException if {@code maxIndex} is negative
+     */
     public static <T> T[] ensureCapacity(T[] array, int maxIndex) {
+        if (maxIndex < 0)
+            throw new IllegalArgumentException("maxIndex=" + maxIndex);
         if (maxIndex < array.length) {
             return array;
         } else {
@@ -52,7 +72,18 @@ public class ArrayUtils {
         }
     }
 
+    /**
+     * Ensure the given array has length at least {@code maxIndex + 1}.
+     *
+     * @param array original array
+     * @param maxIndex exclusive lower bound for desired length
+     * @return possibly reallocated array of length at least {@code maxIndex + 1}
+     * @throws NullPointerException if {@code array} is null
+     * @throws IllegalArgumentException if {@code maxIndex} is negative
+     */
     public static byte[] ensureCapacity(byte[] array, int maxIndex) {
+        if (maxIndex < 0)
+            throw new IllegalArgumentException("maxIndex=" + maxIndex);
         if (maxIndex < array.length) {
             return array;
         } else {
@@ -63,7 +94,18 @@ public class ArrayUtils {
         }
     }
 
+    /**
+     * Ensure the given array has length at least {@code maxIndex + 1}.
+     *
+     * @param array original array
+     * @param maxIndex exclusive lower bound for desired length
+     * @return possibly reallocated array of length at least {@code maxIndex + 1}
+     * @throws NullPointerException if {@code array} is null
+     * @throws IllegalArgumentException if {@code maxIndex} is negative
+     */
     public static char[] ensureCapacity(char[] array, int maxIndex) {
+        if (maxIndex < 0)
+            throw new IllegalArgumentException("maxIndex=" + maxIndex);
         if (maxIndex < array.length) {
             return array;
         } else {
@@ -74,7 +116,18 @@ public class ArrayUtils {
         }
     }
 
+    /**
+     * Ensure the given array has length at least {@code maxIndex + 1}.
+     *
+     * @param array original array
+     * @param maxIndex exclusive lower bound for desired length
+     * @return possibly reallocated array of length at least {@code maxIndex + 1}
+     * @throws NullPointerException if {@code array} is null
+     * @throws IllegalArgumentException if {@code maxIndex} is negative
+     */
     public static int[] ensureCapacity(int[] array, int maxIndex) {
+        if (maxIndex < 0)
+            throw new IllegalArgumentException("maxIndex=" + maxIndex);
         if (maxIndex < array.length) {
             return array;
         } else {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/ByteBuffer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/ByteBuffer.java
@@ -174,8 +174,13 @@ public class ByteBuffer {
     }
 
     /** Extract an integer at position bp from elems.
+     *
+     * @param bp starting offset
+     * @throws IllegalArgumentException if there is not enough data in this buffer
+     * @throws IllegalArgumentException if {@code bp} is negative
      */
     public int getInt(int bp) {
+        verifyRange(bp, 4);
         return
             ((elems[bp] & 0xFF) << 24) +
             ((elems[bp+1] & 0xFF) << 16) +
@@ -185,8 +190,13 @@ public class ByteBuffer {
 
 
     /** Extract a long integer at position bp from elems.
+     *
+     * @param bp starting offset
+     * @throws IllegalArgumentException if there is not enough data in this buffer
+     * @throws IllegalArgumentException if {@code bp} is negative
      */
     public long getLong(int bp) {
+        verifyRange(bp, 8);
         DataInputStream elemsin =
             new DataInputStream(new ByteArrayInputStream(elems, bp, 8));
         try {
@@ -197,8 +207,13 @@ public class ByteBuffer {
     }
 
     /** Extract a float at position bp from elems.
+     *
+     * @param bp starting offset
+     * @throws IllegalArgumentException if there is not enough data in this buffer
+     * @throws IllegalArgumentException if {@code bp} is negative
      */
     public float getFloat(int bp) {
+        verifyRange(bp, 4);
         DataInputStream elemsin =
             new DataInputStream(new ByteArrayInputStream(elems, bp, 4));
         try {
@@ -209,8 +224,13 @@ public class ByteBuffer {
     }
 
     /** Extract a double at position bp from elems.
+     *
+     * @param bp starting offset
+     * @throws IllegalArgumentException if there is not enough data in this buffer
+     * @throws IllegalArgumentException if {@code bp} is negative
      */
     public double getDouble(int bp) {
+        verifyRange(bp, 8);
         DataInputStream elemsin =
             new DataInputStream(new ByteArrayInputStream(elems, bp, 8));
         try {
@@ -221,13 +241,25 @@ public class ByteBuffer {
     }
 
     /** Extract a character at position bp from elems.
+     *
+     * @param bp starting offset
+     * @throws IllegalArgumentException if there is not enough data in this buffer
+     * @throws IllegalArgumentException if {@code bp} is negative
      */
     public char getChar(int bp) {
+        verifyRange(bp, 2);
         return
             (char)(((elems[bp] & 0xFF) << 8) + (elems[bp+1] & 0xFF));
     }
 
+    /** Extract a byte at position bp from elems.
+     *
+     * @param bp starting offset
+     * @throws IllegalArgumentException if there is not enough data in this buffer
+     * @throws IllegalArgumentException if {@code bp} is negative
+     */
     public byte getByte(int bp) {
+        verifyRange(bp, 1);
         return elems[bp];
     }
 
@@ -241,5 +273,17 @@ public class ByteBuffer {
      */
     public Name toName(Names names) {
         return names.fromUtf(elems, 0, length);
+    }
+
+    /** Verify there are at least the specified number of bytes in this buffer at the specified offset.
+     *
+     * @param off starting offset
+     * @param len required length
+     * @throws IllegalArgumentException if there is not enough data in this buffer
+     * @throws IllegalArgumentException if {@code off} or {@code len} is negative
+     */
+    public void verifyRange(int off, int len) {
+        if (off < 0 || len < 0 || off + len < 0 || off + len > length)
+            throw new IllegalArgumentException("off=" + off + ", len=" + len + ", length=" + length);
     }
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/ByteBuffer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/ByteBuffer.java
@@ -178,10 +178,10 @@ public class ByteBuffer {
     /** Extract an integer at position bp from elems.
      *
      * @param bp starting offset
-     * @throws IllegalArgumentException if there is not enough data in this buffer
+     * @throws UnderflowException if there is not enough data in this buffer
      * @throws IllegalArgumentException if {@code bp} is negative
      */
-    public int getInt(int bp) {
+    public int getInt(int bp) throws UnderflowException {
         verifyRange(bp, 4);
         return
             ((elems[bp] & 0xFF) << 24) +
@@ -194,10 +194,10 @@ public class ByteBuffer {
     /** Extract a long integer at position bp from elems.
      *
      * @param bp starting offset
-     * @throws IllegalArgumentException if there is not enough data in this buffer
+     * @throws UnderflowException if there is not enough data in this buffer
      * @throws IllegalArgumentException if {@code bp} is negative
      */
-    public long getLong(int bp) {
+    public long getLong(int bp) throws UnderflowException {
         verifyRange(bp, 8);
         DataInputStream elemsin =
             new DataInputStream(new ByteArrayInputStream(elems, bp, 8));
@@ -211,10 +211,10 @@ public class ByteBuffer {
     /** Extract a float at position bp from elems.
      *
      * @param bp starting offset
-     * @throws IllegalArgumentException if there is not enough data in this buffer
+     * @throws UnderflowException if there is not enough data in this buffer
      * @throws IllegalArgumentException if {@code bp} is negative
      */
-    public float getFloat(int bp) {
+    public float getFloat(int bp) throws UnderflowException {
         verifyRange(bp, 4);
         DataInputStream elemsin =
             new DataInputStream(new ByteArrayInputStream(elems, bp, 4));
@@ -228,10 +228,10 @@ public class ByteBuffer {
     /** Extract a double at position bp from elems.
      *
      * @param bp starting offset
-     * @throws IllegalArgumentException if there is not enough data in this buffer
+     * @throws UnderflowException if there is not enough data in this buffer
      * @throws IllegalArgumentException if {@code bp} is negative
      */
-    public double getDouble(int bp) {
+    public double getDouble(int bp) throws UnderflowException {
         verifyRange(bp, 8);
         DataInputStream elemsin =
             new DataInputStream(new ByteArrayInputStream(elems, bp, 8));
@@ -245,10 +245,10 @@ public class ByteBuffer {
     /** Extract a character at position bp from elems.
      *
      * @param bp starting offset
-     * @throws IllegalArgumentException if there is not enough data in this buffer
+     * @throws UnderflowException if there is not enough data in this buffer
      * @throws IllegalArgumentException if {@code bp} is negative
      */
-    public char getChar(int bp) {
+    public char getChar(int bp) throws UnderflowException {
         verifyRange(bp, 2);
         return
             (char)(((elems[bp] & 0xFF) << 8) + (elems[bp+1] & 0xFF));
@@ -257,10 +257,10 @@ public class ByteBuffer {
     /** Extract a byte at position bp from elems.
      *
      * @param bp starting offset
-     * @throws IllegalArgumentException if there is not enough data in this buffer
+     * @throws UnderflowException if there is not enough data in this buffer
      * @throws IllegalArgumentException if {@code bp} is negative
      */
-    public byte getByte(int bp) {
+    public byte getByte(int bp) throws UnderflowException {
         verifyRange(bp, 1);
         return elems[bp];
     }
@@ -281,11 +281,34 @@ public class ByteBuffer {
      *
      * @param off starting offset
      * @param len required length
-     * @throws IllegalArgumentException if there is not enough data in this buffer
+     * @throws UnderflowException if there is not enough data in this buffer
      * @throws IllegalArgumentException if {@code off} or {@code len} is negative
      */
-    public void verifyRange(int off, int len) {
-        if (off < 0 || len < 0 || off + len < 0 || off + len > length)
-            throw new IllegalArgumentException("off=" + off + ", len=" + len + ", length=" + length);
+    public void verifyRange(int off, int len) throws UnderflowException {
+        if (off < 0 || len < 0)
+            throw new IllegalArgumentException("off=" + off + ", len=" + len);
+        if (off + len < 0 || off + len > length)
+            throw new UnderflowException(length);
+    }
+
+// UnderflowException
+
+    /** Thrown when trying to read past the end of the buffer.
+     */
+    public static class UnderflowException extends Exception {
+
+        private static final long serialVersionUID = 0;
+
+        private final int length;
+
+        public UnderflowException(int length) {
+            this.length = length;
+        }
+
+        /** Get the length of the buffer, which apparently is not long enough.
+         */
+        public int getLength() {
+            return length;
+        }
     }
 }

--- a/test/langtools/tools/javac/classreader/TruncatedClassFileTest.java
+++ b/test/langtools/tools/javac/classreader/TruncatedClassFileTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8302514
+ * @summary Verify truncated class files are detected and reported as truncated
+ */
+
+import com.sun.tools.javac.Main;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+
+public class TruncatedClassFileTest {
+
+    // We want a bunch of stuff in this file to make the classfile complicated
+    private static final String A_SOURCE = """
+        public class ClassA {
+            public static final boolean z = true;
+            public static final byte b = 7;
+            public static final char c = '*';
+            public static final short s = -12;
+            public static final int i = 123;
+            public static final float f = 123f;
+            public static final long j = 0x1234567812345678L;
+            public static final double d = Math.PI;
+            public static final String str = new String("test123");
+            @SuppressWarnings("blah")
+            public ClassA() {
+                new Thread();
+            }
+        }
+    """;
+
+    // This file will get compiled against a trunctated version of A.class
+    private static final String B_SOURCE = """
+        public class ClassB {
+            public ClassB() {
+                new ClassA();
+            }
+        }
+    """;
+
+    private static final File A_SOURCE_FILE = new File("ClassA.java");
+    private static final File B_SOURCE_FILE = new File("ClassB.java");
+    private static final File A_CLASS_FILE = new File("ClassA.class");
+
+    private static void createSourceFile(File file, String content) throws IOException {
+        try (PrintStream output = new PrintStream(new FileOutputStream(file))) {
+            output.println(content);
+        }
+    }
+
+    public static void main(String... args) throws Exception {
+
+        // Create A.java and B.java
+        createSourceFile(A_SOURCE_FILE, A_SOURCE);
+        createSourceFile(B_SOURCE_FILE, B_SOURCE);
+
+        // Compile A.java
+        createSourceFile(A_SOURCE_FILE, A_SOURCE);
+        int ret = Main.compile(new String[] { A_SOURCE_FILE.toString() });
+        if (ret != 0)
+            throw new AssertionError("compilation of " + A_SOURCE_FILE + " failed");
+        A_SOURCE_FILE.delete();
+
+        // Read A.class
+        final byte[] classfile = Files.readAllBytes(A_CLASS_FILE.toPath());
+
+        // Now compile B.java with truncated versions of A.class
+        for (int length = 0; length < classfile.length; length++) {
+
+            // Write out truncated class file A.class
+            try (FileOutputStream output = new FileOutputStream(A_CLASS_FILE)) {
+                output.write(classfile, 0, length);
+            }
+
+            // Try to compile file B.java
+            final StringWriter diags = new StringWriter();
+            final String[] params = new String[] {
+                "-classpath",
+                ".",
+                "-XDrawDiagnostics",
+                B_SOURCE_FILE.toString()
+            };
+            ret = Main.compile(params, new PrintWriter(diags, true));
+            if (ret == 0)
+                throw new AssertionError("compilation with truncated class file (" + length + ") succeeded?");
+            final String errmsg = "compiler.misc.bad.class.truncated.at.offset: " + length;
+            if (!diags.toString().contains(errmsg))
+                throw new AssertionError("error message not found for truncated class file (" + length + "): " + diags);
+        }
+    }
+}

--- a/test/langtools/tools/javac/diags/examples.not-yet.txt
+++ b/test/langtools/tools/javac/diags/examples.not-yet.txt
@@ -45,6 +45,7 @@ compiler.err.type.var.more.than.once                    # UNUSED
 compiler.err.type.var.more.than.once.in.result          # UNUSED
 compiler.err.unexpected.type
 compiler.misc.bad.class.signature                       # bad class file
+compiler.misc.bad.class.truncated.at.offset             # bad class file
 compiler.misc.bad.const.pool.tag                        # bad class file
 compiler.misc.bad.const.pool.tag.at                     # bad class file
 compiler.misc.unexpected.const.pool.tag.at              # bad class file

--- a/test/langtools/tools/javac/modules/EdgeCases.java
+++ b/test/langtools/tools/javac/modules/EdgeCases.java
@@ -381,7 +381,7 @@ public class EdgeCases extends ModuleTestBase {
             .getOutputLines(OutputKind.DIRECT);
 
         List<String> expected = Arrays.asList(
-                "- compiler.err.cant.access: <error>.module-info, (compiler.misc.bad.class.file.header: module-info.class, (compiler.misc.illegal.start.of.class.file))",
+                "- compiler.err.cant.access: <error>.module-info, (compiler.misc.bad.class.file.header: module-info.class, (compiler.misc.bad.class.truncated.at.offset: 0))",
                 "1 error");
 
         if (!expected.equals(log)) {

--- a/test/langtools/tools/javac/processing/model/completionfailure/NoAbortForBadClassFile.java
+++ b/test/langtools/tools/javac/processing/model/completionfailure/NoAbortForBadClassFile.java
@@ -102,7 +102,7 @@ public class NoAbortForBadClassFile extends TestRunner {
                 .getOutputLines(Task.OutputKind.DIRECT);
 
         List<String> expectedOut = Arrays.asList(
-                "Test.java:1:57: compiler.err.cant.access: test.Broken, (compiler.misc.bad.class.file.header: Broken.class, (compiler.misc.class.file.wrong.class: java.lang.AutoCloseable))",
+                "Test.java:1:57: compiler.err.cant.access: test.Broken, (compiler.misc.bad.class.file.header: Broken.class, (compiler.misc.bad.class.truncated.at.offset: 0))",
                  "Test.java:1:73: compiler.err.cant.resolve.location.args: kindname.method, unknown, , , (compiler.misc.location: kindname.class, java.lang.String, null)",
                  "2 errors"
         );


### PR DESCRIPTION
When javac encounters an empty class file, you get the following strange error referring to `java.lang.AutoCloseable`:
```
Test.java:3: error: cannot access Empty
        new Empty();
            ^
  bad class file: ./Empty.class
    class file contains wrong class: java.lang.AutoCloseable
    Please remove or make sure it appears in the correct subdirectory of the classpath.
1 error
```
This is a side effect of javac blindly reading past the end of the data in a data buffer. Further investigation revealed three distinct bugs in this area of the code:

1. There are several unchecked corner cases in `ByteBuffer` and `ArrayUtils` that could potentially lead to `ArrayIndexOutOfBoundsException`s and/or infinite loops. Instead we should "fail fast" on any attempt to read or allocate data out of bounds.
1. The method `ByteBuffer.appendStream()` assumes that the result from `InputStream.available()` is always accurate, but this is not guaranteed. As a result, class files could (in theory) be read incorrectly by the compiler, especially when they come from non-standard sources.
1. There is no systematic protection against truncated class files. Instead, depending on where exactly it is truncated, a truncated class file generates one of several possible different errors:
   * `index 25926 is not within pool size 13`
   * `bad constant pool tag: 0 at 28317`
   * `unexpected constant pool tag: 10 at 11`
   * `class file is invalid for class Empty`
   * `class file contains wrong class: java.lang.AutoCloseable`

This patch fixes issues 1 and 2, and addresses 3 by having `ByteBuffer` throw a new unchecked `UnderflowException` if ever data is read past the end of the buffer. Then `PoolReader`, `ClassReader`, and `ModuleNameReader` are updated to catch this exception and convert it into a bad class file error. As a result, truncated class files generate a consistent `class file truncated at offset X` error regardless of where they are truncated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302514](https://bugs.openjdk.org/browse/JDK-8302514): Misleading error generated when empty class file encountered


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12574/head:pull/12574` \
`$ git checkout pull/12574`

Update a local copy of the PR: \
`$ git checkout pull/12574` \
`$ git pull https://git.openjdk.org/jdk pull/12574/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12574`

View PR using the GUI difftool: \
`$ git pr show -t 12574`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12574.diff">https://git.openjdk.org/jdk/pull/12574.diff</a>

</details>
