### PR TITLE
8303351: [IR Framework] Add missing cpu feature avx512bw after JDK-8302681

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -71,6 +71,7 @@ public class IREncodingPrinter {
         "avx",
         "avx2",
         "avx512",
+        "avx512bw",
         "avx512dq",
         "avx512vl",
         "avx512f",


### PR DESCRIPTION
Hi all,

testlibrary_tests/ir_framework/tests/TestCPUFeatureCheck.java fails on our AVX512 machines.
This is because `avx512bw` isn't in the verified list after JDK-8302681.

Let's fix it.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303351](https://bugs.openjdk.org/browse/JDK-8303351): [IR Framework] Add missing cpu feature avx512bw after JDK-8302681


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12785/head:pull/12785` \
`$ git checkout pull/12785`

Update a local copy of the PR: \
`$ git checkout pull/12785` \
`$ git pull https://git.openjdk.org/jdk pull/12785/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12785`

View PR using the GUI difftool: \
`$ git pr show -t 12785`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12785.diff">https://git.openjdk.org/jdk/pull/12785.diff</a>

</details>
