### PR TITLE
8029370: (fc) FileChannel javadoc not clear for cases where position == size

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -633,7 +633,7 @@ public abstract class FileChannel
      * bytes free in its output buffer.
      *
      * <p> This method does not modify this channel's position.  If the given
-     * position is greater than the file's current size then no bytes are
+     * position is greater than or equal to the file's current size then no bytes are
      * transferred.  If the target channel has a position then bytes are
      * written starting at that position and then the position is incremented
      * by the number of bytes written.
@@ -761,7 +761,7 @@ public abstract class FileChannel
      * #read(ByteBuffer)} method, except that bytes are read starting at the
      * given file position rather than at the channel's current position.  This
      * method does not modify this channel's position.  If the given position
-     * is greater than the file's current size then no bytes are read.  </p>
+     * is greater than or equal to the file's current size then no bytes are read.  </p>
      *
      * @param  dst
      *         The buffer into which bytes are to be transferred
@@ -806,7 +806,7 @@ public abstract class FileChannel
      * #write(ByteBuffer)} method, except that bytes are written starting at
      * the given file position rather than at the channel's current position.
      * This method does not modify this channel's position.  If the given
-     * position is greater than the file's current size then the file will be
+     * position is greater than or equal to the file's current size then the file will be
      * grown to accommodate the new bytes; the values of any bytes between the
      * previous end-of-file and the newly-written bytes are unspecified.  </p>
      *


### PR DESCRIPTION
Modify the specifications of the `java.nio.channels.FileChannel` methods `transferTo`, `read(ByteBuffer,long)`, and `write(ByteBuffer,long)` to state "greater than or equal to the file's current size" with respect to the given position instead of "greater than the file's current size."

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8303141](https://bugs.openjdk.org/browse/JDK-8303141) to be approved

### Issues
 * [JDK-8029370](https://bugs.openjdk.org/browse/JDK-8029370): (fc) FileChannel javadoc not clear for cases where position == size
 * [JDK-8303141](https://bugs.openjdk.org/browse/JDK-8303141): (fc) FileChannel javadoc not clear for cases where position == size (**CSR**)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12735/head:pull/12735` \
`$ git checkout pull/12735`

Update a local copy of the PR: \
`$ git checkout pull/12735` \
`$ git pull https://git.openjdk.org/jdk pull/12735/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12735`

View PR using the GUI difftool: \
`$ git pr show -t 12735`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12735.diff">https://git.openjdk.org/jdk/pull/12735.diff</a>

</details>
