### PR TITLE
Improve scalability of Class.forName using a CopyOnWriteArrayList for URLClassPath loaders

### DIFF
--- a/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
+++ b/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
@@ -224,6 +224,7 @@ public class URLClassPath {
         if (closed) {
             return Collections.emptyList();
         }
+        closed = true;
         List<IOException> result = new ArrayList<>();
         for (Loader loader : loaders) {
             try {
@@ -232,7 +233,6 @@ public class URLClassPath {
                 result.add(e);
             }
         }
-        closed = true;
         return result;
     }
 

--- a/test/micro/org/openjdk/bench/java/lang/ClassForName.java
+++ b/test/micro/org/openjdk/bench/java/lang/ClassForName.java
@@ -72,9 +72,31 @@ public class ClassForName {
         bh.consume(Class.forName(getClass().getModule(), "java.lang.StringUTF16"));
     }
 
+    @Benchmark
+    public void forNameWithModuleMany(Blackhole bh) throws ClassNotFoundException {
+        bh.consume(Class.forName(getClass().getModule(), "java.util.Spliterator"));
+        bh.consume(Class.forName(getClass().getModule(), "java.util.Random"));
+        bh.consume(Class.forName(getClass().getModule(), "java.util.Arrays"));
+        bh.consume(Class.forName(getClass().getModule(), "java.lang.String"));
+        bh.consume(Class.forName(getClass().getModule(), "java.lang.StringLatin1"));
+        bh.consume(Class.forName(getClass().getModule(), "java.lang.StringUTF16"));
+        bh.consume(Class.forName(getClass().getModule(), "java.util.List"));
+        bh.consume(Class.forName(getClass().getModule(), "java.util.Map"));
+        bh.consume(Class.forName(getClass().getModule(), "java.util.Set"));
+        bh.consume(Class.forName(getClass().getModule(), "java.lang.Class"));
+        bh.consume(Class.forName(getClass().getModule(), "java.lang.Float"));
+        bh.consume(Class.forName(getClass().getModule(), "java.lang.Integer"));
+        bh.consume(Class.forName(getClass().getModule(), "java.lang.Double"));
+        bh.consume(Class.forName(getClass().getModule(), "java.lang.Boolean"));
+        bh.consume(Class.forName(getClass().getModule(), "java.lang.System"));
+        bh.consume(Class.forName(getClass().getModule(), "java.lang.Long"));
+        bh.consume(Class.forName(getClass().getModule(), "java.lang.StringBuilder"));
+        bh.consume(Class.forName(getClass().getModule(), "java.lang.StringBuffer"));
+    }
+
     /** Calls Class.forName with the three different names over and over again. All classes asked for exist. */
     @Benchmark
-    public void forNameTriple(Blackhole bh) throws ClassNotFoundException {
+    public void forName(Blackhole bh) throws ClassNotFoundException {
         bh.consume(Class.forName(aName));
         bh.consume(Class.forName(bName));
         bh.consume(Class.forName(cName));

--- a/test/micro/org/openjdk/bench/java/lang/ClassForName.java
+++ b/test/micro/org/openjdk/bench/java/lang/ClassForName.java
@@ -58,13 +58,23 @@ public class ClassForName {
 
     /** Calls Class.forName with the same name over and over again. The class asked for exists. */
     @Benchmark
-    public void test1(Blackhole bh) throws ClassNotFoundException {
-        bh.consume(Class.forName(aName));
+    public Class<?> forNameSingle() throws ClassNotFoundException {
+        return Class.forName(aName);
+    }
+
+    @Benchmark
+    public void forNameWithModule(Blackhole bh) throws ClassNotFoundException {
+        bh.consume(Class.forName(getClass().getModule(), "java.util.Spliterator"));
+        bh.consume(Class.forName(getClass().getModule(), "java.util.Random"));
+        bh.consume(Class.forName(getClass().getModule(), "java.util.Arrays"));
+        bh.consume(Class.forName(getClass().getModule(), "java.lang.String"));
+        bh.consume(Class.forName(getClass().getModule(), "java.lang.StringLatin1"));
+        bh.consume(Class.forName(getClass().getModule(), "java.lang.StringUTF16"));
     }
 
     /** Calls Class.forName with the three different names over and over again. All classes asked for exist. */
     @Benchmark
-    public void test3(Blackhole bh) throws ClassNotFoundException {
+    public void forNameTriple(Blackhole bh) throws ClassNotFoundException {
         bh.consume(Class.forName(aName));
         bh.consume(Class.forName(bName));
         bh.consume(Class.forName(cName));


### PR DESCRIPTION
Experiment that improve scalability for Class.forName in microbenchmarks. This might have an effect on https://bugs.openjdk.org/browse/JDK-8302314

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12619/head:pull/12619` \
`$ git checkout pull/12619`

Update a local copy of the PR: \
`$ git checkout pull/12619` \
`$ git pull https://git.openjdk.org/jdk pull/12619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12619`

View PR using the GUI difftool: \
`$ git pr show -t 12619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12619.diff">https://git.openjdk.org/jdk/pull/12619.diff</a>

</details>
