### PR TITLE
Shenandoah: Inline resolve/sfx paths into LRB mid-path

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -854,6 +854,7 @@ public:
   void testptr(Register src1, Address src2) { LP64_ONLY(testq(src1, src2)) NOT_LP64(testl(src1, src2)); }
   void testptr(Register src1, Register src2);
 
+  void xorptr(Register dst, int32_t src) { LP64_ONLY(xorq(dst, src)) NOT_LP64(xorl(dst, src)); }
   void xorptr(Register dst, Register src) { LP64_ONLY(xorq(dst, src)) NOT_LP64(xorl(dst, src)); }
   void xorptr(Register dst, Address src) { LP64_ONLY(xorq(dst, src)) NOT_LP64(xorl(dst, src)); }
 

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.hpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.hpp
@@ -60,7 +60,7 @@ private:
   static void test_null(Node*& ctrl, Node* val, Node*& null_ctrl, PhaseIdealLoop* phase);
   static void test_gc_state(Node*& ctrl, Node* raw_mem, Node*& heap_stable_ctrl,
                             PhaseIdealLoop* phase, int flags);
-  static void call_lrb_stub(Node*& ctrl, Node*& val, Node* load_addr,
+  static void call_lrb_stub(Node*& ctrl, Node*& val, Node* load_addr, Node*& result_mem,
                             DecoratorSet decorators, PhaseIdealLoop* phase);
   static void test_in_cset(Node*& ctrl, Node*& not_cset_ctrl, Node* val, Node* raw_mem, PhaseIdealLoop* phase);
   static void move_gc_state_test_out_of_loop(IfNode* iff, PhaseIdealLoop* phase);

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.cpp
@@ -41,6 +41,10 @@
 class ShenandoahBarrierSetC1;
 class ShenandoahBarrierSetC2;
 
+volatile int ShenandoahBarrierSet::total_slow_paths = 0;
+volatile int ShenandoahBarrierSet::simple_slow_paths = 0;
+
+
 ShenandoahBarrierSet::ShenandoahBarrierSet(ShenandoahHeap* heap) :
   BarrierSet(make_barrier_set_assembler<ShenandoahBarrierSetAssembler>(),
              make_barrier_set_c1<ShenandoahBarrierSetC1>(),

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.hpp
@@ -37,6 +37,9 @@ private:
   BufferNode::Allocator _satb_mark_queue_buffer_allocator;
   ShenandoahSATBMarkQueueSet _satb_mark_queue_set;
 
+  static volatile int total_slow_paths;
+  static volatile int simple_slow_paths;
+
 public:
   ShenandoahBarrierSet(ShenandoahHeap* heap);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -59,6 +59,8 @@ inline oop ShenandoahBarrierSet::load_reference_barrier_mutator(oop obj, T* load
   assert(ShenandoahLoadRefBarrier, "should be enabled");
   shenandoah_assert_in_cset(load_addr, obj);
 
+  //Atomic::inc(&total_slow_paths);
+
   oop fwd = resolve_forwarded_not_null_mutator(obj);
   if (obj == fwd) {
     assert(_heap->is_evacuation_in_progress(),
@@ -67,7 +69,12 @@ inline oop ShenandoahBarrierSet::load_reference_barrier_mutator(oop obj, T* load
     ShenandoahEvacOOMScope scope(t);
     fwd = _heap->evacuate_object(obj, t);
   }
-
+  // else Atomic::inc(&simple_slow_paths);
+  /*
+  if ((total_slow_paths % 1000) == 0) {
+    tty->print_cr("total slow paths: %d, simple slow_paths: %d, ratio: %f", total_slow_paths, simple_slow_paths,  (float) simple_slow_paths / (float)total_slow_paths);
+  }
+  */
   if (load_addr != nullptr && fwd != obj) {
     // Since we are here and we know the load address, update the reference.
     ShenandoahHeap::atomic_update_oop(fwd, load_addr, obj);

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -2203,6 +2203,7 @@ inline bool Type::is_floatingpoint() const {
 #define MulXNode     MulLNode
 #define AndXNode     AndLNode
 #define OrXNode      OrLNode
+#define XorXNode     XorLNode
 #define CmpXNode     CmpLNode
 #define SubXNode     SubLNode
 #define LShiftXNode  LShiftLNode
@@ -2249,6 +2250,7 @@ inline bool Type::is_floatingpoint() const {
 #define MulXNode     MulINode
 #define AndXNode     AndINode
 #define OrXNode      OrINode
+#define XorXNode     XorINode
 #define CmpXNode     CmpINode
 #define SubXNode     SubINode
 #define LShiftXNode  LShiftINode


### PR DESCRIPTION
Currently, when an LRB encounters an already-evacuated object, it still calls into the runtime in order to load the fwd-ptr and fix the field from which the reference has been loaded. Calling the runtime seems quite a large overhead for those few operations (basically a load with some masking and a CAS). It seems potentially benefitial to inline the non-evacuation path into generated code, right after the in-cset test, and do the resolve and self-fixing there, if possible, and only call into the runtime for the actual evacuation.

A little experiment showed that typically, around 20%-97% of all LRB slow-path calls return fast with only resolve and sfx. This number varies greatly with the workload. Using this change, that number drops to almost zero (of course). The additional generated code for the resolve and sfx paths looks something like this:

movptr(dst, Address(dst, oopDesc::mark_offset_in_bytes()));
// This readily gets resolved obj in dst, if lowest 2 bits == 0.
xorptr(dst, markWord::lock_mask_in_place);
testb(dst, markWord::lock_mask_in_place);
 jcc(Assembler::notZero, slowpath);
cmpxchgptr(dst, addr, obj); // Update field to point to resolved obj

Initial benchmarking results are inconclusive, but may be more pronounced with GenShen. In traditional Shenandoah, performance is likely dominated by concurrent marking cost.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12774/head:pull/12774` \
`$ git checkout pull/12774`

Update a local copy of the PR: \
`$ git checkout pull/12774` \
`$ git pull https://git.openjdk.org/jdk.git pull/12774/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12774`

View PR using the GUI difftool: \
`$ git pr show -t 12774`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12774.diff">https://git.openjdk.org/jdk/pull/12774.diff</a>

</details>
