### PR TITLE
8300792: Refactor examples in java.net.http to use @snippet

### DIFF
--- a/src/java.net.http/share/classes/java/net/http/HttpClient.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpClient.java
@@ -85,27 +85,31 @@ import jdk.internal.net.http.HttpClientBuilderImpl;
  * </ul>
  *
  * <p><b>Synchronous Example</b>
- * <pre>{@code    HttpClient client = HttpClient.newBuilder()
+ * {@snippet :
+ *   HttpClient client = HttpClient.newBuilder()
  *        .version(Version.HTTP_1_1)
  *        .followRedirects(Redirect.NORMAL)
  *        .connectTimeout(Duration.ofSeconds(20))
  *        .proxy(ProxySelector.of(new InetSocketAddress("proxy.example.com", 80)))
  *        .authenticator(Authenticator.getDefault())
  *        .build();
+ *
  *   HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
  *   System.out.println(response.statusCode());
- *   System.out.println(response.body());  }</pre>
+ *   System.out.println(response.body());}
  *
  * <p><b>Asynchronous Example</b>
- * <pre>{@code    HttpRequest request = HttpRequest.newBuilder()
+ * {@snippet :
+ *    HttpRequest request = HttpRequest.newBuilder()
  *        .uri(URI.create("https://foo.com/"))
  *        .timeout(Duration.ofMinutes(2))
  *        .header("Content-Type", "application/json")
  *        .POST(BodyPublishers.ofFile(Paths.get("file.json")))
  *        .build();
+ *
  *   client.sendAsync(request, BodyHandlers.ofString())
  *        .thenApply(HttpResponse::body)
- *        .thenAccept(System.out::println);  }</pre>
+ *        .thenAccept(System.out::println);}
  *
  * <p> <a id="securitychecks"><b>Security checks</b></a>
  *
@@ -688,20 +692,23 @@ public abstract class HttpClient {
      * Creates a new {@code WebSocket} builder (optional operation).
      *
      * <p> <b>Example</b>
-     * <pre>{@code    HttpClient client = HttpClient.newHttpClient();
+     * {@snippet :
+     *   HttpClient client = HttpClient.newHttpClient();
      *   CompletableFuture<WebSocket> ws = client.newWebSocketBuilder()
-     *           .buildAsync(URI.create("ws://websocket.example.com"), listener); }</pre>
+     *      .buildAsync(URI.create("ws://websocket.example.com"), listener);}
      *
      * <p> Finer control over the WebSocket Opening Handshake can be achieved
      * by using a custom {@code HttpClient}.
      *
      * <p> <b>Example</b>
-     * <pre>{@code    InetSocketAddress addr = new InetSocketAddress("proxy.example.com", 80);
+     * {@snippet :
+     *   InetSocketAddress addr = new InetSocketAddress("proxy.example.com", 80);
      *   HttpClient client = HttpClient.newBuilder()
      *           .proxy(ProxySelector.of(addr))
      *           .build();
+     *
      *   CompletableFuture<WebSocket> ws = client.newWebSocketBuilder()
-     *           .buildAsync(URI.create("ws://websocket.example.com"), listener); }</pre>
+     *           .buildAsync(URI.create("ws://websocket.example.com"), listener);}
      *
      * @implSpec The default implementation of this method throws
      * {@code UnsupportedOperationException}. Clients obtained through

--- a/src/java.net.http/share/classes/java/net/http/HttpClient.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,10 +93,9 @@ import jdk.internal.net.http.HttpClientBuilderImpl;
  *        .proxy(ProxySelector.of(new InetSocketAddress("proxy.example.com", 80)))
  *        .authenticator(Authenticator.getDefault())
  *        .build();
- *
  *   HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
  *   System.out.println(response.statusCode());
- *   System.out.println(response.body());}
+ *   System.out.println(response.body());  }
  *
  * <p><b>Asynchronous Example</b>
  * {@snippet :
@@ -106,10 +105,9 @@ import jdk.internal.net.http.HttpClientBuilderImpl;
  *        .header("Content-Type", "application/json")
  *        .POST(BodyPublishers.ofFile(Paths.get("file.json")))
  *        .build();
- *
  *   client.sendAsync(request, BodyHandlers.ofString())
  *        .thenApply(HttpResponse::body)
- *        .thenAccept(System.out::println);}
+ *        .thenAccept(System.out::println);  }
  *
  * <p> <a id="securitychecks"><b>Security checks</b></a>
  *
@@ -695,7 +693,7 @@ public abstract class HttpClient {
      * {@snippet :
      *   HttpClient client = HttpClient.newHttpClient();
      *   CompletableFuture<WebSocket> ws = client.newWebSocketBuilder()
-     *      .buildAsync(URI.create("ws://websocket.example.com"), listener);}
+     *      .buildAsync(URI.create("ws://websocket.example.com"), listener);  }
      *
      * <p> Finer control over the WebSocket Opening Handshake can be achieved
      * by using a custom {@code HttpClient}.
