### PR TITLE
8302798: Refactor -XX:+UseOSErrorReporting for noreturn crash reporting

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2471,8 +2471,10 @@ LONG WINAPI Handle_FLT_Exception(struct _EXCEPTION_POINTERS* exceptionInfo) {
 
 static inline void report_error(Thread* t, DWORD exception_code,
                                 address addr, void* siginfo, void* context) {
-  VMError::report_and_die(t, exception_code, addr, siginfo, context);
-
+  using ARA = VMError::AfterReportAction;
+  VMError::report_and_maybe_die((UseOSErrorReporting ? ARA::Return : ARA::Die),
+                                t, exception_code, addr, siginfo, context,
+                                "%s", "");
   // If UseOSErrorReporting, this will return here and save the error file
   // somewhere where we can find it in the minidump.
 }

--- a/src/hotspot/os/windows/vmError_windows.cpp
+++ b/src/hotspot/os/windows/vmError_windows.cpp
@@ -31,8 +31,12 @@
 
 LONG WINAPI crash_handler(struct _EXCEPTION_POINTERS* exceptionInfo) {
   DWORD exception_code = exceptionInfo->ExceptionRecord->ExceptionCode;
-  VMError::report_and_die(nullptr, exception_code, nullptr, exceptionInfo->ExceptionRecord,
-                          exceptionInfo->ContextRecord);
+  using ARA = VMError::AfterReportAction;
+  VMError::report_and_maybe_die((UseOSErrorReporting ? ARA::Return : ARA::Die),
+                                nullptr, exception_code, nullptr,
+                                exceptionInfo->ExceptionRecord,
+                                exceptionInfo->ContextRecord,
+                                "%s", "");
   return EXCEPTION_CONTINUE_SEARCH;
 }
 

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -216,10 +216,6 @@ void report_vm_out_of_memory(const char* file, int line, size_t size,
 
   VMError::report_and_die(Thread::current_or_null(), file, line, size, vm_err_type, detail_fmt, detail_args);
   va_end(detail_args);
-
-  // The UseOSErrorReporting option in report_and_die() may allow a return
-  // to here. If so then we'll have to figure out how to handle it.
-  guarantee(false, "report_and_die() should not return here");
 }
 
 void report_should_not_call(const char* file, int line) {

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1388,6 +1388,12 @@ void VMError::report_and_maybe_die_impl(AfterReportAction after_report_action,
                                         const char* filename, int lineno,
                                         size_t size)
 {
+  // Non-termination is only permitted when Windows-only UseOSErrorReporting
+  // is enabled.
+  assert(after_report_action == AfterReportAction::Die
+         WINDOWS_ONLY( || UseOSErrorReporting),
+         "must terminate");
+
   // A single scratch buffer to be used from here on.
   // Do not rely on it being preserved across function calls.
   static char buffer[O_BUFLEN];

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -171,6 +171,30 @@ public:
                              VMErrorType vm_err_type, const char* detail_fmt,
                              va_list detail_args) ATTRIBUTE_PRINTF(6, 0);
 
+  // AfterReportAction and report_and_maybe_die support Windows-only
+  // UseOSErrorReporting.
+  enum class AfterReportAction { Return, Die };
+
+  // Error reporting function that is allowed to return to the caller
+  // if so requested by the after_report_action.  Otherwise, die after
+  // reporting the error.
+  static void report_and_maybe_die(AfterReportAction after_report_action,
+                                   Thread* thread, unsigned int sig, address pc,
+                                   void* siginfo, void* context,
+                                   const char* detail_fmt, ...) ATTRIBUTE_PRINTF(7, 8);
+
+private:
+  // Shared implementation of report_and_die and report_and_maybe_die.
+  static void report_and_maybe_die_impl(AfterReportAction after_report_action,
+                                        int id, const char* message,
+                                        const char* detail_fmt, va_list detail_args,
+                                        Thread* thread, address pc, void* siginfo,
+                                        void* context,
+                                        const char* filename, int lineno,
+                                        size_t size) ATTRIBUTE_PRINTF(4, 0);
+
+public:
+
   // reporting OutOfMemoryError
   static void report_java_out_of_memory(const char* message);
 


### PR DESCRIPTION
Please review this change to the implementation of the Windows-specific option
UseOSErrorReporting, toward allowing crash reporting functions to be declared
noreturn.  VMError::report_and_die no longer conditionally returns if the
Windows-only option UseOSErrorReporting is true.

The core of VM crash reporting has been renamed and privatized, and now takes
an additional argument indicating whether the caller just wants reporting or
also wants termination after reporting.  The Windows top-level and unhandled
exception filters call into that to request reporting, and also termination if
UseOSErrorReporting is false, otherwise returning from the call and taking
further action.  All other callers of VM crash reporting include termination.

So if we get a structured exception on Windows and the option is true then we
report it and then end up walking up the exception handlers until running out,
when Windows crash behavior gets a shot.  This is essentially the same as
before the change, just checking the option in a different place (in the
Windows-specific caller, rather than in an #ifdef block in the shared code).

In addition, the core VM crash reporter uses BREAKPOINT before termination if 
UseOSErrorReporting is true.  So if we have an assertion failure we report it
and then end up walking up the exception handlers (because of the breakpoint
exception) until running out, when Windows crash behavior gets a shot.

So if there is an attached debugger (or JIT debugging is enabled), this leads
an assertion failure to hit the debugger inside the crash reporter rather than
after it returned (due to the old behavior for UseOSErrorReporting) from the
failed assertion (hitting the BREAKPOINT there).

Note that on Windows, ::breakpoint() calls DebugBreak(), raising a breakpoint
exception, which ends up being unhandled if UseOSErrorReporting is true.

There is a pre-existing bug that I'll be reporting separately.  If
UseOSErrorReporting and CreateCoredumpOnCrash are both true, we create an
empty .mdmp file.  We shouldn't create that file when UseOSErrorReporting.

Testing:
mach5 tier1-3

Manual testing with the following, to verify expected behavior that is the
same as before the change.

# -XX:ErrorHandlerTest=N
# 1: assertion failure
# 2: guarantee failure
# 14: SIGSEGV
# 15: divide by zero
path/to/bin/java \
  -XX:+UnlockDiagnosticVMOptions \
  -XX:+ErrorLogSecondaryErrorDetails \
  -XX:+UseOSErrorReporting \
  -XX:ErrorHandlerTest=1 \
  TestDebug.java

--- TestDebug.java ---
import java.lang.String;
public class TestDebug {
    static private volatile String dummy;
    public static void main(String[] args) throws Exception {
        while (true) {
            dummy = new String("foo bar");
        }
    }
}
--- end TestDebug.java ---

I need someone with a better understanding of Windows to test the interaction
with Windows Error Reporting (WER).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302798](https://bugs.openjdk.org/browse/JDK-8302798): Refactor -XX:+UseOSErrorReporting for noreturn crash reporting


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12651/head:pull/12651` \
`$ git checkout pull/12651`

Update a local copy of the PR: \
`$ git checkout pull/12651` \
`$ git pull https://git.openjdk.org/jdk pull/12651/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12651`

View PR using the GUI difftool: \
`$ git pr show -t 12651`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12651.diff">https://git.openjdk.org/jdk/pull/12651.diff</a>

</details>
