### PR TITLE
8303344: After JDK-8302760, G1 heap verification does not exit VM after errors

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -648,7 +648,7 @@ bool HeapRegion::verify_liveness_and_remset(VerifyOption vo) const {
                           p2i(p), p2i(top()));
     return true;
   }
-  return false;
+  return (cl.num_failures() + other_failures) > 0;
 }
 
 bool HeapRegion::verify(VerifyOption vo) const {

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -648,7 +648,7 @@ bool HeapRegion::verify_liveness_and_remset(VerifyOption vo) const {
                           p2i(p), p2i(top()));
     return true;
   }
-  return (cl.num_failures() + other_failures) > 0;
+  return (cl.num_failures() + other_failures) != 0;
 }
 
 bool HeapRegion::verify(VerifyOption vo) const {


### PR DESCRIPTION
Hi all,

  please review this bug introduced in the refactoring of [JDK-8302760](https://bugs.openjdk.org/browse/JDK-8302760) where heap verification does not exit the VM because it fails to propagate errors.
Apologies for the botched refactoring.

Testing: local testing with VM changes to introduce errors

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303344](https://bugs.openjdk.org/browse/JDK-8303344): After JDK-8302760, G1 heap verification does not exit VM after errors


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12783/head:pull/12783` \
`$ git checkout pull/12783`

Update a local copy of the PR: \
`$ git checkout pull/12783` \
`$ git pull https://git.openjdk.org/jdk pull/12783/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12783`

View PR using the GUI difftool: \
`$ git pr show -t 12783`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12783.diff">https://git.openjdk.org/jdk/pull/12783.diff</a>

</details>
