### PR TITLE
JDK-8302811: NMT.random_reallocs_vm fails if NMT is off

### DIFF
--- a/test/hotspot/gtest/nmt/test_nmt_cornercases.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_cornercases.cpp
@@ -104,7 +104,9 @@ static void* do_realloc(void* p, size_t old_size, size_t new_size, uint8_t old_c
   if (old_size < new_size) {
     GtestUtils::check_range((char*)p2, old_size, old_content);
 #ifdef ASSERT
-    GtestUtils::check_range((char*)p2 + old_size, new_size - old_size, uninitBlockPad);
+    if (MemTracker::enabled()) {
+      GtestUtils::check_range((char*)p2 + old_size, new_size - old_size, uninitBlockPad);
+    }
 #endif
   } else {
     GtestUtils::check_range((char*)p2, new_size, old_content);


### PR DESCRIPTION
Trivial patch to fix a test error.

The test checks, among other things, that reallocated-grown buffers get their newly added space zapped by hotspot in debug builds.

However, hotspot can only zap if NMT is enabled. With NMT disabled, it lacks the necessary information to do so.

Note that this bug had been hidden by [JDK-8302810](https://bugs.openjdk.org/browse/JDK-8302810).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302811](https://bugs.openjdk.org/browse/JDK-8302811): NMT.random_reallocs_vm fails if NMT is off


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - Committer)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12630/head:pull/12630` \
`$ git checkout pull/12630`

Update a local copy of the PR: \
`$ git checkout pull/12630` \
`$ git pull https://git.openjdk.org/jdk pull/12630/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12630`

View PR using the GUI difftool: \
`$ git pr show -t 12630`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12630.diff">https://git.openjdk.org/jdk/pull/12630.diff</a>

</details>
