### PR TITLE
JDK-8302846: IGV: Zoom stuck when zooming out on large graphs

### DIFF
--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/actions/ZoomLevelAction.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/actions/ZoomLevelAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/actions/ZoomLevelAction.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/actions/ZoomLevelAction.java
@@ -40,6 +40,8 @@ public final class ZoomLevelAction extends JComboBox<String> implements ChangedL
 
     private final DiagramViewer diagramScene;
 
+    boolean updateZoomInScene = true;
+
     @Override
     public void actionPerformed(ActionEvent e) {
         EditorTopComponent editor = EditorTopComponent.getActive();
@@ -58,6 +60,9 @@ public final class ZoomLevelAction extends JComboBox<String> implements ChangedL
             level = Math.max(level, minLevel);
             level = Math.min(level, maxLevel);
             setZoomLevel(level);
+            if (updateZoomInScene) {
+                diagramScene.setZoomPercentage(level);
+            }
         } catch(NumberFormatException exception) {
             changed(diagramScene);
         }
@@ -84,11 +89,12 @@ public final class ZoomLevelAction extends JComboBox<String> implements ChangedL
 
     private void setZoomLevel(int zoomLevel) {
         setSelectedItem(zoomLevel + "%");
-        diagramScene.setZoomPercentage(zoomLevel);
     }
 
     @Override
     public void changed(DiagramViewer diagramViewer) {
-        setSelectedItem(diagramViewer.getZoomPercentage() + "%");
+        updateZoomInScene = false;
+        setZoomLevel(diagramViewer.getZoomPercentage());
+        updateZoomInScene = true;
     }
 }


### PR DESCRIPTION
# Problem 
In the IdealGraphVisualizer (IGV) the user can zoom in and out using either the mouse-wheel or by entering/selecting a value in the zoom combo-box. The zoom combo-box is implemented in `ZoomLevelAction.java`: 
- `ZoomLevelAction` has a listener on `scene.getZoomChangedEvent()` which calls `changed(..)` each time the zoom level of the `diagramScene` changes, e.g. when the user zooms in/out with the mouse-wheel. 
- `actionPerformed(..)` is called when the user enters/selects a zoom level in the combo-box, in which case it calls `setZoomLevel(..)` -> `diagramScene.setZoomPercentage(zoomLevel)` to update the zooming of the scene. 
- `changed(..)` calls `setSelectedItem(..)` which updates the content of the combo-box and triggers a also a call to `actionPerformed(..)`. Unfortunately, in this case we should not call `diagramScene.setZoomPercentage(zoomLevel)` because the `diagramScene` is updating the `ZoomLevelAction` and not vice versa. The problem only reveals for small zooming level because `ZoomLevelAction` uses an integer for the zooming level (1-100%) while the `diagramScene` uses a float (1.0f is 100%). In the example where the bug occurs, mouse wheel zooming changed zoom level in `diagramScene` from 0.01 to 0.012 -  then `diagramScene` updates the `ZoomLevelAction` which rounds 1.2% to 1% :  and now the BUG: `ZoomLevelAction ` sets `diagramScene` zooming again to 0.01. The zooming is stuck at 0.01

# Solution
When `diagramScene` updates the `ZoomLevelAction`, `actionPerformed(..)` should not call `diagramScene.setZoomPercentage(zoomLevel)`. So we introduce a ` boolean updateZoomInScene` that is set to `false` when a change of zoom in `diagramScene ` triggered the  `actionPerformed(..)`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302846](https://bugs.openjdk.org/browse/JDK-8302846): IGV: Zoom stuck when zooming out on large graphs


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**) ⚠️ Review applies to [9f97bf39](https://git.openjdk.org/jdk/pull/12652/files/9f97bf39462a5b7cb2cfea89f1dd9b7475cde973)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [9f97bf39](https://git.openjdk.org/jdk/pull/12652/files/9f97bf39462a5b7cb2cfea89f1dd9b7475cde973)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12652/head:pull/12652` \
`$ git checkout pull/12652`

Update a local copy of the PR: \
`$ git checkout pull/12652` \
`$ git pull https://git.openjdk.org/jdk pull/12652/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12652`

View PR using the GUI difftool: \
`$ git pr show -t 12652`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12652.diff">https://git.openjdk.org/jdk/pull/12652.diff</a>

</details>
