### PR TITLE
8303024: (fs) WindowsFileSystem.supportedFileAttributeViews can use Set.of

### DIFF
--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystem.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,8 +203,7 @@ class WindowsFileSystem
     }
 
     // supported views
-    private static final Set<String> supportedFileAttributeViews = Collections
-        .unmodifiableSet(new HashSet<String>(Arrays.asList("basic", "dos", "acl", "owner", "user")));
+    private static final Set<String> supportedFileAttributeViews = Set.of("basic", "dos", "acl", "owner", "user");
 
     @Override
     public Set<String> supportedFileAttributeViews() {


### PR DESCRIPTION
Simply clean up. I need someone to help me open an issue on JBS, thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303024](https://bugs.openjdk.org/browse/JDK-8303024): (fs) WindowsFileSystem.supportedFileAttributeViews can use Set.of


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12697/head:pull/12697` \
`$ git checkout pull/12697`

Update a local copy of the PR: \
`$ git checkout pull/12697` \
`$ git pull https://git.openjdk.org/jdk pull/12697/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12697`

View PR using the GUI difftool: \
`$ git pr show -t 12697`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12697.diff">https://git.openjdk.org/jdk/pull/12697.diff</a>

</details>
