### PR TITLE
8301869: Regression ~14% in J2dBench-bimg_misc-* in 21-b5 only on linux-aarch64

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -120,11 +120,11 @@ ifeq ($(call isTargetOs, windows), true)
   LIBAWT_VERSIONINFO_RESOURCE := $(TOPDIR)/src/$(MODULE)/windows/native/libawt/windows/awt.rc
 endif
 
-# Turn off all warnings for debug_mem.c This is needed because the specific warning
-# about initializing a declared 'extern' cannot be turned off individually. Only
-# applies to debug builds. This limitation in gcc is tracked in
-# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=45977
 ifeq ($(TOOLCHAIN_TYPE), gcc)
+  # Turn off all warnings for debug_mem.c This is needed because the specific warning
+  # about initializing a declared 'extern' cannot be turned off individually. Only
+  # applies to debug builds. This limitation in gcc is tracked in
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=45977
   BUILD_LIBAWT_debug_mem.c_CFLAGS := -w
   # This option improves performance of FillRect/FillOval in Java2D by 15% for some gcc
   LIBAWT_CFLAGS += -fpic

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -126,9 +126,7 @@ endif
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=45977
 ifeq ($(TOOLCHAIN_TYPE), gcc)
   BUILD_LIBAWT_debug_mem.c_CFLAGS := -w
-  # This option forces gcc to generate position independent code, so
-  # that any cleanup of code related to AWT will not change the
-  # generated code and cause performance issues in J2DBench
+  # This option improves performance of FillRect/FillOval in Java2D by 15% for some gcc
   LIBAWT_CFLAGS += -fpic
 endif
 

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -126,8 +126,10 @@ endif
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=45977
 ifeq ($(TOOLCHAIN_TYPE), gcc)
   BUILD_LIBAWT_debug_mem.c_CFLAGS := -w
-  # This option improves performance of MaskFill in Java2D by 20% for some gcc
-  LIBAWT_CFLAGS += -fgcse-after-reload
+  # This option forces gcc to generate position independent code, so
+  # that any cleanup of code related to AWT will not change the
+  # generated code and cause performance issues in J2DBench
+  LIBAWT_CFLAGS += -fpic
 endif
 
 $(eval $(call SetupJdkLibrary, BUILD_LIBAWT, \


### PR DESCRIPTION
Under https://bugs.openjdk.org/browse/JDK-8264846 we moved to -O3 level of gcc optimizations from -O1 level for libawt build. This improved our J2DBench performance numbers in some options considerably.

Recent changes done under https://bugs.openjdk.org/browse/JDK-8299337 causes difference in generated code by gcc and this is resulting in performance regression for bimg_misc-* J2DBench options in our performance servers. Under https://bugs.openjdk.org/browse/JDK-8299337 we have just removed unused variables and it is a cleanup task.

We can force gcc to generate position independent code by using -fpic option.Also i have removed -fgcse-after-reload option for gcc, because this is by default covered under -O3 level of optimization introduced under https://bugs.openjdk.org/browse/JDK-8264846.

With this change bimg_misc-* J2DBench option performance regression is resolved and there are no regression in other options of J2DBench or SwingMark and it is verified in our performance servers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301869](https://bugs.openjdk.org/browse/JDK-8301869): Regression ~14% in J2dBench-bimg_misc-* in 21-b5 only on linux-aarch64


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [e8d25674](https://git.openjdk.org/jdk/pull/12761/files/e8d25674d8ca3824869f3861d3c2789e42e4c18e)


### Contributors
 * Sergey Bylokhov `<serb@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12761/head:pull/12761` \
`$ git checkout pull/12761`

Update a local copy of the PR: \
`$ git checkout pull/12761` \
`$ git pull https://git.openjdk.org/jdk.git pull/12761/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12761`

View PR using the GUI difftool: \
`$ git pr show -t 12761`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12761.diff">https://git.openjdk.org/jdk/pull/12761.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12761#issuecomment-1446201677)