### PR TITLE
Remove stream usage from Symtab.lookupPackage()

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -722,10 +722,7 @@ public class Symtab {
         if ((pack != null && pack.exists()) || onlyExisting)
             return pack;
 
-        boolean dependsOnUnnamed = msym.requires != null &&
-                                   msym.requires.stream()
-                                                .map(rd -> rd.module)
-                                                .anyMatch(mod -> mod == unnamedModule);
+        boolean dependsOnUnnamed = dependsOnUnnamed(msym);
 
         if (dependsOnUnnamed) {
             //msyms depends on the unnamed module, for which we generally don't know
@@ -754,6 +751,19 @@ public class Symtab {
         }
 
         return enterPackage(msym, flatName);
+    }
+
+    private boolean dependsOnUnnamed(ModuleSymbol msym) {
+        if (msym.requires == null) {
+            return false;
+        }
+        for (Directive.RequiresDirective rd : msym.requires) {
+            ModuleSymbol mod = rd.module;
+            if (mod == unnamedModule) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static final Map<ModuleSymbol, ClassSymbol> EMPTY = new HashMap<>();


### PR DESCRIPTION
Hi,

I'm currently profiling some compilation phases of internal projects and noticed in allocation profiles that `Symtab.lookupPackage` takes up ~2% overall. The majority of this is spent in `.stream().anyMatch()` usages to find out if the given module symbol depends on the unnamed module.
<img width="762" alt="image" src="https://user-images.githubusercontent.com/6304496/220456462-7f0da8d8-574e-487d-9bf8-2f67b121f275.png">

This PR desugars the code into a simple loop.

If you think this is worthwhile I'd appreciate if this is sponsored. I'd also need a ticket number for that because I can't create tickets. CLA should be signed though.

Let me know what you think.
Cheers,
Christoph

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12700/head:pull/12700` \
`$ git checkout pull/12700`

Update a local copy of the PR: \
`$ git checkout pull/12700` \
`$ git pull https://git.openjdk.org/jdk pull/12700/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12700`

View PR using the GUI difftool: \
`$ git pr show -t 12700`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12700.diff">https://git.openjdk.org/jdk/pull/12700.diff</a>

</details>
