### PR TITLE
JDK-8302670: use-after-free related to PhaseIterGVN interaction with Unique_Node_List and Node_Stack

### DIFF
--- a/src/hotspot/share/libadt/dict.cpp
+++ b/src/hotspot/share/libadt/dict.cpp
@@ -92,10 +92,6 @@ Dict::Dict(const Dict &d, Arena* arena)
   }
 }
 
-//------------------------------~Dict------------------------------------------
-// Delete an existing dictionary.
-Dict::~Dict() { }
-
 //------------------------------doubhash---------------------------------------
 // Double hash table size.  If can't do so, just suffer.  If can, then run
 // thru old hash table, moving things to new table.  Note that since hash

--- a/src/hotspot/share/libadt/dict.hpp
+++ b/src/hotspot/share/libadt/dict.hpp
@@ -60,7 +60,9 @@ class Dict : public AnyObj { // Dictionary structure
   Dict(CmpKey cmp, Hash hash);
   Dict(CmpKey cmp, Hash hash, Arena* arena, int size = 16);
   Dict(const Dict &base, Arena* arena); // Deep-copy
-  ~Dict();
+
+  Dict(Dict&&) = default;
+  Dict& operator=(Dict&&) = default;
 
   // Return # of key-value pairs in dict
   uint32_t Size(void) const { return _cnt; }

--- a/src/hotspot/share/libadt/dict.hpp
+++ b/src/hotspot/share/libadt/dict.hpp
@@ -30,6 +30,7 @@
 #include "memory/allocation.hpp"
 #include "memory/resourceArea.hpp"
 #include "runtime/javaThread.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 class Dict;
 
@@ -75,6 +76,8 @@ class Dict : public AnyObj { // Dictionary structure
 
   // Print out the dictionary contents as key-value pairs
   void print();
+
+  NONCOPYABLE(Dict);
 };
 
 // Hashing functions

--- a/src/hotspot/share/libadt/vectset.hpp
+++ b/src/hotspot/share/libadt/vectset.hpp
@@ -54,7 +54,9 @@ private:
 public:
   VectorSet();
   VectorSet(Arena* arena);
-  ~VectorSet() {}
+
+  VectorSet(VectorSet&&) = default;
+  VectorSet& operator=(VectorSet&&) = default;
 
   void insert(uint elem);
   bool is_empty() const;
@@ -110,6 +112,18 @@ public:
     }
     uint32_t mask = 1U << (elem & bit_mask);
     _data[word] |= mask;
+  }
+
+  void replace_with(VectorSet *vs) {
+    if (this != vs) {
+      _size = vs->_size;
+      _data = vs->_data;
+      _data_size = vs->_data_size;
+      _set_arena = vs->_set_arena;
+      vs->_size = 0;
+      vs->_data = nullptr;
+      vs->_data_size = 0;
+    }
   }
 
   NONCOPYABLE(VectorSet);

--- a/src/hotspot/share/libadt/vectset.hpp
+++ b/src/hotspot/share/libadt/vectset.hpp
@@ -27,6 +27,7 @@
 
 #include "memory/allocation.hpp"
 #include "utilities/copy.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 // Vector Sets
 
@@ -110,6 +111,8 @@ public:
     uint32_t mask = 1U << (elem & bit_mask);
     _data[word] |= mask;
   }
