### PR TITLE
JDK-8303010: Add /DEBUG to LDFLAGS for MSVC with ASan

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -434,8 +434,9 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_ADDRESS_SANITIZER],
         elif test "x$TOOLCHAIN_TYPE" = "xmicrosoft"; then
           # -Oy- is equivalent to -fno-omit-frame-pointer in GCC/Clang.
           ASAN_CFLAGS="-fsanitize=address -Oy- -DADDRESS_SANITIZER"
-          # MSVC produces a warning if you pass -fsanitize=address to the linker.
-          ASAN_LDFLAGS=""
+          # MSVC produces a warning if you pass -fsanitize=address to the linker. It also complains
+          $ if -DEBUG is not passed to the linker when building with ASan.
+          ASAN_LDFLAGS="-debug"
         fi
         JVM_CFLAGS="$JVM_CFLAGS $ASAN_CFLAGS"
         JVM_LDFLAGS="$JVM_LDFLAGS $ASAN_LDFLAGS"


### PR DESCRIPTION
Add `/DEBUG` to `LDFLAGS` for MSVC with ASan. Without it MSVC produces lots of warnings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303010](https://bugs.openjdk.org/browse/JDK-8303010): Add /DEBUG to LDFLAGS for MSVC with ASan


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12693/head:pull/12693` \
`$ git checkout pull/12693`

Update a local copy of the PR: \
`$ git checkout pull/12693` \
`$ git pull https://git.openjdk.org/jdk pull/12693/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12693`

View PR using the GUI difftool: \
`$ git pr show -t 12693`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12693.diff">https://git.openjdk.org/jdk/pull/12693.diff</a>

</details>
