### PR TITLE
8302837: Kernel32.cpp array memory release invokes undefined behaviour

### DIFF
--- a/src/jdk.internal.le/windows/native/lible/Kernel32.cpp
+++ b/src/jdk.internal.le/windows/native/lible/Kernel32.cpp
@@ -461,7 +461,7 @@ JNIEXPORT void JNICALL Java_jdk_internal_org_jline_terminal_impl_jna_win_Kernel3
     INPUT_RECORD *buffer = new INPUT_RECORD[in_nLength];
     DWORD numberOfEventsRead;
     if (!ReadConsoleInputW(h, buffer, in_nLength, &numberOfEventsRead)) {
-        delete buffer;
+        delete[] buffer;
         DWORD error = GetLastError();
         jobject exc = env->NewObject(lastErrorExceptionClass,
                                      lastErrorExceptionConstructor,
@@ -565,7 +565,7 @@ JNIEXPORT void JNICALL Java_jdk_internal_org_jline_terminal_impl_jna_win_Kernel3
         env->SetObjectArrayElement(out_lpBuffer, i, record);
     }
     env->SetIntField(out_lpNumberOfEventsRead, intByReferenceValue, numberOfEventsRead);
-    delete buffer;
+    delete[] buffer;
 }
 
 /*
@@ -657,7 +657,7 @@ JNIEXPORT void JNICALL Java_jdk_internal_org_jline_terminal_impl_jna_win_Kernel3
     env->GetCharArrayRegion(in_lpBuffer, 0, in_nNumberOfCharsToWrite, chars);
     DWORD written;
     if (!WriteConsoleW(h, chars, in_nNumberOfCharsToWrite, &written, NULL)) {
-        delete chars;
+        delete[] chars;
         DWORD error = GetLastError();
         jobject exc = env->NewObject(lastErrorExceptionClass,
                                      lastErrorExceptionConstructor,
@@ -667,7 +667,7 @@ JNIEXPORT void JNICALL Java_jdk_internal_org_jline_terminal_impl_jna_win_Kernel3
     }
 
     env->SetIntField(out_lpNumberOfCharsWritten, intByReferenceValue, written);
-    delete chars;
+    delete[] chars;
 }
 
 /*


### PR DESCRIPTION
When several arrays are allocated with the new operator in Kernel32, they use the wrong set of delete operators when freeing the allocated memory. In C++ this is undefined behaviour and they should be converted to use the correct operators

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302837](https://bugs.openjdk.org/browse/JDK-8302837): Kernel32.cpp array memory release invokes undefined behaviour


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12649/head:pull/12649` \
`$ git checkout pull/12649`

Update a local copy of the PR: \
`$ git checkout pull/12649` \
`$ git pull https://git.openjdk.org/jdk pull/12649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12649`

View PR using the GUI difftool: \
`$ git pr show -t 12649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12649.diff">https://git.openjdk.org/jdk/pull/12649.diff</a>

</details>
