### PR TITLE
8302741: ZGC: Remove Universe::verify calls

### DIFF
--- a/src/hotspot/share/gc/z/zDriver.cpp
+++ b/src/hotspot/share/gc/z/zDriver.cpp
@@ -319,12 +319,7 @@ void ZDriver::concurrent_reset_relocation_set() {
 }
 
 void ZDriver::pause_verify() {
-  if (VerifyBeforeGC || VerifyDuringGC || VerifyAfterGC) {
-    // Full verification
-    VM_Verify op;
-    VMThread::execute(&op);
-  } else if (ZVerifyRoots || ZVerifyObjects) {
-    // Limited verification
+  if (ZVerifyRoots || ZVerifyObjects) {
     VM_ZVerify op;
     VMThread::execute(&op);
   }


### PR DESCRIPTION
ZGC has both explicit verification of roots and objects, and indirect verification via `Universe::verify`. Universe::verify doesn't play that well with highly concurrent GCs, so we've had to turn off most of the calls to it. But, we still have one call to it just after non-strong reference processing. The intention was that all pointers should have been remapped and cleaned at that point, so all roots should be verifiable. However, Universe::verify also verifies non-roots (E.g. the CLD graph, which is not always a root set), and that causes problems because of finalizeble marking. After marking and non-strong reference processing, the object graph (including metadata) can have finalizable marked references, which causes the verification from Universe::verify to fail.

The proposed fix is to remove the call to Universe::heap, but still retain verification via the ZGC specific verification instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302741](https://bugs.openjdk.org/browse/JDK-8302741): ZGC: Remove Universe::verify calls


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12653/head:pull/12653` \
`$ git checkout pull/12653`

Update a local copy of the PR: \
`$ git checkout pull/12653` \
`$ git pull https://git.openjdk.org/jdk pull/12653/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12653`

View PR using the GUI difftool: \
`$ git pr show -t 12653`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12653.diff">https://git.openjdk.org/jdk/pull/12653.diff</a>

</details>
