### PR TITLE
8302681: [IR Framework] Only allow cpuFeatures from a verified list

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -240,7 +240,8 @@ public class IREncodingPrinter {
         }
 
         // Please verify new CPU features before adding them. If we allow non-existent features
-        // on this list, we will ignore tests and never execute them.
+        // on this list, we will ignore tests and never execute them. Consult CPU_FEATURE_FLAGS
+        // in corresponding vm_version_.hpp file to find correct cpu feature's name.
         List<String> verifiedCPUFeatures = new ArrayList<String>( Arrays.asList(
             // x86
             "fma",

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -253,8 +253,7 @@ public class IREncodingPrinter {
             "avx512f",
             // arm
             "asimd",
-            "sve", // TODO: ok?
-            "sve1" // TODO: ok?
+            "sve"
         ));
 
         if (!verifiedCPUFeatures.contains(feature)) {

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -55,6 +55,31 @@ public class IREncodingPrinter {
     private Method method;
     private int ruleIndex;
 
+    // Please verify new CPU features before adding them. If we allow non-existent features
+    // on this list, we will ignore tests and never execute them. Consult CPU_FEATURE_FLAGS
+    // in corresponding vm_version_.hpp file to find correct cpu feature's name.
+    private static final List<String> verifiedCPUFeatures = new ArrayList<String>( Arrays.asList(
+        // x86
+        "fma",
+        // Intel SSE
+        "sse",
+        "sse2",
+        "sse3",
+        "ssse3",
+        "sse4.1",
+        // Intel AVX
+        "avx",
+        "avx2",
+        "avx512",
+        "avx512dq",
+        "avx512vl",
+        "avx512f",
+        // AArch64
+        "sha3",
+        "asimd",
+        "sve"
+    ));
+
     public IREncodingPrinter() {
         output.append(START).append(System.lineSeparator());
         output.append("<method>,{comma separated applied @IR rule ids}").append(System.lineSeparator());
@@ -238,31 +263,6 @@ public class IREncodingPrinter {
             TestFormat.failNoThrow("Provided empty value for feature " + feature + failAt());
             return false;
         }
-
-        // Please verify new CPU features before adding them. If we allow non-existent features
-        // on this list, we will ignore tests and never execute them. Consult CPU_FEATURE_FLAGS
-        // in corresponding vm_version_.hpp file to find correct cpu feature's name.
-        List<String> verifiedCPUFeatures = new ArrayList<String>( Arrays.asList(
-            // x86
-            "fma",
-            // Intel SSE
-            "sse",
-            "sse2",
-            "sse3",
-            "ssse3",
-            "sse4.1",
-            // Intel AVX
-            "avx",
-            "avx2",
-            "avx512",
-            "avx512dq",
-            "avx512vl",
-            "avx512f",
-            // AArch64
-            "sha3",
-            "asimd",
-            "sve"
-        ));
 
         if (!verifiedCPUFeatures.contains(feature)) {
             TestFormat.failNoThrow("Provided CPU feature is not in verified list: " + feature + failAt());

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -240,8 +240,13 @@ public class IREncodingPrinter {
         }
 
         List<String> verifiedCPUFeatures = new ArrayList<String>( Arrays.asList(
+            // General
+            "sha3",
+            "fma",
             // Intel SSE
+            "sse",
             "sse2",
+            "sse3",
             "ssse3",
             "sse4.1",
             // Intel AVX
@@ -251,7 +256,7 @@ public class IREncodingPrinter {
             "avx512dq",
             "avx512vl",
             "avx512f",
-            // arm
+            // Arm
             "asimd",
             "sve"
         ));

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -239,6 +239,29 @@ public class IREncodingPrinter {
             return false;
         }
 
+        List<String> verifiedCPUFeatures = new ArrayList<String>( Arrays.asList(
+            // Intel SSE
+            "sse2",
+            "ssse3",
+            "sse4.1",
+            // Intel AVX
+            "avx",
+            "avx2",
+            "avx512",
+            "avx512dq",
+            "avx512vl",
+            "avx512f",
+            // arm
+            "asimd",
+            "sve", // TODO: ok?
+            "sve1" // TODO: ok?
+        ));
+
+        if (!verifiedCPUFeatures.contains(feature)) {
+            TestFormat.failNoThrow("Provided CPU feature is not in verified list: " + feature + failAt());
+            return false;
+        }
+
         boolean trueValue = value.contains("true");
         boolean falseValue = value.contains("false");
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -239,6 +239,8 @@ public class IREncodingPrinter {
             return false;
         }
 
+        // Please verify new CPU features before adding them. If we allow non-existent features
+        // on this list, we will ignore tests and never execute them.
         List<String> verifiedCPUFeatures = new ArrayList<String>( Arrays.asList(
             // General
             "sha3",

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -258,7 +258,7 @@ public class IREncodingPrinter {
             "avx512dq",
             "avx512vl",
             "avx512f",
-            // Arm
+            // AArch64
             "asimd",
             "sve"
         ));

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -242,8 +242,7 @@ public class IREncodingPrinter {
         // Please verify new CPU features before adding them. If we allow non-existent features
         // on this list, we will ignore tests and never execute them.
         List<String> verifiedCPUFeatures = new ArrayList<String>( Arrays.asList(
-            // General
-            "sha3",
+            // x86
             "fma",
             // Intel SSE
             "sse",
@@ -259,6 +258,7 @@ public class IREncodingPrinter {
             "avx512vl",
             "avx512f",
             // AArch64
+            "sha3",
             "asimd",
             "sve"
         ));

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorLogicalOpIdentityTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorLogicalOpIdentityTest.java
@@ -302,7 +302,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform AndV(AndV(a, b, m), b, m) ==> AndV(a, b, m)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.AND_V, "1"}, applyIfCPUFeatureOr = {"sve1", "true", "avx512", "true"})
+    @IR(counts = {IRNode.AND_V, "1"}, applyIfCPUFeatureOr = {"sve", "true", "avx512", "true"})
     public static void testAndMaskSameValue1() {
         VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
         IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
@@ -323,7 +323,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform AndV(AndV(a, b, m), a, m) ==> AndV(a, b, m)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.AND_V, "1"}, applyIfCPUFeatureOr = {"sve1", "true", "avx512", "true"})
+    @IR(counts = {IRNode.AND_V, "1"}, applyIfCPUFeatureOr = {"sve", "true", "avx512", "true"})
     public static void testAndMaskSameValue2() {
         VectorMask<Long> mask = VectorMask.fromArray(L_SPECIES, m, 0);
         LongVector av = LongVector.fromArray(L_SPECIES, la, 0);
@@ -344,7 +344,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform AndV(a, AndV(a, b, m), m) ==> AndV(a, b, m)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.AND_V, "1"}, applyIfCPUFeatureOr = {"sve1", "true", "avx512", "true"})
+    @IR(counts = {IRNode.AND_V, "1"}, applyIfCPUFeatureOr = {"sve", "true", "avx512", "true"})
     public static void testAndMaskSameValue3() {
         VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
         IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
@@ -566,7 +566,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform OrV(OrV(a, b, m), b, m) ==> OrV(a, b, m)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.OR_V, "1"}, applyIfCPUFeatureOr = {"sve1", "true", "avx512", "true"})
+    @IR(counts = {IRNode.OR_V, "1"}, applyIfCPUFeatureOr = {"sve", "true", "avx512", "true"})
     public static void testOrMaskSameValue1() {
         VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
         IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
@@ -587,7 +587,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform OrV(OrV(a, b, m), a, m) ==> OrV(a, b, m)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.OR_V, "1"}, applyIfCPUFeatureOr = {"sve1", "true", "avx512", "true"})
+    @IR(counts = {IRNode.OR_V, "1"}, applyIfCPUFeatureOr = {"sve", "true", "avx512", "true"})
     public static void testOrMaskSameValue2() {
         VectorMask<Long> mask = VectorMask.fromArray(L_SPECIES, m, 0);
         LongVector av = LongVector.fromArray(L_SPECIES, la, 0);
@@ -608,7 +608,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform OrV(a, OrV(a, b, m), m) ==> OrV(a, b, m)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.OR_V, "1"}, applyIfCPUFeatureOr = {"sve1", "true", "avx512", "true"})
+    @IR(counts = {IRNode.OR_V, "1"}, applyIfCPUFeatureOr = {"sve", "true", "avx512", "true"})
     public static void testOrMaskSameValue3() {
         VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
         IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPreconditions.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPreconditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPreconditions.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPreconditions.java
@@ -45,13 +45,13 @@ public class TestPreconditions {
         counts = {IRNode.LOOP, ">= 1000"})
     public static void testApplyIfOnly() {}
 
-    // The IR check should not be applied, since asimd is arm and sse intel.
+    // The IR check should not be applied, since asimd is aarch64 and sse intel.
     @Test
     @IR(applyIfCPUFeatureAnd = {"asimd", "true", "sse", "true"},
         counts = {IRNode.LOOP, ">= 1000"})
     public static void testApplyIfCPUFeatureOnly() {}
 
-    // The IR check should not be applied, since asimd is arm and sse intel.
+    // The IR check should not be applied, since asimd is aarch64 and sse intel.
     @Test
     @IR(applyIfCPUFeatureAnd = {"asimd", "true", "sse", "true"},
         applyIf = {"LoopMaxUnroll", "= 8"},

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPreconditions.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPreconditions.java
@@ -45,15 +45,15 @@ public class TestPreconditions {
         counts = {IRNode.LOOP, ">= 1000"})
     public static void testApplyIfOnly() {}
 
-    // The IR check should not be applied, since the CPU feature does not exist.
+    // The IR check should not be applied, since asimd is arm and sse intel.
     @Test
-    @IR(applyIfCPUFeature = {"this-feature-does-not-exist-at-all", "true"},
+    @IR(applyIfCPUFeatureAnd = {"asimd", "true", "sse", "true"},
         counts = {IRNode.LOOP, ">= 1000"})
     public static void testApplyIfCPUFeatureOnly() {}
 
-    // The IR check should not be applied, since the CPU feature does not exist.
+    // The IR check should not be applied, since asimd is arm and sse intel.
     @Test
-    @IR(applyIfCPUFeature = {"this-feature-does-not-exist-at-all", "true"},
+    @IR(applyIfCPUFeatureAnd = {"asimd", "true", "sse", "true"},
         applyIf = {"LoopMaxUnroll", "= 8"},
         counts = {IRNode.LOOP, ">= 1000"})
     public static void testApplyBoth() {}


### PR DESCRIPTION
Wrongly typed cpuFeatures can lead to an IR rule being ignored.
Example: https://github.com/openjdk/jdk/pull/12601 [JDK-8302668](https://bugs.openjdk.org/browse/JDK-8302668)

We should have a list of verified cpuFeatures, and assert if one is used that is not in that list. That way, typos and bad copies can be avoided, and we make sure the tests run when intended.

I verified the `intel` cpuFeatures by hand on my laptop. And for `asimd` and `sve` I asked @tobiasholenstein and @nick-arm .

`sve1` seems to have been a typo, and I am changing it to `sve`.

Note: cpu-features can be displayed like this: `./java -Xlog:os+cpu --version`

On my machine, I get:
```
cmov, fxsr, ht, mmx, 3dnowpref, sse, sse2, sse3, ssse3, sse4.1, sse4.2, popcnt, lzcnt, tsc, tscinvbit, avx, avx2, aes, erms, clmul, bmi1, bmi2, adx, avx512f, avx512dq, avx512cd, avx512bw, avx512vl, sha, fma, vzeroupper, avx512_vpopcntdq, avx512_vpclmulqdq, avx512_vaes, avx512_vnni, clflush, clflushopt, clwb, avx512_vbmi2, avx512_vbmi, rdtscp, rdpid, fsrm, gfni, avx512_bitalg, f16c, pku, ospke, cet_ibt, cet_ss, avx512_ifma
```

@nick-arm got this on one of his machines:
```
fp, asimd, evtstrm, aes, pmull, sha1, sha256, crc32, lse, dcpop, sha3, sha512, sve, paca
```

@tobiasholenstein got this:
```
fp, asimd, aes, pmull, sha1, sha256, crc32, lse, sha3, sha512
```

I had to adapt a test that used a non-existent cpu feature. I replaced it with an impossible combination.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302681](https://bugs.openjdk.org/browse/JDK-8302681): [IR Framework] Only allow cpuFeatures from a verified list


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [340741eb](https://git.openjdk.org/jdk/pull/12669/files/340741ebc346d7e135a123658ca8ee9cccda98a5)
 * [Pengfei Li](https://openjdk.org/census#pli) (@pfustc - Committer) ⚠️ Review applies to [340741eb](https://git.openjdk.org/jdk/pull/12669/files/340741ebc346d7e135a123658ca8ee9cccda98a5)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [adaed88f](https://git.openjdk.org/jdk/pull/12669/files/adaed88fa14e106c6b4048dcb3de14a4d4940c9b)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12669/head:pull/12669` \
`$ git checkout pull/12669`

Update a local copy of the PR: \
`$ git checkout pull/12669` \
`$ git pull https://git.openjdk.org/jdk pull/12669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12669`

View PR using the GUI difftool: \
`$ git pr show -t 12669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12669.diff">https://git.openjdk.org/jdk/pull/12669.diff</a>

</details>
