### PR TITLE
JDK-8290822: C2: assert in PhaseIdealLoop::do_unroll() is subject to undefined behavior

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2278,8 +2278,8 @@ void PhaseIdealLoop::do_unroll(IdealLoopTree *loop, Node_List &old_new, bool adj
 
     // Verify that policy_unroll result is still valid.
     const TypeInt* limit_type = _igvn.type(limit)->is_int();
-    assert(stride_con > 0 && ((limit_type->_hi - stride_con) < limit_type->_hi) ||
-           stride_con < 0 && ((limit_type->_lo - stride_con) > limit_type->_lo),
+    assert((stride_con > 0 && ((min_jint + stride_con) > limit_type->_hi)) ||
+           (stride_con < 0 && ((max_jint + stride_con) < limit_type->_lo)),
            "sanity");
 
     if (limit->is_Con()) {

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2278,8 +2278,8 @@ void PhaseIdealLoop::do_unroll(IdealLoopTree *loop, Node_List &old_new, bool adj
 
     // Verify that policy_unroll result is still valid.
     const TypeInt* limit_type = _igvn.type(limit)->is_int();
-    assert((stride_con > 0 && ((min_jint + stride_con) > limit_type->_hi)) ||
-           (stride_con < 0 && ((max_jint + stride_con) < limit_type->_lo)),
+    assert((stride_con > 0 && ((min_jint + stride_con) <= limit_type->_hi)) ||
+           (stride_con < 0 && ((max_jint + stride_con) >= limit_type->_lo)),
            "sanity");
 
     if (limit->is_Con()) {


### PR DESCRIPTION
The following assert had undefined behavior (UB) because of _signed_ integer underflow/overflow: 
```
    assert(stride_con > 0 && ((limit_type->_hi - stride_con) < limit_type->_hi) || 
           stride_con < 0 && ((limit_type->_lo - stride_con) > limit_type->_lo), 
           "sanity"); 
```

# Solution 
The fix is to check for underflow/overflow (the purpose of the assert) without actually underflowing/overflowing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290822](https://bugs.openjdk.org/browse/JDK-8290822): C2: assert in PhaseIdealLoop::do_unroll() is subject to undefined behavior


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12576/head:pull/12576` \
`$ git checkout pull/12576`

Update a local copy of the PR: \
`$ git checkout pull/12576` \
`$ git pull https://git.openjdk.org/jdk pull/12576/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12576`

View PR using the GUI difftool: \
`$ git pr show -t 12576`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12576.diff">https://git.openjdk.org/jdk/pull/12576.diff</a>

</details>
