### PR TITLE
8302864: Parallel: Remove PSVirtualSpace::pointer_delta

### DIFF
--- a/src/hotspot/share/gc/parallel/psVirtualspace.hpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.hpp
@@ -52,9 +52,6 @@ class PSVirtualSpace : public CHeapObj<mtGC> {
   // os::commit_memory() or os::uncommit_memory().
   bool _special;
 
-  // Convenience wrapper.
-  inline static size_t pointer_delta(const char* left, const char* right);
-
  public:
   PSVirtualSpace(ReservedSpace rs, size_t alignment);
 
@@ -124,17 +121,13 @@ class PSVirtualSpace : public CHeapObj<mtGC> {
 //
 // PSVirtualSpace inlines.
 //
-inline size_t
-PSVirtualSpace::pointer_delta(const char* left, const char* right) {
-  return ::pointer_delta((void *)left, (void*)right, sizeof(char));
-}
 
 inline size_t PSVirtualSpace::committed_size() const {
-  return pointer_delta(committed_high_addr(), committed_low_addr());
+  return pointer_delta(committed_high_addr(), committed_low_addr(), sizeof(char));
 }
 
 inline size_t PSVirtualSpace::reserved_size() const {
-  return pointer_delta(reserved_high_addr(), reserved_low_addr());
+  return pointer_delta(reserved_high_addr(), reserved_low_addr(), sizeof(char));
 }
 
 inline size_t PSVirtualSpace::uncommitted_size() const {


### PR DESCRIPTION
Simple removing redundant code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302864](https://bugs.openjdk.org/browse/JDK-8302864): Parallel: Remove PSVirtualSpace::pointer_delta


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12657/head:pull/12657` \
`$ git checkout pull/12657`

Update a local copy of the PR: \
`$ git checkout pull/12657` \
`$ git pull https://git.openjdk.org/jdk pull/12657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12657`

View PR using the GUI difftool: \
`$ git pr show -t 12657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12657.diff">https://git.openjdk.org/jdk/pull/12657.diff</a>

</details>
