### PR TITLE
8302882: Newly added test javax/swing/JFileChooser/JFileChooserFontReset.java fails with HeadlessException

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/JFileChooserFontReset.java
+++ b/test/jdk/javax/swing/JFileChooser/JFileChooserFontReset.java
@@ -22,7 +22,8 @@
  */
 /*
  * @test
- * @bug 6753661
+ * @bug 6753661 8302882
+ * @key headful
  * @summary  Verifies if JFileChooser font reset after Look & Feel change
  * @run main JFileChooserFontReset
  */


### PR DESCRIPTION
Added key headful to the test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302882](https://bugs.openjdk.org/browse/JDK-8302882): Newly added test javax/swing/JFileChooser/JFileChooserFontReset.java fails with HeadlessException


### Reviewers
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12666/head:pull/12666` \
`$ git checkout pull/12666`

Update a local copy of the PR: \
`$ git checkout pull/12666` \
`$ git pull https://git.openjdk.org/jdk pull/12666/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12666`

View PR using the GUI difftool: \
`$ git pr show -t 12666`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12666.diff">https://git.openjdk.org/jdk/pull/12666.diff</a>

</details>
