### PR TITLE
JDK-8303047: avoid NULL after 8301661

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1301,7 +1301,7 @@ void os::print_os_info(outputStream* st) {
 
 #ifdef __APPLE__
 static void print_sysctl_info_string(const char* sysctlkey, outputStream* st, char* buf, size_t size) {
-  if (sysctlbyname(sysctlkey, buf, &size, NULL, 0) >= 0) {
+  if (sysctlbyname(sysctlkey, buf, &size, nullptr, 0) >= 0) {
     st->print_cr("%s:%s", sysctlkey, buf);
   }
 }
@@ -1309,7 +1309,7 @@ static void print_sysctl_info_string(const char* sysctlkey, outputStream* st, ch
 static void print_sysctl_info_uint64(const char* sysctlkey, outputStream* st) {
   uint64_t val;
   size_t size=sizeof(uint64_t);
-  if (sysctlbyname(sysctlkey, &val, &size, NULL, 0) >= 0) {
+  if (sysctlbyname(sysctlkey, &val, &size, nullptr, 0) >= 0) {
     st->print_cr("%s:%llu", sysctlkey, val);
   }
 }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1897,7 +1897,7 @@ void os::pd_print_cpu_info(outputStream* st, char* buf, size_t buflen) {
   }
 
   size_t sz_check = sizeof(PROCESSOR_POWER_INFORMATION) * (size_t)proc_count;
-  NTSTATUS status = ::CallNtPowerInformation(ProcessorInformation, NULL, 0, buf, (ULONG) buflen);
+  NTSTATUS status = ::CallNtPowerInformation(ProcessorInformation, nullptr, 0, buf, (ULONG) buflen);
   int max_mhz = -1, current_mhz = -1, mhz_limit = -1;
   bool same_vals_for_all_cpus = true;
 


### PR DESCRIPTION
JDK-8301661 introduced a few usages of NULL in os_bsd.cpp and os_windows.cpp. This should be avoided and replaced by nullptr .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303047](https://bugs.openjdk.org/browse/JDK-8303047): avoid NULL after 8301661


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12709/head:pull/12709` \
`$ git checkout pull/12709`

Update a local copy of the PR: \
`$ git checkout pull/12709` \
`$ git pull https://git.openjdk.org/jdk pull/12709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12709`

View PR using the GUI difftool: \
`$ git pr show -t 12709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12709.diff">https://git.openjdk.org/jdk/pull/12709.diff</a>

</details>
