### PR TITLE
8303186: Missing Classpath exception from Continuation.c

### DIFF
--- a/src/java.base/share/native/libjava/Continuation.c
+++ b/src/java.base/share/native/libjava/Continuation.c
@@ -4,7 +4,9 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or


### PR DESCRIPTION
This PR adds the Classpath exception to the header file of `src/java.base/share/native/libjava/Continuation.c`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303186](https://bugs.openjdk.org/browse/JDK-8303186): Missing Classpath exception from Continuation.c


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12747/head:pull/12747` \
`$ git checkout pull/12747`

Update a local copy of the PR: \
`$ git checkout pull/12747` \
`$ git pull https://git.openjdk.org/jdk pull/12747/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12747`

View PR using the GUI difftool: \
`$ git pr show -t 12747`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12747.diff">https://git.openjdk.org/jdk/pull/12747.diff</a>

</details>
