### PR TITLE
JDK-8302595: use-after-free related to GraphKit::clone_map

### DIFF
--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -937,6 +937,7 @@ class Compile : public Phase {
   PhaseGVN*         initial_gvn()               { return _initial_gvn; }
   Unique_Node_List* for_igvn()                  { return _for_igvn; }
   inline void       record_for_igvn(Node* n);   // Body is after class Unique_Node_List.
+  inline void       remove_for_igvn(Node* n);   // Body is after class Unique_Node_List.
   void          set_initial_gvn(PhaseGVN *gvn)           { _initial_gvn = gvn; }
   void          set_for_igvn(Unique_Node_List *for_igvn) { _for_igvn = for_igvn; }
 

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -936,8 +936,8 @@ class Compile : public Phase {
   // Parsing, optimization
   PhaseGVN*         initial_gvn()               { return _initial_gvn; }
   Unique_Node_List* for_igvn()                  { return _for_igvn; }
-  inline void       record_for_igvn(Node* n);   // Body is after class Unique_Node_List.
-  inline void       remove_for_igvn(Node* n);   // Body is after class Unique_Node_List.
+  inline void       record_for_igvn(Node* n);   // Body is after class Unique_Node_List in node.hpp.
+  inline void       remove_for_igvn(Node* n);   // Body is after class Unique_Node_List in node.hpp.
   void          set_initial_gvn(PhaseGVN *gvn)           { _initial_gvn = gvn; }
   void          set_for_igvn(Unique_Node_List *for_igvn) { _for_igvn = for_igvn; }
 

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -735,6 +735,34 @@ SafePointNode* GraphKit::clone_map() {
   return clonemap;
 }
 
+//-----------------------------destruct_map_clone------------------------------
+//
+// Order of destruct is important to increase the likelyhood that memory can be re-used. We need
+// to destruct/free/delete in the exact opposite order as clone_map().
+void GraphKit::destruct_map_clone(SafePointNode* m) {
+  if (m == nullptr) return;
+
+  Node* mem = m->memory();
+  JVMState* jvms = m->jvms();
+
+  if (jvms != nullptr) {
+    delete jvms;
+    m->set_jvms(nullptr);
+  }
+
+  if (mem != nullptr) {
+    m->set_memory(nullptr);
+  }
+
+  remove_for_igvn(m);
+  gvn().clear_type(m);
+  m->destruct(&_gvn);
+
+  if (mem != nullptr) {
+    gvn().clear_type(mem);
+    mem->destruct(&_gvn);
+  }
+}
 
 //-----------------------------set_map_clone-----------------------------------
 void GraphKit::set_map_clone(SafePointNode* m) {

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -739,24 +739,24 @@ SafePointNode* GraphKit::clone_map() {
 //
 // Order of destruct is important to increase the likelyhood that memory can be re-used. We need
 // to destruct/free/delete in the exact opposite order as clone_map().
-void GraphKit::destruct_map_clone(SafePointNode* m) {
-  if (m == nullptr) return;
+void GraphKit::destruct_map_clone(SafePointNode* sfp) {
+  if (sfp == nullptr) return;
 
-  Node* mem = m->memory();
-  JVMState* jvms = m->jvms();
+  Node* mem = sfp->memory();
+  JVMState* jvms = sfp->jvms();
 
   if (jvms != nullptr) {
     delete jvms;
-    m->set_jvms(nullptr);
+    sfp->set_jvms(nullptr);
   }
 
   if (mem != nullptr) {
-    m->set_memory(nullptr);
+    sfp->set_memory(nullptr);
   }
 
-  remove_for_igvn(m);
-  gvn().clear_type(m);
-  m->destruct(&_gvn);
+  remove_for_igvn(sfp);
+  gvn().clear_type(sfp);
+  sfp->destruct(&_gvn);
 
   if (mem != nullptr) {
     gvn().clear_type(mem);

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -747,11 +747,6 @@ void GraphKit::destruct_map_clone(SafePointNode* sfp) {
 
   if (jvms != nullptr) {
     delete jvms;
-    sfp->set_jvms(nullptr);
-  }
-
-  if (mem != nullptr) {
-    sfp->set_memory(nullptr);
   }
 
   remove_for_igvn(sfp);

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -174,7 +174,7 @@ class GraphKit : public Phase {
   // Reverses the work done by clone_map(). Should only be used when the node returned by
   // clone_map() is ultimately not used. Calling Node::destruct directly in the previously
   // mentioned circumstance instead of this method may result in use-after-free.
-  void destruct_map_clone(SafePointNode* m);
+  void destruct_map_clone(SafePointNode* sfp);
 
   // Set the map to a clone of the given one.
   void set_map_clone(SafePointNode* m);

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -94,6 +94,7 @@ class GraphKit : public Phase {
   void*         barrier_set_state() const { return C->barrier_set_state(); }
 
   void record_for_igvn(Node* n) const { C->record_for_igvn(n); }  // delegate to Compile
+  void remove_for_igvn(Node* n) const { C->remove_for_igvn(n); }
 
   // Handy well-known nodes:
   Node*         null()          const { return zerocon(T_OBJECT); }
@@ -169,6 +170,11 @@ class GraphKit : public Phase {
 
   // Clone the existing map state.  (Implements PreserveJVMState.)
   SafePointNode* clone_map();
+
+  // Reverses the work done by clone_map(). Should only be used when the node returned by
+  // clone_map() is ultimately not used. Calling Node::destruct directly in the previously
+  // mentioned circumstance instead of this method may result in use-after-free.
+  void destruct_map_clone(SafePointNode* m);
 
   // Set the map to a clone of the given one.
   void set_map_clone(SafePointNode* m);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1646,7 +1646,7 @@ bool LibraryCallKit::inline_string_char_access(bool is_store) {
     set_sp(old_sp);
     return false;
   }
-  old_map->destruct(&_gvn);
+  destruct_map_clone(old_map);
   if (is_store) {
     access_store_at(value, adr, TypeAryPtr::BYTES, ch, TypeInt::CHAR, T_CHAR, IN_HEAP | MO_UNORDERED | C2_MISMATCHED);
   } else {
@@ -2361,7 +2361,7 @@ bool LibraryCallKit::inline_unsafe_access(bool is_store, const BasicType type, c
     mismatched = true; // conservatively mark all "wide" on-heap accesses as mismatched
   }
 
-  old_map->destruct(&_gvn);
+  destruct_map_clone(old_map);
   assert(!mismatched || alias_type->adr_type()->is_oopptr(), "off-heap access can't be mismatched");
 
   if (mismatched) {
@@ -2612,7 +2612,7 @@ bool LibraryCallKit::inline_unsafe_load_store(const BasicType type, const LoadSt
     return false;
   }
 
-  old_map->destruct(&_gvn);
+  destruct_map_clone(old_map);
 
   // For CAS, unlike inline_unsafe_access, there seems no point in
   // trying to refine types. Just use the coarse types here.

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1672,6 +1672,11 @@ inline void Compile::record_for_igvn(Node* n) {
   _for_igvn->push(n);
 }
 
+// Inline definition of Compile::remove_for_igvn must be deferred to this point.
+inline void Compile::remove_for_igvn(Node* n) {
+  _for_igvn->remove(n);
+}
+
 //------------------------------Node_Stack-------------------------------------
 class Node_Stack {
   friend class VMStructs;

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -239,6 +239,10 @@ public:
     assert(t != NULL, "type must not be null");
     _types.map(n->_idx, t);
   }
+  void    clear_type(const Node* n) {
+    if (n->_idx < _types.Size())
+      _types.map(n->_idx, NULL);
+  }
   // Record an initial type for a node, the node's bottom type.
   void    set_type_bottom(const Node* n) {
     // Use this for initialization when bottom_type() (or better) is not handy.

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -240,8 +240,9 @@ public:
     _types.map(n->_idx, t);
   }
   void    clear_type(const Node* n) {
-    if (n->_idx < _types.Size())
+    if (n->_idx < _types.Size()) {
       _types.map(n->_idx, NULL);
+    }
   }
   // Record an initial type for a node, the node's bottom type.
   void    set_type_bottom(const Node* n) {

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -1113,7 +1113,7 @@ bool LibraryCallKit::inline_vector_mem_operation(bool is_store) {
     set_result(box);
   }
 
-  old_map->destruct(&_gvn);
+  destruct_map_clone(old_map);
 
   if (needs_cpu_membar) {
     insert_mem_bar(Op_MemBarCPUOrder);
@@ -1372,7 +1372,7 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
     set_result(box);
   }
 
-  old_map->destruct(&_gvn);
+  destruct_map_clone(old_map);
 
   if (can_access_non_heap) {
     insert_mem_bar(Op_MemBarCPUOrder);
@@ -1585,7 +1585,7 @@ bool LibraryCallKit::inline_vector_gather_scatter(bool is_scatter) {
     set_result(box);
   }
 
-  old_map->destruct(&_gvn);
+  destruct_map_clone(old_map);
 
   C->set_max_vector_size(MAX2(C->max_vector_size(), (uint)(num_elem * type2aelembytes(elem_bt))));
   return true;


### PR DESCRIPTION
`GraphKit::clone_map` duplicates `SafePointNode` and calls `Compile::record_for_igvn`. In some cases `SafePointNode` is not used so `Node::destruct` is called to cleanup. The `Unique_Node_List` returned by `Compile::for_igvn` still references the node which resides in freed memory which may or may not have been reused. We additionally need to remove the node from `Unique_Node_List` as well to prevent this from happening.

I introduced `GraphKit::destruct_map_clone` which undoes `GraphKit::clone_map`. It even clears the type, though I am not sure if this is necessary so feel free to suggest otherwise. Additionally it calls `delete` on `JVMState`, which is a noop, but it seems like the correct thing to do in case its ever changed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8302595](https://bugs.openjdk.org/browse/JDK-8302595): use-after-free related to GraphKit::clone_map


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [3385ae23](https://git.openjdk.org/jdk/pull/12578/files/3385ae23e853219b2c74873d2be0d80c78e2d4ff)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [3385ae23](https://git.openjdk.org/jdk/pull/12578/files/3385ae23e853219b2c74873d2be0d80c78e2d4ff)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12578/head:pull/12578` \
`$ git checkout pull/12578`

Update a local copy of the PR: \
`$ git checkout pull/12578` \
`$ git pull https://git.openjdk.org/jdk pull/12578/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12578`

View PR using the GUI difftool: \
`$ git pr show -t 12578`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12578.diff">https://git.openjdk.org/jdk/pull/12578.diff</a>

</details>
