### PR TITLE
8302667

### DIFF
--- a/src/java.base/share/native/libjli/emessages.h
+++ b/src/java.base/share/native/libjli/emessages.h
@@ -108,7 +108,7 @@
 #define DLL_ERROR1      "Error: dl failure on line %d"
 #define DLL_ERROR2      "Error: failed %s, because %s"
 #define DLL_ERROR3      "Error: could not find executable %s"
-#define DLL_ERROR4      "Error: loading: %s"
+#define DLL_ERROR4      "Error: Failed to load %s"
 
 #define REG_ERROR1      "Error: opening registry key '%s'"
 #define REG_ERROR2      "Error: Failed reading value of registry key:\n\t%s\\CurrentVersion"


### PR DESCRIPTION
DLL_ERROR4 is a macro expanding to an error message when a failure to load a generic item (shared libraries or an exported symbol from said libraries for example) occurs. "Error: loading:" is not a very pretty message, so this small change results in "Error: Failed to load %s" instead, which looks better and also means the message makes more sense if we want to append a reason behind as well, such as "Error: Failed to load libjvm.so because xxx"