### PR TITLE
8302776: RISC-V: Fix typo CSR_INSTERT to CSR_INSTRET

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1059,7 +1059,7 @@ void MacroAssembler::wrap_label(Register r1, Register r2, Label &L,
     csrr(Rd, CSR);                            \
   }
 
-  INSN(rdinstret,  CSR_INSTERT);
+  INSN(rdinstret,  CSR_INSTRET);
   INSN(rdcycle,    CSR_CYCLE);
   INSN(rdtime,     CSR_TIME);
   INSN(frcsr,      CSR_FCSR);

--- a/src/hotspot/cpu/riscv/register_riscv.hpp
+++ b/src/hotspot/cpu/riscv/register_riscv.hpp
@@ -41,7 +41,7 @@
 #define CSR_VLENB    0xC22        // VLEN/8 (vector register length in bytes)
 #define CSR_CYCLE    0xc00        // Cycle counter for RDCYCLE instruction.
 #define CSR_TIME     0xc01        // Timer for RDTIME instruction.
-#define CSR_INSTERT  0xc02        // Instructions-retired counter for RDINSTRET instruction.
+#define CSR_INSTRET  0xc02        // Instructions-retired counter for RDINSTRET instruction.
 
 class VMRegImpl;
 typedef VMRegImpl* VMReg;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302776](https://bugs.openjdk.org/browse/JDK-8302776): RISC-V: Fix typo CSR_INSTERT to CSR_INSTRET


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12616/head:pull/12616` \
`$ git checkout pull/12616`

Update a local copy of the PR: \
`$ git checkout pull/12616` \
`$ git pull https://git.openjdk.org/jdk pull/12616/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12616`

View PR using the GUI difftool: \
`$ git pr show -t 12616`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12616.diff">https://git.openjdk.org/jdk/pull/12616.diff</a>

</details>
