### PR TITLE
8302905: arm32 Raspberry Pi OS build broken by JDK-8301494

### DIFF
--- a/src/hotspot/cpu/arm/interpreterRT_arm.cpp
+++ b/src/hotspot/cpu/arm/interpreterRT_arm.cpp
@@ -263,7 +263,7 @@ class SlowSignatureHandler: public NativeSignatureIterator {
 
   virtual void pass_object() {
     intptr_t from_addr = (intptr_t)(_from + Interpreter::local_offset_in_bytes(0));
-    *_to++ = (*(intptr_t*)from_addr == 0) ? (intptr_t)nullptr : from_addr;
+    *_to++ = (*(intptr_t*)from_addr == 0) ? 0 : from_addr;
     _from -= Interpreter::stackElementSize;
    }
 
@@ -306,9 +306,9 @@ class SlowSignatureHandler: public NativeSignatureIterator {
   virtual void pass_object() {
     intptr_t from_addr = (intptr_t)(_from + Interpreter::local_offset_in_bytes(0));
     if(_last_gp < GPR_PARAMS) {
-      _toGP[_last_gp++] = (*(intptr_t*)from_addr == 0) ? nullptr : from_addr;
+      _toGP[_last_gp++] = (*(intptr_t*)from_addr == 0) ? 0 : from_addr;
     } else {
-      *_to++ = (*(intptr_t*)from_addr == 0) ? nullptr : from_addr;
+      *_to++ = (*(intptr_t*)from_addr == 0) ? 0 : from_addr;
     }
     _from -= Interpreter::stackElementSize;
   }


### PR DESCRIPTION
Trivial fix that replaces `nullptr` with 0 in `intptr_t` expressions. This seems more appropriate than casting `nullptr` to `intptr_t`.

Tested with local ARM32 build.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302905](https://bugs.openjdk.org/browse/JDK-8302905): arm32 Raspberry Pi OS build broken by JDK-8301494


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)
 * [Martin Buchholz](https://openjdk.org/census#martin) (@Martin-Buchholz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12679/head:pull/12679` \
`$ git checkout pull/12679`

Update a local copy of the PR: \
`$ git checkout pull/12679` \
`$ git pull https://git.openjdk.org/jdk pull/12679/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12679`

View PR using the GUI difftool: \
`$ git pr show -t 12679`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12679.diff">https://git.openjdk.org/jdk/pull/12679.diff</a>

</details>
