### PR TITLE
8303084: G1 Heap region liveness verification has inverted return value

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -535,9 +535,9 @@ class G1VerifyLiveAndRemSetClosure : public BasicOopIterateClosure {
       }
       log.error("----------");
       _num_failures++;
-      return true;
+      return false;
     }
-    return false;
+    return true;
   }
 
   template <class T>


### PR DESCRIPTION
Hi all,

  please review a fix for a mess-up in [JDK-8303084](https://bugs.openjdk.org/browse/JDK-8303084) where the return value of `G1VerifyLiveAndRemSetClosure::verify_liveness()` is inverted.

Thanks to @albertnetymk for noticing.

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303084](https://bugs.openjdk.org/browse/JDK-8303084): G1 Heap region liveness verification has inverted return value


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12721/head:pull/12721` \
`$ git checkout pull/12721`

Update a local copy of the PR: \
`$ git checkout pull/12721` \
`$ git pull https://git.openjdk.org/jdk pull/12721/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12721`

View PR using the GUI difftool: \
`$ git pr show -t 12721`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12721.diff">https://git.openjdk.org/jdk/pull/12721.diff</a>

</details>
