### PR TITLE
8302888: containers/docker/TestJcmd.java fails when run as root under podman

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestJcmd.java
+++ b/test/hotspot/jtreg/containers/docker/TestJcmd.java
@@ -169,7 +169,8 @@ public class TestJcmd {
             .addDockerOpts("--name", CONTAINER_NAME)
             .addClassOptions("" + TIME_TO_RUN_CONTAINER_PROCESS);
 
-        if (IS_PODMAN) {
+        String uid = getId("-u");
+        if (IS_PODMAN && !ROOT_UID.equals(uid)) {
             // map the current userid to the one in the target namespace
             opts.addDockerOpts("--userns=keep-id");
         }

--- a/test/hotspot/jtreg/containers/docker/TestJcmd.java
+++ b/test/hotspot/jtreg/containers/docker/TestJcmd.java
@@ -169,8 +169,7 @@ public class TestJcmd {
             .addDockerOpts("--name", CONTAINER_NAME)
             .addClassOptions("" + TIME_TO_RUN_CONTAINER_PROCESS);
 
-        String uid = getId("-u");
-        if (IS_PODMAN && !ROOT_UID.equals(uid)) {
+        if (IS_PODMAN && !ROOT_UID.equals(getId("-u"))) {
             // map the current userid to the one in the target namespace
             opts.addDockerOpts("--userns=keep-id");
         }


### PR DESCRIPTION
Could I please get a review of this trivial test fix? When `podman` is being used and the test is being run as root, which some of the other container tests require, the test fails because of the not-supported `--userns=keep-id` option:

```
# id -u
0
# podman run --rm -ti --userns=keep-id fedora:37
Error: keep-id is only supported in rootless mode
```

I propose to only add it when non-root.

Testing:

- [x] Ran the test with podman as root/regular user. Both passed. It failed before when run as root.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302888](https://bugs.openjdk.org/browse/JDK-8302888): containers/docker/TestJcmd.java fails when run as root under podman


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12673/head:pull/12673` \
`$ git checkout pull/12673`

Update a local copy of the PR: \
`$ git checkout pull/12673` \
`$ git pull https://git.openjdk.org/jdk pull/12673/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12673`

View PR using the GUI difftool: \
`$ git pr show -t 12673`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12673.diff">https://git.openjdk.org/jdk/pull/12673.diff</a>

</details>
