### PR TITLE
8302873: ZGC: dump barrier data in C2 Mach nodes

### DIFF
--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
@@ -28,6 +28,7 @@
 #include "memory/allocation.hpp"
 #include "oops/accessDecorators.hpp"
 #include "opto/loopnode.hpp"
+#include "opto/machnode.hpp"
 #include "opto/matcher.hpp"
 #include "opto/memnode.hpp"
 #include "utilities/globalDefinitions.hpp"
@@ -302,6 +303,12 @@ public:
   virtual void emit_stubs(CodeBuffer& cb) const { }
 
   static int arraycopy_payload_base_offset(bool is_array);
+
+#ifndef PRODUCT
+  virtual void dump_barrier_data(const MachNode* mach, outputStream* st) const {
+    st->print("%x", mach->barrier_data());
+  };
+#endif
 };
 
 #endif // SHARE_GC_SHARED_C2_BARRIERSETC2_HPP

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -564,3 +564,20 @@ void ZBarrierSetC2::compute_liveness_at_stubs() const {
     }
   }
 }
+
+#ifndef PRODUCT
+void ZBarrierSetC2::dump_barrier_data(const MachNode* mach, outputStream* st) const {
+  if ((mach->barrier_data() & ZLoadBarrierStrong) != 0) {
+    st->print("strong ");
+  }
+  if ((mach->barrier_data() & ZLoadBarrierWeak) != 0) {
+    st->print("weak ");
+  }
+  if ((mach->barrier_data() & ZLoadBarrierPhantom) != 0) {
+    st->print("phantom ");
+  }
+  if ((mach->barrier_data() & ZLoadBarrierNoKeepalive) != 0) {
+    st->print("nokeepalive ");
+  }
+}
+#endif // !PRODUCT

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.hpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,6 +91,10 @@ public:
   virtual void late_barrier_analysis() const;
   virtual int estimate_stub_size() const;
   virtual void emit_stubs(CodeBuffer& cb) const;
+
+#ifndef PRODUCT
+  virtual void dump_barrier_data(const MachNode* mach, outputStream* st) const;
+#endif
 };
 
 #endif // SHARE_GC_Z_C2_ZBARRIERSETC2_HPP

--- a/src/hotspot/share/opto/machnode.cpp
+++ b/src/hotspot/share/opto/machnode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,8 @@
  */
 
 #include "precompiled.hpp"
+#include "gc/shared/barrierSet.hpp"
+#include "gc/shared/c2/barrierSetC2.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "memory/universe.hpp"
 #include "oops/compressedOops.hpp"
@@ -534,6 +536,11 @@ void MachTypeNode::dump_spec(outputStream *st) const {
     _bottom_type->dump_on(st);
   } else {
     st->print(" NULL");
+  }
+  if (barrier_data() != 0) {
+    st->print(" barrier(");
+    BarrierSet::barrier_set()->barrier_set_c2()->dump_barrier_data(this, st);
+    st->print(")");
   }
 }
 #endif


### PR DESCRIPTION
This changeset adds (debug-only) support for printing ZGC barrier data in a human-readable form as part of the C2 Mach node dumps. This is useful for debugging, IGV visualization (e.g. to create [barrier-specific filters](https://user-images.githubusercontent.com/8792647/216639224-aa288dd8-72cc-43a5-a445-a93d65004dac.png)), and for matching nodes in IR test framework checks (e.g. to write [barrier optimization tests](https://github.com/openjdk/zgc/blob/zgc_generational/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java)).

#### Testing

- tier1 (x64 and aaarch64; linux, windows, and macosx; release and debug mode)
- tested manually that the expected barrier information is dumped when using ZGC
- tested manually that the dumps remain unchanged when using another GC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302873](https://bugs.openjdk.org/browse/JDK-8302873): ZGC: dump barrier data in C2 Mach nodes


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12662/head:pull/12662` \
`$ git checkout pull/12662`

Update a local copy of the PR: \
`$ git checkout pull/12662` \
`$ git pull https://git.openjdk.org/jdk pull/12662/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12662`

View PR using the GUI difftool: \
`$ git pr show -t 12662`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12662.diff">https://git.openjdk.org/jdk/pull/12662.diff</a>

</details>
