### PR TITLE
8302976: C2 intrinsification of Float.floatToFloat16 and Float.float16ToFloat yields different result than the interpreter

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -451,8 +451,9 @@ JRT_LEAF(jshort, SharedRuntime::f2hf(jfloat  x))
   bits.f = x;
   jint doppel = bits.i;
   jshort sign_bit = (jshort) ((doppel & 0x80000000) >> 16);
-  if (g_isnan(x))
-    return (jshort)(sign_bit | 0x7c00 | (doppel & 0x007fe000) >> 13 | (doppel & 0x00001ff0) >> 4 | (doppel & 0x0000000f));
+  if (g_isnan(x)) {
+    return (jshort)(sign_bit | 0x7c00 | 0x0200 | (doppel & 0x007fe000) >> 13 | (doppel & 0x00001ff0) >> 4 | (doppel & 0x0000000f));
+  }
 
   jfloat abs_f = (x >= 0.0f) ? x : (x * -1.0f);
 
@@ -521,7 +522,7 @@ JRT_LEAF(jfloat, SharedRuntime::hf2f(jshort x))
       bits.i = 0x7f800000;
       return sign * bits.f;
     } else {
-      bits.i = (hf_sign_bit << 16) | 0x7f800000 |
+      bits.i = (hf_sign_bit << 16) | 0x7f800000 | 0x00400000 |
                (hf_significand_bits << significand_shift);
       return bits.f;
     }

--- a/src/java.base/share/classes/java/lang/Float.java
+++ b/src/java.base/share/classes/java/lang/Float.java
@@ -1045,6 +1045,7 @@ public final class Float extends Number
                 sign * Float.POSITIVE_INFINITY :
                 Float.intBitsToFloat((bin16SignBit << 16) |
                                      0x7f80_0000 |
+                                     0x0040_0000 | //QNaN
                                      // Preserve NaN signif bits
                                      ( bin16SignifBits << SIGNIF_SHIFT ));
         }
@@ -1097,6 +1098,7 @@ public final class Float extends Number
             // Preserve sign and attempt to preserve significand bits
             return (short)(sign_bit
                     | 0x7c00 // max exponent + 1
+                    | 0x0200 // QNaN
                     // Preserve high order bit of float NaN in the
                     // binary16 result NaN (tenth bit); OR in remaining
                     // bits into lower 9 bits of binary 16 significand.

--- a/test/jdk/java/lang/Float/Binary16Conversion.java
+++ b/test/jdk/java/lang/Float/Binary16Conversion.java
@@ -337,6 +337,7 @@ public class Binary16Conversion {
             // Preserve sign and attempt to preserve significand bits
             return (short)(sign_bit
                     | 0x7c00 // max exponent + 1
+                    | 0x0200 // QNaN
                     // Preserve high order bit of float NaN in the
                     // binary16 result NaN (tenth bit); OR in remaining
                     // bits into lower 9 bits of binary 16 significand.

--- a/test/jdk/java/lang/Float/Binary16ConversionNaN.java
+++ b/test/jdk/java/lang/Float/Binary16ConversionNaN.java
@@ -81,7 +81,7 @@ public class Binary16ConversionNaN {
         float f =  Float.float16ToFloat(s);
         short s2 = Float.floatToFloat16(f);
 
-        if (s != s2) {
+        if (s2 != (s | 0x0200)) { // 0x0200 is QNaN bit
             errors++;
             System.out.println("Roundtrip failure on NaN value " +
                                Integer.toHexString(0xFFFF & (int)s) +


### PR DESCRIPTION
Change the java/lang/float.java and the corresponding shared runtime constant expression evaluation to generate QNaN.
The HW instructions generate QNaNs and not SNaNs for floating point instructions. This happens across double, float, and float16 data types. The most significant bit of mantissa is set to 1 for QNaNs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302976](https://bugs.openjdk.org/browse/JDK-8302976): C2 intrinsification of Float.floatToFloat16 and Float.float16ToFloat yields different result than the interpreter


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12704/head:pull/12704` \
`$ git checkout pull/12704`

Update a local copy of the PR: \
`$ git checkout pull/12704` \
`$ git pull https://git.openjdk.org/jdk pull/12704/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12704`

View PR using the GUI difftool: \
`$ git pr show -t 12704`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12704.diff">https://git.openjdk.org/jdk/pull/12704.diff</a>

</details>
