### PR TITLE
8303102: jcmd: ManagementAgent.status truncates the text longer than O_BUFLEN

### DIFF
--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -807,7 +807,8 @@ void JMXStatusDCmd::execute(DCmdSource source, TRAPS) {
   if (str != nullptr) {
       char* out = java_lang_String::as_utf8_string(str);
       if (out) {
-          output()->print_cr("%s", out);
+          // Avoid using print_cr() because length maybe longer than O_BUFLEN
+          output()->print_raw_cr(out);
           return;
       }
   }

--- a/test/jdk/sun/management/jmxremote/startstop/JMXStatusTest.java
+++ b/test/jdk/sun/management/jmxremote/startstop/JMXStatusTest.java
@@ -33,7 +33,7 @@ import jdk.test.lib.process.ProcessTools;
 
 /**
  * @test
- * @bug 8023093 8138748 8142398
+ * @bug 8023093 8138748 8142398 8303102
  * @summary Performs a sanity test for the ManagementAgent.status diagnostic command.
  *          Management agent may be disabled, started (only local connections) and started.
  *          The test asserts that the expected text is being printed.

--- a/test/jdk/sun/management/jmxremote/startstop/JMXStatusTest.java
+++ b/test/jdk/sun/management/jmxremote/startstop/JMXStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Implementation of the "ManagementAgent.status" indirectly depends on the size of "O_BUFLEN".

The root cause is usage of [print_cr()](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/utilities/ostream.cpp#L153) which may [truncate](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/utilities/ostream.cpp#L101) the output.

The solution is similar to the [JDK-8263640](https://bugs.openjdk.org/browse/JDK-8263640). see discussion about that approach https://github.com/openjdk/jdk/pull/4616

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303102](https://bugs.openjdk.org/browse/JDK-8303102): jcmd: ManagementAgent.status truncates the text longer than O_BUFLEN


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12724/head:pull/12724` \
`$ git checkout pull/12724`

Update a local copy of the PR: \
`$ git checkout pull/12724` \
`$ git pull https://git.openjdk.org/jdk pull/12724/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12724`

View PR using the GUI difftool: \
`$ git pr show -t 12724`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12724.diff">https://git.openjdk.org/jdk/pull/12724.diff</a>

</details>
