### PR TITLE
JDK-8303072: Memory leak in exeNullCallerTest.cpp

### DIFF
--- a/test/jdk/jni/nullCaller/exeNullCallerTest.cpp
+++ b/test/jdk/jni/nullCaller/exeNullCallerTest.cpp
@@ -55,9 +55,11 @@ void getBundle(JNIEnv* env) {
     // msg = b.getString("message");
     jstring msg = (jstring) m_ResourceBundle_getString.callReturnNotNull(b, env->NewStringUTF("message"));
 
-    if (std::string("Hello!") != env->GetStringUTFChars(msg, NULL)) {
+    const char* chars = env->GetStringUTFChars(msg, nullptr);
+    if (std::string("Hello!") != chars) {
         emitErrorMessageAndExit("Bundle didn't contain expected content");
     }
+    env->ReleaseStringUTFChars(msg, chars);
 
     // ResourceBundle.clearCache()
     m_ResourceBundle_clearCache.callVoidMethod();


### PR DESCRIPTION
Fix trivial memory leak that occurs during tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303072](https://bugs.openjdk.org/browse/JDK-8303072): Memory leak in exeNullCallerTest.cpp


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12715/head:pull/12715` \
`$ git checkout pull/12715`

Update a local copy of the PR: \
`$ git checkout pull/12715` \
`$ git pull https://git.openjdk.org/jdk pull/12715/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12715`

View PR using the GUI difftool: \
`$ git pr show -t 12715`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12715.diff">https://git.openjdk.org/jdk/pull/12715.diff</a>

</details>
