### PR TITLE
8302927: Unproblemlist Fuzz.java from ProblemList-zgc.txt again

### DIFF
--- a/test/jdk/ProblemList-zgc.txt
+++ b/test/jdk/ProblemList-zgc.txt
@@ -27,5 +27,4 @@
 #
 #############################################################################
 
-jdk/internal/vm/Continuation/Fuzz.java#default 8298058 generic-x64
 java/util/concurrent/locks/Lock/OOMEInAQS.java 8298066 windows-x64


### PR DESCRIPTION
The previous removal of Fuzz from the ProblemList got undone in a merge from JDK 20. This patch removes the test from the ProblemList again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302927](https://bugs.openjdk.org/browse/JDK-8302927): Unproblemlist Fuzz.java from ProblemList-zgc.txt again


### Reviewers
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12684/head:pull/12684` \
`$ git checkout pull/12684`

Update a local copy of the PR: \
`$ git checkout pull/12684` \
`$ git pull https://git.openjdk.org/jdk pull/12684/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12684`

View PR using the GUI difftool: \
`$ git pr show -t 12684`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12684.diff">https://git.openjdk.org/jdk/pull/12684.diff</a>

</details>
