### PR TITLE
8302867: G1: Removing unused variable in G1CardTable::initialize

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardTable.cpp
+++ b/src/hotspot/share/gc/g1/g1CardTable.cpp
@@ -52,8 +52,6 @@ void G1CardTable::initialize(G1RegionToSpaceMapper* mapper) {
 
   _byte_map_size = mapper->reserved().byte_size();
 
-  size_t num_cards = cards_required(_whole_heap.word_size());
-
   HeapWord* low_bound  = _whole_heap.start();
   HeapWord* high_bound = _whole_heap.end();
 


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302867](https://bugs.openjdk.org/browse/JDK-8302867): G1: Removing unused variable in G1CardTable::initialize


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12658/head:pull/12658` \
`$ git checkout pull/12658`

Update a local copy of the PR: \
`$ git checkout pull/12658` \
`$ git pull https://git.openjdk.org/jdk pull/12658/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12658`

View PR using the GUI difftool: \
`$ git pr show -t 12658`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12658.diff">https://git.openjdk.org/jdk/pull/12658.diff</a>

</details>
