### PR TITLE
Speed up case-insensitive string comparison

### DIFF
--- a/src/java.base/share/classes/java/lang/CharacterData.java
+++ b/src/java.base/share/classes/java/lang/CharacterData.java
@@ -72,15 +72,19 @@ abstract class CharacterData {
         if (ch >>> 8 == 0) {     // fast-path
             return CharacterDataLatin1.instance;
         } else {
-            return switch (ch >>> 16) {  //plane 00-16
-                case 0 -> CharacterData00.instance;
-                case 1 -> CharacterData01.instance;
-                case 2 -> CharacterData02.instance;
-                case 3 -> CharacterData03.instance;
-                case 14 -> CharacterData0E.instance;
-                case 15, 16 -> CharacterDataPrivateUse.instance; // Both cases Private Use
-                default -> CharacterDataUndefined.instance;
-            };
+            return ofUnicode(ch);
         }
+    }
+    // Fast-path when the caller knows that the code point is not latin1
+    static CharacterData ofUnicode(int ch) {
+        return switch (ch >>> 16) {  //plane 00-16
+            case 0 -> CharacterData00.instance;
+            case 1 -> CharacterData01.instance;
+            case 2 -> CharacterData02.instance;
+            case 3 -> CharacterData03.instance;
+            case 14 -> CharacterData0E.instance;
+            case 15, 16 -> CharacterDataPrivateUse.instance; // Both cases Private Use
+            default -> CharacterDataUndefined.instance;
+        };
     }
 }

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -33,8 +33,6 @@ import java.util.function.IntConsumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import jdk.internal.util.ArraysSupport;
-import jdk.internal.vm.annotation.DontInline;
-import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 
 import static java.lang.String.UTF16;
