### PR TITLE
8303073: (bf) Temporarily reinstate private DirectByteBuffer(long, int) constructor

### DIFF
--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -187,6 +187,11 @@ class Direct$Type$Buffer$RW$$BO$
         att = null;
     }
 
+    // Temporarily keep the long,int constructor around
+    private Direct$Type$Buffer(long addr, int cap) {
+        this(addr, (long)cap);
+    }
+
     // Throw an IllegalArgumentException if the capacity is not in
     // the range [0, Integer.MAX_VALUE]
     //
@@ -270,7 +275,7 @@ class Direct$Type$Buffer$RW$$BO$
         return new Direct$Type$Buffer$RW$$BO$(this,
                                               -1,
                                               0,
-                                              rem, 
+                                              rem,
                                               rem,
                                               off,
 #if[byte]


### PR DESCRIPTION
We have a dependency on the renaissance benchmark suite for performance regression testing, which in turn has a dependency on a version of Spark that calls a private constructor that was recently chaned. To facilitate ongoing regression testing we want to temporarily put back a constructor with the old signature.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303073](https://bugs.openjdk.org/browse/JDK-8303073): (bf) Temporarily reinstate private DirectByteBuffer(long, int) constructor


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12717/head:pull/12717` \
`$ git checkout pull/12717`

Update a local copy of the PR: \
`$ git checkout pull/12717` \
`$ git pull https://git.openjdk.org/jdk pull/12717/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12717`

View PR using the GUI difftool: \
`$ git pr show -t 12717`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12717.diff">https://git.openjdk.org/jdk/pull/12717.diff</a>

</details>
