### PR TITLE
8303135: JFR: Log periodic events using periodic tag

### DIFF
--- a/src/hotspot/share/jfr/utilities/jfrLogTagSets.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrLogTagSets.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,6 +55,8 @@
   JFR_LOG_TAG(jfr, system, metadata) \
   JFR_LOG_TAG(jfr, system, streaming) \
   JFR_LOG_TAG(jfr, system, throttle) \
+  JFR_LOG_TAG(jfr, system, periodic) \
+  JFR_LOG_TAG(jfr, periodic) \
   JFR_LOG_TAG(jfr, metadata) \
   JFR_LOG_TAG(jfr, event) \
   JFR_LOG_TAG(jfr, setting) \

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/LogTag.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/LogTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,25 +71,33 @@ public enum LogTag {
      */
     JFR_SYSTEM_THROTTLE(8),
     /**
+     *  Covers periodic task work (for Hotspot developer)
+     */
+    JFR_SYSTEM_PERIODIC(9),
+    /**
+     *  Covers periodic event work (for users of the JDK)
+     */
+    JFR_PERIODIC(10),
+    /**
      *  Covers metadata for Java user (for Hotspot developers)
      */
-    JFR_METADATA(9),
+    JFR_METADATA(11),
     /**
      * Covers events (for users of the JDK)
      */
-    JFR_EVENT(10),
+    JFR_EVENT(12),
     /**
      * Covers setting (for users of the JDK)
      */
-    JFR_SETTING(11),
+    JFR_SETTING(13),
     /**
      * Covers usage of jcmd with JFR
      */
-    JFR_DCMD(12),
+    JFR_DCMD(14),
     /**
      * -XX:StartFlightRecording
      */
-    JFR_START(13);
+    JFR_START(15);
 
     /* set from native side */
     volatile int tagSetLevel = 100; // prevent logging if JVM log system has not been initialized

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/BatchManager.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/BatchManager.java
@@ -50,6 +50,7 @@ final class BatchManager {
     }
 
     public void refresh(long iteration, List<PeriodicTask> tasks) {
+        Logger.log(LogTag.JFR_SYSTEM_PERIODIC, LogLevel.DEBUG, "Grouping tasks into batches. Iteration " + iteration);
         groupTasksIntoBatches(tasks);
         this.iteration = iteration;
         logBatches();
@@ -107,19 +108,17 @@ final class BatchManager {
     }
 
     private void logBatches() {
-        if (!Logger.shouldLog(LogTag.JFR, LogLevel.TRACE)) {
+        if (!Logger.shouldLog(LogTag.JFR_SYSTEM_PERIODIC, LogLevel.TRACE)) {
             return;
         }
-        String prefix = "Periodic task: settings iteration: " + iteration + ", batch period: ";
         for (Batch batch : batches) {
-            String batchPrefix = prefix + batch.getPeriod();
             for (PeriodicTask task : batch.getTasks()) {
-                logTrace(batchPrefix + ", period: " + task.getPeriod() + ", task: " + task.getName());
+                logTrace("Batched task [0.." + task.getPeriod() + "] step " + batch.getPeriod() + " " + task.getName());
             }
         }
     }
 
     private void logTrace(String text) {
-       Logger.log(LogTag.JFR_SYSTEM, LogLevel.TRACE, text);
+       Logger.log(LogTag.JFR_SYSTEM_PERIODIC, LogLevel.DEBUG, text);
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/EventTask.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/EventTask.java
@@ -33,7 +33,7 @@ abstract class EventTask extends PeriodicTask {
     private final PlatformEventType eventType;
 
     public EventTask(PlatformEventType eventType, LookupKey lookupKey) {
-        super(lookupKey, eventType.getLogName());
+        super(lookupKey, "event " + eventType.getLogName());
         this.eventType = eventType;
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/FlushTask.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/FlushTask.java
@@ -39,7 +39,7 @@ final class FlushTask extends PeriodicTask {
     private volatile long flushInterval = Long.MAX_VALUE;
 
     public FlushTask() {
-        super(new LookupKey(new Object()), "JFR: Flush Task");
+        super(new LookupKey(new Object()), "flush task");
     }
 
     @Override

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/PeriodicEvents.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/PeriodicEvents.java
@@ -31,6 +31,9 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import jdk.jfr.Event;
 import jdk.jfr.internal.JVM;
+import jdk.jfr.internal.LogLevel;
+import jdk.jfr.internal.LogTag;
+import jdk.jfr.internal.Logger;
 import jdk.jfr.internal.PlatformEventType;
 
 /**
@@ -132,6 +135,7 @@ public final class PeriodicEvents {
 
         }
         boolean flush = false;
+        Logger.log(LogTag.JFR_PERIODIC, LogLevel.DEBUG,"Periodic work started");
         for (Batch batch : batchManager.getBatches()) {
             long left = 0;
             long r_period = batch.getPeriod();
@@ -178,6 +182,7 @@ public final class PeriodicEvents {
         if (flush) {
             flushTask.run(eventTimestamp, PeriodicType.INTERVAL);
         }
+        Logger.log(LogTag.JFR_PERIODIC, LogLevel.DEBUG,"Periodic work ended");
         lastTimeMillis = now;
         return min;
     }


### PR DESCRIPTION
Could I have a review of PR that improves logging for periodic events. 

Testing: jdk/jdk/jfr, tier1, tier2

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303135](https://bugs.openjdk.org/browse/JDK-8303135): JFR: Log periodic events using periodic tag


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12741/head:pull/12741` \
`$ git checkout pull/12741`

Update a local copy of the PR: \
`$ git checkout pull/12741` \
`$ git pull https://git.openjdk.org/jdk pull/12741/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12741`

View PR using the GUI difftool: \
`$ git pr show -t 12741`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12741.diff">https://git.openjdk.org/jdk/pull/12741.diff</a>

</details>
