### PR TITLE
8302979: (fs) Files usage of SUPPORTED_CHARSETS could be simplified

### DIFF
--- a/src/java.base/share/classes/java/nio/file/FileChannelLinesSpliterator.java
+++ b/src/java.base/share/classes/java/nio/file/FileChannelLinesSpliterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,6 @@ import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -70,13 +69,11 @@ import jdk.internal.access.JavaNioAccess;
  */
 final class FileChannelLinesSpliterator implements Spliterator<String> {
 
-    static final Set<String> SUPPORTED_CHARSET_NAMES;
-    static {
-        SUPPORTED_CHARSET_NAMES = new HashSet<>();
-        SUPPORTED_CHARSET_NAMES.add(UTF_8.INSTANCE.name());
-        SUPPORTED_CHARSET_NAMES.add(ISO_8859_1.INSTANCE.name());
-        SUPPORTED_CHARSET_NAMES.add(US_ASCII.INSTANCE.name());
-    }
+    static final Set<Charset> SUPPORTED_CHARSETS = Set.of(
+            UTF_8.INSTANCE,
+            ISO_8859_1.INSTANCE,
+            US_ASCII.INSTANCE
+    );
 
     private final FileChannel fc;
     private final Charset cs;

--- a/src/java.base/share/classes/java/nio/file/FileChannelLinesSpliterator.java
+++ b/src/java.base/share/classes/java/nio/file/FileChannelLinesSpliterator.java
@@ -70,9 +70,9 @@ import jdk.internal.access.JavaNioAccess;
 final class FileChannelLinesSpliterator implements Spliterator<String> {
 
     static final Set<Charset> SUPPORTED_CHARSETS = Set.of(
-            UTF_8.INSTANCE,
-            ISO_8859_1.INSTANCE,
-            US_ASCII.INSTANCE
+        UTF_8.INSTANCE,
+        ISO_8859_1.INSTANCE,
+        US_ASCII.INSTANCE
     );
 
     private final FileChannel fc;

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -4103,7 +4103,7 @@ public final class Files {
         // 3) the file size is such that all bytes can be indexed by int values
         //    (this limitation is imposed by ByteBuffer)
         if (path.getFileSystem() == FileSystems.getDefault() &&
-            FileChannelLinesSpliterator.SUPPORTED_CHARSET_NAMES.contains(cs.name())) {
+            FileChannelLinesSpliterator.SUPPORTED_CHARSETS.contains(cs)) {
             FileChannel fc = FileChannel.open(path, StandardOpenOption.READ);
 
             Stream<String> fcls = createFileChannelLinesStream(fc, cs);


### PR DESCRIPTION
Code of `Files.lines()` could be slightly simplified:

- use charsets instead of their names
- use `Set.of()` instead of `HashSet` in `FileChannelLinesSpliterator`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302979](https://bugs.openjdk.org/browse/JDK-8302979): (fs) Files usage of SUPPORTED_CHARSETS could be simplified


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [a4a2b389](https://git.openjdk.org/jdk/pull/12688/files/a4a2b3890ffd4ba1846af38fac443dd2d8398b5e)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12688/head:pull/12688` \
`$ git checkout pull/12688`

Update a local copy of the PR: \
`$ git checkout pull/12688` \
`$ git pull https://git.openjdk.org/jdk pull/12688/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12688`

View PR using the GUI difftool: \
`$ git pr show -t 12688`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12688.diff">https://git.openjdk.org/jdk/pull/12688.diff</a>

</details>
