### PR TITLE
8302868: Serial: Remove CardTableRS::initialize

### DIFF
--- a/src/hotspot/share/gc/shared/cardTableRS.cpp
+++ b/src/hotspot/share/gc/shared/cardTableRS.cpp
@@ -434,10 +434,6 @@ void CardTableRS::verify() {
 CardTableRS::CardTableRS(MemRegion whole_heap) :
   CardTable(whole_heap) { }
 
-void CardTableRS::initialize() {
-  CardTable::initialize();
-}
-
 void CardTableRS::non_clean_card_iterate(TenuredSpace* sp,
                                          MemRegion mr,
                                          OopIterateClosure* cl,

--- a/src/hotspot/share/gc/shared/cardTableRS.hpp
+++ b/src/hotspot/share/gc/shared/cardTableRS.hpp
@@ -62,7 +62,6 @@ public:
   }
 
   void verify();
-  void initialize() override;
 
   void clear_into_younger(Generation* old_gen);
 


### PR DESCRIPTION
Simple removing redundant code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302868](https://bugs.openjdk.org/browse/JDK-8302868): Serial: Remove CardTableRS::initialize


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12659/head:pull/12659` \
`$ git checkout pull/12659`

Update a local copy of the PR: \
`$ git checkout pull/12659` \
`$ git pull https://git.openjdk.org/jdk pull/12659/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12659`

View PR using the GUI difftool: \
`$ git pr show -t 12659`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12659.diff">https://git.openjdk.org/jdk/pull/12659.diff</a>

</details>
