### PR TITLE
8302813: awt.image.incrementaldraw can use Boolean.parseBoolean() to parse the system property

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -617,7 +617,8 @@ public abstract class Component implements ImageObserver, MenuContainer,
      * Static properties for incremental drawing.
      * @see #imageUpdate
      */
-    static boolean isInc;
+    @SuppressWarnings("removal")
+    static final boolean isInc = Boolean.parseBoolean(AccessController.doPrivileged(new GetPropertyAction("awt.image.incrementaldraw")));
     static int incRate;
     static {
         /* ensure that the necessary native libraries are loaded */
@@ -626,11 +627,6 @@ public abstract class Component implements ImageObserver, MenuContainer,
         if (!GraphicsEnvironment.isHeadless()) {
             initIDs();
         }
-
-        @SuppressWarnings("removal")
-        String s = java.security.AccessController.doPrivileged(
-                                                               new GetPropertyAction("awt.image.incrementaldraw"));
-        isInc = (s == null || s.equals("true"));
 
         @SuppressWarnings("removal")
         String s2 = java.security.AccessController.doPrivileged(

--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -618,7 +618,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
      * @see #imageUpdate
      */
     @SuppressWarnings("removal")
-    static final boolean isInc = Boolean.parseBoolean(AccessController.doPrivileged(new GetPropertyAction("awt.image.incrementaldraw")));
+    private static final boolean isInc = Boolean.parseBoolean(AccessController.doPrivileged(new GetPropertyAction("awt.image.incrementaldraw")));
     static int incRate;
     static {
         /* ensure that the necessary native libraries are loaded */


### PR DESCRIPTION
Please review this change which moves the parsing of the `awt.image.incrementaldraw` property from the static initializer block into the field itself by invoking `Boolean.parseBoolean()` on the system property getter.

Hopefully in the near future we can do away with `AccessController`s and simply go with `System.getProperty` :)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302813](https://bugs.openjdk.org/browse/JDK-8302813): awt.image.incrementaldraw can use Boolean.parseBoolean() to parse the system property


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12639/head:pull/12639` \
`$ git checkout pull/12639`

Update a local copy of the PR: \
`$ git checkout pull/12639` \
`$ git pull https://git.openjdk.org/jdk pull/12639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12639`

View PR using the GUI difftool: \
`$ git pr show -t 12639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12639.diff">https://git.openjdk.org/jdk/pull/12639.diff</a>

</details>
