### PR TITLE
8301117: Remove old_size param from ResizeableResourceHashtable::resize()

### DIFF
--- a/src/hotspot/share/gc/g1/g1CodeRootSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CodeRootSet.cpp
@@ -38,7 +38,7 @@ void G1CodeRootSet::add(nmethod* nm) {
   }
   added = _table->put(nm, nm);
   if (added && _table->table_size() == SmallSize && length() == Threshold) {
-    _table->resize(SmallSize, LargeSize);
+    _table->resize(LargeSize);
   }
 }
 

--- a/src/hotspot/share/utilities/resizeableResourceHash.hpp
+++ b/src/hotspot/share/utilities/resizeableResourceHash.hpp
@@ -98,19 +98,19 @@ public:
     }
     if (BASE::number_of_entries() / int(old_size) > load_factor) {
       unsigned new_size = MIN2<unsigned>(old_size * 2, _max_size);
-      resize(old_size, new_size);
+      resize(new_size);
       return true;
     } else {
       return false;
     }
   }
 
-  void resize(unsigned old_size, unsigned new_size) {
+  void resize(unsigned new_size) {
     Node** old_table = BASE::_table;
     Node** new_table = BASE::alloc_table(new_size);
 
     Node* const* bucket = old_table;
-    while (bucket < &old_table[old_size]) {
+    while (bucket < &old_table[BASE::_table_size]) {
       Node* node = *bucket;
       while (node != nullptr) {
         Node* next = node->_next;


### PR DESCRIPTION
`old_size` is removed from the function parameters in definitions and calls.
`table_size` is used as old size.
### Test
mach5 tiers 1-5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301117](https://bugs.openjdk.org/browse/JDK-8301117): Remove old_size param from ResizeableResourceHashtable::resize()


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12635/head:pull/12635` \
`$ git checkout pull/12635`

Update a local copy of the PR: \
`$ git checkout pull/12635` \
`$ git pull https://git.openjdk.org/jdk pull/12635/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12635`

View PR using the GUI difftool: \
`$ git pr show -t 12635`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12635.diff">https://git.openjdk.org/jdk/pull/12635.diff</a>

</details>
