### PR TITLE
8302877: Speed up latin1 case conversions

### DIFF
--- a/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,30 +135,36 @@ class CharacterDataLatin1 extends CharacterData {
     }
 
     int toLowerCase(int ch) {
-        int mapChar = ch;
-        int val = getProperties(ch);
-
-        if (((val & $$maskLowerCase) != 0) && 
-                ((val & $$maskCaseOffset) != $$maskCaseOffset)) { 
-            int offset = val << $$shiftCaseOffsetSign >> ($$shiftCaseOffsetSign+$$shiftCaseOffset);
-            mapChar = ch + offset;
+        if (ch < 'A') { // Fast path for low code points
+            return ch;
         }
-        return mapChar;
+        int l = ch | 0x20; // Lowercase using 'oldest ASCII trick in the book'
+        if ( l <= 'z' // In range a-z
+                || (l >= 0xE0 && l <= 0xFE && l != 0xF7)) { // ..or agrave-thorn, excluding division
+            return l;
+        }
+        return ch;
     }
 
     int toUpperCase(int ch) {
-        int mapChar = ch;
-        int val = getProperties(ch);
-
-        if ((val & $$maskUpperCase) != 0) {
-            if ((val & $$maskCaseOffset) != $$maskCaseOffset) {
-                int offset = val  << $$shiftCaseOffsetSign >> ($$shiftCaseOffsetSign+$$shiftCaseOffset);
-                mapChar =  ch - offset;
-            } else if (ch == 0x00B5) {
-                mapChar = 0x039C;
-            }
+        if (ch < 'a') { // Fast path for low code points
+            return ch;
         }
-        return mapChar;
+        int U = ch & 0xDF; // Uppercase using 'oldest ASCII trick in the book'
+        if (U <= 'Z' // In range A-Z
+                || (U >= 0xC0 && U <= 0xDE && U != 0xD7)) { // ..or Agrave-Thorn, excluding multiplication
+            return U;
+        }
+
+        // Special-case for 'Y with Diaeresis' which uppercases out of latin1
+        if (ch == 0xFF) {
+            return 0x178;
+        }
+        // Special-case for 'Mu' which uppercases out of latin1
+        if (ch == 0xB5) {
+            return 0x39C;
+        }
+        return ch;
     }
 
     int toTitleCase(int ch) {

--- a/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
@@ -156,13 +156,13 @@ class CharacterDataLatin1 extends CharacterData {
             return U;
         }
 
-        // Special-case for 'Y with Diaeresis' which uppercases out of latin1
+        // Special-case for 'y with Diaeresis' which uppercases out of latin1
         if (ch == 0xFF) {
-            return 0x178;
+            return 0x178; // Capital Letter Y with Diaeresis
         }
-        // Special-case for 'Mu' which uppercases out of latin1
+        // Special-case for 'Micro Sign' which uppercases out of latin1
         if (ch == 0xB5) {
-            return 0x39C;
+            return 0x39C; // Greek Capital Letter Mu
         }
         return ch;
     }

--- a/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
@@ -139,7 +139,7 @@ class CharacterDataLatin1 extends CharacterData {
             return ch;
         }
         int l = ch | 0x20; // Lowercase using 'oldest ASCII trick in the book'
-        if ( l <= 'z' // In range a-z
+        if (l <= 'z' // In range a-z
                 || (l >= 0xE0 && l <= 0xFE && l != 0xF7)) { // ..or agrave-thorn, excluding division
             return l;
         }

--- a/test/jdk/java/lang/Character/Latin1CaseConversion.java
+++ b/test/jdk/java/lang/Character/Latin1CaseConversion.java
@@ -28,7 +28,7 @@ import static org.testng.Assert.fail;
 
 /**
  * @test
- * @summary Provides exchaustive verification of Character.toUpperCase and Character.toLowerCase
+ * @summary Provides exhaustive verification of Character.toUpperCase and Character.toLowerCase
  * for all code points in the latin1 range 0-255.
  * @run testng Latin1CaseConversion
  */

--- a/test/jdk/java/lang/Character/Latin1CaseConversion.java
+++ b/test/jdk/java/lang/Character/Latin1CaseConversion.java
@@ -28,6 +28,7 @@ import static org.testng.Assert.fail;
 
 /**
  * @test
+ * @bug 8302877
  * @summary Provides exhaustive verification of Character.toUpperCase and Character.toLowerCase
  * for all code points in the latin1 range 0-255.
  * @run testng Latin1CaseConversion

--- a/test/jdk/java/lang/Character/Latin1CaseConversion.java
+++ b/test/jdk/java/lang/Character/Latin1CaseConversion.java
@@ -30,12 +30,12 @@ import static org.testng.Assert.fail;
  * @test
  * @summary Provides exchaustive verification of Character.toUpperCase and Character.toLowerCase
  * for all code points in the latin1 range 0-255.
- * @run testng Latin1CaseFolding
+ * @run testng Latin1CaseConversion
  */
-public class Latin1CaseFolding {
+public class Latin1CaseConversion {
 
     @Test
-    public void shouldCaseFoldLatin1() {
+    public void shouldUpperCaseAndLowerCaseLatin1() {
         for (int c = 0; c < 256; c++) {
             int upper = Character.toUpperCase(c);
             int lower = Character.toLowerCase(c);
@@ -50,9 +50,9 @@ public class Latin1CaseFolding {
             } else if (c <= 0x7A) { // a-z
                 assertEquals(upper, c - 32);
                 assertEquals(lower, c);
-            } else if (c < 0xB5) { // Between z and my
+            } else if (c < 0xB5) { // Between z and Micro Sign
                 assertUnchanged(upper, lower, c);
-            } else if (c == 0xB5) { // Special case for my
+            } else if (c == 0xB5) { // Special case for Micro Sign
                 assertEquals(upper, 0x39C);
                 assertEquals(lower, c);
             } else if (c < 0xC0) { // Between my and A-grave

--- a/test/jdk/java/lang/Character/Latin1CaseFolding.java
+++ b/test/jdk/java/lang/Character/Latin1CaseFolding.java
@@ -45,19 +45,19 @@ public class Latin1CaseFolding {
             } else if (c <= 0x5A) { // A-Z
                 assertEquals(upper, c);
                 assertEquals(lower, c + 32);
-            }  else if (c < 0x61) { // Between Z and a
+            } else if (c < 0x61) { // Between Z and a
                 assertUnchanged(upper, lower, c);
-            }  else if (c <= 0x7A) { // a-z
+            } else if (c <= 0x7A) { // a-z
                 assertEquals(upper, c - 32);
                 assertEquals(lower, c);
-            }  else if (c < 0xB5) { // Between z and my
+            } else if (c < 0xB5) { // Between z and my
                 assertUnchanged(upper, lower, c);
             } else if (c == 0xB5) { // Special case for my
                 assertEquals(upper, 0x39C);
                 assertEquals(lower, c);
             } else if (c < 0xC0) { // Between my and A-grave
                 assertUnchanged(upper, lower, c);
-            }  else if (c < 0xD7) { // A-grave - O with Diaeresis
+            } else if (c < 0xD7) { // A-grave - O with Diaeresis
                 assertEquals(upper, c);
                 assertEquals(lower, c + 32);
             } else if (c == 0xD7) { // Multiplication
@@ -72,7 +72,7 @@ public class Latin1CaseFolding {
                 assertEquals(lower, c);
             } else if (c == 0xF7) { // Division
                 assertUnchanged(upper, lower, c);
-            }  else if (c < 0xFF) { // o with slash - thorn
+            } else if (c < 0xFF) { // o with slash - thorn
                 assertEquals(upper, c - 32);
                 assertEquals(lower, c);
             } else if (c == 0XFF) { // Special case for y with Diaeresis

--- a/test/jdk/java/lang/Character/Latin1CaseFolding.java
+++ b/test/jdk/java/lang/Character/Latin1CaseFolding.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+/**
+ * @test
+ * @summary Provides exchaustive verification of Character.toUpperCase and Character.toLowerCase
+ * for all code points in the latin1 range 0-255.
+ * @run testng Latin1CaseFolding
+ */
+public class Latin1CaseFolding {
+
+    @Test
+    public void shouldCaseFoldLatin1() {
+        for (int c = 0; c < 256; c++) {
+            int upper = Character.toUpperCase(c);
+            int lower = Character.toLowerCase(c);
+
+            if (c < 0x41) { // Before A
+                assertUnchanged(upper, lower, c);
+            } else if (c <= 0x5A) { // A-Z
+                assertEquals(upper, c);
+                assertEquals(lower, c + 32);
+            }  else if (c < 0x61) { // Between Z and a
+                assertUnchanged(upper, lower, c);
+            }  else if (c <= 0x7A) { // a-z
+                assertEquals(upper, c - 32);
+                assertEquals(lower, c);
+            }  else if (c < 0xB5) { // Between z and my
+                assertUnchanged(upper, lower, c);
+            } else if (c == 0xB5) { // Special case for my
+                assertEquals(upper, 0x39C);
+                assertEquals(lower, c);
+            } else if (c < 0xC0) { // Between my and A-grave
+                assertUnchanged(upper, lower, c);
+            }  else if (c < 0xD7) { // A-grave - O with Diaeresis
+                assertEquals(upper, c);
+                assertEquals(lower, c + 32);
+            } else if (c == 0xD7) { // Multiplication
+                assertUnchanged(upper, lower, c);
+            } else if (c <= 0xDE) { // O with slash - Thorn
+                assertEquals(upper, c);
+                assertEquals(lower, c + 32);
+            } else if (c == 0xDF) { // Sharp s
+                assertUnchanged(upper, lower, c);
+            } else if (c < 0xF7) { // a-grave - divsion
+                assertEquals(upper, c - 32);
+                assertEquals(lower, c);
+            } else if (c == 0xF7) { // Division
+                assertUnchanged(upper, lower, c);
+            }  else if (c < 0xFF) { // o with slash - thorn
+                assertEquals(upper, c - 32);
+                assertEquals(lower, c);
+            } else if (c == 0XFF) { // Special case for y with Diaeresis
+                assertEquals(upper, 0x178);
+                assertEquals(lower, c);
+            } else {
+                fail("Uncovered code point: " + Integer.toHexString(c));
+            }
+        }
+    }
+
+    private static void assertUnchanged(int upper, int lower, int c) {
+        assertEquals(upper, c);
+        assertEquals(lower, c);
+    }
+}

--- a/test/jdk/sun/text/resources/LocaleData
+++ b/test/jdk/sun/text/resources/LocaleData
@@ -2230,7 +2230,7 @@ FormatData/ar_YE/NumberElements/8=\u2030
 FormatData/ar_YE/NumberElements/9=\u221e
 FormatData/ar_YE/NumberElements/10=\ufffd
 
-# bug #4113654 (this is obviously not an exchaustive test; I'm trying it here for a single
+# bug #4113654 (this is obviously not an exhaustive test; I'm trying it here for a single
 # inheritance chain only.  This bug fix also gets tested fairly well by the tests for all
 # the other bugs as given above)
 FormatData//NumberPatterns/0=#,##0.###;-#,##0.###

--- a/test/jdk/sun/text/resources/LocaleData.cldr
+++ b/test/jdk/sun/text/resources/LocaleData.cldr
@@ -2185,7 +2185,7 @@ FormatData/ar_YE/arab.NumberElements/8=\u0609
 FormatData/ar_YE/arab.NumberElements/9=\u221e
 FormatData/ar_YE/arab.NumberElements/10=\u0644\u064a\u0633\u00a0\u0631\u0642\u0645
 
-# bug #4113654 (this is obviously not an exchaustive test; I'm trying it here for a single
+# bug #4113654 (this is obviously not an exhaustive test; I'm trying it here for a single
 # inheritance chain only.  This bug fix also gets tested fairly well by the tests for all
 # the other bugs as given above)
 FormatData//latn.NumberPatterns/0=#,##0.###

--- a/test/micro/org/openjdk/bench/java/lang/Characters.java
+++ b/test/micro/org/openjdk/bench/java/lang/Characters.java
@@ -89,7 +89,7 @@ public class Characters {
     @Warmup(iterations = 5, time = 1)
     @Measurement(iterations = 5, time = 1)
     @Fork(3)
-    public static class Latin1CaseConversions {
+    public static class CaseConversions {
         @Param({
                 "low",     // 0x09 pre A
                 "A",       // 0x41 uppercase A

--- a/test/micro/org/openjdk/bench/java/lang/Characters.java
+++ b/test/micro/org/openjdk/bench/java/lang/Characters.java
@@ -112,7 +112,7 @@ public class Characters {
                 case "a-grave" -> 0xE0;
                 case "yD"      -> 0xE0;
                 case "micro"   -> 0xFF;
-                default -> throw new IllegalArgumentException("Unknown character: " + codePoint);
+                default -> Integer.parseInt(codePoint);;
             };
         }
         @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/Characters.java
+++ b/test/micro/org/openjdk/bench/java/lang/Characters.java
@@ -91,13 +91,13 @@ public class Characters {
     @Fork(3)
     public static class Latin1CaseConversions {
         @Param({
-                "low",   // 0x09 pre A
-                "A",  // 0x41 uppercase A
-                "a",  // 0x61 lowercase a
+                "low",     // 0x09 pre A
+                "A",       // 0x41 uppercase A
+                "a",       // 0x61 lowercase a
                 "A-grave", // 0xC0 uppercase A-grave
                 "a-grave", // 0xE0 lowercase a-grave
-                "micro", // 0xB5 lowercase 'Micro Sign'
-                "yD" // 0xFF lowercase 'y with Diaeresis'
+                "micro",   // 0xB5 lowercase 'Micro Sign'
+                "yD"       // 0xFF lowercase 'y with Diaeresis'
         })
         private String codePoint;
         private int cp;
@@ -105,13 +105,13 @@ public class Characters {
         @Setup(Level.Trial)
         public void setup() {
             cp = switch (codePoint) {
-                case "low" -> 0x09;
-                case "A" -> 0x41;
-                case "a" -> 0x61;
+                case "low"     -> 0x09;
+                case "A"       -> 0x41;
+                case "a"       -> 0x61;
                 case "A-grave" -> 0xC0;
                 case "a-grave" -> 0xE0;
-                case "yD" -> 0xE0;
-                case "micro" -> 0xFF;
+                case "yD"      -> 0xE0;
+                case "micro"   -> 0xFF;
                 default -> throw new IllegalArgumentException("Unknown character: " + codePoint);
             };
         }

--- a/test/micro/org/openjdk/bench/java/lang/Characters.java
+++ b/test/micro/org/openjdk/bench/java/lang/Characters.java
@@ -89,14 +89,14 @@ public class Characters {
     @Warmup(iterations = 5, time = 1)
     @Measurement(iterations = 5, time = 1)
     @Fork(3)
-    public static class Latin1CaseFolding {
+    public static class Latin1CaseConversions {
         @Param({
                 "low",   // 0x09 pre A
                 "A",  // 0x41 uppercase A
                 "a",  // 0x61 lowercase a
                 "A-grave", // 0xC0 uppercase A-grave
                 "a-grave", // 0xE0 lowercase a-grave
-                "mu", // 0xB5 lowercase 'my'
+                "micro", // 0xB5 lowercase 'Micro Sign'
                 "yD" // 0xFF lowercase 'y with Diaeresis'
         })
         private String codePoint;
@@ -111,7 +111,7 @@ public class Characters {
                 case "A-grave" -> 0xC0;
                 case "a-grave" -> 0xE0;
                 case "yD" -> 0xE0;
-                case "mu" -> 0xFF;
+                case "micro" -> 0xFF;
                 default -> throw new IllegalArgumentException("Unknown character: " + codePoint);
             };
         }


### PR DESCRIPTION
This PR suggests we speed up Character.toUpperCase and Character.toLowerCase for latin1 code points by applying the 'oldest ASCII trick in the book'.

This takes advantage of the fact that latin1 uppercase code points are always 0x20 lower than their lowercase (with the exception of two code points which uppercase out of latin1).

To verify the correctness of the new implementation, the test `Latin1CaseConversion` is added with an exhaustive verification of toUpperCase/toLowerCase for all latin1 code points.

The implementation needs to balance the performance of the various ranges in latin1. An effort has been made to favour operations on ASCII code points, without causing excessive regression for higher code points.

Performance is benchmarked for 7 chosen sample code points, each representing a range or a special-case.  Results in the first comment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302877](https://bugs.openjdk.org/browse/JDK-8302877): Speed up latin1 case conversions


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to [70c624d7](https://git.openjdk.org/jdk/pull/12623/files/70c624d7d95a431ff2eb48f9d54b3aacb8f2ce02)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12623/head:pull/12623` \
`$ git checkout pull/12623`

Update a local copy of the PR: \
`$ git checkout pull/12623` \
`$ git pull https://git.openjdk.org/jdk pull/12623/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12623`

View PR using the GUI difftool: \
`$ git pr show -t 12623`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12623.diff">https://git.openjdk.org/jdk/pull/12623.diff</a>

</details>
