### PR TITLE
8302777: CDS should not relocate heap if mapping fails

### DIFF
--- a/src/hotspot/share/cds/archiveHeapLoader.cpp
+++ b/src/hotspot/share/cds/archiveHeapLoader.cpp
@@ -472,7 +472,9 @@ void ArchiveHeapLoader::finish_initialization() {
       verify_loaded_heap();
     }
   }
-  patch_native_pointers();
+  if (is_fully_available()) {
+    patch_native_pointers();
+  }
 }
 
 void ArchiveHeapLoader::finish_loaded_heap() {


### PR DESCRIPTION
Please review this trivial fix: if the CDS archive heap is not available due to CRC errors, we shouldn't try to relocate its contents.

The bug was introduced in [JDK-8296158](https://bugs.openjdk.org/browse/JDK-8296158). Previously, if the CRC check fails, `FileMapRegion::mapped_base()` will be NULL for the heap regions, and thus we will skip the relocation in [`ArchiveHeapLoader::patch_native_pointers()`](https://github.com/openjdk/jdk/blob/a917fb3fcf0fe1a4c4de86c08ae4041462848b82/src/hotspot/share/cds/archiveHeapLoader.cpp#L535-L550).

However, since [JDK-8296158](https://bugs.openjdk.org/browse/JDK-8296158), `FileMapRegion::mapped_base()`  might be non-zero after CRC check has failed.

A proper fix is in [JDK-8302790](https://bugs.openjdk.org/browse/JDK-8302790) -- we should clear `FileMapRegion::mapped_base()`  when mapping fails.

However, that's a more involved fix and requires more testing. 

In the meantime, this PR will fix this crash. Also, it's a good idea to make sure the archive heap is available before doing anything with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302777](https://bugs.openjdk.org/browse/JDK-8302777): CDS should not relocate heap if mapping fails


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12622/head:pull/12622` \
`$ git checkout pull/12622`

Update a local copy of the PR: \
`$ git checkout pull/12622` \
`$ git pull https://git.openjdk.org/jdk pull/12622/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12622`

View PR using the GUI difftool: \
`$ git pr show -t 12622`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12622.diff">https://git.openjdk.org/jdk/pull/12622.diff</a>

</details>
