### PR TITLE
8303016: Invalid escapes in grep patterns

### DIFF
--- a/make/autoconf/basic_tools.m4
+++ b/make/autoconf/basic_tools.m4
@@ -443,7 +443,7 @@ AC_DEFUN_ONCE([BASIC_SETUP_PANDOC],
 
     PANDOC_MARKDOWN_FLAG="markdown"
     AC_MSG_CHECKING([if the pandoc smart extension needs to be disabled for markdown])
-    if $PANDOC --list-extensions | $GREP -q '\+smart'; then
+    if $PANDOC --list-extensions | $GREP -q '+smart'; then
       AC_MSG_RESULT([yes])
       PANDOC_MARKDOWN_FLAG="markdown-smart"
     else

--- a/make/autoconf/boot-jdk.m4
+++ b/make/autoconf/boot-jdk.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/autoconf/boot-jdk.m4
+++ b/make/autoconf/boot-jdk.m4
@@ -382,7 +382,7 @@ AC_DEFUN_ONCE([BOOTJDK_SETUP_BOOT_JDK],
   # Finally, set some other options...
 
   # Determine if the boot jdk jar supports the --date option
-  if $JAR --help 2>&1 | $GREP -q "\-\-date=TIMESTAMP"; then
+  if $JAR --help 2>&1 | $GREP -q -e "--date=TIMESTAMP"; then
     BOOT_JDK_JAR_SUPPORTS_DATE=true
   else
     BOOT_JDK_JAR_SUPPORTS_DATE=false

--- a/make/autoconf/util_paths.m4
+++ b/make/autoconf/util_paths.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/autoconf/util_paths.m4
+++ b/make/autoconf/util_paths.m4
@@ -521,7 +521,7 @@ AC_DEFUN([UTIL_REMOVE_SYMBOLIC_LINKS],
       sym_link_dir=`pwd -P`
       # Resolve file symlinks
       while test $COUNTER -lt 20; do
-        ISLINK=`$LS -l $sym_link_dir/$sym_link_file | $GREP '\->' | $SED -e 's/.*-> \(.*\)/\1/'`
+        ISLINK=`$LS -l $sym_link_dir/$sym_link_file | $GREP -e '->' | $SED -e 's/.*-> \(.*\)/\1/'`
         if test "x$ISLINK" == x; then
           # This is not a symbolic link! We are done!
           break


### PR DESCRIPTION
In a few grep patterns characters are escaped when they shouldn't be. Some grep versions seem to ignore this, but Cygwin grep generates a warning: 

/usr/bin/grep: warning: stray \ before + 
/usr/bin/grep: warning: stray \ before - 

Note that "+" is not a special character in the default "basic mode" of grep, so no escaping needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303016](https://bugs.openjdk.org/browse/JDK-8303016): Invalid escapes in grep patterns


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12695/head:pull/12695` \
`$ git checkout pull/12695`

Update a local copy of the PR: \
`$ git checkout pull/12695` \
`$ git pull https://git.openjdk.org/jdk pull/12695/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12695`

View PR using the GUI difftool: \
`$ git pr show -t 12695`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12695.diff">https://git.openjdk.org/jdk/pull/12695.diff</a>

</details>
