### PR TITLE
8287885: Local classes cause ClassLoader error if the type names are similar but not same

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -478,7 +478,7 @@ public class Check {
      *  To help avoid clashes on case-insensitive filesystems,
      *  we use case-insensitive local class names in our map.
      *  While this means clearLocalClassNameIndexes() could clear
-     *  keys for more than one symbol, its only invoked after
+     *  keys for more than one symbol, it's only invoked after
      *  all related local classes have been processed for a class.
      *  We only lowercase A-Z to avoid any locale issues.
      */


### PR DESCRIPTION
The compiler doesn't really support case-insensitive filesystems. However, we can still avoid name clashes for local classes because their names are synthesized with indexed names like`$1`, `$2`, etc.

So previously, a class like this:
```java
public class Test {

    void method1() {
        enum ABC { A, B, C; };
    }

    void method2() {
        enum Abc { A, B, C; };
    } 
}
```
would generate these classfiles:
```
Test.class
Test$1ABC.class
Test$1Abc.class
```
the latter two of which clash on case-insensitive filesystems. After this patch, these non-clashing classfiles are generated instead:
```
Test.class
Test$1ABC.class
Test$2Abc.class
```

The only thing slightly wonky about this patch is that `clearLocalClassNameIndexes()` since local classes `ABC` and `Abc` share the same index, clearing either one clears both. But this is harmless, because these indexes are cleared in a batch, during a final "cleanup" step after processing the containing class.

To avoid any locale weirdness, we only collapse ASCII letters A-Z/a-z. So this is clearly a limited, tactical fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287885](https://bugs.openjdk.org/browse/JDK-8287885): Local classes cause ClassLoader error if the type names are similar but not same


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12678/head:pull/12678` \
`$ git checkout pull/12678`

Update a local copy of the PR: \
`$ git checkout pull/12678` \
`$ git pull https://git.openjdk.org/jdk pull/12678/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12678`

View PR using the GUI difftool: \
`$ git pr show -t 12678`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12678.diff">https://git.openjdk.org/jdk/pull/12678.diff</a>

</details>
