### PR TITLE
8303175: (fs) Deprecate com.sun.nio.file.SensitivityWatchEventModifier for removal

### DIFF
--- a/src/jdk.unsupported/share/classes/com/sun/nio/file/SensitivityWatchEventModifier.java
+++ b/src/jdk.unsupported/share/classes/com/sun/nio/file/SensitivityWatchEventModifier.java
@@ -33,11 +33,12 @@ import jdk.internal.misc.FileSystemOption;
  * watch service implementation that polls the file system.
  *
  * @deprecated
- * This {@code enum} is only used by the polling implementation of
- * {@link java.nio.file.WatchService WatchService}.  The polling
- * {@code WatchService} is used only on macOS and likely to be removed
- * in a future release when a version based on the native file event
- * notification facility becomes available.
+ * The polling implementation of {@link java.nio.file.WatchService WatchService}
+ * no longer recognizes this {@link java.nio.file.WatchEvent.Modifier
+ * WatchEvent.Modifier}.  This was the only {@code WatchService} in the JDK
+ * which used this {@code WatchEvent.Modifier}.  Therefore this
+ * {@code WatchEvent.Modifier} class is vestigial and should be removed in a
+ * future release.
  *
  * @since 1.7
  */

--- a/src/jdk.unsupported/share/classes/com/sun/nio/file/SensitivityWatchEventModifier.java
+++ b/src/jdk.unsupported/share/classes/com/sun/nio/file/SensitivityWatchEventModifier.java
@@ -42,7 +42,7 @@ import jdk.internal.misc.FileSystemOption;
  * @since 1.7
  */
 
-@Deprecated(since="7", forRemoval = true)
+@Deprecated(since="21", forRemoval = true)
 public enum SensitivityWatchEventModifier implements Modifier {
     /**
      * High sensitivity.

--- a/src/jdk.unsupported/share/classes/com/sun/nio/file/SensitivityWatchEventModifier.java
+++ b/src/jdk.unsupported/share/classes/com/sun/nio/file/SensitivityWatchEventModifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,8 +33,15 @@ import jdk.internal.misc.FileSystemOption;
  * watch service implementation that polls the file system.
  *
  * @since 1.7
+ *
+ * @deprecated
+ * This {@code enum} is only used by the polling implementation of
+ * {@code WatchService}.  This implementation is used only on macOS and
+ * likely to be removed in a future release when a version based on the native
+ * file event notification facility becomes available.
  */
 
+@Deprecated(since="7", forRemoval = true)
 public enum SensitivityWatchEventModifier implements Modifier {
     /**
      * High sensitivity.

--- a/src/jdk.unsupported/share/classes/com/sun/nio/file/SensitivityWatchEventModifier.java
+++ b/src/jdk.unsupported/share/classes/com/sun/nio/file/SensitivityWatchEventModifier.java
@@ -32,13 +32,14 @@ import jdk.internal.misc.FileSystemOption;
  * Defines the <em>sensitivity levels</em> when registering objects with a
  * watch service implementation that polls the file system.
  *
- * @since 1.7
- *
  * @deprecated
  * This {@code enum} is only used by the polling implementation of
- * {@code WatchService}.  This implementation is used only on macOS and
- * likely to be removed in a future release when a version based on the native
- * file event notification facility becomes available.
+ * {@link java.nio.file.WatchService WatchService}.  The polling
+ * {@code WatchService} is used only on macOS and likely to be removed
+ * in a future release when a version based on the native file event
+ * notification facility becomes available.
+ *
+ * @since 1.7
  */
 
 @Deprecated(since="7", forRemoval = true)

--- a/src/jdk.unsupported/share/classes/com/sun/nio/file/SensitivityWatchEventModifier.java
+++ b/src/jdk.unsupported/share/classes/com/sun/nio/file/SensitivityWatchEventModifier.java
@@ -33,12 +33,12 @@ import jdk.internal.misc.FileSystemOption;
  * watch service implementation that polls the file system.
  *
  * @deprecated
- * The polling implementation of {@link java.nio.file.WatchService WatchService}
- * no longer recognizes this {@link java.nio.file.WatchEvent.Modifier
- * WatchEvent.Modifier}.  This was the only {@code WatchService} in the JDK
- * which used this {@code WatchEvent.Modifier}.  Therefore this
- * {@code WatchEvent.Modifier} class is vestigial and should be removed in a
- * future release.
+ * The sensitivity levels were historically used by polling-based
+ * {@link java.nio.file.WatchService WatchService} implementations to configure
+ * the polling interval. They are are no longer used. The {@code WatchService}
+ * implementations in the JDK ignore these {@link java.nio.file.WatchEvent
+ * WatchEvent} modifiers if they are specified when registering a directory
+ * to be watched.
  *
  * @since 1.7
  */


### PR DESCRIPTION
Deprecate `SensitivityWatchEventModifier` for now instead of directly removing it as proposed in #12626.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8303188](https://bugs.openjdk.org/browse/JDK-8303188) to be approved

### Issues
 * [JDK-8303175](https://bugs.openjdk.org/browse/JDK-8303175): (fs) Deprecate com.sun.nio.file.SensitivityWatchEventModifier for removal
 * [JDK-8303188](https://bugs.openjdk.org/browse/JDK-8303188): (fs) Deprecate com.sun.nio.file.SensitivityWatchEventModifier for removal (**CSR**)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to [b3ea4f71](https://git.openjdk.org/jdk/pull/12746/files/b3ea4f71d8e8a36afb3bd8df69621310560cc4d6)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12746/head:pull/12746` \
`$ git checkout pull/12746`

Update a local copy of the PR: \
`$ git checkout pull/12746` \
`$ git pull https://git.openjdk.org/jdk pull/12746/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12746`

View PR using the GUI difftool: \
`$ git pr show -t 12746`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12746.diff">https://git.openjdk.org/jdk/pull/12746.diff</a>

</details>
