### PR TITLE
8302977: ZGC: Doesn't support gc/TestVerifySubSet.java

### DIFF
--- a/test/hotspot/jtreg/gc/TestVerifySubSet.java
+++ b/test/hotspot/jtreg/gc/TestVerifySubSet.java
@@ -27,7 +27,7 @@ package gc;
  * @bug 8072725
  * @summary Test VerifySubSet option
  *
- * @comment ZGC doesn't support Universe::verify will not print the output below
+ * @comment ZGC doesn't use Universe::verify and will not log the output below
  * @requires !vm.gc.Z
  *
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/TestVerifySubSet.java
+++ b/test/hotspot/jtreg/gc/TestVerifySubSet.java
@@ -26,6 +26,10 @@ package gc;
 /* @test TestVerifySubSet.java
  * @bug 8072725
  * @summary Test VerifySubSet option
+ *
+ * @comment ZGC doesn't support Universe::verify will not print the output below
+ * @requires !vm.gc.Z
+ *
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @run main gc.TestVerifySubSet


### PR DESCRIPTION
8302741 removed ZGC's usage of Universe::verify. This breaks gc/TestVerifySubSet.java, which looks for this output.

I propose this trivial patch to simply exclude ZGC from running this test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302977](https://bugs.openjdk.org/browse/JDK-8302977): ZGC: Doesn't support gc/TestVerifySubSet.java


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12686/head:pull/12686` \
`$ git checkout pull/12686`

Update a local copy of the PR: \
`$ git checkout pull/12686` \
`$ git pull https://git.openjdk.org/jdk pull/12686/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12686`

View PR using the GUI difftool: \
`$ git pr show -t 12686`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12686.diff">https://git.openjdk.org/jdk/pull/12686.diff</a>

</details>
