### PR TITLE
8302789: (fs) Files.copy should include unsupported copy option in exception message

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -474,7 +474,7 @@ abstract class UnixFileSystem
                 }
                 if (option == null)
                     throw new NullPointerException();
-                throw new UnsupportedOperationException("Unsupported copy option");
+                throw new UnsupportedOperationException("Unsupported copy option: " + option);
             }
             return flags;
         }
@@ -496,7 +496,7 @@ abstract class UnixFileSystem
                 }
                 if (option == null)
                     throw new NullPointerException();
-                throw new UnsupportedOperationException("Unsupported copy option");
+                throw new UnsupportedOperationException("Unsupported option: " + option);
             }
 
             // a move requires that all attributes be copied but only fail if

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileCopy.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileCopy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -301,7 +301,7 @@ class WindowsFileCopy {
                 continue;
             }
             if (option == null) throw new NullPointerException();
-            throw new UnsupportedOperationException("Unsupported move option: " + option);
+            throw new UnsupportedOperationException("Unsupported option: " + option);
         }
 
         @SuppressWarnings("removal")

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileCopy.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileCopy.java
@@ -81,7 +81,7 @@ class WindowsFileCopy {
             }
             if (option == null)
                 throw new NullPointerException();
-            throw new UnsupportedOperationException("Unsupported copy option");
+            throw new UnsupportedOperationException("Unsupported copy option: " + option);
         }
 
         // check permissions. If the source file is a symbolic link then
@@ -301,7 +301,7 @@ class WindowsFileCopy {
                 continue;
             }
             if (option == null) throw new NullPointerException();
-            throw new UnsupportedOperationException("Unsupported copy option");
+            throw new UnsupportedOperationException("Unsupported move option: " + option);
         }
 
         @SuppressWarnings("removal")


### PR DESCRIPTION
This PR also adds the names of unsupported copy options to the the exception message for "Files::move" methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302789](https://bugs.openjdk.org/browse/JDK-8302789): (fs) Files.copy should include unsupported copy option in exception message


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12625/head:pull/12625` \
`$ git checkout pull/12625`

Update a local copy of the PR: \
`$ git checkout pull/12625` \
`$ git pull https://git.openjdk.org/jdk pull/12625/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12625`

View PR using the GUI difftool: \
`$ git pr show -t 12625`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12625.diff">https://git.openjdk.org/jdk/pull/12625.diff</a>

</details>
