### PR TITLE
8303067: G1: Remove unimplemented G1FullGCScope::heap_transition

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullGCScope.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.hpp
@@ -73,7 +73,6 @@ public:
 
   STWGCTimer* timer();
   G1FullGCTracer* tracer();
-  G1HeapTransition* heap_transition();
   size_t region_compaction_threshold() const;
 };
 


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303067](https://bugs.openjdk.org/browse/JDK-8303067): G1: Remove unimplemented G1FullGCScope::heap_transition


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12712/head:pull/12712` \
`$ git checkout pull/12712`

Update a local copy of the PR: \
`$ git checkout pull/12712` \
`$ git pull https://git.openjdk.org/jdk pull/12712/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12712`

View PR using the GUI difftool: \
`$ git pr show -t 12712`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12712.diff">https://git.openjdk.org/jdk/pull/12712.diff</a>

</details>
