### PR TITLE
8302815 Use new Math.clamp method in core libraries

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -308,8 +308,8 @@ public class ObjectInputStream
          * The maximum number of interfaces allowed for a proxy is limited to 65535 by
          * {@link java.lang.reflect.Proxy#newProxyInstance(ClassLoader, Class[], InvocationHandler)}.
          */
-        static final int PROXY_INTERFACE_LIMIT = Math.max(0, Math.min(65535, GetIntegerAction
-                .privilegedGetProperty("jdk.serialProxyInterfaceLimit", 65535)));
+        static final int PROXY_INTERFACE_LIMIT = Math.clamp(GetIntegerAction
+                .privilegedGetProperty("jdk.serialProxyInterfaceLimit", 65535), 0, 65535);
     }
 
     /*

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -3649,13 +3649,11 @@ public class DecimalFormat extends NumberFormat {
      */
     @Override
     public void setMaximumIntegerDigits(int newValue) {
-        maximumIntegerDigits = Math.min(Math.max(0, newValue), MAXIMUM_INTEGER_DIGITS);
-        super.setMaximumIntegerDigits((maximumIntegerDigits > DOUBLE_INTEGER_DIGITS) ?
-            DOUBLE_INTEGER_DIGITS : maximumIntegerDigits);
+        maximumIntegerDigits = Math.clamp(newValue, 0, MAXIMUM_INTEGER_DIGITS);
+        super.setMaximumIntegerDigits(Math.min(maximumIntegerDigits, DOUBLE_INTEGER_DIGITS));
         if (minimumIntegerDigits > maximumIntegerDigits) {
             minimumIntegerDigits = maximumIntegerDigits;
-            super.setMinimumIntegerDigits((minimumIntegerDigits > DOUBLE_INTEGER_DIGITS) ?
-                DOUBLE_INTEGER_DIGITS : minimumIntegerDigits);
+            super.setMinimumIntegerDigits(Math.min(minimumIntegerDigits, DOUBLE_INTEGER_DIGITS));
         }
         fastPathCheckNeeded = true;
     }
