### PR TITLE
8303083: (bf) Remove private DirectByteBuffer(long, int) constructor before JDK 21 GA

### DIFF
--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -187,11 +187,6 @@ class Direct$Type$Buffer$RW$$BO$
         att = null;
     }
 
-    // Temporarily keep the long,int constructor around
-    private Direct$Type$Buffer(long addr, int cap) {
-        this(addr, (long)cap);
-    }
-
     // Throw an IllegalArgumentException if the capacity is not in
     // the range [0, Integer.MAX_VALUE]
     //


### PR DESCRIPTION
Remove the `DirectByteBuffer` constructor what was originally removed by #11873 and subsequently reinstated #12717.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303083](https://bugs.openjdk.org/browse/JDK-8303083): (bf) Remove private DirectByteBuffer(long, int) constructor before JDK 21 GA


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12745/head:pull/12745` \
`$ git checkout pull/12745`

Update a local copy of the PR: \
`$ git checkout pull/12745` \
`$ git pull https://git.openjdk.org/jdk pull/12745/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12745`

View PR using the GUI difftool: \
`$ git pr show -t 12745`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12745.diff">https://git.openjdk.org/jdk/pull/12745.diff</a>

</details>
