### PR TITLE
8302017: Allocate BadPaddingException only if it will be thrown

### DIFF
--- a/src/java.base/share/classes/sun/security/rsa/RSAPadding.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAPadding.java
@@ -366,10 +366,8 @@ public final class RSAPadding {
         byte[] data = new byte[n];
         System.arraycopy(padded, p, data, 0, n);
 
-        BadPaddingException bpe = new BadPaddingException("Decryption error");
-
         if (bp) {
-            throw bpe;
+            throw new BadPaddingException("Decryption error");
         } else {
             return data;
         }
@@ -485,10 +483,8 @@ public final class RSAPadding {
         byte [] m = new byte[EM.length - mStart];
         System.arraycopy(EM, mStart, m, 0, m.length);
 
-        BadPaddingException bpe = new BadPaddingException("Decryption error");
-
         if (bp) {
-            throw bpe;
+            throw new BadPaddingException("Decryption error");
         } else {
             return m;
         }


### PR DESCRIPTION
This change will move the instantiation of BadPaddingException into the branch of the if statement where it is thrown. This will decrease the overhead of calling `unpadV15` and `unpadOAEP`.  Please see the associated work item for past discussions regarding this change.

The build and tier1 tests pass locally on mac-aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302017](https://bugs.openjdk.org/browse/JDK-8302017): Allocate BadPaddingException only if it will be thrown


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)


### Contributors
 * Alex Dubrouski `<adubrouski@linkedin.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12732/head:pull/12732` \
`$ git checkout pull/12732`

Update a local copy of the PR: \
`$ git checkout pull/12732` \
`$ git pull https://git.openjdk.org/jdk pull/12732/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12732`

View PR using the GUI difftool: \
`$ git pr show -t 12732`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12732.diff">https://git.openjdk.org/jdk/pull/12732.diff</a>

</details>
