### PR TITLE
8301404: Replace os::malloc with os::realloc, so we only have 1 code path

### DIFF
--- a/src/hotspot/share/services/mallocHeader.hpp
+++ b/src/hotspot/share/services/mallocHeader.hpp
@@ -120,9 +120,9 @@ class MallocHeader {
 public:
   // Contains all of the necessary data to to deaccount block with NMT.
   struct FreeInfo {
-    const size_t size;
-    const MEMFLAGS flags;
-    const uint32_t mst_marker;
+    size_t size;
+    MEMFLAGS flags;
+    uint32_t mst_marker;
   };
 
   inline MallocHeader(size_t size, MEMFLAGS flags, uint32_t mst_marker);


### PR DESCRIPTION
Please review this enhancement, which eliminates a duplicate and almost identical path we have for malloc() and realloc(), and collapses  them down to only one codepath, by taking advantage of fact that `malloc() == realloc(NULL)`

Tested with MACH5 tier1,2,3,4,5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301404](https://bugs.openjdk.org/browse/JDK-8301404): Replace os::malloc with os::realloc, so we only have 1 code path


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12621/head:pull/12621` \
`$ git checkout pull/12621`

Update a local copy of the PR: \
`$ git checkout pull/12621` \
`$ git pull https://git.openjdk.org/jdk pull/12621/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12621`

View PR using the GUI difftool: \
`$ git pr show -t 12621`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12621.diff">https://git.openjdk.org/jdk/pull/12621.diff</a>

</details>