@@ -708,7 +706,7 @@ public abstract class HttpClient {
      *           .build();
      *
      *   CompletableFuture<WebSocket> ws = client.newWebSocketBuilder()
-     *           .buildAsync(URI.create("ws://websocket.example.com"), listener);}
+     *           .buildAsync(URI.create("ws://websocket.example.com"), listener);  }
      *
      * @implSpec The default implementation of this method throws
      * {@code UnsupportedOperationException}. Clients obtained through

--- a/src/java.net.http/share/classes/java/net/http/HttpRequest.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpRequest.java
@@ -573,15 +573,17 @@ public abstract class HttpRequest {
      *        .uri(URI.create("https://foo.com/"))
      *        .header("Content-Type", "text/plain; charset=UTF-8")
      *        .POST(BodyPublishers.ofString("some body text"))
-     *        .build();
+     *        .build(); }
      *
+     * {@snippet :
      *   // Request body from a File
      *   HttpRequest request = HttpRequest.newBuilder()
      *        .uri(URI.create("https://foo.com/"))
      *        .header("Content-Type", "application/json")
      *        .POST(BodyPublishers.ofFile(Paths.get("file.json")))
-     *        .build();
+     *        .build(); }
      *
+     * {@snippet :
      *   // Request body from a byte array
      *   HttpRequest request = HttpRequest.newBuilder()
      *        .uri(URI.create("https://foo.com/"))

--- a/src/java.net.http/share/classes/java/net/http/HttpRequest.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpRequest.java
@@ -344,13 +344,16 @@ public abstract class HttpRequest {
      * <br><br>
      * <ul>
      *  <li> Retain all headers:
-     *  {@snippet : HttpRequest.newBuilder(request, (n, v) -> true)}
+     *  {@snippet :
+     *  HttpRequest.newBuilder(request, (n, v) -> true) }
      *
      *  <li> Remove all headers:
-     *  {@snippet : HttpRequest.newBuilder(request, (n, v) -> false)}
+     *  {@snippet :
+     *  HttpRequest.newBuilder(request, (n, v) -> false) }
      *
      *  <li> Remove a particular header (e.g. Foo-Bar):
-     *  {@snippet : HttpRequest.newBuilder(request, (name, value) -> !name.equalsIgnoreCase("Foo-Bar"))}
+     *  {@snippet :
+     *  HttpRequest.newBuilder(request, (name, value) -> !name.equalsIgnoreCase("Foo-Bar")) }
      * </ul>
      *
      * @param request the original request

--- a/src/java.net.http/share/classes/java/net/http/HttpRequest.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpRequest.java
@@ -76,8 +76,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  *   client.sendAsync(request, BodyHandlers.ofString())
  *         .thenApply(HttpResponse::body)
  *         .thenAccept(System.out::println)
- *         .join();
- *   }
+ *         .join(); }
  *
  * <p>The class {@link BodyPublishers BodyPublishers} provides implementations
  * of many common publishers. Alternatively, a custom {@code BodyPublisher}
