### PR TITLE
8303020: Remove carriage return in pandoc version string

### DIFF
--- a/make/autoconf/basic_tools.m4
+++ b/make/autoconf/basic_tools.m4
@@ -434,7 +434,7 @@ AC_DEFUN_ONCE([BASIC_SETUP_PANDOC],
 
   if test "x$PANDOC" != x; then
     AC_MSG_CHECKING([for pandoc version])
-    PANDOC_VERSION=`$PANDOC --version 2>&1 | $HEAD -1 | $CUT -d " " -f 2`
+    PANDOC_VERSION=`$PANDOC --version 2>&1 | $TR -d '\r' | $HEAD -1 | $CUT -d " " -f 2`
     AC_MSG_RESULT([$PANDOC_VERSION])
 
     if test "x$PANDOC_VERSION" != x$RECOMMENDED_PANDOC_VERSION; then


### PR DESCRIPTION
On windows/cygwin, the PANDOC_VERSION variable includes the carriage return ('\r') which makes the version check fail:

checking for pandoc version... 2.19.2
, not the recommended version 2.19.2n 2.19.2