### PR TITLE
8303261: JFR: jdk/jfr/api/consumer/streaming/TestJVMCrash.java doesn't retry

### DIFF
--- a/test/jdk/jdk/jfr/api/consumer/streaming/TestJVMCrash.java
+++ b/test/jdk/jdk/jfr/api/consumer/streaming/TestJVMCrash.java
@@ -40,7 +40,7 @@ import jdk.jfr.consumer.EventStream;
  */
 public class TestJVMCrash {
 
-    public static void main(String... args) throws Exception  {
+    public static void main(String... args) {
         int id = 1;
         while (true) {
             try (TestProcess process = new TestProcess("crash-application-" + id++, false /* createCore */))  {
@@ -61,6 +61,9 @@ public class TestJVMCrash {
                     }
                     System.out.println("Incorrect event count. Retrying...");
                 }
+            } catch (Exception e) {
+                System.out.println("Exception: " + e.getMessage());
+                System.out.println("Retrying...");
             }
         }
     }


### PR DESCRIPTION
Could I have review of this test fix. Problem is that an exception is thrown when the TestProcess class tries to access the repository and the process is not available. It's unclear why this is the case, but it leads to an exception, which exits the test retry lopp. Fix is to catch the exception, print the message and retry. 

Testing. 100 * jdk/jfr/api/consumer/streaming/TestJVMCrash.java

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303261](https://bugs.openjdk.org/browse/JDK-8303261): JFR: jdk/jfr/api/consumer/streaming/TestJVMCrash.java doesn't retry


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12776/head:pull/12776` \
`$ git checkout pull/12776`

Update a local copy of the PR: \
`$ git checkout pull/12776` \
`$ git pull https://git.openjdk.org/jdk pull/12776/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12776`

View PR using the GUI difftool: \
`$ git pr show -t 12776`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12776.diff">https://git.openjdk.org/jdk/pull/12776.diff</a>

</details>
