### PR TITLE
8303013: Always do remembered set verification during G1 Full GC

### DIFF
--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -280,10 +280,6 @@
           "as a percentage of the heap size.")                              \
           range(0, 100)                                                     \
                                                                             \
-  product(bool, G1VerifyRSetsDuringFullGC, false, DIAGNOSTIC,               \
-          "If true, perform verification of each heap region's "            \
-          "remembered set when verifying the heap during a full GC.")       \
-                                                                            \
   product(bool, G1VerifyHeapRegionCodeRoots, false, DIAGNOSTIC,             \
           "Verify the code root lists attached to each heap region.")       \
                                                                             \

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -487,7 +487,6 @@ class G1VerifyLiveAndRemSetClosure : public BasicOopIterateClosure {
 
   G1CollectedHeap* _g1h;
   VerifyOption _vo;
-  bool _verify_remsets;
 
   oop _containing_obj;
 
@@ -591,16 +590,15 @@ class G1VerifyLiveAndRemSetClosure : public BasicOopIterateClosure {
     oop obj = CompressedOops::decode_not_null(heap_oop);
 
     bool is_live = verify_liveness(p, obj);
-    if (is_live && _verify_remsets) {
+    if (is_live) {
       verify_remset(p, obj);
     }
   }
 
 public:
-  G1VerifyLiveAndRemSetClosure(G1CollectedHeap* g1h, VerifyOption vo, bool verify_remsets) :
+  G1VerifyLiveAndRemSetClosure(G1CollectedHeap* g1h, VerifyOption vo) :
     _g1h(G1CollectedHeap::heap()),
     _vo(vo),
-    _verify_remsets(verify_remsets),
     _containing_obj(nullptr),
     _num_failures(0),
     _ct(_g1h->card_table()) { }
@@ -618,8 +616,7 @@ public:
 bool HeapRegion::verify_liveness_and_remset(VerifyOption vo) const {
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
 
-  bool verify_rem_sets = !g1h->collector_state()->in_full_gc() || G1VerifyRSetsDuringFullGC;
-  G1VerifyLiveAndRemSetClosure cl(g1h, vo, verify_rem_sets);
+  G1VerifyLiveAndRemSetClosure cl(g1h, vo);
 
   size_t other_failures = 0;
 

--- a/test/hotspot/jtreg/gc/g1/TestVerificationInConcurrentCycle.java
+++ b/test/hotspot/jtreg/gc/g1/TestVerificationInConcurrentCycle.java
@@ -35,7 +35,7 @@ package gc.g1;
  *   -Xbootclasspath/a:.
  *   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *   -XX:+VerifyBeforeGC -XX:+VerifyDuringGC -XX:+VerifyAfterGC
- *   -XX:+G1VerifyRSetsDuringFullGC -XX:+G1VerifyHeapRegionCodeRoots
+ *   -XX:+G1VerifyHeapRegionCodeRoots
  *   -XX:+VerifyRememberedSets -XX:+VerifyObjectStartArray
  *   -XX:+G1VerifyBitmaps
  *   gc.g1.TestVerificationInConcurrentCycle
@@ -54,7 +54,7 @@ package gc.g1;
  *   -Xbootclasspath/a:.
  *   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *   -XX:+VerifyBeforeGC -XX:+VerifyDuringGC -XX:+VerifyAfterGC
- *   -XX:+G1VerifyRSetsDuringFullGC -XX:+G1VerifyHeapRegionCodeRoots
+ *   -XX:+G1VerifyHeapRegionCodeRoots
  *   -XX:+VerifyRememberedSets -XX:+VerifyObjectStartArray
  *   gc.g1.TestVerificationInConcurrentCycle
  */


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that removes the `G1VerifyRSetsDuringFullGC` flag because it seems superfluous: if we are doing verification, we likely want to have all subsystems checked; now there is the argument that remset verification is somewhat expensive, and hence the reason for this flag. However I believe that the existing flags to control verification execution (`VerifyGCType`) are much better than this particular flag.

There is a `VerifyRememberedSets` flag available that is currently only used in Parallel GC that might be used here to control all remembered set verification; however I believe that if we do verification, we typically want all of it (and it can be toned down by `VerifyGCType` and friends). If you think it is useful, I can enable G1 to honour `VerifyRememberedSets` too (with a default of `true` and obviously only active if other verification is enabled).

Testing: tier1-3

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303013](https://bugs.openjdk.org/browse/JDK-8303013): Always do remembered set verification during G1 Full GC


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12781/head:pull/12781` \
`$ git checkout pull/12781`

Update a local copy of the PR: \
`$ git checkout pull/12781` \
`$ git pull https://git.openjdk.org/jdk pull/12781/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12781`

View PR using the GUI difftool: \
`$ git pr show -t 12781`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12781.diff">https://git.openjdk.org/jdk/pull/12781.diff</a>

</details>
