### PR TITLE
8302880: Fix includes in g1ConcurrentMarkObjArrayProcessor files

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkObjArrayProcessor.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkObjArrayProcessor.cpp
@@ -23,8 +23,13 @@
  */
 
 #include "precompiled.hpp"
+#include "gc/g1/g1CollectedHeap.inline.hpp"
 #include "gc/g1/g1ConcurrentMark.inline.hpp"
 #include "gc/g1/g1ConcurrentMarkObjArrayProcessor.inline.hpp"
+#include "gc/g1/heapRegion.inline.hpp"
+#include "gc/shared/gc_globals.hpp"
+#include "memory/memRegion.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 void G1CMObjArrayProcessor::push_array_slice(HeapWord* what) {
   _task->push(G1TaskQueueEntry::from_slice(what));

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkObjArrayProcessor.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkObjArrayProcessor.inline.hpp
@@ -29,7 +29,7 @@
 
 #include "oops/oop.inline.hpp"
 #include "oops/oopsHierarchy.hpp"
-#include "runtime/globals.hpp"
+#include "gc/shared/gc_globals.hpp"
 
 inline bool G1CMObjArrayProcessor::should_be_sliced(oop obj) {
   return obj->is_objArray() && ((objArrayOop)obj)->size() >= 2 * ObjArrayMarkingStride;


### PR DESCRIPTION
Hi all,

  please review this change that fixes includes in `g1ConcurrentMarkObjArrayProcessor*`.

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302880](https://bugs.openjdk.org/browse/JDK-8302880): Fix includes in g1ConcurrentMarkObjArrayProcessor files


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12671/head:pull/12671` \
`$ git checkout pull/12671`

Update a local copy of the PR: \
`$ git checkout pull/12671` \
`$ git pull https://git.openjdk.org/jdk pull/12671/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12671`

View PR using the GUI difftool: \
`$ git pr show -t 12671`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12671.diff">https://git.openjdk.org/jdk/pull/12671.diff</a>

</details>
