### PR TITLE
8303227: JniObjWithEnv should be NullablePointer compliant

### DIFF
--- a/src/jdk.jpackage/windows/native/libjpackage/JniUtils.h
+++ b/src/jdk.jpackage/windows/native/libjpackage/JniUtils.h
@@ -26,6 +26,7 @@
 #ifndef JNIUTILS_H
 #define JNIUTILS_H
 
+#include <cstddef>
 #include <memory>
 #include "jni.h"
 #include "tstrings.h"
@@ -41,12 +42,23 @@ struct JniObjWithEnv {
     JniObjWithEnv(JNIEnv *env, jobject obj) : env(env), obj(obj) {
     }
 
+    JniObjWithEnv(const std::nullptr_t ptr) : env(ptr), obj(ptr) {
+    }
+
     bool operator == (const JniObjWithEnv& other) const {
         return env == other.env && obj == other.obj;
     }
 
     bool operator != (const JniObjWithEnv& other) const {
         return ! operator == (other);
+    }
+
+    bool operator == (const std::nullptr_t ptr) const {
+        return env == ptr || obj == ptr;
+    }
+
+    bool operator != (const std::nullptr_t ptr) const {
+        return env != ptr && obj != ptr;
     }
 
     explicit operator bool() const {


### PR DESCRIPTION
JniObjWithEnv is a struct that is commonly managed by std::unique_ptr. Although it can support managing objects that are not raw pointers, any such objects have to be [NullablePointers](https://en.cppreference.com/w/cpp/named_req/NullablePointer). In the past this has [broken the build when compiler upgrades were carried out](https://bugs.openjdk.org/browse/JDK-8244220), so we should add in the final requirements to make the struct a true NullablePointer once and for all, to prevent similar issues from happening in the future

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303227](https://bugs.openjdk.org/browse/JDK-8303227): JniObjWithEnv should be NullablePointer compliant


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12758/head:pull/12758` \
`$ git checkout pull/12758`

Update a local copy of the PR: \
`$ git checkout pull/12758` \
`$ git pull https://git.openjdk.org/jdk pull/12758/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12758`

View PR using the GUI difftool: \
`$ git pr show -t 12758`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12758.diff">https://git.openjdk.org/jdk/pull/12758.diff</a>

</details>
