### PR TITLE
JDK-8302812: JDK-8302455 broke ClassLoaderStatsTest on 32-bit

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/vm/ClassLoaderStatsTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/ClassLoaderStatsTest.java
@@ -36,6 +36,7 @@
  * @test
  * @summary Test of diagnostic command VM.classloader_stats (-UseCCP)
  * @library /test/lib
+ * @requires vm.bits != "32"
  * @modules java.base/jdk.internal.misc
  *          java.compiler
  *          java.management


### PR DESCRIPTION
Trivial fix for a trivial problem. CCS=off variant of test needs to be excluded on 32-bit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302812](https://bugs.openjdk.org/browse/JDK-8302812): JDK-8302455 broke ClassLoaderStatsTest on 32-bit


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12631/head:pull/12631` \
`$ git checkout pull/12631`

Update a local copy of the PR: \
`$ git checkout pull/12631` \
`$ git pull https://git.openjdk.org/jdk pull/12631/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12631`

View PR using the GUI difftool: \
`$ git pr show -t 12631`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12631.diff">https://git.openjdk.org/jdk/pull/12631.diff</a>

</details>
