### PR TITLE
8302518: Add missing Op_RoundDoubleMode in VectorNode::vector_operands()

### DIFF
--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -551,6 +551,7 @@ void VectorNode::vector_operands(Node* n, uint* start, uint* end) {
   case Op_LShiftI:  case Op_LShiftL:
   case Op_RShiftI:  case Op_RShiftL:
   case Op_URShiftI: case Op_URShiftL:
+  case Op_RoundDoubleMode:
     *start = 1;
     *end   = 2; // 1 vector operand
     break;

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -555,6 +555,13 @@ void VectorNode::vector_operands(Node* n, uint* start, uint* end) {
     *start = 1;
     *end   = 2; // 1 vector operand
     break;
+  case Op_RotateLeft:
+  case Op_RotateRight:
+    // Rotate shift could have 1 or 2 vector operand(s), depending on
+    // whether shift distance is a supported constant or not.
+    *start = 1;
+    *end   = (n->is_Con() && Matcher::supports_vector_constant_rotates(n->get_int())) ? 2 : 3;
+    break;
   case Op_AddI: case Op_AddL: case Op_AddF: case Op_AddD:
   case Op_SubI: case Op_SubL: case Op_SubF: case Op_SubD:
   case Op_MulI: case Op_MulL: case Op_MulF: case Op_MulD:


### PR DESCRIPTION
This is a one-line fix.

`VectorNode::vector_operands()` is a C2 function used to get a half-open range of `[start, end)` defining which operands are vectors to process. `Op_RoundDoubleMode` has two operands but only the 1st one is a vector. Its 2nd operand is the rounding mode. Missing this op results in its 2nd operand treated as a vector. It is fortunate that it hasn't caused any issue yet as the code follows just treated the 2nd input as an immediate to replicate later. If we add some check like `n->is_Vector()` for the vectorized node then, there will be issues. We should fix this potential problem.

Tested tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8302518](https://bugs.openjdk.org/browse/JDK-8302518): Add missing Op_RoundDoubleMode in VectorNode::vector_operands()


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [53038661](https://git.openjdk.org/jdk/pull/12584/files/5303866122f3f58cac2d6cc348a9c48f28cd8146)
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12584/head:pull/12584` \
`$ git checkout pull/12584`

Update a local copy of the PR: \
`$ git checkout pull/12584` \
`$ git pull https://git.openjdk.org/jdk pull/12584/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12584`

View PR using the GUI difftool: \
`$ git pr show -t 12584`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12584.diff">https://git.openjdk.org/jdk/pull/12584.diff</a>

</details>
