### PR TITLE
8303085: Runtime problem list cleanup

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -84,15 +84,9 @@ gc/stress/TestStressG1Humongous.java 8286554 windows-x64
 
 # :hotspot_runtime
 
-runtime/cds/appcds/jigsaw/modulepath/ModulePathAndCP_JFR.java 8253437 windows-x64
+
 runtime/jni/terminatedThread/TestTerminatedThread.java 8219652 aix-ppc64
 runtime/handshake/HandshakeSuspendExitTest.java 8294313 generic-all
-runtime/os/TestTracePageSizes.java#no-options 8267460 linux-aarch64
-runtime/os/TestTracePageSizes.java#explicit-large-page-size 8267460 linux-aarch64
-runtime/os/TestTracePageSizes.java#compiler-options 8267460 linux-aarch64
-runtime/os/TestTracePageSizes.java#G1 8267460 linux-aarch64
-runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
-runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
 runtime/vthread/RedefineClass.java 8297286 generic-all
 runtime/vthread/TestObjectAllocationSampleEvent.java 8297286 generic-all
@@ -163,7 +157,6 @@ vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manySame_b/TestDescription.java 
 
 vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn001/forceEarlyReturn001.java 7199837 generic-all
 
-vmTestbase/nsk/stress/except/except012.java 8297977 generic-all
 vmTestbase/nsk/stress/strace/strace002.java 8288912 macosx-x64,windows-x64
 vmTestbase/nsk/stress/strace/strace003.java 8297824 macosx-x64,windows-x64
 vmTestbase/nsk/stress/strace/strace004.java 8297824 macosx-x64,windows-x64


### PR DESCRIPTION
Identified several Runtime related entries in HotSpot problem list that could be removed because issues are no longer reproducible. Reran corresponding tests multiple times (200-400 times) before removal. See comments in the bug for details.