### PR TITLE
8302150: Speed up compiler/codegen/Test7100757.java

### DIFF
--- a/test/hotspot/jtreg/compiler/codegen/Test7100757.java
+++ b/test/hotspot/jtreg/compiler/codegen/Test7100757.java
@@ -50,7 +50,7 @@ public class Test7100757 {
     Random rnd = Utils.getRandomInstance();
     long[] ra = new long[(NBITS+63)/64];
 
-    for(int l=0; l < 5000000; l++) {
+    for(int l=0; l < 50_000; l++) {
 
       for(int r = 0; r < ra.length; r++) {
         ra[r] = rnd.nextLong();

--- a/test/hotspot/jtreg/compiler/codegen/Test7100757.java
+++ b/test/hotspot/jtreg/compiler/codegen/Test7100757.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This test took over `11 seconds`. It had a very high iteration count of `5_000_000`.

I lowered it to `50_000`, it now takes about `0.7 seconds`, so over `15x speedup`.

I ensured that the same compilations still happen, with and without `-Xbatch`, this is the reason why I could not set it all the way down to `10_000` (the speedup at this point was hardly noticable anyway):

```
    554 1023       3       compiler.codegen.Test7100757::test (274 bytes)
    561 1028 %     4       compiler.codegen.Test7100757::test @ 14 (274 bytes)
    578 1033       4       compiler.codegen.Test7100757::test (274 bytes)
    593 1023       3       compiler.codegen.Test7100757::test (274 bytes)   made not entrant
    599 1034 %     3       compiler.codegen.Test7100757::main @ 32 (65 bytes)
    600 1035       3       compiler.codegen.Test7100757::main (65 bytes)
    615 1036 %     4       compiler.codegen.Test7100757::main @ 32 (65 bytes)
    635 1034 %     3       compiler.codegen.Test7100757::main @ 32 (65 bytes)   made not entrant
    676 1036 %     4       compiler.codegen.Test7100757::main @ 32 (65 bytes)   made not entrant
```

I am not sure if the test only reproduced intermittently, but if it did it would now probably reproduce with lower frequency, but hopefully still eventually (maybe 100x less less often). Or maybe the original author just did not notice that the iteration count was a bit excessive.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302150](https://bugs.openjdk.org/browse/JDK-8302150): Speed up compiler/codegen/Test7100757.java


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12618/head:pull/12618` \
`$ git checkout pull/12618`

Update a local copy of the PR: \
`$ git checkout pull/12618` \
`$ git pull https://git.openjdk.org/jdk pull/12618/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12618`

View PR using the GUI difftool: \
`$ git pr show -t 12618`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12618.diff">https://git.openjdk.org/jdk/pull/12618.diff</a>

</details>
