### PR TITLE
8302983: ZoneRulesProvider.registerProvider() twice will remove provider

### DIFF
--- a/src/java.base/share/classes/java/time/zone/ZoneRulesProvider.java
+++ b/src/java.base/share/classes/java/time/zone/ZoneRulesProvider.java
@@ -316,10 +316,12 @@ public abstract class ZoneRulesProvider {
             Objects.requireNonNull(zoneId, "zoneId");
             ZoneRulesProvider old = ZONES.putIfAbsent(zoneId, provider);
             if (old != null) {
-                // restore old state
-                ZONES.put(zoneId, old);
-                provider.provideZoneIds().stream()
-                    .forEach(id -> ZONES.remove(id, provider));
+                if(!old.equals(provider)) {
+                    // restore old state
+                    ZONES.put(zoneId, old);
+                    provider.provideZoneIds().stream()
+                        .forEach(id -> ZONES.remove(id, provider));
+                }
                 throw new ZoneRulesException(
                     "Unable to register zone as one already registered with that ID: " + zoneId +
                     ", currently loading from provider: " + provider);

--- a/src/java.base/share/classes/java/time/zone/ZoneRulesProvider.java
+++ b/src/java.base/share/classes/java/time/zone/ZoneRulesProvider.java
@@ -316,11 +316,10 @@ public abstract class ZoneRulesProvider {
             Objects.requireNonNull(zoneId, "zoneId");
             ZoneRulesProvider old = ZONES.putIfAbsent(zoneId, provider);
             if (old != null) {
-                if(!old.equals(provider)) {
+                if (!old.equals(provider)) {
                     // restore old state
                     ZONES.put(zoneId, old);
-                    provider.provideZoneIds().stream()
-                        .forEach(id -> ZONES.remove(id, provider));
+                    provider.provideZoneIds().forEach(id -> ZONES.remove(id, provider));
                 }
                 throw new ZoneRulesException(
                     "Unable to register zone as one already registered with that ID: " + zoneId +

--- a/test/jdk/java/time/test/java/time/zone/TestZoneRulesProvider.java
+++ b/test/jdk/java/time/test/java/time/zone/TestZoneRulesProvider.java
@@ -40,43 +40,27 @@ import static org.testng.Assert.fail;
 
 /**
  * @summary Tests for ZoneRulesProvider class.
- * @bug 8299571
- * @bug 8302983
+ * @bug 8299571 8302983
  */
 @Test
 public class TestZoneRulesProvider {
-    private static final Set<String> MY_ZONE_IDS =
-        new LinkedHashSet(Arrays.asList(new String[] {"MyID_1", "MyID_2", "CET", "MyID_3"}));
 
     /**
      * Tests whether partially registered zones are cleaned on a provider registration
      * failure, in case a duplicated zone is detected.
+     * @bug 8299571
      */
     @Test
     public void test_registerDuplicatedZone() {
+        Set<String> myZoneIds = new LinkedHashSet<>(Arrays.asList(new String[] {"MyID_1", "MyID_2", "CET", "MyID_3"}));
         try {
-            ZoneRulesProvider.registerProvider(new ZoneRulesProvider() {
-                @Override
-                protected Set<String> provideZoneIds() {
-                    return MY_ZONE_IDS;
-                }
-
-                @Override
-                protected ZoneRules provideRules(String zoneId, boolean forCaching) {
-                    return null;
-                }
-
-                @Override
-                protected NavigableMap<String, ZoneRules> provideVersions(String zoneId) {
-                    return null;
-                }
-            });
+            ZoneRulesProvider.registerProvider(new IdsOnlyZoneRulesProvider(myZoneIds));
             throw new RuntimeException("Registering a provider that duplicates a zone should throw an exception");
         } catch (ZoneRulesException e) {
             // Ignore. Failure on registration is expected.
         }
 
-        MY_ZONE_IDS.stream().forEach(id -> {
+        myZoneIds.stream().forEach(id -> {
             var isCET = id.equals("CET");
 
             // availability check
@@ -97,45 +81,59 @@ public class TestZoneRulesProvider {
 
     /**
      * Tests whether registering a provider twice will still leave it registered.
+     * @bug 8302983
      */
     @Test
     public void test_registerTwice() {
         String zone = "MyID";
-        var provider = new ZoneRulesProvider() {
-            @Override
-            protected Set<String> provideZoneIds() {
-                return Set.of(zone);
-            }
-
-            @Override
-            protected ZoneRules provideRules(String zoneId, boolean forCaching) {
-                return null;
-            }
-
-            @Override
-            protected NavigableMap<String, ZoneRules> provideVersions(String zoneId) {
-                return null;
-            }
-        }
+        var provider = new IdsOnlyZoneRulesProvider(Set.of(zone));
         assertFalse(ZoneId.getAvailableZoneIds().contains(zone), "Unexpected availability for " + zone);
         ZoneRulesProvider.registerProvider(provider);
         assertTrue(ZoneId.getAvailableZoneIds().contains(zone), "Unexpected non-availability for " + zone);
-        assertNotNull(ZoneId.of(zone), "ZoneId instance for " + zone + " should be obtainable");
+        try {
+            ZoneId.of(zone);
+        } catch (ZoneRulesException e) {
+            fail("ZoneId instance for " + zone + " should be obtainable");
+        }
 
         try {
             ZoneRulesProvider.registerProvider(provider);
-            throw new RuntimeException("Registering an already registered provider should throw an exception");
+            fail("Registering an already registered provider should throw an exception");
         } catch (ZoneRulesException e) {
             // Ignore. Failure on duplicate registration is expected.
         }
 
         // availability check
-        assertTrue(ZoneId.getAvailableZoneIds().contains(zone), "Unexpected non-availability for " + id);
+        assertTrue(ZoneId.getAvailableZoneIds().contains(zone), "Unexpected non-availability for " + zone);
         // instantiation check
         try {
-            assertNotNull(ZoneId.of(zone), "ZoneId instance for " + zone + " should still be obtainable");
+            ZoneId.of(zone);
         } catch (ZoneRulesException e) {
             fail("ZoneId instance for " + zone + " should still be obtainable", e);
+        }
+    }
+
+    private static class IdsOnlyZoneRulesProvider extends ZoneRulesProvider {
+
+        private final Set<String> zones;
+
+        IdsOnlyZoneRulesProvider(Set<String> zones) {
+            this.zones = zones;
+        }
+
+        @Override
+        protected Set<String> provideZoneIds() {
+            return zones;
+        }
+
+        @Override
+        protected ZoneRules provideRules(String zoneId, boolean forCaching) {
+            return null;
+        }
+
+        @Override
+        protected NavigableMap<String, ZoneRules> provideVersions(String zoneId) {
+            return null;
         }
     }
 }


### PR DESCRIPTION
Fixes JDK-8302983 (and duplicate JDK-8302898)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302983](https://bugs.openjdk.org/browse/JDK-8302983): ZoneRulesProvider.registerProvider() twice will remove provider


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12690/head:pull/12690` \
`$ git checkout pull/12690`

Update a local copy of the PR: \
`$ git checkout pull/12690` \
`$ git pull https://git.openjdk.org/jdk.git pull/12690/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12690`

View PR using the GUI difftool: \
`$ git pr show -t 12690`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12690.diff">https://git.openjdk.org/jdk/pull/12690.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12690#issuecomment-1438917348)