### PR TITLE
8303238: Create generalizations for existing LShift ideal transforms

### DIFF
--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -847,21 +847,74 @@ Node *LShiftINode::Ideal(PhaseGVN *phase, bool can_reshape) {
     }
   }
 
-  // Check for "(x>>c0)<<c0" which just masks off low bits
-  if( (add1_op == Op_RShiftI || add1_op == Op_URShiftI ) &&
-      add1->in(2) == in(2) )
-    // Convert to "(x & -(1<<c0))"
-    return new AndINode(add1->in(1),phase->intcon( -(1<<con)));
+  // Check for "(x >> C1) << C2" which just masks off low bits
+  if (add1_op == Op_RShiftI || add1_op == Op_URShiftI) {
+    // Special case C1 == C2
+    if (add1->in(2) == in(2)) {
+      // Convert to "(x & -(1 << C2))"
+      return new AndINode(add1->in(1), phase->intcon(-(1 << con)));
+    } else {
+      int add1Con = 0;
+      const_shift_count(phase, add1, &add1Con);
 
-  // Check for "((x>>c0) & Y)<<c0" which just masks off more low bits
-  if( add1_op == Op_AndI ) {
+      // Wait until the right shift has been sharpened to the correct count
+      if (add1Con > 0 && add1Con < BitsPerJavaInteger) {
+        // As loop parsing can produce LShiftI nodes, we should wait until the graph is fully formed
+        // to apply optimizations, otherwise we can inadvertently stop vectorization opportunities.
+        if (phase->is_IterGVN()) {
+          if (con > add1Con) {
+            // Creates "(x << (C2 - C1)) & -(1 << C2)"
+            Node* lshift = phase->transform(new LShiftINode(add1->in(1), phase->intcon(con - add1Con)));
+            return new AndINode(lshift, phase->intcon(-(1 << con)));
+          } else {
+            assert(con < add1Con, "must be (%d < %d)", con, add1Con);
+            // Creates "(x >> (C1 - C2)) & -(1 << C2)"
+
+            // Handle logical and arithmetic shifts
+            Node* rshift;
+            if (add1_op == Op_RShiftI) {
+              rshift = phase->transform(new RShiftINode(add1->in(1), phase->intcon(add1Con - con)));
+            } else {
+              rshift = phase->transform(new URShiftINode(add1->in(1), phase->intcon(add1Con - con)));
+            }
+
+            return new AndINode(rshift, phase->intcon(-(1 << con)));
+          }
+        } else {
+          phase->record_for_igvn(this);
+        }
+      }
+    }
+  }
+
+  // Check for "((x >> C1) & Y) << C2" which just masks off more low bits
+  if (add1_op == Op_AndI) {
     Node *add2 = add1->in(1);
     int add2_op = add2->Opcode();
-    if( (add2_op == Op_RShiftI || add2_op == Op_URShiftI ) &&
-        add2->in(2) == in(2) ) {
-      // Convert to "(x & (Y<<c0))"
-      Node *y_sh = phase->transform( new LShiftINode( add1->in(2), in(2) ) );
-      return new AndINode( add2->in(1), y_sh );
+    if (add2_op == Op_RShiftI || add2_op == Op_URShiftI) {
+      // Special case C1 == C2
+      if (add2->in(2) == in(2)) {
+        // Convert to "(x & (Y << C2))"
+        Node* y_sh = phase->transform(new LShiftINode(add1->in(2), phase->intcon(con)));
+        return new AndINode(add2->in(1), y_sh);
+      }
+
+      int add2Con = 0;
+      const_shift_count(phase, add2, &add2Con);
+      if (add2Con > 0 && add2Con < BitsPerJavaInteger) {
+        if (phase->is_IterGVN()) {
+          // Convert to "((x >> C1) << C2) & (Y << C2)"
+
+          // Make "(x >> C1) << C2", which will get folded away by the rule above
+          Node* x_sh = phase->transform(new LShiftINode(add2, phase->intcon(con)));
+          // Make "Y << C2", which will simplify when Y is a constant
+          Node* y_sh = phase->transform(new LShiftINode(add1->in(2), phase->intcon(con)));
+
+          return new AndINode(x_sh, y_sh);
+        } else {
+          phase->record_for_igvn(this);
+        }
+      }
     }
   }
 
@@ -970,21 +1023,74 @@ Node *LShiftLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     }
   }
 
