### PR TITLE
8303169: Remove Windows specific workaround from libdt

### DIFF
--- a/src/jdk.jdi/share/native/libdt_shmem/shmemBase.c
+++ b/src/jdk.jdi/share/native/libdt_shmem/shmemBase.c
@@ -31,9 +31,7 @@
 #include "shmemBase.h"
 #include "jdwpTransport.h"  /* for Packet, TransportCallback */
 
-#if defined(_WIN32)
-  #define PRId64 "I64d"
-#endif
+#include <inttypes.h>
 
 #define MIN(x,y) ((x)<(y)?(x):(y))
 

--- a/src/jdk.jdi/share/native/libdt_shmem/shmemBase.c
+++ b/src/jdk.jdi/share/native/libdt_shmem/shmemBase.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,12 +26,11 @@
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 #include "sysShmem.h"
 #include "shmemBase.h"
 #include "jdwpTransport.h"  /* for Packet, TransportCallback */
-
-#include <inttypes.h>
 
 #define MIN(x,y) ((x)<(y)?(x):(y))
 


### PR DESCRIPTION
We no longer need to define PrId64 ourselves since the Visual C++ compiler supports inttypes.h on the only versions we support, so we can just replace it with an include to the standard header instead

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303169](https://bugs.openjdk.org/browse/JDK-8303169): Remove Windows specific workaround from libdt


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [e6b8b2a4](https://git.openjdk.org/jdk/pull/12744/files/e6b8b2a437dfd47c3f173d0da4c7fa35efa446a0)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [e6b8b2a4](https://git.openjdk.org/jdk/pull/12744/files/e6b8b2a437dfd47c3f173d0da4c7fa35efa446a0)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) ⚠️ Review applies to [e6b8b2a4](https://git.openjdk.org/jdk/pull/12744/files/e6b8b2a437dfd47c3f173d0da4c7fa35efa446a0)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12744/head:pull/12744` \
`$ git checkout pull/12744`

Update a local copy of the PR: \
`$ git checkout pull/12744` \
`$ git pull https://git.openjdk.org/jdk pull/12744/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12744`

View PR using the GUI difftool: \
`$ git pr show -t 12744`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12744.diff">https://git.openjdk.org/jdk/pull/12744.diff</a>

</details>
