### PR TITLE
8303198: System and Runtime.exit() resilience to logging errors

### DIFF
--- a/src/java.base/share/classes/java/lang/Shutdown.java
+++ b/src/java.base/share/classes/java/lang/Shutdown.java
@@ -157,36 +157,38 @@ class Shutdown {
      * which should pass a nonzero status code.
      */
     static void exit(int status) {
-        System.Logger log = getRuntimeExitLogger(); // Locate the logger without holding the lock;
+        logRuntimeExit(status);         // Log without holding the lock;
+
         synchronized (Shutdown.class) {
             /* Synchronize on the class object, causing any other thread
              * that attempts to initiate shutdown to stall indefinitely
              */
-            if (log != null) {
-                Throwable throwable = new Throwable("Runtime.exit(" + status + ")");
-                log.log(System.Logger.Level.DEBUG, "Runtime.exit() called with status: " + status,
-                        throwable);
-            }
             beforeHalt();
             runHooks();
             halt(status);
         }
     }
 
-    /* Locate and return the logger for Shutdown.exit, if it is functional and DEBUG enabled.
-     * Exceptions should not prevent System.exit; the exception is printed and otherwise ignored.
+    /* Locate the logger and log the Runtime.exit(status).
+     * Catch and ignore any and all exceptions.
      */
-    private static System.Logger getRuntimeExitLogger() {
+    private static void logRuntimeExit(int status) {
         try {
             System.Logger log = System.getLogger("java.lang.Runtime");
-            return (log.isLoggable(System.Logger.Level.DEBUG)) ? log : null;
+            if (log.isLoggable(System.Logger.Level.DEBUG)) {
+                Throwable throwable = new Throwable("Runtime.exit(" + status + ")");
+                log.log(System.Logger.Level.DEBUG, "Runtime.exit() called with status: " + status,
+                        throwable);
+            }
         } catch (Throwable throwable) {
-            // Exceptions from locating the Logger are printed but do not prevent exit
-            System.err.println("Runtime.exit() log finder failed with: " + throwable.getMessage());
+            try {
+                // Exceptions from the Logger are printed but do not prevent exit
+                System.err.println("Runtime.exit() logging failed: " + throwable.getMessage());
+            } catch (Throwable throwable2) {
+                // Ignore
+            }
         }
-        return null;
     }
-
 
     /* Invoked by the JNI DestroyJavaVM procedure when the last non-daemon
      * thread has finished.  Unlike the exit method, this method does not

--- a/src/java.base/share/classes/java/lang/Shutdown.java
+++ b/src/java.base/share/classes/java/lang/Shutdown.java
@@ -183,7 +183,8 @@ class Shutdown {
         } catch (Throwable throwable) {
             try {
                 // Exceptions from the Logger are printed but do not prevent exit
-                System.err.println("Runtime.exit() logging failed: " + throwable.getMessage());
+                System.err.println("Runtime.exit(" + status + ") logging failed: " +
+                        throwable.getMessage());
             } catch (Throwable throwable2) {
                 // Ignore
             }

--- a/test/jdk/java/lang/RuntimeTests/RuntimeExitLogTest.java
+++ b/test/jdk/java/lang/RuntimeTests/RuntimeExitLogTest.java
@@ -87,7 +87,7 @@ public class RuntimeExitLogTest {
                 Arguments.of(List.of("-DThrowingHandler",
                         "-Djava.util.logging.config.file=" +
                         Path.of(TEST_SRC, "ExitLogging-FINE.properties").toString()), 5,
-                        "Runtime.exit() logging failed: Exception in publish")
+                        "Runtime.exit(5) logging failed: Exception in publish")
                 );
     }
 


### PR DESCRIPTION
Consolidate logging and handle exceptions by printing to standard error and ignoring the exception.
Exceptions while logging will not interfere with Runtime.exit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303198](https://bugs.openjdk.org/browse/JDK-8303198): System and Runtime.exit() resilience to logging errors


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12770/head:pull/12770` \
`$ git checkout pull/12770`

Update a local copy of the PR: \
`$ git checkout pull/12770` \
`$ git pull https://git.openjdk.org/jdk pull/12770/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12770`

View PR using the GUI difftool: \
`$ git pr show -t 12770`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12770.diff">https://git.openjdk.org/jdk/pull/12770.diff</a>

</details>
