### PR TITLE
8303054: Remove unused variables in GCTraceTimeLoggerImpl::log_end

### DIFF
--- a/src/hotspot/share/gc/shared/gcTraceTime.cpp
+++ b/src/hotspot/share/gc/shared/gcTraceTime.cpp
@@ -49,8 +49,6 @@ void GCTraceTimeLoggerImpl::log_start(Ticks start) {
 
 void GCTraceTimeLoggerImpl::log_end(Ticks end) {
   double duration_in_ms = TimeHelper::counter_to_millis(end.value() - _start.value());
-  double start_time_in_secs = TimeHelper::counter_to_seconds(_start.value());
-  double stop_time_in_secs = TimeHelper::counter_to_seconds(end.value());
 
   LogStream out(_out_end);
 


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303054](https://bugs.openjdk.org/browse/JDK-8303054): Remove unused variables in GCTraceTimeLoggerImpl::log_end


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12711/head:pull/12711` \
`$ git checkout pull/12711`

Update a local copy of the PR: \
`$ git checkout pull/12711` \
`$ git pull https://git.openjdk.org/jdk pull/12711/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12711`

View PR using the GUI difftool: \
`$ git pr show -t 12711`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12711.diff">https://git.openjdk.org/jdk/pull/12711.diff</a>

</details>
