### PR TITLE
8303264: Refactor nsk/stress/strace to extract shared and remove redundant code

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/StraceBase.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/StraceBase.java
@@ -23,6 +23,8 @@
 
 package nsk.stress.strace;
 
+import nsk.share.Log;
+
 public class StraceBase {
 
     private static final String[] EXPECTED_SYSTEM_CLASSES = {
@@ -55,6 +57,18 @@ public class StraceBase {
                 return true;
         }
         return false;
+    }
+
+    static final long waitTime = 2 * 60000;
+
+    private static final Log log = new Log(System.out);
+
+    static void display(String message) {
+        log.display(message);
+    }
+
+    static void complain(String message) {
+        log.complain(message);
     }
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace001.java
@@ -45,12 +45,6 @@
  */
 package nsk.stress.strace;
 
-import nsk.share.ArgumentParser;
-import nsk.share.Failure;
-import nsk.share.Log;
-
-import java.io.PrintStream;
-
 /**
  * The test check up <code>java.lang.Thread.getStackTrace()</code> method for many threads,
  * that recursively invoke a pure java method in running mode ("alive" stack).
@@ -66,29 +60,14 @@ public class strace001 extends StraceBase {
     static final int REPEAT_COUNT = 10;
 
     static volatile boolean isLocked = false;
-    static PrintStream out;
-    static long waitTime = 2;
 
     static Object waitStart = new Object();
 
     static strace001Thread[] threads;
     static StackTraceElement[][] snapshots = new StackTraceElement[THRD_COUNT][];
-    static Log log;
-
-    public static void main(String[] args) {
-        out = System.out;
-        int exitCode = run(args);
-        System.exit(exitCode + 95);
-    }
 
     volatile int achivedCount = 0;
-
-    public static int run(String[] args) {
-
-        ArgumentParser argHandler = new ArgumentParser(args);
-        log = new Log(out, argHandler);
-        waitTime = argHandler.getWaitTime() * 60000;
-
+    public static void main(String[] args) {
         strace001 test = new strace001();
         boolean res = true;
 
@@ -102,11 +81,9 @@ public class strace001 extends StraceBase {
         }
 
         if (!res) {
-            complain("***>>>Test failed<<<***");
-            return 2;
+            new RuntimeException("***>>>Test failed<<<***");
         }
 
-        return 0;
     }
 
     void startThreads() {
@@ -217,13 +194,6 @@ public class strace001 extends StraceBase {
         isLocked = false;
     }
 
-    static void display(String message) {
-        log.display(message);
-    }
-
-    static void complain(String message) {
-        log.complain(message);
-    }
 }
 
 class strace001Thread extends Thread {
@@ -265,7 +235,7 @@ class strace001Thread extends Thread {
                         strace001.complain("" + e);
                     }
                     if (alltime > strace001.waitTime) {
-                        throw new Failure("out of wait time");
+                        throw new RuntimeException("out of wait time");
                     }
                 }
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace002.java
@@ -50,11 +50,6 @@
 
 package nsk.stress.strace;
 
-import nsk.share.ArgumentParser;
-import nsk.share.Failure;
-import nsk.share.Log;
-
-import java.io.PrintStream;
 import java.util.Map;
 
 /**
@@ -73,28 +68,15 @@ public class strace002 extends StraceBase {
     static final int REPEAT_COUNT = 10;
 
     static volatile boolean isLocked = false;
-    static PrintStream out;
-    static long waitTime = 2;
 
     static Object waitStart = new Object();
 
     static strace002Thread[] threads;
     static StackTraceElement[][] snapshots = new StackTraceElement[THRD_COUNT][];
-    static Log log;
-
-    public static void main(String[] args) {
-        out = System.out;
-        int exitCode = run(args);
-        System.exit(exitCode + 95);
-    }
 
     volatile int achivedCount = 0;
 
-    public static int run(String[] args) {
-
-        ArgumentParser argHandler = new ArgumentParser(args);
-        log = new Log(out, argHandler);
-        waitTime = argHandler.getWaitTime() * 60000;
+    public static void main(String[] args) {
 
         strace002 test = new strace002();
         boolean res = true;
@@ -109,11 +91,9 @@ public class strace002 extends StraceBase {
         }
 
         if (!res) {
-            complain("***>>>Test failed<<<***");
-            return 2;
+            new RuntimeException("***>>>Test failed<<<***");
         }
 
-        return 0;
     }
 
     void startThreads() {
@@ -159,9 +139,9 @@ public class strace002 extends StraceBase {
 
     boolean makeSnapshot(int repeat_number) {
 
-        Map traces = Thread.getAllStackTraces();
+        Map<Thread, StackTraceElement[]> traces = Thread.getAllStackTraces();
         for (int i = 0; i < threads.length; i++) {
-            snapshots[i] = (StackTraceElement[]) traces.get(threads[i]);
+            snapshots[i] = traces.get(threads[i]);
         }
 
         return checkTraces(repeat_number);
@@ -225,15 +205,6 @@ public class strace002 extends StraceBase {
         isLocked = false;
     }
 
-    static void display(String message) {
-        log.display(message);
-    }
-
-    static void complain(String message) {
-        log.complain(message);
-    }
-
-
 }
 
 class strace002Thread extends Thread {
@@ -275,7 +246,7 @@ class strace002Thread extends Thread {
                         strace002.complain("" + e);
                     }
                     if (alltime > strace002.waitTime) {
-                        throw new Failure("out of wait time");
+                        throw new RuntimeException("out of wait time");
                     }
                 }
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace003.java
@@ -47,10 +47,6 @@
 
 package nsk.stress.strace;
 
-import nsk.share.ArgumentParser;
-import nsk.share.Log;
-
-import java.io.PrintStream;
 
 /**
  * The test check up <code>java.lang.Thread.getStackTrace()</code> method for many threads,
@@ -67,27 +63,15 @@ public class strace003 extends StraceBase {
     static final int REPEAT_COUNT = 10;
 
     static volatile boolean isLocked = false;
-    static PrintStream out;
-    static long waitTime = 2;
 
     static Object waitStart = new Object();
 
     static strace003Thread[] threads;
     static StackTraceElement[][] snapshots = new StackTraceElement[THRD_COUNT][];
-    static Log log;
 
     volatile int achivedCount = 0;
 
     public static void main(String[] args) {
-        out = System.out;
-        int exitCode = run(args);
-        System.exit(exitCode + 95);
-    }
-
-    public static int run(String[] args) {
-        ArgumentParser argHandler = new ArgumentParser(args);
-        log = new Log(out, argHandler);
-        waitTime = argHandler.getWaitTime() * 60000;
 
         strace003 test = new strace003();
         boolean res = true;
@@ -102,11 +86,9 @@ public class strace003 extends StraceBase {
         }
 
         if (!res) {
-            complain("***>>>Test failed<<<***");
-            return 2;
+            new RuntimeException("***>>>Test failed<<<***");
         }
 
-        return 0;
     }
 
     void startThreads() {
@@ -215,14 +197,6 @@ public class strace003 extends StraceBase {
             complain("" + e);
         }
         isLocked = false;
-    }
-
-    static void display(String message) {
-        log.display(message);
-    }
-
-    static void complain(String message) {
-        log.complain(message);
     }
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace004.java
@@ -47,10 +47,6 @@
 
 package nsk.stress.strace;
 
-import nsk.share.ArgumentParser;
-import nsk.share.Log;
-
-import java.io.PrintStream;
 import java.util.Map;
 
 /**
@@ -66,30 +62,16 @@ public class strace004 extends StraceBase {
     static final int DEPTH = 100;
     static final int THRD_COUNT = 100;
     static final int REPEAT_COUNT = 10;
-
     static volatile boolean isLocked = false;
-    static PrintStream out;
-    static long waitTime = 2;
 
     static Object waitStart = new Object();
 
     static strace004Thread[] threads;
     static StackTraceElement[][] snapshots = new StackTraceElement[THRD_COUNT][];
-    static Log log;
 
     volatile int achivedCount = 0;
 
     public static void main(String[] args) {
-        out = System.out;
-        int exitCode = run(args);
-        System.exit(exitCode + 95);
-    }
-
-    public static int run(String[] args) {
-        ArgumentParser argHandler = new ArgumentParser(args);
-        log = new Log(out, argHandler);
-        waitTime = argHandler.getWaitTime() * 60000;
-
         strace004 test = new strace004();
         boolean res = true;
 
@@ -103,11 +85,9 @@ public class strace004 extends StraceBase {
         }
 
         if (!res) {
-            complain("***>>>Test failed<<<***");
-            return 2;
+            new RuntimeException("***>>>Test failed<<<***");
         }
 
-        return 0;
     }
 
     void startThreads() {
@@ -153,9 +133,9 @@ public class strace004 extends StraceBase {
 
     boolean makeSnapshot(int repeat_number) {
 
-        Map traces = Thread.getAllStackTraces();
+        Map<Thread, StackTraceElement[]> traces = Thread.getAllStackTraces();
         for (int i = 0; i < threads.length; i++) {
-            snapshots[i] = (StackTraceElement[]) traces.get(threads[i]);
+            snapshots[i] = traces.get(threads[i]);
         }
 
         return checkTraces(repeat_number);
@@ -217,14 +197,6 @@ public class strace004 extends StraceBase {
             complain("" + e);
         }
         isLocked = false;
-    }
-
-    static void display(String message) {
-        log.display(message);
-    }
-
-    static void complain(String message) {
-        log.complain(message);
     }
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace005.java
@@ -41,66 +41,6 @@
  *     This test is almost the same as nsk.stress.strace.strace001 and
  *     nsk.stress.strace.strace003 except for the recursive methods are
  *     pure java and native one.
- * COMMENTS
- * Below assertion is revealed on engineer's build. It is needed to check
- * on a promoted build.
- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- * waiting for all threads started ...
- * Unexpected Signal : 11 occurred at PC=0xFDBB7820
- * Function=[Unknown. Nearest: SUNWprivate_1.1+0x3B7820]
- * Library=java/vitp/jdk/4593133/solaris-sparc/jre/lib/sparc/client/libjvm.so
- * Current Java thread:
- *         at nsk.stress.strace.strace005Thread.recursiveMethod2(Native Method)
- *         at nsk.stress.strace.strace005Thread.recursiveMethod1(strace005.java:285)
- *     . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
- *         at nsk.stress.strace.strace005Thread.recursiveMethod2(Native Method)
- *         at nsk.stress.strace.strace005Thread.recursiveMethod1(strace005.java:285)
- *         at nsk.stress.strace.strace005Thread.recursiveMethod2(Native Method)
- * Dynamic libraries:
- * 0x10000         jdk/4593133/solaris-sparc/bin/java
- * 0xff350000      /usr/lib/libthread.so.1
- * 0xff390000      /usr/lib/libdl.so.1
- * 0xff200000      /usr/lib/libc.so.1
- * 0xff330000      /usr/platform/SUNW,Ultra-60/lib/libc_psr.so.1
- * 0xfd800000      java/vitp/jdk/4593133/solaris-sparc/jre/lib/sparc/client/libjvm.so
- * 0xff2d0000      /usr/lib/libCrun.so.1
- * 0xff1d0000      /usr/lib/libsocket.so.1
- * 0xff100000      /usr/lib/libnsl.so.1
- * 0xff0d0000      /usr/lib/libm.so.1
- * 0xff0b0000      /usr/lib/libsched.so.1
- * 0xff300000      /usr/lib/libw.so.1
- * 0xff090000      /usr/lib/libmp.so.2
- * 0xff050000      java/vitp/jdk/4593133/solaris-sparc/jre/lib/sparc/native_threads/libhpi.so
- * 0xfd7d0000      java/vitp/jdk/4593133/solaris-sparc/jre/lib/sparc/libverify.so
- * 0xfd790000      java/vitp/jdk/4593133/solaris-sparc/jre/lib/sparc/libjava.so
- * 0xfe7e0000      java/vitp/jdk/4593133/solaris-sparc/jre/lib/sparc/libzip.so
- * 0xfc6e0000      java/vitp/tests/4593133/src/libstrace005.so
- * Heap at VM Abort:
- * Heap
- *  def new generation   total 2112K, used 336K [0xf1800000, 0xf1a20000, 0xf1f10000)
- *   eden space 2048K,  16% used [0xf1800000, 0xf1854300, 0xf1a00000)
- *   from space 64K,   0% used [0xf1a00000, 0xf1a00000, 0xf1a10000)
- *   to   space 64K,   0% used [0xf1a10000, 0xf1a10000, 0xf1a20000)
- *  tenured generation   total 1408K, used 0K [0xf1f10000, 0xf2070000, 0xf5800000)
- *    the space 1408K,   0% used [0xf1f10000, 0xf1f10000, 0xf1f10200, 0xf2070000)
- *  compacting perm gen  total 4096K, used 1020K [0xf5800000, 0xf5c00000, 0xf9800000)
- *    the space 4096K,  24% used [0xf5800000, 0xf58ff028, 0xf58ff200, 0xf5c00000)
- * Local Time = Fri Apr 25 18:09:16 2003
- * Elapsed Time = 13
- * #
- * # HotSpot Virtual Machine Error : 11
- * # Error ID : src/share/vm/runtime/os.cpp, 753 [ Patched ]
- * # Please report this error at
- * # http://java.sun.com/cgi-bin/bugreport.cgi
- * #
- * # Java VM: Java HotSpot(TM) Client VM (1.4.1-internal-debug mixed mode)
- * #
- * # An error report file has been saved as hs_err_pid16847.log.
- * # Please refer to the file for further information.
- * #
- * Dumping core....
- * Abort
- * Finished at: Fri Apr 25 18:09:17 NSK 2003
  *
  * @library /vmTestbase
  *          /test/lib
@@ -109,11 +49,6 @@
 
 package nsk.stress.strace;
 
-import nsk.share.ArgumentParser;
-import nsk.share.Failure;
-import nsk.share.Log;
-
-import java.io.PrintStream;
 
 /**
  * The test checks up <code>java.lang.Thread.getStackTrace()</code> method for many threads,
@@ -131,28 +66,15 @@ public class strace005 extends StraceBase {
     static final int REPEAT_COUNT = 10;
 
     static volatile boolean isLocked = false;
-    static PrintStream out;
-    static long waitTime = 2;
 
     static Object waitStart = new Object();
 
     static strace005Thread[] threads;
     static StackTraceElement[][] snapshots = new StackTraceElement[THRD_COUNT][];
-    static Log log;
 
     volatile int achivedCount = 0;
 
     public static void main(String[] args) {
-        out = System.out;
-        int exitCode = run(args);
-        System.exit(exitCode + 95);
-    }
-
-    public static int run(String[] args) {
-        ArgumentParser argHandler = new ArgumentParser(args);
-        log = new Log(out, argHandler);
-        waitTime = argHandler.getWaitTime() * 60000;
-
         strace005 test = new strace005();
         boolean res = true;
 
@@ -166,11 +88,9 @@ public class strace005 extends StraceBase {
         }
 
         if (!res) {
-            complain("***>>>Test failed<<<***");
-            return 2;
+            new RuntimeException("***>>>Test failed<<<***");
         }
 
-        return 0;
     }
 
     void startThreads() {
@@ -292,14 +212,6 @@ public class strace005 extends StraceBase {
         isLocked = false;
     }
 
-    static void display(String message) {
-        log.display(message);
-    }
-
-    static void complain(String message) {
-        log.complain(message);
-    }
-
 }
 
 /**
@@ -354,7 +266,7 @@ class strace005Thread extends Thread {
                         strace005.complain("" + e);
                     }
                     if (alltime > strace005.waitTime) {
-                        throw new Failure("out of wait time");
+                        throw new RuntimeException("out of wait time");
                     }
                 }
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace006.java
@@ -40,8 +40,6 @@
  *       method.
  *     This test is almost the same as nsk.stress.strace.strace005 except for
  *     checking is performed for java.lang.Thread.getAllStackTraces() method.
- * COMMENTS
- *     Similar assertion is thrown (see strace005.README).
  *
  * @library /vmTestbase
  *          /test/lib
@@ -50,11 +48,6 @@
 
 package nsk.stress.strace;
 
-import nsk.share.ArgumentParser;
-import nsk.share.Failure;
-import nsk.share.Log;
-
-import java.io.PrintStream;
 import java.util.Map;
 
 /**
@@ -71,29 +64,16 @@ public class strace006 extends StraceBase {
     static final int THRD_COUNT = 100;
     static final int REPEAT_COUNT = 10;
 
-
     static volatile boolean isLocked = false;
-    static PrintStream out;
-    static long waitTime = 2;
 
     static Object waitStart = new Object();
 
     static strace006Thread[] threads;
     static StackTraceElement[][] snapshots = new StackTraceElement[THRD_COUNT][];
-    static Log log;
 
     volatile int achivedCount = 0;
 
     public static void main(String[] args) {
-        out = System.out;
-        int exitCode = run(args);
-        System.exit(exitCode + 95);
-    }
-
-    public static int run(String[] args) {
-        ArgumentParser argHandler = new ArgumentParser(args);
-        log = new Log(out, argHandler);
-        waitTime = argHandler.getWaitTime() * 60000;
 
         strace006 test = new strace006();
         boolean res = true;
@@ -108,11 +88,9 @@ public class strace006 extends StraceBase {
         }
 
         if (!res) {
-            complain("***>>>Test failed<<<***");
-            return 2;
+            new RuntimeException("***>>>Test failed<<<***");
         }
 
-        return 0;
     }
 
     void startThreads() {
@@ -173,9 +151,9 @@ public class strace006 extends StraceBase {
             }
         }
 
-        Map traces = Thread.getAllStackTraces();
+        Map<Thread, StackTraceElement[]> traces = Thread.getAllStackTraces();
         for (int i = 0; i < threads.length; i++) {
-            snapshots[i] = (StackTraceElement[]) traces.get(threads[i]);
+            snapshots[i] = traces.get(threads[i]);
         }
 
         return checkTraces(repeat_number);
@@ -236,14 +214,6 @@ public class strace006 extends StraceBase {
         isLocked = false;
     }
 
-    static void display(String message) {
-        log.display(message);
-    }
-
-    static void complain(String message) {
-        log.complain(message);
-    }
-
 }
 
 /**
@@ -298,7 +268,7 @@ class strace006Thread extends Thread {
                         strace006.complain("" + e);
                     }
                     if (alltime > strace006.waitTime) {
-                        throw new Failure("out of wait time");
+                        throw new RuntimeException("out of wait time");
                     }
                 }
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace008.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace008.java
@@ -51,10 +51,6 @@
 
 package nsk.stress.strace;
 
-import nsk.share.ArgumentParser;
-import nsk.share.Log;
-
-import java.io.PrintStream;
 import java.util.Map;
 
 /**
@@ -72,43 +68,25 @@ public class strace008 extends StraceBase {
     static final int SLEEP_TIME = 50;
     static final String NATIVE_LIB = "strace008";
 
-
-    static long waitTime = 2;
-
     static Object doSnapshot = new Object();
     static volatile boolean isSnapshotDone = false;
     static volatile int achivedCount = 0;
-    static PrintStream out;
-    static Log log;
 
     static strace008Thread[] threads;
 
     public static void main(String[] args) {
-        out = System.out;
-        int exitCode = run(args);
-        System.exit(exitCode + 95);
-    }
-
-    public static int run(String[] args) {
-        ArgumentParser argHandler = new ArgumentParser(args);
-        log = new Log(out, argHandler);
-        waitTime = argHandler.getWaitTime() * 60000;
-
-        boolean res = true;
 
         startThreads();
 
-        res = makeSnapshot();
+        boolean res = makeSnapshot();
 
         finishThreads();
 
         if (!res) {
-            complain("***>>>Test failed<<<***");
-            return 2;
+            new RuntimeException("***>>>Test failed<<<***");
         }
 
         display(">>>Test passed<<<");
-        return 0;
     }
 
     static void startThreads() {
@@ -138,8 +116,8 @@ public class strace008 extends StraceBase {
     static boolean makeSnapshot() {
 
         display("making all threads snapshots...");
-        Map traces = Thread.getAllStackTraces();
-        int count = ((StackTraceElement[]) traces.get(threads[0])).length;
+        Map<Thread, StackTraceElement[]> traces = Thread.getAllStackTraces();
+        int count = traces.get(threads[0]).length;
 
         display("making snapshots of each thread...");
         StackTraceElement[][] elements = new StackTraceElement[THRD_COUNT][];
@@ -150,7 +128,7 @@ public class strace008 extends StraceBase {
         display("checking lengths of stack traces...");
         StackTraceElement[] all;
         for (int i = 1; i < THRD_COUNT; i++) {
-            all = (StackTraceElement[]) traces.get(threads[i]);
+            all = traces.get(threads[i]);
             int k = all.length;
             if (count - k > 4) {
                 complain("wrong lengths of stack traces:\n\t"
@@ -164,7 +142,7 @@ public class strace008 extends StraceBase {
         display("checking stack traces...");
         boolean res = true;
         for (int i = 0; i < THRD_COUNT; i++) {
-            all = (StackTraceElement[]) traces.get(threads[i]);
+            all = traces.get(threads[i]);
             if (!checkTraces(threads[i].getName(), elements[i], all)) {
                 res = false;
             }
@@ -196,7 +174,6 @@ public class strace008 extends StraceBase {
         }
         return res;
     }
-
     static void finishThreads() {
         isSnapshotDone = true;
 /*        try {
@@ -211,14 +188,6 @@ public class strace008 extends StraceBase {
         }
  */
         isSnapshotDone = false;
-    }
-
-    static void display(String message) {
-        log.display(message);
-    }
-
-    static void complain(String message) {
-        log.complain(message);
     }
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace009.java
@@ -50,10 +50,6 @@
 
 package nsk.stress.strace;
 
