### PR TITLE
7016187: `javac -h` could generate conflict .h for inner class and class name with '_'

### DIFF
--- a/test/langtools/tools/javac/nativeHeaders/NativeHeaderTest.java
+++ b/test/langtools/tools/javac/nativeHeaders/NativeHeaderTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7150368 8003412 8000407
+ * @bug 7150368 8003412 8000407 7016187
  * @summary javac should include basic ability to generate native headers
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file
@@ -147,6 +147,32 @@ public class NativeHeaderTest {
         if (gk == GenKind.FULL) expect.add("C.h");
 
         test(rk, gk, files, expect);
+    }
+
+    @Test
+    void conflictTest(RunKind rk, GenKind gk) throws Exception {
+
+        // These two classes will generate the same header file "Foo_Bar.h"
+        List<File> files = new ArrayList<File>();
+        files.add(createFile("p/Foo.java", """
+            public class Foo {
+                public static class Bar {
+                    public static native void method1();
+                }
+            }
+        """));
+        files.add(createFile("p/Foo_Bar.java", """
+            public class Foo_Bar {
+                public static native void method2();
+            }
+        """));
+
+        try {
+            test(rk, gk, files, null);
+            throw new AssertionError("expected failure");
+        } catch (Exception e) {
+            // expected
+        }
     }
 
     /**


### PR DESCRIPTION
Consider these two classes:
```java
public class Foo_Bar {
    public static native void method();
}
```
```java
public class Foo {
    public static class Bar {
        public static native void method();
    }
}
```
If you run `javac -h` to generate native header files, classes `Foo_Bar` and `Foo$Bar` will want to generate the same native header file `Foo_Bar.h`.

Currently, javac does not detect this situation, so in effect you get a "last writer wins" situation.

This patch causes compilation to fail instead in this case with an error like this:
```
Foo.java:2: error: error while writing Bar: native header file collision between Foo_Bar and Foo$Bar (both generate Foo_Bar.h)
    public static class Bar {
                  ^
1 error
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-7016187](https://bugs.openjdk.org/browse/JDK-7016187): `javac -h` could generate conflict .h for inner class and class name with '_'


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12602/head:pull/12602` \
`$ git checkout pull/12602`

Update a local copy of the PR: \
`$ git checkout pull/12602` \
`$ git pull https://git.openjdk.org/jdk pull/12602/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12602`

View PR using the GUI difftool: \
`$ git pr show -t 12602`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12602.diff">https://git.openjdk.org/jdk/pull/12602.diff</a>

</details>
