### PR TITLE
8302981: Fix a typo in the doc comment for java.lang.Record.equals

### DIFF
--- a/src/java.base/share/classes/java/lang/Record.java
+++ b/src/java.base/share/classes/java/lang/Record.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,7 +115,7 @@ public abstract class Record {
      * <li> If the component is of a reference type, the component is
      * considered equal if and only if {@link
      * java.util.Objects#equals(Object,Object)
-     * Objects.equals(this.c, r.c} would return {@code true}.
+     * Objects.equals(this.c, r.c)} would return {@code true}.
      *
      * <li> If the component is of a primitive type, using the
      * corresponding primitive wrapper class {@code PW} (the


### PR DESCRIPTION
Please review this trivial fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302981](https://bugs.openjdk.org/browse/JDK-8302981): Fix a typo in the doc comment for java.lang.Record.equals


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12689/head:pull/12689` \
`$ git checkout pull/12689`

Update a local copy of the PR: \
`$ git checkout pull/12689` \
`$ git pull https://git.openjdk.org/jdk pull/12689/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12689`

View PR using the GUI difftool: \
`$ git pr show -t 12689`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12689.diff">https://git.openjdk.org/jdk/pull/12689.diff</a>

</details>
