### PR TITLE
8302732: sun/net/www/http/HttpClient/MultiThreadTest.java still failing intermittently

### DIFF
--- a/src/java.base/share/classes/sun/net/www/http/KeepAliveCache.java
+++ b/src/java.base/share/classes/sun/net/www/http/KeepAliveCache.java
@@ -276,6 +276,9 @@ public class KeepAliveCache
                     removeVector(key);
                 }
             } finally {
+                if (isEmpty()) {
+                    keepAliveTimer = null;
+                }
                 cacheLock.unlock();
                 // close connections outside cacheLock
                 if (closeList != null) {
@@ -284,7 +287,7 @@ public class KeepAliveCache
                     }
                 }
             }
-        } while (!isEmpty());
+        } while (keepAliveTimer == Thread.currentThread());
     }
 
     /*

--- a/src/java.base/share/classes/sun/net/www/http/KeepAliveCache.java
+++ b/src/java.base/share/classes/sun/net/www/http/KeepAliveCache.java
@@ -243,7 +243,7 @@ public class KeepAliveCache
             cacheLock.lock();
             try {
                 if (isEmpty()) {
-                    // nothing was in the cache in the last LIFETIME - exit
+                    // cache not used in the last LIFETIME - exit
                     keepAliveTimer = null;
                     break;
                 }

--- a/test/jdk/sun/net/www/http/HttpClient/KeepAliveTest.java
+++ b/test/jdk/sun/net/www/http/HttpClient/KeepAliveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1230,7 +1230,7 @@ public class KeepAliveTest {
             System.out.println("ProxyHostUsingSystemProperty:" + System.getProperty("http.proxyHost"));
             System.out.println("http.keepAlive.time.server=" + System.getProperty("http.keepAlive.time.server"));
             System.out.println("http.keepAlive.time.proxy=" + System.getProperty("http.keepAlive.time.proxy"));
-            Class clientVectorClass = Class.forName("sun.net.www.http.ClientVector");
+            Class clientVectorClass = Class.forName("sun.net.www.http.KeepAliveCache$ClientVector");
             //      System.out.println("clientVectorClass=" + clientVectorClass);
             Field napField = clientVectorClass.getDeclaredField("nap");
             napField.setAccessible(true);


### PR DESCRIPTION
Please review this fix for a race in KeepAliveCache.

The sweeper thread (`KeepAliveCache.run()`) terminates when the cache is empty. The check for empty cache was performed  without holding the cache lock. As a result, there was a small window of time where a new connection could be added to the cache while the sweeper thread was stopping. The added connection would then be removed from cache without closing when a new sweeper thread was started.

As an additional observation, the check for empty cache was performed after sweeping. The cache could be empty because all connections were closed, or because all connections were busy. In the latter case, a new thread was created soon after the old one terminated.

This patch addresses both these issues. The sweeper thread makes the decision to terminate while holding the lock, and other threads are aware of that when they acquire the lock. Also, the sweeper thread only terminates if the cache is empty AND there was no cache activity in the last `LIFETIME` (5 seconds).

Tier1-3 clean. No new tests, the issue was very hard to reproduce without adding delays in production code..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302732](https://bugs.openjdk.org/browse/JDK-8302732): sun/net/www/http/HttpClient/MultiThreadTest.java still failing intermittently


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12676/head:pull/12676` \
`$ git checkout pull/12676`

Update a local copy of the PR: \
`$ git checkout pull/12676` \
`$ git pull https://git.openjdk.org/jdk pull/12676/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12676`

View PR using the GUI difftool: \
`$ git pr show -t 12676`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12676.diff">https://git.openjdk.org/jdk/pull/12676.diff</a>

</details>
