### PR TITLE
8302625: Bad copyright line after JDK-8302385

### DIFF
--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/MetaspaceTestArena.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/MetaspaceTestArena.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, 2023, SAP SE. All rights reserved.
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Fixed bad copyright line after [JDK-8302385](https://bugs.openjdk.org/browse/JDK-8302385).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302625](https://bugs.openjdk.org/browse/JDK-8302625): Bad copyright line after JDK-8302385


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12582/head:pull/12582` \
`$ git checkout pull/12582`

Update a local copy of the PR: \
`$ git checkout pull/12582` \
`$ git pull https://git.openjdk.org/jdk pull/12582/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12582`

View PR using the GUI difftool: \
`$ git pr show -t 12582`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12582.diff">https://git.openjdk.org/jdk/pull/12582.diff</a>

</details>
