### PR TITLE
8302907: [PPC64] Use more constexpr in class Register

### DIFF
--- a/src/hotspot/cpu/ppc/register_ppc.hpp
+++ b/src/hotspot/cpu/ppc/register_ppc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,14 +92,14 @@ class Register {
   inline constexpr friend Register as_Register(int encoding);
 
   // accessors
-  int encoding() const { assert(is_valid(), "invalid register"); return _encoding; }
+  constexpr int encoding() const { assert(is_valid(), "invalid register"); return _encoding; }
   inline VMReg as_VMReg() const;
   Register successor() const { return Register(encoding() + 1); }
 
   // testers
-  bool is_valid()       const { return ( 0 <= _encoding && _encoding <  number_of_registers); }
-  bool is_volatile()    const { return ( 0 <= _encoding && _encoding <= 13 ); }
-  bool is_nonvolatile() const { return (14 <= _encoding && _encoding <= 31 ); }
+  constexpr bool is_valid()       const { return ( 0 <= _encoding && _encoding <  number_of_registers); }
+  constexpr bool is_volatile()    const { return ( 0 <= _encoding && _encoding <= 13 ); }
+  constexpr bool is_nonvolatile() const { return (14 <= _encoding && _encoding <= 31 ); }
 
   const char* name() const;
 };
@@ -163,12 +163,12 @@ class ConditionRegister {
   inline constexpr friend ConditionRegister as_ConditionRegister(int encoding);
 
   // accessors
-  int encoding() const { assert(is_valid(), "invalid register"); return _encoding; }
+  constexpr int encoding() const { assert(is_valid(), "invalid register"); return _encoding; }
   inline VMReg as_VMReg() const;
 
   // testers
-  bool is_valid()       const { return (0 <= _encoding && _encoding <  number_of_registers); }
-  bool is_nonvolatile() const { return (2 <= _encoding && _encoding <= 4 );  }
+  constexpr bool is_valid()       const { return (0 <= _encoding && _encoding <  number_of_registers); }
+  constexpr bool is_nonvolatile() const { return (2 <= _encoding && _encoding <= 4 );  }
 
   const char* name() const;
 };
@@ -207,12 +207,12 @@ class FloatRegister {
   inline constexpr friend FloatRegister as_FloatRegister(int encoding);
 
   // accessors
-  int encoding() const { assert(is_valid(), "invalid register"); return _encoding; }
+  constexpr int encoding() const { assert(is_valid(), "invalid register"); return _encoding; }
   inline VMReg as_VMReg() const;
   FloatRegister successor() const { return FloatRegister(encoding() + 1); }
 
   // testers
-  bool is_valid() const { return (0 <= _encoding && _encoding < number_of_registers); }
+  constexpr bool is_valid() const { return (0 <= _encoding && _encoding < number_of_registers); }
 
   const char* name() const;
 
@@ -279,11 +279,11 @@ class SpecialRegister {
   inline constexpr friend SpecialRegister as_SpecialRegister(int encoding);
 
   // accessors
-  int encoding() const { assert(is_valid(), "invalid register"); return _encoding; }
+  constexpr int encoding() const { assert(is_valid(), "invalid register"); return _encoding; }
   inline VMReg as_VMReg() const;
 
   // testers
-  bool is_valid() const { return (0 <= _encoding && _encoding < number_of_registers); }
+  constexpr bool is_valid() const { return (0 <= _encoding && _encoding < number_of_registers); }
 
   const char* name() const;
 };
@@ -318,10 +318,10 @@ class VectorRegister {
   inline constexpr friend VectorRegister as_VectorRegister(int encoding);
 
   // accessors
-  int encoding()  const { assert(is_valid(), "invalid register"); return _encoding; }
+  constexpr int encoding() const { assert(is_valid(), "invalid register"); return _encoding; }
 
   // testers
-  bool is_valid() const { return (0 <= _encoding && _encoding < number_of_registers); }
+  constexpr bool is_valid() const { return (0 <= _encoding && _encoding < number_of_registers); }
 
   const char* name() const;
 
@@ -387,11 +387,11 @@ class VectorSRegister {
   inline constexpr friend VectorSRegister as_VectorSRegister(int encoding);
 
   // accessors
-  int encoding() const { assert(is_valid(), "invalid register"); return _encoding; }
+  constexpr int encoding() const { assert(is_valid(), "invalid register"); return _encoding; }
   inline VMReg as_VMReg() const;
 
   // testers
-  bool is_valid() const { return (0 <= _encoding && _encoding < number_of_registers); }
+  constexpr bool is_valid() const { return (0 <= _encoding && _encoding < number_of_registers); }
 
   const char* name() const;
 


### PR DESCRIPTION
We should use `constexpr` more often in order to make it better usable. (I got compile errors when trying to use the `encoding()` in another `constexpr`.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302907](https://bugs.openjdk.org/browse/JDK-8302907): [PPC64] Use more constexpr in class Register


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12681/head:pull/12681` \
`$ git checkout pull/12681`

Update a local copy of the PR: \
`$ git checkout pull/12681` \
`$ git pull https://git.openjdk.org/jdk pull/12681/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12681`

View PR using the GUI difftool: \
`$ git pr show -t 12681`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12681.diff">https://git.openjdk.org/jdk/pull/12681.diff</a>

</details>
