### PR TITLE
JDK-8303051: Stop saving 5 chunks in each ChunkPool

### DIFF
--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -82,7 +82,7 @@ class ChunkPool {
   // Prune the pool
   void prune() {
     Chunk* cur = _first;
-    Chunk* next;
+    Chunk* next = nullptr;
     // Free all chunks while in ThreadCritical lock
     // so NMT adjustment is stable.
     ThreadCritical tc;

--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -86,7 +86,7 @@ class ChunkPool {
     // Free all chunks while in ThreadCritical lock
     // so NMT adjustment is stable.
     ThreadCritical tc;
-    while(cur != nullptr) {
+    while (cur != nullptr) {
       next = cur->next();
       os::free(cur);
       _num_chunks--;

--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -88,6 +88,7 @@ class ChunkPool {
       os::free(cur);
       cur = next;
     }
+    _first = nullptr;
   }
 
   static void clean() {


### PR DESCRIPTION
In the 4 pre-defined ChunkPools the pruner save 5 chunks for re-use later in the program. The pruner runs every 5 seconds and saves the first 5 chunks that were last freed and put into the pool. In other words: The lifetime of these 5 chunks are indeterminate, we don't know when these will be freed. This is a problem, because these chunks are allocated with os::malloc(). We might be clobbering our underlying malloc's capacity to shrink its own arena sizes because of the placement of these chunks, and it would be very difficult for us to know whether this is the case.

I suggest that we stop saving these 4*5 chunks and always remove all free chunks when cleaning the pools.

Passes Arena gtests, running tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303051](https://bugs.openjdk.org/browse/JDK-8303051): Stop saving 5 chunks in each ChunkPool


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12710/head:pull/12710` \
`$ git checkout pull/12710`

Update a local copy of the PR: \
`$ git checkout pull/12710` \
`$ git pull https://git.openjdk.org/jdk pull/12710/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12710`

View PR using the GUI difftool: \
`$ git pr show -t 12710`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12710.diff">https://git.openjdk.org/jdk/pull/12710.diff</a>

</details>
