### PR TITLE
8302870: More information needed from failures in vmTestbase ThreadUtils.waitThreadState

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/thread/ThreadUtils.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/thread/ThreadUtils.java
@@ -25,10 +25,11 @@ package nsk.monitoring.share.thread;
 
 import nsk.share.log.Log;
 import nsk.share.TestFailure;
+
+import java.io.PrintStream;
 import java.lang.management.LockInfo;
 import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
-import java.io.PrintStream;
 
 public final class ThreadUtils {
         private ThreadUtils() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/thread/ThreadUtils.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/thread/ThreadUtils.java
@@ -206,11 +206,11 @@ public final class ThreadUtils {
         }
 
         public static void printStackTrace(PrintStream out, Thread t) {
-            StackTraceElement[] stacktrace = t.getStackTrace();
-            for (int i = 0; i < stacktrace.length; i++) {
-                StackTraceElement ste = stacktrace[i];
-                out.println(INDENT + "at " + ste.toString());
-            }
+                StackTraceElement[] stacktrace = t.getStackTrace();
+                for (int i = 0; i < stacktrace.length; i++) {
+                        StackTraceElement ste = stacktrace[i];
+                        out.println(INDENT + "at " + ste.toString());
+                }
         }
 
         /**
@@ -229,32 +229,32 @@ public final class ThreadUtils {
         }
 
         // Most uses of waitThreadState usually succeed without retries.
-        // Sleep time increased to help avoid spurious failures.
+        // These values should avoid spurious failures.
         public final static int waitThreadStateRetries = 10;
         public final static long waitThreadStateSleepTime = 1000;
 
         public static void waitThreadState(Thread thread, Thread.State state) {
                 int retries = 0;
-                long ctime = System.currentTimeMillis();
-                long ctime2 = 0;
+                long startTime = System.currentTimeMillis();
+                long elapsedTime = 0;
                 while (thread.getState() != state) {
                         if (retries++ > waitThreadStateRetries) {
-                            // Failed to see desired state, give info to help diagnose the isuse.
-                            // Show the thread, and fail with Exception showing retries and time taken.
-                            ctime2 = System.currentTimeMillis() - ctime;
-                            System.err.println("waitThreadState: problem thread: " + thread);
-                            printStackTrace(System.err, thread);
-                            throw new TestFailure("Thread " + thread + " with current state " + thread.getState() + " did not reach state "
-                                                  + state + " with number of retries: " + retries + ", time: " + ctime2);
+                                // Failed to see desired state, give info to help diagnose the isuse.
+                                // Show the thread, and fail with Exception showing retries and time taken.
+                                elapsedTime = System.currentTimeMillis() - startTime;
+                                System.err.println("waitThreadState: problem thread: " + thread);
+                                printStackTrace(System.err, thread);
+                                throw new TestFailure("Thread " + thread + " with current state " + thread.getState() + " did not reach state "
+                                                      + state + " with number of retries: " + retries + ", time: " + elapsedTime);
                         }
                         try {
-                            Thread.sleep(waitThreadStateSleepTime);
+                                Thread.sleep(waitThreadStateSleepTime);
                         } catch (InterruptedException e) {
                         }
                 }
                 // Show retries and time, so we know what "normal" looks like:
-                ctime2 = System.currentTimeMillis() - ctime;
-                System.out.println("waitThreadState: OK. retries: " + retries + " time: " + ctime2);
+                elapsedTime = System.currentTimeMillis() - startTime;
+                System.out.println("waitThreadState: OK. retries: " + retries + " time: " + elapsedTime);
         }
 
         /**

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/thread/ThreadUtils.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/thread/ThreadUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ import nsk.share.TestFailure;
 import java.lang.management.LockInfo;
 import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
+import java.io.PrintStream;
 
 public final class ThreadUtils {
         private ThreadUtils() {
@@ -203,6 +204,14 @@ public final class ThreadUtils {
 
         }
 
+        public static void printStackTrace(PrintStream out, Thread t) {
+            StackTraceElement[] stacktrace = t.getStackTrace();
+            for (int i = 0; i < stacktrace.length; i++) {
+                StackTraceElement ste = stacktrace[i];
+                out.println(INDENT + "at " + ste.toString());
+            }
+        }
+
         /**
          * Dump information about threads.
          *
@@ -218,20 +227,33 @@ public final class ThreadUtils {
                 }
         }
 
+        // Most uses of waitThreadState usually succeed without retries.
+        // Sleep time increased to help avoid spurious failures.
         public final static int waitThreadStateRetries = 10;
-        public final static long waitThreadStateSleepTime = 100;
+        public final static long waitThreadStateSleepTime = 1000;
 
         public static void waitThreadState(Thread thread, Thread.State state) {
                 int retries = 0;
                 long ctime = System.currentTimeMillis();
+                long ctime2 = 0;
                 while (thread.getState() != state) {
-                        if (retries++ > waitThreadStateRetries)
-                                throw new TestFailure("Thread " + thread + " with current state " + thread.getState() + " did not reach state " + state + " with number of  retries: " + retries + ", time: " + (System.currentTimeMillis() - ctime));
+                        if (retries++ > waitThreadStateRetries) {
+                            // Failed to see desired state, give info to help diagnose the isuse.
+                            // Show the thread, and fail with Exception showing retries and time taken.
+                            ctime2 = System.currentTimeMillis() - ctime;
+                            System.err.println("waitThreadState: problem thread: " + thread);
+                            printStackTrace(System.err, thread);
+                            throw new TestFailure("Thread " + thread + " with current state " + thread.getState() + " did not reach state "
+                                                  + state + " with number of retries: " + retries + ", time: " + ctime2);
+                        }
                         try {
-                                Thread.sleep(waitThreadStateSleepTime);
+                            Thread.sleep(waitThreadStateSleepTime);
                         } catch (InterruptedException e) {
                         }
                 }
+                // Show retries and time, so we know what "normal" looks like:
+                ctime2 = System.currentTimeMillis() - ctime;
+                System.out.println("waitThreadState: OK. retries: " + retries + " time: " + ctime2);
         }
 
         /**


### PR DESCRIPTION
Test update to make failures such as JDK-8076494 more informative.

Waiting for a thread to change state: give more time (to distinguish a real deadlock from some other delay), and log the thread stackframes when the expected state change is not observed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302870](https://bugs.openjdk.org/browse/JDK-8302870): More information needed from failures in vmTestbase ThreadUtils.waitThreadState


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12661/head:pull/12661` \
`$ git checkout pull/12661`

Update a local copy of the PR: \
`$ git checkout pull/12661` \
`$ git pull https://git.openjdk.org/jdk pull/12661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12661`

View PR using the GUI difftool: \
`$ git pr show -t 12661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12661.diff">https://git.openjdk.org/jdk/pull/12661.diff</a>

</details>
