### PR TITLE
8303244: G1: call CardTable::clear_MemRegion directly

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardTable.cpp
+++ b/src/hotspot/share/gc/g1/g1CardTable.cpp
@@ -44,7 +44,7 @@ void G1CardTable::verify_g1_young_region(MemRegion mr) {
 void G1CardTableChangedListener::on_commit(uint start_idx, size_t num_regions, bool zero_filled) {
   // Default value for a clean card on the card table is -1. So we cannot take advantage of the zero_filled parameter.
   MemRegion mr(G1CollectedHeap::heap()->bottom_addr_for_region(start_idx), num_regions * HeapRegion::GrainWords);
-  _card_table->clear(mr);
+  _card_table->clear_MemRegion(mr);
 }
 
 void G1CardTable::initialize(G1RegionToSpaceMapper* mapper) {

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -135,7 +135,7 @@ void HeapRegion::hr_clear(bool clear_space) {
 
 void HeapRegion::clear_cardtable() {
   G1CardTable* ct = G1CollectedHeap::heap()->card_table();
-  ct->clear(MemRegion(bottom(), end()));
+  ct->clear_MemRegion(MemRegion(bottom(), end()));
 }
 
 void HeapRegion::calc_gc_efficiency() {


### PR DESCRIPTION
Simple refactoring to skip a guard in card-table clearing.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303244](https://bugs.openjdk.org/browse/JDK-8303244): G1: call CardTable::clear_MemRegion directly


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12764/head:pull/12764` \
`$ git checkout pull/12764`

Update a local copy of the PR: \
`$ git checkout pull/12764` \
`$ git pull https://git.openjdk.org/jdk pull/12764/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12764`

View PR using the GUI difftool: \
`$ git pr show -t 12764`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12764.diff">https://git.openjdk.org/jdk/pull/12764.diff</a>

</details>
