### PR TITLE
8295979: [IR Framework] Improve IR matching warning

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -74,7 +74,7 @@ public class IREncodingPrinter {
             for (IR irAnno : irAnnos) {
                 ruleIndex = i + 1;
                 try {
-                    if (shouldApplyIrRule(irAnno, m.getName())) {
+                    if (shouldApplyIrRule(irAnno, m.getName(), ruleIndex, irAnnos.length)) {
                         validRules.add(ruleIndex);
                     }
                 } catch (TestFormatException e) {
@@ -96,35 +96,36 @@ public class IREncodingPrinter {
         }
     }
 
-    private void printDisableReason(String method, String reason) {
-        TestFrameworkSocket.write("Disabling IR matching for " + method + ": " + reason + ".",
+    private void printDisableReason(String method, String reason, String[] apply, int ruleIndex, int ruleMax) {
+        TestFrameworkSocket.write("Disabling IR matching for rule " + ruleIndex + " of " + ruleMax + " in " +
+                                  method + ": " + reason + ": " + String.join(", ", apply),
                                   "[IREncodingPrinter]", true);
     }
 
-    private boolean shouldApplyIrRule(IR irAnno, String m) {
+    private boolean shouldApplyIrRule(IR irAnno, String m, int ruleIndex, int ruleMax) {
         checkIRAnnotations(irAnno);
         if (isIRNodeUnsupported(irAnno)) {
             return false;
         } else if (irAnno.applyIf().length != 0 && !hasAllRequiredFlags(irAnno.applyIf(), "applyIf")) {
-            printDisableReason(m, "Flag constraint not met");
+            printDisableReason(m, "Flag constraint not met (applyIf)", irAnno.applyIf(), ruleIndex, ruleMax);
             return false;
         } else if (irAnno.applyIfNot().length != 0 && !hasNoRequiredFlags(irAnno.applyIfNot(), "applyIfNot")) {
-            printDisableReason(m, "Flag constraint not met");
+            printDisableReason(m, "Flag constraint not met (applyIfNot)", irAnno.applyIfNot(), ruleIndex, ruleMax);
             return false;
         } else if (irAnno.applyIfAnd().length != 0 && !hasAllRequiredFlags(irAnno.applyIfAnd(), "applyIfAnd")) {
-            printDisableReason(m, "All flag constraints not met");
+            printDisableReason(m, "Not all flag constraints are met (applyIfAnd)", irAnno.applyIfAnd(), ruleIndex, ruleMax);
             return false;
         } else if (irAnno.applyIfOr().length != 0 && hasNoRequiredFlags(irAnno.applyIfOr(), "applyIfOr")) {
-            printDisableReason(m, "None of the flag constraints met");
+            printDisableReason(m, "None of the flag constraints met (applyIfOr)", irAnno.applyIfOr(), ruleIndex, ruleMax);
             return false;
         } else if (irAnno.applyIfCPUFeature().length != 0 && !hasAllRequiredCPUFeature(irAnno.applyIfCPUFeature())) {
-            printDisableReason(m, "Feature constraint not met");
+            printDisableReason(m, "Feature constraint not met (applyIfCPUFeature)", irAnno.applyIfCPUFeature(), ruleIndex, ruleMax);
             return false;
         } else if (irAnno.applyIfCPUFeatureAnd().length != 0 && !hasAllRequiredCPUFeature(irAnno.applyIfCPUFeatureAnd())) {
-            printDisableReason(m, "All feature constraints not met");
+            printDisableReason(m, "Not all feature constraints are met (applyIfCPUFeatureAnd)", irAnno.applyIfCPUFeatureAnd(), ruleIndex, ruleMax);
             return false;
         } else if (irAnno.applyIfCPUFeatureOr().length != 0 && !hasAnyRequiredCPUFeature(irAnno.applyIfCPUFeatureOr())) {
-            printDisableReason(m, "None of the feature constraints met");
+            printDisableReason(m, "None of the feature constraints met (applyIfCPUFeatureOr)", irAnno.applyIfCPUFeatureOr(), ruleIndex, ruleMax);
             return false;
         } else {
             // All preconditions satisfied: apply rule.


### PR DESCRIPTION
The IR framework already warns that some rule was not applied. But it was not clear which ones were not applied.

I now say which one was not applied (eg `2 of 3`). I improved the wording, it was not always correct. And I also print the constraints, so that one can more quickly understand why it was not applied.

Given the numbers `x of N` one can easily deduce if there are still rules that were applied.

Examples:

```
[IREncodingPrinter] Disabling IR matching for rule 1 of 3 in testReductionAndLong: None of the flag constraints met (applyIfOr): SuperWordReductions, false, LoopMaxUnroll, <= 4
[IREncodingPrinter] Disabling IR matching for rule 3 of 3 in testReductionAndLong: Not all feature constraints are met (applyIfCPUFeatureAnd): sse4.1, true, avx2, false
[IREncodingPrinter] Disabling IR matching for rule 1 of 3 in testReductionOrLong: None of the flag constraints met (applyIfOr): SuperWordReductions, false, LoopMaxUnroll, <= 4
[IREncodingPrinter] Disabling IR matching for rule 3 of 3 in testReductionOrLong: Not all feature constraints are met (applyIfCPUFeatureAnd): sse4.1, true, avx2, false

[IREncodingPrinter] Disabling IR matching for rule 1 of 3 in testReductionMulLong: None of the flag constraints met (applyIfOr): SuperWordReductions, false, LoopMaxUnroll, <= 4
[IREncodingPrinter] Disabling IR matching for rule 2 of 3 in testReductionMulLong: None of the feature constraints met (applyIfCPUFeatureOr): avx512dq, true, sve, true
[IREncodingPrinter] Disabling IR matching for rule 3 of 3 in testReductionMulLong: Not all feature constraints are met (applyIfCPUFeatureAnd): sse4.1, true, avx2, false
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295979](https://bugs.openjdk.org/browse/JDK-8295979): [IR Framework] Improve IR matching warning


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [c59291d2](https://git.openjdk.org/jdk/pull/12589/files/c59291d249fb71d7459e624e0b6a87b66dfba9ea)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12589/head:pull/12589` \
`$ git checkout pull/12589`

Update a local copy of the PR: \
`$ git checkout pull/12589` \
`$ git pull https://git.openjdk.org/jdk pull/12589/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12589`

View PR using the GUI difftool: \
`$ git pr show -t 12589`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12589.diff">https://git.openjdk.org/jdk/pull/12589.diff</a>

</details>
