### PR TITLE
8014021: TreeMaker.Params behaves inconsistently when the owning method has the same number of parameters as the number of parameter types requested

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
@@ -1378,7 +1378,7 @@ public class TypeEnter implements Completer {
 
         @Override
         public List<Name> superArgs() {
-            List<JCVariableDecl> params = make.Params(constructorSymbol(), constructorType().getParameterTypes());
+            List<JCVariableDecl> params = make.Params(constructorSymbol());
             if (!enclosingType().hasTag(NONE)) {
                 params = params.tail;
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
@@ -1378,7 +1378,7 @@ public class TypeEnter implements Completer {
 
         @Override
         public List<Name> superArgs() {
-            List<JCVariableDecl> params = make.Params(constructorType().getParameterTypes(), constructorSymbol());
+            List<JCVariableDecl> params = make.Params(constructorSymbol(), constructorType().getParameterTypes());
             if (!enclosingType().hasTag(NONE)) {
                 params = params.tail;
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
@@ -1035,7 +1035,7 @@ public class TreeMaker implements JCTree.Factory {
                 m.name != names.init ? Type(mtype.getReturnType()) : null,
                 TypeParams(mtype.getTypeArguments()),
                 null, // receiver type
-                Params(mtype.getParameterTypes(), m),
+                Params(m, mtype.getParameterTypes()),
                 Types(mtype.getThrownTypes()),
                 body,
                 null,
@@ -1064,19 +1064,20 @@ public class TreeMaker implements JCTree.Factory {
         return VarDef(new VarSymbol(PARAMETER, name, argtype, owner), null);
     }
 
-    /** Create a list of value parameter trees x0, ..., xn from a list of
-     *  their types and their owner.
+    /** Create a list of value parameter trees for a method's parameters.
+     *  If the method has parameter names defined, use those same symbols,
+     *  otherwse create placeholders x0, x1, ..., xn.
      */
-    public List<JCVariableDecl> Params(List<Type> argtypes, Symbol owner) {
+    public List<JCVariableDecl> Params(MethodSymbol mth, List<Type> argtypes) {
         ListBuffer<JCVariableDecl> params = new ListBuffer<>();
-        MethodSymbol mth = (owner.kind == MTH) ? ((MethodSymbol)owner) : null;
-        if (mth != null && mth.params != null && argtypes.length() == mth.params.length()) {
-            for (VarSymbol param : ((MethodSymbol)owner).params)
+        if (mth.params != null) {
+            Assert.check(argtypes.length() == mth.params.length());
+            for (VarSymbol param : mth.params)
                 params.append(VarDef(param, null));
         } else {
             int i = 0;
             for (List<Type> l = argtypes; l.nonEmpty(); l = l.tail)
-                params.append(Param(paramName(i++), l.head, owner));
+                params.append(Param(paramName(i++), l.head, mth));
         }
         return params.toList();
     }


### PR DESCRIPTION
The method `TreeMaker.Params` has what appears to be strange behavior: normally it creates parameters of the types passed in. However, if the given owner is a method, and the method happens to have the same number of parameters as the number of parameters requested, then the types of the owner method's parameters are used instead. This is weird and confusing.

What's really going on is that a method owner is _always_ being passed in, and when that method has parameters defined, there are _always_ exactly as many of them as there are types provided.

So what this method is really doing is just reusing the same symbols for the methods parameters if the method has them defined, otherwise creating the same number of placeholder parameters `x0`, `x1`, `x2`, etc.

This patch refactors this method and clarifies its usage to eliminate the confusion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8014021](https://bugs.openjdk.org/browse/JDK-8014021): TreeMaker.Params behaves inconsistently when the owning method has the same number of parameters as the number of parameter types requested


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12627/head:pull/12627` \
`$ git checkout pull/12627`

Update a local copy of the PR: \
`$ git checkout pull/12627` \
`$ git pull https://git.openjdk.org/jdk pull/12627/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12627`

View PR using the GUI difftool: \
`$ git pr show -t 12627`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12627.diff">https://git.openjdk.org/jdk/pull/12627.diff</a>

</details>
