### PR TITLE
8302781: CDS archive heap not reproducible after JDK-8296344

### DIFF
--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -286,6 +286,11 @@ bool HeapShared::archive_object(oop obj) {
     count_allocation(obj->size());
     ArchiveHeapWriter::add_source_obj(obj);
 
+    // The archived objects are discovered in a predictable order. Compute
+    // their identity_hash() as soon as we see them. This ensure that the
+    // the identity_hash in the object header will have a predictable value,
+    // making the archive reproducible.
+    obj->identity_hash();
     CachedOopInfo info = make_cached_oop_info();
     archived_object_cache()->put(obj, info);
     mark_native_pointers(obj);

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -287,7 +287,7 @@ bool HeapShared::archive_object(oop obj) {
     ArchiveHeapWriter::add_source_obj(obj);
 
     // The archived objects are discovered in a predictable order. Compute
-    // their identity_hash() as soon as we see them. This ensure that the
+    // their identity_hash() as soon as we see them. This ensures that the
     // the identity_hash in the object header will have a predictable value,
     // making the archive reproducible.
     obj->identity_hash();


### PR DESCRIPTION
[JDK-8296344](https://bugs.openjdk.org/browse/JDK-8296344) changed the order of when `oopDesc::identity_hash()` is called for the archived heap object.

This one-liner fix restores the order, so that we initialize the `identity_hash` part of the archived object headers predictably.

Please see [my comment in the JBS report](https://bugs.openjdk.org/browse/JDK-8302781?focusedCommentId=14561163&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14561163) for details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302781](https://bugs.openjdk.org/browse/JDK-8302781): CDS archive heap not reproducible after JDK-8296344


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to [0eb32cf9](https://git.openjdk.org/jdk/pull/12628/files/0eb32cf9670f4f7f53c83c2a7ac9fb6f9b445e79)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12628/head:pull/12628` \
`$ git checkout pull/12628`

Update a local copy of the PR: \
`$ git checkout pull/12628` \
`$ git pull https://git.openjdk.org/jdk pull/12628/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12628`

View PR using the GUI difftool: \
`$ git pr show -t 12628`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12628.diff">https://git.openjdk.org/jdk/pull/12628.diff</a>

</details>
