### PR TITLE
8290903: Enable function warning attribute for Clang build once Clang supports merging

### DIFF
--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -69,11 +69,7 @@
 
 #endif // clang/gcc version check
 
-#if (__GNUC__ >= 10)
-// TODO: Re-enable warning attribute for Clang once
-// https://github.com/llvm/llvm-project/issues/56519 is fixed and released.
-// || (defined(__clang_major__) && (__clang_major__ >= 14))
-
+#if (__GNUC__ >= 10)|| (defined(__clang_major__) && (__clang_major__ >= 14))
 // Use "warning" attribute to detect uses of "forbidden" functions.
 //
 // Note: The warning attribute is available since GCC 9, but disabling pragmas


### PR DESCRIPTION
The warning attribute is enabled..

### Test
mach5 tier1-5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290903](https://bugs.openjdk.org/browse/JDK-8290903): Enable function warning attribute for Clang build once Clang supports merging


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12634/head:pull/12634` \
`$ git checkout pull/12634`

Update a local copy of the PR: \
`$ git checkout pull/12634` \
`$ git pull https://git.openjdk.org/jdk.git pull/12634/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12634`

View PR using the GUI difftool: \
`$ git pr show -t 12634`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12634.diff">https://git.openjdk.org/jdk/pull/12634.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12634#issuecomment-1435701162)