### PR TITLE
8299777: Test runtime/NMT/BaselineWithParameter.java timed out

### DIFF
--- a/test/hotspot/jtreg/runtime/NMT/BaselineWithParameter.java
+++ b/test/hotspot/jtreg/runtime/NMT/BaselineWithParameter.java
@@ -46,7 +46,8 @@ public class BaselineWithParameter {
 
     // Run 'jcmd <pid> VM.native_memory baseline=false'
     pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "baseline=false"});
-    pb.start().waitFor();
+    output = new OutputAnalyzer(pb.start());
+    output.shouldContain("Total: reserved");
 
     // Run 'jcmd <pid> VM.native_memory summary=false'
     pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "summary=false"});

--- a/test/hotspot/jtreg/runtime/NMT/JcmdDetailDiff.java
+++ b/test/hotspot/jtreg/runtime/NMT/JcmdDetailDiff.java
@@ -54,7 +54,6 @@ public class JcmdDetailDiff {
 
         // Run 'jcmd <pid> VM.native_memory baseline=true'
         pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "baseline=true"});
-        pb.start().waitFor();
 
         output = new OutputAnalyzer(pb.start());
         output.shouldContain("Baseline taken");

--- a/test/hotspot/jtreg/runtime/NMT/JcmdSummaryClass.java
+++ b/test/hotspot/jtreg/runtime/NMT/JcmdSummaryClass.java
@@ -48,11 +48,10 @@ public class JcmdSummaryClass {
 
         // Run 'jcmd <pid> VM.native_memory baseline=true'
         pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory"});
-        pb.start().waitFor();
+        output = new OutputAnalyzer(pb.start());
 
         String classes_line = "classes #\\d+";
         String instance_array_classes_line = "instance classes #\\d+, array classes #\\d+";
-        output = new OutputAnalyzer(pb.start());
         output.shouldMatch(classes_line);
         output.shouldMatch(instance_array_classes_line);
     }

--- a/test/hotspot/jtreg/runtime/NMT/JcmdSummaryDiff.java
+++ b/test/hotspot/jtreg/runtime/NMT/JcmdSummaryDiff.java
@@ -54,7 +54,6 @@ public class JcmdSummaryDiff {
 
         // Run 'jcmd <pid> VM.native_memory baseline=true'
         pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "baseline=true"});
-        pb.start().waitFor();
 
         output = new OutputAnalyzer(pb.start());
         output.shouldContain("Baseline taken");


### PR DESCRIPTION
I found this issue while debugging a hang in runtime/NMT/JcmdSummaryClass.java. We have the same issue in a few other NMT tests, and the BaselineWithParameter.java is one of them.

The common pattern among these tests is that they have one main process that forks a jcmd process against itself. The forked jcmd process writes its output to stdout (and maybe stderr). The problematic part of these tests is that the main process doesn't drain the streams of the forked jcmd before it calls waitFor(). This usually works and the tests passes, and I guess that's because there's some internal buffer that the jcmd process can write to without blocking. However, if too much data gets written the process gets blocked and the test times out. I can reproduce this by artificially adding more output to the NMT jcmd with the following patch

```
diff --git a/src/hotspot/share/services/nmtDCmd.cpp b/src/hotspot/share/services/nmtDCmd.cpp
index f64c65c2dc8..42dbe6c1ae2 100644
--- a/src/hotspot/share/services/nmtDCmd.cpp
+++ b/src/hotspot/share/services/nmtDCmd.cpp
@@ -108,6 +108,11 @@ void NMTDCmd::execute(DCmdSource source, TRAPS) {
   // Serialize NMT query
   MutexLocker locker(THREAD, MemTracker::query_lock());
 
+  // Fill up the output
+  for (int i = 0; i < 8 * 1024; i++) {
+    output()->print_cr("Fake line: %d", i);
+  }
+
   if (_summary.value()) {
     report(true, scale_unit);
   } else if (_detail.value()) {
```

This is the problematic test pattern:
```
// Set up command line
pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory"});

// Test hangs here waiting for the jcmd process to finish,
// which it won't because nothing accepts its written output.
pb.start().waitFor();

// Verify the output - (secondary bug here, see comments below)
output = new OutputAnalyzer(pb.start());
```

The correct way to write these tests is simply to remove the waitFor call and let the OutputAnalyzer deal with waiting for the forked process to finish:
```
// Set up command line
pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory"});

// Start the process and verify the output
output = new OutputAnalyzer(pb.start());
```

The secondary problem with this tests is that they forks the jcmd process twice, via two calls to pb.start(). This isn't causing the hangs, but we shouldn't be doing that.

I've tested this fix by running the tests in runtime/NMT with and without the nmtDcmd.cpp patch above.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299777](https://bugs.openjdk.org/browse/JDK-8299777): Test runtime/NMT/BaselineWithParameter.java timed out


### Reviewers
 * [Gerard Ziemski](https://openjdk.org/census#gziemski) (@gerard-ziemski - Committer)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12663/head:pull/12663` \
`$ git checkout pull/12663`

Update a local copy of the PR: \
`$ git checkout pull/12663` \
`$ git pull https://git.openjdk.org/jdk pull/12663/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12663`

View PR using the GUI difftool: \
`$ git pr show -t 12663`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12663.diff">https://git.openjdk.org/jdk/pull/12663.diff</a>

</details>
