### PR TITLE
8289497:java/awt/EmbeddedFrame/EmbeddedFrameGrabTest/EmbeddedFrameGra…

### DIFF
--- a/test/jdk/java/awt/EmbeddedFrame/EmbeddedFrameGrabTest/EmbeddedFrameGrabTest.java
+++ b/test/jdk/java/awt/EmbeddedFrame/EmbeddedFrameGrabTest/EmbeddedFrameGrabTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,7 +103,12 @@ public class EmbeddedFrameGrabTest {
         robot.mouseRelease(InputEvent.BUTTON1_MASK);
         robot.delay(1000);
         if (!combo.isPopupVisible()) {
-            throw new RuntimeException("Combobox popup is not visible!");
+            robot.mousePress(InputEvent.BUTTON1_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            robot.delay(1000);
+            if (!combo.isPopupVisible()) {
+                throw new RuntimeException("Combobox popup is not visible!");
+            }
         }
         robot.mouseMove(clos.x + clos.width / 2, clos.y + clos.height + 3);
         robot.mousePress(InputEvent.BUTTON1_MASK);


### PR DESCRIPTION
EmbeddedFrameGrabTest.java still fails on Windows Server 2016/2019 (deployed on VMware Cloud Services), 
but passed on Windows 10 22H2.
This problem seems unexpected WM_LBUTTONDOWN message is sent to EmbeddedFrame peer at first click on specific platform.
So, I propose adding once retry click at first action.
After this change, test is passed on Windows Server 2019.

Please review this fix.
Thank you.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12739/head:pull/12739` \
`$ git checkout pull/12739`

Update a local copy of the PR: \
`$ git checkout pull/12739` \
`$ git pull https://git.openjdk.org/jdk.git pull/12739/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12739`

View PR using the GUI difftool: \
`$ git pr show -t 12739`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12739.diff">https://git.openjdk.org/jdk/pull/12739.diff</a>

</details>