@@ -360,6 +358,9 @@ final class StringUTF16 {
 
     // Case insensitive comparison of two code points
     private static int compareCodePointCI(int cp1, int cp2) {
+        if (latin1EqualsIgnoreCase(cp1, cp2)) {
+            return 0;
+        }
         // try converting both characters to uppercase.
         // If the results match, then the comparison scan should
         // continue.
@@ -377,6 +378,24 @@ final class StringUTF16 {
             }
         }
         return 0;
+    }
+    /**
+     *  Version of {@link StringLatin1#isLatinEqualIC(byte, byte)} for comparing
+     *  unicode code points. See the StringLatin1 version for a more extensive explanation.
+     *
+     * @param cp1 a unicode code point
+     * @param cp2 another unicode code point
+     * @return true if the two code points are considered equals ignoring case in ISO/IEC 8859-1.
+     */
+    static boolean latin1EqualsIgnoreCase(int cp1, int cp2) {
+        if (cp1 > 0xDE || cp2 > 0xDE) {
+            return false; // Quicly reject high points
+        }
+        int A = cp1 & 0xDF; // Oldest ASCII trick in the book
+        return ( (A >= 'A' && A <= 'Z') // In range A-Z
+                || (A >= 0xC0)) // ..or Agrave-Thorn
+                && A != 0xD7 // But not multiply
+                && A == (cp2 & 0xDF); // b has same uppercase
     }
 
     // Returns a code point from the code unit pointed by "index". If it is

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -364,15 +364,16 @@ final class StringUTF16 {
         // try converting both characters to uppercase.
         // If the results match, then the comparison scan should
         // continue.
-        cp1 = Character.toUpperCase(cp1);
-        cp2 = Character.toUpperCase(cp2);
+
+        cp1 = CharacterData.ofUnicode(cp1).toUpperCase(cp1);
+        cp2 = CharacterData.ofUnicode(cp2).toUpperCase(cp2);
         if (cp1 != cp2) {
             // Unfortunately, conversion to uppercase does not work properly
             // for the Georgian alphabet, which has strange rules about case
             // conversion.  So we need to make one last check before
             // exiting.
-            cp1 = Character.toLowerCase(cp1);
-            cp2 = Character.toLowerCase(cp2);
+            cp1 = CharacterData.ofUnicode(cp1).toLowerCase(cp1);
+            cp2 = CharacterData.ofUnicode(cp2).toLowerCase(cp2);
             if (cp1 != cp2) {
                 return cp1 - cp2;
             }

--- a/test/jdk/java/lang/String/CompactString/EqualsIgnoreCase.java
+++ b/test/jdk/java/lang/String/CompactString/EqualsIgnoreCase.java
@@ -25,6 +25,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static p1.Test.assertFalse;
+import static p1.Test.assertTrue;
 
 /*
  * @test
@@ -94,13 +96,9 @@ public class EqualsIgnoreCase extends CompactString {
                     if (Character.toUpperCase(ac) == Character.toUpperCase(bc)
                             || Character.toLowerCase(ac) == Character.toLowerCase(bc)) {
 
-                        if (!as.equalsIgnoreCase(bs)) {
-                            throw new RuntimeException(ac + " != " + bc);
-                        }
+                        assertTrue(as.equalsIgnoreCase(bs));
                     } else {
-                        if (as.equalsIgnoreCase(bs)) {
-                            throw new RuntimeException(ac + " != " + bc);
-                        }
+                        assertFalse(as.equalsIgnoreCase(bs));
                     }
                 }
             }

--- a/test/jdk/java/lang/String/CompactString/EqualsIgnoreCase.java
+++ b/test/jdk/java/lang/String/CompactString/EqualsIgnoreCase.java
@@ -24,9 +24,7 @@
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
-import static p1.Test.assertFalse;
-import static p1.Test.assertTrue;
+import static org.testng.Assert.*;
 
 /*
  * @test
@@ -84,18 +82,16 @@ public class EqualsIgnoreCase extends CompactString {
      */
     @Test
     public void checkConsistencyWithCharacterUppercaseLowerCase() {
-        for (int a = 0; a < 256; a++) {
-            for (int b = 0; b < 256; b++) {
-                if (a != b) {
-                    char ac = (char) a, bc = (char) b;
-                    byte ab = (byte) a, bb = (byte) b;
+        for (int ab = 0; ab < 256; ab++) {
+            for (int bb = 0; bb < 256; bb++) {
+                if (ab != bb) {
+                    char a = (char) ab, b = (char) bb;
 
-                    String as = Character.toString(ac);
-                    String bs = Character.toString(bc);
+                    String as = Character.toString(a);
+                    String bs = Character.toString(b);
 
-                    if (Character.toUpperCase(ac) == Character.toUpperCase(bc)
-                            || Character.toLowerCase(ac) == Character.toLowerCase(bc)) {
-
+                    if (Character.toUpperCase(a) == Character.toUpperCase(b)
+                            || Character.toLowerCase(a) == Character.toLowerCase(b)) {
                         assertTrue(as.equalsIgnoreCase(bs));
                     } else {
                         assertFalse(as.equalsIgnoreCase(bs));

--- a/test/jdk/java/lang/String/CompactString/EqualsIgnoreCase.java
+++ b/test/jdk/java/lang/String/CompactString/EqualsIgnoreCase.java
@@ -75,4 +75,35 @@ public class EqualsIgnoreCase extends CompactString {
                                             source));
                         });
     }
+
+    /**
+     * Exhaustively check that all lat1 code point pairs are equalsIgnoreCased
+     * in a manner consistent with Character.toUpperCase, Character.toLowerCase
+     */
+    @Test
+    public void checkConsistencyWithCharacterUppercaseLowerCase() {
+        for (int a = 0; a < 256; a++) {
+            for (int b = 0; b < 256; b++) {
+                if (a != b) {
+                    char ac = (char) a, bc = (char) b;
+                    byte ab = (byte) a, bb = (byte) b;
+
+                    String as = Character.toString(ac);
+                    String bs = Character.toString(bc);
+
+                    if (Character.toUpperCase(ac) == Character.toUpperCase(bc)
+                            || Character.toLowerCase(ac) == Character.toLowerCase(bc)) {
+
+                        if (!as.equalsIgnoreCase(bs)) {
+                            throw new RuntimeException(ac + " != " + bc);
+                        }
+                    } else {
+                        if (as.equalsIgnoreCase(bs)) {
+                            throw new RuntimeException(ac + " != " + bc);
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/test/jdk/java/lang/String/CompactString/RegionMatches.java
+++ b/test/jdk/java/lang/String/CompactString/RegionMatches.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,9 +96,11 @@ public class RegionMatches extends CompactString {
                 // Turkish I with dot
                 new Object[] { "\u0130", false, 0, "i", 0, 1, false },
                 new Object[] { "\u0130", true,  0, "i", 0, 1, true },
+                new Object[] { "\u0130", true,  0, "I", 0, 1, true },
                 // i without dot
                 new Object[] { "\u0131", false, 0, "i", 0, 1, false },
                 new Object[] { "\u0131", true,  0, "i", 0, 1, true },
+                new Object[] { "\u0131", true,  0, "I", 0, 1, true },
                 // Exhaustive list of 1-char latin1 strings that match
                 // case-insensitively:
                 // for (char c1 = 0; c1 < 255; c1++) {

--- a/test/micro/org/openjdk/bench/java/lang/StringComparisonsIC.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringComparisonsIC.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+/*
+ * This benchmark naively explores String::regionMatches, ignoring case
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 3)
+public class StringComparisonsIC {
+
+    @Param({"6", "15", "1024"})
+    public int size;
+
+    @Param({"mixed", "lat", "utf16"})
+    public String coders;
+    @Param({"true","false"})
+    public boolean Az;
+
+    private String leftString;
+    private String rightString;
+    private int offset;
+
+    @Setup
+    public void setup() {
+        String ue = "\u025b";
+        String e = "e";
+
+
+        switch (coders) {
+            case "utf16" -> {
+                leftString = ue + e.repeat(size) + ue.repeat(size);
+                rightString = leftString;
+            }
+            case "mixed" -> {
+                leftString = ue + e.repeat(size) + ue.repeat(size);
+                rightString = e + e.repeat(size) + "1".repeat(size);
+            }
+            case "lat" -> {
+                leftString = e + e.repeat(size) + "1".repeat(size);
+                rightString = leftString;
+            }
+        }
+        rightString = rightString.toUpperCase(Locale.ENGLISH);
+
+        offset = 1 + (Az ? 0 : size);
+    }
+
+
+    @Benchmark
+    public boolean regionMatchesIC() {
+        return leftString.regionMatches(true,offset, rightString, offset, size);
+    }
+
+
+
+}


### PR DESCRIPTION
We can speed up case-insensitive string comparison as follows:

- In Latin1, case folding lowercase code points are always found 0x20 higher than their uppercase counterpart. We can apply 'the oldest ASCII trick in the book" here, also for  the latin1 letters which are non-ASCII.
- When comparing strings with mixed coders (lat1/utf16 strings), we know that the left side is always lat1. Unicode only has two code point case-folding into lat1 territory, 0x130 and 0x131. Special-casing the handing of these two code points  avoids calling Character.toUppercase and Character.toLowerCase.
- We can shortcut utf16/utf16 comparisons if both code points are lat1 and apply the oldest trick in the book here as well.
- In true unicode utf16/utf-16 comparisons we know that code points are non-latin1, so the fast-path in CharacterData.of is actually not a fast-path. Adding CharacterData.ofUnicode gives a nice speedup. 

Benchmark results show significant speedups:

https://jmh.morethan.io/?gists=f95413117e003b37c367dbb9ee4ddd39,2be4f6e4f425ef723d95757b5b35d5ca

Testing for correctness:

- EqualsIgnoreCase is augmented to exhaustively verify that all lat1 code point pairs are equalsIgnoreCased in a manner consistent with Character.toUpperCase, Character.toLowerCase.
- RegionMatches is extended to add coverage for Turkic case-insensitive comparison when comparing 'I with dot' and 'i with dot' against the ASCII uppercase 'I'. The test currently compares against lowercase ASCII 'i' only, this is insufficient.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Contributors
 * Claes Redestad `<redestad@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12583/head:pull/12583` \
`$ git checkout pull/12583`

Update a local copy of the PR: \
`$ git checkout pull/12583` \
`$ git pull https://git.openjdk.org/jdk pull/12583/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12583`

View PR using the GUI difftool: \
`$ git pr show -t 12583`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12583.diff">https://git.openjdk.org/jdk/pull/12583.diff</a>

</details>
