### PR TITLE
JDK-8302800: Augment NaN handling tests of FDLIBM methods

### DIFF
--- a/test/jdk/java/lang/Math/CubeRootTests.java
+++ b/test/jdk/java/lang/Math/CubeRootTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @library /test/lib
  * @build jdk.test.lib.RandomFactory
+ * @build Tests
  * @run main CubeRootTests
  * @bug 4347132 4939441 8078672
  * @summary Tests for {Math, StrictMath}.cbrt (use -Dseed=X to set PRNG seed)
@@ -32,6 +33,7 @@
  */
 
 import jdk.test.lib.RandomFactory;
+import static java.lang.Double.longBitsToDouble;
 
 public class CubeRootTests {
     private CubeRootTests(){}
@@ -42,7 +44,7 @@ public class CubeRootTests {
     // Initialize shared random number generator
     static java.util.Random rand = RandomFactory.getRandom();
 
-    static int testCubeRootCase(double input, double expected) {
+    private static int testCubeRootCase(double input, double expected) {
         int failures=0;
 
         failures+=Tests.test("Math.cbrt",        input, Math::cbrt,        expected);
@@ -53,22 +55,17 @@ public class CubeRootTests {
         return failures;
     }
 
-    static int testCubeRoot() {
+    private static int testCubeRoot() {
         int failures = 0;
+
+        for(double nan : Tests.NaNs) {
+            failures += testCubeRootCase(nan, NaNd);
+        }
+
         double [][] testCases = {
-            {NaNd,                      NaNd},
-            {Double.longBitsToDouble(0x7FF0000000000001L),      NaNd},
-            {Double.longBitsToDouble(0xFFF0000000000001L),      NaNd},
-            {Double.longBitsToDouble(0x7FF8555555555555L),      NaNd},
-            {Double.longBitsToDouble(0xFFF8555555555555L),      NaNd},
-            {Double.longBitsToDouble(0x7FFFFFFFFFFFFFFFL),      NaNd},
-            {Double.longBitsToDouble(0xFFFFFFFFFFFFFFFFL),      NaNd},
-            {Double.longBitsToDouble(0x7FFDeadBeef00000L),      NaNd},
-            {Double.longBitsToDouble(0xFFFDeadBeef00000L),      NaNd},
-            {Double.longBitsToDouble(0x7FFCafeBabe00000L),      NaNd},
-            {Double.longBitsToDouble(0xFFFCafeBabe00000L),      NaNd},
             {Double.POSITIVE_INFINITY,  Double.POSITIVE_INFINITY},
             {Double.NEGATIVE_INFINITY,  Double.NEGATIVE_INFINITY},
+
             {+0.0,                      +0.0},
             {-0.0,                      -0.0},
             {+1.0,                      +1.0},

--- a/test/jdk/java/lang/Math/Expm1Tests.java
+++ b/test/jdk/java/lang/Math/Expm1Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,13 @@
 /*
  * @test
  * @bug 4851638 4900189 4939441
+ * @build Tests
+ * @build Expm1Tests
+ * @run main Expm1Tests
  * @summary Tests for {Math, StrictMath}.expm1
  */
+
+import static java.lang.Double.longBitsToDouble;
 
 /*
  * The Taylor expansion of expxm1(x) = exp(x) -1 is
@@ -48,21 +53,14 @@ public class Expm1Tests {
     static final double infinityD = Double.POSITIVE_INFINITY;
     static final double NaNd = Double.NaN;
 
-    static int testExpm1() {
+    private static int testExpm1() {
         int failures = 0;
 
+        for(double nan : Tests.NaNs) {
+            failures += testExpm1Case(nan, NaNd);
+        }
+
         double [][] testCases = {
-            {Double.NaN,                NaNd},
-            {Double.longBitsToDouble(0x7FF0000000000001L),      NaNd},
-            {Double.longBitsToDouble(0xFFF0000000000001L),      NaNd},
-            {Double.longBitsToDouble(0x7FF8555555555555L),      NaNd},
-            {Double.longBitsToDouble(0xFFF8555555555555L),      NaNd},
-            {Double.longBitsToDouble(0x7FFFFFFFFFFFFFFFL),      NaNd},
-            {Double.longBitsToDouble(0xFFFFFFFFFFFFFFFFL),      NaNd},
-            {Double.longBitsToDouble(0x7FFDeadBeef00000L),      NaNd},
-            {Double.longBitsToDouble(0xFFFDeadBeef00000L),      NaNd},
-            {Double.longBitsToDouble(0x7FFCafeBabe00000L),      NaNd},
-            {Double.longBitsToDouble(0xFFFCafeBabe00000L),      NaNd},
             {infinityD,                 infinityD},
             {-infinityD,                -1.0},
             {-0.0,                      -0.0},

--- a/test/jdk/java/lang/Math/HyperbolicTests.java
+++ b/test/jdk/java/lang/Math/HyperbolicTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,13 @@
 /*
  * @test
  * @bug 4851625 4900189 4939441
+ * @build Tests
+ * @build HyperbolicTests
+ * @run main HyperbolicTests
  * @summary Tests for {Math, StrictMath}.{sinh, cosh, tanh}
  */
+
+import static java.lang.Double.longBitsToDouble;
 
 public class HyperbolicTests {
     private HyperbolicTests(){}
@@ -248,19 +253,12 @@ public class HyperbolicTests {
                                                 3.0);
         }
 
+        for(double nan : Tests.NaNs) {
+            failures += testSinhCaseWithUlpDiff(nan, NaNd, 0);
+        }
+
         double [][] specialTestCases = {
             {0.0,                       0.0},
-            {NaNd,                      NaNd},
-            {Double.longBitsToDouble(0x7FF0000000000001L),      NaNd},
-            {Double.longBitsToDouble(0xFFF0000000000001L),      NaNd},
-            {Double.longBitsToDouble(0x7FF8555555555555L),      NaNd},
-            {Double.longBitsToDouble(0xFFF8555555555555L),      NaNd},
-            {Double.longBitsToDouble(0x7FFFFFFFFFFFFFFFL),      NaNd},
-            {Double.longBitsToDouble(0xFFFFFFFFFFFFFFFFL),      NaNd},
-            {Double.longBitsToDouble(0x7FFDeadBeef00000L),      NaNd},
-            {Double.longBitsToDouble(0xFFFDeadBeef00000L),      NaNd},
-            {Double.longBitsToDouble(0x7FFCafeBabe00000L),      NaNd},
-            {Double.longBitsToDouble(0xFFFCafeBabe00000L),      NaNd},
             {Double.POSITIVE_INFINITY,  Double.POSITIVE_INFINITY}
         };
 
@@ -590,19 +588,12 @@ public class HyperbolicTests {
                                                 3.0);
         }
 
+        for(double nan : Tests.NaNs) {
+            failures += testCoshCaseWithUlpDiff(nan, NaNd, 0);
+        }
+
         double [][] specialTestCases = {
             {0.0,                       1.0},
-            {NaNd,                      NaNd},
-            {Double.longBitsToDouble(0x7FF0000000000001L),      NaNd},
-            {Double.longBitsToDouble(0xFFF0000000000001L),      NaNd},
-            {Double.longBitsToDouble(0x7FF8555555555555L),      NaNd},
-            {Double.longBitsToDouble(0xFFF8555555555555L),      NaNd},
-            {Double.longBitsToDouble(0x7FFFFFFFFFFFFFFFL),      NaNd},
-            {Double.longBitsToDouble(0xFFFFFFFFFFFFFFFFL),      NaNd},
-            {Double.longBitsToDouble(0x7FFDeadBeef00000L),      NaNd},
-            {Double.longBitsToDouble(0xFFFDeadBeef00000L),      NaNd},
-            {Double.longBitsToDouble(0x7FFCafeBabe00000L),      NaNd},
-            {Double.longBitsToDouble(0xFFFCafeBabe00000L),      NaNd},
             {Double.POSITIVE_INFINITY,  Double.POSITIVE_INFINITY}
         };
 
@@ -938,19 +929,12 @@ public class HyperbolicTests {
                                                 3.0);
         }
 
+        for(double nan : Tests.NaNs) {
+            failures += testTanhCaseWithUlpDiff(nan, NaNd, 0);
+        }
+
         double [][] specialTestCases = {
             {0.0,                       0.0},
-            {NaNd,                      NaNd},
-            {Double.longBitsToDouble(0x7FF0000000000001L),      NaNd},
-            {Double.longBitsToDouble(0xFFF0000000000001L),      NaNd},
-            {Double.longBitsToDouble(0x7FF8555555555555L),      NaNd},
-            {Double.longBitsToDouble(0xFFF8555555555555L),      NaNd},
-            {Double.longBitsToDouble(0x7FFFFFFFFFFFFFFFL),      NaNd},
-            {Double.longBitsToDouble(0xFFFFFFFFFFFFFFFFL),      NaNd},
-            {Double.longBitsToDouble(0x7FFDeadBeef00000L),      NaNd},
-            {Double.longBitsToDouble(0xFFFDeadBeef00000L),      NaNd},
-            {Double.longBitsToDouble(0x7FFCafeBabe00000L),      NaNd},
-            {Double.longBitsToDouble(0xFFFCafeBabe00000L),      NaNd},
             {Double.POSITIVE_INFINITY,  1.0}
         };
 

--- a/test/jdk/java/lang/Math/InverseTrigTests.java
+++ b/test/jdk/java/lang/Math/InverseTrigTests.java
@@ -30,6 +30,8 @@
  * @summary Tests for {Math, StrictMath}.{asin, acos, atan}
  */
 
+import static java.lang.Double.longBitsToDouble;
+
 public class InverseTrigTests {
     private InverseTrigTests(){}
 
@@ -64,8 +66,11 @@ public class InverseTrigTests {
     private static int testAsinSpecialCases() {
         int failures = 0;
 
+        for(double nan : Tests.NaNs) {
+            failures += testAsinCase(nan, NaNd);
+        }
+
         double [][] testCases = {
-            {NaNd,                NaNd},
             {Math.nextUp(1.0),    NaNd},
             {Math.nextDown(-1.0), NaNd},
             { InfinityD,          NaNd},
@@ -86,8 +91,8 @@ public class InverseTrigTests {
     private static int testAsinCase(double input, double expected) {
         int failures=0;
 
-        failures+=Tests.test("Math.asin",       input, Math::asin,       expected);
-        failures+=Tests.test("StrictMath.asin", input, StrictMath::asin, expected);
+        failures += Tests.test("Math.asin",       input, Math::asin,       expected);
+        failures += Tests.test("StrictMath.asin", input, StrictMath::asin, expected);
 
         return failures;
     }
@@ -105,8 +110,11 @@ public class InverseTrigTests {
     private static int testAcosSpecialCases() {
         int failures = 0;
 
+        for(double nan : Tests.NaNs) {
+            failures += testAcosCase(nan, NaNd);
+        }
+
         double [][] testCases = {
-            {NaNd,                NaNd},
             {Math.nextUp(1.0),    NaNd},
             {Math.nextDown(-1.0), NaNd},
             {InfinityD,           NaNd},
@@ -126,8 +134,8 @@ public class InverseTrigTests {
     private static int testAcosCase(double input, double expected) {
         int failures=0;
 
-        failures+=Tests.test("Math.acos",       input, Math::acos,       expected);
-        failures+=Tests.test("StrictMath.acos", input, StrictMath::acos, expected);
+        failures += Tests.test("Math.acos",       input, Math::acos,       expected);
+        failures += Tests.test("StrictMath.acos", input, StrictMath::acos, expected);
 
         return failures;
     }
@@ -148,9 +156,11 @@ public class InverseTrigTests {
     private static int testAtanSpecialCases() {
         int failures = 0;
 
-        double [][] testCases = {
-            {NaNd,       NaNd},
+        for(double nan : Tests.NaNs) {
+            failures += testAtanCase(nan, NaNd);
+        }
 
+        double [][] testCases = {
             {-0.0,       -0.0},
             {+0.0,       +0.0},
 
@@ -169,8 +179,8 @@ public class InverseTrigTests {
     private static int testAtanCase(double input, double expected) {
         int failures=0;
 
-        failures+=Tests.test("Math.atan",       input, Math::atan,       expected);
-        failures+=Tests.test("StrictMath.atan", input, StrictMath::atan, expected);
+        failures += Tests.test("Math.atan",       input, Math::atan,       expected);
+        failures += Tests.test("StrictMath.atan", input, StrictMath::atan, expected);
 
         return failures;
     }

--- a/test/jdk/java/lang/Math/Log10Tests.java
+++ b/test/jdk/java/lang/Math/Log10Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,43 +24,41 @@
 /*
  * @test
  * @bug 4074599 4939441
+ * @build Tests
+ * @build Log10Tests
+ * @run main Log10Tests
  * @summary Tests for {Math, StrictMath}.log10
  */
+
+import static java.lang.Double.longBitsToDouble;
 
 public class Log10Tests {
     private Log10Tests(){}
 
-    static final double infinityD = Double.POSITIVE_INFINITY;
-    static final double NaNd = Double.NaN;
-    static final double LN_10 = StrictMath.log(10.0);
+    private static final double infinityD = Double.POSITIVE_INFINITY;
+    private static final double NaNd = Double.NaN;
+    private static final double LN_10 = StrictMath.log(10.0);
 
     // Initialize shared random number generator
     static java.util.Random rand = new java.util.Random(0L);
 
-    static int testLog10Case(double input, double expected) {
+    private static int testLog10Case(double input, double expected) {
         int failures=0;
 
-        failures+=Tests.test("Math.log10",       input, Math::log10,       expected);
-        failures+=Tests.test("StrictMath.log10", input, StrictMath::log10, expected);
+        failures += Tests.test("Math.log10",       input, Math::log10,       expected);
+        failures += Tests.test("StrictMath.log10", input, StrictMath::log10, expected);
 
         return failures;
     }
 
-    static int testLog10() {
+    private static int testLog10() {
         int failures = 0;
 
+        for(double nan : Tests.NaNs) {
+            failures += testLog10Case(nan, NaNd);
+        }
+
         double [][] testCases = {
-            {Double.NaN,                NaNd},
-            {Double.longBitsToDouble(0x7FF0000000000001L),      NaNd},
-            {Double.longBitsToDouble(0xFFF0000000000001L),      NaNd},
-            {Double.longBitsToDouble(0x7FF8555555555555L),      NaNd},
-            {Double.longBitsToDouble(0xFFF8555555555555L),      NaNd},
-            {Double.longBitsToDouble(0x7FFFFFFFFFFFFFFFL),      NaNd},
-            {Double.longBitsToDouble(0xFFFFFFFFFFFFFFFFL),      NaNd},
-            {Double.longBitsToDouble(0x7FFDeadBeef00000L),      NaNd},
-            {Double.longBitsToDouble(0xFFFDeadBeef00000L),      NaNd},
-            {Double.longBitsToDouble(0x7FFCafeBabe00000L),      NaNd},
-            {Double.longBitsToDouble(0xFFFCafeBabe00000L),      NaNd},
             {Double.NEGATIVE_INFINITY,  NaNd},
             {-8.0,                      NaNd},
             {-1.0,                      NaNd},

--- a/test/jdk/java/lang/Math/Log1pTests.java
+++ b/test/jdk/java/lang/Math/Log1pTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
  * @test
  * @library /test/lib
  * @build jdk.test.lib.RandomFactory
+ * @build Tests
+ * @build Log1pTests
  * @run main Log1pTests
  * @bug 4851638 4939441 8078672
  * @summary Tests for {Math, StrictMath}.log1p (use -Dseed=X to set PRNG seed)
@@ -59,21 +61,14 @@ public class Log1pTests {
      * Also x/(x+1) < ln(1+x) < x
      */
 
-    static int testLog1p() {
+    private static int testLog1p() {
         int failures = 0;
 
+        for(double nan : Tests.NaNs) {
+            failures += testLog1pCase(nan, NaNd);
+        }
+
         double [][] testCases = {
-            {Double.NaN,                NaNd},
-            {Double.longBitsToDouble(0x7FF0000000000001L),      NaNd},
-            {Double.longBitsToDouble(0xFFF0000000000001L),      NaNd},
-            {Double.longBitsToDouble(0x7FF8555555555555L),      NaNd},
-            {Double.longBitsToDouble(0xFFF8555555555555L),      NaNd},
-            {Double.longBitsToDouble(0x7FFFFFFFFFFFFFFFL),      NaNd},
-            {Double.longBitsToDouble(0xFFFFFFFFFFFFFFFFL),      NaNd},
-            {Double.longBitsToDouble(0x7FFDeadBeef00000L),      NaNd},
-            {Double.longBitsToDouble(0xFFFDeadBeef00000L),      NaNd},
-            {Double.longBitsToDouble(0x7FFCafeBabe00000L),      NaNd},
-            {Double.longBitsToDouble(0xFFFCafeBabe00000L),      NaNd},
             {Double.NEGATIVE_INFINITY,  NaNd},
             {-8.0,                      NaNd},
             {-1.0,                      -infinityD},

--- a/test/jdk/java/lang/Math/Tests.java
+++ b/test/jdk/java/lang/Math/Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 import java.util.function.DoubleBinaryOperator;
 import java.util.function.DoubleUnaryOperator;
 import java.util.function.DoubleToIntFunction;
+import static java.lang.Double.longBitsToDouble;
 
 /*
  * Shared static test methods for numerical tests.  Sharing these
@@ -36,6 +37,38 @@ import java.util.function.DoubleToIntFunction;
 
 public class Tests {
     private Tests(){}; // do not instantiate
+
+    static volatile double zero = 0.0;
+
+    // Create NaN value at runtime; use volatile to foil compile-time
+    // constant folding.
+    private static final double PLATFORM_NAN = zero / zero;
+
+    public static final double[] NaNs = {
+            Double.NaN,
+            PLATFORM_NAN,
+            bitwiseNegate(PLATFORM_NAN),
+            // Exotic NaN bit patterns. Includes values that would
+            // *not* be considered a NaN if only the high-order
+            // 32-bits were examined.
+            longBitsToDouble(0x7FF0_0000_0000_0001L),
+            longBitsToDouble(0xFFF0_0000_0000_0001L),
+            longBitsToDouble(0x7FF8_5555_5555_5555L),
+            longBitsToDouble(0xFFF8_5555_5555_5555L),
+            longBitsToDouble(0x7FFF_FFFF_FFFF_FFFFL),
+            longBitsToDouble(0xFFFF_FFFF_FFFF_FFFFL),
+            longBitsToDouble(0x7FF0_0000_7FFF_FFFFL),
+            longBitsToDouble(0xFFF0_0000_7FFF_FFFFL),
+            longBitsToDouble(0x7FF0_Dead_Beef_0000L),
+            longBitsToDouble(0xFFF0_Dead_Beef_0000L),
+            longBitsToDouble(0x7FF0_Cafe_Babe_0000L),
+            longBitsToDouble(0xFFF0_Cafe_Babe_0000L),
+    };
+
+    public static double bitwiseNegate(double d) {
+        long SIGNBIT = 0x8000_0000_0000_0000L;
+        return longBitsToDouble(Double.doubleToRawLongBits(d) ^ SIGNBIT );
+    }
 
     public static String toHexString(float f) {
         if (!Float.isNaN(f))

--- a/test/jdk/java/lang/Math/Tests.java
+++ b/test/jdk/java/lang/Math/Tests.java
@@ -38,10 +38,10 @@ import static java.lang.Double.longBitsToDouble;
 public class Tests {
     private Tests(){}; // do not instantiate
 
+    // Used to create a NaN value at runtime; mark as volatile to foil
+    // compile-time constant folding.
     static volatile double zero = 0.0;
 
-    // Create NaN value at runtime; use volatile to foil compile-time
-    // constant folding.
     private static final double PLATFORM_NAN = zero / zero;
 
     public static final double[] NaNs = {


### PR DESCRIPTION
Augment NaN-handling tests to include exotic NaN bit patterns. Assuming this changeset goes back first, I'll update https://github.com/openjdk/jdk/pull/12608 to follow the same convention afterward.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302800](https://bugs.openjdk.org/browse/JDK-8302800): Augment NaN handling tests of FDLIBM methods


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to [b4f2a1dd](https://git.openjdk.org/jdk/pull/12644/files/b4f2a1dd10bbf53fb877c0687e64d6583f75060a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12644/head:pull/12644` \
`$ git checkout pull/12644`

Update a local copy of the PR: \
`$ git checkout pull/12644` \
`$ git pull https://git.openjdk.org/jdk pull/12644/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12644`

View PR using the GUI difftool: \
`$ git pr show -t 12644`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12644.diff">https://git.openjdk.org/jdk/pull/12644.diff</a>

</details>