@@ -3670,13 +3668,11 @@ public class DecimalFormat extends NumberFormat {
      */
     @Override
     public void setMinimumIntegerDigits(int newValue) {
-        minimumIntegerDigits = Math.min(Math.max(0, newValue), MAXIMUM_INTEGER_DIGITS);
-        super.setMinimumIntegerDigits((minimumIntegerDigits > DOUBLE_INTEGER_DIGITS) ?
-            DOUBLE_INTEGER_DIGITS : minimumIntegerDigits);
+        minimumIntegerDigits = Math.clamp(newValue, 0, MAXIMUM_INTEGER_DIGITS);
+        super.setMinimumIntegerDigits(Math.min(minimumIntegerDigits, DOUBLE_INTEGER_DIGITS));
         if (minimumIntegerDigits > maximumIntegerDigits) {
             maximumIntegerDigits = minimumIntegerDigits;
-            super.setMaximumIntegerDigits((maximumIntegerDigits > DOUBLE_INTEGER_DIGITS) ?
-                DOUBLE_INTEGER_DIGITS : maximumIntegerDigits);
+            super.setMaximumIntegerDigits(Math.min(maximumIntegerDigits, DOUBLE_INTEGER_DIGITS));
         }
         fastPathCheckNeeded = true;
     }
@@ -3691,13 +3687,11 @@ public class DecimalFormat extends NumberFormat {
      */
     @Override
     public void setMaximumFractionDigits(int newValue) {
-        maximumFractionDigits = Math.min(Math.max(0, newValue), MAXIMUM_FRACTION_DIGITS);
-        super.setMaximumFractionDigits((maximumFractionDigits > DOUBLE_FRACTION_DIGITS) ?
-            DOUBLE_FRACTION_DIGITS : maximumFractionDigits);
+        maximumFractionDigits = Math.clamp(newValue, 0, MAXIMUM_FRACTION_DIGITS);
+        super.setMaximumFractionDigits(Math.min(maximumFractionDigits, DOUBLE_FRACTION_DIGITS));
         if (minimumFractionDigits > maximumFractionDigits) {
             minimumFractionDigits = maximumFractionDigits;
-            super.setMinimumFractionDigits((minimumFractionDigits > DOUBLE_FRACTION_DIGITS) ?
-                DOUBLE_FRACTION_DIGITS : minimumFractionDigits);
+            super.setMinimumFractionDigits(Math.min(minimumFractionDigits, DOUBLE_FRACTION_DIGITS));
         }
         fastPathCheckNeeded = true;
     }
@@ -3712,13 +3706,11 @@ public class DecimalFormat extends NumberFormat {
      */
     @Override
     public void setMinimumFractionDigits(int newValue) {
-        minimumFractionDigits = Math.min(Math.max(0, newValue), MAXIMUM_FRACTION_DIGITS);
-        super.setMinimumFractionDigits((minimumFractionDigits > DOUBLE_FRACTION_DIGITS) ?
-            DOUBLE_FRACTION_DIGITS : minimumFractionDigits);
+        minimumFractionDigits = Math.clamp(newValue, 0, MAXIMUM_FRACTION_DIGITS);
+        super.setMinimumFractionDigits(Math.min(minimumFractionDigits, DOUBLE_FRACTION_DIGITS));
         if (minimumFractionDigits > maximumFractionDigits) {
             maximumFractionDigits = minimumFractionDigits;
-            super.setMaximumFractionDigits((maximumFractionDigits > DOUBLE_FRACTION_DIGITS) ?
-                DOUBLE_FRACTION_DIGITS : maximumFractionDigits);
+            super.setMaximumFractionDigits(Math.min(maximumFractionDigits, DOUBLE_FRACTION_DIGITS));
         }
         fastPathCheckNeeded = true;
     }

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -3572,7 +3572,7 @@ public final class DateTimeFormatterBuilder {
                     }
                 }
             } else {
-                int outputScale = Math.min(Math.max(fraction.scale(), minWidth), maxWidth);
+                int outputScale = Math.clamp(fraction.scale(), minWidth, maxWidth);
                 fraction = fraction.setScale(outputScale, RoundingMode.FLOOR);
                 if (decimalPoint) {
                     buf.append(decimalStyle.getDecimalSeparator());

--- a/src/java.base/share/classes/java/util/HashMap.java
+++ b/src/java.base/share/classes/java/util/HashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/HashMap.java
+++ b/src/java.base/share/classes/java/util/HashMap.java
@@ -1523,7 +1523,7 @@ public class HashMap<K,V> extends AbstractMap<K,V>
         if (lf <= 0 || Float.isNaN(lf))
             throw new InvalidObjectException("Illegal load factor: " + lf);
 
-        lf = Math.min(Math.max(0.25f, lf), 4.0f);
+        lf = Math.clamp(lf, 0.25f, 4.0f);
         HashMap.UnsafeHolder.putLoadFactor(this, lf);
 
         reinitialize();

--- a/src/java.base/share/classes/java/util/HashSet.java
+++ b/src/java.base/share/classes/java/util/HashSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/HashSet.java
+++ b/src/java.base/share/classes/java/util/HashSet.java
@@ -322,7 +322,7 @@ public class HashSet<E>
                                              loadFactor);
         }
         // Clamp load factor to range of 0.25...4.0.
-        loadFactor = Math.min(Math.max(0.25f, loadFactor), 4.0f);
+        loadFactor = Math.clamp(loadFactor, 0.25f, 4.0f);
 
         // Read size and verify non-negative.
         int size = s.readInt();

--- a/src/java.base/share/classes/java/util/Hashtable.java
+++ b/src/java.base/share/classes/java/util/Hashtable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/Hashtable.java
+++ b/src/java.base/share/classes/java/util/Hashtable.java
@@ -1270,7 +1270,7 @@ public class Hashtable<K,V>
         float lf = fields.get("loadFactor", 0.75f);
         if (lf <= 0 || Float.isNaN(lf))
             throw new StreamCorruptedException("Illegal load factor: " + lf);
-        lf = Math.min(Math.max(0.25f, lf), 4.0f);
+        lf = Math.clamp(lf, 0.25f, 4.0f);
 
         // Read the original length of the array and number of elements
         int origlength = s.readInt();

--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
@@ -2714,9 +2714,9 @@ public class ForkJoinPool extends AbstractExecutorService {
         this.saturate = saturate;
         this.config = asyncMode ? FIFO : 0;
         this.keepAlive = Math.max(unit.toMillis(keepAliveTime), TIMEOUT_SLOP);
-        int corep = Math.min(Math.max(corePoolSize, p), MAX_CAP);
-        int maxSpares = Math.max(0, Math.min(maximumPoolSize - p, MAX_CAP));
-        int minAvail = Math.max(0, Math.min(minimumRunnable, MAX_CAP));
+        int corep = Math.clamp(corePoolSize, p, MAX_CAP);
+        int maxSpares = Math.clamp(maximumPoolSize - p, 0, MAX_CAP);
+        int minAvail = Math.clamp(minimumRunnable, 0, MAX_CAP);
         this.bounds = (long)(minAvail & SMASK) | (long)(maxSpares << SWIDTH) |
             ((long)corep << 32);
         int size = 1 << (33 - Integer.numberOfLeadingZeros(p - 1));
@@ -2747,7 +2747,7 @@ public class ForkJoinPool extends AbstractExecutorService {
             String ms = System.getProperty
                 ("java.util.concurrent.ForkJoinPool.common.maximumSpares");
             if (ms != null)
-                maxSpares = Math.max(0, Math.min(MAX_CAP, Integer.parseInt(ms)));
+                maxSpares = Math.clamp(Integer.parseInt(ms), 0, MAX_CAP);
             String sf = System.getProperty
                 ("java.util.concurrent.ForkJoinPool.common.threadFactory");
             String sh = System.getProperty

--- a/src/java.base/share/classes/java/util/stream/SliceOps.java
+++ b/src/java.base/share/classes/java/util/stream/SliceOps.java
@@ -50,7 +50,7 @@ final class SliceOps {
      * @return the sliced size
      */
     private static long calcSize(long size, long skip, long limit) {
-        return size >= 0 ? Math.max(0, Math.min(size - skip, limit)) : -1;
+        return size >= 0 ? Math.clamp(size - skip, 0, limit) : -1;
     }
 
     /**

--- a/src/java.base/share/classes/java/util/stream/SliceOps.java
+++ b/src/java.base/share/classes/java/util/stream/SliceOps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
@@ -154,7 +154,7 @@ public class LinuxRISCV64CallArranger {
         // Aggregates or scalars passed on the stack are aligned to the greater of
         // the type alignment and XLEN bits, but never more than the stack alignment.
         void alignStack(long alignment) {
-            alignment = Utils.alignUp(Math.min(Math.max(alignment, STACK_SLOT_SIZE), 16), STACK_SLOT_SIZE);
+            alignment = Utils.alignUp(Math.clamp(alignment, STACK_SLOT_SIZE, 16), STACK_SLOT_SIZE);
             stackOffset = Utils.alignUp(stackOffset, alignment);
         }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2023, Institute of Software, Chinese Academy of Sciences.
  * All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.

--- a/src/java.base/share/classes/jdk/internal/jrtfs/JrtPath.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/JrtPath.java
@@ -870,8 +870,8 @@ final class JrtPath implements Path {
     // between first and last, inclusive
     private static long lowMask(char first, char last) {
         long m = 0;
-        int f = Math.max(Math.min(first, 63), 0);
-        int l = Math.max(Math.min(last, 63), 0);
+        int f = Math.clamp(first, 0, 63);
+        int l = Math.clamp(last, 0, 63);
         for (int i = f; i <= l; i++)
             m |= 1L << i;
         return m;
@@ -881,8 +881,8 @@ final class JrtPath implements Path {
     // between first and last, inclusive
     private static long highMask(char first, char last) {
         long m = 0;
-        int f = Math.max(Math.min(first, 127), 64) - 64;
-        int l = Math.max(Math.min(last, 127), 64) - 64;
+        int f = Math.clamp(first, 64, 127) - 64;
+        int l = Math.clamp(last, 64, 127) - 64;
         for (int i = f; i <= l; i++)
             m |= 1L << i;
         return m;

--- a/src/java.base/share/classes/jdk/internal/jrtfs/JrtPath.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/JrtPath.java
@@ -870,8 +870,8 @@ final class JrtPath implements Path {
     // between first and last, inclusive
     private static long lowMask(char first, char last) {
         long m = 0;
-        int f = Math.clamp(first, 0, 63);
-        int l = Math.clamp(last, 0, 63);
+        int f = Math.max(Math.min(first, 63), 0);
+        int l = Math.max(Math.min(last, 63), 0);
         for (int i = f; i <= l; i++)
             m |= 1L << i;
         return m;
@@ -881,8 +881,8 @@ final class JrtPath implements Path {
     // between first and last, inclusive
     private static long highMask(char first, char last) {
         long m = 0;
-        int f = Math.clamp(first, 64, 127) - 64;
-        int l = Math.clamp(last, 64, 127) - 64;
+        int f = Math.max(Math.min(first, 127), 64) - 64;
+        int l = Math.max(Math.min(last, 127), 64) - 64;
         for (int i = f; i <= l; i++)
             m |= 1L << i;
         return m;

--- a/src/java.base/share/classes/jdk/internal/math/FloatingDecimal.java
+++ b/src/java.base/share/classes/jdk/internal/math/FloatingDecimal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/math/FloatingDecimal.java
+++ b/src/java.base/share/classes/jdk/internal/math/FloatingDecimal.java
@@ -1538,7 +1538,7 @@ public class FloatingDecimal{
                     }
                 }
             }
-            fValue = Math.max(Float.MIN_VALUE, Math.min(Float.MAX_VALUE, (float) dValue));
+            fValue = Math.clamp((float) dValue, Float.MIN_VALUE, Float.MAX_VALUE);
 
             //
             // fValue is now approximately the result.

--- a/src/java.base/unix/classes/sun/nio/fs/UnixUriUtils.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixUriUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/unix/classes/sun/nio/fs/UnixUriUtils.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixUriUtils.java
@@ -162,8 +162,8 @@ class UnixUriUtils {
     // between first and last, inclusive
     private static long lowMask(char first, char last) {
         long m = 0;
-        int f = Math.max(Math.min(first, 63), 0);
-        int l = Math.max(Math.min(last, 63), 0);
+        int f = Math.clamp(first, 0, 63);
+        int l = Math.clamp(last, 0, 63);
         for (int i = f; i <= l; i++)
             m |= 1L << i;
         return m;
@@ -173,8 +173,8 @@ class UnixUriUtils {
     // between first and last, inclusive
     private static long highMask(char first, char last) {
         long m = 0;
-        int f = Math.max(Math.min(first, 127), 64) - 64;
-        int l = Math.max(Math.min(last, 127), 64) - 64;
+        int f = Math.clamp(first, 64, 127) - 64;
+        int l = Math.clamp(last, 64, 127) - 64;
         for (int i = f; i <= l; i++)
             m |= 1L << i;
         return m;


### PR DESCRIPTION
For cleanup and dogfooding the new method, it would be nice to use Math.clamp where possible in java.base. See PR #12428.

As Math.clamp performs an additional check that min is not greater than max, I conservatively replaced only those occurrences where I can see that this invariant is always held. There are more occurrences, where clamp can be potentially used but it's unclear whether min <= max is always true.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302815](https://bugs.openjdk.org/browse/JDK-8302815): Use new Math.clamp method in core libraries


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [be13683b](https://git.openjdk.org/jdk/pull/12633/files/be13683ba2f435c9e8083e69bbab70fe9cc197b3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12633/head:pull/12633` \
`$ git checkout pull/12633`

Update a local copy of the PR: \
`$ git checkout pull/12633` \
`$ git pull https://git.openjdk.org/jdk pull/12633/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12633`

View PR using the GUI difftool: \
`$ git pr show -t 12633`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12633.diff">https://git.openjdk.org/jdk/pull/12633.diff</a>

</details>
