### PR TITLE
8303045: Remove RegionNode::LoopStatus::NeverIrreducibleEntry assert with wrong assumption

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -436,7 +436,6 @@ bool RegionNode::are_all_nodes_in_infinite_subgraph(Unique_Node_List& worklist) 
 #endif //ASSERT
 
 void RegionNode::set_loop_status(RegionNode::LoopStatus status) {
-  assert(status != RegionNode::LoopStatus::NeverIrreducibleEntry, "do not set this");
   assert(loop_status() == RegionNode::LoopStatus::NeverIrreducibleEntry, "why set our status again?");
   _loop_status = status;
 }

--- a/test/hotspot/jtreg/compiler/loopopts/TestInlinedSplitFallInIrreducibleLoopStatus.jasm
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInlinedSplitFallInIrreducibleLoopStatus.jasm
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+super public class TestInlinedSplitFallInIrreducibleLoopStatus
+{
+    public Method "<init>":"()V"
+    stack 2 locals 1
+    {
+        aload_0;
+        invokespecial  Method java/lang/Object."<init>":"()V";
+        return;
+    }
+
+    static Method test_inner:"(III)V"
+    stack 20 locals 10
+    {
+        iload_0;
+        ifeq LEND; // skip everything at runtime
+
+        // Some knarly construct to have two fall-in edges for LOOP
+        iconst_1;
+        ifeq ENTRY1; // eventually collapses
+        goto ENTRY2;
+    ENTRY1:
+        iconst_0;
+        ifeq LOOP;
+    ENTRY2:
+        iload      1;
+        ifge LOOP;
+        goto ENTRY1;
+
+    LOOP:
+        // split_fall_in happens at this Region
+        iconst_0;
+        iflt LOOP;
+        iload      2;
+        ifeq LEND;
+        goto LOOP;
+
+    LEND:
+        return;
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/TestInlinedSplitFallInIrreducibleLoopStatusMain.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInlinedSplitFallInIrreducibleLoopStatusMain.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8303045
+ * @compile TestInlinedSplitFallInIrreducibleLoopStatus.jasm
+ * @summary Regions that are inlined are by default tagged as NeverIrreducibleEntry.
+ *          Test that if a split_fall_in happens to such a region, we do not throw
+ *          a spurious assert.
+ * @run main/othervm
+ *      -XX:CompileCommand=compileonly,TestInlinedSplitFallInIrreducibleLoopStatus::test*
+ *      -XX:CompileCommand=compileonly,TestInlinedSplitFallInIrreducibleLoopStatusMain::test*
+ *      -Xbatch -XX:PerMethodTrapLimit=0
+ *      TestInlinedSplitFallInIrreducibleLoopStatusMain
+ */
+
+public class TestInlinedSplitFallInIrreducibleLoopStatusMain {
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 10_000; i++) {
+            test_outer(0, 0, 0);
+        }
+    }
+    static void test_outer(int v0, int v1, int v2) {
+        // inline method test_inner
+        TestInlinedSplitFallInIrreducibleLoopStatus.test_inner(v0, v1, v2);
+    }
+}


### PR DESCRIPTION
I had to remove the first of these two asserts:
https://github.com/openjdk/jdk/blob/ac7119f0d5319a3fb44dc67a938c3e1eb21b9202/src/hotspot/share/opto/cfgnode.cpp#L438-L442

**Context**

The original idea for the two asserts was that we cannot accidentally lose information:
The default value is `NeverIrreducibleEntry`, and once we change it to a different value (`Reducible` or `MaybeIrreducibleEntry`) we have no reason to ever go back to the default.

However, for this, the second assert suffices: we should only set the value if it is still at default.

**Details: explanation of regression test**

I have an example where the first assert fails, it is the regression test that is attached here.

We inline
https://github.com/openjdk/jdk/blob/c6b4728177753513c87ee025a99f373e97de1466/test/hotspot/jtreg/compiler/loopopts/TestInlinedSplitFallInIrreducibleLoopStatusMain.java#L45-L48

And in the inlined method, we have a region on which `IdealLoopTree::split_fall_in` is called:
https://github.com/openjdk/jdk/blob/c6b4728177753513c87ee025a99f373e97de1466/test/hotspot/jtreg/compiler/loopopts/TestInlinedSplitFallInIrreducibleLoopStatus.jasm#L53-L54

Since the region is in an inlined method, its loop status is still `NeverIrreducibleEntry` (we can only set it to `Reducible` if we are absolutely sure there is no enclosing irreducible loop. And we only want to set `MaybeIrreducibleEntry` if we have to, because then we have to do additional work when an entry is lost).
Now, when we do `split_fall_in`, we copy the loop status from the `_head` region to the new `landing_pad`. So we essentially did `set_loop_status(NeverIrreducibleEntry)`, which triggered the assert.
https://github.com/openjdk/jdk/blob/c6b4728177753513c87ee025a99f373e97de1466/src/hotspot/share/opto/loopnode.cpp#L3144

![image_480](https://user-images.githubusercontent.com/32593061/220640119-8fe59143-bd6e-42fe-8df0-1b01f1e87fb5.png)
Here the graph of the test, before we call `split_fall_in`. Red: `test_outer`. Orange: `test_inner`. Yellow: the loop inside `test_inner`, with `_head == 78 Region`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303045](https://bugs.openjdk.org/browse/JDK-8303045): Remove RegionNode::LoopStatus::NeverIrreducibleEntry assert with wrong assumption


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12713/head:pull/12713` \
`$ git checkout pull/12713`

Update a local copy of the PR: \
`$ git checkout pull/12713` \
`$ git pull https://git.openjdk.org/jdk pull/12713/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12713`

View PR using the GUI difftool: \
`$ git pr show -t 12713`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12713.diff">https://git.openjdk.org/jdk/pull/12713.diff</a>

</details>
