### PR TITLE
JDK-8303071: Memory leaks in libjdwp

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/transport.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/transport.c
@@ -508,7 +508,7 @@ transport_startTransport(jboolean isServer, char *name, char *address,
     trans = info->transport;
 
     if (isServer) {
-        char *retAddress;
+        char *retAddress = NULL;
         char *launchCommand;
         jvmtiError error;
         int len;
@@ -607,9 +607,13 @@ transport_startTransport(jboolean isServer, char *name, char *address,
                     name, retAddress));
             }
         }
+        jvmtiDeallocate(retAddress);
         return JDWP_ERROR(NONE);
 
 handleError:
+        if (retAddress != NULL) {
+            jvmtiDeallocate(retAddress);
+        }
         freeTransportInfo(info);
     } else {
         /*

--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.c
@@ -243,7 +243,7 @@ util_initialize(JNIEnv *env)
         }
         localSystemThreadGroup = groups[0];
         saveGlobalRef(env, localSystemThreadGroup, &(gdata->systemThreadGroup));
-        JVMTI_FUNC_PTR(gdata->jvmti,Deallocate)(gdata->jvmti, groups);
+        jvmtiDeallocate(groups);
 
         /* Get some basic Java property values we will need at some point */
         gdata->property_java_version

--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.c
@@ -243,6 +243,7 @@ util_initialize(JNIEnv *env)
         }
         localSystemThreadGroup = groups[0];
         saveGlobalRef(env, localSystemThreadGroup, &(gdata->systemThreadGroup));
+        JVMTI_FUNC_PTR(gdata->jvmti,Deallocate)(gdata->jvmti, groups);
 
         /* Get some basic Java property values we will need at some point */
         gdata->property_java_version


### PR DESCRIPTION
Fix minor memory leaks in libjdwp.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303071](https://bugs.openjdk.org/browse/JDK-8303071): Memory leaks in libjdwp


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12716/head:pull/12716` \
`$ git checkout pull/12716`

Update a local copy of the PR: \
`$ git checkout pull/12716` \
`$ git pull https://git.openjdk.org/jdk pull/12716/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12716`

View PR using the GUI difftool: \
`$ git pr show -t 12716`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12716.diff">https://git.openjdk.org/jdk/pull/12716.diff</a>

</details>
