### PR TITLE
fix typo - use '&&' instead of '&'

### DIFF
--- a/src/java.base/share/classes/java/util/Properties.java
+++ b/src/java.base/share/classes/java/util/Properties.java
@@ -725,7 +725,7 @@ public class Properties extends Hashtable<Object,Object> {
                     outBuffer.append('\\'); outBuffer.append(aChar);
                     break;
                 default:
-                    if (((aChar < 0x0020) || (aChar > 0x007e)) && escapeUnicode ) {
+                    if (escapeUnicode && ((aChar < 0x0020) || (aChar > 0x007e))) {
                         outBuffer.append("\\u");
                         outBuffer.append(hex.toHexDigits(aChar));
                     } else {

--- a/src/java.base/share/classes/java/util/Properties.java
+++ b/src/java.base/share/classes/java/util/Properties.java
@@ -725,7 +725,7 @@ public class Properties extends Hashtable<Object,Object> {
                     outBuffer.append('\\'); outBuffer.append(aChar);
                     break;
                 default:
-                    if (((aChar < 0x0020) || (aChar > 0x007e)) & escapeUnicode ) {
+                    if (((aChar < 0x0020) || (aChar > 0x007e)) && escapeUnicode ) {
                         outBuffer.append("\\u");
                         outBuffer.append(hex.toHexDigits(aChar));
                     } else {


### PR DESCRIPTION
https://github.com/openjdk/jdk/blob/f2b03f9a2c0fca853211e41a1ddf46195dd56698/src/java.base/share/classes/java/util/Properties.java#L728

`EscapeUnicode` is a boolean value

Although the result is still correct, I think should use `&&` instead of `&`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewers
 * [Sergey Tsypanov](https://openjdk.org/census#stsypanov) (@stsypanov - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12767/head:pull/12767` \
`$ git checkout pull/12767`

Update a local copy of the PR: \
`$ git checkout pull/12767` \
`$ git pull https://git.openjdk.org/jdk pull/12767/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12767`

View PR using the GUI difftool: \
`$ git pr show -t 12767`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12767.diff">https://git.openjdk.org/jdk/pull/12767.diff</a>

</details>
