### PR TITLE
8303131: pandoc.exe mangles all processed html files

### DIFF
--- a/make/common/ProcessMarkdown.gmk
+++ b/make/common/ProcessMarkdown.gmk
@@ -84,7 +84,7 @@ define ProcessMarkdown
 	$$(call MakeDir, $$(SUPPORT_OUTPUTDIR)/markdown $$(dir $$($1_$2_PANDOC_OUTPUT)))
 	$$(call ExecuteWithLog, $$(SUPPORT_OUTPUTDIR)/markdown/$$($1_$2_MARKER), \
 	    $$(PANDOC) $$($1_OPTIONS) -f $$(PANDOC_MARKDOWN_FLAG) \
-	    -t $$($1_FORMAT) --standalone \
+	    -t $$($1_FORMAT) --eol=lf --standalone \
 	    $$($1_$2_CSS_OPTION) $$($1_$2_OPTIONS_FROM_SRC) $$($1_$2_OPTIONS) \
 	    '$$($1_$2_PANDOC_INPUT)' -o '$$($1_$2_PANDOC_OUTPUT)')
         ifneq ($$(findstring $$(LOG_LEVEL), debug trace),)


### PR DESCRIPTION
pandoc.exe follows the Windows CRLF format of newlines, whereas we only ever have LF in our documentation files. As a result whenever we generate html the resulting html files will all be mangled, even if there was no change to the corresponding markdown file. This passes --eol=lf to pandoc so that it always uses LF no matter the platform, since we never ever seem to use (or even want to use) CRLF at all, so that pandoc will exhibit consistent behaviour on all platforms

pandoc by default uses the --eol=native option, which is LF on macOS, Linux and UNIX, so this change will not affect their html generation whatsoever, but will make the lives of Windows JDK developers and _especially_ JDK developers working with MSYS2 a hell of a lot easier (*cries internally)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303131](https://bugs.openjdk.org/browse/JDK-8303131): pandoc.exe mangles all processed html files


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12733/head:pull/12733` \
`$ git checkout pull/12733`

Update a local copy of the PR: \
`$ git checkout pull/12733` \
`$ git pull https://git.openjdk.org/jdk pull/12733/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12733`

View PR using the GUI difftool: \
`$ git pr show -t 12733`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12733.diff">https://git.openjdk.org/jdk/pull/12733.diff</a>

</details>
