### PR TITLE
8302668: [TESTBUG] Tests require feature sse4_1 which does not exist, should be sse4.1

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicByteOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicByteOpTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, 2023, Arm Limited. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,7 +108,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.MUL_V, ">0"})
     public byte[] vectorMul() {
         byte[] res = new byte[SIZE];
@@ -118,7 +119,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.MUL_V, ">0", IRNode.ADD_V, ">0"})
     public byte[] vectorMulAdd() {
         byte[] res = new byte[SIZE];
@@ -129,7 +130,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.MUL_V, ">0", IRNode.SUB_V, ">0"})
     public byte[] vectorMulSub() {
         byte[] res = new byte[SIZE];
@@ -186,7 +187,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
 
     // ---------------- Shift ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.LSHIFT_V, ">0"})
     public byte[] vectorShiftLeft() {
         byte[] res = new byte[SIZE];
@@ -197,7 +198,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.RSHIFT_V, ">0"})
     public byte[] vectorSignedShiftRight() {
         byte[] res = new byte[SIZE];
@@ -208,7 +209,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.RSHIFT_V, ">0"})
     public byte[] vectorUnsignedShiftRight() {
         byte[] res = new byte[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicIntOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicIntOpTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, 2023, Arm Limited. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,7 +108,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.MUL_V, ">0"})
     public int[] vectorMul() {
         int[] res = new int[SIZE];
@@ -118,7 +119,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.MUL_V, ">0", IRNode.ADD_V, ">0"})
     public int[] vectorMulAdd() {
         int[] res = new int[SIZE];
@@ -129,7 +130,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.MUL_V, ">0", IRNode.SUB_V, ">0"})
     public int[] vectorMulSub() {
         int[] res = new int[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicLongOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicLongOpTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, 2023, Arm Limited. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,9 +120,9 @@ public class BasicLongOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "sse4.1", "true"},
         counts = {IRNode.ADD_V, ">0"})
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "sse4.1", "true"},
         counts = {IRNode.MUL_V, ">0"})
     public long[] vectorMulAdd() {
         long[] res = new long[SIZE];
@@ -132,7 +133,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "sse4.1", "true"},
         counts = {IRNode.MUL_V, ">0", IRNode.SUB_V, ">0"})
     public long[] vectorMulSub() {
         long[] res = new long[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopArrayIndexComputeTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopArrayIndexComputeTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, 2023, Arm Limited. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,9 +105,9 @@ public class LoopArrayIndexComputeTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.MUL_V, ">0"})
     public int[] indexPlusInvariant() {
         int[] res = new int[SIZE];
@@ -132,9 +133,9 @@ public class LoopArrayIndexComputeTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.MUL_V, ">0"})
     public int[] indexWithInvariantAndConstant() {
         int[] res = new int[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopCombinedOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopCombinedOpTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, 2023, Arm Limited. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,7 +94,7 @@ public class LoopCombinedOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] opWithLoopInvariant() {
         int[] res = new int[SIZE];
@@ -104,7 +105,7 @@ public class LoopCombinedOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] opWithConstantAndLoopInvariant() {
         int[] res = new int[SIZE];
@@ -126,7 +127,7 @@ public class LoopCombinedOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] multipleOpsWithMultipleConstants() {
         int[] res = new int[SIZE];
@@ -152,7 +153,7 @@ public class LoopCombinedOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] multipleStoresWithCommonSubExpression() {
         int[] res1 = new int[SIZE];
@@ -297,7 +298,7 @@ public class LoopCombinedOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] manuallyUnrolledStride2() {
         int[] res = new int[SIZE];
@@ -309,7 +310,7 @@ public class LoopCombinedOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int partialVectorizableLoop() {
         int[] res = new int[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopLiveOutNodesTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopLiveOutNodesTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, 2023, Arm Limited. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +68,7 @@ public class LoopLiveOutNodesTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int SimpleIvUsed() {
         int i = 0;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopRangeStrideTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopRangeStrideTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, 2023, Arm Limited. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,7 +111,7 @@ public class LoopRangeStrideTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] shortInductionLoop() {
         int[] res = new int[SIZE];
@@ -175,7 +176,7 @@ public class LoopRangeStrideTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] countDownLoop() {
         int[] res = new int[SIZE];
@@ -196,7 +197,7 @@ public class LoopRangeStrideTest extends VectorizationTestRunner {
 
     // ---------- Stride with scale ----------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] countupLoopWithNegScale() {
         int[] res = new int[SIZE];
@@ -207,7 +208,7 @@ public class LoopRangeStrideTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] countDownLoopWithNegScale() {
         int[] res = new int[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/MultipleLoopsTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/MultipleLoopsTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, 2023, Arm Limited. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,7 +98,7 @@ public class MultipleLoopsTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] nestedLoopOuterNonCounted() {
         int i = 1;
@@ -113,7 +114,7 @@ public class MultipleLoopsTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4_1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] nestedLoopIndexCompute() {
         int[] res = new int[SIZE];


### PR DESCRIPTION
I found some IR tests where the `cpuFeature` was non-existant, so these rules were always ignored on intel machines.

To quote @vnkozlov :
```
sse4_1  comes from /proc/cpuinfo. sse4.1 is in CPU_FEATURE_FLAGS and produced by VM output.
IR framework gets info from WHITE_BOX.getCPUFeatures() which calls VM_Version::features_string().
So you are right tests should use sse4.1
```

Maybe the IR framework should check that we only use `cpuFeatures` that are in a verified list? That way we could avoid IR rules not being executed because of a typo / wrong copy. Filed RFE: [JDK-8302681](https://bugs.openjdk.org/browse/JDK-8302681)

This is the list of tests before my patch. They are not showing up after my patch, which means the tests are running now.
Warnings are done with my other patch that I will integrate soon https://github.com/openjdk/jdk/pull/12589.
```
test/hotspot/jtreg/compiler/vectorization/runner/BasicIntOpTest.java
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in vectorMul: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in vectorMulSub: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in vectorMulAdd: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true

test/hotspot/jtreg/compiler/vectorization/runner/MultipleLoopsTest.java
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in nestedLoopOuterNonCounted: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in nestedLoopIndexCompute: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true

test/hotspot/jtreg/compiler/vectorization/runner/BasicByteOpTest.java
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in vectorMulSub: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in vectorMul: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in vectorUnsignedShiftRight: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in vectorMulAdd: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in vectorShiftLeft: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in vectorSignedShiftRight: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true

test/hotspot/jtreg/compiler/vectorization/runner/BasicLongOpTest.java
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in vectorMulSub: None of the feature constraints met (applyIfCPUFeatureOr): sve, true, sse4_1, true
[IREncodingPrinter] Disabling IR matching for rule 1 of 2 in vectorMulAdd: None of the feature constraints met (applyIfCPUFeatureOr): sve, true, sse4_1, true
[IREncodingPrinter] Disabling IR matching for rule 2 of 2 in vectorMulAdd: None of the feature constraints met (applyIfCPUFeatureOr): sve, true, sse4_1, true

test/hotspot/jtreg/compiler/vectorization/runner/LoopLiveOutNodesTest.java
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in SimpleIvUsed: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true

test/hotspot/jtreg/compiler/vectorization/runner/LoopArrayIndexComputeTest.java
[IREncodingPrinter] Disabling IR matching for rule 1 of 2 in indexWithInvariantAndConstant: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true
[IREncodingPrinter] Disabling IR matching for rule 2 of 2 in indexWithInvariantAndConstant: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true
[IREncodingPrinter] Disabling IR matching for rule 1 of 2 in indexPlusInvariant: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true
[IREncodingPrinter] Disabling IR matching for rule 2 of 2 in indexPlusInvariant: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true

test/hotspot/jtreg/compiler/vectorization/runner/LoopRangeStrideTest.java
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in countupLoopWithNegScale: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in countDownLoop: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in countDownLoopWithNegScale: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in shortInductionLoop: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true

test/hotspot/jtreg/compiler/vectorization/runner/LoopCombinedOpTest.java
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in opWithConstantAndLoopInvariant: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in partialVectorizableLoop: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in opWithLoopInvariant: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in multipleOpsWithMultipleConstants: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in multipleStoresWithCommonSubExpression: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true
[IREncodingPrinter] Disabling IR matching for rule 1 of 1 in manuallyUnrolledStride2: None of the feature constraints met (applyIfCPUFeatureOr): asimd, true, sse4_1, true
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302668](https://bugs.openjdk.org/browse/JDK-8302668): [TESTBUG]  Tests require feature sse4_1 which does not exist, should be sse4.1


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12601/head:pull/12601` \
`$ git checkout pull/12601`

Update a local copy of the PR: \
`$ git checkout pull/12601` \
`$ git pull https://git.openjdk.org/jdk pull/12601/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12601`

View PR using the GUI difftool: \
`$ git pr show -t 12601`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12601.diff">https://git.openjdk.org/jdk/pull/12601.diff</a>

</details>
