### PR TITLE
8303033: Build failure with the micro bench mark

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/Characters.java
+++ b/test/micro/org/openjdk/bench/java/lang/Characters.java
@@ -112,7 +112,7 @@ public class Characters {
                 case "a-grave" -> 0xE0;
                 case "yD"      -> 0xE0;
                 case "micro"   -> 0xFF;
-                default -> Integer.parseInt(codePoint);;
+                default -> Integer.parseInt(codePoint);
             };
         }
         @Benchmark


### PR DESCRIPTION
The last commit to #12623 introduced a compilation error caused by an extra semicolon. This PR fixes this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303033](https://bugs.openjdk.org/browse/JDK-8303033): Build failure with the micro bench mark


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12701/head:pull/12701` \
`$ git checkout pull/12701`

Update a local copy of the PR: \
`$ git checkout pull/12701` \
`$ git pull https://git.openjdk.org/jdk pull/12701/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12701`

View PR using the GUI difftool: \
`$ git pr show -t 12701`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12701.diff">https://git.openjdk.org/jdk/pull/12701.diff</a>

</details>
