### PR TITLE
8302661: Parallel: Remove PSVirtualSpace::is_aligned

### DIFF
--- a/src/hotspot/share/gc/parallel/psVirtualspace.cpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.cpp
@@ -105,7 +105,7 @@ bool PSVirtualSpace::shrink_by(size_t bytes) {
 
 #ifndef PRODUCT
 void PSVirtualSpace::verify() const {
-  assert(is_aligned(alignment(), os::vm_page_size()), "bad alignment");
+  assert(is_aligned(_alignment, os::vm_page_size()), "bad alignment");
   assert(is_aligned(reserved_low_addr(), _alignment), "bad reserved_low_addr");
   assert(is_aligned(reserved_high_addr(), _alignment), "bad reserved_high_addr");
   assert(is_aligned(committed_low_addr(), _alignment), "bad committed_low_addr");

--- a/src/hotspot/share/gc/parallel/psVirtualspace.cpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.cpp
@@ -69,7 +69,7 @@ void PSVirtualSpace::release() {
 }
 
 bool PSVirtualSpace::expand_by(size_t bytes) {
-  assert(is_aligned(bytes), "arg not aligned");
+  assert(is_aligned(bytes, _alignment), "arg not aligned");
   DEBUG_ONLY(PSVirtualSpaceVerifier this_verifier(this));
 
   if (uncommitted_size() < bytes) {
@@ -87,7 +87,7 @@ bool PSVirtualSpace::expand_by(size_t bytes) {
 }
 
 bool PSVirtualSpace::shrink_by(size_t bytes) {
-  assert(is_aligned(bytes), "arg not aligned");
+  assert(is_aligned(bytes, _alignment), "arg not aligned");
   DEBUG_ONLY(PSVirtualSpaceVerifier this_verifier(this));
 
   if (committed_size() < bytes) {
@@ -104,20 +104,12 @@ bool PSVirtualSpace::shrink_by(size_t bytes) {
 }
 
 #ifndef PRODUCT
-bool PSVirtualSpace::is_aligned(size_t value) const {
-  return ::is_aligned(value, alignment());
-}
-
-bool PSVirtualSpace::is_aligned(char* value) const {
-  return is_aligned((size_t)value);
-}
-
 void PSVirtualSpace::verify() const {
-  assert(::is_aligned(alignment(), os::vm_page_size()), "bad alignment");
-  assert(is_aligned(reserved_low_addr()), "bad reserved_low_addr");
-  assert(is_aligned(reserved_high_addr()), "bad reserved_high_addr");
-  assert(is_aligned(committed_low_addr()), "bad committed_low_addr");
-  assert(is_aligned(committed_high_addr()), "bad committed_high_addr");
+  assert(is_aligned(alignment(), os::vm_page_size()), "bad alignment");
+  assert(is_aligned(reserved_low_addr(), _alignment), "bad reserved_low_addr");
+  assert(is_aligned(reserved_high_addr(), _alignment), "bad reserved_high_addr");
+  assert(is_aligned(committed_low_addr(), _alignment), "bad committed_low_addr");
+  assert(is_aligned(committed_high_addr(), _alignment), "bad committed_high_addr");
 
   // Reserved region must be non-empty or both addrs must be 0.
   assert(reserved_low_addr() < reserved_high_addr() ||

--- a/src/hotspot/share/gc/parallel/psVirtualspace.cpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.cpp
@@ -26,6 +26,7 @@
 #include "gc/parallel/psVirtualspace.hpp"
 #include "memory/virtualspace.hpp"
 #include "runtime/os.hpp"
+#include "utilities/align.hpp"
 
 // PSVirtualSpace
 
@@ -103,14 +104,8 @@ bool PSVirtualSpace::shrink_by(size_t bytes) {
 }
 
 #ifndef PRODUCT
-bool PSVirtualSpace::is_aligned(size_t value, size_t align) {
-  const size_t tmp_value = value + align - 1;
-  const size_t mask = ~(align - 1);
-  return (tmp_value & mask) == value;
-}
-
 bool PSVirtualSpace::is_aligned(size_t value) const {
-  return is_aligned(value, alignment());
+  return ::is_aligned(value, alignment());
 }
 
 bool PSVirtualSpace::is_aligned(char* value) const {
@@ -118,7 +113,7 @@ bool PSVirtualSpace::is_aligned(char* value) const {
 }
 
 void PSVirtualSpace::verify() const {
-  assert(is_aligned(alignment(), os::vm_page_size()), "bad alignment");
+  assert(::is_aligned(alignment(), os::vm_page_size()), "bad alignment");
   assert(is_aligned(reserved_low_addr()), "bad reserved_low_addr");
   assert(is_aligned(reserved_high_addr()), "bad reserved_high_addr");
   assert(is_aligned(committed_low_addr()), "bad committed_low_addr");

--- a/src/hotspot/share/gc/parallel/psVirtualspace.hpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.hpp
@@ -35,7 +35,7 @@
 
 class PSVirtualSpace : public CHeapObj<mtGC> {
   friend class VMStructs;
- protected:
+
   // The space is committed/uncommitted in chunks of size _alignment.  The
   // ReservedSpace passed to initialize() must be aligned to this value.
   const size_t _alignment;
@@ -94,10 +94,9 @@ class PSVirtualSpace : public CHeapObj<mtGC> {
 
 #ifndef PRODUCT
   // Debugging
-  static  bool is_aligned(size_t val, size_t align);
-          bool is_aligned(size_t val) const;
-          bool is_aligned(char* val) const;
-          void verify() const;
+  bool is_aligned(size_t val) const;
+  bool is_aligned(char* val) const;
+  void verify() const;
 
   // Helper class to verify a space when entering/leaving a block.
   class PSVirtualSpaceVerifier: public StackObj {

--- a/src/hotspot/share/gc/parallel/psVirtualspace.hpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.hpp
@@ -94,8 +94,6 @@ class PSVirtualSpace : public CHeapObj<mtGC> {
 
 #ifndef PRODUCT
   // Debugging
-  bool is_aligned(size_t val) const;
-  bool is_aligned(char* val) const;
   void verify() const;
 
   // Helper class to verify a space when entering/leaving a block.


### PR DESCRIPTION
Simple removing redundant code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302661](https://bugs.openjdk.org/browse/JDK-8302661): Parallel: Remove PSVirtualSpace::is_aligned


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [ee0e244d](https://git.openjdk.org/jdk/pull/12592/files/ee0e244deba00a43e8ae7e43b3196b1d1458dc48)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12592/head:pull/12592` \
`$ git checkout pull/12592`

Update a local copy of the PR: \
`$ git checkout pull/12592` \
`$ git pull https://git.openjdk.org/jdk pull/12592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12592`

View PR using the GUI difftool: \
`$ git pr show -t 12592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12592.diff">https://git.openjdk.org/jdk/pull/12592.diff</a>

</details>
