### PR TITLE
8302674: Parallel: Remove unused methods in MutableNUMASpace

### DIFF
--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.hpp
@@ -97,15 +97,6 @@ class MutableNUMASpace : public MutableSpace {
       delete _alloc_rate;
     }
 
-    void add_invalid_region(MemRegion r) {
-      if (!_invalid_region.is_empty()) {
-      _invalid_region.set_start(MIN2(_invalid_region.start(), r.start()));
-      _invalid_region.set_end(MAX2(_invalid_region.end(), r.end()));
-      } else {
-      _invalid_region = r;
-      }
-    }
-
     static bool equals(void* lgrp_id_value, LGRPSpace* p) {
       return *(int*)lgrp_id_value == p->lgrp_id();
     }
@@ -161,8 +152,7 @@ class MutableNUMASpace : public MutableSpace {
 
   // Bias region towards the lgrp.
   void bias_region(MemRegion mr, int lgrp_id);
-  // Free pages in a given region.
-  void free_region(MemRegion mr);
+
   // Get current chunk size.
   size_t current_chunk_size(int i);
   // Get default chunk size (equally divide the space).
@@ -176,17 +166,8 @@ class MutableNUMASpace : public MutableSpace {
   // |----bottom_region--|---intersection---|------top_region------|
   void select_tails(MemRegion new_region, MemRegion intersection,
                     MemRegion* bottom_region, MemRegion *top_region);
-  // Try to merge the invalid region with the bottom or top region by decreasing
-  // the intersection area. Return the invalid_region aligned to the page_size()
-  // boundary if it's inside the intersection. Return non-empty invalid_region
-  // if it lies inside the intersection (also page-aligned).
-  // |------------------new_region---------------------------------|
-  // |----------------|-------invalid---|--------------------------|
-  // |----bottom_region--|---intersection---|------top_region------|
-  void merge_regions(MemRegion new_region, MemRegion* intersection,
-                     MemRegion *invalid_region);
 
- public:
+public:
   GrowableArray<LGRPSpace*>* lgrp_spaces() const     { return _lgrp_spaces;       }
   MutableNUMASpace(size_t alignment);
   virtual ~MutableNUMASpace();


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302674](https://bugs.openjdk.org/browse/JDK-8302674): Parallel: Remove unused methods in MutableNUMASpace


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12598/head:pull/12598` \
`$ git checkout pull/12598`

Update a local copy of the PR: \
`$ git checkout pull/12598` \
`$ git pull https://git.openjdk.org/jdk pull/12598/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12598`

View PR using the GUI difftool: \
`$ git pr show -t 12598`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12598.diff">https://git.openjdk.org/jdk/pull/12598.diff</a>

</details>
