### PR TITLE
8143900: OptimizeStringConcat has an opaque dependency on Integer.sizeTable field

### DIFF
--- a/src/hotspot/share/opto/stringopts.cpp
+++ b/src/hotspot/share/opto/stringopts.cpp
@@ -1160,7 +1160,7 @@ bool StringConcat::validate_control_flow() {
   return !fail;
 }
 
-// Mirror of Integer.stringSize, return the count of digits in integer,
+// Mirror of Integer.stringSize() method, return the count of digits in integer,
 Node* PhaseStringOpts::int_stringSize(GraphKit& kit, Node* arg) {
   if (arg->is_Con()) {
     // Constant integer. Compute constant length

--- a/src/hotspot/share/opto/stringopts.cpp
+++ b/src/hotspot/share/opto/stringopts.cpp
@@ -1238,7 +1238,7 @@ Node* PhaseStringOpts::int_stringSize(GraphKit& kit, Node* arg) {
   Node* cmp = __ CmpI(val, temp);
   Node* cmpb = __ Bool(cmp, BoolTest::gt);
   IfNode* iff3 = kit.create_and_map_if(kit.control(), cmpb, PROB_MIN, COUNT_UNKNOWN);
-  Node* cmp_le = __ IfFalse(iff3);  
+  Node* cmp_le = __ IfFalse(iff3);
   kit.set_control(cmp_le);
 
   loop->init_req(2, kit.control());

--- a/src/hotspot/share/opto/stringopts.hpp
+++ b/src/hotspot/share/opto/stringopts.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,9 +43,6 @@ class PhaseStringOpts : public Phase {
   // Memory slices needed for code gen
   int byte_adr_idx;
 
-  // Integer.sizeTable - used for int to String conversion
-  ciField* size_table_field;
-
   // A set for use by various stages
   VectorSet _visited;
 
@@ -58,9 +55,6 @@ class PhaseStringOpts : public Phase {
 
   // Replace all the SB calls in concat with an optimization String allocation
   void replace_string_concat(StringConcat* concat);
-
-  // Load the value of a static field, performing any constant folding.
-  Node* fetch_static_field(GraphKit& kit, ciField* field);
 
   // Compute the number of characters required to represent the int value
   Node* int_stringSize(GraphKit& kit, Node* value);

--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -529,10 +529,6 @@ public final class Integer extends Number
         return charPos;
     }
 
-    // Left here for compatibility reasons, see JDK-8143900.
-    static final int [] sizeTable = { 9, 99, 999, 9999, 99999, 999999, 9999999,
-                                      99999999, 999999999, Integer.MAX_VALUE };
-
     /**
      * Returns the string representation size for a given int value.
      *


### PR DESCRIPTION
Hi, can I have a review for this patch? I noticed a strange field Integer.sizeTable which is used by PhaseStringOpts, after digging into the history, I think it could be replaced by an in-place array allocation and initialization. Before it, we are fetching from Integer.sizeTable and get num of digit in integer by iterating size table, now we fetch from in-place sizeTable and get size from that. The changed IR looks like this:

![image](https://user-images.githubusercontent.com/5010047/220239446-7b8b8381-b300-4f2c-a24a-aa19ec9e2f88.png)

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8143900](https://bugs.openjdk.org/browse/JDK-8143900): OptimizeStringConcat has an opaque dependency on Integer.sizeTable field


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12680/head:pull/12680` \
`$ git checkout pull/12680`

Update a local copy of the PR: \
`$ git checkout pull/12680` \
`$ git pull https://git.openjdk.org/jdk pull/12680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12680`

View PR using the GUI difftool: \
`$ git pr show -t 12680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12680.diff">https://git.openjdk.org/jdk/pull/12680.diff</a>

</details>
