### PR TITLE
JDK-8292583: Comment for ciArrayKlass::make is wrong

### DIFF
--- a/src/hotspot/share/ci/ciArrayKlass.cpp
+++ b/src/hotspot/share/ci/ciArrayKlass.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/ci/ciArrayKlass.cpp
+++ b/src/hotspot/share/ci/ciArrayKlass.cpp
@@ -94,9 +94,9 @@ bool ciArrayKlass::is_leaf_type() {
 
 
 // ------------------------------------------------------------------
-// ciArrayKlass::base_element_type
+// ciArrayKlass::make
 //
-// What type is obtained when this array is indexed as many times as possible?
+// Make an array klass of the specified element type.
 ciArrayKlass* ciArrayKlass::make(ciType* element_type) {
   if (element_type->is_primitive_type()) {
     return ciTypeArrayKlass::make(element_type->basic_type());


### PR DESCRIPTION
The comment for ciArrayKlass::make is wrong (probably a result of a copy/paste).

Fixing the comment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292583](https://bugs.openjdk.org/browse/JDK-8292583): Comment for ciArrayKlass::make is wrong


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12740/head:pull/12740` \
`$ git checkout pull/12740`

Update a local copy of the PR: \
`$ git checkout pull/12740` \
`$ git pull https://git.openjdk.org/jdk pull/12740/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12740`

View PR using the GUI difftool: \
`$ git pr show -t 12740`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12740.diff">https://git.openjdk.org/jdk/pull/12740.diff</a>

</details>
