### PR TITLE
8280113: (dc) DatagramSocket.receive does not always throw when the channel is closed

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/DatagramChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/DatagramChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -581,7 +581,7 @@ class DatagramChannelImpl
                             n = receive(dst, connected);
                         }
                     }
-                    if (n >= 0) {
+                    if (n > 0 || (n == 0 && isOpen())) {
                         // sender address is in socket address buffer
                         sender = sourceSocketAddress();
                     }
@@ -701,7 +701,7 @@ class DatagramChannelImpl
                 park(Net.POLLIN);
                 n = receive(dst, connected);
             }
-            if (n >= 0) {
+            if (n > 0 || (n == 0 && isOpen())) {
                 // sender address is in socket address buffer
                 sender = sourceSocketAddress();
             }
@@ -738,7 +738,7 @@ class DatagramChannelImpl
                     park(Net.POLLIN, remainingNanos);
                     n = receive(dst, connected);
                 }
-                if (n >= 0) {
+                if (n > 0 || (n == 0 && isOpen())) {
                     // sender address is in socket address buffer
                     sender = sourceSocketAddress();
                 }
@@ -787,9 +787,9 @@ class DatagramChannelImpl
         NIO_ACCESS.acquireSession(bb);
         try {
             int n = receive0(fd,
-                            ((DirectBuffer)bb).address() + pos, rem,
-                            sourceSockAddr.address(),
-                            connected);
+                             ((DirectBuffer)bb).address() + pos, rem,
+                             sourceSockAddr.address(),
+                             connected);
             if (n > 0)
                 bb.position(pos + n);
             return n;

--- a/test/jdk/java/nio/channels/DatagramChannel/AdaptorAsyncCloseAfterReceive.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/AdaptorAsyncCloseAfterReceive.java
@@ -78,13 +78,14 @@ class AdaptorAsyncCloseAfterReceive {
 
             populateSocketAddressCaches(dc);
 
-            // schedule socket to be closed while main thead blocked in receive
             DatagramSocket s = dc.socket();
+            s.setSoTimeout(timeout);
+
+            // schedule socket to be closed while main thread blocked in receive
             Future<?> future = scheduler.schedule(() -> s.close(), 1, TimeUnit.SECONDS);
             try {
                 byte[] ba = new byte[maxLength];
                 DatagramPacket p = new DatagramPacket(ba, maxLength);
-                s.setSoTimeout(timeout);
                 assertThrows(SocketException.class, () -> s.receive(p));
             } finally {
                 future.cancel(true);

--- a/test/jdk/java/nio/channels/DatagramChannel/AdaptorAsyncCloseAfterReceive.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/AdaptorAsyncCloseAfterReceive.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8280113
+ * @summary Test async close of a DatagramSocket obtained from a DatagramChannel where
+ *     the DatagramChannel's internal socket address caches are already populated
+ * @enablePreview
+ * @library /test/lib
+ * @run junit AdaptorAsyncCloseAfterReceive
+ */
+
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketException;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import jdk.test.lib.thread.VThreadRunner;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterAll;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AdaptorAsyncCloseAfterReceive {
+
+    // used for scheduling socket close
+    private static ScheduledExecutorService scheduler;
+
+    @BeforeAll
+    static void setup() {
+        scheduler = Executors.newSingleThreadScheduledExecutor();
+    }
+
+    @AfterAll
+    static void finish() {
+        scheduler.shutdown();
+    }
+
+    /**
+     * Test closing a DatagramSocket, obtained from a DatagramChannel, while the main
+     * thread is blocked in receive. The receive method should throw rather than
+     * completing with the sender address of a previous datagram.
+     */
+    @ParameterizedTest
+    @CsvSource({"0,0", "100,0", "0,60000", "100,60000"})
+    void testReceive(int maxLength, int timeout) throws Exception {
+        try (DatagramChannel dc = DatagramChannel.open()) {
+            dc.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+
+            populateSocketAddressCaches(dc);
+
+            // schedule socket to be closed while main thead blocked in receive
+            DatagramSocket s = dc.socket();
+            Future<?> future = scheduler.schedule(() -> s.close(), 1, TimeUnit.SECONDS);
+            try {
+                byte[] ba = new byte[maxLength];
+                DatagramPacket p = new DatagramPacket(ba, maxLength);
+                s.setSoTimeout(timeout);
+                assertThrows(SocketException.class, () -> s.receive(p));
+            } finally {
+                future.cancel(true);
+            }
+        }
+    }
+
+    /**
+     * Send and receive a few messages to ensure that the DatagramChannel internal
+     * socket address cache is populated. This setup is also done in a virtual
+     * thread to ensure that the underlying socket is non-blocking.
+     */
+    private void populateSocketAddressCaches(DatagramChannel dc) throws Exception {
+        VThreadRunner.run(() -> {
+            InetSocketAddress remote = (InetSocketAddress) dc.getLocalAddress();
+            if (remote.getAddress().isAnyLocalAddress()) {
+                InetAddress lb = InetAddress.getLoopbackAddress();
+                remote = new InetSocketAddress(lb, dc.socket().getLocalPort());
+            }
+            for (int i = 0; i < 2; i++) {
+                ByteBuffer bb = ByteBuffer.allocate(32);
+                dc.send(bb, remote);
+                bb.rewind();
+                dc.receive(bb);
+            }
+        });
+    }
+}


### PR DESCRIPTION
This is an issue with the async close of a DatagramChannel when a thread is blocked in its adaptor's receive method and the underlying socket is non-blocking.  The async close causes poll to wakeup and the underlying receive to return 0 so it can't be distinguished from a receive of a zero-length datagram. The channel state needs to be checked to distinguish the two cases so that AsynchronousCloseException can be thrown if the channel has been closed. The bug goes back to JDK 14 when caching of sockaddr structured was introduced.

The test case creates the conditions to exercise the case for both the timed and untimed receive. The bug report is the timed case, which receives two datagrams before attempting a timed receive. The harder case to test is the untimed case so the test uses a virtual thread to force the underlying socket to be non-blocking.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280113](https://bugs.openjdk.org/browse/JDK-8280113): (dc) DatagramSocket.receive does not always throw when the channel is closed


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [1990f4f0](https://git.openjdk.org/jdk/pull/12674/files/1990f4f0c94686fecd893dca9aec25ffab58f5aa)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12674/head:pull/12674` \
`$ git checkout pull/12674`

Update a local copy of the PR: \
`$ git checkout pull/12674` \
`$ git pull https://git.openjdk.org/jdk pull/12674/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12674`

View PR using the GUI difftool: \
`$ git pr show -t 12674`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12674.diff">https://git.openjdk.org/jdk/pull/12674.diff</a>

</details>
