### PR TITLE
8303266: Prefer ArrayList to LinkedList in JImageTask

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jimage/JImageTask.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jimage/JImageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@ import java.nio.file.Files;
 import java.nio.file.PathMatcher;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.MissingResourceException;
@@ -110,7 +109,7 @@ class JImageTask {
         boolean help;
         boolean verbose;
         boolean version;
-        List<File> jimages = new LinkedList<>();
+        List<File> jimages = new ArrayList<>();
     }
 
     enum Task {


### PR DESCRIPTION
`LinkedList` is used as a field `jdk.tools.jimage.JImageTask.OptionsValues#jimages`
It's created, filled (with `add`) and then iterated. No removes from the head or something like this. `ArrayList` should be preferred as more efficient and widely used (more chances for JIT) collection.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303266](https://bugs.openjdk.org/browse/JDK-8303266): Prefer ArrayList to LinkedList in JImageTask


### Reviewers
 * [Jim Laskey](https://openjdk.org/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12760/head:pull/12760` \
`$ git checkout pull/12760`

Update a local copy of the PR: \
`$ git checkout pull/12760` \
`$ git pull https://git.openjdk.org/jdk pull/12760/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12760`

View PR using the GUI difftool: \
`$ git pr show -t 12760`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12760.diff">https://git.openjdk.org/jdk/pull/12760.diff</a>

</details>
