### PR TITLE
8302358: Behavior of adler32 changes after JDK-8300208

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_adler.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_adler.cpp
@@ -282,6 +282,7 @@ address StubGenerator::generate_updateBytesAdler32() {
 
   // continue loop
   __ movdl(xa, a_d);
+  __ vpxor(yb, yb, yb, Assembler::AVX_256bit);
   __ jmp(SLOOP1);
 
   __ bind(FINISH);

--- a/test/hotspot/jtreg/compiler/intrinsics/zip/TestAdler32.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/zip/TestAdler32.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/intrinsics/zip/TestAdler32.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/zip/TestAdler32.java
@@ -146,7 +146,7 @@ public class TestAdler32 {
         if (adler0.getValue() != adler1.getValue()) {
             System.err.printf("ERROR: adler0 = %08x, adler1 = %08x\n",
                               adler0.getValue(), adler1.getValue());
-            throw new AssertionError("TEST FAILED", null);
+            return false;
         }
         return true;
     }
@@ -166,6 +166,7 @@ public class TestAdler32 {
         int len1 = 8;    // the  8B/iteration loop
         int len2 = 32;   // the 32B/iteration loop
         int len3 = 4096; // the 4KB/iteration loop
+        int len4 = 5521; // the adler limit
 
         byte[] b = initializedBytes(len3*16, 0);
         int[] offsets = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 32, 64, 128, 256, 512 };
@@ -176,6 +177,8 @@ public class TestAdler32 {
                         len2*2, len2*4, len2*8, len2*16, len2*32, len2*64,
                         len3, len3+1, len3+3, len3+5, len3+7,
                         len3*2, len3*4, len3*8,
+                        len4, len4+1, len4+3, len4+5, len4+7, len4+len1, len4+len2, len4+len3,
+                        len4*2, len4*4, len4*2+1, len4*4+4,
                         len1+len2, len1+len2+1, len1+len2+3, len1+len2+5, len1+len2+7,
                         len1+len3, len1+len3+1, len1+len3+3, len1+len3+5, len1+len3+7,
                         len2+len3, len2+len3+1, len2+len3+3, len2+len3+5, len2+len3+7,
@@ -214,8 +217,9 @@ public class TestAdler32 {
         for (i = 0; i < offsets.length; i++) {
             for (j = 0; j < sizes.length; j++) {
                 if (!check(adler0[i*sizes.length + j], adler1[i*sizes.length + j])) {
-                    System.out.printf("offsets[%d] = %d", i, offsets[i]);
-                    System.out.printf("\tsizes[%d] = %d\n", j, sizes[j]);
+                    System.out.printf("Failed at: offsets[%d] = %d", i, offsets[i]);
+                    System.out.printf(", sizes[%d] = %d\n", j, sizes[j]);
+                    throw new AssertionError("TEST FAILED", null);
                 }
             }
         }

--- a/test/hotspot/jtreg/compiler/intrinsics/zip/TestAdler32.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/zip/TestAdler32.java
@@ -166,7 +166,7 @@ public class TestAdler32 {
         int len1 = 8;    // the  8B/iteration loop
         int len2 = 32;   // the 32B/iteration loop
         int len3 = 4096; // the 4KB/iteration loop
-        int len4 = 5521; // the adler limit
+        int len4 = 5552; // the adler limit
 
         byte[] b = initializedBytes(len3*16, 0);
         int[] offsets = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 32, 64, 128, 256, 512 };


### PR DESCRIPTION
This PR fixes the issue in Adler computation on x86_64. The problem was  due to a missing register clear. Also the test is updated to capture the failed test case.

Please review.

Best Regards,
Sandhya

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302358](https://bugs.openjdk.org/browse/JDK-8302358): Behavior of adler32 changes after JDK-8300208


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12581/head:pull/12581` \
`$ git checkout pull/12581`

Update a local copy of the PR: \
`$ git checkout pull/12581` \
`$ git pull https://git.openjdk.org/jdk pull/12581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12581`

View PR using the GUI difftool: \
`$ git pr show -t 12581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12581.diff">https://git.openjdk.org/jdk/pull/12581.diff</a>

</details>
