### PR TITLE
8303232: java.util.Date.parse(String) and java.util.Date(String) don't declare thrown IllegalArgumentException

### DIFF
--- a/src/java.base/share/classes/java/util/Date.java
+++ b/src/java.base/share/classes/java/util/Date.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -260,6 +260,8 @@ public class Date
      * {@link Date#parse} method.
      *
      * @param   s   a string representation of the date.
+     * @throws IllegalArgumentException if {@code s} cannot be interpreted as a
+     * representation of a date and time.
      * @see     java.text.DateFormat
      * @see     java.util.Date#parse(java.lang.String)
      * @deprecated As of JDK version 1.1,
@@ -441,6 +443,8 @@ public class Date
      * @param   s   a string to be parsed as a date.
      * @return  the number of milliseconds since January 1, 1970, 00:00:00 GMT
      *          represented by the string argument.
+     * @throws IllegalArgumentException if {@code s} cannot be interpreted as a
+     * representation of a date and time.
      * @see     java.text.DateFormat
      * @deprecated As of JDK version 1.1,
      * replaced by {@code DateFormat.parse(String s)}.


### PR DESCRIPTION
The method `java.util.Date.parse(String)` and as a result, constructor `java.util.Date(String)` throw an `IllegalArgumentException`. This exception is not properly referenced in the javadoc, and this PR simply adds the throws javadoc tag to make it apparent.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8303263](https://bugs.openjdk.org/browse/JDK-8303263) to be approved

### Issues
 * [JDK-8303232](https://bugs.openjdk.org/browse/JDK-8303232): java.util.Date.parse(String) and java.util.Date(String) don't declare thrown IllegalArgumentException
 * [JDK-8303263](https://bugs.openjdk.org/browse/JDK-8303263): java.util.Date.parse(String) and java.util.Date(String) don't declare thrown IllegalArgumentException (**CSR**)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12779/head:pull/12779` \
`$ git checkout pull/12779`

Update a local copy of the PR: \
`$ git checkout pull/12779` \
`$ git pull https://git.openjdk.org/jdk pull/12779/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12779`

View PR using the GUI difftool: \
`$ git pr show -t 12779`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12779.diff">https://git.openjdk.org/jdk/pull/12779.diff</a>

</details>
