### PR TITLE
JDK-8302989: Add missing INCLUDE_CDS checks

### DIFF
--- a/src/hotspot/share/classfile/classLoaderExt.cpp
+++ b/src/hotspot/share/classfile/classLoaderExt.cpp
@@ -57,10 +57,12 @@ bool ClassLoaderExt::_has_platform_classes = false;
 bool ClassLoaderExt::_has_non_jar_in_classpath = false;
 
 void ClassLoaderExt::append_boot_classpath(ClassPathEntry* new_entry) {
+#if INCLUDE_CDS
   if (UseSharedSpaces) {
     warning("Sharing is only supported for boot loader classes because bootstrap classpath has been appended");
     FileMapInfo::current_info()->set_has_platform_or_app_classes(false);
   }
+#endif
   ClassLoader::add_to_boot_append_entries(new_entry);
 }
 

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -5224,6 +5224,7 @@ void java_lang_InternalError::serialize_offsets(SerializeClosure* f) {
 
 // Compute field offsets of all the classes in this file
 void JavaClasses::compute_offsets() {
+#if INCLUDE_CDS
   if (UseSharedSpaces) {
     JVMTI_ONLY(assert(JvmtiExport::is_early_phase() && !(JvmtiExport::should_post_class_file_load_hook() &&
                                                          JvmtiExport::has_early_class_hook_env()),
@@ -5234,6 +5235,7 @@ void JavaClasses::compute_offsets() {
     // by JavaClasses::serialize_offsets, without computing the offsets again.
     return;
   }
+#endif
 
   // We have already called the compute_offsets() of the
   // BASIC_JAVA_CLASSES_DO_PART1 classes (java_lang_String, java_lang_Class and

--- a/src/hotspot/share/classfile/vmClasses.cpp
+++ b/src/hotspot/share/classfile/vmClasses.cpp
@@ -167,6 +167,7 @@ void vmClasses::resolve_all(TRAPS) {
   Universe::initialize_basic_type_mirrors(CHECK);
   Universe::fixup_mirrors(CHECK);
 
+#if INCLUDE_CDS
   if (UseSharedSpaces) {
     // These should already have been initialized during CDS dump.
     assert(vmClasses::Reference_klass()->reference_type() == REF_NONE, "sanity");
@@ -174,7 +175,9 @@ void vmClasses::resolve_all(TRAPS) {
     assert(vmClasses::WeakReference_klass()->reference_type() == REF_WEAK, "sanity");
     assert(vmClasses::FinalReference_klass()->reference_type() == REF_FINAL, "sanity");
     assert(vmClasses::PhantomReference_klass()->reference_type() == REF_PHANTOM, "sanity");
-  } else {
+  } else
+#endif
+  {
     // If CDS is not enabled, the references classes must be initialized in
     // this order before the rest of the vmClasses can be resolved.
     resolve_through(VM_CLASS_ID(Reference_klass), scan, CHECK);
@@ -208,6 +211,7 @@ void vmClasses::resolve_all(TRAPS) {
   //_box_klasses[T_ARRAY]   = vmClasses::object_klass();
 
 #ifdef ASSERT
+#if INCLUDE_CDS
   if (UseSharedSpaces) {
     JVMTI_ONLY(assert(JvmtiExport::is_early_phase(),
                       "All well known classes must be resolved in JVMTI early phase"));
@@ -216,6 +220,7 @@ void vmClasses::resolve_all(TRAPS) {
       assert(k->is_shared(), "must not be replaced by JVMTI class file load hook");
     }
   }
+#endif
 #endif
 
   InstanceStackChunkKlass::init_offset_of_stack();

--- a/src/hotspot/share/oops/compressedOops.cpp
+++ b/src/hotspot/share/oops/compressedOops.cpp
@@ -201,6 +201,7 @@ void CompressedKlassPointers::initialize(address addr, size_t len) {
   int shift;
   size_t range;
 
+#if INCLUDE_CDS
   if (UseSharedSpaces || DumpSharedSpaces) {
 
     // Special requirements if CDS is active:
@@ -235,8 +236,9 @@ void CompressedKlassPointers::initialize(address addr, size_t len) {
     assert(len <= 4 * G, "Encoding range cannot be larger than 4G");
     range = 4 * G;
 
-  } else {
-
+  } else
+#endif
+  {
     // Otherwise we attempt to use a zero base if the range fits in lower 32G.
     if (end <= (address)KlassEncodingMetaspaceMax) {
       base = 0;
@@ -254,7 +256,6 @@ void CompressedKlassPointers::initialize(address addr, size_t len) {
     } else {
       shift = LogKlassAlignmentInBytes;
     }
-
   }
 
   set_base(base);

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2653,29 +2653,23 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
     } else if (match_option(option, "-Xcomp")) {
       // for testing the compiler; turn off all flags that inhibit compilation
           set_mode_flags(_comp);
-    // -Xshare:dump
+#if INCLUDE_CDS
     } else if (match_option(option, "-Xshare:dump")) {
-#if INCLUDE_CDS
       DumpSharedSpaces = true;
-#endif
-    // -Xshare:on
     } else if (match_option(option, "-Xshare:on")) {
-#if INCLUDE_CDS
       UseSharedSpaces = true;
       RequireSharedSpaces = true;
-#endif
     // -Xshare:auto || -XX:ArchiveClassesAtExit=<archive file>
     } else if (match_option(option, "-Xshare:auto")) {
-#if INCLUDE_CDS
       UseSharedSpaces = true;
       RequireSharedSpaces = false;
-#endif
       xshare_auto_cmd_line = true;
-    // -Xshare:off
     } else if (match_option(option, "-Xshare:off")) {
-#if INCLUDE_CDS
       UseSharedSpaces = false;
       RequireSharedSpaces = false;
+#else
+    } else if (match_option(option, "-Xshare:")) {
+      warning("Option %s is not supported in this VM", option->optionString);
 #endif
     // -Xverify
     } else if (match_option(option, "-Xverify", &tail)) {

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1455,7 +1455,9 @@ static void no_shared_spaces(const char* message) {
     vm_exit_during_initialization("Unable to use shared archive", message);
   } else {
     log_info(cds)("Unable to use shared archive: %s", message);
+#if INCLUDE_CDS
     UseSharedSpaces = false;
+#endif
   }
 }
 
@@ -2653,20 +2655,28 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
           set_mode_flags(_comp);
     // -Xshare:dump
     } else if (match_option(option, "-Xshare:dump")) {
+#if INCLUDE_CDS
       DumpSharedSpaces = true;
+#endif
     // -Xshare:on
     } else if (match_option(option, "-Xshare:on")) {
+#if INCLUDE_CDS
       UseSharedSpaces = true;
       RequireSharedSpaces = true;
+#endif
     // -Xshare:auto || -XX:ArchiveClassesAtExit=<archive file>
     } else if (match_option(option, "-Xshare:auto")) {
+#if INCLUDE_CDS
       UseSharedSpaces = true;
       RequireSharedSpaces = false;
+#endif
       xshare_auto_cmd_line = true;
     // -Xshare:off
     } else if (match_option(option, "-Xshare:off")) {
+#if INCLUDE_CDS
       UseSharedSpaces = false;
       RequireSharedSpaces = false;
+#endif
     // -Xverify
     } else if (match_option(option, "-Xverify", &tail)) {
       if (strcmp(tail, ":all") == 0 || strcmp(tail, "") == 0) {
@@ -2915,8 +2925,10 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
   //   -Xshare:on
   //   -Xlog:class+path=info
   if (PrintSharedArchiveAndExit) {
+#if INCLUDE_CDS
     UseSharedSpaces = true;
     RequireSharedSpaces = true;
+#endif
     LogConfiguration::configure_stdout(LogLevel::Info, true, LOG_TAGS(class, path));
   }
 
@@ -3393,7 +3405,9 @@ void Arguments::set_shared_spaces_flags_and_archive_paths() {
     if (RequireSharedSpaces) {
       warning("Cannot dump shared archive while using shared archive");
     }
+#if INCLUDE_CDS
     UseSharedSpaces = false;
+#endif
   }
 #if INCLUDE_CDS
   // Initialize shared archive paths which could include both base and dynamic archive paths
@@ -3969,7 +3983,9 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
   if ((UseSharedSpaces && xshare_auto_cmd_line) ||
       log_is_enabled(Info, cds)) {
     warning("Shared spaces are not supported in this VM");
+#if INCLUDE_CDS
     UseSharedSpaces = false;
+#endif
     LogConfiguration::configure_stdout(LogLevel::Off, true, LOG_TAGS(cds));
   }
   no_shared_spaces("CDS Disabled");

--- a/src/hotspot/share/utilities/globalDefinitions.cpp
+++ b/src/hotspot/share/utilities/globalDefinitions.cpp
@@ -44,20 +44,12 @@ int BitsPerHeapOop     = 0;
 bool DumpSharedSpaces;
 bool DynamicDumpSharedSpaces;
 bool RequireSharedSpaces;
-#else
-const bool DumpSharedSpaces = false;
-const bool DynamicDumpSharedSpaces = false;
-const bool RequireSharedSpaces = false;
-#endif
 
-#if INCLUDE_CDS
 // export it only in the CDS case, there it is used
 // in SA java code
 extern "C" {
 JNIEXPORT jboolean UseSharedSpaces = true;
 }
-#else
-const bool UseSharedSpaces = false;
 #endif
 
 // Object alignment, in units of HeapWords.

--- a/src/hotspot/share/utilities/globalDefinitions.cpp
+++ b/src/hotspot/share/utilities/globalDefinitions.cpp
@@ -40,12 +40,25 @@ int BytesPerHeapOop    = 0;
 int BitsPerHeapOop     = 0;
 
 // Old CDS options
+#if INCLUDE_CDS
 bool DumpSharedSpaces;
 bool DynamicDumpSharedSpaces;
 bool RequireSharedSpaces;
+#else
+const bool DumpSharedSpaces = false;
+const bool DynamicDumpSharedSpaces = false;
+const bool RequireSharedSpaces = false;
+#endif
+
+#if INCLUDE_CDS
+// export it only in the CDS case, there it is used
+// in SA java code
 extern "C" {
 JNIEXPORT jboolean UseSharedSpaces = true;
 }
+#else
+const bool UseSharedSpaces = false;
+#endif
 
 // Object alignment, in units of HeapWords.
 // Defaults are -1 so things will break badly if incorrectly initialized.

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -574,13 +574,25 @@ const int max_method_code_size = 64*K - 1;  // JVM spec, 2nd ed. section 4.8.1 (
 
 //----------------------------------------------------------------------------------------------------
 // old CDS options
+#if INCLUDE_CDS
 extern bool DumpSharedSpaces;
 extern bool DynamicDumpSharedSpaces;
 extern bool RequireSharedSpaces;
+#else
+extern const bool DumpSharedSpaces;
+extern const bool DynamicDumpSharedSpaces;
+extern const bool RequireSharedSpaces;
+#endif
+
+#if INCLUDE_CDS
 extern "C" {
 // Make sure UseSharedSpaces is accessible to the serviceability agent.
 extern JNIEXPORT jboolean UseSharedSpaces;
 }
+#else
+// in non CDS mode do not export it
+extern const bool UseSharedSpaces;
+#endif
 
 //----------------------------------------------------------------------------------------------------
 // Object alignment, in units of HeapWords.

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -578,20 +578,16 @@ const int max_method_code_size = 64*K - 1;  // JVM spec, 2nd ed. section 4.8.1 (
 extern bool DumpSharedSpaces;
 extern bool DynamicDumpSharedSpaces;
 extern bool RequireSharedSpaces;
-#else
-extern const bool DumpSharedSpaces;
-extern const bool DynamicDumpSharedSpaces;
-extern const bool RequireSharedSpaces;
-#endif
 
-#if INCLUDE_CDS
 extern "C" {
 // Make sure UseSharedSpaces is accessible to the serviceability agent.
 extern JNIEXPORT jboolean UseSharedSpaces;
 }
 #else
-// in non CDS mode do not export it
-extern const bool UseSharedSpaces;
+const bool DumpSharedSpaces = false;
+const bool DynamicDumpSharedSpaces = false;
+const bool RequireSharedSpaces = false;
+const bool UseSharedSpaces = false;
 #endif
 
 //----------------------------------------------------------------------------------------------------

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
@@ -947,7 +947,11 @@ public class VM {
             // UseSharedSpaces as a symbol in jvm.dll.
             address = VM.getVM().getDebugger().lookup(null, "jvm!UseSharedSpaces");
         }
-        sharingEnabled = address.getJBooleanAt(0);
+        if (address == null) { // INCLUDE_CDS is disabled
+            sharingEnabled = Boolean.FALSE;
+        } else {
+            sharingEnabled = address.getJBooleanAt(0);
+        }
     }
     return sharingEnabled.booleanValue();
   }


### PR DESCRIPTION
The cds only coding in hotspot is usually guarded with the INCLUDE_CDS macro so that it can be removed at compile time in case the correct configure flags are set.
However at some places INCLUDE_CDS is missing and should be added.

One question - should (additionally to the UseSharedSpaces code section)  the DumpSharedSpaces code sections be guarded as well with INCLUDE_CDS macros ?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302989](https://bugs.openjdk.org/browse/JDK-8302989): Add missing INCLUDE_CDS checks


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**) ⚠️ Review applies to [6c22a2a7](https://git.openjdk.org/jdk/pull/12691/files/6c22a2a7304c76442498067b37d4b059c1a631cf)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12691/head:pull/12691` \
`$ git checkout pull/12691`

Update a local copy of the PR: \
`$ git checkout pull/12691` \
`$ git pull https://git.openjdk.org/jdk.git pull/12691/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12691`

View PR using the GUI difftool: \
`$ git pr show -t 12691`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12691.diff">https://git.openjdk.org/jdk/pull/12691.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12691#issuecomment-1438621374)