-  // Check for "(x>>c0)<<c0" which just masks off low bits
-  if( (add1_op == Op_RShiftL || add1_op == Op_URShiftL ) &&
-      add1->in(2) == in(2) )
-    // Convert to "(x & -(1<<c0))"
-    return new AndLNode(add1->in(1),phase->longcon( -(CONST64(1)<<con)));
+  // Check for "(x >> C1) << C2" which just masks off low bits
+  if (add1_op == Op_RShiftL || add1_op == Op_URShiftL) {
+    // Special case C1 == C2
+    if (add1->in(2) == in(2)) {
+      // Convert to "(x & -(1 << C2))"
+      return new AndLNode(add1->in(1), phase->longcon(-(CONST64(1) << con)));
+    } else {
+      int add1Con = 0;
+      const_shift_count(phase, add1, &add1Con);
 
-  // Check for "((x>>c0) & Y)<<c0" which just masks off more low bits
-  if( add1_op == Op_AndL ) {
-    Node *add2 = add1->in(1);
+      // Wait until the right shift has been sharpened to the correct count
+      if (add1Con > 0 && add1Con < BitsPerJavaLong) {
+        // As loop parsing can produce LShiftI nodes, we should wait until the graph is fully formed
+        // to apply optimizations, otherwise we can inadvertently stop vectorization opportunities.
+        if (phase->is_IterGVN()) {
+          if (con > add1Con) {
+            // Creates "(x << (C2 - C1)) & -(1 << C2)"
+            Node* lshift = phase->transform(new LShiftLNode(add1->in(1), phase->intcon(con - add1Con)));
+            return new AndLNode(lshift, phase->longcon(-(CONST64(1) << con)));
+          } else {
+            assert(con < add1Con, "must be (%d < %d)", con, add1Con);
+            // Creates "(x >> (C1 - C2)) & -(1 << C2)"
+
+            // Handle logical and arithmetic shifts
+            Node* rshift;
+            if (add1_op == Op_RShiftL) {
+              rshift = phase->transform(new RShiftLNode(add1->in(1), phase->intcon(add1Con - con)));
+            } else {
+              rshift = phase->transform(new URShiftLNode(add1->in(1), phase->intcon(add1Con - con)));
+            }
+
+            return new AndLNode(rshift, phase->longcon(-(CONST64(1) << con)));
+          }
+        } else {
+          phase->record_for_igvn(this);
+        }
+      }
+    }
+  }
+
+  // Check for "((x >> C1) & Y) << C2" which just masks off more low bits
+  if (add1_op == Op_AndL) {
+    Node* add2 = add1->in(1);
     int add2_op = add2->Opcode();
-    if( (add2_op == Op_RShiftL || add2_op == Op_URShiftL ) &&
-        add2->in(2) == in(2) ) {
-      // Convert to "(x & (Y<<c0))"
-      Node *y_sh = phase->transform( new LShiftLNode( add1->in(2), in(2) ) );
-      return new AndLNode( add2->in(1), y_sh );
+    if (add2_op == Op_RShiftL || add2_op == Op_URShiftL) {
+      // Special case C1 == C2
+      if (add2->in(2) == in(2)) {
+        // Convert to "(x & (Y << C2))"
+        Node* y_sh = phase->transform(new LShiftLNode(add1->in(2), phase->intcon(con)));
+        return new AndLNode(add2->in(1), y_sh);
+      }
+
+      int add2Con = 0;
+      const_shift_count(phase, add2, &add2Con);
+      if (add2Con > 0 && add2Con < BitsPerJavaLong) {
+        if (phase->is_IterGVN()) {
+          // Convert to "((x >> C1) << C2) & (Y << C2)"
+
+          // Make "(x >> C1) << C2", which will get folded away by the rule above
+          Node* x_sh = phase->transform(new LShiftLNode(add2, phase->intcon(con)));
+          // Make "Y << C2", which will simplify when Y is a constant
+          Node* y_sh = phase->transform(new LShiftLNode(add1->in(2), phase->intcon(con)));
+
+          return new AndLNode(x_sh, y_sh);
+        } else {
+          phase->record_for_igvn(this);
+        }
+      }
     }
   }
 

--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -847,9 +847,9 @@ Node *LShiftINode::Ideal(PhaseGVN *phase, bool can_reshape) {
     }
   }
 
-  // Check for "(x >> C1) << C2" which just masks off low bits
+  // Check for "(x >> C1) << C2"
   if (add1_op == Op_RShiftI || add1_op == Op_URShiftI) {
-    // Special case C1 == C2
+    // Special case C1 == C2, which just masks off low bits
     if (add1->in(2) == in(2)) {
       // Convert to "(x & -(1 << C2))"
       return new AndINode(add1->in(1), phase->intcon(-(1 << con)));
@@ -887,12 +887,12 @@ Node *LShiftINode::Ideal(PhaseGVN *phase, bool can_reshape) {
     }
   }
 
-  // Check for "((x >> C1) & Y) << C2" which just masks off more low bits
+  // Check for "((x >> C1) & Y) << C2"
   if (add1_op == Op_AndI) {
     Node *add2 = add1->in(1);
     int add2_op = add2->Opcode();
     if (add2_op == Op_RShiftI || add2_op == Op_URShiftI) {
-      // Special case C1 == C2
+      // Special case C1 == C2, which just masks off low bits
       if (add2->in(2) == in(2)) {
         // Convert to "(x & (Y << C2))"
         Node* y_sh = phase->transform(new LShiftINode(add1->in(2), phase->intcon(con)));
@@ -1023,9 +1023,9 @@ Node *LShiftLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     }
   }
 
-  // Check for "(x >> C1) << C2" which just masks off low bits
+  // Check for "(x >> C1) << C2"
   if (add1_op == Op_RShiftL || add1_op == Op_URShiftL) {
-    // Special case C1 == C2
+    // Special case C1 == C2, which just masks off low bits
     if (add1->in(2) == in(2)) {
       // Convert to "(x & -(1 << C2))"
       return new AndLNode(add1->in(1), phase->longcon(-(CONST64(1) << con)));
@@ -1063,12 +1063,12 @@ Node *LShiftLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     }
   }
 
-  // Check for "((x >> C1) & Y) << C2" which just masks off more low bits
+  // Check for "((x >> C1) & Y) << C2"
   if (add1_op == Op_AndL) {
     Node* add2 = add1->in(1);
     int add2_op = add2->Opcode();
     if (add2_op == Op_RShiftL || add2_op == Op_URShiftL) {
-      // Special case C1 == C2
+      // Special case C1 == C2, which just masks off low bits
       if (add2->in(2) == in(2)) {
         // Convert to "(x & (Y << C2))"
         Node* y_sh = phase->transform(new LShiftLNode(add1->in(2), phase->intcon(con)));

--- a/test/hotspot/jtreg/compiler/c2/irTests/LShiftINodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/LShiftINodeIdealizationTests.java
@@ -27,7 +27,7 @@ import compiler.lib.ir_framework.*;
 
 /*
  * @test
- * @bug 8297384
+ * @bug 8297384 8303238
  * @summary Test that Ideal transformations of LShiftINode* are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.LShiftINodeIdealizationTests
@@ -119,7 +119,7 @@ public class LShiftINodeIdealizationTests {
     @Test
     @IR(failOn = { IRNode.RSHIFT })
     @IR(counts = { IRNode.AND, "1", IRNode.LSHIFT, "1" })
-    // Checks (x >> 4) << 8 => (x << 4) & 0xFF00
+    // Checks ((x >> 4) & 0xFF) << 8 => (x << 4) & 0xFF00
     public int test7(int x) {
         return ((x >> 4) & 0xFF) << 8;
     }
@@ -127,7 +127,7 @@ public class LShiftINodeIdealizationTests {
     @Test
     @IR(failOn = { IRNode.URSHIFT })
     @IR(counts = { IRNode.AND, "1", IRNode.LSHIFT, "1" })
-    // Checks (x >> 4) << 8 => (x << 4) & 0xFF00
+    // Checks ((x >>> 4) & 0xFF) << 8 => (x << 4) & 0xFF00
     public int test8(int x) {
         return ((x >>> 4) & 0xFF) << 8;
     }

--- a/test/hotspot/jtreg/compiler/c2/irTests/LShiftLNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/LShiftLNodeIdealizationTests.java
@@ -27,6 +27,7 @@ import compiler.lib.ir_framework.*;
 
 /*
  * @test
+ * @bug 8303238
  * @summary Test that Ideal transformations of LShiftLNode* are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.LShiftLNodeIdealizationTests
@@ -100,7 +101,7 @@ public class LShiftLNodeIdealizationTests {
     @Test
     @IR(failOn = { IRNode.RSHIFT })
     @IR(counts = { IRNode.AND, "1", IRNode.LSHIFT, "1" })
-    // Checks (x >> 4) << 8 => (x << 4) & 0xFF00
+    // Checks ((x >> 4) & 0xFF) << 8 => (x << 4) & 0xFF00
     public long test7(long x) {
         return ((x >> 4L) & 0xFFL) << 8L;
     }
@@ -108,7 +109,7 @@ public class LShiftLNodeIdealizationTests {
     @Test
     @IR(failOn = { IRNode.URSHIFT })
     @IR(counts = { IRNode.AND, "1", IRNode.LSHIFT, "1" })
-    // Checks (x >> 4) << 8 => (x << 4) & 0xFF00
+    // Checks ((x >>> 4) & 0xFF) << 8 => (x << 4) & 0xFF00
     public long test8(long x) {
         return ((x >>> 4L) & 0xFFL) << 8L;
     }

--- a/test/hotspot/jtreg/compiler/c2/irTests/LShiftLNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/LShiftLNodeIdealizationTests.java
@@ -27,25 +27,24 @@ import compiler.lib.ir_framework.*;
 
 /*
  * @test
- * @bug 8297384
- * @summary Test that Ideal transformations of LShiftINode* are being performed as expected.
+ * @summary Test that Ideal transformations of LShiftLNode* are being performed as expected.
  * @library /test/lib /
- * @run driver compiler.c2.irTests.LShiftINodeIdealizationTests
+ * @run driver compiler.c2.irTests.LShiftLNodeIdealizationTests
  */
-public class LShiftINodeIdealizationTests {
+public class LShiftLNodeIdealizationTests {
     public static void main(String[] args) {
         TestFramework.run();
     }
 
-    @Run(test = { "test1", "test2", "test3", "test4", "test5", "test6", "test7", "test8" })
+    @Run(test = { "test3", "test4", "test5", "test6", "test7", "test8" })
     public void runMethod() {
-        int a = RunInfo.getRandom().nextInt();
-        int b = RunInfo.getRandom().nextInt();
-        int c = RunInfo.getRandom().nextInt();
-        int d = RunInfo.getRandom().nextInt();
+        long a = RunInfo.getRandom().nextLong();
+        long b = RunInfo.getRandom().nextLong();
+        long c = RunInfo.getRandom().nextLong();
+        long d = RunInfo.getRandom().nextLong();
 
-        int min = Integer.MIN_VALUE;
-        int max = Integer.MAX_VALUE;
+        long min = Long.MIN_VALUE;
+        long max = Long.MAX_VALUE;
 
         assertResult(0);
         assertResult(a);
@@ -57,78 +56,60 @@ public class LShiftINodeIdealizationTests {
     }
 
     @DontCompile
-    public void assertResult(int a) {
-        Asserts.assertEQ((a >> 2022) << 2022, test1(a));
-        Asserts.assertEQ((a >>> 2022) << 2022, test2(a));
-        Asserts.assertEQ((a >> 4) << 8, test3(a));
-        Asserts.assertEQ((a >>> 4) << 8, test4(a));
-        Asserts.assertEQ((a >> 8) << 4, test5(a));
-        Asserts.assertEQ((a >>> 8) << 4, test6(a));
-        Asserts.assertEQ(((a >> 4) & 0xFF) << 8, test7(a));
-        Asserts.assertEQ(((a >>> 4) & 0xFF) << 8, test8(a));
-    }
-
-    @Test
-    @IR(failOn = { IRNode.LSHIFT, IRNode.RSHIFT })
-    @IR(counts = { IRNode.AND, "1" })
-    // Checks (x >> 2022) << 2022 => x & C where C = -(1 << 6)
-    public int test1(int x) {
-        return (x >> 2022) << 2022;
-    }
-
-    @Test
-    @IR(failOn = { IRNode.LSHIFT, IRNode.URSHIFT })
-    @IR(counts = { IRNode.AND, "1" })
-    // Checks (x >>> 2022) << 2022 => x & C where C = -(1 << 6)
-    public int test2(int x) {
-        return (x >>> 2022) << 2022;
+    public void assertResult(long a) {
+        Asserts.assertEQ((a >> 4L) << 8L, test3(a));
+        Asserts.assertEQ((a >>> 4L) << 8L, test4(a));
+        Asserts.assertEQ((a >> 8L) << 4L, test5(a));
+        Asserts.assertEQ((a >>> 8L) << 4L, test6(a));
+        Asserts.assertEQ(((a >> 4L) & 0xFFL) << 8L, test7(a));
+        Asserts.assertEQ(((a >>> 4L) & 0xFFL) << 8L, test8(a));
     }
 
     @Test
     @IR(failOn = { IRNode.RSHIFT })
     @IR(counts = { IRNode.AND, "1", IRNode.LSHIFT, "1" })
     // Checks (x >> 4) << 8 => (x << 4) & -16
-    public int test3(int x) {
-        return (x >> 4) << 8;
+    public long test3(long x) {
+        return (x >> 4L) << 8L;
     }
 
     @Test
     @IR(failOn = { IRNode.URSHIFT })
     @IR(counts = { IRNode.AND, "1", IRNode.LSHIFT, "1" })
     // Checks (x >>> 4) << 8 => (x << 4) & -16
-    public int test4(int x) {
-        return (x >>> 4) << 8;
+    public long test4(long x) {
+        return (x >>> 4L) << 8L;
     }
 
     @Test
     @IR(failOn = { IRNode.LSHIFT })
     @IR(counts = { IRNode.AND, "1", IRNode.RSHIFT, "1" })
     // Checks (x >> 8) << 4 => (x >> 4) & -16
-    public int test5(int x) {
-        return (x >> 8) << 4;
+    public long test5(long x) {
+        return (x >> 8L) << 4L;
     }
 
     @Test
     @IR(failOn = { IRNode.LSHIFT })
     @IR(counts = { IRNode.AND, "1", IRNode.URSHIFT, "1" })
     // Checks (x >>> 8) << 4 => (x >>> 4) & -16
-    public int test6(int x) {
-        return (x >>> 8) << 4;
+    public long test6(long x) {
+        return (x >>> 8L) << 4L;
     }
 
     @Test
     @IR(failOn = { IRNode.RSHIFT })
     @IR(counts = { IRNode.AND, "1", IRNode.LSHIFT, "1" })
     // Checks (x >> 4) << 8 => (x << 4) & 0xFF00
-    public int test7(int x) {
-        return ((x >> 4) & 0xFF) << 8;
+    public long test7(long x) {
+        return ((x >> 4L) & 0xFFL) << 8L;
     }
 
     @Test
     @IR(failOn = { IRNode.URSHIFT })
     @IR(counts = { IRNode.AND, "1", IRNode.LSHIFT, "1" })
     // Checks (x >> 4) << 8 => (x << 4) & 0xFF00
-    public int test8(int x) {
-        return ((x >>> 4) & 0xFF) << 8;
+    public long test8(long x) {
+        return ((x >>> 4L) & 0xFFL) << 8L;
     }
 }

--- a/test/micro/org/openjdk/bench/vm/compiler/LShiftNodeIdealize.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/LShiftNodeIdealize.java
@@ -97,7 +97,6 @@ public class LShiftNodeIdealize {
     @State(Scope.Benchmark)
     public static class BenchState {
         int[] ints;
-        Random random = new Random();
 
         public BenchState() {
 
@@ -105,6 +104,7 @@ public class LShiftNodeIdealize {
 
         @Setup
         public void setup() {
+            Random random = new Random(1000);
             ints = new int[64];
             for (int i = 0; i < 64; i++) {
                 ints[i] = random.nextInt();

--- a/test/micro/org/openjdk/bench/vm/compiler/LShiftNodeIdealize.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/LShiftNodeIdealize.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
+public class LShiftNodeIdealize {
+    private static final int SIZE = 3000;
+
+    @Benchmark
+    public void testShiftInt(Blackhole blackhole) {
+        for (int i = 0; i < SIZE; i++) {
+            blackhole.consume((i >> 4) << 8);
+        }
+    }
+
+    @Benchmark
+    public void testShiftInt2(Blackhole blackhole) {
+        for (int i = 0; i < SIZE; i++) {
+            blackhole.consume((i >> 8) << 4);
+        }
+    }
+
+    @Benchmark
+    public void testShiftAndInt(Blackhole blackhole) {
+        for (int i = 0; i < SIZE; i++) {
+            blackhole.consume(((i >> 4) & 0x01) << 8);
+        }
+    }
+
+    @Benchmark
+    public void testShiftLong(Blackhole blackhole) {
+        for (long i = 0; i < SIZE; i++) {
+            blackhole.consume((i >> 4L) << 8L);
+        }
+    }
+
+    @Benchmark
+    public void testShiftLong2(Blackhole blackhole) {
+        for (long i = 0; i < SIZE; i++) {
+            blackhole.consume((i >> 8L) << 4L);
+        }
+    }
+
+    @Benchmark
+    public void testShiftAndLong(Blackhole blackhole) {
+        for (long i = 0; i < SIZE; i++) {
+            blackhole.consume(((i >> 4L) & 0x01L) << 8L);
+        }
+    }
+
+    @Benchmark
+    public void testRgbaToAbgr(Blackhole blackhole, BenchState state) {
+        for (int i = 0; i < 64; i++) {
+            blackhole.consume(rgbaToAbgr(state.ints[i]));
+        }
+    }
+
+    private static int rgbaToAbgr(int i) {
+        int r = i & 0xFF;
+        int g = (i & 0xFF00) >> 8;
+        int b = (i & 0xFF0000) >> 16;
+        int a = (i & 0xFF000000) >> 24;
+
+        return (r << 24) | (g << 16) | (b << 8) | a;
+    }
+
+    @State(Scope.Benchmark)
+    public static class BenchState {
+        int[] ints;
+        Random random = new Random();
+
+        public BenchState() {
+
+        }
+
+        @Setup
+        public void setup() {
+            ints = new int[64];
+            for (int i = 0; i < 64; i++) {
+                ints[i] = random.nextInt();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hello,
I would like to generalize two ideal transforms for bitwise shifts. Left shift nodes perform the transformations `(x >> C1) << C2 => x & (-1 << C2)` and `((x >> C1) & Y) << C2 => x & (Y << C2)`, but only when the case where `C1 == C2`. However, it is possible to use both of these rules to improve cases where the constants aren't equal, by removing one of the shifts and replacing it with a bitwise and. This transformation is profitable because typically more bitwise ands can be dispatched per cycle than bit shifts. In addition, the strength reduction from a shift to a bitwise and can allow more profitable transformations to occur. These patterns are found throughout the JDK, mainly around strings and OW2 ASM. I've attached some profiling results from my (Zen 2) machine below:
```
                                                 Baseline                           Patch              Improvement
Benchmark                            Mode  Cnt    Score     Error  Units      Score    Error  Units
LShiftNodeIdealize.testRgbaToAbgr    avgt   15    63.287 ±  1.770  ns/op  /  54.199 ±  1.408  ns/op     + 14.36%
LShiftNodeIdealize.testShiftAndInt   avgt   15   874.564 ± 15.334  ns/op  / 538.408 ± 11.768  ns/op     + 38.44%
LShiftNodeIdealize.testShiftAndLong  avgt   15  1017.466 ± 29.010  ns/op  / 701.356 ± 18.258  ns/op     + 31.07%
LShiftNodeIdealize.testShiftInt      avgt   15   663.865 ± 14.226  ns/op  / 533.588 ±  9.949  ns/op     + 19.63%
LShiftNodeIdealize.testShiftInt2     avgt   15   658.976 ± 32.856  ns/op  / 649.871 ± 10.598  ns/op     +  1.38%
LShiftNodeIdealize.testShiftLong     avgt   15   815.540 ± 14.721  ns/op  / 689.270 ± 14.028  ns/op     + 15.48%
LShiftNodeIdealize.testShiftLong2    avgt   15   817.936 ± 23.573  ns/op  / 810.185 ± 14.983  ns/op     +  0.95%
```

In addition, in the process of making this PR I've found a missing ideal transform for `RShiftLNode`, so right shifts of large numbers (such as `x >> 65`) are not properly folded down, like how they are `RShiftINode` and `URShiftLNode`. I'll address this in a future RFR.

Testing: GHA, tier1 local, and performance testing

Thanks,
Jasmine K

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8303238](https://bugs.openjdk.org/browse/JDK-8303238): Create generalizations for existing LShift ideal transforms


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [bd161561](https://git.openjdk.org/jdk/pull/12734/files/bd1615614119b249377f69c79f77ac97d5d4c4f0)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12734/head:pull/12734` \
`$ git checkout pull/12734`

Update a local copy of the PR: \
`$ git checkout pull/12734` \
`$ git pull https://git.openjdk.org/jdk pull/12734/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12734`

View PR using the GUI difftool: \
`$ git pr show -t 12734`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12734.diff">https://git.openjdk.org/jdk/pull/12734.diff</a>

</details>
