### PR TITLE
8303068: Memory leak in DwarfFile::LineNumberProgram::run_line_number_program

### DIFF
--- a/src/hotspot/share/utilities/elfFile.cpp
+++ b/src/hotspot/share/utilities/elfFile.cpp
@@ -1330,8 +1330,7 @@ bool DwarfFile::LineNumberProgram::run_line_number_program(char* filename, const
       if (does_offset_match_entry(previous_address, previous_file, previous_line)) {
         // We are using an int for the line number which should never be larger than INT_MAX for any files.
         *line = (int)_state->_line;
-        bool ret = get_filename_from_header(_state->_file, filename, filename_len);
-        return ret;
+        return get_filename_from_header(_state->_file, filename, filename_len);
       }
 
       // We do not actually store the matrix while searching the correct entry. Enable logging to print/debug it.
@@ -1347,6 +1346,7 @@ bool DwarfFile::LineNumberProgram::run_line_number_program(char* filename, const
       }
     }
   }
+
   assert(false, "Did not find an entry in the line number information matrix that matches " UINT32_FORMAT_X_0, _offset_in_library);
   return false;
 }

--- a/src/hotspot/share/utilities/elfFile.cpp
+++ b/src/hotspot/share/utilities/elfFile.cpp
@@ -1315,7 +1315,6 @@ bool DwarfFile::LineNumberProgram::run_line_number_program(char* filename, const
   while (_reader.has_bytes_left()) {
     if (!apply_opcode()) {
       assert(false, "Could not apply opcode");
-      delete _state;
       return false;
     }
 
@@ -1332,7 +1331,6 @@ bool DwarfFile::LineNumberProgram::run_line_number_program(char* filename, const
         // We are using an int for the line number which should never be larger than INT_MAX for any files.
         *line = (int)_state->_line;
         bool ret = get_filename_from_header(_state->_file, filename, filename_len);
-        delete _state;
         return ret;
       }
 
@@ -1349,7 +1347,6 @@ bool DwarfFile::LineNumberProgram::run_line_number_program(char* filename, const
       }
     }
   }
-  delete _state;
   assert(false, "Did not find an entry in the line number information matrix that matches " UINT32_FORMAT_X_0, _offset_in_library);
   return false;
 }

--- a/src/hotspot/share/utilities/elfFile.cpp
+++ b/src/hotspot/share/utilities/elfFile.cpp
@@ -1315,6 +1315,7 @@ bool DwarfFile::LineNumberProgram::run_line_number_program(char* filename, const
   while (_reader.has_bytes_left()) {
     if (!apply_opcode()) {
       assert(false, "Could not apply opcode");
+      delete _state;
       return false;
     }
 
@@ -1330,7 +1331,9 @@ bool DwarfFile::LineNumberProgram::run_line_number_program(char* filename, const
       if (does_offset_match_entry(previous_address, previous_file, previous_line)) {
         // We are using an int for the line number which should never be larger than INT_MAX for any files.
         *line = (int)_state->_line;
-        return get_filename_from_header(_state->_file, filename, filename_len);
+        bool ret = get_filename_from_header(_state->_file, filename, filename_len);
+        delete _state;
+        return ret;
       }
 
       // We do not actually store the matrix while searching the correct entry. Enable logging to print/debug it.
@@ -1346,7 +1349,7 @@ bool DwarfFile::LineNumberProgram::run_line_number_program(char* filename, const
       }
     }
   }
-
+  delete _state;
   assert(false, "Did not find an entry in the line number information matrix that matches " UINT32_FORMAT_X_0, _offset_in_library);
   return false;
 }

--- a/src/hotspot/share/utilities/elfFile.hpp
+++ b/src/hotspot/share/utilities/elfFile.hpp
@@ -877,6 +877,8 @@ class DwarfFile : public ElfFile {
       : _dwarf_file(dwarf_file), _reader(dwarf_file->fd()), _offset_in_library(offset_in_library),
         _debug_line_offset(debug_line_offset), _is_pc_after_call(is_pc_after_call) {}
 
+    ~LineNumberProgram() { delete _state; }
+
     bool find_filename_and_line_number(char* filename, size_t filename_len, int* line);
   };
 


### PR DESCRIPTION
After allocating:
```
_state = new (std::nothrow) LineNumberProgramState(_header);
```
we need to `delete _state` before returning.

Testing: tiers 1-3

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303068](https://bugs.openjdk.org/browse/JDK-8303068): Memory leak in DwarfFile::LineNumberProgram::run_line_number_program


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - Committer)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12738/head:pull/12738` \
`$ git checkout pull/12738`

Update a local copy of the PR: \
`$ git checkout pull/12738` \
`$ git pull https://git.openjdk.org/jdk pull/12738/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12738`

View PR using the GUI difftool: \
`$ git pr show -t 12738`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12738.diff">https://git.openjdk.org/jdk/pull/12738.diff</a>

</details>
