### PR TITLE
8302623: jarsigner - use BufferedOutputStream to improve performance while creating the signed jar

### DIFF
--- a/src/jdk.jartool/share/classes/jdk/security/jarsigner/JarSigner.java
+++ b/src/jdk.jartool/share/classes/jdk/security/jarsigner/JarSigner.java
@@ -688,7 +688,8 @@ public final class JarSigner {
             throw new AssertionError(asae);
         }
 
-        ZipOutputStream zos = new ZipOutputStream(os);
+        ZipOutputStream zos = new ZipOutputStream(
+                (os instanceof BufferedOutputStream) ? os : new BufferedOutputStream(os));
 
         Manifest manifest = new Manifest();
         byte[] mfRawBytes = null;

--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
@@ -1965,9 +1965,9 @@ public class Main {
         builder.setProperty("sectionsOnly", Boolean.toString(!signManifest));
         builder.setProperty("internalSF", Boolean.toString(!externalSF));
 
-        OutputStream os = null;
+        FileOutputStream fos = null;
         try {
-            os = new BufferedOutputStream(new FileOutputStream(signedJarFile));
+            fos = new FileOutputStream(signedJarFile);
         } catch (IOException ioe) {
             error(rb.getString("unable.to.create.")+tmpJarName, ioe);
         }
@@ -1978,7 +1978,7 @@ public class Main {
         try {
             Event.setReportListener(Event.ReporterCategory.ZIPFILEATTRS,
                     (t, o) -> extraAttrsDetected = true);
-            builder.build().sign(zipFile, os);
+            builder.build().sign(zipFile, fos);
         } catch (JarSignerException e) {
             failedCause = e.getCause();
             if (failedCause instanceof SocketTimeoutException
@@ -2008,8 +2008,8 @@ public class Main {
                 zipFile = null;
             }
 
-            if (os != null) {
-                os.close();
+            if (fos != null) {
+                fos.close();
             }
 
             Event.clearReportListener(Event.ReporterCategory.ZIPFILEATTRS);

--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
@@ -1965,9 +1965,9 @@ public class Main {
         builder.setProperty("sectionsOnly", Boolean.toString(!signManifest));
         builder.setProperty("internalSF", Boolean.toString(!externalSF));
 
-        FileOutputStream fos = null;
+        OutputStream os = null;
         try {
-            fos = new FileOutputStream(signedJarFile);
+            os = new BufferedOutputStream(new FileOutputStream(signedJarFile));
         } catch (IOException ioe) {
             error(rb.getString("unable.to.create.")+tmpJarName, ioe);
         }
@@ -1978,7 +1978,7 @@ public class Main {
         try {
             Event.setReportListener(Event.ReporterCategory.ZIPFILEATTRS,
                     (t, o) -> extraAttrsDetected = true);
-            builder.build().sign(zipFile, fos);
+            builder.build().sign(zipFile, os);
         } catch (JarSignerException e) {
             failedCause = e.getCause();
             if (failedCause instanceof SocketTimeoutException
@@ -2008,8 +2008,8 @@ public class Main {
                 zipFile = null;
             }
 
-            if (fos != null) {
-                fos.close();
+            if (os != null) {
+                os.close();
             }
 
             Event.clearReportListener(Event.ReporterCategory.ZIPFILEATTRS);


### PR DESCRIPTION
Can I please get a review for this change which improves the jarsigner tool's performance (especially) when dealing with large jar files? This addresses https://bugs.openjdk.org/browse/JDK-8302623.

As noted in the JBS issue, wrapping the target `FileOutputStream` with the `BufferedOutputStream` reduces the amount of write calls that happen on the file and has shown to improve the amount of time it takes to sign the jar files.

On a macOS M1, the numbers before and after this change are as follows (`time` command was used to get these numbers):

```console
JDK 19, 3GB file: 144.52s user 19.79s system 98% cpu 2:46.80 total
JDK with this change, (same) 3GB file: 139.27s user 4.86s system 97% cpu 2:27.41 total
```
```console
JDK 19, 6GB file: 289.38s user 38.87s system 99% cpu 5:28.90 total
JDK with this change, (same) 6GB file: 279.69s user 9.93s system 99% cpu 4:49.88 total 
```
No new tests have been added for this change. The current existing tests in `test/jdk/sun/security/tools/jarsigner` continue to pass locally. tier testing is currently in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302623](https://bugs.openjdk.org/browse/JDK-8302623): jarsigner - use BufferedOutputStream to improve performance while creating the signed jar


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12588/head:pull/12588` \
`$ git checkout pull/12588`

Update a local copy of the PR: \
`$ git checkout pull/12588` \
`$ git pull https://git.openjdk.org/jdk pull/12588/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12588`

View PR using the GUI difftool: \
`$ git pr show -t 12588`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12588.diff">https://git.openjdk.org/jdk/pull/12588.diff</a>

</details>
