### PR TITLE
8302791: Add specific ClassLoader object to Proxy IllegalArgumentException message

### DIFF
--- a/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -407,6 +407,11 @@ public abstract class ClassLoader {
         return nid;
     }
 
+    // Returns nameAndId string for exception message printing
+    String nameAndId() {
+        return nameAndId;
+    }
+
     /**
      * Creates a new class loader of the specified name and using the
      * specified parent class loader for delegation.

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2660,6 +2660,10 @@ public final class System {
                                                       Continuation continuation) {
                 return StackWalker.newInstance(options, null, contScope, continuation);
             }
+
+            public String getLoaderNameID(ClassLoader loader) {
+                return loader.nameAndId();
+            }
         });
     }
 }

--- a/src/java.base/share/classes/java/lang/reflect/Proxy.java
+++ b/src/java.base/share/classes/java/lang/reflect/Proxy.java
@@ -877,10 +877,10 @@ public class Proxy implements java.io.Serializable {
             } catch (ClassNotFoundException e) {
             }
             if (type != c) {
-                /**
-                 * If classloader has a name explicitly set then
+                /*
+                 * If the classloader has a name explicitly set then
                  *        <loader-name>@<id>
-                 * If classloader has no name then
+                 * If the classloader has no name then
                  *        <qualified-class-name>@<id>
                  */
                 String nid = (ld.getName() != null) ? ld.getName() + "@" + Integer.toHexString(System.identityHashCode(ld))

--- a/src/java.base/share/classes/java/lang/reflect/Proxy.java
+++ b/src/java.base/share/classes/java/lang/reflect/Proxy.java
@@ -883,8 +883,9 @@ public class Proxy implements java.io.Serializable {
                  * If the classloader has no name then
                  *        <qualified-class-name>@<id>
                  */
-                String nid = (ld.getName() != null) ? ld.getName() + "@" + Integer.toHexString(System.identityHashCode(ld))
-                                                    : Objects.toIdentityString(ld);
+                String nid = (ld.getName() != null)
+                             ? ld.getName() + "@" + Integer.toHexString(System.identityHashCode(ld))
+                             : Objects.toIdentityString(ld);
                 throw new IllegalArgumentException(c.getName() +
                         " referenced from a method is not visible from class loader: " + nid);
             }

--- a/src/java.base/share/classes/java/lang/reflect/Proxy.java
+++ b/src/java.base/share/classes/java/lang/reflect/Proxy.java
@@ -878,7 +878,7 @@ public class Proxy implements java.io.Serializable {
             }
             if (type != c) {
                 throw new IllegalArgumentException(c.getName() +
-                        " referenced from a method is not visible from class loader");
+                        " referenced from a method is not visible from class loader: " + ld);
             }
         }
 

--- a/src/java.base/share/classes/java/lang/reflect/Proxy.java
+++ b/src/java.base/share/classes/java/lang/reflect/Proxy.java
@@ -877,8 +877,16 @@ public class Proxy implements java.io.Serializable {
             } catch (ClassNotFoundException e) {
             }
             if (type != c) {
+                /**
+                * If classloader has a name explicitly set then
+                *        <loader-name>@<id>
+                * If classloader has no name then
+                *        <qualified-class-name>@<id>
+                */
+                String nid = (ld.getName() != null) ? ld.getName() + "@" + Integer.toHexString(System.identityHashCode(ld))
+                                                    : Objects.toIdentityString(ld);
                 throw new IllegalArgumentException(c.getName() +
-                        " referenced from a method is not visible from class loader: " + ld);
+                        " referenced from a method is not visible from class loader: " + nid);
             }
         }
 

--- a/src/java.base/share/classes/java/lang/reflect/Proxy.java
+++ b/src/java.base/share/classes/java/lang/reflect/Proxy.java
@@ -878,11 +878,11 @@ public class Proxy implements java.io.Serializable {
             }
             if (type != c) {
                 /**
-                * If classloader has a name explicitly set then
-                *        <loader-name>@<id>
-                * If classloader has no name then
-                *        <qualified-class-name>@<id>
-                */
+                 * If classloader has a name explicitly set then
+                 *        <loader-name>@<id>
+                 * If classloader has no name then
+                 *        <qualified-class-name>@<id>
+                 */
                 String nid = (ld.getName() != null) ? ld.getName() + "@" + Integer.toHexString(System.identityHashCode(ld))
                                                     : Objects.toIdentityString(ld);
                 throw new IllegalArgumentException(c.getName() +

--- a/src/java.base/share/classes/java/lang/reflect/Proxy.java
+++ b/src/java.base/share/classes/java/lang/reflect/Proxy.java
@@ -877,17 +877,8 @@ public class Proxy implements java.io.Serializable {
             } catch (ClassNotFoundException e) {
             }
             if (type != c) {
-                /*
-                 * If the classloader has a name explicitly set then
-                 *        <loader-name>@<id>
-                 * If the classloader has no name then
-                 *        <qualified-class-name>@<id>
-                 */
-                String nid = (ld.getName() != null)
-                             ? ld.getName() + "@" + Integer.toHexString(System.identityHashCode(ld))
-                             : Objects.toIdentityString(ld);
                 throw new IllegalArgumentException(c.getName() +
-                        " referenced from a method is not visible from class loader: " + nid);
+                        " referenced from a method is not visible from class loader: " + JLA.getLoaderNameID(ld));
             }
         }
 

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -564,4 +564,9 @@ public interface JavaLangAccess {
     StackWalker newStackWalkerInstance(Set<StackWalker.Option> options,
                                        ContinuationScope contScope,
                                        Continuation continuation);
+    /**
+     * Returns '<loader-name>' @<id> if classloader has a name
+     * explicitly set otherwise <qualified-class-name> @<id>
+     */
+    String getLoaderNameID(ClassLoader loader);
 }


### PR DESCRIPTION
Added specific class loader object to proxy IllegalArgumentException from which the class was not visible

The bug report for the same: https://bugs.openjdk.org/browse/JDK-8302791

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302791](https://bugs.openjdk.org/browse/JDK-8302791): Add specific ClassLoader object to Proxy IllegalArgumentException message


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [ba561eef](https://git.openjdk.org/jdk/pull/12641/files/ba561eefe2d3db653fa14de6b56c166e6bdafc41)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12641/head:pull/12641` \
`$ git checkout pull/12641`

Update a local copy of the PR: \
`$ git checkout pull/12641` \
`$ git pull https://git.openjdk.org/jdk pull/12641/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12641`

View PR using the GUI difftool: \
`$ git pr show -t 12641`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12641.diff">https://git.openjdk.org/jdk/pull/12641.diff</a>

</details>
