### PR TITLE
8303070: Memory leak in DCmdArgument<char*>::parse_value

### DIFF
--- a/src/hotspot/share/services/diagnosticArgument.cpp
+++ b/src/hotspot/share/services/diagnosticArgument.cpp
@@ -178,10 +178,15 @@ template <> void DCmdArgument<bool>::init_value(TRAPS) {
 
 template <> void DCmdArgument<bool>::destroy_value() { }
 
+template <> void DCmdArgument<char*>::destroy_value() {
+  FREE_C_HEAP_ARRAY(char, _value);
+  set_value(nullptr);
+}
+
 template <> void DCmdArgument<char*>::parse_value(const char* str,
                                                   size_t len, TRAPS) {
   if (str == nullptr) {
-    _value = nullptr;
+    destroy_value();
   } else {
     // Use realloc as we may have a default set.
     _value = REALLOC_C_HEAP_ARRAY(char, _value, len + 1, mtInternal);
@@ -195,11 +200,6 @@ template <> void DCmdArgument<char*>::init_value(TRAPS) {
   if (has_default()) {
     this->parse_value(_default_string, strlen(_default_string), THREAD);
   }
-}
-
-template <> void DCmdArgument<char*>::destroy_value() {
-  FREE_C_HEAP_ARRAY(char, _value);
-  set_value(nullptr);
 }
 
 template <> void DCmdArgument<NanoTimeArgument>::parse_value(const char* str,

--- a/src/hotspot/share/services/diagnosticArgument.cpp
+++ b/src/hotspot/share/services/diagnosticArgument.cpp
@@ -194,9 +194,6 @@ template <> void DCmdArgument<char*>::init_value(TRAPS) {
   set_value(nullptr); // Must be initialized before calling parse_value
   if (has_default() && _default_string != nullptr) {
     this->parse_value(_default_string, strlen(_default_string), THREAD);
-    if (HAS_PENDING_EXCEPTION) {
-     fatal("Default string must be parsable");
-    }
   }
 }
 

--- a/src/hotspot/share/services/diagnosticArgument.cpp
+++ b/src/hotspot/share/services/diagnosticArgument.cpp
@@ -183,20 +183,20 @@ template <> void DCmdArgument<char*>::parse_value(const char* str,
   if (str == nullptr) {
     _value = nullptr;
   } else {
-    _value = NEW_C_HEAP_ARRAY(char, len + 1, mtInternal);
+    // Use realloc as we may have a default set.
+    _value = REALLOC_C_HEAP_ARRAY(char, _value, len + 1, mtInternal);
     int n = os::snprintf(_value, len + 1, "%.*s", (int)len, str);
     assert((size_t)n <= len, "Unexpected number of characters in string");
   }
 }
 
 template <> void DCmdArgument<char*>::init_value(TRAPS) {
+  set_value(nullptr); // Must be initialized before calling parse_value
   if (has_default() && _default_string != nullptr) {
     this->parse_value(_default_string, strlen(_default_string), THREAD);
     if (HAS_PENDING_EXCEPTION) {
      fatal("Default string must be parsable");
     }
-  } else {
-    set_value(nullptr);
   }
 }
 

--- a/src/hotspot/share/services/diagnosticArgument.cpp
+++ b/src/hotspot/share/services/diagnosticArgument.cpp
@@ -192,7 +192,7 @@ template <> void DCmdArgument<char*>::parse_value(const char* str,
 
 template <> void DCmdArgument<char*>::init_value(TRAPS) {
   set_value(nullptr); // Must be initialized before calling parse_value
-  if (has_default() && _default_string != nullptr) {
+  if (has_default()) {
     this->parse_value(_default_string, strlen(_default_string), THREAD);
   }
 }

--- a/test/hotspot/jtreg/runtime/NMT/JcmdScale.java
+++ b/test/hotspot/jtreg/runtime/NMT/JcmdScale.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,5 +74,12 @@ public class JcmdScale {
     output = new OutputAnalyzer(pb.start());
     output.shouldContain("Incorrect scale value: apa");
 
+    pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "summary", "scale="});
+    output = new OutputAnalyzer(pb.start());
+    output.shouldContain("Incorrect scale value:");
+
+    pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "summary", "scale"});
+    output = new OutputAnalyzer(pb.start());
+    output.shouldContain("Incorrect scale value: (null)");
   }
 }


### PR DESCRIPTION
If we have a default value for the char* DCmdArgument we copy it into the `_value` field using `parse_value` to make a copy in C-heap. If we then parse an actual argument value, we replace the default but don't free it. The parse method needs to use realloc.

Thanks to @jcking for spotting the cause.

Testing: tiers 1-3 

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303070](https://bugs.openjdk.org/browse/JDK-8303070): Memory leak in DCmdArgument&lt;char*&gt;::parse_value


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)
 * [Justin King](https://openjdk.org/census#jcking) (@jcking - Committer)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - Committer)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12737/head:pull/12737` \
`$ git checkout pull/12737`

Update a local copy of the PR: \
`$ git checkout pull/12737` \
`$ git pull https://git.openjdk.org/jdk pull/12737/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12737`

View PR using the GUI difftool: \
`$ git pr show -t 12737`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12737.diff">https://git.openjdk.org/jdk/pull/12737.diff</a>

</details>
