### PR TITLE
8302856: Typo in FlightRecorderMXBeanImpl

### DIFF
--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/FlightRecorderMXBeanImpl.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/FlightRecorderMXBeanImpl.java
@@ -96,7 +96,7 @@ final class FlightRecorderMXBeanImpl extends StandardEmitterMBean implements Fli
             AccessController.doPrivileged(new PrivilegedAction<Void>() {
                 @Override
                 public Void run() {
-                    sendNotification(createNotication(recording));
+                    sendNotification(createNotification(recording));
                     return null;
                 }
             }, context);
@@ -457,7 +457,7 @@ final class FlightRecorderMXBeanImpl extends StandardEmitterMBean implements Fli
         listeners.removeAll(toBeRemoved);
     }
 
-    private Notification createNotication(Recording recording) {
+    private Notification createNotification(Recording recording) {
         try {
             Long id = recording.getId();
             Object oldValue = changes.get(recording.getId());
@@ -470,7 +470,7 @@ final class FlightRecorderMXBeanImpl extends StandardEmitterMBean implements Fli
             return new AttributeChangeNotification(getObjectName(), sequenceNumber.incrementAndGet(), System.currentTimeMillis(), "Recording " + recording.getName() + " is "
                     + recording.getState(), ATTRIBUTE_RECORDINGS, newValue.getClass().getName(), oldValue, newValue);
         } catch (AttributeNotFoundException | MBeanException | ReflectionException e) {
-            throw new RuntimeException("Could not create notifcation for FlightRecorderMXBean. " + e.getMessage(), e);
+            throw new RuntimeException("Could not create notification for FlightRecorderMXBean. " + e.getMessage(), e);
         }
     }
 }


### PR DESCRIPTION
This PR fixes two typos.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302856](https://bugs.openjdk.org/browse/JDK-8302856): Typo in FlightRecorderMXBeanImpl


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12655/head:pull/12655` \
`$ git checkout pull/12655`

Update a local copy of the PR: \
`$ git checkout pull/12655` \
`$ git pull https://git.openjdk.org/jdk pull/12655/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12655`

View PR using the GUI difftool: \
`$ git pr show -t 12655`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12655.diff">https://git.openjdk.org/jdk/pull/12655.diff</a>

</details>
