### PR TITLE
JDK-8302594: use-after-free in Node::destruct

### DIFF
--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -619,30 +619,11 @@ void Node::destruct(PhaseValues* phase) {
   // See if the input array was allocated just prior to the object
   int edge_size = _max*sizeof(void*);
   int out_edge_size = _outmax*sizeof(void*);
-  char *edge_end = ((char*)_in) + edge_size;
+  char *in_array = ((char*)_in);
+  char *edge_end = in_array + edge_size;
   char *out_array = (char*)(_out == NO_OUT_ARRAY? NULL: _out);
   int node_size = size_of();
 
-  // Free the output edge array
-  if (out_edge_size > 0) {
-    compile->node_arena()->Afree(out_array, out_edge_size);
-  }
-
-  // Free the input edge array and the node itself
-  if( edge_end == (char*)this ) {
-    // It was; free the input array and object all in one hit
-#ifndef ASSERT
-    compile->node_arena()->Afree(_in,edge_size+node_size);
-#endif
-  } else {
-    // Free just the input array
-    compile->node_arena()->Afree(_in,edge_size);
-
-    // Free just the object
-#ifndef ASSERT
-    compile->node_arena()->Afree(this,node_size);
-#endif
-  }
   if (is_macro()) {
     compile->remove_macro_node(this);
   }
@@ -665,6 +646,7 @@ void Node::destruct(PhaseValues* phase) {
   }
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
   bs->unregister_potential_barrier_node(this);
+
 #ifdef ASSERT
   // We will not actually delete the storage, but we'll make the node unusable.
   *(address*)this = badAddress;  // smash the C++ vtbl, probably
@@ -672,6 +654,27 @@ void Node::destruct(PhaseValues* phase) {
   _max = _cnt = _outmax = _outcnt = 0;
   compile->remove_modified_node(this);
 #endif
+
+  // Free the output edge array
+  if (out_edge_size > 0) {
+    compile->node_arena()->Afree(out_array, out_edge_size);
+  }
+
+  // Free the input edge array and the node itself
+  if( edge_end == (char*)this ) {
+    // It was; free the input array and object all in one hit
+#ifndef ASSERT
+    compile->node_arena()->Afree(in_array, edge_size+node_size);
+#endif
+  } else {
+    // Free just the input array
+    compile->node_arena()->Afree(in_array, edge_size);
+
+    // Free just the object
+#ifndef ASSERT
+    compile->node_arena()->Afree(this, node_size);
+#endif
+  }
 }
 
 //------------------------------grow-------------------------------------------


### PR DESCRIPTION
Instrumenting Arena for ASan revealed some `use-after-free` behavior in C2. One of them is in `Node::destruct`, where the storage for `Node` is free'd and then fields are accessed. Thankfully none of the methods called allocate, but they could in the future. To resolve this, we move the calls to `Afree` to the end of `Node::destruct`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8302594](https://bugs.openjdk.org/browse/JDK-8302594): use-after-free in Node::destruct


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12577/head:pull/12577` \
`$ git checkout pull/12577`

Update a local copy of the PR: \
`$ git checkout pull/12577` \
`$ git pull https://git.openjdk.org/jdk pull/12577/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12577`

View PR using the GUI difftool: \
`$ git pr show -t 12577`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12577.diff">https://git.openjdk.org/jdk/pull/12577.diff</a>

</details>
