### PR TITLE
8303089: [jittester] Add time limit to IRTree generation

### DIFF
--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ProductionLimiter.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ProductionLimiter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,16 @@
  */
 
 package jdk.test.lib.jittester;
+
+import java.time.Duration;
+import java.time.Instant;
+
 // an utility class to limit steps in the production of an expression
 public class ProductionLimiter {
 
     private static Integer limit = -1;
+
+    private static Instant limitInstant;
 
     public static void setUnlimited() {
         limit = -1;
@@ -44,5 +50,23 @@ public class ProductionLimiter {
         if (limit != -1 && limit <= 0) {
             throw new ProductionFailedException();
         }
+
+        if (Instant.now().isAfter(limitInstant)) {
+            long paramsLimitSeconds = ProductionParams.productionLimitSeconds.value();
+            Duration elapsed = Duration.between(limitInstant.minusSeconds(paramsLimitSeconds), Instant.now());
+            String elapsedStr = String.format("%d:%02d:%02d",
+                    elapsed.toHoursPart(), elapsed.toMinutesPart(), elapsed.toSecondsPart());
+
+            Duration timeLimit = Duration.ofSeconds(paramsLimitSeconds);
+            String timeLimitStr = String.format("%d:%02d:%02d",
+                            timeLimit.toHoursPart(), timeLimit.toMinutesPart(), timeLimit.toSecondsPart());
+
+            throw new RuntimeException(String.format("A test generation took %s while limit is %s",
+                        elapsedStr, timeLimitStr));
+        }
+    }
+
+    public static void resetTimer() {
+        limitInstant = Instant.now().plusSeconds(ProductionParams.productionLimitSeconds.value());
     }
 }

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ProductionParams.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ProductionParams.java
@@ -29,6 +29,7 @@ import jdk.test.lib.jittester.utils.OptionResolver.Option;
 public class ProductionParams {
 
     public static Option<Integer> productionLimit = null;
+    public static Option<Integer> productionLimitSeconds = null;
     public static Option<Integer> dataMemberLimit = null;
     public static Option<Integer> statementLimit = null;
     public static Option<Integer> testStatementLimit = null;
@@ -81,6 +82,7 @@ public class ProductionParams {
 
     public static void register(OptionResolver optionResolver) {
         productionLimit = optionResolver.addIntegerOption('l', "production-limit", 100, "Limit on steps in the production of an expression");
+        productionLimitSeconds = optionResolver.addIntegerOption("production-limit-seconds", 600, "Limit the time a test generation may take");
         dataMemberLimit = optionResolver.addIntegerOption('v', "data-member-limit", 10, "Upper limit on data members");
         statementLimit = optionResolver.addIntegerOption('s', "statement-limit", 30, "Upper limit on statements in function");
         testStatementLimit = optionResolver.addIntegerOption('e', "test-statement-limit", 300, "Upper limit on statements in test() function");


### PR DESCRIPTION
Sometimes, the generation could take more than an hour and probably never stop. This PR adds a time limit (defaults to 10 minutes) to the generation of a single test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303089](https://bugs.openjdk.org/browse/JDK-8303089): [jittester] Add time limit to IRTree generation


### Reviewers
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12722/head:pull/12722` \
`$ git checkout pull/12722`

Update a local copy of the PR: \
`$ git checkout pull/12722` \
`$ git pull https://git.openjdk.org/jdk pull/12722/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12722`

View PR using the GUI difftool: \
`$ git pr show -t 12722`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12722.diff">https://git.openjdk.org/jdk/pull/12722.diff</a>

</details>