@@ -565,7 +564,8 @@ public abstract class HttpRequest {
      * convert common high-level Java objects into a flow of data suitable for
      * sending as a request body:
      *
-     * {@snippet :    // Request body from a String
+     * {@snippet :
+     *   // Request body from a String
      *   HttpRequest request = HttpRequest.newBuilder()
      *        .uri(URI.create("https://foo.com/"))
      *        .header("Content-Type", "text/plain; charset=UTF-8")
@@ -583,8 +583,7 @@ public abstract class HttpRequest {
      *   HttpRequest request = HttpRequest.newBuilder()
      *        .uri(URI.create("https://foo.com/"))
      *        .POST(BodyPublishers.ofByteArray(new byte[] { ... }))
-     *        .build();
-     * }
+     *        .build(); }
      *
      * @since 11
      */

--- a/src/java.net.http/share/classes/java/net/http/HttpRequest.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.net.http/share/classes/java/net/http/HttpRequest.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpRequest.java
@@ -66,14 +66,18 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * <p> The following is an example of a GET request that prints the response
  * body as a String:
  *
- * <pre>{@code    HttpClient client = HttpClient.newHttpClient();
+ * {@snippet :
+ *   HttpClient client = HttpClient.newHttpClient();
+ *
  *   HttpRequest request = HttpRequest.newBuilder()
  *         .uri(URI.create("http://foo.com/"))
  *         .build();
+ *
  *   client.sendAsync(request, BodyHandlers.ofString())
  *         .thenApply(HttpResponse::body)
  *         .thenAccept(System.out::println)
- *         .join(); }</pre>
+ *         .join();
+ *   }
  *
  * <p>The class {@link BodyPublishers BodyPublishers} provides implementations
  * of many common publishers. Alternatively, a custom {@code BodyPublisher}
@@ -341,13 +345,13 @@ public abstract class HttpRequest {
      * <br><br>
      * <ul>
      *  <li> Retain all headers:
-     *  <pre>{@code HttpRequest.newBuilder(request, (n, v) -> true)}</pre>
+     *  {@snippet : HttpRequest.newBuilder(request, (n, v) -> true)}
      *
      *  <li> Remove all headers:
-     *  <pre>{@code HttpRequest.newBuilder(request, (n, v) -> false)}</pre>
+     *  {@snippet : HttpRequest.newBuilder(request, (n, v) -> false)}
      *
      *  <li> Remove a particular header (e.g. Foo-Bar):
-     *  <pre>{@code HttpRequest.newBuilder(request, (name, value) -> !name.equalsIgnoreCase("Foo-Bar"))}</pre>
+     *  {@snippet : HttpRequest.newBuilder(request, (name, value) -> !name.equalsIgnoreCase("Foo-Bar"))}
      * </ul>
      *
      * @param request the original request
@@ -561,7 +565,7 @@ public abstract class HttpRequest {
      * convert common high-level Java objects into a flow of data suitable for
      * sending as a request body:
      *
-     *  <pre>{@code    // Request body from a String
+     * {@snippet :    // Request body from a String
      *   HttpRequest request = HttpRequest.newBuilder()
      *        .uri(URI.create("https://foo.com/"))
      *        .header("Content-Type", "text/plain; charset=UTF-8")
@@ -579,7 +583,8 @@ public abstract class HttpRequest {
      *   HttpRequest request = HttpRequest.newBuilder()
      *        .uri(URI.create("https://foo.com/"))
      *        .POST(BodyPublishers.ofByteArray(new byte[] { ... }))
-     *        .build(); }</pre>
+     *        .build();
+     * }
      *
      * @since 11
      */

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -79,8 +79,7 @@ import static jdk.internal.net.http.common.Utils.charsetFrom;
  *
  * {@snippet :
  *     HttpResponse<String> response = client
- *     .send(request, BodyHandlers.ofString());
- * }
+ *     .send(request, BodyHandlers.ofString()); }
  *
  * <p> The class {@link BodyHandlers BodyHandlers} provides implementations
  * of many common response handlers. Alternatively, a custom {@code BodyHandler}
@@ -220,8 +219,7 @@ public interface HttpResponse<T> {
      *
      *  client.sendAsync(request, BodyHandlers.ofFile(Paths.get("/tmp/f")))
      *        .thenApply(HttpResponse::body)
-     *        .thenAccept(System.out::println);
-     * }
+     *        .thenAccept(System.out::println); }
      *
      * Note, that even though the pre-defined handlers do not examine the
      * response code, the response code and headers are always retrievable from
@@ -237,8 +235,7 @@ public interface HttpResponse<T> {
      *                      : BodySubscribers.replacing(Paths.get("/NULL"));
      *  client.sendAsync(request, bodyHandler)
      *        .thenApply(HttpResponse::body)
-     *        .thenAccept(System.out::println);
-     * }
+     *        .thenAccept(System.out::println); }
      *
      * @param <T> the response body type
      * @see BodyHandlers
@@ -278,7 +275,8 @@ public interface HttpResponse<T> {
      * <p>The following are examples of using the predefined body handlers to
      * convert a flow of response body data into common high-level Java objects:
      *
-     * {@snippet :    // Receives the response body as a String
+     * {@snippet :
+     *   // Receives the response body as a String
      *   HttpResponse<String> response = client
      *     .send(request, BodyHandlers.ofString());
      *
@@ -292,8 +290,7 @@ public interface HttpResponse<T> {
      *
      *   // Discards the response body
      *   HttpResponse<Void> response = client
-     *     .send(request, BodyHandlers.discarding());
-     * }
+     *     .send(request, BodyHandlers.discarding()); }
      *
      * @since 11
      */
@@ -349,7 +346,7 @@ public interface HttpResponse<T> {
          *
          * <p> For example:
          * {@snippet :
-         * TextSubscriber subscriber = ...;  // accumulates bytes and transforms them into a String
+         *  TextSubscriber subscriber = ...;  // accumulates bytes and transforms them into a String
          *  HttpResponse<String> response = client.sendAsync(request,
          *      BodyHandlers.fromSubscriber(subscriber, TextSubscriber::getTextResult)).join();
          *  String text = response.body(); }
@@ -931,8 +928,7 @@ public interface HttpResponse<T> {
      *   // Accumulates the response body as a String then maps it to its bytes
      *   HttpResponse<byte[]> response = client
      *     .send(request, responseInfo ->
-     *        BodySubscribers.mapping(BodySubscribers.ofString(UTF_8), String::getBytes));
-     * }
+     *        BodySubscribers.mapping(BodySubscribers.ofString(UTF_8), String::getBytes)); }
      *
      * @since 11
      */
@@ -1001,7 +997,7 @@ public interface HttpResponse<T> {
          * BodySubscriber} and {@code Flow.Subscriber}.
          *
          * @implNote This is equivalent to calling {@snippet :
-         *      fromLineSubscriber(subscriber, s -> null, StandardCharsets.UTF_8, null)}
+         *      fromLineSubscriber(subscriber, s -> null, StandardCharsets.UTF_8, null) }
          *
          * @param subscriber the subscriber
          * @return a body subscriber

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -279,16 +279,19 @@ public interface HttpResponse<T> {
      * {@snippet :
      *   // Receives the response body as a String
      *   HttpResponse<String> response = client
-     *     .send(request, BodyHandlers.ofString());
+     *     .send(request, BodyHandlers.ofString()); }
      *
+     * {@snippet :
      *   // Receives the response body as a file
      *   HttpResponse<Path> response = client
-     *     .send(request, BodyHandlers.ofFile(Paths.get("example.html")));
+     *     .send(request, BodyHandlers.ofFile(Paths.get("example.html"))); }
      *
+     * {@snippet :
      *   // Receives the response body as an InputStream
      *   HttpResponse<InputStream> response = client
-     *     .send(request, BodyHandlers.ofInputStream());
+     *     .send(request, BodyHandlers.ofInputStream()); }
      *
+     * {@snippet :
      *   // Discards the response body
      *   HttpResponse<Void> response = client
      *     .send(request, BodyHandlers.discarding());  }

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -79,7 +79,7 @@ import static jdk.internal.net.http.common.Utils.charsetFrom;
  *
  * {@snippet :
  *     HttpResponse<String> response = client
- *     .send(request, BodyHandlers.ofString()); }
+ *       .send(request, BodyHandlers.ofString()); }
  *
  * <p> The class {@link BodyHandlers BodyHandlers} provides implementations
  * of many common response handlers. Alternatively, a custom {@code BodyHandler}
@@ -227,7 +227,8 @@ public interface HttpResponse<T> {
      *
      * <p> In the second example, the function returns a different subscriber
      * depending on the status code.
-     * {@snippet :   HttpRequest request = HttpRequest.newBuilder()
+     * {@snippet :
+     *    HttpRequest request = HttpRequest.newBuilder()
      *        .uri(URI.create("http://www.foo.com/"))
      *        .build();
      *  BodyHandler<Path> bodyHandler = (rspInfo) -> rspInfo.statusCode() == 200
@@ -1337,7 +1338,8 @@ public interface HttpResponse<T> {
          * convert an {@code InputStream} into any annotated Java type.
          *
          * <p>For example:
-         * {@snippet :  public static <W> BodySubscriber<Supplier<W>> asJSON(Class<W> targetType) {
+         * {@snippet :
+         *   public static <W> BodySubscriber<Supplier<W>> asJSON(Class<W> targetType) {
          *     BodySubscriber<InputStream> upstream = BodySubscribers.ofInputStream();
          *
          *     BodySubscriber<Supplier<W>> downstream = BodySubscribers.mapping(

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -919,16 +919,19 @@ public interface HttpResponse<T> {
      * {@snippet :
      *   // Streams the response body to a File
      *   HttpResponse<Path> response = client
-     *     .send(request, responseInfo -> BodySubscribers.ofFile(Paths.get("example.html"));
+     *     .send(request, responseInfo -> BodySubscribers.ofFile(Paths.get("example.html")); }
      *
+     * {@snippet :
      *   // Accumulates the response body and returns it as a byte[]
      *   HttpResponse<byte[]> response = client
-     *     .send(request, responseInfo -> BodySubscribers.ofByteArray());
+     *     .send(request, responseInfo -> BodySubscribers.ofByteArray()); }
      *
+     * {@snippet :
      *   // Discards the response body
      *   HttpResponse<Void> response = client
-     *     .send(request, responseInfo -> BodySubscribers.discarding());
+     *     .send(request, responseInfo -> BodySubscribers.discarding()); }
      *
+     * {@snippet :
      *   // Accumulates the response body as a String then maps it to its bytes
      *   HttpResponse<byte[]> response = client
      *     .send(request, responseInfo ->

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -290,7 +290,7 @@ public interface HttpResponse<T> {
      *
      *   // Discards the response body
      *   HttpResponse<Void> response = client
-     *     .send(request, BodyHandlers.discarding()); }
+     *     .send(request, BodyHandlers.discarding());  }
      *
      * @since 11
      */

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -77,8 +77,10 @@ import static jdk.internal.net.http.common.Utils.charsetFrom;
  *
  * <p> The following is an example of retrieving a response as a String:
  *
- * <pre>{@code    HttpResponse<String> response = client
- *     .send(request, BodyHandlers.ofString()); }</pre>
+ * {@snippet :
+ *     HttpResponse<String> response = client
+ *     .send(request, BodyHandlers.ofString());
+ * }
  *
  * <p> The class {@link BodyHandlers BodyHandlers} provides implementations
  * of many common response handlers. Alternatively, a custom {@code BodyHandler}
@@ -211,12 +213,15 @@ public interface HttpResponse<T> {
      * predefined body handlers} that always process the response body in the
      * same way ( streams the response body to a file ).
      *
-     * <pre>{@code   HttpRequest request = HttpRequest.newBuilder()
+     * {@snippet :
+     *    HttpRequest request = HttpRequest.newBuilder()
      *        .uri(URI.create("http://www.foo.com/"))
      *        .build();
+     *
      *  client.sendAsync(request, BodyHandlers.ofFile(Paths.get("/tmp/f")))
      *        .thenApply(HttpResponse::body)
-     *        .thenAccept(System.out::println); }</pre>
+     *        .thenAccept(System.out::println);
+     * }
      *
      * Note, that even though the pre-defined handlers do not examine the
      * response code, the response code and headers are always retrievable from
@@ -224,7 +229,7 @@ public interface HttpResponse<T> {
      *
      * <p> In the second example, the function returns a different subscriber
      * depending on the status code.
-     * <pre>{@code   HttpRequest request = HttpRequest.newBuilder()
+     * {@snippet :   HttpRequest request = HttpRequest.newBuilder()
      *        .uri(URI.create("http://www.foo.com/"))
      *        .build();
      *  BodyHandler<Path> bodyHandler = (rspInfo) -> rspInfo.statusCode() == 200
@@ -232,7 +237,8 @@ public interface HttpResponse<T> {
      *                      : BodySubscribers.replacing(Paths.get("/NULL"));
      *  client.sendAsync(request, bodyHandler)
      *        .thenApply(HttpResponse::body)
-     *        .thenAccept(System.out::println); }</pre>
+     *        .thenAccept(System.out::println);
+     * }
      *
      * @param <T> the response body type
      * @see BodyHandlers
@@ -272,7 +278,7 @@ public interface HttpResponse<T> {
      * <p>The following are examples of using the predefined body handlers to
      * convert a flow of response body data into common high-level Java objects:
      *
-     * <pre>{@code    // Receives the response body as a String
+     * {@snippet :    // Receives the response body as a String
      *   HttpResponse<String> response = client
      *     .send(request, BodyHandlers.ofString());
      *
@@ -286,7 +292,8 @@ public interface HttpResponse<T> {
      *
      *   // Discards the response body
      *   HttpResponse<Void> response = client
-     *     .send(request, BodyHandlers.discarding());  }</pre>
+     *     .send(request, BodyHandlers.discarding());
+     * }
      *
      * @since 11
      */
@@ -310,10 +317,11 @@ public interface HttpResponse<T> {
          * BodySubscriber} and {@code Flow.Subscriber}.
          *
          * <p> For example:
-         * <pre> {@code  TextSubscriber subscriber = new TextSubscriber();
+         * {@snippet :
+         *  TextSubscriber subscriber = new TextSubscriber();
          *  HttpResponse<Void> response = client.sendAsync(request,
          *      BodyHandlers.fromSubscriber(subscriber)).join();
-         *  System.out.println(response.statusCode()); }</pre>
+         *  System.out.println(response.statusCode()); }
          *
          * @param subscriber the subscriber
          * @return a response body handler
@@ -340,10 +348,11 @@ public interface HttpResponse<T> {
          * BodySubscriber} and {@code Flow.Subscriber}.
          *
          * <p> For example:
-         * <pre> {@code  TextSubscriber subscriber = ...;  // accumulates bytes and transforms them into a String
+         * {@snippet :
+         * TextSubscriber subscriber = ...;  // accumulates bytes and transforms them into a String
          *  HttpResponse<String> response = client.sendAsync(request,
          *      BodyHandlers.fromSubscriber(subscriber, TextSubscriber::getTextResult)).join();
-         *  String text = response.body(); }</pre>
+         *  String text = response.body(); }
          *
          * @param <S> the type of the Subscriber
          * @param <T> the type of the response body
@@ -380,7 +389,8 @@ public interface HttpResponse<T> {
          * text line by line.
          *
          * <p> For example:
-         * <pre> {@code  // A PrintSubscriber that implements Flow.Subscriber<String>
+         * {@snippet :
+         *  // A PrintSubscriber that implements Flow.Subscriber<String>
          *  // and print lines received by onNext() on System.out
          *  PrintSubscriber subscriber = new PrintSubscriber(System.out);
          *  client.sendAsync(request, BodyHandlers.fromLineSubscriber(subscriber))
@@ -389,7 +399,7 @@ public interface HttpResponse<T> {
          *          if (status != 200) {
          *              System.err.printf("ERROR: %d status received%n", status);
          *          }
-         *      }); }</pre>
+         *      }); }
          *
          * @param subscriber the subscriber
          * @return a response body handler
@@ -423,7 +433,8 @@ public interface HttpResponse<T> {
          * text line by line.
          *
          * <p> For example:
-         * <pre> {@code  // A LineParserSubscriber that implements Flow.Subscriber<String>
+         * {@snippet :
+         *  // A LineParserSubscriber that implements Flow.Subscriber<String>
          *  // and accumulates lines that match a particular pattern
          *  Pattern pattern = ...;
          *  LineParserSubscriber subscriber = new LineParserSubscriber(pattern);
@@ -431,7 +442,7 @@ public interface HttpResponse<T> {
          *      BodyHandlers.fromLineSubscriber(subscriber, s -> s.getMatchingLines(), "\n"));
          *  if (response.statusCode() != 200) {
          *      System.err.printf("ERROR: %d status received%n", response.statusCode());
-         *  } }</pre>
+         *  } }
          *
          *
          * @param <S> the type of the Subscriber
@@ -904,7 +915,8 @@ public interface HttpResponse<T> {
      * to convert a flow of response body data into common high-level Java
      * objects:
      *
-     * <pre>{@code    // Streams the response body to a File
+     * {@snippet :
+     *   // Streams the response body to a File
      *   HttpResponse<Path> response = client
      *     .send(request, responseInfo -> BodySubscribers.ofFile(Paths.get("example.html"));
      *
@@ -920,7 +932,7 @@ public interface HttpResponse<T> {
      *   HttpResponse<byte[]> response = client
      *     .send(request, responseInfo ->
      *        BodySubscribers.mapping(BodySubscribers.ofString(UTF_8), String::getBytes));
-     * }</pre>
+     * }
      *
      * @since 11
      */
@@ -988,9 +1000,8 @@ public interface HttpResponse<T> {
          * @apiNote This method can be used as an adapter between {@code
          * BodySubscriber} and {@code Flow.Subscriber}.
          *
-         * @implNote This is equivalent to calling <pre>{@code
-         *      fromLineSubscriber(subscriber, s -> null, StandardCharsets.UTF_8, null)
-         * }</pre>
+         * @implNote This is equivalent to calling {@snippet :
+         *      fromLineSubscriber(subscriber, s -> null, StandardCharsets.UTF_8, null)}
          *
          * @param subscriber the subscriber
          * @return a body subscriber
@@ -1330,7 +1341,7 @@ public interface HttpResponse<T> {
          * convert an {@code InputStream} into any annotated Java type.
          *
          * <p>For example:
-         * <pre> {@code  public static <W> BodySubscriber<Supplier<W>> asJSON(Class<W> targetType) {
+         * {@snippet :  public static <W> BodySubscriber<Supplier<W>> asJSON(Class<W> targetType) {
          *     BodySubscriber<InputStream> upstream = BodySubscribers.ofInputStream();
          *
          *     BodySubscriber<Supplier<W>> downstream = BodySubscribers.mapping(
@@ -1344,7 +1355,7 @@ public interface HttpResponse<T> {
          *               }
          *           });
          *    return downstream;
-         *  } }</pre>
+         *  } }
          *
          * @param <T> the upstream body type
          * @param <U> the type of the body subscriber returned

--- a/src/java.net.http/share/classes/java/net/http/WebSocket.java
+++ b/src/java.net.http/share/classes/java/net/http/WebSocket.java
@@ -279,7 +279,7 @@ public interface WebSocket {
      *            }
      *            return accumulatedMessage;
      *        }
-     *    };}
+     *    }; }
      *
      * @since 11
      */
@@ -292,7 +292,7 @@ public interface WebSocket {
          * typically used to make a request for more invocations.
          *
          * @implSpec The default implementation is equivalent to:
-         * {@snippet :     webSocket.request(1); }
+         * {@snippet : webSocket.request(1);}
          *
          * @param webSocket
          *         the WebSocket that has been connected
@@ -660,11 +660,12 @@ public interface WebSocket {
      * @apiNote Use the provided integer constant {@link #NORMAL_CLOSURE} as a
      * status code and an empty string as a reason in a typical case:
      * {@snippet :
-     *      CompletableFuture<WebSocket> webSocket = //...
+     *      CompletableFuture<WebSocket> webSocket = ...
      *      webSocket.thenCompose(ws -> ws.sendText("Hello, ", false))
      *             .thenCompose(ws -> ws.sendText("world!", true))
      *             .thenCompose(ws -> ws.sendClose(WebSocket.NORMAL_CLOSURE, ""))
-     *             .join(); }
+     *             .join();
+     * }
      *
      * The {@code sendClose} method does not close this WebSocket's input. It
      * merely closes this WebSocket's output by sending a Close message. To
@@ -680,17 +681,16 @@ public interface WebSocket {
      *                                         CharSequence data,
      *                                         boolean last) {
      *            alarm.snooze();
-     *            // ...
+     *            ...
      *        }
-     *        // ...
+     *        ...
      *    };
-     *    // ...
+     *    ...
      *    Runnable startTimer = () -> {
      *        MyTimer idleTimer = new MyTimer();
      *        idleTimer.add(alarm, 30, TimeUnit.SECONDS);
      *    };
-     *    webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok").thenRun(startTimer);
-     * } </pre>
+     *    webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok").thenRun(startTimer); }
      *
      * @param statusCode
      *         the status code

--- a/src/java.net.http/share/classes/java/net/http/WebSocket.java
+++ b/src/java.net.http/share/classes/java/net/http/WebSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -292,7 +292,7 @@ public interface WebSocket {
          * typically used to make a request for more invocations.
          *
          * @implSpec The default implementation is equivalent to:
-         * {@snippet : webSocket.request(1);}
+         * {@snippet : webSocket.request(1); }
          *
          * @param webSocket
          *         the WebSocket that has been connected
@@ -740,7 +740,6 @@ public interface WebSocket {
      *            webSocket.request(1);
      *            return null;
      *        }
-     *    //...
      *    }; }
      *
      * @param n

--- a/src/java.net.http/share/classes/java/net/http/WebSocket.java
+++ b/src/java.net.http/share/classes/java/net/http/WebSocket.java
@@ -258,7 +258,8 @@ public interface WebSocket {
      * Here is an example of a listener that requests invocations, one at a
      * time, until a complete message has been accumulated, then processes
      * the result, and completes the {@code CompletionStage}:
-     * <pre>{@code     WebSocket.Listener listener = new WebSocket.Listener() {
+     * {@snippet :
+     *        WebSocket.Listener listener = new WebSocket.Listener() {
      *
      *        List<CharSequence> parts = new ArrayList<>();
      *        CompletableFuture<?> accumulatedMessage = new CompletableFuture<>();
@@ -278,8 +279,7 @@ public interface WebSocket {
      *            }
      *            return accumulatedMessage;
      *        }
-     *    ...
-     *    } } </pre>
+     *    };}
      *
      * @since 11
      */
@@ -292,7 +292,7 @@ public interface WebSocket {
          * typically used to make a request for more invocations.
          *
          * @implSpec The default implementation is equivalent to:
-         * <pre>{@code     webSocket.request(1); }</pre>
+         * {@snippet :     webSocket.request(1); }
          *
          * @param webSocket
          *         the WebSocket that has been connected
@@ -308,8 +308,9 @@ public interface WebSocket {
          * this {@code CompletionStage} has completed.
          *
          * @implSpec The default implementation is equivalent to:
-         * <pre>{@code     webSocket.request(1);
-         *    return null; }</pre>
+         * {@snippet :
+         *    webSocket.request(1);
+         *    return null; }
          *
          * @implNote The {@code data} is always a legal UTF-16 sequence.
          *
@@ -343,8 +344,9 @@ public interface WebSocket {
          * this {@code CompletionStage} has completed.
          *
          * @implSpec The default implementation is equivalent to:
-         * <pre>{@code     webSocket.request(1);
-         *    return null; }</pre>
+         * {@snippet :
+         *    webSocket.request(1);
+         *    return null; }
          *
          * @param webSocket
          *         the WebSocket on which the data has been received
@@ -381,8 +383,9 @@ public interface WebSocket {
          * this {@code CompletionStage} has completed.
          *
          * @implSpec The default implementation is equivalent to:
-         * <pre>{@code     webSocket.request(1);
-         *    return null; }</pre>
+         * {@snippet :
+         *    webSocket.request(1);
+         *    return null; }
          *
          * @param webSocket
          *         the WebSocket on which the message has been received
@@ -412,8 +415,9 @@ public interface WebSocket {
          * this {@code CompletionStage} has completed.
          *
          * @implSpec The default implementation is equivalent to:
-         * <pre>{@code     webSocket.request(1);
-         *    return null; }</pre>
+         * {@snippet :
+         *    webSocket.request(1);
+         *    return null; }
          *
          * @param webSocket
          *         the WebSocket on which the message has been received
@@ -456,12 +460,13 @@ public interface WebSocket {
          * <p> To specify a custom closure code or reason code the
          * {@code sendClose} method may be invoked from inside the
          * {@code onClose} invocation:
-         * <pre>{@code     public CompletionStage<?> onClose(WebSocket webSocket,
-         *                                      int statusCode,
-         *                                      String reason) {
+         * {@snippet :
+         *       public CompletionStage<?> onClose(WebSocket webSocket,
+         *                            int statusCode,
+         *                            String reason) {
          *        webSocket.sendClose(CUSTOM_STATUS_CODE, CUSTOM_REASON);
          *        return new CompletableFuture<Void>();
-         *    } } </pre>
+         *    } }
          *
          * @implSpec The default implementation of this method returns
          * {@code null}, indicating that the output should be closed
@@ -654,11 +659,12 @@ public interface WebSocket {
      *
      * @apiNote Use the provided integer constant {@link #NORMAL_CLOSURE} as a
      * status code and an empty string as a reason in a typical case:
-     * <pre>{@code     CompletableFuture<WebSocket> webSocket = ...
-     *    webSocket.thenCompose(ws -> ws.sendText("Hello, ", false))
+     * {@snippet :
+     *      CompletableFuture<WebSocket> webSocket = //...
+     *      webSocket.thenCompose(ws -> ws.sendText("Hello, ", false))
      *             .thenCompose(ws -> ws.sendText("world!", true))
      *             .thenCompose(ws -> ws.sendClose(WebSocket.NORMAL_CLOSURE, ""))
-     *             .join(); }</pre>
+     *             .join(); }
      *
      * The {@code sendClose} method does not close this WebSocket's input. It
      * merely closes this WebSocket's output by sending a Close message. To
@@ -666,18 +672,19 @@ public interface WebSocket {
      * example of an application that sends a Close message, and then starts a
      * timer. Once no data has been received within the specified timeout, the
      * timer goes off and the alarm aborts {@code WebSocket}:
-     * <pre>{@code     MyAlarm alarm = new MyAlarm(webSocket::abort);
+     * {@snippet :
+     *    MyAlarm alarm = new MyAlarm(webSocket::abort);
      *    WebSocket.Listener listener = new WebSocket.Listener() {
      *
      *        public CompletionStage<?> onText(WebSocket webSocket,
      *                                         CharSequence data,
      *                                         boolean last) {
      *            alarm.snooze();
-     *            ...
+     *            // ...
      *        }
-     *        ...
+     *        // ...
      *    };
-     *    ...
+     *    // ...
      *    Runnable startTimer = () -> {
      *        MyTimer idleTimer = new MyTimer();
      *        idleTimer.add(alarm, 30, TimeUnit.SECONDS);
@@ -717,7 +724,8 @@ public interface WebSocket {
      * <p> Here is an example of a listener that requests invocations, one at a
      * time, until a complete message has been accumulated, and then processes
      * the result:
-     * <pre>{@code     WebSocket.Listener listener = new WebSocket.Listener() {
+     * {@snippet :
+     *        WebSocket.Listener listener = new WebSocket.Listener() {
      *
      *        StringBuilder text = new StringBuilder();
      *
@@ -732,8 +740,8 @@ public interface WebSocket {
      *            webSocket.request(1);
      *            return null;
      *        }
-     *    ...
-     *    } } </pre>
+     *    //...
+     *    }; }
      *
      * @param n
      *         the number of invocations

--- a/src/java.net.http/share/classes/java/net/http/WebSocket.java
+++ b/src/java.net.http/share/classes/java/net/http/WebSocket.java
@@ -292,7 +292,8 @@ public interface WebSocket {
          * typically used to make a request for more invocations.
          *
          * @implSpec The default implementation is equivalent to:
-         * {@snippet : webSocket.request(1); }
+         * {@snippet :
+         *  webSocket.request(1); }
          *
          * @param webSocket
          *         the WebSocket that has been connected


### PR DESCRIPTION
Refactored instances of `@code` to instead use `@snippet`.

I also spent some time looking into using external snippets to reference the existing files `JavadocExamples` and `WebSocketExample` though ultimately thought it was better to keep the docs pretty much as they had been with only a few small changes to formatting.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300792](https://bugs.openjdk.org/browse/JDK-8300792): Refactor examples in java.net.http to use @snippet


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12692/head:pull/12692` \
`$ git checkout pull/12692`

Update a local copy of the PR: \
`$ git checkout pull/12692` \
`$ git pull https://git.openjdk.org/jdk pull/12692/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12692`

View PR using the GUI difftool: \
`$ git pr show -t 12692`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12692.diff">https://git.openjdk.org/jdk/pull/12692.diff</a>

</details>
