### PR TITLE
JDK-8302656: Missing spaces in output of -XX:+CIPrintMethodCodes

### DIFF
--- a/src/hotspot/share/interpreter/bytecodeTracer.cpp
+++ b/src/hotspot/share/interpreter/bytecodeTracer.cpp
@@ -652,8 +652,8 @@ void BytecodePrinter::bytecode_epilog(int bci, outputStream* st) {
   if (mdo != nullptr) {
     ProfileData* data = mdo->bci_to_data(bci);
     if (data != nullptr) {
-      st->print("  %d", mdo->dp_to_di(data->dp()));
-      st->fill_to(6);
+      st->print("  %d ", mdo->dp_to_di(data->dp()));
+      st->fill_to(7);
       data->print_data_on(st, mdo);
     }
   }

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -126,8 +126,8 @@ void ProfileData::print_data_on(outputStream* st, const MethodData* md) const {
 }
 
 void ProfileData::print_shared(outputStream* st, const char* name, const char* extra) const {
-  st->print("bci: %d", bci());
-  st->fill_to(tab_width_one);
+  st->print("bci: %d ", bci());
+  st->fill_to(tab_width_one + 1);
   st->print("%s", name);
   tab(st);
   int trap = trap_state();


### PR DESCRIPTION
When printing bytecode and method data with `-XX:+CIPrintMethodCodes` we got some lines with missing whitespace: 
``` 
  11760bci: 1895VirtualCallData count(0) nonprofiled_count(0) entries(0) 
``` 

The reason for this is the use of `st->fill_to(6);` which fills up the stream with whitespace up to length 6. In our case we have 2 whitespaces before and then a  numbers >=1000 which already adds up to 6+ characters in the stream.

**Solution**: Always add a whitespace afterwards. Now 

```
  0    bci: 2    VirtualCallData    count(0) nonprofiled_count(0) entries(0)
  48   bci: 19   VirtualCallData    count(0) nonprofiled_count(0) entries(0)
  552  bci: 109  VirtualCallData    count(0) nonprofiled_count(0) entries(0)
  7320 bci: 1207 VirtualCallData    count(0) nonprofiled_count(0) entries(0)
  11760 bci: 1895 VirtualCallData count(0) nonprofiled_count(0) entries(0) 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302656](https://bugs.openjdk.org/browse/JDK-8302656): Missing spaces in output of -XX:+CIPrintMethodCodes


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12591/head:pull/12591` \
`$ git checkout pull/12591`

Update a local copy of the PR: \
`$ git checkout pull/12591` \
`$ git pull https://git.openjdk.org/jdk pull/12591/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12591`

View PR using the GUI difftool: \
`$ git pr show -t 12591`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12591.diff">https://git.openjdk.org/jdk/pull/12591.diff</a>

</details>
