### PR TITLE
8303133: Update ProcessTools.startProcess(...) to exit early if process exit before linePredicate is printed.

### DIFF
--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -222,13 +222,17 @@ public final class ProcessTools {
 
                 if (latch.getCount() != 0) {
                     if (!p.isAlive()) {
-                        throw new RuntimeException("Started process " + name + " is not alive.");
+                        // Give some extra time for the StreamPumper to run after the process completed
+                        Thread.sleep(1000);
+                        if (latch.getCount() > 0) {
+                            throw new RuntimeException("Started process " + name + " is not alive.");
+                        }
                     } else {
                         throw new TimeoutException();
                     }
                 }
             }
-        } catch (TimeoutException | RuntimeException e) {
+        } catch (TimeoutException | RuntimeException | InterruptedException e) {
             System.err.println("Failed to start a process (thread dump follows)");
             for (Map.Entry<Thread, StackTraceElement[]> s : Thread.getAllStackTraces().entrySet()) {
                 printStack(s.getKey(), s.getValue());

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -225,7 +225,7 @@ public final class ProcessTools {
                         // Give some extra time for the StreamPumper to run after the process completed
                         Thread.sleep(1000);
                         if (latch.getCount() > 0) {
-                            throw new RuntimeException("Started process " + name + " is not alive.");
+                            throw new RuntimeException("Started process " + name + " terminated before producing the expected output.");
                         }
                     } else {
                         throw new TimeoutException();

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -220,7 +220,7 @@ public final class ProcessTools {
                 Utils.waitForCondition(() -> latch.getCount() == 0 || !p.isAlive(),
                         unit.toMillis(Utils.adjustTimeout(timeout)), 1000);
 
-                if (latch.getCount() != 0) {
+                if (latch.getCount() > 0) {
                     if (!p.isAlive()) {
                         // Give some extra time for the StreamPumper to run after the process completed
                         Thread.sleep(1000);

--- a/test/lib/jdk/test/lib/thread/ProcessThread.java
+++ b/test/lib/jdk/test/lib/thread/ProcessThread.java
@@ -150,8 +150,6 @@ public class ProcessThread extends TestThread {
          */
         @Override
         public void xrun() throws Throwable {
-            String name = Thread.currentThread().getName();
-
             try {
                 this.process = ProcessTools.startProcess(name, processBuilder, waitfor);
             } catch (Throwable t) {

--- a/test/lib/jdk/test/lib/thread/ProcessThread.java
+++ b/test/lib/jdk/test/lib/thread/ProcessThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -150,16 +150,23 @@ public class ProcessThread extends TestThread {
          */
         @Override
         public void xrun() throws Throwable {
-            this.process = ProcessTools.startProcess(name, processBuilder, waitfor);
-            // Release when process is started
-            latch.countDown();
+            String name = Thread.currentThread().getName();
 
-            // Will block...
             try {
-                this.process.waitFor();
-                output = new OutputAnalyzer(this.process);
+                this.process = ProcessTools.startProcess(name, processBuilder, waitfor);
             } catch (Throwable t) {
-                String name = Thread.currentThread().getName();
+                System.out.println(String.format("ProcessThread[%s] failed: %s", name, t.toString()));
+                throw t;
+            } finally {
+                // Release when process is started or failed
+                latch.countDown();
+            }
+
+            try {
+                output = new OutputAnalyzer(this.process);
+                // Will block...
+                this.process.waitFor();
+            } catch (Throwable t) {
                 System.out.println(String.format("ProcessThread[%s] failed: %s", name, t.toString()));
                 throw t;
             } finally {


### PR DESCRIPTION
The solution proposed by Stefan K

The startProcess() might wait forever for the expected line if the process exits (failed to start). It makes sense to just fail earlier in such cases.

The fix also move
'output = new OutputAnalyzer(this.process);'
in method xrun() to be able to try to print them in waitFor is failed/interrupted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303133](https://bugs.openjdk.org/browse/JDK-8303133): Update ProcessTools.startProcess(...) to exit early if process exit before linePredicate is printed.


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12751/head:pull/12751` \
`$ git checkout pull/12751`

Update a local copy of the PR: \
`$ git checkout pull/12751` \
`$ git pull https://git.openjdk.org/jdk pull/12751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12751`

View PR using the GUI difftool: \
`$ git pr show -t 12751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12751.diff">https://git.openjdk.org/jdk/pull/12751.diff</a>

</details>
