### PR TITLE
8299338: AssertionError in ResponseSubscribers$HttpResponseInputStream::onSubscribe

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Exchange.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Exchange.java
@@ -266,7 +266,7 @@ class Http1Exchange<T> extends ExchangeImpl<T> {
     // The Http1ResponseBodySubscriber is registered with the HttpClient
     // to ensure that it gets completed if the SelectorManager aborts due
     // to unexpected exceptions.
-    private void registerResponseSubscriber(Http1ResponseBodySubscriber<T> subscriber) {
+    private boolean registerResponseSubscriber(Http1ResponseBodySubscriber<T> subscriber) {
         Throwable failed = null;
         synchronized (lock) {
             failed = this.failed;
@@ -276,13 +276,14 @@ class Http1Exchange<T> extends ExchangeImpl<T> {
         }
         if (failed != null) {
             subscriber.onError(failed);
+            return false;
         } else {
-            client.registerSubscriber(subscriber);
+            return client.registerSubscriber(subscriber);
         }
     }
 
-    private void unregisterResponseSubscriber(Http1ResponseBodySubscriber<T> subscriber) {
-        client.unregisterSubscriber(subscriber);
+    private boolean unregisterResponseSubscriber(Http1ResponseBodySubscriber<T> subscriber) {
+        return client.unregisterSubscriber(subscriber);
     }
 
     @Override

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -583,7 +583,7 @@ final class HttpClientImpl extends HttpClient implements Trackable {
     }
 
     /**
-     * Remove the given subscriber to the subscribers list.
+     * Remove the given subscriber from the subscribers list.
      * @param subscriber the subscriber
      * @return true if the subscriber was found and removed from the list.
      */

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -557,7 +557,14 @@ final class HttpClientImpl extends HttpClient implements Trackable {
         client.subscribers.forEach(s -> s.onError(t));
     }
 
-    public void registerSubscriber(HttpBodySubscriberWrapper<?> subscriber) {
+    /**
+     * Adds the given subscriber to the subscribers list, or call
+     * its {@linkplain HttpBodySubscriberWrapper#onError onError}
+     * method if the client is shutting down.
+     * @param subscriber the subscriber
+     * @return true if the subscriber was added to the list.
+     */
+    public boolean registerSubscriber(HttpBodySubscriberWrapper<?> subscriber) {
         if (!selmgr.isClosed()) {
             synchronized (selmgr) {
                 if (!selmgr.isClosed()) {
@@ -567,20 +574,28 @@ final class HttpClientImpl extends HttpClient implements Trackable {
                             debug.log("body subscriber registered: " + count);
                         }
                     }
-                    return;
+                    return true;
                 }
             }
         }
         subscriber.onError(selmgr.selectorClosedException());
+        return false;
     }
 
-    public void unregisterSubscriber(HttpBodySubscriberWrapper<?> subscriber) {
+    /**
+     * Remove the given subscriber to the subscribers list.
+     * @param subscriber the subscriber
+     * @return true if the subscriber was found and removed from the list.
+     */
+    public boolean unregisterSubscriber(HttpBodySubscriberWrapper<?> subscriber) {
         if (subscribers.remove(subscriber)) {
             long count = pendingSubscribersCount.decrementAndGet();
             if (debug.on()) {
                 debug.log("body subscriber unregistered: " + count);
             }
+            return true;
         }
+        return false;
     }
 
     private void closeConnection(HttpConnection conn) {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
@@ -563,7 +563,7 @@ public class ResponseSubscribers {
                             assert buffers.remainingCapacity() > 1 || failed != null
                                     : "buffers capacity: " + buffers.remainingCapacity()
                                     + ", closed: " + closed + ", terminated: "
-                                    + buffers.contains(LAST_BUFFER)
+                                    + buffers.contains(LAST_LIST)
                                     + ", failed: " + failed;
                         }
                     }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
@@ -559,10 +559,12 @@ public class ResponseSubscribers {
                         closed = this.closed;
                         if (!closed) {
                             this.subscription = s;
-                            // should contain at least 2
-                            assert buffers.remainingCapacity() > 1
+                            // should contain at least 2, unless closed or failed.
+                            assert buffers.remainingCapacity() > 1 || failed != null
                                     : "buffers capacity: " + buffers.remainingCapacity()
-                                    + " closed: " + closed + " failed: " + failed;
+                                    + ", closed: " + closed + ", terminated: "
+                                    + buffers.contains(LAST_BUFFER)
+                                    + ", failed: " + failed;
                         }
                     }
                     if (closed) {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
@@ -545,7 +545,7 @@ public class ResponseSubscribers {
         @Override
         public void onSubscribe(Flow.Subscription s) {
             Objects.requireNonNull(s);
-            if (debug.on()) debug.log("onSubscribed called");
+            if (debug.on()) debug.log("onSubscribe called");
             try {
                 if (!subscribed.compareAndSet(false, true)) {
                     if (debug.on()) debug.log("Already subscribed: canceling");
@@ -580,7 +580,7 @@ public class ResponseSubscribers {
             } catch (Throwable t) {
                 failed = t;
                 if (debug.on())
-                    debug.log("onSubscribed failed", t);
+                    debug.log("onSubscribe failed", t);
                 try {
                     close();
                 } catch (IOException x) {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -351,12 +351,12 @@ class Stream<T> extends ExchangeImpl<T> {
     // The Http2StreamResponseSubscriber is registered with the HttpClient
     // to ensure that it gets completed if the SelectorManager aborts due
     // to unexpected exceptions.
-    private void registerResponseSubscriber(Http2StreamResponseSubscriber<?> subscriber) {
-        client().registerSubscriber(subscriber);
+    private boolean registerResponseSubscriber(Http2StreamResponseSubscriber<?> subscriber) {
+        return client().registerSubscriber(subscriber);
     }
 
-    private void unregisterResponseSubscriber(Http2StreamResponseSubscriber<?> subscriber) {
-        client().unregisterSubscriber(subscriber);
+    private boolean unregisterResponseSubscriber(Http2StreamResponseSubscriber<?> subscriber) {
+        return client().unregisterSubscriber(subscriber);
     }
 
     @Override

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/HttpBodySubscriberWrapper.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/HttpBodySubscriberWrapper.java
@@ -275,21 +275,6 @@ public class HttpBodySubscriberWrapper<T> implements TrustedSubscriber<T> {
     }
 
     /**
-     * Called right before the userSubscriber::onSubscribe is called.
-     * @apiNote
-     * This method may be used by subclasses to perform cleanup
-     * related actions after a subscription has been successfully
-     * accepted.
-     * This method is called while holding a subscription
-     * lock.
-     * @implSpec
-     * This method calls {@link #tryRegister()}
-     */
-    protected void onSubscribed() {
-        tryRegister();
-    }
-
-    /**
      * Complete the subscriber, either normally or exceptionally
      * ensure that the subscriber is completed only once.
      * @param t a throwable, or {@code null}
@@ -381,8 +366,8 @@ public class HttpBodySubscriberWrapper<T> implements TrustedSubscriber<T> {
         // subscription is finished before calling onError;
         subscriptionLock.lock();
         try {
+            tryRegister();
             if (markSubscribed()) {
-                onSubscribed();
                 SubscriptionWrapper wrapped = new SubscriptionWrapper(subscription);
                 userSubscriber.onSubscribe(this.subscription = wrapped);
             } else {

--- a/test/jdk/java/net/httpclient/AsyncExecutorShutdown.java
+++ b/test/jdk/java/net/httpclient/AsyncExecutorShutdown.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8277969
+ * @bug 8277969 8299338
  * @summary Test for edge case where the executor is not accepting
  *          new tasks while the client is still running
  * @library /test/lib /test/jdk/java/net/httpclient/lib


### PR DESCRIPTION
This fix revisits an assertion that has been observed failing in ResponseSubscribers.HttpResponseInputStream.

The HttpResponseInputStream has the logic to wait until a buffer has been taken out of the queue before requesting a new one. Therefore there should at most be one byte buffer in the queue, except in the case of error (or asychronous close), where a LAST_LIST sentinel is inserted in the queue to unblock the consumer of the input stream, which might be blocked in queue.take().

The  HttpResponseInputStream thus asserts, when processing a subscription, that the remaining capacity of the queue should be greater than 1 (unless already closed), to ensure that there will be room for the LAST_LIST sentinel. However, in case of asynchronous shutdown of the executor, it's possible that the subscriber will be marked failed and the LAST_LIST sentinel inserted into the queue before/at the same time that the subscription is processed.

This fix proposes to relax the assertion to only fire if closed == false and failed == null and capacity <= 1 when processing the subscription

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299338](https://bugs.openjdk.org/browse/JDK-8299338): AssertionError in ResponseSubscribers$HttpResponseInputStream::onSubscribe


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12677/head:pull/12677` \
`$ git checkout pull/12677`

Update a local copy of the PR: \
`$ git checkout pull/12677` \
`$ git pull https://git.openjdk.org/jdk pull/12677/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12677`

View PR using the GUI difftool: \
`$ git pr show -t 12677`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12677.diff">https://git.openjdk.org/jdk/pull/12677.diff</a>

</details>
