### PR TITLE
8302858: Polish FlightRecorderMXBeanImpl

### DIFF
--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/FlightRecorderMXBeanImpl.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/FlightRecorderMXBeanImpl.java
@@ -288,8 +288,8 @@ final class FlightRecorderMXBeanImpl extends StandardEmitterMBean implements Fli
             if (!OPTIONS.contains(key)) {
                 throw new IllegalArgumentException("Unknown recording option: " + key + ". Valid options are " + OPTIONS + ".");
             }
-            if (value == null) {
-                throw new IllegalArgumentException("Incorrect value for option " + key + ". Values must not be null.");
+            if (value != null && !(value instanceof String)) {
+                throw new IllegalArgumentException("Incorrect value for option " + key + ". Values must be of type " + String.class + " .");
             }
         }
 

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/FlightRecorderMXBeanImpl.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/FlightRecorderMXBeanImpl.java
@@ -111,7 +111,7 @@ final class FlightRecorderMXBeanImpl extends StandardEmitterMBean implements Fli
     private static final String OPTION_DUMP_ON_EXIT = "dumpOnExit";
     private static final String OPTION_DURATION = "duration";
     private static final String OPTION_DESTINATION = "destination";
-    private static final List<String> OPTIONS = Arrays.asList(new String[] { OPTION_DUMP_ON_EXIT, OPTION_DURATION, OPTION_NAME, OPTION_MAX_AGE, OPTION_MAX_SIZE, OPTION_DISK, OPTION_DESTINATION, });
+    private static final List<String> OPTIONS = Arrays.asList(OPTION_DUMP_ON_EXIT, OPTION_DURATION, OPTION_NAME, OPTION_MAX_AGE, OPTION_MAX_SIZE, OPTION_DISK, OPTION_DESTINATION);
     private final StreamManager streamHandler = new StreamManager();
     private final Map<Long, Object> changes = new ConcurrentHashMap<>();
     private final AtomicLong sequenceNumber = new AtomicLong();
@@ -282,14 +282,14 @@ final class FlightRecorderMXBeanImpl extends StandardEmitterMBean implements Fli
         for (Map.Entry<String, String> entry : ops.entrySet()) {
             Object key = entry.getKey();
             Object value = entry.getValue();
-            if (!(key instanceof String)) {
-                throw new IllegalArgumentException("Option key must not be null, or other type than " + String.class);
+            if (key == null) {
+                throw new IllegalArgumentException("Option key must not be null.");
             }
             if (!OPTIONS.contains(key)) {
                 throw new IllegalArgumentException("Unknown recording option: " + key + ". Valid options are " + OPTIONS + ".");
             }
-            if (value != null && !(value instanceof String)) {
-                throw new IllegalArgumentException("Incorrect value for option " + key + ". Values must be of type " + String.class + " .");
+            if (value == null) {
+                throw new IllegalArgumentException("Incorrect value for option " + key + ". Values must not be null.");
             }
         }
 
@@ -303,12 +303,12 @@ final class FlightRecorderMXBeanImpl extends StandardEmitterMBean implements Fli
         validateOption(ops, OPTION_DESTINATION, x -> MBeanUtils.destination(r, x));
 
         // All OK, now set them.atomically
-        setOption(ops, OPTION_DUMP_ON_EXIT, "false", MBeanUtils::booleanValue, x -> r.setDumpOnExit(x));
-        setOption(ops, OPTION_DISK, "true", MBeanUtils::booleanValue, x -> r.setToDisk(x));
-        setOption(ops, OPTION_NAME, String.valueOf(r.getId()), Function.identity(), x -> r.setName(x));
-        setOption(ops, OPTION_MAX_AGE, null, MBeanUtils::duration, x -> r.setMaxAge(x));
-        setOption(ops, OPTION_MAX_SIZE, "0", MBeanUtils::size, x -> r.setMaxSize(x));
-        setOption(ops, OPTION_DURATION, null, MBeanUtils::duration, x -> r.setDuration(x));
+        setOption(ops, OPTION_DUMP_ON_EXIT, "false", MBeanUtils::booleanValue, r::setDumpOnExit);
+        setOption(ops, OPTION_DISK, "true", MBeanUtils::booleanValue, r::setToDisk);
+        setOption(ops, OPTION_NAME, String.valueOf(r.getId()), Function.identity(), r::setName);
+        setOption(ops, OPTION_MAX_AGE, null, MBeanUtils::duration, r::setMaxAge);
+        setOption(ops, OPTION_MAX_SIZE, "0", MBeanUtils::size, r::setMaxSize);
+        setOption(ops, OPTION_DURATION, null, MBeanUtils::duration, r::setDuration);
         setOption(ops, OPTION_DESTINATION, null, x -> MBeanUtils.destination(r, x), x -> setOptionDestination(r, x));
     }
 

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/FlightRecorderMXBeanImpl.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/FlightRecorderMXBeanImpl.java
@@ -302,7 +302,7 @@ final class FlightRecorderMXBeanImpl extends StandardEmitterMBean implements Fli
         validateOption(ops, OPTION_DURATION, MBeanUtils::duration);
         validateOption(ops, OPTION_DESTINATION, x -> MBeanUtils.destination(r, x));
 
-        // All OK, now set them.atomically
+        // All OK, now set them
         setOption(ops, OPTION_DUMP_ON_EXIT, "false", MBeanUtils::booleanValue, r::setDumpOnExit);
         setOption(ops, OPTION_DISK, "true", MBeanUtils::booleanValue, r::setToDisk);
         setOption(ops, OPTION_NAME, String.valueOf(r.getId()), Function.identity(), r::setName);

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/FlightRecorderMXBeanImpl.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/FlightRecorderMXBeanImpl.java
@@ -282,8 +282,9 @@ final class FlightRecorderMXBeanImpl extends StandardEmitterMBean implements Fli
         for (Map.Entry<String, String> entry : ops.entrySet()) {
             Object key = entry.getKey();
             Object value = entry.getValue();
-            if (key == null) {
-                throw new IllegalArgumentException("Option key must not be null.");
+            // Keys and values may be sent over the network
+            if (!(key instanceof String)) {
+                throw new IllegalArgumentException("Option key must not be null, or other type than " + String.class);
             }
             if (!OPTIONS.contains(key)) {
                 throw new IllegalArgumentException("Unknown recording option: " + key + ". Valid options are " + OPTIONS + ".");


### PR DESCRIPTION
This PR proposes some polishing of the `FlightRecorderMXBeanImpl` class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302858](https://bugs.openjdk.org/browse/JDK-8302858): Polish FlightRecorderMXBeanImpl


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12656/head:pull/12656` \
`$ git checkout pull/12656`

Update a local copy of the PR: \
`$ git checkout pull/12656` \
`$ git pull https://git.openjdk.org/jdk pull/12656/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12656`

View PR using the GUI difftool: \
`$ git pr show -t 12656`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12656.diff">https://git.openjdk.org/jdk/pull/12656.diff</a>

</details>
