### PR TITLE
8303216: Prefer ArrayList to LinkedList in sun.net.httpserver.ServerImpl

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
@@ -54,10 +54,10 @@ import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.Timer;
@@ -164,7 +164,7 @@ class ServerImpl {
             logger.log (Level.DEBUG, "MAX_REQ_TIME:  "+MAX_REQ_TIME);
             logger.log (Level.DEBUG, "MAX_RSP_TIME:  "+MAX_RSP_TIME);
         }
-        events = new LinkedList<Event>();
+        events = new ArrayList<>();
         logger.log (Level.DEBUG, "HttpServer created "+protocol+" "+ addr);
     }
 
@@ -431,8 +431,7 @@ class ServerImpl {
             }
         }
 
-        final LinkedList<HttpConnection> connsToRegister =
-                new LinkedList<HttpConnection>();
+        final ArrayList<HttpConnection> connsToRegister = new ArrayList<>();
 
         void reRegister (HttpConnection c) {
             /* re-register with selector */
@@ -457,7 +456,7 @@ class ServerImpl {
                     synchronized (lolock) {
                         if (events.size() > 0) {
                             list = events;
-                            events = new LinkedList<Event>();
+                            events = new ArrayList<>();
                         }
                     }
 
@@ -1017,7 +1016,7 @@ class ServerImpl {
      */
     class IdleTimeoutTask extends TimerTask {
         public void run () {
-            LinkedList<HttpConnection> toClose = new LinkedList<HttpConnection>();
+            ArrayList<HttpConnection> toClose = new ArrayList<>();
             final long currentTime = System.currentTimeMillis();
             synchronized (idleConnections) {
                 final Iterator<HttpConnection> it = idleConnections.iterator();
@@ -1058,7 +1057,7 @@ class ServerImpl {
 
         // runs every TIMER_MILLIS
         public void run () {
-            LinkedList<HttpConnection> toClose = new LinkedList<HttpConnection>();
+            ArrayList<HttpConnection> toClose = new ArrayList<>();
             final long currentTime = System.currentTimeMillis();
             synchronized (reqConnections) {
                 if (MAX_REQ_TIME != -1) {
@@ -1075,7 +1074,7 @@ class ServerImpl {
                     }
                 }
             }
-            toClose = new LinkedList<HttpConnection>();
+            toClose = new ArrayList<>();
             synchronized (rspConnections) {
                 if (MAX_RSP_TIME != -1) {
                     for (HttpConnection c : rspConnections) {


### PR DESCRIPTION
LinkedList is used in a few places in `ServerImpl`.
There is only add/iterator/clear/size calls on this lists. No removes from the head or something like this. ArrayList should be preferred as more efficient and widely used (more chances for JIT) collection.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303216](https://bugs.openjdk.org/browse/JDK-8303216): Prefer ArrayList to LinkedList in sun.net.httpserver.ServerImpl


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer)
 * [Sergey Tsypanov](https://openjdk.org/census#stsypanov) (@stsypanov - Author)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12756/head:pull/12756` \
`$ git checkout pull/12756`

Update a local copy of the PR: \
`$ git checkout pull/12756` \
`$ git pull https://git.openjdk.org/jdk pull/12756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12756`

View PR using the GUI difftool: \
`$ git pr show -t 12756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12756.diff">https://git.openjdk.org/jdk/pull/12756.diff</a>

</details>
