### PR TITLE
8302975: Remove redundant mark verification during G1 Full GC

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
@@ -42,7 +42,6 @@ G1FullGCMarker::G1FullGCMarker(G1FullCollector* collector,
     _objarray_stack(),
     _preserved_stack(preserved_stack),
     _mark_closure(worker_id, this, ClassLoaderData::_claim_stw_fullgc_mark, G1CollectedHeap::heap()->ref_processor_stw()),
-    _verify_closure(G1CollectedHeap::heap(), VerifyOption::G1UseFullMarking),
     _stack_closure(this),
     _cld_closure(mark_closure(), ClassLoaderData::_claim_stw_fullgc_mark),
     _mark_stats_cache(mark_stats, G1RegionMarkStatsCache::RegionMarkStatsCacheSize) {

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.hpp
@@ -63,7 +63,6 @@ class G1FullGCMarker : public CHeapObj<mtGC> {
 
   // Marking closures
   G1MarkAndPushClosure  _mark_closure;
-  G1VerifyLiveClosure   _verify_closure;
   G1FollowStackClosure  _stack_closure;
   CLDToOopClosure       _cld_closure;
   StringDedup::Requests _string_dedup_requests;

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
@@ -123,14 +123,6 @@ void G1FullGCMarker::follow_array_chunk(objArrayOop array, int index) {
   }
 
   array->oop_iterate_range(mark_closure(), beg_index, end_index);
-
-  if (VerifyDuringGC) {
-    _verify_closure.set_containing_obj(array);
-    array->oop_iterate_range(&_verify_closure, beg_index, end_index);
-    if (_verify_closure.has_failures()) {
-      fatal("there should not have been any failures");
-    }
-  }
 }
 
 inline void G1FullGCMarker::follow_object(oop obj) {
@@ -141,16 +133,6 @@ inline void G1FullGCMarker::follow_object(oop obj) {
     follow_array((objArrayOop)obj);
   } else {
     obj->oop_iterate(mark_closure());
-    if (VerifyDuringGC) {
-      if (obj->is_instanceRef()) {
-        return;
-      }
-      _verify_closure.set_containing_obj(obj);
-      obj->oop_iterate(&_verify_closure);
-      if (_verify_closure.has_failures()) {
-        fatal("there should not have been any failures");
-      }
-    }
   }
 }
 


### PR DESCRIPTION
Hi all,

  please review this remove of some redundant verification code that also opens opportunities for further cleanup in PR#12260. In particular it removes verification of marks during g1 full gc marking: this is checked after marking already, and actually in `G1FullGCMarker::mark_and_push` anyway.

To make this change small, I did not move the `G1VerifyLiveClosure` somewhere private, and anyway it will be refactored in PR#12260 after this has been pushed again..

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302975](https://bugs.openjdk.org/browse/JDK-8302975): Remove redundant mark verification during G1 Full GC


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12687/head:pull/12687` \
`$ git checkout pull/12687`

Update a local copy of the PR: \
`$ git checkout pull/12687` \
`$ git pull https://git.openjdk.org/jdk pull/12687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12687`

View PR using the GUI difftool: \
`$ git pr show -t 12687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12687.diff">https://git.openjdk.org/jdk/pull/12687.diff</a>

</details>
