### PR TITLE
Speed up case-insensitive string comparison

### DIFF
--- a/src/java.base/share/classes/java/lang/CharacterData.java
+++ b/src/java.base/share/classes/java/lang/CharacterData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/CharacterData.java
+++ b/src/java.base/share/classes/java/lang/CharacterData.java
@@ -72,15 +72,19 @@ abstract class CharacterData {
         if (ch >>> 8 == 0) {     // fast-path
             return CharacterDataLatin1.instance;
         } else {
-            return switch (ch >>> 16) {  //plane 00-16
-                case 0 -> CharacterData00.instance;
-                case 1 -> CharacterData01.instance;
-                case 2 -> CharacterData02.instance;
-                case 3 -> CharacterData03.instance;
-                case 14 -> CharacterData0E.instance;
-                case 15, 16 -> CharacterDataPrivateUse.instance; // Both cases Private Use
-                default -> CharacterDataUndefined.instance;
-            };
+            return ofUnicode(ch);
         }
+    }
+    // Fast-path when the caller knows that the code point is not latin1
+    static CharacterData ofUnicode(int ch) {
+        return switch (ch >>> 16) {  //plane 00-16
+            case 0 -> CharacterData00.instance;
+            case 1 -> CharacterData01.instance;
+            case 2 -> CharacterData02.instance;
+            case 3 -> CharacterData03.instance;
+            case 14 -> CharacterData0E.instance;
+            case 15, 16 -> CharacterDataPrivateUse.instance; // Both cases Private Use
+            default -> CharacterDataUndefined.instance;
+        };
     }
 }

