### PR TITLE
8303130: Document required Accessibility permissions on macOS

### DIFF
--- a/doc/testing.html
+++ b/doc/testing.html
@@ -626,9 +626,9 @@ disable the delay, type <code>regedit</code> in the Search and then
 select Registry Editor; navigate to the following key:
 <code>HKEY_CURRENT_USER\Control Panel\Desktop</code>; make sure the
 <code>ForegroundLockTimeout</code> value is set to 0.</p>
-<p>Additional information about Client UI tests configuration for vrious
-operating systems can be obtained at [Automated client GUI testing
-system set up requirements]
+<p>Additional information about Client UI tests configuration for
+various operating systems can be obtained at [Automated client GUI
+testing system set up requirements]
 (https://wiki.openjdk.org/display/ClientLibs/Automated+client+GUI+testing+system+set+up+requirements)</p>
 <h2 id="editing-this-document">Editing this document</h2>
 <p>If you want to contribute changes to this document, edit

--- a/doc/testing.html
+++ b/doc/testing.html
@@ -584,7 +584,7 @@ operating system. Usually that causes the test failure. So it is highly
 recommended to disable system key shortcuts prior testing. The steps to
 access and disable system key shortcuts for various platforms are
 provided below.</p>
-<h5 id="macos">MacOS</h5>
+<h5 id="macos">macOS</h5>
 <p>Choose Apple menu; System Preferences, click Keyboard, then click
 Shortcuts; select or deselect desired shortcut.</p>
 <p>For example,
@@ -607,25 +607,29 @@ look for "Turn off Windows key hotkeys" and double click on it; enable
 or disable hotkeys.</p>
 <p>Note: restart is required to make the settings take effect.</p>
 <h4 id="robot-api">Robot API</h4>
-<p>Most part of automated Client UI tests use Robot API to control the
-UI. Usually the default operating system settings need to be adjusted
-for correct work of Robot functionality. The detailed steps how to
-access and update that settings for different platforms are provided
+<p>Most automated Client UI tests use <code>Robot</code> API to control
+the UI. Usually, the default operating system settings need to be
+adjusted for Robot to work correctly. The detailed steps how to access
+and update these settings for different platforms are provided
 below.</p>
-<h5 id="macos-1">MacOS</h5>
-<p>Robot functionality is not permitted to control your Mac by default
-starting from MacOS 10.15. To enable it choose Apple menu; System
-Settings, click Privacy &amp; Security; select Accessibility and ensure
-the following apps are allowed to control your computer:
-<code>Java</code> and <code>Terminal</code>. If the tests are run from
-an IDE, the IDE should be granted this permission too.</p>
+<h5 id="macos-1">macOS</h5>
+<p><code>Robot</code> is not permitted to control your Mac by default
+since macOS 10.15. To allow it, choose Apple menu -&gt; System Settings,
+click Privacy &amp; Security; then click Accessibility and ensure the
+following apps are allowed to control your computer: <em>Java</em> and
+<em>Terminal</em>. If the tests are run from an IDE, the IDE should be
+granted this permission too.</p>
 <h5 id="windows-1">Windows</h5>
-<p>On Windows there is a delay in focus transfer. Usually it causes
-automated UI test failure. To discard the delay type
-<code>regedit</code> in the Search and then select Registry Editor;
-navigate to the following key:
-<code>HKEY_CURRENT_USER\Control Panel\Desktop\ForegroundLockTimeout</code>;
-make sure its value is set to 0.</p>
+<p>On Windows if Cygwin terminal is used to run the tests, there is a
+delay in focus transfer. Usually it causes automated UI test failure. To
+disable the delay, type <code>regedit</code> in the Search and then
+select Registry Editor; navigate to the following key:
+<code>HKEY_CURRENT_USER\Control Panel\Desktop</code>; make sure the
+<code>ForegroundLockTimeout</code> value is set to 0.</p>
+<p>Additional information about Client UI tests configuration for vrious
+operating systems can be obtained at [Automated client GUI testing
+system set up requirements]
+(https://wiki.openjdk.org/display/ClientLibs/Automated+client+GUI+testing+system+set+up+requirements)</p>
 <h2 id="editing-this-document">Editing this document</h2>
 <p>If you want to contribute changes to this document, edit
 <code>doc/testing.md</code> and then run

--- a/doc/testing.html
+++ b/doc/testing.html
@@ -578,12 +578,13 @@ directories.</p>
 <p>For more notes about the PKCS11 tests, please refer to
 test/jdk/sun/security/pkcs11/README.</p>
 <h3 id="client-ui-tests">Client UI Tests</h3>
+<h4 id="system-key-shortcuts">System key shortcuts</h4>
 <p>Some Client UI tests use key sequences which may be reserved by the
 operating system. Usually that causes the test failure. So it is highly
 recommended to disable system key shortcuts prior testing. The steps to
 access and disable system key shortcuts for various platforms are
 provided below.</p>
-<h4 id="macos">MacOS</h4>
+<h5 id="macos">MacOS</h5>
 <p>Choose Apple menu; System Preferences, click Keyboard, then click
 Shortcuts; select or deselect desired shortcut.</p>
 <p>For example,
@@ -594,17 +595,37 @@ operating system. To run the test correctly the default global key
 shortcut should be disabled using the steps described above, and then
 deselect "Turn keyboard access on or off" option which is responsible
 for <code>CTRL + F1</code> combination.</p>
-<h4 id="linux">Linux</h4>
+<h5 id="linux">Linux</h5>
 <p>Open the Activities overview and start typing Settings; Choose
 Settings, click Devices, then click Keyboard; set or override desired
 shortcut.</p>
-<h4 id="windows">Windows</h4>
+<h5 id="windows">Windows</h5>
 <p>Type <code>gpedit</code> in the Search and then click Edit group
 policy; navigate to User Configuration -&gt; Administrative Templates
 -&gt; Windows Components -&gt; File Explorer; in the right-side pane
 look for "Turn off Windows key hotkeys" and double click on it; enable
 or disable hotkeys.</p>
 <p>Note: restart is required to make the settings take effect.</p>
+<h4 id="robot-api">Robot API</h4>
+<p>Most part of automated Client UI tests use Robot API to control the
+UI. Usually the default operating system settings need to be adjusted
+for correct work of Robot functionality. The detailed steps how to
+access and update that settings for different platforms are provided
+below.</p>
+<h5 id="macos-1">MacOS</h5>
+<p>Robot functionality is not permitted to control your Mac by default
+starting from MacOS 10.15. To enable it choose Apple menu; System
+Settings, click Privacy &amp; Security; select Accessibility and ensure
+the following apps are allowed to control your computer:
+<code>Java</code> and <code>Terminal</code>. If the tests are run from
+an IDE, the IDE should be granted this permission too.</p>
+<h5 id="windows-1">Windows</h5>
+<p>On Windows there is a delay in focus transfer. Usually it causes
+automated UI test failure. To discard the delay type
+<code>regedit</code> in the Search and then select Registry Editor;
+navigate to the following key:
+<code>HKEY_CURRENT_USER\Control Panel\Desktop\ForegroundLockTimeout</code>;
+make sure its value is set to 0.</p>
 <h2 id="editing-this-document">Editing this document</h2>
 <p>If you want to contribute changes to this document, edit
 <code>doc/testing.md</code> and then run

--- a/doc/testing.html
+++ b/doc/testing.html
@@ -627,9 +627,9 @@ select Registry Editor; navigate to the following key:
 <code>HKEY_CURRENT_USER\Control Panel\Desktop</code>; make sure the
 <code>ForegroundLockTimeout</code> value is set to 0.</p>
 <p>Additional information about Client UI tests configuration for
-various operating systems can be obtained at [Automated client GUI
-testing system set up requirements]
-(https://wiki.openjdk.org/display/ClientLibs/Automated+client+GUI+testing+system+set+up+requirements)</p>
+various operating systems can be obtained at <a
+href="https://wiki.openjdk.org/display/ClientLibs/Automated+client+GUI+testing+system+set+up+requirements">Automated
+client GUI testing system set up requirements</a></p>
 <h2 id="editing-this-document">Editing this document</h2>
 <p>If you want to contribute changes to this document, edit
 <code>doc/testing.md</code> and then run

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -613,7 +613,7 @@ system. Usually that causes the test failure. So it is highly recommended to
 disable system key shortcuts prior testing. The steps to access and disable
 system key shortcuts for various platforms are provided below.
 
-##### MacOS
+##### macOS
 
 Choose Apple menu; System Preferences, click Keyboard, then click Shortcuts;
 select or deselect desired shortcut.
@@ -642,26 +642,30 @@ Note: restart is required to make the settings take effect.
 
 #### Robot API
 
-Most part of automated Client UI tests use Robot API to control the UI. Usually
-the default operating system settings need to be adjusted for correct work of
-Robot functionality. The detailed steps how to access and update that settings
+Most automated Client UI tests use `Robot` API to control the UI. Usually,
+the default operating system settings need to be adjusted for Robot
+to work correctly. The detailed steps how to access and update these settings
 for different platforms are provided below.
 
-##### MacOS
+##### macOS
 
-Robot functionality is not permitted to control your Mac by default starting
-from MacOS 10.15. To enable it choose Apple menu; System Settings, click
-Privacy & Security; select Accessibility and ensure the following apps are
-allowed to control your computer: `Java` and `Terminal`. If the tests are run
+`Robot` is not permitted to control your Mac by default since
+macOS 10.15. To allow it, choose Apple menu -> System Settings, click
+Privacy & Security; then click Accessibility and ensure the following apps are
+allowed to control your computer: *Java* and *Terminal*. If the tests are run
 from an IDE, the IDE should be granted this permission too.
 
 ##### Windows
 
-On Windows there is a delay in focus transfer. Usually it causes automated
-UI test failure. To discard the delay type `regedit` in the Search and then
-select Registry Editor; navigate to the following key:
-`HKEY_CURRENT_USER\Control Panel\Desktop\ForegroundLockTimeout`; make sure
-its value is set to 0.
+On Windows if Cygwin terminal is used to run the tests, there is a delay in
+focus transfer. Usually it causes automated UI test failure. To disable the
+delay, type `regedit` in the Search and then select Registry Editor; navigate
+to the following key: `HKEY_CURRENT_USER\Control Panel\Desktop`; make sure
+the `ForegroundLockTimeout` value is set to 0.
+
+Additional information about Client UI tests configuration for vrious operating
+systems can be obtained at [Automated client GUI testing system set up
+requirements] (https://wiki.openjdk.org/display/ClientLibs/Automated+client+GUI+testing+system+set+up+requirements)
 
 ## Editing this document
 

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -606,12 +606,14 @@ test/jdk/sun/security/pkcs11/README.
 
 ### Client UI Tests
 
+#### System key shortcuts
+
 Some Client UI tests use key sequences which may be reserved by the operating
 system. Usually that causes the test failure. So it is highly recommended to
 disable system key shortcuts prior testing. The steps to access and disable
 system key shortcuts for various platforms are provided below.
 
-#### MacOS
+##### MacOS
 
 Choose Apple menu; System Preferences, click Keyboard, then click Shortcuts;
 select or deselect desired shortcut.
@@ -624,12 +626,12 @@ test correctly the default global key shortcut should be disabled using the
 steps described above, and then deselect "Turn keyboard access on or off"
 option which is responsible for `CTRL + F1` combination.
 
-#### Linux
+##### Linux
 
 Open the Activities overview and start typing Settings; Choose Settings, click
 Devices, then click Keyboard; set or override desired shortcut.
 
-#### Windows
+##### Windows
 
 Type `gpedit` in the Search and then click Edit group policy; navigate to User
 Configuration -> Administrative Templates -> Windows Components -> File
@@ -637,6 +639,29 @@ Explorer; in the right-side pane look for "Turn off Windows key hotkeys" and
 double click on it; enable or disable hotkeys.
 
 Note: restart is required to make the settings take effect.
+
+#### Robot API
+
+Most part of automated Client UI tests use Robot API to control the UI. Usually
+the default operating system settings need to be adjusted for correct work of
+Robot functionality. The detailed steps how to access and update that settings
+for different platforms are provided below.
+
+##### MacOS
+
+Robot functionality is not permitted to control your Mac by default starting
+from MacOS 10.15. To enable it choose Apple menu; System Settings, click
+Privacy & Security; select Accessibility and ensure the following apps are
+allowed to control your computer: `Java` and `Terminal`. If the tests are run
+from an IDE, the IDE should be granted this permission too.
+
+##### Windows
+
+On Windows there is a delay in focus transfer. Usually it causes automated
+UI test failure. To discard the delay type `regedit` in the Search and then
+select Registry Editor; navigate to the following key:
+`HKEY_CURRENT_USER\Control Panel\Desktop\ForegroundLockTimeout`; make sure
+its value is set to 0.
 
 ## Editing this document
 

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -665,7 +665,7 @@ the `ForegroundLockTimeout` value is set to 0.
 
 Additional information about Client UI tests configuration for various operating
 systems can be obtained at [Automated client GUI testing system set up
-requirements] (https://wiki.openjdk.org/display/ClientLibs/Automated+client+GUI+testing+system+set+up+requirements)
+requirements](https://wiki.openjdk.org/display/ClientLibs/Automated+client+GUI+testing+system+set+up+requirements)
 
 ## Editing this document
 

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -663,7 +663,7 @@ delay, type `regedit` in the Search and then select Registry Editor; navigate
 to the following key: `HKEY_CURRENT_USER\Control Panel\Desktop`; make sure
 the `ForegroundLockTimeout` value is set to 0.
 
-Additional information about Client UI tests configuration for vrious operating
+Additional information about Client UI tests configuration for various operating
 systems can be obtained at [Automated client GUI testing system set up
 requirements] (https://wiki.openjdk.org/display/ClientLibs/Automated+client+GUI+testing+system+set+up+requirements)
 


### PR DESCRIPTION
Added the section devoted to client UI test which use Robot API

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303130](https://bugs.openjdk.org/browse/JDK-8303130): Document required Accessibility permissions on macOS


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [1ce9b932](https://git.openjdk.org/jdk/pull/12772/files/1ce9b932e571fd84f78af51752a3ba54f37a6f1c)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12772/head:pull/12772` \
`$ git checkout pull/12772`

Update a local copy of the PR: \
`$ git checkout pull/12772` \
`$ git pull https://git.openjdk.org/jdk pull/12772/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12772`

View PR using the GUI difftool: \
`$ git pr show -t 12772`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12772.diff">https://git.openjdk.org/jdk/pull/12772.diff</a>

</details>