-import nsk.share.ArgumentParser;
-import nsk.share.Log;
-
-import java.io.PrintStream;
 import java.util.Map;
 
 /**
@@ -70,27 +66,13 @@ public class strace009 extends StraceBase {
     static final String NATIVE_LIB = "strace009";
     static final int SLEEP_TIME = 50;
 
-
-    static long waitTime = 2;
-
     static Object doSnapshot = new Object();
     static volatile boolean isSnapshotDone = false;
     static volatile int achivedCount = 0;
-    static PrintStream out;
-    static Log log;
 
     static strace009Thread[] threads;
 
     public static void main(String[] args) {
-        out = System.out;
-        int exitCode = run(args);
-        System.exit(exitCode + 95);
-    }
-
-    public static int run(String[] args) {
-        ArgumentParser argHandler = new ArgumentParser(args);
-        log = new Log(out, argHandler);
-        waitTime = argHandler.getWaitTime() * 60000;
 
         boolean res = true;
 
@@ -101,12 +83,10 @@ public class strace009 extends StraceBase {
         finishThreads();
 
         if (!res) {
-            complain("***>>>Test failed<<<***");
-            return 2;
+            new RuntimeException("***>>>Test failed<<<***");
         }
 
         display(">>>Test passed<<<");
-        return 0;
     }
 
     static void startThreads() {
@@ -136,8 +116,8 @@ public class strace009 extends StraceBase {
     static boolean makeSnapshot() {
 
         display("making all threads snapshots...");
-        Map traces = Thread.getAllStackTraces();
-        int count = ((StackTraceElement[]) traces.get(threads[0])).length;
+        Map<Thread, StackTraceElement[]> traces = Thread.getAllStackTraces();
+        int count = traces.get(threads[0]).length;
 
         display("making snapshots of each thread...");
         StackTraceElement[][] elements = new StackTraceElement[THRD_COUNT][];
@@ -148,7 +128,7 @@ public class strace009 extends StraceBase {
         display("checking lengths of stack traces...");
         StackTraceElement[] all;
         for (int i = 1; i < THRD_COUNT; i++) {
-            all = (StackTraceElement[]) traces.get(threads[i]);
+            all = traces.get(threads[i]);
             int k = all.length;
             if (count - k > 2) {
                 complain("wrong lengths of stack traces:\n\t"
@@ -162,7 +142,7 @@ public class strace009 extends StraceBase {
         display("checking stack traces...");
         boolean res = true;
         for (int i = 0; i < THRD_COUNT; i++) {
-            all = (StackTraceElement[]) traces.get(threads[i]);
+            all = traces.get(threads[i]);
             if (!checkTraces(threads[i].getName(), elements[i], all)) {
                 res = false;
             }
@@ -208,14 +188,6 @@ public class strace009 extends StraceBase {
             complain("" + e);
         }
         isSnapshotDone = false;
-    }
-
-    static void display(String message) {
-        log.display(message);
-    }
-
-    static void complain(String message) {
-        log.complain(message);
     }
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace015.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace015.java
@@ -51,10 +51,6 @@
 
 package nsk.stress.strace;
 
-import nsk.share.ArgumentParser;
-import nsk.share.Log;
-
-import java.io.PrintStream;
 import java.util.Map;
 
 /**
@@ -69,42 +65,25 @@ public class strace015 extends StraceBase {
     static final int DEPTH = 100;
     static final int THRD_COUNT = 100;
 
-    static PrintStream out;
-    static long waitTime = 2;
-
     static Object lockedObject = new Object();
 
     static volatile int achivedCount = 0;
     strace015Thread[] threads;
-    static Log log;
 
     public static void main(String[] args) {
-        out = System.out;
-        int exitCode = run(args);
-        System.exit(exitCode + 95);
-    }
-
-    public static int run(String[] args) {
-        ArgumentParser argHandler = new ArgumentParser(args);
-        log = new Log(out, argHandler);
-        waitTime = argHandler.getWaitTime() * 60000;
-
         strace015 test = new strace015();
-        boolean res = true;
 
         test.startThreads();
 
-        res = test.makeSnapshot();
+        boolean res = test.makeSnapshot();
 
         test.finishThreads();
 
         if (!res) {
-            complain("***>>>Test failed<<<***");
-            return 2;
+            new RuntimeException("***>>>Test failed<<<***");
         }
 
         display(">>>Test passed<<<");
-        return 0;
     }
 
     void startThreads() {
@@ -138,16 +117,12 @@ public class strace015 extends StraceBase {
 
     boolean makeSnapshot() {
 
-        Map traces = null;
-        int count = 0;
-        StackTraceElement[][] elements = null;
-
         display("making all threads snapshots...");
-        traces = Thread.getAllStackTraces();
-        count = ((StackTraceElement[]) traces.get(threads[0])).length;
+        Map<Thread, StackTraceElement[]> traces = Thread.getAllStackTraces();
+        int count = traces.get(threads[0]).length;
 
         display("making snapshots of each thread...");
-        elements = new StackTraceElement[THRD_COUNT][];
+        StackTraceElement[][] elements = new StackTraceElement[THRD_COUNT][];
         for (int i = 0; i < THRD_COUNT; i++) {
             elements[i] = threads[i].getStackTrace();
         }
@@ -162,7 +137,7 @@ public class strace015 extends StraceBase {
         display("checking lengths of stack traces...");
         StackTraceElement[] all;
         for (int i = 1; i < THRD_COUNT; i++) {
-            all = (StackTraceElement[]) traces.get(threads[i]);
+            all = traces.get(threads[i]);
             int k = all.length;
             if (count - k > 2) {
                 complain("wrong lengths of stack traces:\n\t"
@@ -176,7 +151,7 @@ public class strace015 extends StraceBase {
         display("checking stack traces...");
         boolean res = true;
         for (int i = 0; i < THRD_COUNT; i++) {
-            all = (StackTraceElement[]) traces.get(threads[i]);
+            all = traces.get(threads[i]);
             if (!checkTraces(threads[i].getName(), elements[i], all)) {
                 res = false;
             }
@@ -220,14 +195,6 @@ public class strace015 extends StraceBase {
         } catch (InterruptedException e) {
             complain("" + e);
         }
-    }
-
-    static void display(String message) {
-        log.display(message);
-    }
-
-    static void complain(String message) {
-        log.complain(message);
     }
 
 }


### PR DESCRIPTION
Some old nsk code is removed, and logging is moved to the based class. 
No functional changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303264](https://bugs.openjdk.org/browse/JDK-8303264): Refactor nsk/stress/strace to extract shared and remove redundant code


### Reviewers
 * [Mikhailo Seledtsov](https://openjdk.org/census#mseledtsov) (@mseledts - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12777/head:pull/12777` \
`$ git checkout pull/12777`

Update a local copy of the PR: \
`$ git checkout pull/12777` \
`$ git pull https://git.openjdk.org/jdk pull/12777/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12777`

View PR using the GUI difftool: \
`$ git pr show -t 12777`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12777.diff">https://git.openjdk.org/jdk/pull/12777.diff</a>

</details>
