### PR TITLE
JDK-8301959: Compile command in compiler.loopopts.TestRemoveEmptyCountedLoop does not work

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyCountedLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyCountedLoop.java
@@ -28,10 +28,10 @@
  * @key stress randomness
  *
  * @run main/othervm -XX:-TieredCompilation -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM
- *                   -XX:CompileOnly=compiler.loopopts.TestRemoveEmptyCountedLoop::test*
+ *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestRemoveEmptyCountedLoop::test*
  *                   compiler.loopopts.TestRemoveEmptyCountedLoop
  * @run main/othervm -XX:-TieredCompilation -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:StressSeed=2160808391
- *                   -XX:CompileOnly=compiler.loopopts.TestRemoveEmptyCountedLoop::test*
+ *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestRemoveEmptyCountedLoop::test*
  *                   compiler.loopopts.TestRemoveEmptyCountedLoop
  */
 


### PR DESCRIPTION
`TestRemoveEmptyCountedLoop.java` used an asterisk operator in CompileOnly which is not supported: 
 `-XX:CompileOnly=compiler.loopopts.TestRemoveEmptyCountedLoop::test*`

# Solution
Changed the test to use `-XX:CompileCommand=compileonly` which supports the asterisk operator

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301959](https://bugs.openjdk.org/browse/JDK-8301959): Compile command in compiler.loopopts.TestRemoveEmptyCountedLoop does not work


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12575/head:pull/12575` \
`$ git checkout pull/12575`

Update a local copy of the PR: \
`$ git checkout pull/12575` \
`$ git pull https://git.openjdk.org/jdk pull/12575/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12575`

View PR using the GUI difftool: \
`$ git pr show -t 12575`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12575.diff">https://git.openjdk.org/jdk/pull/12575.diff</a>

</details>