+
+  NONCOPYABLE(VectorSet);
 };
 
 #endif // SHARE_LIBADT_VECTSET_HPP

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -2778,7 +2778,7 @@ void Node_Array::grow(uint i) {
 }
 
 void Node_Array::insert(uint i, Node* n) {
-  if (_nodes[_max - 1]) {
+  if (_nodes == nullptr || _nodes[_max - 1]) {
     grow(_max);
   }
   Copy::conjoint_words_to_higher((HeapWord*)&_nodes[i], (HeapWord*)&_nodes[i + 1], ((_max - i - 1) * sizeof(Node*)));
@@ -2979,7 +2979,7 @@ void Unique_Node_List::remove_useless_nodes(VectorSet &useful) {
 void Node_Stack::grow() {
   size_t old_top = pointer_delta(_inode_top,_inodes,sizeof(INode)); // save _top
   size_t old_max = pointer_delta(_inode_max,_inodes,sizeof(INode));
-  size_t max = old_max << 1;             // max * 2
+  size_t max = MAX2(old_max << 1, (size_t) OptoNodeListSize);             // max * 2
   _inodes = REALLOC_ARENA_ARRAY(_a, INode, _inodes, old_max, max);
   _inode_max = _inodes + max;
   _inode_top = _inodes + old_top;        // restore _top

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -29,6 +29,7 @@
 #include "opto/compile.hpp"
 #include "opto/type.hpp"
 #include "utilities/copy.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 // Portions of code courtesy of Clifford Click
 
@@ -1581,6 +1582,8 @@ public:
   uint size() const { return _cnt; }
   void dump() const;
   void dump_simple() const;
+
+  NONCOPYABLE(Node_List);
 };
 
 //------------------------------Unique_Node_List-------------------------------
@@ -1635,6 +1638,8 @@ public:
 #ifndef PRODUCT
   void print_set() const { _in_worklist.print(); }
 #endif
+
+  NONCOPYABLE(Unique_Node_List);
 };
 
 // Unique_Mixed_Node_List
@@ -1665,6 +1670,8 @@ public:
 private:
   Dict _visited_set;
   Node_List _worklist;
+
+  NONCOPYABLE(Unique_Mixed_Node_List);
 };
 
 // Inline definition of Compile::record_for_igvn must be deferred to this point.
@@ -1745,6 +1752,8 @@ public:
 
   // Node_Stack is used to map nodes.
   Node* find(uint idx) const;
+
+  NONCOPYABLE(Node_Stack);
 };
 
 

--- a/src/hotspot/share/opto/phase.hpp
+++ b/src/hotspot/share/opto/phase.hpp
@@ -26,6 +26,7 @@
 #define SHARE_OPTO_PHASE_HPP
 
 #include "runtime/timer.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 class IfNode;
 class MergeMemNode;
@@ -147,6 +148,8 @@ public:
   Phase( PhaseNumber pnum );
 
   static void print_timers();
+
+  NONCOPYABLE(Phase);
 };
 
 #endif // SHARE_OPTO_PHASE_HPP

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -507,7 +507,7 @@ PhaseRenumberLive::PhaseRenumberLive(PhaseGVN* gvn,
   }
 
   // Replace the compiler's type information with the updated type information.
-  gvn->replace_types(_new_type_array);
+  gvn->replace_types(&_new_type_array);
 
   // Update the unique node count of the compilation to the number of currently live nodes.
   C->set_unique(_live_node_count);

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -32,6 +32,7 @@
 #include "opto/node.hpp"
 #include "opto/phase.hpp"
 #include "opto/type.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 class BarrierSetC2;
 class Compile;
@@ -112,6 +113,8 @@ public:
   uint   _total_inserts;        // For debugging, total inserts into hash table
   uint   _total_insert_probes;  // For debugging, total probes while inserting
 #endif
+
+  NONCOPYABLE(NodeHash);
 };
 
 
@@ -139,6 +142,8 @@ public:
 #ifndef PRODUCT
   void dump() const;
 #endif
+
+  NONCOPYABLE(Type_Array);
 };
 
 

--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -74,7 +74,7 @@ void PhaseVector::do_cleanup() {
   }
   {
     Compile::TracePhase tp("incrementalInline_igvn", &timers[_t_vector_igvn]);
-    _igvn = PhaseIterGVN(C->initial_gvn());
+    _igvn.reset(C->initial_gvn());
     _igvn.optimize();
     if (C->failing())  return;
   }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302670](https://bugs.openjdk.org/browse/JDK-8302670): use-after-free related to PhaseIterGVN interaction with Unique_Node_List and Node_Stack


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12703/head:pull/12703` \
`$ git checkout pull/12703`

Update a local copy of the PR: \
`$ git checkout pull/12703` \
`$ git pull https://git.openjdk.org/jdk pull/12703/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12703`

View PR using the GUI difftool: \
`$ git pr show -t 12703`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12703.diff">https://git.openjdk.org/jdk/pull/12703.diff</a>

</details>
