### PR TITLE
8302615: make JVMTI thread cpu time functions optional for virtual threads

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -11058,7 +11058,8 @@ myInit() {
       </parameters>
       <errors>
         <error id="JVMTI_ERROR_UNSUPPORTED_OPERATION">
-          Current thread is a virtual thread.
+          The current thread is a virtual thread and the implementation does not support
+          getting the current thread CPU time when the current thread is a virtual thread.
         </error>
       </errors>
     </function>
@@ -11140,7 +11141,8 @@ myInit() {
       </parameters>
       <errors>
         <error id="JVMTI_ERROR_UNSUPPORTED_OPERATION">
-          <paramlink id="thread"/> is a virtual thread.
+          <paramlink id="thread"/> is a virtual thread and the implementation does not
+          support getting the thread CPU time of a virtual thread.
         </error>
       </errors>
     </function>


### PR DESCRIPTION
This is a minor JVM TI spec update for two timer functions `GetCurrentThreadCpuTime` and `GetThreadCpuTime` to allow implementations to support virtual threads.

The CSR is:
[JDK-8302616](https://bugs.openjdk.org/browse/JDK-8302616): make JVMTI thread cpu time functions optional for virtual threads

No testing is needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8302616](https://bugs.openjdk.org/browse/JDK-8302616) to be approved

### Issues
 * [JDK-8302615](https://bugs.openjdk.org/browse/JDK-8302615): make JVMTI thread cpu time functions optional for virtual threads
 * [JDK-8302616](https://bugs.openjdk.org/browse/JDK-8302616): make JVMTI thread cpu time functions optional for virtual threads (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12604/head:pull/12604` \
`$ git checkout pull/12604`

Update a local copy of the PR: \
`$ git checkout pull/12604` \
`$ git pull https://git.openjdk.org/jdk pull/12604/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12604`

View PR using the GUI difftool: \
`$ git pr show -t 12604`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12604.diff">https://git.openjdk.org/jdk/pull/12604.diff</a>

</details>
