### PR TITLE
8302315: Examine cost of clone of primitive arrays compared to arraycopy

### DIFF
--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -3536,18 +3536,11 @@ public class Arrays {
      */
     public static byte[] copyOf(byte[] original, int newLength) {
         if (newLength == original.length) {
-            return copyOf(original);
+            return original.clone();
         }
         byte[] copy = new byte[newLength];
         System.arraycopy(original, 0, copy, 0,
                          Math.min(original.length, newLength));
-        return copy;
-    }
-
-    @ForceInline
-    private static byte[] copyOf(byte[] original) {
-        byte[] copy = new byte[original.length];
-        System.arraycopy(original, 0, copy, 0, original.length);
         return copy;
     }
 
@@ -3570,18 +3563,11 @@ public class Arrays {
      */
     public static short[] copyOf(short[] original, int newLength) {
         if (newLength == original.length) {
-            return copyOf(original);
+            return original.clone();
         }
         short[] copy = new short[newLength];
         System.arraycopy(original, 0, copy, 0,
                          Math.min(original.length, newLength));
-        return copy;
-    }
-
-    @ForceInline
-    private static short[] copyOf(short[] original) {
-        short[] copy = new short[original.length];
-        System.arraycopy(original, 0, copy, 0, original.length);
         return copy;
     }
 
@@ -3604,7 +3590,7 @@ public class Arrays {
      */
     public static int[] copyOf(int[] original, int newLength) {
         if (newLength == original.length) {
-            return copyOf(original);
+            return original.clone();
         }
         int[] copy = new int[newLength];
         System.arraycopy(original, 0, copy, 0,
@@ -3612,12 +3598,6 @@ public class Arrays {
         return copy;
     }
 
-    @ForceInline
-    private static int[] copyOf(int[] original) {
-        int[] copy = new int[original.length];
-        System.arraycopy(original, 0, copy, 0, original.length);
-        return copy;
-    }
 
     /**
      * Copies the specified array, truncating or padding with zeros (if necessary)
@@ -3638,18 +3618,11 @@ public class Arrays {
      */
     public static long[] copyOf(long[] original, int newLength) {
         if (newLength == original.length) {
-            return copyOf(original);
+            return original.clone();
         }
         long[] copy = new long[newLength];
         System.arraycopy(original, 0, copy, 0,
                          Math.min(original.length, newLength));
-        return copy;
-    }
-
-    @ForceInline
-    private static long[] copyOf(long[] original) {
-        long[] copy = new long[original.length];
-        System.arraycopy(original, 0, copy, 0, original.length);
         return copy;
     }
 
@@ -3672,18 +3645,11 @@ public class Arrays {
      */
     public static char[] copyOf(char[] original, int newLength) {
         if (newLength == original.length) {
-            return copyOf(original);
+            return original.clone();
         }
         char[] copy = new char[newLength];
         System.arraycopy(original, 0, copy, 0,
                          Math.min(original.length, newLength));
-        return copy;
-    }
-
-    @ForceInline
-    private static char[] copyOf(char[] original) {
-        char[] copy = new char[original.length];
-        System.arraycopy(original, 0, copy, 0, original.length);
         return copy;
     }
 
@@ -3706,18 +3672,11 @@ public class Arrays {
      */
     public static float[] copyOf(float[] original, int newLength) {
         if (newLength == original.length) {
-            return copyOf(original);
+            return original.clone();
         }
         float[] copy = new float[newLength];
         System.arraycopy(original, 0, copy, 0,
                          Math.min(original.length, newLength));
-        return copy;
-    }
-
-    @ForceInline
-    private static float[] copyOf(float[] original) {
-        float[] copy = new float[original.length];
-        System.arraycopy(original, 0, copy, 0, original.length);
         return copy;
     }
 
@@ -3740,18 +3699,11 @@ public class Arrays {
      */
     public static double[] copyOf(double[] original, int newLength) {
         if (newLength == original.length) {
-            return copyOf(original);
+            return original.clone();
         }
         double[] copy = new double[newLength];
         System.arraycopy(original, 0, copy, 0,
                          Math.min(original.length, newLength));
-        return copy;
-    }
-
-    @ForceInline
-    private static double[] copyOf(double[] original) {
-        double[] copy = new double[original.length];
-        System.arraycopy(original, 0, copy, 0, original.length);
         return copy;
     }
 
@@ -3774,18 +3726,11 @@ public class Arrays {
      */
     public static boolean[] copyOf(boolean[] original, int newLength) {
         if (newLength == original.length) {
-            return copyOf(original);
+            return original.clone();
         }
         boolean[] copy = new boolean[newLength];
         System.arraycopy(original, 0, copy, 0,
                          Math.min(original.length, newLength));
-        return copy;
-    }
-
-    @ForceInline
-    private static boolean[] copyOf(boolean[] original) {
-        boolean[] copy = new boolean[original.length];
-        System.arraycopy(original, 0, copy, 0, original.length);
         return copy;
     }
 
@@ -3908,7 +3853,7 @@ public class Arrays {
         if (from != 0 || to != original.length)
             return copyOfRangeByte(original, from, to);
         else // from == 0 && to == original.length
-            return copyOf(original);
+            return original.clone();
     }
 
     @ForceInline
@@ -3952,7 +3897,7 @@ public class Arrays {
         if (from != 0 || to != original.length)
             return copyOfRangeShort(original, from, to);
         else // from == 0 && to == original.length
-            return copyOf(original);
+            return original.clone();
     }
 
     @ForceInline
@@ -3996,7 +3941,7 @@ public class Arrays {
         if (from != 0 || to != original.length)
             return copyOfRangeInt(original, from, to);
         else // from == 0 && to == original.length
-            return copyOf(original);
+            return original.clone();
     }
 
     @ForceInline
@@ -4040,7 +3985,7 @@ public class Arrays {
         if (from != 0 || to != original.length)
             return copyOfRangeLong(original, from, to);
         else // from == 0 && to == original.length
-            return copyOf(original);
+            return original.clone();
     }
 
     @ForceInline
@@ -4084,7 +4029,7 @@ public class Arrays {
         if (from != 0 || to != original.length)
             return copyOfRangeChar(original, from, to);
         else // from == 0 && to == original.length
-            return copyOf(original);
+            return original.clone();
     }
 
     @ForceInline
@@ -4128,7 +4073,7 @@ public class Arrays {
         if (from != 0 || to != original.length)
             return copyOfRangeFloat(original, from, to);
         else // from == 0 && to == original.length
-            return copyOf(original);
+            return original.clone();
     }
 
     @ForceInline
@@ -4172,7 +4117,7 @@ public class Arrays {
         if (from != 0 || to != original.length)
             return copyOfRangeDouble(original, from, to);
         else // from == 0 && to == original.length
-            return copyOf(original);
+            return original.clone();
     }
 
     @ForceInline
@@ -4216,7 +4161,7 @@ public class Arrays {
         if (from != 0 || to != original.length)
             return copyOfRangeBoolean(original, from, to);
         else // from == 0 && to == original.length
-            return copyOf(original);
+            return original.clone();
     }
 
     @ForceInline

--- a/test/micro/org/openjdk/bench/java/lang/ArrayClone.java
+++ b/test/micro/org/openjdk/bench/java/lang/ArrayClone.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * Compare array clone with equivalent System.arraycopy-based routines
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 2, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 15, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@State(Scope.Benchmark)
+public class ArrayClone {
+
+    @Param({"0", "10", "100", "1000"})
+    int size;
+
+    private byte[] bytes;
+    private int[] ints;
+
+    @Setup
+    public void setup() {
+        bytes = new byte[size];
+        ints = new int[size];
+        ThreadLocalRandom.current().nextBytes(bytes);
+        for (int i = 0; i < ints.length; i++) {
+            ints[i] = ThreadLocalRandom.current().nextInt();
+        }
+    }
+
+    @Benchmark
+    public byte[] byteClone() {
+        return bytes.clone();
+    }
+
+    @Benchmark
+    public byte[] byteArraycopy() {
+        byte[] copy = new byte[bytes.length];
+        System.arraycopy(bytes, 0, copy, 0, bytes.length);
+        return copy;
+    }
+
+    @Benchmark
+    public int[] intClone() {
+        return ints.clone();
+    }
+
+    @Benchmark
+    public int[] intArraycopy() {
+        int[] copy = new int[ints.length];
+        System.arraycopy(ints, 0, copy, 0, ints.length);
+        return copy;
+    }
+
+}


### PR DESCRIPTION
During work on #12453 @schlosna reported that `array.clone()` might underperform `System.arraycopy` in microbenchmarks and I opted to go with `arraycopy` throughout while investigating.

Testing on x86 (SandyBridge, AVX2) I observe no difference at all between the setups. On aarch the only difference I can observe is that arraycopy seem curiously slow for input size = 0, otherwise no statistically significant difference. All tests ran on builds from JDK mainline and 21-b9.

Since the reported difference was small and mostly visible on very large arrays I conclude that the maintainability win we get from using `clone()` is preferable. I've added the microbenchmark provided by @schlosna here.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302315](https://bugs.openjdk.org/browse/JDK-8302315): Examine cost of clone of primitive arrays compared to arraycopy


### Reviewers
 * @schlosna (no known openjdk.org user name / role)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12613/head:pull/12613` \
`$ git checkout pull/12613`

Update a local copy of the PR: \
`$ git checkout pull/12613` \
`$ git pull https://git.openjdk.org/jdk pull/12613/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12613`

View PR using the GUI difftool: \
`$ git pr show -t 12613`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12613.diff">https://git.openjdk.org/jdk/pull/12613.diff</a>

</details>
