### PR TITLE
8303078: Reduce allocations when pretty printing JCTree during compilation

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocPretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocPretty.java
@@ -94,7 +94,7 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     /**
      * Print list with separators.
      */
-    protected void print(List<? extends DocTree> list, String sep) throws IOException {
+    protected void print(List<? extends DocTree> list, char sep) throws IOException {
         if (list.isEmpty())
             return;
         boolean first = true;
@@ -188,8 +188,8 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
             List<? extends DocTree> t = node.getBlockTags();
             print(b);
             if (!b.isEmpty() && !t.isEmpty())
-                print("\n");
-            print(t, "\n");
+                print('\n');
+            print(t, '\n');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -498,7 +498,7 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
             List<? extends DocTree> attrs = node.getAttributes();
             if (!attrs.isEmpty()) {
                 print(' ');
-                print(attrs, " ");
+                print(attrs, ' ');
             }
             if (node.getBody() != null) {
                 print(" :\n");
@@ -533,7 +533,7 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
             List<? extends DocTree> attrs = node.getAttributes();
             if (!attrs.isEmpty()) {
                 print(' ');
-                print(attrs, " ");
+                print(attrs, ' ');
                 DocTree last = node.getAttributes().get(attrs.size() - 1);
                 if (node.isSelfClosing() && last instanceof AttributeTree attributeTree
                         && attributeTree.getValueKind() == ValueKind.UNQUOTED)

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocPretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocPretty.java
@@ -94,7 +94,7 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     /**
      * Print list with separators.
      */
-    protected void print(List<? extends DocTree> list, char sep) throws IOException {
+    private void print(List<? extends DocTree> list, char sep) throws IOException {
         if (list.isEmpty())
             return;
         boolean first = true;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocPretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocPretty.java
@@ -76,6 +76,12 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
         out.write(Convert.escapeUnicode(s.toString()));
     }
 
+    /** Print character. Should be only used internally for known ASCII characters.
+     */
+    private void print(char c) throws IOException {
+        out.write(c);
+    }
+
     /**
      * Print list.
      */
@@ -107,7 +113,7 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     }
 
     protected void printTagName(DocTree node) throws IOException {
-        out.write("@");
+        out.write('@');
         out.write(node.getKind().tagName);
     }
 
@@ -128,7 +134,8 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
                 case DOUBLE -> "\"";
             };
             if (quote != null) {
-                print("=" + quote);
+                print('=');
+                print(quote);
                 print(node.getValue());
                 print(quote);
             }
@@ -142,7 +149,7 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     public Void visitAuthor(AuthorTree node, Void p) {
         try {
             printTagName(node);
-            print(" ");
+            print(' ');
             print(node.getName());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -165,7 +172,7 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
         try {
             printTagName(node);
             if (!node.getBody().isEmpty()) {
-                print(" ");
+                print(' ');
                 print(node.getBody());
             }
         } catch (IOException e) {
@@ -192,9 +199,9 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     @Override @DefinedBy(Api.COMPILER_TREE)
     public Void visitDocRoot(DocRootTree node, Void p) {
         try {
-            print("{");
+            print('{');
             printTagName(node);
-            print("}");
+            print('}');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -216,7 +223,7 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
         try {
             print("</");
             print(node.getName());
-            print(">");
+            print('>');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -226,9 +233,9 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     @Override @DefinedBy(Api.COMPILER_TREE)
     public Void visitEntity(EntityTree node, Void p) {
         try {
-            print("&");
+            print('&');
             print(node.getName());
-            print(";");
+            print(';');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -248,7 +255,7 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     @Override @DefinedBy(Api.COMPILER_TREE)
     public Void visitEscape(EscapeTree node, Void p) {
         try {
-            out.write("@");
+            out.write('@');
             print(node.getBody());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -261,7 +268,7 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
         try {
             printTagName(node);
             if (!node.getBody().isEmpty()) {
-                print(" ");
+                print(' ');
                 print(node.getBody());
             }
         } catch (IOException e) {
@@ -283,15 +290,15 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     @Override @DefinedBy(Api.COMPILER_TREE)
     public Void visitIndex(IndexTree node, Void p) {
         try {
-            print("{");
+            print('{');
             printTagName(node);
-            print(" ");
+            print(' ');
             print(node.getSearchTerm());
             if (!node.getDescription().isEmpty()) {
-                print(" ");
+                print(' ');
                 print(node.getDescription());
             }
-            print("}");
+            print('}');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -301,9 +308,9 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     @Override @DefinedBy(Api.COMPILER_TREE)
     public Void visitInheritDoc(InheritDocTree node, Void p) {
         try {
-            print("{");
+            print('{');
             printTagName(node);
-            print("}");
+            print('}');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -313,15 +320,15 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     @Override @DefinedBy(Api.COMPILER_TREE)
     public Void visitLink(LinkTree node, Void p) {
         try {
-            print("{");
+            print('{');
             printTagName(node);
-            print(" ");
+            print(' ');
             print(node.getReference());
             if (!node.getLabel().isEmpty()) {
-                print(" ");
+                print(' ');
                 print(node.getLabel());
             }
-            print("}");
+            print('}');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -331,14 +338,14 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     @Override @DefinedBy(Api.COMPILER_TREE)
     public Void visitLiteral(LiteralTree node, Void p) {
         try {
-            print("{");
+            print('{');
             printTagName(node);
             String body = node.getBody().getBody();
             if (!body.isEmpty() && !Character.isWhitespace(body.charAt(0))) {
-                print(" ");
+                print(' ');
             }
             print(node.getBody());
-            print("}");
+            print('}');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -349,12 +356,12 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     public Void visitParam(ParamTree node, Void p) {
         try {
             printTagName(node);
-            print(" ");
-            if (node.isTypeParameter()) print("<");
+            print(' ');
+            if (node.isTypeParameter()) print('<');
             print(node.getName());
-            if (node.isTypeParameter()) print(">");
+            if (node.isTypeParameter()) print('>');
             if (!node.getDescription().isEmpty()) {
-                print(" ");
+                print(' ');
                 print(node.getDescription());
             }
         } catch (IOException e) {
@@ -367,10 +374,10 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     public Void visitProvides(ProvidesTree node, Void p) {
         try {
             printTagName(node);
-            print(" ");
+            print(' ');
             print(node.getServiceType());
             if (!node.getDescription().isEmpty()) {
-                print(" ");
+                print(' ');
                 print(node.getDescription());
             }
         } catch (IOException e) {
@@ -393,13 +400,13 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     public Void visitReturn(ReturnTree node, Void p) {
         try {
             if (node.isInline()) {
-                print("{");
+                print('{');
             }
             printTagName(node);
-            print(" ");
+            print(' ');
             print(node.getDescription());
             if (node.isInline()) {
-                print("}");
+                print('}');
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -414,7 +421,7 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
             boolean first = true;
             boolean needSep = true;
             for (DocTree t: node.getReference()) {
-                if (needSep) print(" ");
+                if (needSep) print(' ');
                 needSep = (first && (t instanceof ReferenceTree));
                 first = false;
                 print(t);
@@ -430,7 +437,7 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
         try {
             printTagName(node);
             if (!node.getDescription().isEmpty()) {
-                print(" ");
+                print(' ');
                 print(node.getDescription());
             }
         } catch (IOException e) {
@@ -444,7 +451,7 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
         try {
             printTagName(node);
             if (!node.getDescription().isEmpty()) {
-                print(" ");
+                print(' ');
                 print(node.getDescription());
             }
         } catch (IOException e) {
@@ -457,12 +464,12 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     public Void visitSerialField(SerialFieldTree node, Void p) {
         try {
             printTagName(node);
-            print(" ");
+            print(' ');
             print(node.getName());
-            print(" ");
+            print(' ');
             print(node.getType());
             if (!node.getDescription().isEmpty()) {
-                print(" ");
+                print(' ');
                 print(node.getDescription());
             }
         } catch (IOException e) {
@@ -475,7 +482,7 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     public Void visitSince(SinceTree node, Void p) {
         try {
             printTagName(node);
-            print(" ");
+            print(' ');
             print(node.getBody());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -486,18 +493,18 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     @Override @DefinedBy(Api.COMPILER_TREE)
     public Void visitSnippet(SnippetTree node, Void p) {
         try {
-            print("{");
+            print('{');
             printTagName(node);
             List<? extends DocTree> attrs = node.getAttributes();
             if (!attrs.isEmpty()) {
-                print(" ");
+                print(' ');
                 print(attrs, " ");
             }
             if (node.getBody() != null) {
                 print(" :\n");
                 print(node.getBody());
             }
-            print("}");
+            print('}');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -508,9 +515,9 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     public Void visitSpec(SpecTree node, Void p) {
         try {
             printTagName(node);
-            print(" ");
+            print(' ');
             print(node.getURL());
-            print(" ");
+            print(' ');
             print(node.getTitle());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -521,20 +528,20 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     @Override @DefinedBy(Api.COMPILER_TREE)
     public Void visitStartElement(StartElementTree node, Void p) {
         try {
-            print("<");
+            print('<');
             print(node.getName());
             List<? extends DocTree> attrs = node.getAttributes();
             if (!attrs.isEmpty()) {
-                print(" ");
+                print(' ');
                 print(attrs, " ");
                 DocTree last = node.getAttributes().get(attrs.size() - 1);
                 if (node.isSelfClosing() && last instanceof AttributeTree attributeTree
                         && attributeTree.getValueKind() == ValueKind.UNQUOTED)
-                    print(" ");
+                    print(' ');
             }
             if (node.isSelfClosing())
-                print("/");
-            print(">");
+                print('/');
+            print('>');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -544,13 +551,13 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     @Override @DefinedBy(Api.COMPILER_TREE)
     public Void visitSummary(SummaryTree node, Void p) {
         try {
-            print("{");
+            print('{');
             printTagName(node);
             if (!node.getSummary().isEmpty()) {
-                print(" ");
+                print(' ');
                 print(node.getSummary());
             }
-            print("}");
+            print('}');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -560,11 +567,11 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     @Override @DefinedBy(Api.COMPILER_TREE)
     public Void visitSystemProperty(SystemPropertyTree node, Void p) {
         try {
-            print("{");
+            print('{');
             printTagName(node);
-            print(" ");
+            print(' ');
             print(node.getPropertyName());
-            print("}");
+            print('}');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -585,10 +592,10 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     public Void visitThrows(ThrowsTree node, Void p) {
         try {
             printTagName(node);
-            print(" ");
+            print(' ');
             print(node.getExceptionName());
             if (!node.getDescription().isEmpty()) {
-                print(" ");
+                print(' ');
                 print(node.getDescription());
             }
         } catch (IOException e) {
@@ -600,9 +607,9 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     @Override @DefinedBy(Api.COMPILER_TREE)
     public Void visitUnknownBlockTag(UnknownBlockTagTree node, Void p) {
         try {
-            print("@");
+            print('@');
             print(node.getTagName());
-            print(" ");
+            print(' ');
             print(node.getContent());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -613,12 +620,12 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     @Override @DefinedBy(Api.COMPILER_TREE)
     public Void visitUnknownInlineTag(UnknownInlineTagTree node, Void p) {
         try {
-            print("{");
-            print("@");
+            print('{');
+            print('@');
             print(node.getTagName());
-            print(" ");
+            print(' ');
             print(node.getContent());
-            print("}");
+            print('}');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -629,10 +636,10 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     public Void visitUses(UsesTree node, Void p) {
         try {
             printTagName(node);
-            print(" ");
+            print(' ');
             print(node.getServiceType());
             if (!node.getDescription().isEmpty()) {
-                print(" ");
+                print(' ');
                 print(node.getDescription());
             }
         } catch (IOException e) {
@@ -644,17 +651,17 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     @Override @DefinedBy(Api.COMPILER_TREE)
     public Void visitValue(ValueTree node, Void p) {
         try {
-            print("{");
+            print('{');
             printTagName(node);
             if (node.getFormat() != null) {
-                print(" ");
+                print(' ');
                 print(node.getFormat());
             }
             if (node.getReference() != null) {
-                print(" ");
+                print(' ');
                 print(node.getReference());
             }
-            print("}");
+            print('}');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -665,7 +672,7 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     public Void visitVersion(VersionTree node, Void p) {
         try {
             printTagName(node);
-            print(" ");
+            print(' ');
             print(node.getBody());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -676,7 +683,9 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     @Override @DefinedBy(Api.COMPILER_TREE)
     public Void visitOther(DocTree node, Void p) {
         try {
-            print("(UNKNOWN: " + node + ")");
+            print("(UNKNOWN: ");
+            print(node);
+            print(')');
             println();
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
@@ -1464,9 +1464,9 @@ public class Pretty extends JCTree.Visitor {
                     print("null");
                     break;
                 default:
-                    print("\"");
+                    print('"');
                     print(Convert.quote(tree.value.toString()));
-                    print("\"");
+                    print('"');
                     break;
             }
         } catch (IOException e) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
@@ -1244,11 +1244,11 @@ public class Pretty extends JCTree.Visitor {
             if (tree.paramKind == JCLambda.ParameterKind.EXPLICIT) {
                 printExprs(tree.params);
             } else {
-                char sep = '\0';
+                String sep = "";
                 for (JCVariableDecl param : tree.params) {
                     print(sep);
                     print(param.name);
-                    sep = ',';
+                    sep = ",";
                 }
             }
             print(")->");

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
@@ -1244,11 +1244,11 @@ public class Pretty extends JCTree.Visitor {
             if (tree.paramKind == JCLambda.ParameterKind.EXPLICIT) {
                 printExprs(tree.params);
             } else {
-                String sep = "";
+                char sep = '\0';
                 for (JCVariableDecl param : tree.params) {
                     print(sep);
                     print(param.name);
-                    sep = ",";
+                    sep = ',';
                 }
             }
             print(")->");
@@ -1453,9 +1453,9 @@ public class Pretty extends JCTree.Visitor {
                     print(tree.value.toString());
                     break;
                 case CHAR:
-                    print("\'");
+                    print('\'');
                     print(Convert.quote(String.valueOf((char)((Number)tree.value).intValue())));
-                    print("\'");
+                    print('\'');
                     break;
                 case BOOLEAN:
                     print(((Number)tree.value).intValue() == 1 ? "true" : "false");

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
@@ -132,6 +132,12 @@ public class Pretty extends JCTree.Visitor {
         out.write(Convert.escapeUnicode(s.toString()));
     }
 
+    /** Print character. Should be only used internally for known ASCII characters.
+     */
+    private void print(char c) throws IOException {
+        out.write(c);
+    }
+
     /** Print new line.
      */
     public void println() throws IOException {
@@ -247,8 +253,8 @@ public class Pretty extends JCTree.Visitor {
     public void printFlags(long flags) throws IOException {
         if ((flags & SYNTHETIC) != 0) print("/*synthetic*/ ");
         print(TreeInfo.flagNames(flags));
-        if ((flags & ExtendedStandardFlags) != 0) print(" ");
-        if ((flags & ANNOTATION) != 0) print("@");
+        if ((flags & ExtendedStandardFlags) != 0) print(' ');
+        if ((flags & ANNOTATION) != 0) print('@');
     }
 
     public void printAnnotations(List<JCAnnotation> trees) throws IOException {
@@ -262,7 +268,7 @@ public class Pretty extends JCTree.Visitor {
     public void printTypeAnnotations(List<JCAnnotation> trees) throws IOException {
         for (List<JCAnnotation> l = trees; l.nonEmpty(); l = l.tail) {
             printExpr(l.head);
-            print(" ");
+            print(' ');
         }
     }
 
@@ -279,7 +285,7 @@ public class Pretty extends JCTree.Visitor {
                 while (pos < dc.length()) {
                     align();
                     print(" *");
-                    if (pos < dc.length() && dc.charAt(pos) > ' ') print(" ");
+                    if (pos < dc.length() && dc.charAt(pos) > ' ') print(' ');
                     print(dc.substring(pos, endpos)); println();
                     pos = endpos + 1;
                     endpos = lineEndPos(dc, pos);
@@ -301,35 +307,35 @@ public class Pretty extends JCTree.Visitor {
      */
     public void printTypeParameters(List<JCTypeParameter> trees) throws IOException {
         if (trees.nonEmpty()) {
-            print("<");
+            print('<');
             printExprs(trees);
-            print(">");
+            print('>');
         }
     }
 
     /** Print a block.
      */
     public void printBlock(List<? extends JCTree> stats) throws IOException {
-        print("{");
+        print('{');
         println();
         indent();
         printStats(stats);
         undent();
         align();
-        print("}");
+        print('}');
     }
 
     /** Print a block.
      */
     public void printEnumBody(List<JCTree> stats) throws IOException {
-        print("{");
+        print('{');
         println();
         indent();
         boolean first = true;
         for (List<JCTree> l = stats; l.nonEmpty(); l = l.tail) {
             if (isEnumerator(l.head)) {
                 if (!first) {
-                    print(",");
+                    print(',');
                     println();
                 }
                 align();
@@ -337,7 +343,7 @@ public class Pretty extends JCTree.Visitor {
                 first = false;
             }
         }
-        print(";");
+        print(';');
         println();
         for (List<JCTree> l = stats; l.nonEmpty(); l = l.tail) {
             if (!isEnumerator(l.head)) {
@@ -348,7 +354,7 @@ public class Pretty extends JCTree.Visitor {
         }
         undent();
         align();
-        print("}");
+        print('}');
     }
 
     /** Is the given tree an enumerator definition? */
@@ -429,7 +435,7 @@ public class Pretty extends JCTree.Visitor {
             if (tree.pid != null) {
                 print("package ");
                 printExpr(tree.pid);
-                print(";");
+                print(';');
                 println();
             }
         } catch (IOException e) {
@@ -448,9 +454,9 @@ public class Pretty extends JCTree.Visitor {
             print("module ");
             printExpr(tree.qualId);
             if (tree.directives == null) {
-                print(";");
+                print(';');
             } else {
-                print(" ");
+                print(' ');
                 printBlock(tree.directives);
             }
             println();
@@ -468,7 +474,7 @@ public class Pretty extends JCTree.Visitor {
                 print(" to ");
                 printExprs(tree.moduleNames);
             }
-            print(";");
+            print(';');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -483,7 +489,7 @@ public class Pretty extends JCTree.Visitor {
                 print(" to ");
                 printExprs(tree.moduleNames);
             }
-            print(";");
+            print(';');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -496,7 +502,7 @@ public class Pretty extends JCTree.Visitor {
             printExpr(tree.serviceName);
             print(" with ");
             printExprs(tree.implNames);
-            print(";");
+            print(';');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -511,7 +517,7 @@ public class Pretty extends JCTree.Visitor {
             if (tree.isTransitive)
                 print("transitive ");
             printExpr(tree.moduleName);
-            print(";");
+            print(';');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -522,7 +528,7 @@ public class Pretty extends JCTree.Visitor {
         try {
             print("uses ");
             printExpr(tree.qualid);
-            print(";");
+            print(';');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -533,7 +539,7 @@ public class Pretty extends JCTree.Visitor {
             print("import ");
             if (tree.staticImport) print("static ");
             printExpr(tree.qualid);
-            print(";");
+            print(';');
             println();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -549,7 +555,8 @@ public class Pretty extends JCTree.Visitor {
             Name enclClassNamePrev = enclClassName;
             enclClassName = tree.name;
             if ((tree.mods.flags & INTERFACE) != 0) {
-                print("interface " + tree.name);
+                print("interface ");
+                print(tree.name);
                 printTypeParameters(tree.typarams);
                 if (tree.implementing.nonEmpty()) {
                     print(" extends ");
@@ -561,9 +568,10 @@ public class Pretty extends JCTree.Visitor {
                 }
             } else {
                 if ((tree.mods.flags & ENUM) != 0)
-                    print("enum " + tree.name);
+                    print("enum ");
                 else
-                    print("class " + tree.name);
+                    print("class ");
+                print(tree.name);
                 printTypeParameters(tree.typarams);
                 if (tree.extending != null) {
                     print(" extends ");
@@ -578,7 +586,7 @@ public class Pretty extends JCTree.Visitor {
                     printExprs(tree.permitting);
                 }
             }
-            print(" ");
+            print(' ');
             if ((tree.mods.flags & ENUM) != 0) {
                 printEnumBody(tree.defs);
             } else {
@@ -604,9 +612,10 @@ public class Pretty extends JCTree.Visitor {
                 print(enclClassName != null ? enclClassName : tree.name);
             } else {
                 printExpr(tree.restype);
-                print(" " + tree.name);
+                print(' ');
+                print(tree.name);
             }
-            print("(");
+            print('(');
             if (tree.recvparam!=null) {
                 printExpr(tree.recvparam);
                 if (tree.params.size() > 0) {
@@ -614,7 +623,7 @@ public class Pretty extends JCTree.Visitor {
                 }
             }
             printExprs(tree.params);
-            print(")");
+            print(')');
             if (tree.thrown.nonEmpty()) {
                 print(" throws ");
                 printExprs(tree.thrown);
@@ -624,10 +633,10 @@ public class Pretty extends JCTree.Visitor {
                 printExpr(tree.defaultValue);
             }
             if (tree.body != null) {
-                print(" ");
+                print(' ');
                 printStat(tree.body);
             } else {
-                print(";");
+                print(';');
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -649,12 +658,12 @@ public class Pretty extends JCTree.Visitor {
                         if (sourceOutput) {
                             print(" /*enum*/ ");
                             if (init.args != null && init.args.nonEmpty()) {
-                                print("(");
+                                print('(');
                                 print(init.args);
-                                print(")");
+                                print(')');
                             }
                             if (init.def != null && init.def.defs != null) {
-                                print(" ");
+                                print(' ');
                                 printBlock(init.def.defs);
                             }
                             return;
@@ -665,18 +674,18 @@ public class Pretty extends JCTree.Visitor {
                                 printTypeAnnotations(init.def.mods.annotations);
                             }
                             printExpr(init.clazz);
-                            print("(");
+                            print('(');
                             printExprs(init.args);
-                            print(")");
+                            print(')');
                             print(" */");
                             print(" /*enum*/ ");
                             if (init.args != null && init.args.nonEmpty()) {
-                                print("(");
+                                print('(');
                                 printExprs(init.args);
-                                print(")");
+                                print(')');
                             }
                             if (init.def != null && init.def.defs != null) {
-                                print(" ");
+                                print(' ');
                                 printBlock(init.def.defs);
                             }
                             return;
@@ -700,16 +709,18 @@ public class Pretty extends JCTree.Visitor {
                         print(' ');
                         printTypeAnnotations(tas);
                     }
-                    print("... " + tree.name);
+                    print("... ");
+                    print(tree.name);
                 } else {
                     printExpr(tree.vartype);
-                    print(" " + tree.name);
+                    print(' ');
+                    print(tree.name);
                 }
                 if (tree.init != null) {
                     print(" = ");
                     printExpr(tree.init);
                 }
-                if (prec == TreeInfo.notExpression) print(";");
+                if (prec == TreeInfo.notExpression) print(';');
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -718,7 +729,7 @@ public class Pretty extends JCTree.Visitor {
 
     public void visitSkip(JCSkip tree) {
         try {
-            print(";");
+            print(';');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -742,11 +753,11 @@ public class Pretty extends JCTree.Visitor {
             if (tree.cond.hasTag(PARENS)) {
                 printExpr(tree.cond);
             } else {
-                print("(");
+                print('(');
                 printExpr(tree.cond);
-                print(")");
+                print(')');
             }
-            print(";");
+            print(';');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -758,11 +769,11 @@ public class Pretty extends JCTree.Visitor {
             if (tree.cond.hasTag(PARENS)) {
                 printExpr(tree.cond);
             } else {
-                print("(");
+                print('(');
                 printExpr(tree.cond);
-                print(")");
+                print(')');
             }
-            print(" ");
+            print(' ');
             printStat(tree.body);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -777,7 +788,8 @@ public class Pretty extends JCTree.Visitor {
                     printExpr(tree.init.head);
                     for (List<JCStatement> l = tree.init.tail; l.nonEmpty(); l = l.tail) {
                         JCVariableDecl vdef = (JCVariableDecl)l.head;
-                        print(", " + vdef.name);
+                        print(", ");
+                        print(vdef.name);
                         if (vdef.init != null) {
                             print(" = ");
                             printExpr(vdef.init);
@@ -813,7 +825,8 @@ public class Pretty extends JCTree.Visitor {
 
     public void visitLabelled(JCLabeledStatement tree) {
         try {
-            print(tree.label + ": ");
+            print(tree.label);
+            print(": ");
             printStat(tree.body);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -826,15 +839,15 @@ public class Pretty extends JCTree.Visitor {
             if (tree.selector.hasTag(PARENS)) {
                 printExpr(tree.selector);
             } else {
-                print("(");
+                print('(');
                 printExpr(tree.selector);
-                print(")");
+                print(')');
             }
             print(" {");
             println();
             printStats(tree.cases);
             align();
-            print("}");
+            print('}');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -849,7 +862,7 @@ public class Pretty extends JCTree.Visitor {
                 printExprs(tree.labels);
             }
             if (tree.caseKind == JCCase.STATEMENT) {
-                print(":");
+                print(':');
                 println();
                 indent();
                 printStats(tree.stats);
@@ -905,15 +918,15 @@ public class Pretty extends JCTree.Visitor {
             if (tree.selector.hasTag(PARENS)) {
                 printExpr(tree.selector);
             } else {
-                print("(");
+                print('(');
                 printExpr(tree.selector);
-                print(")");
+                print(')');
             }
             print(" {");
             println();
             printStats(tree.cases);
             align();
-            print("}");
+            print('}');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -930,9 +943,9 @@ public class Pretty extends JCTree.Visitor {
     @Override
     public void visitParenthesizedPattern(JCParenthesizedPattern patt) {
         try {
-            print("(");
+            print('(');
             printExpr(patt.pattern);
-            print(")");
+            print(')');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -942,9 +955,9 @@ public class Pretty extends JCTree.Visitor {
     public void visitRecordPattern(JCRecordPattern tree) {
         try {
             printExpr(tree.deconstructor);
-            print("(");
+            print('(');
             printExprs(tree.nested);
-            print(")");
+            print(')');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -956,11 +969,11 @@ public class Pretty extends JCTree.Visitor {
             if (tree.lock.hasTag(PARENS)) {
                 printExpr(tree.lock);
             } else {
-                print("(");
+                print('(');
                 printExpr(tree.lock);
-                print(")");
+                print(')');
             }
-            print(" ");
+            print(' ');
             printStat(tree.body);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -971,7 +984,7 @@ public class Pretty extends JCTree.Visitor {
         try {
             print("try ");
             if (tree.resources.nonEmpty()) {
-                print("(");
+                print('(');
                 boolean first = true;
                 for (JCTree var : tree.resources) {
                     if (!first) {
@@ -1027,11 +1040,11 @@ public class Pretty extends JCTree.Visitor {
             if (tree.cond.hasTag(PARENS)) {
                 printExpr(tree.cond);
             } else {
-                print("(");
+                print('(');
                 printExpr(tree.cond);
-                print(")");
+                print(')');
             }
-            print(" ");
+            print(' ');
             printStat(tree.thenpart);
             if (tree.elsepart != null) {
                 print(" else ");
@@ -1045,7 +1058,7 @@ public class Pretty extends JCTree.Visitor {
     public void visitExec(JCExpressionStatement tree) {
         try {
             printExpr(tree.expr);
-            if (prec == TreeInfo.notExpression) print(";");
+            if (prec == TreeInfo.notExpression) print(';');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -1054,8 +1067,11 @@ public class Pretty extends JCTree.Visitor {
     public void visitBreak(JCBreak tree) {
         try {
             print("break");
-            if (tree.label != null) print(" " + tree.label);
-            print(";");
+            if (tree.label != null) {
+                print(' ');
+                print(tree.label);
+            }
+            print(';');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -1064,9 +1080,9 @@ public class Pretty extends JCTree.Visitor {
     public void visitYield(JCYield tree) {
         try {
             print("yield");
-            print(" ");
+            print(' ');
             printExpr(tree.value);
-            print(";");
+            print(';');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -1075,8 +1091,11 @@ public class Pretty extends JCTree.Visitor {
     public void visitContinue(JCContinue tree) {
         try {
             print("continue");
-            if (tree.label != null) print(" " + tree.label);
-            print(";");
+            if (tree.label != null) {
+                print(' ');
+                print(tree.label);
+            }
+            print(';');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -1086,10 +1105,10 @@ public class Pretty extends JCTree.Visitor {
         try {
             print("return");
             if (tree.expr != null) {
-                print(" ");
+                print(' ');
                 printExpr(tree.expr);
             }
-            print(";");
+            print(';');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -1099,7 +1118,7 @@ public class Pretty extends JCTree.Visitor {
         try {
             print("throw ");
             printExpr(tree.expr);
-            print(";");
+            print(';');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -1113,7 +1132,7 @@ public class Pretty extends JCTree.Visitor {
                 print(" : ");
                 printExpr(tree.detail);
             }
-            print(";");
+            print(';');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -1127,19 +1146,20 @@ public class Pretty extends JCTree.Visitor {
                     printExpr(left.selected);
                     print(".<");
                     printExprs(tree.typeargs);
-                    print(">" + left.name);
+                    print('>');
+                    print(left.name);
                 } else {
-                    print("<");
+                    print('<');
                     printExprs(tree.typeargs);
-                    print(">");
+                    print('>');
                     printExpr(tree.meth);
                 }
             } else {
                 printExpr(tree.meth);
             }
-            print("(");
+            print('(');
             printExprs(tree.args);
-            print(")");
+            print(')');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -1149,21 +1169,21 @@ public class Pretty extends JCTree.Visitor {
         try {
             if (tree.encl != null) {
                 printExpr(tree.encl);
-                print(".");
+                print('.');
             }
             print("new ");
             if (!tree.typeargs.isEmpty()) {
-                print("<");
+                print('<');
                 printExprs(tree.typeargs);
-                print(">");
+                print('>');
             }
             if (tree.def != null && tree.def.mods.annotations.nonEmpty()) {
                 printTypeAnnotations(tree.def.mods.annotations);
             }
             printExpr(tree.clazz);
-            print("(");
+            print('(');
             printExprs(tree.args);
-            print(")");
+            print(')');
             if (tree.def != null) {
                 Name enclClassNamePrev = enclClassName;
                 enclClassName =
@@ -1201,17 +1221,17 @@ public class Pretty extends JCTree.Visitor {
                         print(' ');
                         printTypeAnnotations(da.get(i));
                     }
-                    print("[");
+                    print('[');
                     i++;
                     printExpr(l.head);
-                    print("]");
+                    print(']');
                 }
                 printBrackets(elem);
             }
             if (tree.elems != null) {
-                print("{");
+                print('{');
                 printExprs(tree.elems);
-                print("}");
+                print('}');
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -1220,7 +1240,7 @@ public class Pretty extends JCTree.Visitor {
 
     public void visitLambda(JCLambda tree) {
         try {
-            print("(");
+            print('(');
             if (tree.paramKind == JCLambda.ParameterKind.EXPLICIT) {
                 printExprs(tree.params);
             } else {
@@ -1240,9 +1260,9 @@ public class Pretty extends JCTree.Visitor {
 
     public void visitParens(JCParens tree) {
         try {
-            print("(");
+            print('(');
             printExpr(tree.expr);
-            print(")");
+            print(')');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -1298,7 +1318,9 @@ public class Pretty extends JCTree.Visitor {
         try {
             open(prec, TreeInfo.assignopPrec);
             printExpr(tree.lhs, TreeInfo.assignopPrec + 1);
-            print(" " + operatorName(tree.getTag().noAssignOp()) + "= ");
+            print(' ');
+            print(operatorName(tree.getTag().noAssignOp()));
+            print("= ");
             printExpr(tree.rhs, TreeInfo.assignopPrec);
             close(prec, TreeInfo.assignopPrec);
         } catch (IOException e) {
@@ -1330,7 +1352,9 @@ public class Pretty extends JCTree.Visitor {
             String opname = operatorName(tree.getTag());
             open(prec, ownprec);
             printExpr(tree.lhs, ownprec);
-            print(" " + opname + " ");
+            print(' ');
+            print(opname);
+            print(' ');
             printExpr(tree.rhs, ownprec + 1);
             close(prec, ownprec);
         } catch (IOException e) {
@@ -1341,9 +1365,9 @@ public class Pretty extends JCTree.Visitor {
     public void visitTypeCast(JCTypeCast tree) {
         try {
             open(prec, TreeInfo.prefixPrec);
-            print("(");
+            print('(');
             printExpr(tree.clazz);
-            print(")");
+            print(')');
             printExpr(tree.expr, TreeInfo.prefixPrec);
             close(prec, TreeInfo.prefixPrec);
         } catch (IOException e) {
@@ -1370,9 +1394,9 @@ public class Pretty extends JCTree.Visitor {
     public void visitIndexed(JCArrayAccess tree) {
         try {
             printExpr(tree.indexed, TreeInfo.postfixPrec);
-            print("[");
+            print('[');
             printExpr(tree.index);
-            print("]");
+            print(']');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -1381,7 +1405,8 @@ public class Pretty extends JCTree.Visitor {
     public void visitSelect(JCFieldAccess tree) {
         try {
             printExpr(tree.selected, TreeInfo.postfixPrec);
-            print("." + tree.name);
+            print('.');
+            print(tree.name);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -1392,9 +1417,9 @@ public class Pretty extends JCTree.Visitor {
             printExpr(tree.expr);
             print("::");
             if (tree.typeargs != null) {
-                print("<");
+                print('<');
                 printExprs(tree.typeargs);
-                print(">");
+                print('>');
             }
             print(tree.getMode() == ReferenceMode.INVOKE ? tree.name : "new");
         } catch (IOException e) {
@@ -1417,19 +1442,20 @@ public class Pretty extends JCTree.Visitor {
                     print(tree.value.toString());
                     break;
                 case LONG:
-                    print(tree.value + "L");
+                    print(tree.value);
+                    print('L');
                     break;
                 case FLOAT:
-                    print(tree.value + "F");
+                    print(tree.value);
+                    print('F');
                     break;
                 case DOUBLE:
                     print(tree.value.toString());
                     break;
                 case CHAR:
-                    print("\'" +
-                            Convert.quote(
-                            String.valueOf((char)((Number)tree.value).intValue())) +
-                            "\'");
+                    print("\'");
+                    print(Convert.quote(String.valueOf((char)((Number)tree.value).intValue())));
+                    print("\'");
                     break;
                 case BOOLEAN:
                     print(((Number)tree.value).intValue() == 1 ? "true" : "false");
@@ -1438,7 +1464,9 @@ public class Pretty extends JCTree.Visitor {
                     print("null");
                     break;
                 default:
-                    print("\"" + Convert.quote(tree.value.toString()) + "\"");
+                    print("\"");
+                    print(Convert.quote(tree.value.toString()));
+                    print("\"");
                     break;
             }
         } catch (IOException e) {
@@ -1524,9 +1552,9 @@ public class Pretty extends JCTree.Visitor {
     public void visitTypeApply(JCTypeApply tree) {
         try {
             printExpr(tree.clazz);
-            print("<");
+            print('<');
             printExprs(tree.arguments);
-            print(">");
+            print('>');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -1593,7 +1621,11 @@ public class Pretty extends JCTree.Visitor {
 
     public void visitLetExpr(LetExpr tree) {
         try {
-            print("(let " + tree.defs + " in " + tree.expr + ")");
+            print("(let ");
+            print(tree.defs);
+            print(" in ");
+            print(tree.expr);
+            print(')');
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -1610,12 +1642,12 @@ public class Pretty extends JCTree.Visitor {
 
     public void visitAnnotation(JCAnnotation tree) {
         try {
-            print("@");
+            print('@');
             printExpr(tree.annotationType);
             if (!tree.args.isEmpty()) {
-                print("(");
+                print('(');
                 printExprs(tree.args);
-                print(")");
+                print(')');
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -1627,7 +1659,7 @@ public class Pretty extends JCTree.Visitor {
             if (tree.underlyingType.hasTag(SELECT)) {
                 JCFieldAccess access = (JCFieldAccess) tree.underlyingType;
                 printExpr(access.selected, TreeInfo.postfixPrec);
-                print(".");
+                print('.');
                 printTypeAnnotations(tree.annotations);
                 print(access.name);
             } else if (tree.underlyingType.hasTag(TYPEARRAY)) {
@@ -1644,7 +1676,9 @@ public class Pretty extends JCTree.Visitor {
 
     public void visitTree(JCTree tree) {
         try {
-            print("(UNKNOWN: " + tree.getTag() + ")");
+            print("(UNKNOWN: ");
+            print(tree.getTag());
+            print(')');
             println();
         } catch (IOException e) {
             throw new UncheckedIOException(e);


### PR DESCRIPTION
Hi,

I've been recently optimizing a few project pipelines and always noticed that their compilation step is somewhat "expensive".  Zooming into the issue always revealed Lombok to be a larger contributor. Unfortunately, I can't get rid of Lombok in this customer project (before you ask).

Apparently, Lombok is printing the respective `JCTree` here and there to check for type matches. I can't imagine this to be super efficient, but that's how it is at the moment.
<img width="948" alt="image" src="https://user-images.githubusercontent.com/6304496/220134737-bd9b508c-a908-448b-b0d1-e960db28b24a.png">

Anyhow, regardless of the Lombok inefficiencies I think there are some optimization opportunities in the JDK itself. 

1. Overall, `Pretty.visitSelect` accounts for 8-10% of the total allocations in this project. And among those there are StringBuilder allocations coming from the following:

```
    public void visitSelect(JCFieldAccess tree) {
        try {
            printExpr(tree.selected, TreeInfo.postfixPrec);
            // StringBuilder allocations hiding in here.
            print("." + tree.name);
        } catch (IOException e) {
            throw new UncheckedIOException(e);
        }
    }
```

This PR splits the `print` calls into two separate ones to avoid this String concatenation.
```
...
            printExpr(tree.selected, TreeInfo.postfixPrec);
            print('.');
            print(tree.name);
...
```

Secondly, the `print` method takes an `Object` which seems like a good fit for another (private?) variant of it that only takes a `char`. By this we would probably avoid any eventual boxing and avoid any conversion with `Convert.escapeUnicode(s.toString())` that seems superfluous for chars like `.`, ` `, or any braces like `(`, `{` etc. 

This is currently a draft PR as long as the scope is not clarified. It currently only includes the necessary changes that would optimize the particular use-case. But there are more cases where e.g. the new `char` variant could be used and/or any String concatenation could be split into separate `print` calls.

Let me know what you think and if I should include the other cases as well. If you think this is worthwhile, I'd appreciate if this is is sponsored. (Including creating an issue as I can't do this myself apparently. I will of course squash everything together with the proper issue ID once available.)

I've contributed before, so the CLA should be signed.

Cheers,
Christoph

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303078](https://bugs.openjdk.org/browse/JDK-8303078): Reduce allocations when pretty printing JCTree during compilation


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12667/head:pull/12667` \
`$ git checkout pull/12667`

Update a local copy of the PR: \
`$ git checkout pull/12667` \
`$ git pull https://git.openjdk.org/jdk pull/12667/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12667`

View PR using the GUI difftool: \
`$ git pr show -t 12667`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12667.diff">https://git.openjdk.org/jdk/pull/12667.diff</a>

</details>
