### PR TITLE
8303267: Prefer ArrayList to LinkedList in ConcurrentLocksPrinter

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ConcurrentLocksPrinter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ConcurrentLocksPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import sun.jvm.hotspot.memory.*;
 import sun.jvm.hotspot.oops.*;
 
 public class ConcurrentLocksPrinter {
-    private Map<JavaThread, List<Oop>> locksMap = new HashMap<>();
+    private final Map<JavaThread, List<Oop>> locksMap = new HashMap<>();
 
     public ConcurrentLocksPrinter() {
         fillLocks();
@@ -42,8 +42,7 @@ public class ConcurrentLocksPrinter {
         if (locks == null || locks.isEmpty()) {
             tty.println("    - None");
         } else {
-            for (Iterator<Oop> itr = locks.iterator(); itr.hasNext();) {
-                Oop oop = itr.next();
+            for (Oop oop : locks) {
                 tty.println("    - <" + oop.getHandle() + ">, (a " +
                        oop.getKlass().getName().asString() + ")");
             }
@@ -71,12 +70,8 @@ public class ConcurrentLocksPrinter {
                     public boolean doObj(Oop oop) {
                         JavaThread thread = getOwnerThread(oop);
                         if (thread != null) {
-                            List<Oop> locks = locksMap.get(thread);
-                            if (locks == null) {
-                                locks = new LinkedList<>();
-                                locksMap.put(thread, locks);
-                            }
-                            locks.add(oop);
+                            locksMap.computeIfAbsent(thread, t -> new ArrayList<>())
+                                    .add(oop);
                         }
                         return false;
                     }


### PR DESCRIPTION
LinkedList is used as value in `sun.jvm.hotspot.runtime.ConcurrentLocksPrinter#locksMap` Map.
There is only add/iterator calls on this lists. No removes from the head or something like this. Not sure why LinkedList was used, but ArrayList should be preferred as more efficient and widely used collection.

Also I've done some related code cleaned:
1. Mark field `locksMap` as final
2. Use Map.computeIfAbsent
3. Use enhanced-for cycle instead of `for` with iterator

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303267](https://bugs.openjdk.org/browse/JDK-8303267): Prefer ArrayList to LinkedList in ConcurrentLocksPrinter


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12763/head:pull/12763` \
`$ git checkout pull/12763`

Update a local copy of the PR: \
`$ git checkout pull/12763` \
`$ git pull https://git.openjdk.org/jdk pull/12763/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12763`

View PR using the GUI difftool: \
`$ git pr show -t 12763`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12763.diff">https://git.openjdk.org/jdk/pull/12763.diff</a>

</details>
