### PR TITLE
8302783: Improve CRC32C intrinsic with crypto pmull on AArch64

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -3968,6 +3968,64 @@ void MacroAssembler::kernel_crc32(Register crc, Register buf, Register len,
     mvnw(crc, crc);
 }
 
+void MacroAssembler::kernel_crc32c_using_crypto_pmull(Register crc, Register buf,
+        Register len, Register tmp0, Register tmp1, Register tmp2, Register tmp3) {
+    Label CRC_by4_loop, CRC_by1_loop, CRC_less128, CRC_by128_pre, CRC_by32_loop, CRC_less32, L_exit;
+    assert_different_registers(crc, buf, len, tmp0, tmp1, tmp2);
+
+    subs(tmp0, len, 384);
+    br(Assembler::GE, CRC_by128_pre);
+  BIND(CRC_less128);
+    subs(len, len, 32);
+    br(Assembler::GE, CRC_by32_loop);
+  BIND(CRC_less32);
+    adds(len, len, 32 - 4);
+    br(Assembler::GE, CRC_by4_loop);
+    adds(len, len, 4);
+    br(Assembler::GT, CRC_by1_loop);
+    b(L_exit);
+
+  BIND(CRC_by32_loop);
+    ldp(tmp0, tmp1, Address(buf));
+    crc32cx(crc, crc, tmp0);
+    ldr(tmp2, Address(buf, 16));
+    crc32cx(crc, crc, tmp1);
+    ldr(tmp3, Address(buf, 24));
+    crc32cx(crc, crc, tmp2);
+    add(buf, buf, 32);
+    subs(len, len, 32);
+    crc32cx(crc, crc, tmp3);
+    br(Assembler::GE, CRC_by32_loop);
+    cmn(len, (u1)32);
+    br(Assembler::NE, CRC_less32);
+    b(L_exit);
+
+  BIND(CRC_by4_loop);
+    ldrw(tmp0, Address(post(buf, 4)));
+    subs(len, len, 4);
+    crc32cw(crc, crc, tmp0);
+    br(Assembler::GE, CRC_by4_loop);
+    adds(len, len, 4);
+    br(Assembler::LE, L_exit);
+  BIND(CRC_by1_loop);
+    ldrb(tmp0, Address(post(buf, 1)));
+    subs(len, len, 1);
+    crc32cb(crc, crc, tmp0);
+    br(Assembler::GT, CRC_by1_loop);
+    b(L_exit);
+
+  BIND(CRC_by128_pre);
+    kernel_crc32_common_fold_using_crypto_pmull(crc, buf, len, tmp0, tmp1, tmp2,
+      4*256*sizeof(juint) + 8*sizeof(juint) + 0x50);
+    mov(crc, 0);
+    crc32cx(crc, crc, tmp0);
+    crc32cx(crc, crc, tmp1);
+
+    cbnz(len, CRC_less128);
+
+  BIND(L_exit);
+}
+
 void MacroAssembler::kernel_crc32c_using_crc32c(Register crc, Register buf,
         Register len, Register tmp0, Register tmp1, Register tmp2,
         Register tmp3) {
@@ -4074,7 +4132,11 @@ void MacroAssembler::kernel_crc32c_using_crc32c(Register crc, Register buf,
 void MacroAssembler::kernel_crc32c(Register crc, Register buf, Register len,
         Register table0, Register table1, Register table2, Register table3,
         Register tmp, Register tmp2, Register tmp3) {
-  kernel_crc32c_using_crc32c(crc, buf, len, table0, table1, table2, table3);
+  if (UseCryptoPmullForCRC32) {
+    kernel_crc32c_using_crypto_pmull(crc, buf, len, table0, table1, table2, table3);
+  } else {
+    kernel_crc32c_using_crc32c(crc, buf, len, table0, table1, table2, table3);
+  }
 }
 
 void MacroAssembler::kernel_crc32_common_fold_using_crypto_pmull(Register crc, Register buf,

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1428,6 +1428,9 @@ public:
   void kernel_crc32_using_crc32(Register crc, Register buf,
         Register len, Register tmp0, Register tmp1, Register tmp2,
         Register tmp3);
+  void kernel_crc32c_using_crypto_pmull(Register crc, Register buf,
+        Register len, Register tmp0, Register tmp1, Register tmp2,
+        Register tmp3);
   void kernel_crc32c_using_crc32c(Register crc, Register buf,
         Register len, Register tmp0, Register tmp1, Register tmp2,
         Register tmp3);

--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.cpp
@@ -302,6 +302,18 @@ ATTRIBUTE_ALIGNED(4096) juint StubRoutines::aarch64::_crc_table[] =
     0x5a546366UL, 0x00000001UL,
     0x751997d0UL, 0x00000001UL,
     0xccaa009eUL, 0x00000000UL,
+
+    // Constants for CRC-32C crypto pmull implementation
+    0x6992cea2UL, 0x00000000UL,
+    0x0d3b6092UL, 0x00000000UL,
+    0x740eef02UL, 0x00000000UL,
+    0x9e4addf8UL, 0x00000000UL,
+    0x1c291d04UL, 0x00000000UL,
+    0xd82c63daUL, 0x00000001UL,
+    0x384aa63aUL, 0x00000001UL,
+    0xba4fc28eUL, 0x00000000UL,
+    0xf20c0dfeUL, 0x00000000UL,
+    0x4cd00bd6UL, 0x00000001UL,
 };
 
 // Accumulation coefficients for adler32 upper 16 bits


### PR DESCRIPTION
This change adds a pmull-based CRC32C intrinsic, and it is more performant than the existing crc32c-instruction-based intrinsic on Neoverse V1. The benchmark shows 10 - 99% improvement. The improvement comes from the execution throughput increase of pmull/pmull2 from 1 on Neoverse N1 to 4 on Neoverse V1 while the latency remains 2 while the throughput of CRC32C instructions did not changed. 

The pmull-based CRC32C intrinsic is enabled by the existing option UseCryptoPmullForCRC32 which also enables the pmull-based CRC32 intrinsic. The option requires crc32c instructions, eor3 in SHA3, and 64-bit pmull/pmull2 in Cryptographic Extension.

With this change, there will be only two different CRC32C intrinsics, crc32c and pmull, while there are four CRC32 intrinsics.

The following test has passed.
test/hotspot/jtreg/compiler/intrinsics/zip/TestCRC32C.java

The throughput reported by [the micro benchmark](https://github.com/openjdk/jdk/blob/master/test/micro/org/openjdk/bench/java/util/TestCRC32C.java) is measured on an EC2 c7g instance. The optimization shows 10 - 99% improvement when the input is at least 384 bytes.

| input               | 64         | 128        | 256        | 384        | 511        | 512        | 1,024      |
| ------------- | ---------- | ---------- | ---------- | ---------- | ---------- | ---------- | ---------- |
|  improvement  | 1.60%      | 0.00%      | 0.00%      | 15.24%     | 10.76%     | 34.32%     | 72.39%     |

| input               | 2,048      | 4,096      | 8,192      | 16,384     | 32,768     | 65,536     |
| ------------- | ---------- | ---------- | ---------- | ---------- | ---------- | ---------- |
|  improvement  | 84.96%     | 92.59%     | 96.19%     | 98.02%     | 99.32%     | 98.36%     |


Baseline
```
Benchmark                    (count)   Mode  Cnt       Score      Error   Units
TestCRC32C.testCRC32CUpdate       64  thrpt   12  196575.739 ± 1824.113  ops/ms
TestCRC32C.testCRC32CUpdate      128  thrpt   12  123666.570 ±    2.730  ops/ms
TestCRC32C.testCRC32CUpdate      256  thrpt   12   70188.989 ±    2.002  ops/ms
TestCRC32C.testCRC32CUpdate      384  thrpt   12   49000.690 ±    1.421  ops/ms
TestCRC32C.testCRC32CUpdate      511  thrpt   12   34106.279 ±   25.390  ops/ms
TestCRC32C.testCRC32CUpdate      512  thrpt   12   37638.349 ±    1.039  ops/ms
TestCRC32C.testCRC32CUpdate     1024  thrpt   12   19526.513 ±    0.439  ops/ms
TestCRC32C.testCRC32CUpdate     2048  thrpt   12    9951.392 ±    4.803  ops/ms
TestCRC32C.testCRC32CUpdate     4096  thrpt   12    5023.268 ±    0.240  ops/ms
TestCRC32C.testCRC32CUpdate     8192  thrpt   12    2523.877 ±    0.062  ops/ms
TestCRC32C.testCRC32CUpdate    16384  thrpt   12    1265.011 ±    0.047  ops/ms
TestCRC32C.testCRC32CUpdate    32768  thrpt   12     632.291 ±    0.058  ops/ms
TestCRC32C.testCRC32CUpdate    65536  thrpt   12     315.396 ±    0.160  ops/ms
```

Crypto pmull
```
Benchmark                    (count)   Mode  Cnt       Score     Error   Units
TestCRC32C.testCRC32CUpdate       64  thrpt   12  199726.599 ± 166.477  ops/ms
TestCRC32C.testCRC32CUpdate      128  thrpt   12  123669.385 ±   1.821  ops/ms
TestCRC32C.testCRC32CUpdate      256  thrpt   12   70188.727 ±   1.313  ops/ms
TestCRC32C.testCRC32CUpdate      384  thrpt   12   56468.837 ±  76.524  ops/ms
TestCRC32C.testCRC32CUpdate      511  thrpt   12   37777.205 ± 406.431  ops/ms
TestCRC32C.testCRC32CUpdate      512  thrpt   12   50554.555 ±  17.169  ops/ms
TestCRC32C.testCRC32CUpdate     1024  thrpt   12   33661.006 ± 140.471  ops/ms
TestCRC32C.testCRC32CUpdate     2048  thrpt   12   18406.482 ± 205.952  ops/ms
TestCRC32C.testCRC32CUpdate     4096  thrpt   12    9674.159 ±  20.390  ops/ms
TestCRC32C.testCRC32CUpdate     8192  thrpt   12    4951.562 ±   6.566  ops/ms
TestCRC32C.testCRC32CUpdate    16384  thrpt   12    2504.970 ±   1.883  ops/ms
TestCRC32C.testCRC32CUpdate    32768  thrpt   12    1260.278 ±   0.484  ops/ms
TestCRC32C.testCRC32CUpdate    65536  thrpt   12     625.608 ±   0.300  ops/ms
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302783](https://bugs.openjdk.org/browse/JDK-8302783): Improve CRC32C intrinsic with crypto pmull on AArch64


### Reviewers
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12624/head:pull/12624` \
`$ git checkout pull/12624`

Update a local copy of the PR: \
`$ git checkout pull/12624` \
`$ git pull https://git.openjdk.org/jdk pull/12624/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12624`

View PR using the GUI difftool: \
`$ git pr show -t 12624`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12624.diff">https://git.openjdk.org/jdk/pull/12624.diff</a>

</details>
