### PR TITLE
8302512: Update IANA Language Subtag Registry to Version 2023-02-14

### DIFF
--- a/src/java.base/share/data/lsrdata/language-subtag-registry.txt
+++ b/src/java.base/share/data/lsrdata/language-subtag-registry.txt
@@ -1,4 +1,4 @@
-File-Date: 2022-08-08
+File-Date: 2023-02-14
 %%
 Type: language
 Subtag: aa
@@ -26378,6 +26378,7 @@ Type: language
 Subtag: nrf
 Description: Jèrriais
 Description: Guernésiais
+Description: Sercquiais
 Added: 2015-02-12
 %%
 Type: language
@@ -46011,6 +46012,11 @@ Type: region
 Subtag: CP
 Description: Clipperton Island
 Added: 2009-07-29
+%%
+Type: region
+Subtag: CQ
+Description: Sark
+Added: 2023-02-07
 %%
 Type: region
 Subtag: CR

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8040211 8191404 8203872 8222980 8225435 8241082 8242010 8247432
  *      8258795 8267038 8287180 8302512
  * @summary Checks the IANA language subtag registry data update
- *          (LSR Revision: 2023-2-14) with Locale and Locale.LanguageRange
+ *          (LSR Revision: 2023-02-14) with Locale and Locale.LanguageRange
  *          class methods.
  * @run main LanguageSubtagRegistryTest
  */

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8040211 8191404 8203872 8222980 8225435 8241082 8242010 8247432
- *      8258795 8267038
+ *      8258795 8267038 8287180 8302512
  * @summary Checks the IANA language subtag registry data update
  *          (LSR Revision: 2023-2-14) with Locale and Locale.LanguageRange
  *          class methods.

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -26,7 +26,7 @@
  * @bug 8040211 8191404 8203872 8222980 8225435 8241082 8242010 8247432
  *      8258795 8267038
  * @summary Checks the IANA language subtag registry data update
- *          (LSR Revision: 2022-08-08) with Locale and Locale.LanguageRange
+ *          (LSR Revision: 2023-2-14) with Locale and Locale.LanguageRange
  *          class methods.
  * @run main LanguageSubtagRegistryTest
  */


### PR DESCRIPTION
Incorporate the latest IANA language subtag registry definition (2023-02-14).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302512](https://bugs.openjdk.org/browse/JDK-8302512): Update IANA Language Subtag Registry to Version 2023-02-14


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12699/head:pull/12699` \
`$ git checkout pull/12699`

Update a local copy of the PR: \
`$ git checkout pull/12699` \
`$ git pull https://git.openjdk.org/jdk pull/12699/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12699`

View PR using the GUI difftool: \
`$ git pr show -t 12699`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12699.diff">https://git.openjdk.org/jdk/pull/12699.diff</a>

</details>
