### PR TITLE
8300654: Remove JVMFlag::flag_error_str as it is unused

### DIFF
--- a/src/hotspot/share/runtime/flags/jvmFlag.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlag.cpp
@@ -450,20 +450,6 @@ void JVMFlag::print_as_flag(outputStream* st) const {
   }
 }
 
-const char* JVMFlag::flag_error_str(JVMFlag::Error error) {
-  switch (error) {
-    case JVMFlag::MISSING_NAME: return "MISSING_NAME";
-    case JVMFlag::MISSING_VALUE: return "MISSING_VALUE";
-    case JVMFlag::NON_WRITABLE: return "NON_WRITABLE";
-    case JVMFlag::OUT_OF_BOUNDS: return "OUT_OF_BOUNDS";
-    case JVMFlag::VIOLATES_CONSTRAINT: return "VIOLATES_CONSTRAINT";
-    case JVMFlag::INVALID_FLAG: return "INVALID_FLAG";
-    case JVMFlag::ERR_OTHER: return "ERR_OTHER";
-    case JVMFlag::SUCCESS: return "SUCCESS";
-    default: ShouldNotReachHere(); return "nullptr";
-  }
-}
-
 //----------------------------------------------------------------------
 // Build flagTable[]
 

--- a/src/hotspot/share/runtime/flags/jvmFlag.hpp
+++ b/src/hotspot/share/runtime/flags/jvmFlag.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -279,8 +279,6 @@ public:
   void print_kind(outputStream* st, unsigned int width) const;
   void print_origin(outputStream* st, unsigned int width) const;
   void print_as_flag(outputStream* st) const;
-
-  static const char* flag_error_str(JVMFlag::Error error);
 
 private:
   // type checking - the following functions make sure you access *_addr as


### PR DESCRIPTION
The function definition and declaration are removed.

### Test
mach5 tiers 1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300654](https://bugs.openjdk.org/browse/JDK-8300654): Remove JVMFlag::flag_error_str as it is unused


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12636/head:pull/12636` \
`$ git checkout pull/12636`

Update a local copy of the PR: \
`$ git checkout pull/12636` \
`$ git pull https://git.openjdk.org/jdk pull/12636/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12636`

View PR using the GUI difftool: \
`$ git pr show -t 12636`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12636.diff">https://git.openjdk.org/jdk/pull/12636.diff</a>

</details>
