### PR TITLE
8306057: False arguments calling dispatch_base for aarch64

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -515,7 +515,7 @@ void InterpreterMacroAssembler::dispatch_only_noverify(TosState state) {
 void InterpreterMacroAssembler::dispatch_next(TosState state, int step, bool generate_poll) {
   // load next bytecode
   ldrb(rscratch1, Address(pre(rbcp, step)));
-  dispatch_base(state, Interpreter::dispatch_table(state), true, generate_poll);
+  dispatch_base(state, Interpreter::dispatch_table(state), /*verifyoop*/true, generate_poll);
 }
 
 void InterpreterMacroAssembler::dispatch_via(TosState state, address* table) {

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -515,7 +515,7 @@ void InterpreterMacroAssembler::dispatch_only_noverify(TosState state) {
 void InterpreterMacroAssembler::dispatch_next(TosState state, int step, bool generate_poll) {
   // load next bytecode
   ldrb(rscratch1, Address(pre(rbcp, step)));
-  dispatch_base(state, Interpreter::dispatch_table(state), generate_poll);
+  dispatch_base(state, Interpreter::dispatch_table(state), true, generate_poll);
 }
 
 void InterpreterMacroAssembler::dispatch_via(TosState state, address* table) {


### PR DESCRIPTION
Hi,
  While I was reading the source codes, I found there might be a bug here.
   
  -- In interp_masm_aarch64.cpp, dispatch_base was define as
              void dispatch_base(TosState state,
                                              address* table,
                                              bool verifyoop = true,
                                              bool generate_poll = false);

  -- But in dispatch_next of interp_masm_aarch64.cpp,
     it is called:
           dispatch_base(state,
                                   Interpreter::dispatch_table(state),
                                   generate_poll);

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306057](https://bugs.openjdk.org/browse/JDK-8306057): False arguments calling dispatch_base for aarch64


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12706/head:pull/12706` \
`$ git checkout pull/12706`

Update a local copy of the PR: \
`$ git checkout pull/12706` \
`$ git pull https://git.openjdk.org/jdk.git pull/12706/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12706`

View PR using the GUI difftool: \
`$ git pr show -t 12706`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12706.diff">https://git.openjdk.org/jdk/pull/12706.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12706#issuecomment-1510773264)