### PR TITLE
8302795: Shared archive failed on old version class with jsr bytecode

### DIFF
--- a/src/hotspot/share/interpreter/rewriter.cpp
+++ b/src/hotspot/share/interpreter/rewriter.cpp
@@ -624,11 +624,6 @@ Rewriter::Rewriter(InstanceKlass* klass, const constantPoolHandle& cpool, Array<
   // rewritten in the RO section of the shared archive.
   // Relocated bytecodes don't have to be restored, only the cp cache entries
   int len = _methods->length();
-#if INCLUDE_CDS
-  // For old shared classes, in order to avoid writing into the CDS archive, don't update
-  // the methods with jsr bytecode.
-  bool do_update = !(UseSharedSpaces && _klass->is_shared() && _klass->major_version() < 50);
-#endif
   for (int i = len-1; i >= 0; i--) {
     methodHandle m(THREAD, _methods->at(i));
 
@@ -642,10 +637,7 @@ Rewriter::Rewriter(InstanceKlass* klass, const constantPoolHandle& cpool, Array<
         return;
       }
       // Method might have gotten rewritten.
-#if INCLUDE_CDS
-      if (do_update)
-#endif
-        methods->at_put(i, m());
+      methods->at_put(i, m());
     }
   }
 }

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2406,7 +2406,21 @@ void InstanceKlass::metaspace_pointers_do(MetaspaceClosure* it) {
 #if INCLUDE_JVMTI
   it->push(&_previous_versions);
 #endif
-  it->push(&_methods);
+#if INCLUDE_CDS
+  // For "old" classes with methods containing the jsr bytecode, the _methods array will
+  // be rewritten during runtime (see Rewriter::rewrite_jsrs()). So setting the _methods to
+  // be writable. The length check on the _methods is necessary because classes which
+  // don't have any methods share the Universe::_the_empty_method_array which is in the RO region.
+  if (_methods != nullptr && _methods->length() > 0 &&
+      !can_be_verified_at_dumptime() && methods_contain_jsr_bytecode()) {
+    // To handle jsr bytecode, new Method* maybe stored into _methods
+    it->push(&_methods, MetaspaceClosure::_writable);
+  } else {
+#endif
+    it->push(&_methods);
+#if INCLUDE_CDS
+  }
+#endif
   it->push(&_default_methods);
   it->push(&_local_interfaces);
   it->push(&_transitive_interfaces);
@@ -2613,6 +2627,21 @@ bool InstanceKlass::can_be_verified_at_dumptime() const {
     }
   }
   return true;
+}
+
+bool InstanceKlass::methods_contain_jsr_bytecode() const {
+  Thread* thread = Thread::current();
+  for (int i = 0; i < _methods->length(); i++) {
+    methodHandle m(thread, _methods->at(i));
+    BytecodeStream bcs(m);
+    while (!bcs.is_last_bytecode()) {
+      Bytecodes::Code opcode = bcs.next();
+      if (opcode == Bytecodes::_jsr || opcode == Bytecodes::_jsr_w) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 #endif // INCLUDE_CDS
 

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1144,6 +1144,7 @@ public:
   void restore_unshareable_info(ClassLoaderData* loader_data, Handle protection_domain, PackageEntry* pkg_entry, TRAPS);
   void init_shared_package_entry();
   bool can_be_verified_at_dumptime() const;
+  bool methods_contain_jsr_bytecode() const;
 #endif
 
   jint compute_modifier_flags() const;

--- a/test/hotspot/jtreg/runtime/cds/appcds/OldClassWithjsr.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/OldClassWithjsr.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+/*
+ * @test
+ * @bug 8302795
+ * @summary CDS support of old classes with major version < JDK_6 (50) for static archive.
+ *          Test old class with jsr bytecode.
+ * @requires vm.cds
+ * @library /test/lib
+ * @compile test-classes/OldClassWithjsrApp.jasm
+ * @run driver OldClassWithjsr
+ */
+
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class OldClassWithjsr {
+    public static void main(String[] args) throws Exception {
+        String mainClass = "OldClassWithjsrApp";
+        String namePrefix = "oldclasswithjsr";
+        String appClasses[] = TestCommon.list(mainClass);
+        JarBuilder.build(namePrefix, appClasses);
+        String appJar = TestCommon.getTestJar(namePrefix + ".jar");
+
+        boolean dynamicMode = CDSTestUtils.DYNAMIC_DUMP;
+
+        // create archive with class list
+        OutputAnalyzer output = TestCommon.dump(appJar, appClasses, "-Xlog:class+load,cds=debug,verification=trace");
+        TestCommon.checkExecReturn(output, 0,
+                                   dynamicMode ? true : false,
+                                   "Skipping " + mainClass + ": Old class has been linked");
+
+        // run with archive
+        TestCommon.run(
+            "-cp", appJar,
+            "-Xlog:class+load,cds=debug,verification=trace",
+            mainClass, "1")
+          .assertNormalExit(out -> {
+              out.shouldContain("Verifying class " + mainClass + " with old format");
+              if (!dynamicMode) {
+                  out.shouldContain(mainClass + " source: shared objects file");
+              } else {
+                  // Old classes were already linked before dynamic dump happened,
+                  // so they couldn't be archived.
+                  out.shouldMatch(".class.load.*" + mainClass + " source:.*" + namePrefix + ".jar");
+              }
+          });
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/OldClassWithjsrApp.jasm
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/OldClassWithjsrApp.jasm
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+super public class OldClassWithjsrApp
+        version 49:0
+{
+
+
+public Method "<init>":"()V"
+        stack 1 locals 1
+{
+// null
+                aload_0;
+                invokespecial   Method java/lang/Object."<init>":"()V";
+                return;
+}
+
+public static Method main:"([Ljava/lang/String;)V"
+        stack 6 locals 2
+{
+                aload_0;
+                iconst_0;
+                aaload;
+                invokestatic    Method java/lang/Integer.parseInt:"(Ljava/lang/String;)I";
+                istore_1;
+        L12:    return;
+        L13:    iload_1;
+                ifeq    L12;
+                jsr     L23;
+                goto    L24;
+        L23:    return;
+        L24:    aconst_null;
+                goto    L13;
+                return;
+}
+}


### PR DESCRIPTION
Please review this simple fix for avoid writing in to CDS archive during runtime while loading a shared old class (major_version < 50) with methods containg the jsr byte code.
Otherwise, JVM crashes with the following message in the hs err log:
`Error accessing class data sharing archive. Mapped file inaccessible during execution, possible disk/network problem.`

Passed tiers 1 - 4 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302795](https://bugs.openjdk.org/browse/JDK-8302795): Shared archive failed on old version class with jsr bytecode


### Reviewers
 * [Yumin Qi](https://openjdk.org/census#minqi) (@yminqi - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12752/head:pull/12752` \
`$ git checkout pull/12752`

Update a local copy of the PR: \
`$ git checkout pull/12752` \
`$ git pull https://git.openjdk.org/jdk pull/12752/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12752`

View PR using the GUI difftool: \
`$ git pr show -t 12752`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12752.diff">https://git.openjdk.org/jdk/pull/12752.diff</a>

</details>
