### PR TITLE
8288912: vmTestbase/nsk/stress/strace/strace002.java fails with Unexpected method name: currentCarrierThread

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -164,7 +164,4 @@ vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manySame_b/TestDescription.java 
 vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn001/forceEarlyReturn001.java 7199837 generic-all
 
 vmTestbase/nsk/stress/except/except012.java 8297977 generic-all
-vmTestbase/nsk/stress/strace/strace002.java 8288912 macosx-x64,windows-x64
-vmTestbase/nsk/stress/strace/strace003.java 8297824 macosx-x64,windows-x64
-vmTestbase/nsk/stress/strace/strace004.java 8297824 macosx-x64,windows-x64
 vmTestbase/nsk/monitoring/ThreadMXBean/ThreadInfo/Multi/Multi005/TestDescription.java 8076494 windows-x64

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/StraceBase.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/StraceBase.java
@@ -36,10 +36,27 @@ public class StraceBase {
             "jdk.internal.vm.StackableScope",
     };
 
+    private static boolean isValidJavaName(String name) {
+        if (!Character.isJavaIdentifierStart(name.charAt(0))) {
+            return false;
+        }
+        for (var ch : name.toCharArray()) {
+            if (!(Character.isJavaIdentifierPart(ch) || ch == '.')) {
+                return false;
+            }
+        }
+        return true;
+    }
+    /**
+     *   Method verifies that StackTraceElement is sane and might be expected it the current stack.
+     */
     final static boolean checkElement(StackTraceElement element) {
         String className = element.getClassName();
+        String methodName = element.getMethodName();
+        if (!isValidJavaName(className) || !isValidJavaName(methodName)) {
+            return false;
+        }
         if (className.startsWith("nsk.stress.strace.strace")) {
-            String methodName = element.getMethodName();
             if (methodName.startsWith("recursiveMethod")
                     || methodName.startsWith("run")) {
                 return true;

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/StraceBase.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/StraceBase.java
@@ -48,7 +48,7 @@ public class StraceBase {
         return true;
     }
     /**
-     *   Method verifies that StackTraceElement is sane and might be expected it the current stack.
+     *   Method verifies that StackTraceElement is sane and might be expected in the current stack.
      */
     final static boolean checkElement(StackTraceElement element) {
         String className = element.getClassName();

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/StraceBase.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/StraceBase.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package nsk.stress.strace;
+
+public class StraceBase {
+
+    private static final String[] EXPECTED_SYSTEM_CLASSES = {
+            "java.lang.ClassLoader",
+            "java.lang.System",
+            "java.lang.Object",
+            "java.lang.Thread",
+            "jdk.internal.event.ThreadSleepEvent",
+            "jdk.internal.misc.Blocker",
+            "jdk.internal.misc.VM",
+            "jdk.internal.vm.StackableScope",
+    };
+
+    final static boolean checkElement(StackTraceElement element) {
+        String className = element.getClassName();
+        if (className.startsWith("nsk.stress.strace.strace")) {
+            String methodName = element.getMethodName();
+            if (methodName.startsWith("recursiveMethod")
+                    || methodName.startsWith("run")) {
+                return true;
+            }
+            return false;
+        }
+        for (var systemClassName : EXPECTED_SYSTEM_CLASSES) {
+            if (className.equals(systemClassName))
+                return true;
+        }
+        return false;
+    }
+
+}

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/StraceBase.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/StraceBase.java
@@ -30,35 +30,22 @@ public class StraceBase {
             "java.lang.System",
             "java.lang.Object",
             "java.lang.Thread",
+            "jdk.internal.event.Event",
             "jdk.internal.event.ThreadSleepEvent",
             "jdk.internal.misc.Blocker",
             "jdk.internal.misc.VM",
             "jdk.internal.vm.StackableScope",
     };
 
-    private static boolean isValidJavaName(String name) {
-        if (!Character.isJavaIdentifierStart(name.charAt(0))) {
-            return false;
-        }
-        for (var ch : name.toCharArray()) {
-            if (!(Character.isJavaIdentifierPart(ch) || ch == '.')) {
-                return false;
-            }
-        }
-        return true;
-    }
     /**
      *   Method verifies that StackTraceElement is sane and might be expected in the current stack.
      */
     final static boolean checkElement(StackTraceElement element) {
         String className = element.getClassName();
         String methodName = element.getMethodName();
-        if (!isValidJavaName(className) || !isValidJavaName(methodName)) {
-            return false;
-        }
-        if (className.startsWith("nsk.stress.strace.strace")) {
-            if (methodName.startsWith("recursiveMethod")
-                    || methodName.startsWith("run")) {
+        if (className.matches("nsk.stress.strace.strace\\d\\d\\dThread")) {
+            if (methodName.matches("recursiveMethod\\d?")
+                    || methodName.equals("run")) {
                 return true;
             }
             return false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,33 +57,13 @@ import java.io.PrintStream;
  * <p>
  * <p>The test creates <code>THRD_COUNT</code> instances of <code>strace001Thread</code>
  * class, tries to get their stack traces and checks up that returned array contains
- * correct stack frames. Each stack frame must be corresponded to one of the following
- * methods defined by the <code>EXPECTED_METHODS</code> array.</p>
- * <p>These checking are performed <code>REPEAT_COUNT</code> times.</p>
+ * correct stack frames.</p>
  */
-public class strace001 {
+public class strace001 extends StraceBase {
 
     static final int DEPTH = 200;
     static final int THRD_COUNT = 100;
     static final int REPEAT_COUNT = 10;
-    static final String[] EXPECTED_METHODS = {
-            "java.lang.System.arraycopy",
-            "java.lang.Object.wait",
-            "java.lang.Object.wait0",
-            "java.lang.Thread.exit",
-            "java.lang.Thread.yield",
-            "java.lang.Thread.yield0",
-            "java.lang.Thread.clearReferences",
-            "java.lang.Thread.currentCarrierThread",
-            "java.lang.Thread.currentThread",
-            "java.lang.Thread.threadContainer",
-            "jdk.internal.misc.Blocker.begin",
-            "jdk.internal.misc.Blocker.currentCarrierThread",
-            "jdk.internal.misc.Blocker.end",
-            "nsk.stress.strace.strace001Thread.run",
-            "nsk.stress.strace.strace001Thread.recursiveMethod"
-    };
-
 
     static volatile boolean isLocked = false;
     static PrintStream out;
@@ -223,15 +203,6 @@ public class strace001 {
             }
         }
         return res;
-    }
-
-    boolean checkElement(StackTraceElement element) {
-        String name = element.getClassName() + "." + element.getMethodName();
-        for (int i = 0; i < EXPECTED_METHODS.length; i++) {
-            if (name.startsWith(EXPECTED_METHODS[i]))
-                return true;
-        }
-        return false;
     }
 
     void finishThreads() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,33 +63,14 @@ import java.util.Map;
  * <p>
  * <p>The test creates <code>THRD_COUNT</code> instances of <code>strace002Thread</code>
  * class, tries to get their stack traces and checks up that returned array contains
- * correct stack frames. Each stack frame must be corresponded to one of the following
- * methods defined by the <code>EXPECTED_METHODS</code> array.</p>
+ * correct stack frames.</p>
  * <p>These checking are performed <code>REPEAT_COUNT</code> times.</p>
  */
-public class strace002 {
+public class strace002 extends StraceBase {
 
     static final int DEPTH = 200;
     static final int THRD_COUNT = 100;
     static final int REPEAT_COUNT = 10;
-    static final String[] EXPECTED_METHODS = {
-            "java.lang.System.arraycopy",
-            "java.lang.Object.wait",
-            "java.lang.Object.wait0",
-            "java.lang.Thread.exit",
-            "java.lang.Thread.yield",
-            "java.lang.Thread.yield0",
-            "java.lang.Thread.clearReferences",
-            "java.lang.Thread.currentCarrierThread",
-            "java.lang.Thread.currentThread",
-            "java.lang.Thread.threadContainer",
-            "jdk.internal.misc.Blocker.begin",
-            "jdk.internal.misc.Blocker.currentCarrierThread",
-            "jdk.internal.misc.Blocker.end",
-            "nsk.stress.strace.strace002Thread.run",
-            "nsk.stress.strace.strace002Thread.recursiveMethod"
-    };
-
 
     static volatile boolean isLocked = false;
     static PrintStream out;
@@ -230,15 +211,6 @@ public class strace002 {
             }
         }
         return res;
-    }
-
-    boolean checkElement(StackTraceElement element) {
-        String name = element.getClassName() + "." + element.getMethodName();
-        for (int i = 0; i < EXPECTED_METHODS.length; i++) {
-            if (name.startsWith(EXPECTED_METHODS[i]))
-                return true;
-        }
-        return false;
     }
 
     void finishThreads() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace003.java
@@ -58,37 +58,13 @@ import java.io.PrintStream;
  * <p>
  * <p>The test creates <code>THRD_COUNT</code> instances of <code>strace003Thread</code>
  * class, tries to get their stack traces and checks up that returned array contains
- * correct stack frames. Each stack frame must be corresponded to one of the following
- * methods defined by the <code>EXPECTED_METHODS</code> array.</p>
- * <p>These checking are performed <code>REPEAT_COUNT</code> times.</p>
+ * correct stack frames. </p>
  */
-public class strace003 {
+public class strace003 extends StraceBase {
 
     static final int DEPTH = 100;
     static final int THRD_COUNT = 100;
     static final int REPEAT_COUNT = 10;
-    static final String[] EXPECTED_METHODS = {
-            "java.lang.System.arraycopy",
-            "java.lang.Object.wait",
-            "java.lang.Object.wait0",
-            "java.lang.System$2.headStackableScope",
-            "java.lang.Thread.headStackableScopes",
-            "java.lang.Thread.exit",
-            "java.lang.Thread.yield",
-            "java.lang.Thread.yield0",
-            "java.lang.Thread.clearReferences",
-            "java.lang.Thread.currentCarrierThread",
-            "java.lang.Thread.currentThread",
-            "java.lang.Thread.threadContainer",
-            "jdk.internal.misc.Blocker.begin",
-            "jdk.internal.misc.Blocker.currentCarrierThread",
-            "jdk.internal.misc.Blocker.end",
-            "jdk.internal.vm.StackableScope.head",
-            "jdk.internal.vm.StackableScope.popAll",
-            "nsk.stress.strace.strace003Thread.run",
-            "nsk.stress.strace.strace003Thread.recursiveMethod"
-    };
-
 
     static volatile boolean isLocked = false;
     static PrintStream out;
@@ -227,15 +203,6 @@ public class strace003 {
             }
         }
         return res;
-    }
-
-    boolean checkElement(StackTraceElement element) {
-        String name = element.getClassName() + "." + element.getMethodName();
-        for (int i = 0; i < EXPECTED_METHODS.length; i++) {
-            if (name.startsWith(EXPECTED_METHODS[i]))
-                return true;
-        }
-        return false;
     }
 
     void finishThreads() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace004.java
@@ -59,37 +59,13 @@ import java.util.Map;
  * <p>
  * <p>The test creates <code>THRD_COUNT</code> instances of <code>strace004Thread</code>
  * class, tries to get their stack traces and checks up that returned array contains
- * correct stack frames. Each stack frame must be corresponded to one of the following
- * methods defined by the <code>EXPECTED_METHODS</code> array.</p>
- * <p>These checking are performed <code>REPEAT_COUNT</code> times.</p>
+ * correct stack frames. </p>
  */
-public class strace004 {
+public class strace004 extends StraceBase {
 
     static final int DEPTH = 100;
     static final int THRD_COUNT = 100;
     static final int REPEAT_COUNT = 10;
-    static final String[] EXPECTED_METHODS = {
-            "java.lang.System.arraycopy",
-            "java.lang.Object.wait",
-            "java.lang.Object.wait0",
-            "java.lang.System$2.headStackableScope",
-            "java.lang.Thread.headStackableScopes",
-            "java.lang.Thread.exit",
-            "java.lang.Thread.yield",
-            "java.lang.Thread.yield0",
-            "java.lang.Thread.clearReferences",
-            "java.lang.Thread.currentCarrierThread",
-            "java.lang.Thread.currentThread",
-            "java.lang.Thread.threadContainer",
-            "jdk.internal.misc.Blocker.begin",
-            "jdk.internal.misc.Blocker.currentCarrierThread",
-            "jdk.internal.misc.Blocker.end",
-            "jdk.internal.vm.StackableScope.head",
-            "jdk.internal.vm.StackableScope.popAll",
-            "nsk.stress.strace.strace004Thread.run",
-            "nsk.stress.strace.strace004Thread.recursiveMethod"
-    };
-
 
     static volatile boolean isLocked = false;
     static PrintStream out;
@@ -229,15 +205,6 @@ public class strace004 {
             }
         }
         return res;
-    }
-
-    boolean checkElement(StackTraceElement element) {
-        String name = element.getClassName() + "." + element.getMethodName();
-        for (int i = 0; i < EXPECTED_METHODS.length; i++) {
-            if (name.startsWith(EXPECTED_METHODS[i]))
-                return true;
-        }
-        return false;
     }
 
     void finishThreads() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace005.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,35 +122,13 @@ import java.io.PrintStream;
  * <p>
  * <p>The test creates <code>THRD_COUNT</code> instances of <code>strace005Thread</code>
  * class, tries to get their stack traces and checks up that returned array contains
- * correct stack frames. Each stack frame must be corresponded to one of the following
- * methods defined by the <code>EXPECTED_METHODS</code> array.</p>
- * <p>These checking are performed <code>REPEAT_COUNT</code> times.</p>
+ * correct stack frames.</p>
  */
-public class strace005 {
+public class strace005 extends StraceBase {
 
     static final int DEPTH = 500;
     static final int THRD_COUNT = 100;
     static final int REPEAT_COUNT = 10;
-    static final String[] EXPECTED_METHODS = {
-            "java.lang.System.arraycopy",
-            "java.lang.Object.wait",
-            "java.lang.Object.wait0",
-            "java.lang.System$2.headStackableScope",
-            "java.lang.Thread.headStackableScopes",
-            "java.lang.Thread.exit",
-            "java.lang.Thread.yield",
-            "java.lang.Thread.yield0",
-            "java.lang.Thread.clearReferences",
-            "java.lang.Thread.currentCarrierThread",
-            "java.lang.Thread.currentThread",
-            "java.lang.Thread.threadContainer",
-            "jdk.internal.vm.StackableScope.head",
-            "jdk.internal.vm.StackableScope.popAll",
-            "nsk.stress.strace.strace005Thread.run",
-            "nsk.stress.strace.strace005Thread.recursiveMethod1",
-            "nsk.stress.strace.strace005Thread.recursiveMethod2"
-    };
-
 
     static volatile boolean isLocked = false;
     static PrintStream out;
@@ -300,15 +278,6 @@ public class strace005 {
             }
         }
         return res;
-    }
-
-    boolean checkElement(StackTraceElement element) {
-        String name = element.getClassName() + "." + element.getMethodName();
-        for (int i = 0; i < EXPECTED_METHODS.length; i++) {
-            if (name.startsWith(EXPECTED_METHODS[i]))
-                return true;
-        }
-        return false;
     }
 
     void finishThreads() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace006.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,30 +66,11 @@ import java.util.Map;
  * methods defined by the <code>expectedMethod</code> array.</p>
  * <p>These checking are performed <code>REPEAT_COUNT</code> times.</p>
  */
-public class strace006 {
+public class strace006 extends StraceBase {
 
     static final int DEPTH = 500;
     static final int THRD_COUNT = 100;
     static final int REPEAT_COUNT = 10;
-    static final String[] EXPECTED_METHODS = {
-            "java.lang.System.arraycopy",
-            "java.lang.Object.wait",
-            "java.lang.Object.wait0",
-            "java.lang.System$2.headStackableScope",
-            "java.lang.Thread.headStackableScopes",
-            "java.lang.Thread.exit",
-            "java.lang.Thread.yield",
-            "java.lang.Thread.yield0",
-            "java.lang.Thread.clearReferences",
-            "java.lang.Thread.currentCarrierThread",
-            "java.lang.Thread.currentThread",
-            "java.lang.Thread.threadContainer",
-            "jdk.internal.vm.StackableScope.head",
-            "jdk.internal.vm.StackableScope.popAll",
-            "nsk.stress.strace.strace006Thread.run",
-            "nsk.stress.strace.strace006Thread.recursiveMethod1",
-            "nsk.stress.strace.strace006Thread.recursiveMethod2"
-    };
 
 
     static volatile boolean isLocked = false;
@@ -242,17 +223,6 @@ public class strace006 {
             }
         }
         return res;
-    }
-
-    boolean checkElement(StackTraceElement element) {
-        if (element.getClassName().equals("java.lang.ClassLoader"))
-            return true;
-        String name = element.getClassName() + "." + element.getMethodName();
-        for (int i = 0; i < EXPECTED_METHODS.length; i++) {
-            if (name.startsWith(EXPECTED_METHODS[i]))
-                return true;
-        }
-        return false;
     }
 
     void finishThreads() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace006.java
@@ -62,8 +62,7 @@ import java.util.Map;
  * java recursion.
  * <p>The test creates <code>THRD_COUNT</code> instances of <code>strace006Thread</code>
  * class, tries to get their stack traces and checks up that returned array contains
- * correct stack frames. Each stack frame must be corresponded to one of the following
- * methods defined by the <code>expectedMethod</code> array.</p>
+ * correct stack frames.</p>
  * <p>These checking are performed <code>REPEAT_COUNT</code> times.</p>
  */
 public class strace006 extends StraceBase {

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace007.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,28 +60,12 @@ import java.util.Map;
  * <code>DEPTH</code> of recursion, the test calls
  * <code>java.lang.Thread.getStackTrace()</code> and
  * <code>java.lang.Thread.getAllStackTraces()</code> methods and checks their results.
- * <p>
- * <p>It is expected that these methods return the same stack traces. Each stack frame
- * for both stack traces must be corresponded to invocation of one of the methods
- * defined by the <code>EXPECTED_METHODS</code> array.</p>
  */
-public class strace007 {
+public class strace007 extends StraceBase {
 
     static final int DEPTH = 500;
     static final int THRD_COUNT = 100;
     static final int SLEEP_TIME = 50;
-    static final String[] EXPECTED_METHODS = {
-            "java.lang.Thread.sleep",
-            "java.lang.Thread.sleep0",
-            "jdk.internal.event.ThreadSleepEvent.<clinit>",
-            "jdk.internal.event.ThreadSleepEvent.isTurnedOn",
-            "jdk.internal.event.ThreadSleepEvent.isEnabled",
-            "java.lang.Thread.currentCarrierThread",
-            "java.lang.Thread.currentThread",
-            "nsk.stress.strace.strace007Thread.run",
-            "nsk.stress.strace.strace007Thread.recursiveMethod"
-    };
-
 
     static PrintStream out;
     static long waitTime = 2;
@@ -205,15 +189,6 @@ public class strace007 {
             }
         }
         return res;
-    }
-
-    static boolean checkElement(StackTraceElement element) {
-        String name = element.getClassName() + "." + element.getMethodName();
-        for (int i = 0; i < EXPECTED_METHODS.length; i++) {
-            if (name.startsWith(EXPECTED_METHODS[i]))
-                return true;
-        }
-        return false;
     }
 
     static void finishThreads() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace008.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace008.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,27 +64,13 @@ import java.util.Map;
  * <code>java.lang.Thread.getStackTrace()</code> and
  * <code>java.lang.Thread.getAllStackTraces()</code> methods and checks their results.
  * <p>
- * It is expected that these methods return the same stack traces. Each stack frame
- * for both stack traces must be corresponded to invocation of one of the methods
- * defined by the <code>EXPECTED_METHODS</code> array.</p>
  */
-public class strace008 {
+public class strace008 extends StraceBase {
 
     static final int DEPTH = 100;
     static final int THRD_COUNT = 50;
     static final int SLEEP_TIME = 50;
     static final String NATIVE_LIB = "strace008";
-    static final String[] EXPECTED_METHODS = {
-            "java.lang.Thread.sleep",
-            "java.lang.Thread.sleep0",
-            "jdk.internal.event.ThreadSleepEvent.<clinit>",
-            "jdk.internal.event.ThreadSleepEvent.isTurnedOn",
-            "jdk.internal.event.ThreadSleepEvent.isEnabled",
-            "java.lang.Thread.currentCarrierThread",
-            "java.lang.Thread.currentThread",
-            "nsk.stress.strace.strace008Thread.run",
-            "nsk.stress.strace.strace008Thread.recursiveMethod"
-    };
 
 
     static long waitTime = 2;
@@ -209,15 +195,6 @@ public class strace008 {
             }
         }
         return res;
-    }
-
-    static boolean checkElement(StackTraceElement element) {
-        String name = element.getClassName() + "." + element.getMethodName();
-        for (int i = 0; i < EXPECTED_METHODS.length; i++) {
-            if (name.startsWith(EXPECTED_METHODS[i]))
-                return true;
-        }
-        return false;
     }
 
     static void finishThreads() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace009.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,29 +62,13 @@ import java.util.Map;
  * defined depth <code>DEPTH</code> of recursion, the test calls
  * <code>java.lang.Thread.getStackTrace()</code> and
  * <code>java.lang.Thread.getAllStackTraces()</code> methods and checks their results.
- * <p>
- * It is expected that these methods return the same stack traces. Each stack frame
- * for both stack traces must be corresponded to invocation of one of the methods
- * defined by the <code>EXPECTED_METHODS</code> array.</p>
  */
-public class strace009 {
+public class strace009 extends StraceBase {
 
     static final int DEPTH = 200;
     static final int THRD_COUNT = 100;
     static final String NATIVE_LIB = "strace009";
     static final int SLEEP_TIME = 50;
-    static final String[] EXPECTED_METHODS = {
-            "java.lang.Thread.sleep",
-            "java.lang.Thread.sleep0",
-            "jdk.internal.event.ThreadSleepEvent.<clinit>",
-            "jdk.internal.event.ThreadSleepEvent.isTurnedOn",
-            "jdk.internal.event.ThreadSleepEvent.isEnabled",
-            "java.lang.Thread.currentCarrierThread",
-            "java.lang.Thread.currentThread",
-            "nsk.stress.strace.strace009Thread.run",
-            "nsk.stress.strace.strace009Thread.recursiveMethod1",
-            "nsk.stress.strace.strace009Thread.recursiveMethod2"
-    };
 
 
     static long waitTime = 2;
@@ -209,15 +193,6 @@ public class strace009 {
             }
         }
         return res;
-    }
-
-    static boolean checkElement(StackTraceElement element) {
-        String name = element.getClassName() + "." + element.getMethodName();
-        for (int i = 0; i < EXPECTED_METHODS.length; i++) {
-            if (name.startsWith(EXPECTED_METHODS[i]))
-                return true;
-        }
-        return false;
     }
 
     static void finishThreads() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace010.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace010.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,26 +60,11 @@ import java.util.Map;
  * <code>DEPTH</code> of recursion, each thread is blocked on entering a monitor.
  * Then the test calls <code>java.lang.Thread.getStackTrace()</code> and
  * <code>java.lang.Thread.getAllStackTraces()</code> methods and checks their results.
- * <p>
- * <p>It is expected that these methods return the same stack traces. Each stack frame
- * for both stack traces must be corresponded to invocation of one of the methods
- * defined by the <code>EXPECTED_METHODS</code> array.</p>
  */
-public class strace010 {
+public class strace010 extends StraceBase {
 
     static final int DEPTH = 500;
     static final int THRD_COUNT = 100;
-    static final String[] EXPECTED_METHODS = {
-            "java.lang.Thread.sleep",
-            "java.lang.Thread.sleep0",
-            "jdk.internal.event.ThreadSleepEvent.<clinit>",
-            "jdk.internal.event.ThreadSleepEvent.isTurnedOn",
-            "jdk.internal.event.ThreadSleepEvent.isEnabled",
-            "java.lang.Thread.currentCarrierThread",
-            "java.lang.Thread.currentThread",
-            "nsk.stress.strace.strace010Thread.run",
-            "nsk.stress.strace.strace010Thread.recursiveMethod"
-    };
 
 
     static PrintStream out;
@@ -227,15 +212,6 @@ public class strace010 {
             }
         }
         return res;
-    }
-
-    boolean checkElement(StackTraceElement element) {
-        String name = element.getClassName() + "." + element.getMethodName();
-        for (int i = 0; i < EXPECTED_METHODS.length; i++) {
-            if (name.startsWith(EXPECTED_METHODS[i]))
-                return true;
-        }
-        return false;
     }
 
     void finishThreads() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace011.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace011.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,25 +62,11 @@ import java.util.Map;
  * Then the test calls <code>java.lang.Thread.getStackTrace()</code> and
  * <code>java.lang.Thread.getAllStackTraces()</code> methods and checks their results.
  * <p>
- * <p>It is expected that these methods return the same stack traces. Each stack frame
- * for both stack traces must be corresponded to invocation of one of the methods
- * defined by the <code>EXPECTED_METHODS</code> array.</p>
  */
-public class strace011 {
+public class strace011 extends StraceBase {
 
     static final int DEPTH = 100;
     static final int THRD_COUNT = 50;
-    static final String[] EXPECTED_METHODS = {
-            "java.lang.Thread.sleep",
-            "java.lang.Thread.sleep0",
-            "jdk.internal.event.ThreadSleepEvent.<clinit>",
-            "jdk.internal.event.ThreadSleepEvent.isTurnedOn",
-            "jdk.internal.event.ThreadSleepEvent.isEnabled",
-            "java.lang.Thread.currentCarrierThread",
-            "java.lang.Thread.currentThread",
-            "nsk.stress.strace.strace011Thread.run",
-            "nsk.stress.strace.strace011Thread.recursiveMethod"
-    };
 
 
     static PrintStream out;
@@ -228,15 +214,6 @@ public class strace011 {
             }
         }
         return res;
-    }
-
-    boolean checkElement(StackTraceElement element) {
-        String name = element.getClassName() + "." + element.getMethodName();
-        for (int i = 0; i < EXPECTED_METHODS.length; i++) {
-            if (name.startsWith(EXPECTED_METHODS[i]))
-                return true;
-        }
-        return false;
     }
 
     void finishThreads() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace012.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace012.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,27 +64,11 @@ import java.util.Map;
  * defined depth <code>DEPTH</code> of recursion, each thread is blocked on entering
  * a monitor. Then the test calls <code>java.lang.Thread.getStackTrace()</code> and
  * <code>java.lang.Thread.getAllStackTraces()</code> methods and checks their results.
- * <p>
- * <p>It is expected that these methods return the same stack traces. Each stack frame
- * for both stack traces must be corresponded to invocation of one of the methods
- * defined by the <code>EXPECTED_METHODS</code> array.</p>
  */
-public class strace012 {
+public class strace012 extends StraceBase {
 
     static final int DEPTH = 100;
     static final int THRD_COUNT = 100;
-    static final String[] EXPECTED_METHODS = {
-            "java.lang.Thread.sleep",
-            "java.lang.Thread.sleep0",
-            "jdk.internal.event.ThreadSleepEvent.<clinit>",
-            "jdk.internal.event.ThreadSleepEvent.isTurnedOn",
-            "jdk.internal.event.ThreadSleepEvent.isEnabled",
-            "java.lang.Thread.currentCarrierThread",
-            "java.lang.Thread.currentThread",
-            "nsk.stress.strace.strace012Thread.run",
-            "nsk.stress.strace.strace012Thread.recursiveMethod1",
-            "nsk.stress.strace.strace012Thread.recursiveMethod2"
-    };
 
 
     static PrintStream out;
@@ -232,15 +216,6 @@ public class strace012 {
             }
         }
         return res;
-    }
-
-    boolean checkElement(StackTraceElement element) {
-        String name = element.getClassName() + "." + element.getMethodName();
-        for (int i = 0; i < EXPECTED_METHODS.length; i++) {
-            if (name.startsWith(EXPECTED_METHODS[i]))
-                return true;
-        }
-        return false;
     }
 
     void finishThreads() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace013.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace013.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,25 +55,11 @@ import java.util.Map;
  * <code>DEPTH</code> of recursion, each thread is switched to wait on a monitor.
  * Then the test calls <code>java.lang.Thread.getStackTrace()</code> and
  * <code>java.lang.Thread.getAllStackTraces()</code> methods and checks their results.
- * <p>
- * <p>It is expected that these methods return the same stack traces. Each stack frame
- * for both stack traces correspond to invocation of one of the methods
- * defined by the <code>EXPECTED_METHODS</code> array.</p>
- *
- * There is some leeway in the expected stack depth as a thread may not have
- * reached the native wait0() call when the stacktrace is taken. So we allow
- * a difference of 3 for the methods: wait(), wait(0), and wait0(0)
  */
-public class strace013 {
+public class strace013 extends StraceBase {
 
     static final int DEPTH = 200;
     static final int THRD_COUNT = 100;
-    static final String[] EXPECTED_METHODS = {
-            "java.lang.Object.wait", // two variants
-            "java.lang.Object.wait0",
-            "nsk.stress.strace.strace013Thread.run",
-            "nsk.stress.strace.strace013Thread.recursiveMethod"
-    };
 
 
     static PrintStream out;
@@ -214,15 +200,6 @@ public class strace013 {
             }
         }
         return res;
-    }
-
-    boolean checkElement(StackTraceElement element) {
-        String name = element.getClassName() + "." + element.getMethodName();
-        for (int i = 0; i < EXPECTED_METHODS.length; i++) {
-            if (name.startsWith(EXPECTED_METHODS[i]))
-                return true;
-        }
-        return false;
     }
 
     void finishThreads() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace014.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace014.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,21 +61,11 @@ import java.util.Map;
  * <code>DEPTH</code> of recursion, each thread is switched to wait a monitor.
  * Then the test calls <code>java.lang.Thread.getStackTrace()</code> and
  * <code>java.lang.Thread.getAllStackTraces()</code> methods and checks their results.
- * <p>
- * <p>It is expected that these methods return the same stack traces. Each stack frame
- * for both stack traces must be corresponded to invocation of one of the methods
- * defined by the <code>EXPECTED_METHODS</code> array.</p>
  */
-public class strace014 {
+public class strace014 extends StraceBase {
 
     static final int DEPTH = 100;
     static final int THRD_COUNT = 100;
-    static final String[] EXPECTED_METHODS = {
-            "java.lang.Object.wait",
-            "java.lang.Object.wait0",
-            "nsk.stress.strace.strace014Thread.run",
-            "nsk.stress.strace.strace014Thread.recursiveMethod"
-    };
 
     static PrintStream out;
     static long waitTime = 2;
@@ -218,15 +208,6 @@ public class strace014 {
             }
         }
         return res;
-    }
-
-    boolean checkElement(StackTraceElement element) {
-        String name = element.getClassName() + "." + element.getMethodName();
-        for (int i = 0; i < EXPECTED_METHODS.length; i++) {
-            if (name.startsWith(EXPECTED_METHODS[i]))
-                return true;
-        }
-        return false;
     }
 
     void finishThreads() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace015.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace015.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,23 +63,11 @@ import java.util.Map;
  * defined depth <code>DEPTH</code> of recursion, each thread is switched to wait
  * a monitor. Then the test calls <code>java.lang.Thread.getStackTrace()</code> and
  * <code>java.lang.Thread.getAllStackTraces()</code> methods and checks their results.
- * <p>
- * <p>It is expected that these methods return the same stack traces. Each stack frame
- * for both stack traces must be corresponded to invocation of one of the methods
- * defined by the <code>EXPECTED_METHODS</code> array.</p>
  */
-public class strace015 {
+public class strace015 extends StraceBase {
 
     static final int DEPTH = 100;
     static final int THRD_COUNT = 100;
-    static final String[] EXPECTED_METHODS = {
-            "java.lang.Object.wait",
-            "java.lang.Object.wait0",
-            "nsk.stress.strace.strace015Thread.run",
-            "nsk.stress.strace.strace015Thread.recursiveMethod1",
-            "nsk.stress.strace.strace015Thread.recursiveMethod2"
-    };
-
 
     static PrintStream out;
     static long waitTime = 2;
@@ -219,15 +207,6 @@ public class strace015 {
             }
         }
         return res;
-    }
-
-    boolean checkElement(StackTraceElement element) {
-        String name = element.getClassName() + "." + element.getMethodName();
-        for (int i = 0; i < EXPECTED_METHODS.length; i++) {
-            if (name.startsWith(EXPECTED_METHODS[i]))
-                return true;
-        }
-        return false;
     }
 
     void finishThreads() {


### PR DESCRIPTION
The fix simplifies stack verification. It doesn't check the method name for system classes.
The StraceBase is used as a base class, not a utility class, to simplify future refactoring.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288912](https://bugs.openjdk.org/browse/JDK-8288912): vmTestbase/nsk/stress/strace/strace002.java fails with Unexpected method name: currentCarrierThread


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12638/head:pull/12638` \
`$ git checkout pull/12638`

Update a local copy of the PR: \
`$ git checkout pull/12638` \
`$ git pull https://git.openjdk.org/jdk pull/12638/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12638`

View PR using the GUI difftool: \
`$ git pr show -t 12638`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12638.diff">https://git.openjdk.org/jdk/pull/12638.diff</a>

</details>