--- a/src/java.base/share/classes/java/lang/CharacterData.java
+++ b/src/java.base/share/classes/java/lang/CharacterData.java
@@ -85,9 +85,9 @@ abstract class CharacterData {
     }
 
     /**
-     * Returns true if the character is a non-latin1 code point
+     * Returns true if the character is a non-latin1 Unicode code point
      * where Character.toLowerCase or Character.toUpperCase
-     * can return values in the Latin1 range.
+     * can return values in the latin1 range.
      */
     static boolean foldsToLatin1(char c) {
         return     c == 0x130

--- a/src/java.base/share/classes/java/lang/CharacterData.java
+++ b/src/java.base/share/classes/java/lang/CharacterData.java
@@ -114,7 +114,7 @@ abstract class CharacterData {
      * an exchaustive test verifies that the constants in this method is always
      * up to date. (See EqualsIgnoreCase.guardUnicodeFoldingToLatin1)
      */
-    static boolean foldsToLatin1(char c) {
+    static boolean foldsToLatin1(int c) {
         // This seems to be slightly faster than a switch:
         return  c == 0x130      // Latin capital letter i with dot above. Upper: i
                 || c == 0x131   // Latin small letter dotless i.          Lower: I

--- a/src/java.base/share/classes/java/lang/CharacterData.java
+++ b/src/java.base/share/classes/java/lang/CharacterData.java
@@ -72,19 +72,15 @@ abstract class CharacterData {
         if (ch >>> 8 == 0) {     // fast-path
             return CharacterDataLatin1.instance;
         } else {
-            return ofUnicode(ch);
+            return switch (ch >>> 16) {  //plane 00-16
+                case 0 -> CharacterData00.instance;
+                case 1 -> CharacterData01.instance;
+                case 2 -> CharacterData02.instance;
+                case 3 -> CharacterData03.instance;
+                case 14 -> CharacterData0E.instance;
+                case 15, 16 -> CharacterDataPrivateUse.instance; // Both cases Private Use
+                default -> CharacterDataUndefined.instance;
+            };
         }
-    }
-    // Fast-path when the caller knows that the code point is not latin1
-    static CharacterData ofUnicode(int ch) {
-        return switch (ch >>> 16) {  //plane 00-16
-            case 0 -> CharacterData00.instance;
-            case 1 -> CharacterData01.instance;
-            case 2 -> CharacterData02.instance;
-            case 3 -> CharacterData03.instance;
-            case 14 -> CharacterData0E.instance;
-            case 15, 16 -> CharacterDataPrivateUse.instance; // Both cases Private Use
-            default -> CharacterDataUndefined.instance;
-        };
     }
 }

--- a/src/java.base/share/classes/java/lang/CharacterData.java
+++ b/src/java.base/share/classes/java/lang/CharacterData.java
@@ -114,17 +114,13 @@ abstract class CharacterData {
      * up to date. (See EqualsIgnoreCase.guardUnicodeFoldingToLatin1)
      */
     static boolean foldsToLatin1(char c) {
-        switch (c) {
-            case 0x130:  // Latin capital letter i with dot above.  Uppercase: i
-            case 0x131:  // Latin small letter dotless i.           Lowercase: I
-            case 0x178:  // Latin capital letter y with diaeresis.  Lowercase: Y with Diaeresis
-            case 0x17F:  // latin small letter long s.              Uppercase: S
-            case 0x1E9E: // latin capital letter sharp s.           Lowercase: Sharp s
-            case 0x212A: // Kelvin sign.                            Lowercase: k
-            case 0x212B: // Angstrom sign.                          Lowercase: A with Overring
-                return true;
-            default:
-                return false;
-        }
+        // This seems to be slightly faster than a switch:
+        return  c == 0x130      // Latin capital letter i with dot above. Upper: i
+                || c == 0x131   // Latin small letter dotless i.          Lower: I
+                || c == 0x178   // Latin capital letter y with diaeresis. Lower: Y with Diaeresis
+                || c == 0x17F   // Latin small letter long s.             Upper: S
+                || c == 0x1E9E  // Latin capital letter sharp s.          Lower: Sharp s
+                || c == 0x212A  // Kelvin sign.                           Lower: k
+                || c == 0x212B; // Angstrom sign.                         Lower: A with Overring
     }
 }

--- a/src/java.base/share/classes/java/lang/CharacterData.java
+++ b/src/java.base/share/classes/java/lang/CharacterData.java
@@ -87,24 +87,25 @@ abstract class CharacterData {
     /**
      * Returns true if the character is a non-latin1 Unicode code point
      * where Character.toLowerCase or Character.toUpperCase return values
-     * in the latin1 range, as if the following code was called:
+     * in the latin1 range <= 0xFF, as if the following code was called:
      *
      * {@snippet :
      *   return c > 0xFF && (Character.toLowerCase(c) <= 0XFF || Character.toUpperCase(c) <= 0XFF);
      * }
      *
-     * For performance reasons, the implementation switches over known constants instead.
-     * These constants were found using an exhaustive search over all code points:
+     * For performance reasons, the implementation compares to a set of known
+     * code points instead. These code points were found using an exhaustive
+     * search over all non-latin1 characters:
      *
      * {@snippet :
      *   for (char c = 256; c < Character.MAX_VALUE; c++) {
      *     char lc = Character.toLowerCase(c);
      *     if (lc <= 0XFF) {
-     *         System.out.println(c + " " + Integer.toHexString(c) + " LC: " + lc);
+     *         System.out.println(Integer.toHexString(c) + " LC: " + lc);
      *     }
      *     char uc = Character.toUpperCase(c);
      *     if (uc <= 0XFF) {
-     *         System.out.println(c + " " + Integer.toHexString(c) + " UC " + uc);
+     *         System.out.println(Integer.toHexString(c) + " UC " + uc);
      *     }
      * }
      * }

--- a/src/java.base/share/classes/java/lang/CharacterData.java
+++ b/src/java.base/share/classes/java/lang/CharacterData.java
@@ -83,4 +83,19 @@ abstract class CharacterData {
             };
         }
     }
+
+    /**
+     * Returns true if the character is a non-latin1 code point
+     * where Character.toLowerCase or Character.toUpperCase
+     * can return values in the Latin1 range.
+     */
+    static boolean foldsToLatin1(char c) {
+        return     c == 0x130
+                || c == 0x131
+                || c == 0x178
+                || c == 0x17F
+                || c == 0x1E9E
+                || c == 0x212A
+                || c == 0x212B;
+    }
 }

--- a/src/java.base/share/classes/java/lang/CharacterData.java
+++ b/src/java.base/share/classes/java/lang/CharacterData.java
@@ -111,7 +111,7 @@ abstract class CharacterData {
      * }
      *
      * To catch regressions caused by future changes in Unicode code folding rules,
-     * an exchaustive test verifies that the constants in this method is always
+     * an exhaustive test verifies that the constants in this method is always
      * up to date. (See EqualsIgnoreCase.guardUnicodeFoldingToLatin1)
      */
     static boolean foldsToLatin1(int c) {

--- a/src/java.base/share/classes/java/lang/CharacterData.java
+++ b/src/java.base/share/classes/java/lang/CharacterData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -390,9 +390,10 @@ final class StringLatin1 {
         while (toffset < last) {
             byte b1 = value[toffset++];
             byte b2 = other[ooffset++];
-            if (b1 != b2 && !latin1EqualsIgnoreCase(b1, b2)) {
-                return false;
+            if (b1 == b2 || latin1EqualsIgnoreCase(b1, b2)) {
+                continue;
             }
+            return false;
         }
         return true;
     }

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -470,7 +470,10 @@ final class StringLatin1 {
      */
     private static boolean latin1EqualsIgnoreCase(byte a, byte b) {
         int A = a & 0xDF; // uppercase a
-        return ( (A >= 'A' && A <= 'Z') // A in range A-Z
+        if (A < 'A') {
+            return false;  // Reject common non-letter ASCII fast
+        }
+        return ( A <= 'Z' // A in range A-Z
                 || (A >= 0xC0 && A <= 0xDE)) // ..or Agrave-Thorn
                 && A != 0xD7 // But not multiply
                 && A == (b & 0xDF); // b has same uppercase

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -403,12 +403,24 @@ final class StringLatin1 {
         while (toffset < last) {
             char c1 = (char)(value[toffset++] & 0xff);
             char c2 = StringUTF16.getChar(other, ooffset++);
-            if (c1 == c2 || StringUTF16.latin1EqualsIgnoreCase(c1, c2)) {
+            // Fast path when codepoints are the same
+            if (c1 == c2) {
                 continue;
             }
+            // Fast path for latin1 letters with folding case
+            if (StringUTF16.latin1EqualsIgnoreCase(c1, c2)) {
+                continue;
+            }
+            // Fast path if both code points are latin1
+            if (c2 <= 0XFF) {
+                return false;
+            }
+            // Fast path for unicode codepoint which cannot fold with latin1
             if (c2 > 0XFF && !CharacterData.foldsToLatin1(c2)) {
                 return false;
             }
+
+            // Slow path for unicode code points folding into latin1
             char u1 = (char) CharacterDataLatin1.instance.toUpperCase(c1);
             char u2 = Character.toUpperCase(c2);
             if (u1 == u2) {

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -454,13 +454,17 @@ final class StringLatin1 {
     }
 
     /**
-     * Latin1 includeds two 'i' code points, the uppercase 0x49 'capital I without dot',
-     * and the lowercase 0x69 'lowercase i with dot'.
+     * Latin1 includes two 'i' code points:
      *
-     * Unicode has two additional 'i' code points: 0x130 (LATIN CAPITAL LETTER I WITH DOT ABOVE)
-     * and 0x131 (LATIN SMALL LETTER DOTLESS I).
+     * 0x49: 'Latin Capital Letter I'
+     * 0x69: 'Latin Small Letter I'
      *
-     * These four code points should be considered equals ignoring case.
+     * Unicode adds two 'i' code points for Turkic languages:
+     *
+     * 0x130: 'Latin Capital Letter I with Dot Above'
+     * 0x131: 'Latin Small Letter Dotless I'
+     *
+     * These four code points should be considered equals when ignoring case.
      *
      * @param lat a latin1 code point
      * @param uc a unicode code point

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -403,7 +403,18 @@ final class StringLatin1 {
         while (toffset < last) {
             char c1 = (char)(value[toffset++] & 0xff);
             char c2 = StringUTF16.getChar(other, ooffset++);
-            if (c1 == c2 || StringUTF16.latin1EqualsIgnoreCase(c1, c2) || turkicIEqualsIgnoreCase(c1, c2)) {
+            if (c1 == c2 || StringUTF16.latin1EqualsIgnoreCase(c1, c2)) {
+                continue;
+            }
+            if (c2 > 0XFF && !CharacterData.foldsToLatin1(c2)) {
+                return false;
+            }
+            char u1 = (char) CharacterDataLatin1.instance.toUpperCase(c1);
+            char u2 = Character.toUpperCase(c2);
+            if (u1 == u2) {
+                continue;
+            }
+            if (Character.toLowerCase(u1) == Character.toLowerCase(u2)) {
                 continue;
             }
             return false;
@@ -451,29 +462,6 @@ final class StringLatin1 {
                 || (A >= 0xC0 && A <= 0xDE)) // ..or Agrave-Thorn
                 && A != 0xD7 // But not multiply
                 && A == (b & 0xDF); // b has same uppercase
-    }
-
-    /**
-     * Latin1 includes two 'i' code points:
-     *
-     * 0x49: 'Latin Capital Letter I'
-     * 0x69: 'Latin Small Letter I'
-     *
-     * Unicode adds two 'i' code points for Turkic languages:
-     *
-     * 0x130: 'Latin Capital Letter I with Dot Above'
-     * 0x131: 'Latin Small Letter Dotless I'
-     *
-     * These four code points should be considered equals when ignoring case.
-     *
-     * @param lat a latin1 code point
-     * @param uc a unicode code point
-     * @return true if the latin code point is either 'i' or 'I'
-     * and the unicode code point is either 0x130 or 0x131
-      */
-    private static boolean turkicIEqualsIgnoreCase(char lat, char uc) {
-        return (uc == 0x130 || uc == 0x131)  // Turkic  'I' with dot, 'i' without dot
-                && (lat == 'i' || lat == 'I');
     }
 
     public static String toLowerCase(String str, byte[] value, Locale locale) {

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -415,7 +415,7 @@ final class StringLatin1 {
             if (c2 <= 0XFF) {
                 return false;
             }
-            // Fast path for unicode codepoint which cannot fold with latin1
+            // Fast path for unicode codepoints which cannot fold info latin1
             if (c2 > 0XFF && !CharacterData.foldsToLatin1(c2)) {
                 return false;
             }

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -416,13 +416,13 @@ final class StringLatin1 {
      * following three code point range pairs:
      *
      * 0x41-0x5A: Uppercase ASCII letters (A-Z)
-     * 0x61-0x71: Lowercase ASCII letters (a-z)
+     * 0x61-0x7A: Lowercase ASCII letters (a-z)
      *
      * 0xC0-0xD6: Uppercase non-ASCII letters, range 1 (A-GRAVE - O with Diaeresis)
      * 0xE0-0xF6: Lowercase non-ASCII letters, range 1 (a-grave - o with Diaeresis)
      *
      * 0xD8-0xDE: Uppercase non-ASCII letters, range 2 (O with slash - Thorn)
-     * 0xF0-0xFE: Lowercase non-ASCII letters, range 2 (o with slash - thorn)
+     * 0xF8-0xFE: Lowercase non-ASCII letters, range 2 (o with slash - thorn)
      *
      * While both ASCII letter ranges are contiguous, the non-ASCII letters are not:
      *

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -370,18 +370,6 @@ final class StringUTF16 {
             return cp1 - cp2;
         }
 
-        // Fast path if one of cp1, cp2 is latin1 and the other
-        // does not case-fold into latin1
-        if (lat1) {
-            if (!CharacterData.foldsToLatin1((char) cp2)) {
-                return cp1 - cp2;
-            }
-        } else if (lat2) {
-            if (!CharacterData.foldsToLatin1((char) cp1)) {
-                return cp1 - cp2;
-            }
-        }
-
         // Slow path:
         // Try converting both characters to uppercase.
         // If the results match, then the comparison scan should

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -358,19 +358,18 @@ final class StringUTF16 {
 
     // Case insensitive comparison of two code points
     private static int compareCodePointCI(int cp1, int cp2) {
-        // Fast path if cp1 and cp2 are case-folding latin1 letters
-        if (cp1 > 0XFF && cp2 >= 0XFF && latin1EqualsIgnoreCase(cp1, cp2)) {
-            return 0;
-        }
-
-        // Fast path if both cp1 and cp2 are latin1
-        boolean lat1 = cp1 <= 0XFF;
-        boolean lat2 = cp2 <= 0XFF;
-        if (lat1 && lat2) {
+        boolean cp1Lat = cp1 <= 0XFF; // Is cp1 latin1?
+        boolean cp2Lat = cp2 <= 0XFF; // Is cp2 latin1?
+        if (cp1Lat && cp2Lat) {
+            // Check case folding
+            if (latin1EqualsIgnoreCase(cp1, cp2)) {
+                return 0;
+            }
+            // Comparing '1' vs '2', 'A' vs 'B' etc
             return cp1 - cp2;
         }
+        // Slow path when both code points are non-latin1
 
-        // Slow path:
         // Try converting both characters to uppercase.
         // If the results match, then the comparison scan should
         // continue.
@@ -398,7 +397,7 @@ final class StringUTF16 {
      * @return true if the two code points are considered equals ignoring case in ISO/IEC 8859-1.
      */
     static boolean latin1EqualsIgnoreCase(int cp1, int cp2) {
-        // Callers should verify this
+        // Callers should verify that both code points are <= 0XFF
         assert cp1 <= 0XFF;
         assert cp2 <= 0XFF;
 

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -33,8 +33,6 @@ import java.util.function.IntConsumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import jdk.internal.util.ArraysSupport;
-import jdk.internal.vm.annotation.DontInline;
-import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 
 import static java.lang.String.UTF16;
@@ -360,6 +358,9 @@ final class StringUTF16 {
 
     // Case insensitive comparison of two code points
     private static int compareCodePointCI(int cp1, int cp2) {
+        if (latin1EqualsIgnoreCase(cp1, cp2)) {
+            return 0;
+        }
         // try converting both characters to uppercase.
         // If the results match, then the comparison scan should
         // continue.
@@ -377,6 +378,24 @@ final class StringUTF16 {
             }
         }
         return 0;
+    }
+    /**
+     *  Version of {@link StringLatin1#isLatinEqualIC(byte, byte)} for comparing
+     *  unicode code points. See the StringLatin1 version for a more extensive explanation.
+     *
+     * @param cp1 a unicode code point
+     * @param cp2 another unicode code point
+     * @return true if the two code points are considered equals ignoring case in ISO/IEC 8859-1.
+     */
+    static boolean latin1EqualsIgnoreCase(int cp1, int cp2) {
+        if (cp1 > 0xDE || cp2 > 0xDE) {
+            return false; // Quicly reject high points
+        }
+        int A = cp1 & 0xDF; // Oldest ASCII trick in the book
+        return ( (A >= 'A' && A <= 'Z') // In range A-Z
+                || (A >= 0xC0)) // ..or Agrave-Thorn
+                && A != 0xD7 // But not multiply
+                && A == (cp2 & 0xDF); // b has same uppercase
     }
 
     // Returns a code point from the code unit pointed by "index". If it is

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -364,16 +364,15 @@ final class StringUTF16 {
         // try converting both characters to uppercase.
         // If the results match, then the comparison scan should
         // continue.
-
-        cp1 = CharacterData.ofUnicode(cp1).toUpperCase(cp1);
-        cp2 = CharacterData.ofUnicode(cp2).toUpperCase(cp2);
+        cp1 = Character.toUpperCase(cp1);
+        cp2 = Character.toUpperCase(cp2);
         if (cp1 != cp2) {
             // Unfortunately, conversion to uppercase does not work properly
             // for the Georgian alphabet, which has strange rules about case
             // conversion.  So we need to make one last check before
             // exiting.
-            cp1 = CharacterData.ofUnicode(cp1).toLowerCase(cp1);
-            cp2 = CharacterData.ofUnicode(cp2).toLowerCase(cp2);
+            cp1 = Character.toLowerCase(cp1);
+            cp2 = Character.toLowerCase(cp2);
             if (cp1 != cp2) {
                 return cp1 - cp2;
             }

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -359,7 +359,7 @@ final class StringUTF16 {
     // Case insensitive comparison of two code points
     private static int compareCodePointCI(int cp1, int cp2) {
         // Fast path if cp1 and cp2 are case-folding latin1 letters
-        if (latin1EqualsIgnoreCase(cp1, cp2)) {
+        if (cp1 > 0XFF && cp2 >= 0XFF && latin1EqualsIgnoreCase(cp1, cp2)) {
             return 0;
         }
 
@@ -391,16 +391,17 @@ final class StringUTF16 {
     }
     /**
      *  Version of {@link StringLatin1#isLatinEqualIC(byte, byte)} for comparing
-     *  unicode code points. See the StringLatin1 version for a more extensive explanation.
+     *  int code points. See the StringLatin1 version for a more extensive explanation.
      *
-     * @param cp1 a unicode code point
-     * @param cp2 another unicode code point
+     * @param cp1 a latin1 code point
+     * @param cp2 another latin1 code point
      * @return true if the two code points are considered equals ignoring case in ISO/IEC 8859-1.
      */
     static boolean latin1EqualsIgnoreCase(int cp1, int cp2) {
-        if (cp1 > 0xFF || cp2 > 0xFF) {
-            return false; // Quickly reject high points
-        }
+        // Callers should verify this
+        assert cp1 <= 0XFF;
+        assert cp2 <= 0XFF;
+
         int A = cp1 & 0xDF; // Oldest ASCII trick in the book
         return ( (A >= 'A' && A <= 'Z') // In range A-Z
                 || (A >= 0xC0 && A <= 0xDE)) // ..or Agrave-Thorn

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -364,15 +364,16 @@ final class StringUTF16 {
         // try converting both characters to uppercase.
         // If the results match, then the comparison scan should
         // continue.
-        cp1 = Character.toUpperCase(cp1);
-        cp2 = Character.toUpperCase(cp2);
+
+        cp1 = CharacterData.ofUnicode(cp1).toUpperCase(cp1);
+        cp2 = CharacterData.ofUnicode(cp2).toUpperCase(cp2);
         if (cp1 != cp2) {
             // Unfortunately, conversion to uppercase does not work properly
             // for the Georgian alphabet, which has strange rules about case
             // conversion.  So we need to make one last check before
             // exiting.
-            cp1 = Character.toLowerCase(cp1);
-            cp2 = Character.toLowerCase(cp2);
+            cp1 = CharacterData.ofUnicode(cp1).toLowerCase(cp1);
+            cp2 = CharacterData.ofUnicode(cp2).toLowerCase(cp2);
             if (cp1 != cp2) {
                 return cp1 - cp2;
             }

--- a/test/jdk/java/lang/String/CompactString/EqualsIgnoreCase.java
+++ b/test/jdk/java/lang/String/CompactString/EqualsIgnoreCase.java
@@ -25,6 +25,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static p1.Test.assertFalse;
+import static p1.Test.assertTrue;
 
 /*
  * @test
@@ -94,13 +96,9 @@ public class EqualsIgnoreCase extends CompactString {
                     if (Character.toUpperCase(ac) == Character.toUpperCase(bc)
                             || Character.toLowerCase(ac) == Character.toLowerCase(bc)) {
 
-                        if (!as.equalsIgnoreCase(bs)) {
-                            throw new RuntimeException(ac + " != " + bc);
-                        }
+                        assertTrue(as.equalsIgnoreCase(bs));
                     } else {
-                        if (as.equalsIgnoreCase(bs)) {
-                            throw new RuntimeException(ac + " != " + bc);
-                        }
+                        assertFalse(as.equalsIgnoreCase(bs));
                     }
                 }
             }

--- a/test/jdk/java/lang/String/CompactString/EqualsIgnoreCase.java
+++ b/test/jdk/java/lang/String/CompactString/EqualsIgnoreCase.java
@@ -24,9 +24,7 @@
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
-import static p1.Test.assertFalse;
-import static p1.Test.assertTrue;
+import static org.testng.Assert.*;
 
 /*
  * @test
@@ -84,18 +82,16 @@ public class EqualsIgnoreCase extends CompactString {
      */
     @Test
     public void checkConsistencyWithCharacterUppercaseLowerCase() {
-        for (int a = 0; a < 256; a++) {
-            for (int b = 0; b < 256; b++) {
-                if (a != b) {
-                    char ac = (char) a, bc = (char) b;
-                    byte ab = (byte) a, bb = (byte) b;
+        for (int ab = 0; ab < 256; ab++) {
+            for (int bb = 0; bb < 256; bb++) {
+                if (ab != bb) {
+                    char a = (char) ab, b = (char) bb;
 
-                    String as = Character.toString(ac);
-                    String bs = Character.toString(bc);
+                    String as = Character.toString(a);
+                    String bs = Character.toString(b);
 
-                    if (Character.toUpperCase(ac) == Character.toUpperCase(bc)
-                            || Character.toLowerCase(ac) == Character.toLowerCase(bc)) {
-
+                    if (Character.toUpperCase(a) == Character.toUpperCase(b)
+                            || Character.toLowerCase(a) == Character.toLowerCase(b)) {
                         assertTrue(as.equalsIgnoreCase(bs));
                     } else {
                         assertFalse(as.equalsIgnoreCase(bs));

--- a/test/jdk/java/lang/String/CompactString/EqualsIgnoreCase.java
+++ b/test/jdk/java/lang/String/CompactString/EqualsIgnoreCase.java
@@ -75,4 +75,35 @@ public class EqualsIgnoreCase extends CompactString {
                                             source));
                         });
     }
+
+    /**
+     * Exhaustively check that all lat1 code point pairs are equalsIgnoreCased
+     * in a manner consistent with Character.toUpperCase, Character.toLowerCase
+     */
+    @Test
+    public void checkConsistencyWithCharacterUppercaseLowerCase() {
+        for (int a = 0; a < 256; a++) {
+            for (int b = 0; b < 256; b++) {
+                if (a != b) {
+                    char ac = (char) a, bc = (char) b;
+                    byte ab = (byte) a, bb = (byte) b;
+
+                    String as = Character.toString(ac);
+                    String bs = Character.toString(bc);
+
+                    if (Character.toUpperCase(ac) == Character.toUpperCase(bc)
+                            || Character.toLowerCase(ac) == Character.toLowerCase(bc)) {
+
+                        if (!as.equalsIgnoreCase(bs)) {
+                            throw new RuntimeException(ac + " != " + bc);
+                        }
+                    } else {
+                        if (as.equalsIgnoreCase(bs)) {
+                            throw new RuntimeException(ac + " != " + bc);
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/test/jdk/java/lang/String/CompactString/EqualsIgnoreCase.java
+++ b/test/jdk/java/lang/String/CompactString/EqualsIgnoreCase.java
@@ -92,11 +92,35 @@ public class EqualsIgnoreCase extends CompactString {
 
                     if (Character.toUpperCase(a) == Character.toUpperCase(b)
                             || Character.toLowerCase(a) == Character.toLowerCase(b)) {
-                        assertTrue(as.equalsIgnoreCase(bs));
+                        assertTrue(as.equalsIgnoreCase(bs),
+                                "Expected %s to equalsIgnoreCase %s".formatted(as, bs));
                     } else {
-                        assertFalse(as.equalsIgnoreCase(bs));
+                        assertFalse(as.equalsIgnoreCase(bs),
+                                "Expected %s to not equalsIgnoreCase %s".formatted(as, bs));
                     }
                 }
+            }
+        }
+    }
+    /**
+     * This guards that CharacterData.foldsToLatins1 is in sync with
+     * Character.toUpperCase and Character.toLowerCase
+     */
+    @Test
+    public void guardUnicodeFoldingToLatin1() {
+        for (char c = 256; c < Character.MAX_VALUE; c++) {
+
+            char lc = Character.toLowerCase(c);
+            if (lc <= 0XFF) {
+                System.out.println(c + " " + Integer.toHexString(c) + " lowercases to " + lc);
+                assertTrue(Character.toString(lc).equalsIgnoreCase(Character.toString(c)),
+                        "%s and its lowercase %s should equalsIgnoreCase".formatted(c, lc));
+            }
+            char uc = Character.toUpperCase(c);
+            if (uc <= 0XFF) {
+                System.out.println(c + " " + Integer.toHexString(c) + " uppercases to " + uc);
+                assertTrue(Character.toString(uc).equalsIgnoreCase(Character.toString(c)),
+                        "%s and its uppercase %s should equalsIgnoreCase".formatted(c, uc));
             }
         }
     }

--- a/test/jdk/java/lang/String/CompactString/RegionMatches.java
+++ b/test/jdk/java/lang/String/CompactString/RegionMatches.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,9 +96,11 @@ public class RegionMatches extends CompactString {
                 // Turkish I with dot
                 new Object[] { "\u0130", false, 0, "i", 0, 1, false },
                 new Object[] { "\u0130", true,  0, "i", 0, 1, true },
+                new Object[] { "\u0130", true,  0, "I", 0, 1, true },
                 // i without dot
                 new Object[] { "\u0131", false, 0, "i", 0, 1, false },
                 new Object[] { "\u0131", true,  0, "i", 0, 1, true },
+                new Object[] { "\u0131", true,  0, "I", 0, 1, true },
                 // Exhaustive list of 1-char latin1 strings that match
                 // case-insensitively:
                 // for (char c1 = 0; c1 < 255; c1++) {

--- a/test/micro/org/openjdk/bench/java/lang/StringComparisonsIC.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringComparisonsIC.java
@@ -51,7 +51,7 @@ public class StringComparisonsIC {
     public static final String UTF_LETTER_MATCH = "utf16-letter-match";
     public static final String UTF_LETTER_MISMATCH = "utf16-letter-mismatch";
     public static final String UTF_NUMBER_MATCH = "utf16-number-match";
-    public static final String UTF_NUMBER_MISMATCH = "utf16-number-minmatch";
+    public static final String UTF_NUMBER_MISMATCH = "utf16-number-mismatch";
     public static final String UTF_UTF_MATCH = "utf16-unicode-match";
     public static final String UTF_UTF_MISMATCH = "utf16-unicode-mismatch";
 
@@ -77,7 +77,7 @@ public class StringComparisonsIC {
             UTF_UTF_MISMATCH
     })
 
-    public String code_content_match;
+    public String coding;
 
     private String leftString;
     private String rightString;
@@ -94,7 +94,7 @@ public class StringComparisonsIC {
         String otherNum =  "2";
 
 
-        switch (code_content_match) {
+        switch (coding) {
             case LAT_LETTER_MATCH -> {
                 leftString = let  + let.repeat(size);
                 rightString = leftString;
@@ -160,7 +160,7 @@ public class StringComparisonsIC {
                 leftString = ue  + ue.repeat(size);
                 rightString = ue + "\u0130".repeat(size);
             }
-            default -> throw new IllegalArgumentException("Unconfigured coder: " + code_content_match);
+            default -> throw new IllegalArgumentException("Unconfigured coder: " + coding);
         }
         rightString = rightString.toUpperCase(Locale.ENGLISH);
     }

--- a/test/micro/org/openjdk/bench/java/lang/StringComparisonsIC.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringComparisonsIC.java
@@ -43,42 +43,47 @@ public class StringComparisonsIC {
 
     @Param({"mixed", "lat", "utf16"})
     public String coders;
-    @Param({"true","false"})
-    public boolean Az;
+    @Param({"az","lat", "utf"})
+    public String letter;
 
     private String leftString;
     private String rightString;
-    private int offset;
 
     @Setup
     public void setup() {
-        String ue = "\u025b";
+
+        String l;
+        switch (letter) {
+            case "az" -> letter = "e";
+            case "lat" -> letter = "1";
+            case "utf" -> letter = "\u025b";
+        }
+
         String e = "e";
+        String ue = "\u025b";
 
 
         switch (coders) {
             case "utf16" -> {
-                leftString = ue + e.repeat(size) + ue.repeat(size);
+                leftString = ue + letter.repeat(size);
                 rightString = leftString;
             }
             case "mixed" -> {
-                leftString = ue + e.repeat(size) + ue.repeat(size);
-                rightString = e + e.repeat(size) + "1".repeat(size);
+                leftString = ue + letter.repeat(size);
+                rightString = e + letter.repeat(size);
             }
             case "lat" -> {
-                leftString = e + e.repeat(size) + "1".repeat(size);
+                leftString = e + letter.repeat(size);
                 rightString = leftString;
             }
         }
         rightString = rightString.toUpperCase(Locale.ENGLISH);
-
-        offset = 1 + (Az ? 0 : size);
     }
 
 
     @Benchmark
     public boolean regionMatchesIC() {
-        return leftString.regionMatches(true,offset, rightString, offset, size);
+        return leftString.regionMatches(true, 1, rightString, 1, size);
     }
 
 

--- a/test/micro/org/openjdk/bench/java/lang/StringComparisonsIC.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringComparisonsIC.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+/*
+ * This benchmark naively explores String::regionMatches, ignoring case
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 3)
+public class StringComparisonsIC {
+
+    @Param({"6", "15", "1024"})
+    public int size;
+
+    @Param({"mixed", "lat", "utf16"})
+    public String coders;
+    @Param({"true","false"})
+    public boolean Az;
+
+    private String leftString;
+    private String rightString;
+    private int offset;
+
+    @Setup
+    public void setup() {
+        String ue = "\u025b";
+        String e = "e";
+
+
+        switch (coders) {
+            case "utf16" -> {
+                leftString = ue + e.repeat(size) + ue.repeat(size);
+                rightString = leftString;
+            }
+            case "mixed" -> {
+                leftString = ue + e.repeat(size) + ue.repeat(size);
+                rightString = e + e.repeat(size) + "1".repeat(size);
+            }
+            case "lat" -> {
+                leftString = e + e.repeat(size) + "1".repeat(size);
+                rightString = leftString;
+            }
+        }
+        rightString = rightString.toUpperCase(Locale.ENGLISH);
+
+        offset = 1 + (Az ? 0 : size);
+    }
+
+
+    @Benchmark
+    public boolean regionMatchesIC() {
+        return leftString.regionMatches(true,offset, rightString, offset, size);
+    }
+
+
+
+}

--- a/test/micro/org/openjdk/bench/java/lang/StringComparisonsIC.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringComparisonsIC.java
@@ -38,28 +38,46 @@ import java.util.concurrent.TimeUnit;
 @Fork(value = 3)
 public class StringComparisonsIC {
 
-    public static final String LAT_AZ = "lat-az";
-    public static final String LAT_LAT = "lat-lat";
-    public static final String MIXED_AZ = "mixed-az";
-    public static final String MIXED_LAT = "mixed-lat";
-    public static final String MIXED_UTF = "mixed-utf";
-    public static final String UTF_AZ = "utf-az";
-    public static final String UTF_LAT = "utf-lat";
-    public static final String UTF_UTF = "utf-utf";
+    public static final String LAT_LETTER_MATCH = "lat1-letter-match";
+    public static final String LAT_LETTER_MISMATCH = "lat1-letter-mismatch";
+    public static final String LAT_NUMBER_MATCH = "lat1-number-match";
+    public static final String LAT_NUMBER_MISMATCH = "lat1-number-mismatch";
+    public static final String MIXED_LETTER_MATCH = "mixed-letter-match";
+    public static final String MIXED_LETTER_MISMATCH = "mixed-letter-mismatch";
+    public static final String MIXED_NUMBER_MATCH = "mixed-number-match";
+    public static final String MIXED_NUMBER_MISMATCH = "mixed-number-mismatch";
+    public static final String MIXED_UTF_MATCH = "mixed-unicode-match";
+    public static final String MIXED_UTF_MISMATCH = "mixed-unicode-mismatch";
+    public static final String UTF_LETTER_MATCH = "utf16-letter-match";
+    public static final String UTF_LETTER_MISMATCH = "utf16-letter-mismatch";
+    public static final String UTF_NUMBER_MATCH = "utf16-number-match";
+    public static final String UTF_NUMBER_MISMATCH = "utf16-number-minmatch";
+    public static final String UTF_UTF_MATCH = "utf16-unicode-match";
+    public static final String UTF_UTF_MISMATCH = "utf16-unicode-mismatch";
 
-    @Param({"6", "15", "1024"})
+    @Param({"1024"})
     public int size;
 
-    @Param({LAT_AZ,
-            LAT_LAT,
-            MIXED_AZ,
-            MIXED_LAT,
-            MIXED_UTF,
-            UTF_AZ,
-            UTF_LAT,
-            UTF_UTF
+    @Param({
+            LAT_LETTER_MATCH,
+            LAT_LETTER_MISMATCH,
+            LAT_NUMBER_MATCH,
+            LAT_NUMBER_MISMATCH,
+            MIXED_LETTER_MATCH,
+            MIXED_LETTER_MISMATCH,
+            MIXED_NUMBER_MATCH,
+            MIXED_NUMBER_MISMATCH,
+            MIXED_UTF_MATCH,
+            MIXED_UTF_MISMATCH,
+            UTF_LETTER_MATCH,
+            UTF_LETTER_MISMATCH,
+            UTF_NUMBER_MATCH,
+            UTF_NUMBER_MISMATCH,
+            UTF_UTF_MATCH,
+            UTF_UTF_MISMATCH
     })
-    public String coders;
+
+    public String code_content_match;
 
     private String leftString;
     private String rightString;
@@ -68,44 +86,81 @@ public class StringComparisonsIC {
     public void setup() {
 
 
-        String az = "e";
+
+        String let = "e";
+        String otherLet = "f";
         String ue = "\u025b";
-        String lat =  "1";
+        String num =  "1";
+        String otherNum =  "2";
 
 
-        switch (coders) {
-            case LAT_AZ -> {
-                leftString = az + az.repeat(size);
+        switch (code_content_match) {
+            case LAT_LETTER_MATCH -> {
+                leftString = let  + let.repeat(size);
                 rightString = leftString;
             }
-            case LAT_LAT -> {
-                leftString = az + lat.repeat(size);
+
+            case LAT_LETTER_MISMATCH -> {
+                leftString = let  + let.repeat(size);
+                rightString = let + otherLet.repeat(size);
+            }
+            case LAT_NUMBER_MATCH -> {
+                leftString = let  + num.repeat(size);
                 rightString = leftString;
             }
-            case MIXED_AZ -> {
-                leftString = az + az.repeat(size);
-                rightString = ue + az.repeat(size);
+            case LAT_NUMBER_MISMATCH -> {
+                leftString = let  + num.repeat(size);
+                rightString = let + otherNum.repeat(size);
             }
-            case MIXED_LAT -> {
-                leftString = az + lat.repeat(size);
-                rightString = ue + lat.repeat(size);
+            case MIXED_LETTER_MATCH -> {
+                leftString = let  + let.repeat(size);
+                rightString = ue + let.repeat(size);
             }
-            case MIXED_UTF -> {
-                leftString = az + az.repeat(size);
+            case MIXED_LETTER_MISMATCH -> {
+                leftString = let  + let.repeat(size);
+                rightString = ue + otherLet.repeat(size);
+            }
+            case MIXED_NUMBER_MATCH -> {
+                leftString = let  + num.repeat(size);
+                rightString = ue + num.repeat(size);
+            }
+            case MIXED_NUMBER_MISMATCH -> {
+                leftString = let  + num.repeat(size);
+                rightString = ue + otherNum.repeat(size);
+            }
+            case MIXED_UTF_MATCH -> {
+                leftString = let  + "i".repeat(size);
+                rightString = ue + "\u0130".repeat(size);
+            }
+            case MIXED_UTF_MISMATCH -> {
+                leftString = let  + let.repeat(size);
+                rightString = ue + "\u0130".repeat(size);
+            }
+            case UTF_LETTER_MATCH -> {
+                leftString = ue  + let.repeat(size);
+                rightString = ue + let.repeat(size);
+            }
+            case UTF_LETTER_MISMATCH -> {
+                leftString = ue  + let.repeat(size);
+                rightString = ue + otherLet.repeat(size);
+            }
+            case UTF_NUMBER_MATCH -> {
+                leftString = ue  + num.repeat(size);
+                rightString = ue + num.repeat(size);
+            }
+            case UTF_NUMBER_MISMATCH -> {
+                leftString = ue  + num.repeat(size);
+                rightString = ue + otherNum.repeat(size);
+            }
+            case UTF_UTF_MATCH -> {
+                leftString = ue  + ue.repeat(size);
                 rightString = ue + ue.repeat(size);
             }
-            case UTF_AZ -> {
-                leftString = ue + az.repeat(size);
-                rightString = leftString;
+            case UTF_UTF_MISMATCH -> {
+                leftString = ue  + ue.repeat(size);
+                rightString = ue + "\u0130".repeat(size);
             }
-            case UTF_LAT -> {
-                leftString = ue + lat.repeat(size);
-                rightString = leftString;
-            }
-            case UTF_UTF -> {
-                leftString = ue + ue.repeat(size);
-                rightString = leftString;
-            }
+            default -> throw new IllegalArgumentException("Unconfigured coder: " + code_content_match);
         }
         rightString = rightString.toUpperCase(Locale.ENGLISH);
     }

--- a/test/micro/org/openjdk/bench/java/lang/StringComparisonsIC.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringComparisonsIC.java
@@ -154,7 +154,7 @@ public class StringComparisonsIC {
             }
             case UTF_UTF_MATCH -> {
                 leftString = ue  + ue.repeat(size);
-                rightString = ue + ue.repeat(size);
+                rightString = leftString;
             }
             case UTF_UTF_MISMATCH -> {
                 leftString = ue  + ue.repeat(size);

--- a/test/micro/org/openjdk/bench/java/lang/StringComparisonsIC.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringComparisonsIC.java
@@ -55,6 +55,9 @@ public class StringComparisonsIC {
     public static final String UTF_UTF_MATCH = "utf16-unicode-match";
     public static final String UTF_UTF_MISMATCH = "utf16-unicode-mismatch";
 
+    public static final String UTF_MIXED_MATCH = "utf16-mixed-match";
+    public static final String UTF_MIXED_MISMATCH = "utf16-mixed-mismatch";
+
     @Param({"1024"})
     public int size;
 
@@ -74,7 +77,9 @@ public class StringComparisonsIC {
             UTF_NUMBER_MATCH,
             UTF_NUMBER_MISMATCH,
             UTF_UTF_MATCH,
-            UTF_UTF_MISMATCH
+            UTF_UTF_MISMATCH,
+            UTF_MIXED_MATCH,
+            UTF_MIXED_MISMATCH
     })
 
     public String coding;
@@ -159,6 +164,14 @@ public class StringComparisonsIC {
             case UTF_UTF_MISMATCH -> {
                 leftString = ue  + ue.repeat(size);
                 rightString = ue + "\u0130".repeat(size);
+            }
+            case UTF_MIXED_MATCH -> {
+                leftString = ue  + "i".repeat(size);
+                rightString = ue + "\u0130".repeat(size);
+            }
+            case UTF_MIXED_MISMATCH -> {
+                leftString = ue  + "i".repeat(size);
+                rightString = ue + ue.repeat(size);
             }
             default -> throw new IllegalArgumentException("Unconfigured coder: " + coding);
         }

--- a/test/micro/org/openjdk/bench/java/lang/StringComparisonsIC.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringComparisonsIC.java
@@ -38,13 +38,28 @@ import java.util.concurrent.TimeUnit;
 @Fork(value = 3)
 public class StringComparisonsIC {
 
+    public static final String LAT_AZ = "lat-az";
+    public static final String LAT_LAT = "lat-lat";
+    public static final String MIXED_AZ = "mixed-az";
+    public static final String MIXED_LAT = "mixed-lat";
+    public static final String MIXED_UTF = "mixed-utf";
+    public static final String UTF_AZ = "utf-az";
+    public static final String UTF_LAT = "utf-lat";
+    public static final String UTF_UTF = "utf-utf";
+
     @Param({"6", "15", "1024"})
     public int size;
 
-    @Param({"mixed", "lat", "utf16"})
+    @Param({LAT_AZ,
+            LAT_LAT,
+            MIXED_AZ,
+            MIXED_LAT,
+            MIXED_UTF,
+            UTF_AZ,
+            UTF_LAT,
+            UTF_UTF
+    })
     public String coders;
-    @Param({"az","lat", "utf"})
-    public String letter;
 
     private String leftString;
     private String rightString;
@@ -52,28 +67,43 @@ public class StringComparisonsIC {
     @Setup
     public void setup() {
 
-        String l;
-        switch (letter) {
-            case "az" -> letter = "e";
-            case "lat" -> letter = "1";
-            case "utf" -> letter = "\u025b";
-        }
 
-        String e = "e";
+        String az = "e";
         String ue = "\u025b";
+        String lat =  "1";
 
 
         switch (coders) {
-            case "utf16" -> {
-                leftString = ue + letter.repeat(size);
+            case LAT_AZ -> {
+                leftString = az + az.repeat(size);
                 rightString = leftString;
             }
-            case "mixed" -> {
-                leftString = ue + letter.repeat(size);
-                rightString = e + letter.repeat(size);
+            case LAT_LAT -> {
+                leftString = az + lat.repeat(size);
+                rightString = leftString;
             }
-            case "lat" -> {
-                leftString = e + letter.repeat(size);
+            case MIXED_AZ -> {
+                leftString = az + az.repeat(size);
+                rightString = ue + az.repeat(size);
+            }
+            case MIXED_LAT -> {
+                leftString = az + lat.repeat(size);
+                rightString = ue + lat.repeat(size);
+            }
+            case MIXED_UTF -> {
+                leftString = az + az.repeat(size);
+                rightString = ue + ue.repeat(size);
+            }
+            case UTF_AZ -> {
+                leftString = ue + az.repeat(size);
+                rightString = leftString;
+            }
+            case UTF_LAT -> {
+                leftString = ue + lat.repeat(size);
+                rightString = leftString;
+            }
+            case UTF_UTF -> {
+                leftString = ue + ue.repeat(size);
                 rightString = leftString;
             }
         }


### PR DESCRIPTION
This PR has been split into smaller, incremental PRs:

- #12623 which speeds up case conversions in Character.toUpperCase and Character.toLowerCase 
- #12632 which speeds up case-insensitive comparison of two latin1-coded strings
- #12637  which speeds up case-insensitive comparison a latin1-coded string with a utf16-coded string 
- A PR for utf16/utf16 comparisons is pending

Original description of this now-obsolete PR follows:

We can speed up case-insensitive string comparison as follows:

- In Latin1, case-folding lowercase code points are always found 0x20 higher than their uppercase counterpart. We can apply 'the oldest ASCII trick in the book" here, also for  the latin1 letters which are non-ASCII.
- When comparing strings with mixed coders (lat1/utf16), we know that the left side is always lat1. Unicode only has two code points case-folding into lat1 territory, 0x130 and 0x131. Special-casing the handing of these two code points  avoids calling Character.toUppercase and Character.toLowerCase.
- We can shortcut utf16/utf16 comparisons if both code points are lat1 and apply the oldest trick in the book here as well.

Benchmark results show significant speedups:

https://jmh.morethan.io/?gists=f95413117e003b37c367dbb9ee4ddd39,2be4f6e4f425ef723d95757b5b35d5ca

Testing for correctness:

- EqualsIgnoreCase is augmented to exhaustively verify that all lat1 code point pairs are equalsIgnoreCased in a manner consistent with Character.toUpperCase, Character.toLowerCase.
- RegionMatches is extended to add coverage for Turkic case-insensitive comparison when comparing 'I with dot' and 'i without dot' against the ASCII uppercase 'I'. The test currently compares against lowercase ASCII 'i' only, this is insufficient.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12586/head:pull/12586` \
`$ git checkout pull/12586`

Update a local copy of the PR: \
`$ git checkout pull/12586` \
`$ git pull https://git.openjdk.org/jdk pull/12586/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12586`

View PR using the GUI difftool: \
`$ git pr show -t 12586`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12586.diff">https://git.openjdk.org/jdk/pull/12586.diff</a>

</details>
