### PR TITLE
8302987: Add uniform and spatially equidistributed bounded double streams to RandomGenerator

### DIFF
--- a/src/java.base/share/classes/java/util/random/RandomGenerator.java
+++ b/src/java.base/share/classes/java/util/random/RandomGenerator.java
@@ -253,7 +253,7 @@ public interface RandomGenerator {
         return doubles(randomNumberOrigin, randomNumberBound).limit(streamSize);
     }
 
-    private DoubleStream equiSpatialDoubles(double left, double right,
+    private DoubleStream equiDoubles(double left, double right,
             boolean isLeftClosed, boolean isRightOpen) {
         /*
          * Inspired by
@@ -395,7 +395,7 @@ public interface RandomGenerator {
                 bound < Double.POSITIVE_INFINITY)) {
             throw new IllegalArgumentException("the interval must not be empty");
         }
-        return equiSpatialDoubles(origin, bound, true, true);
+        return equiDoubles(origin, bound, true, true);
     }
 
     /**
@@ -427,7 +427,7 @@ public interface RandomGenerator {
                 bound < Double.POSITIVE_INFINITY)) {
             throw new IllegalArgumentException("the interval must not be empty");
         }
-        return equiSpatialDoubles(origin, bound, true, false);
+        return equiDoubles(origin, bound, true, false);
     }
 
     /**
@@ -459,7 +459,7 @@ public interface RandomGenerator {
                 bound < Double.POSITIVE_INFINITY)) {
             throw new IllegalArgumentException("the interval must not be empty");
         }
-        return equiSpatialDoubles(origin, bound, false, true);
+        return equiDoubles(origin, bound, false, true);
     }
 
     /**
@@ -491,7 +491,7 @@ public interface RandomGenerator {
                 bound < Double.POSITIVE_INFINITY)) {
             throw new IllegalArgumentException("the interval must not be empty");
         }
-        return equiSpatialDoubles(origin, bound, false, false);
+        return equiDoubles(origin, bound, false, false);
     }
 
     /**

--- a/src/java.base/share/classes/java/util/random/RandomGenerator.java
+++ b/src/java.base/share/classes/java/util/random/RandomGenerator.java
@@ -377,8 +377,6 @@ public interface RandomGenerator {
      * <p>The stream potentially produces all multiples <i>k</i>&delta; (<i>k</i>
      * integer) lying in the given range, where &delta; &ge; {@link Double#MIN_VALUE}
      * is the smallest number for which all these multiples are exact {@code double}s.
-     * The generated {@code double}s are thus equidistant, as close as possible,
-     * and with the largest possible extension.
      *
      * @param origin the least value (inclusive) that can be produced
      * @param bound the upper bound (exclusive) for each value produced
@@ -411,8 +409,6 @@ public interface RandomGenerator {
      * <p>The stream potentially produces all multiples <i>k</i>&delta; (<i>k</i>
      * integer) lying in the given range, where &delta; &ge; {@link Double#MIN_VALUE}
      * is the smallest number for which all these multiples are exact {@code double}s.
-     * The generated {@code double}s are thus equidistant, as close as possible,
-     * and with the largest possible extension.
      *
      * @param origin the least value (inclusive) that can be produced
      * @param bound the upper bound (inclusive) for each value produced
@@ -445,8 +441,6 @@ public interface RandomGenerator {
      * <p>The stream potentially produces all multiples <i>k</i>&delta; (<i>k</i>
      * integer) lying in the given range, where &delta; &ge; {@link Double#MIN_VALUE}
      * is the smallest number for which all these multiples are exact {@code double}s.
-     * The generated {@code double}s are thus equidistant, as close as possible,
-     * and with the largest possible extension.
      *
      * @param origin the least value (exclusive) that can be produced
      * @param bound the upper bound (exclusive) for each value produced
@@ -479,8 +473,6 @@ public interface RandomGenerator {
      * <p>The stream potentially produces all multiples <i>k</i>&delta; (<i>k</i>
      * integer) lying in the given range, where &delta; &ge; {@link Double#MIN_VALUE}
      * is the smallest number for which all these multiples are exact {@code double}s.
-     * The generated {@code double}s are thus equidistant, as close as possible,
-     * and with the largest possible extension.
      *
      * @param origin the least value (exclusive) that can be produced
      * @param bound the upper bound (inclusive) for each value produced

--- a/src/java.base/share/classes/java/util/random/RandomGenerator.java
+++ b/src/java.base/share/classes/java/util/random/RandomGenerator.java
@@ -339,9 +339,9 @@ public interface RandomGenerator {
              * direction of positive infinity.
              * Most of the time, this is equivalent to the ulp of left, but not
              * always.
-             * For example, Math.ulp(-1.0) == 2.220446049250313E-16, whereas
-             * delta == 1.1102230246251565E-16.
-             * 
+             * For example, for left == -1.0, Math.ulp(left) == 2.220446049250313E-16,
+             * whereas delta as computed here is 1.1102230246251565E-16.
+             *
              * Every product k delta lying in [left, -left] is an exact double.
              * Thus, every product k delta lying in I is an exact double, too.
              * Any other positive eps < delta does not meet this property:

--- a/src/java.base/share/classes/java/util/random/RandomGenerator.java
+++ b/src/java.base/share/classes/java/util/random/RandomGenerator.java
@@ -337,6 +337,11 @@ public interface RandomGenerator {
              *
              * delta is the distance from left to the next double in the
              * direction of positive infinity.
+             * Most of the time, this is equivalent to the ulp of left, but not
+             * always.
+             * For example, Math.ulp(-1.0) == 2.220446049250313E-16, whereas
+             * delta == 1.1102230246251565E-16.
+             * 
              * Every product k delta lying in [left, -left] is an exact double.
              * Thus, every product k delta lying in I is an exact double, too.
              * Any other positive eps < delta does not meet this property:

--- a/src/java.base/share/classes/java/util/random/RandomGenerator.java
+++ b/src/java.base/share/classes/java/util/random/RandomGenerator.java
@@ -261,14 +261,25 @@ public interface RandomGenerator {
      * {@code isLeftIncluded}; similarly, the {@code right} boundary is included
      * as indicated by {@code isRightIncluded}.
      *
-     * <p>The stream potentially produces all multiples <i>k</i>&delta;
+     * <p>The stream potentially produces all multiples <i>k</i> &delta;
      * (<i>k</i> integer) lying in the interval specified by the parameters,
      * where &delta; > 0 is the smallest number for which all these multiples
      * are exact {@code double}s.
      * They are therefore all equidistant.
+     * The uniformity of the distribution of the {@code double}s produced by
+     * the stream depends on the quality of the underlying {@link #nextLong(long)}.
      *
-     * <p>The uniformity of the distribution of the {@code double}s produced by
-     * the stream is as good as the one of {@link #nextLong(long)}.
+     * @implNote The default implementation first determines the &delta; above.
+     * It then computes both the smallest integer <i>k</i><sub><i>l</i></sub>
+     * such that <i>k</i><sub><i>l</i></sub> &delta; lies <em>inside</em>
+     * the given interval, and the smallest integer <i>n</i> > 0 such that
+     * (<i>k</i><sub><i>l</i></sub> + <i>n</i>) &delta; lies
+     * <em>outside</em> the interval.
+     * Finally, it returns a stream which generates the {@code double}s
+     * according to (<i>k</i><sub><i>l</i></sub> + {@code nextLong(}<i>n</i>{@code )})
+     * &delta;.
+     * The stream never produces {@code -0.0}, although it may produce
+     * {@code 0.0} if the specified interval contains 0.
      *
      * @param left the left boundary
      * @param right the right boundary
@@ -277,8 +288,6 @@ public interface RandomGenerator {
      *
      * @return a stream of pseudorandomly chosen {@code double} values, each
      *         between {@code left} and {@code right}, as specified above.
-     *         The stream never produces {@code -0.0}, although it may produce
-     *         {@code 0.0} if the specified interval contains 0.
      *
      * @throws IllegalArgumentException if {@code left} is not finite,
      *         or {@code right} is not finite, or if the specified interval
@@ -331,9 +340,9 @@ public interface RandomGenerator {
              * Any other positive eps < delta does not meet this property:
              * some product k eps lying in I is not an exact double.
              * On the other hand, any other eps > delta would generate more
-             * sparse products k eps, that is, less doubles in I.
+             * sparse products k eps, that is, fewer doubles in I.
              * delta is therefore the best value to ensure the largest number
-             * of equidistant doubles in I.
+             * of equidistant doubles in the interval I.
              *
              * left / delta is an exact double and an exact integer with
              *      -2^P <= left / delta <= 0

--- a/src/java.base/share/classes/java/util/random/RandomGenerator.java
+++ b/src/java.base/share/classes/java/util/random/RandomGenerator.java
@@ -318,8 +318,8 @@ public interface RandomGenerator {
          * (k integer) that lies in I is an exact double as well.
          * It turns out that delta is always a power of 2.
          *
-         * kl is the k for the leftmost product k delta in I.
-         * kr is the k for the leftmost product k delta to the right of I.
+         * kl is the smallest k such that k delta is inside I.
+         * kr > kl is the smallest k such that k delta is outside I.
          * n is kr - kl
          */
         double delta;  // captured

--- a/src/java.base/share/classes/java/util/random/RandomGenerator.java
+++ b/src/java.base/share/classes/java/util/random/RandomGenerator.java
@@ -292,6 +292,8 @@ public interface RandomGenerator {
      * @throws IllegalArgumentException if {@code left} is not finite,
      *         or {@code right} is not finite, or if the specified interval
      *         is empty.
+     *
+     * @since 21
      */
     default DoubleStream equiDoubles(double left, double right,
         boolean isLeftIncluded, boolean isRightIncluded) {

--- a/src/java.base/share/classes/java/util/random/RandomGenerator.java
+++ b/src/java.base/share/classes/java/util/random/RandomGenerator.java
@@ -269,7 +269,7 @@ public interface RandomGenerator {
      * The uniformity of the distribution of the {@code double}s produced by
      * the stream depends on the quality of the underlying {@link #nextLong(long)}.
      *
-     * @implNote The default implementation first determines the &delta; above.
+     * @implSpec The default implementation first determines the &delta; above.
      * It then computes both the smallest integer <i>k</i><sub><i>l</i></sub>
      * such that <i>k</i><sub><i>l</i></sub> &delta; lies <em>inside</em>
      * the given interval, and the smallest integer <i>n</i> > 0 such that

--- a/src/java.base/share/classes/java/util/random/RandomGenerator.java
+++ b/src/java.base/share/classes/java/util/random/RandomGenerator.java
@@ -351,8 +351,8 @@ public interface RandomGenerator {
              * Thus, kl is computed exactly.
              *
              * Mathematically,
-             *      kr = ceil(right / delta),           if isRightIncluded
-             *      kr = floor(right / delta) + 1,      if !isRightIncluded
+             *      kr = ceil(right / delta),           if !isRightIncluded
+             *      kr = floor(right / delta) + 1,      if isRightIncluded
              * The double division rd = right / delta never overflows and is
              * exact, except in the presence of underflows. But even underflows
              * do not affect the outcomes of ceil() and floor(), except,

--- a/test/jdk/java/util/Random/EquiDoublesTest.java
+++ b/test/jdk/java/util/Random/EquiDoublesTest.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.RandomFactory;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Iterator;
+import java.util.TreeSet;
+import java.util.random.RandomGenerator;
+import java.util.stream.DoubleStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+/**
+ * @test
+ * @bug 8302987
+ * @key randomness
+ *
+ * @summary Check consistency of RandomGenerator::equiDoubles
+ * @library /test/lib
+ * @run junit EquiDoublesTest
+ *
+ */
+
+public class EquiDoublesTest {
+
+    private static final int SAMPLES = 100_000;
+
+    /*
+     * A factor to use in the tight*() tests to make sure that
+     * all equidistant doubles are generated.
+     */
+    private static final long SAFETY_FACTOR = 100L;
+
+    private static double nextUp(double d, int steps) {
+        for (int i = 0; i < steps; ++i) {
+            d = Math.nextUp(d);
+        }
+        return d;
+    }
+
+    private static double nextDown(double d, int steps) {
+        for (int i = 0; i < steps; ++i) {
+            d = Math.nextDown(d);
+        }
+        return d;
+    }
+
+    private static RandomGenerator rnd() {
+        return RandomFactory.getRandom();
+    }
+
+    static Arguments[] equi() {
+        return new Arguments[] {
+                arguments(0.0, 1e-9),
+                arguments(1.0, 1.1),
+                arguments(1.0e23, 1.1e23),
+                arguments(1.0e300, 1.1e300),
+                arguments(-1.2, 1.1),
+                arguments(-1.2e-30, 1.1e6),
+                arguments(-Double.MIN_VALUE, Double.MIN_VALUE),
+                arguments(-Double.MAX_VALUE, Double.MAX_VALUE),
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void equi(double l, double r) {
+        double[] minmax = new double[2];
+
+        resetMinmax(minmax);
+        DoubleStream equi = rnd().equiDoubles(l, r, true, false);
+        equi.limit(SAMPLES).forEach(d -> updateMinmax(minmax, d));
+        assertTrue(l <= minmax[0]);
+        assertTrue(minmax[1] < r);
+
+        resetMinmax(minmax);
+        equi = rnd().equiDoubles(l, r, true, true);
+        equi.limit(SAMPLES).forEach(d -> updateMinmax(minmax, d));
+        assertTrue(l <= minmax[0]);
+        assertTrue(minmax[1] <= r);
+
+        resetMinmax(minmax);
+        equi = rnd().equiDoubles(l, r, false, true);
+        equi.limit(SAMPLES).forEach(d -> updateMinmax(minmax, d));
+        assertTrue(l < minmax[0]);
+        assertTrue(minmax[1] <= r);
+
+        resetMinmax(minmax);
+        equi = rnd().equiDoubles(l, r, false, false);
+        equi.limit(SAMPLES).forEach(d -> updateMinmax(minmax, d));
+        assertTrue(l < minmax[0]);
+        assertTrue(minmax[1] < r);
+
+        /* with negated intervals */
+        resetMinmax(minmax);
+        equi = rnd().equiDoubles(-r, -l, true, false);
+        equi.limit(SAMPLES).forEach(d -> updateMinmax(minmax, d));
+        assertTrue(-r <= minmax[0]);
+        assertTrue(minmax[1] < -l);
+
+        resetMinmax(minmax);
+        equi = rnd().equiDoubles(-r, -l, true, true);
+        equi.limit(SAMPLES).forEach(d -> updateMinmax(minmax, d));
+        assertTrue(-r <= minmax[0]);
+        assertTrue(minmax[1] <= -l);
+
+        resetMinmax(minmax);
+        equi = rnd().equiDoubles(-r, -l, false, true);
+        equi.limit(SAMPLES).forEach(d -> updateMinmax(minmax, d));
+        assertTrue(-r < minmax[0]);
+        assertTrue(minmax[1] <= -l);
+
+        resetMinmax(minmax);
+        equi = rnd().equiDoubles(-r, -l, false, false);
+        equi.limit(SAMPLES).forEach(d -> updateMinmax(minmax, d));
+        assertTrue(-r < minmax[0]);
+        assertTrue(minmax[1] < -l);
+    }
+
+    private void resetMinmax(double[] minmax) {
+        minmax[0] = Double.POSITIVE_INFINITY;
+        minmax[1] = Double.NEGATIVE_INFINITY;
+    }
+
+    private void updateMinmax(double[] minmax, double d) {
+        if (d < minmax[0]) {
+            minmax[0] = d;
+        }
+        if (d > minmax[1]) {
+            minmax[1] = d;
+        }
+    }
+
+    static Arguments[] tight() {
+        return new Arguments[] {
+                arguments(0.0, (short) 100),
+                arguments(1.0, (short) 100),
+                arguments(1.1, (short) 100),
+                arguments(1.0e23, (short) 100),
+                arguments(1.0e300, (short) 100),
+                arguments(-1.2, (short) 100),
+                arguments(-1.2e-30, (short) 100),
+                arguments(-Double.MIN_VALUE, (short) 100),
+
+                arguments(-Double.MIN_VALUE, (short) 2),
+                arguments(-Double.MAX_VALUE, (short) 2),
+        };
+    }
+
+    /*
+     * All equidistant doubles in a tight range are expected to be generated.
+     * The arguments must be chosen as to not overlap a value with irregular
+     * spacing around it.
+     */
+    @ParameterizedTest
+    @MethodSource
+    void tight(double l, short steps) {
+        double r = nextUp(l, steps);
+
+        TreeSet<Double> set = new TreeSet<>();
+        DoubleStream equi = rnd().equiDoubles(l, r, true, false);
+        equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
+        assertEquals(steps, set.size());
+        checkEquidistance(set);
+
+        set.clear();
+        equi = rnd().equiDoubles(l, r, true, true);
+        equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
+        assertEquals(steps + 1, set.size());
+        checkEquidistance(set);
+
+        set.clear();
+        equi = rnd().equiDoubles(l, r, false, true);
+        equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
+        assertEquals(steps, set.size());
+        checkEquidistance(set);
+
+        set.clear();
+        equi = rnd().equiDoubles(l, r, false, false);
+        equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
+        assertEquals(steps - 1, set.size());
+        checkEquidistance(set);
+
+        /* with negated intervals */
+        set.clear();
+        equi = rnd().equiDoubles(-r, -l, true, true);
+        equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
+        assertEquals(steps + 1, set.size());
+        checkEquidistance(set);
+
+        set.clear();
+        equi = rnd().equiDoubles(-r, -l, true, true);
+        equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
+        assertEquals(steps + 1, set.size());
+        checkEquidistance(set);
+
+        set.clear();
+        equi = rnd().equiDoubles(-r, -l, false, true);
+        equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
+        assertEquals(steps, set.size());
+        checkEquidistance(set);
+
+        set.clear();
+        equi = rnd().equiDoubles(-r, -l, false, false);
+        equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
+        assertEquals(steps - 1, set.size());
+        checkEquidistance(set);
+    }
+
+    static Arguments[] tightWithIrregularSpacing() {
+        return new Arguments[] {
+                arguments(0x1p-1, (short) 15, (short) 23),
+                arguments(0x1p0, (short) 17, (short) 5),
+                arguments(0x1p1, (short) 7, (short) 8),
+                arguments(0x1p-600, (short) 28, (short) 33),
+                arguments(0x1p600, (short) 9, (short) 19),
+        };
+    }
+
+    /*
+     * m must be a power of 2 greater than Double.MIN_NORMAL
+     */
+    @ParameterizedTest
+    @MethodSource
+    void tightWithIrregularSpacing(double m, short lSteps, short rSteps) {
+        double l = nextDown(m, 2 * lSteps);
+        double r = nextUp(m, rSteps);
+        int steps = lSteps + rSteps;
+
+        TreeSet<Double> set = new TreeSet<>();
+        DoubleStream equi = rnd().equiDoubles(l, r, true, false);
+        equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
+        assertEquals(steps, set.size());
+        checkEquidistance(set);
+
+        set.clear();
+        equi = rnd().equiDoubles(l, r, true, true);
+        equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
+        assertEquals(steps + 1, set.size());
+        checkEquidistance(set);
+
+        set.clear();
+        equi = rnd().equiDoubles(l, r, false, true);
+        equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
+        assertEquals(steps, set.size());
+        checkEquidistance(set);
+
+        set.clear();
+        equi = rnd().equiDoubles(l, r, false, false);
+        equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
+        assertEquals(steps - 1, set.size());
+        checkEquidistance(set);
+
+        /* with negated intervals */
+        set.clear();
+        equi = rnd().equiDoubles(-r, -l, true, true);
+        equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
+        assertEquals(steps + 1, set.size());
+        checkEquidistance(set);
+
+        set.clear();
+        equi = rnd().equiDoubles(-r, -l, true, true);
+        equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
+        assertEquals(steps + 1, set.size());
+        checkEquidistance(set);
+
+        set.clear();
+        equi = rnd().equiDoubles(-r, -l, false, true);
+        equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
+        assertEquals(steps, set.size());
+        checkEquidistance(set);
+
+        set.clear();
+        equi = rnd().equiDoubles(-r, -l, false, false);
+        equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
+        assertEquals(steps - 1, set.size());
+        checkEquidistance(set);
+    }
+
+    private void checkEquidistance(TreeSet<Double> set) {
+        if (set.size() < 3) {
+            return;
+        }
+        Iterator<Double> iter = set.iterator();
+        double prev = iter.next();
+        double curr = iter.next();
+        double delta = curr - prev;
+        while (iter.hasNext()) {
+            prev = curr;
+            curr = iter.next();
+            assertEquals(delta, curr - prev);
+        }
+    }
+
+    static Arguments[] empty() {
+        return new Arguments[] {
+                arguments(1.0),
+                arguments(-1.0),
+                arguments(0.0),
+                arguments(nextDown(Double.MAX_VALUE, 1)),
+                arguments(nextUp(-Double.MAX_VALUE, 1)),
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void empty(double l) {
+        assertThrows(IllegalArgumentException.class,
+                () -> rnd().equiDoubles(l, l, true, false)
+        );
+        assertThrows(IllegalArgumentException.class,
+                () -> rnd().equiDoubles(l, nextUp(l, 1), false, false)
+        );
+        assertThrows(IllegalArgumentException.class,
+                () -> rnd().equiDoubles(nextDown(l, 1), l, false, false)
+        );
+        assertThrows(IllegalArgumentException.class,
+                () -> rnd().equiDoubles(l, l, false, true)
+        );
+        assertThrows(IllegalArgumentException.class,
+                () -> rnd().equiDoubles(l, nextDown(l, 1), true, true)
+        );
+        assertThrows(IllegalArgumentException.class,
+                () -> rnd().equiDoubles(nextUp(l, 1), l, true, true)
+        );
+    }
+
+}

--- a/test/jdk/java/util/Random/EquiDoublesTest.java
+++ b/test/jdk/java/util/Random/EquiDoublesTest.java
@@ -54,6 +54,7 @@ public class EquiDoublesTest {
      * all equidistant doubles are generated.
      */
     private static final long SAFETY_FACTOR = 100L;
+    private static final RandomGenerator rnd = RandomFactory.getRandom();
 
     private static double nextUp(double d, int steps) {
         for (int i = 0; i < steps; ++i) {
@@ -67,10 +68,6 @@ public class EquiDoublesTest {
             d = Math.nextDown(d);
         }
         return d;
-    }
-
-    private static RandomGenerator rnd() {
-        return RandomFactory.getRandom();
     }
 
     static Arguments[] equi() {
@@ -92,50 +89,50 @@ public class EquiDoublesTest {
         double[] minmax = new double[2];
 
         resetMinmax(minmax);
-        DoubleStream equi = rnd().equiDoubles(l, r, true, false);
+        DoubleStream equi = rnd.equiDoubles(l, r, true, false);
         equi.limit(SAMPLES).forEach(d -> updateMinmax(minmax, d));
         assertTrue(l <= minmax[0]);
         assertTrue(minmax[1] < r);
 
         resetMinmax(minmax);
-        equi = rnd().equiDoubles(l, r, true, true);
+        equi = rnd.equiDoubles(l, r, true, true);
         equi.limit(SAMPLES).forEach(d -> updateMinmax(minmax, d));
         assertTrue(l <= minmax[0]);
         assertTrue(minmax[1] <= r);
 
         resetMinmax(minmax);
-        equi = rnd().equiDoubles(l, r, false, true);
+        equi = rnd.equiDoubles(l, r, false, true);
         equi.limit(SAMPLES).forEach(d -> updateMinmax(minmax, d));
         assertTrue(l < minmax[0]);
         assertTrue(minmax[1] <= r);
 
         resetMinmax(minmax);
-        equi = rnd().equiDoubles(l, r, false, false);
+        equi = rnd.equiDoubles(l, r, false, false);
         equi.limit(SAMPLES).forEach(d -> updateMinmax(minmax, d));
         assertTrue(l < minmax[0]);
         assertTrue(minmax[1] < r);
 
         /* with negated intervals */
         resetMinmax(minmax);
-        equi = rnd().equiDoubles(-r, -l, true, false);
+        equi = rnd.equiDoubles(-r, -l, true, false);
         equi.limit(SAMPLES).forEach(d -> updateMinmax(minmax, d));
         assertTrue(-r <= minmax[0]);
         assertTrue(minmax[1] < -l);
 
         resetMinmax(minmax);
-        equi = rnd().equiDoubles(-r, -l, true, true);
+        equi = rnd.equiDoubles(-r, -l, true, true);
         equi.limit(SAMPLES).forEach(d -> updateMinmax(minmax, d));
         assertTrue(-r <= minmax[0]);
         assertTrue(minmax[1] <= -l);
 
         resetMinmax(minmax);
-        equi = rnd().equiDoubles(-r, -l, false, true);
+        equi = rnd.equiDoubles(-r, -l, false, true);
         equi.limit(SAMPLES).forEach(d -> updateMinmax(minmax, d));
         assertTrue(-r < minmax[0]);
         assertTrue(minmax[1] <= -l);
 
         resetMinmax(minmax);
-        equi = rnd().equiDoubles(-r, -l, false, false);
+        equi = rnd.equiDoubles(-r, -l, false, false);
         equi.limit(SAMPLES).forEach(d -> updateMinmax(minmax, d));
         assertTrue(-r < minmax[0]);
         assertTrue(minmax[1] < -l);
@@ -182,50 +179,50 @@ public class EquiDoublesTest {
         double r = nextUp(l, steps);
 
         TreeSet<Double> set = new TreeSet<>();
-        DoubleStream equi = rnd().equiDoubles(l, r, true, false);
+        DoubleStream equi = rnd.equiDoubles(l, r, true, false);
         equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
         assertEquals(steps, set.size());
         checkEquidistance(set);
 
         set.clear();
-        equi = rnd().equiDoubles(l, r, true, true);
+        equi = rnd.equiDoubles(l, r, true, true);
         equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
         assertEquals(steps + 1, set.size());
         checkEquidistance(set);
 
         set.clear();
-        equi = rnd().equiDoubles(l, r, false, true);
+        equi = rnd.equiDoubles(l, r, false, true);
         equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
         assertEquals(steps, set.size());
         checkEquidistance(set);
 
         set.clear();
-        equi = rnd().equiDoubles(l, r, false, false);
+        equi = rnd.equiDoubles(l, r, false, false);
         equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
         assertEquals(steps - 1, set.size());
         checkEquidistance(set);
 
         /* with negated intervals */
         set.clear();
-        equi = rnd().equiDoubles(-r, -l, true, true);
+        equi = rnd.equiDoubles(-r, -l, true, true);
         equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
         assertEquals(steps + 1, set.size());
         checkEquidistance(set);
 
         set.clear();
-        equi = rnd().equiDoubles(-r, -l, true, true);
+        equi = rnd.equiDoubles(-r, -l, true, true);
         equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
         assertEquals(steps + 1, set.size());
         checkEquidistance(set);
 
         set.clear();
-        equi = rnd().equiDoubles(-r, -l, false, true);
+        equi = rnd.equiDoubles(-r, -l, false, true);
         equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
         assertEquals(steps, set.size());
         checkEquidistance(set);
 
         set.clear();
-        equi = rnd().equiDoubles(-r, -l, false, false);
+        equi = rnd.equiDoubles(-r, -l, false, false);
         equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
         assertEquals(steps - 1, set.size());
         checkEquidistance(set);
@@ -252,50 +249,50 @@ public class EquiDoublesTest {
         int steps = lSteps + rSteps;
 
         TreeSet<Double> set = new TreeSet<>();
-        DoubleStream equi = rnd().equiDoubles(l, r, true, false);
+        DoubleStream equi = rnd.equiDoubles(l, r, true, false);
         equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
         assertEquals(steps, set.size());
         checkEquidistance(set);
 
         set.clear();
-        equi = rnd().equiDoubles(l, r, true, true);
+        equi = rnd.equiDoubles(l, r, true, true);
         equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
         assertEquals(steps + 1, set.size());
         checkEquidistance(set);
 
         set.clear();
-        equi = rnd().equiDoubles(l, r, false, true);
+        equi = rnd.equiDoubles(l, r, false, true);
         equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
         assertEquals(steps, set.size());
         checkEquidistance(set);
 
         set.clear();
-        equi = rnd().equiDoubles(l, r, false, false);
+        equi = rnd.equiDoubles(l, r, false, false);
         equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
         assertEquals(steps - 1, set.size());
         checkEquidistance(set);
 
         /* with negated intervals */
         set.clear();
-        equi = rnd().equiDoubles(-r, -l, true, true);
+        equi = rnd.equiDoubles(-r, -l, true, true);
         equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
         assertEquals(steps + 1, set.size());
         checkEquidistance(set);
 
         set.clear();
-        equi = rnd().equiDoubles(-r, -l, true, true);
+        equi = rnd.equiDoubles(-r, -l, true, true);
         equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
         assertEquals(steps + 1, set.size());
         checkEquidistance(set);
 
         set.clear();
-        equi = rnd().equiDoubles(-r, -l, false, true);
+        equi = rnd.equiDoubles(-r, -l, false, true);
         equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
         assertEquals(steps, set.size());
         checkEquidistance(set);
 
         set.clear();
-        equi = rnd().equiDoubles(-r, -l, false, false);
+        equi = rnd.equiDoubles(-r, -l, false, false);
         equi.limit(SAFETY_FACTOR * steps).forEach(set::add);
         assertEquals(steps - 1, set.size());
         checkEquidistance(set);
@@ -330,22 +327,22 @@ public class EquiDoublesTest {
     @MethodSource
     void empty(double l) {
         assertThrows(IllegalArgumentException.class,
-                () -> rnd().equiDoubles(l, l, true, false)
+                () -> rnd.equiDoubles(l, l, true, false)
         );
         assertThrows(IllegalArgumentException.class,
-                () -> rnd().equiDoubles(l, nextUp(l, 1), false, false)
+                () -> rnd.equiDoubles(l, nextUp(l, 1), false, false)
         );
         assertThrows(IllegalArgumentException.class,
-                () -> rnd().equiDoubles(nextDown(l, 1), l, false, false)
+                () -> rnd.equiDoubles(nextDown(l, 1), l, false, false)
         );
         assertThrows(IllegalArgumentException.class,
-                () -> rnd().equiDoubles(l, l, false, true)
+                () -> rnd.equiDoubles(l, l, false, true)
         );
         assertThrows(IllegalArgumentException.class,
-                () -> rnd().equiDoubles(l, nextDown(l, 1), true, true)
+                () -> rnd.equiDoubles(l, nextDown(l, 1), true, true)
         );
         assertThrows(IllegalArgumentException.class,
-                () -> rnd().equiDoubles(nextUp(l, 1), l, true, true)
+                () -> rnd.equiDoubles(nextUp(l, 1), l, true, true)
         );
     }
 


### PR DESCRIPTION
The `default` method `nextDouble(double origin, double bound)` in `java.util.random.RandomGenerator` aims at generating a uniformly and spatially equidistributed random `double` in the left-closed and right-open range [`origin`, `bound`). It does so by applying the affine transform `origin + (bound - origin) * r` to a uniformly and spatially equidistributed random `double` `r` in the range [0, 1).

Since floating-point arithmetic suffers from small but noticeable rounding errors, this ends up slightly deforming the distribution of `r` when applying the affine transform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8303584](https://bugs.openjdk.org/browse/JDK-8303584) to be approved

### Issues
 * [JDK-8302987](https://bugs.openjdk.org/browse/JDK-8302987): Add uniform and spatially equidistributed bounded double streams to RandomGenerator (**Enhancement** - P4)
 * [JDK-8303584](https://bugs.openjdk.org/browse/JDK-8303584): Add uniform and spatially equidistributed bounded double streams to RandomGenerator (**CSR**)

### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to [80e49d41](https://git.openjdk.org/jdk/pull/12719/files/80e49d41c58b17d5da9b5ef9aaed5227949902ba)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12719/head:pull/12719` \
`$ git checkout pull/12719`

Update a local copy of the PR: \
`$ git checkout pull/12719` \
`$ git pull https://git.openjdk.org/jdk.git pull/12719/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12719`

View PR using the GUI difftool: \
`$ git pr show -t 12719`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12719.diff">https://git.openjdk.org/jdk/pull/12719.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12719#issuecomment-1440263522)