### PR TITLE
8302849: SurfaceManager might expose partially constructed object

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/image/SurfaceManager.java
+++ b/src/java.desktop/share/classes/sun/awt/image/SurfaceManager.java
@@ -89,7 +89,7 @@ public abstract class SurfaceManager {
         imgaccessor.setSurfaceManager(img, mgr);
     }
 
-    private ConcurrentHashMap<Object,Object> cacheMap;
+    private volatile ConcurrentHashMap<Object,Object> cacheMap;
 
     /**
      * Return an arbitrary cached object for an arbitrary cache key.


### PR DESCRIPTION
This PR proposes to add `volatile` to a variable declaration in order to prevent partially initialized objects to be observed by threads.

`SurfaceManager` is using a lazily initialized cacheMap that is initialized using a double-checked locking mechanism. Generally, objects initialized using such constructs need to be declared volatile. 

See https://en.wikipedia.org/wiki/Double-checked_locking#Usage_in_Java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302849](https://bugs.openjdk.org/browse/JDK-8302849): SurfaceManager might expose partially constructed object


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12654/head:pull/12654` \
`$ git checkout pull/12654`

Update a local copy of the PR: \
`$ git checkout pull/12654` \
`$ git pull https://git.openjdk.org/jdk pull/12654/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12654`

View PR using the GUI difftool: \
`$ git pr show -t 12654`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12654.diff">https://git.openjdk.org/jdk/pull/12654.diff</a>

</details>
