### PR TITLE
JDK-8303349: Simplify link format for generic types in index pages

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesIndexWriter.java
@@ -149,7 +149,7 @@ public class AllClassesIndexWriter extends HtmlDocletWriter {
     protected void addTableRow(Table<TypeElement> table, TypeElement klass) {
         List<Content> rowContents = new ArrayList<>();
         Content classLink = getLink(new HtmlLinkInfo(
-                configuration, HtmlLinkInfo.Kind.LINK_TYPE_PARAMS_AND_BOUNDS, klass));
+                configuration, HtmlLinkInfo.Kind.SHOW_TYPE_PARAMS_IN_LABEL, klass));
         ContentBuilder description = new ContentBuilder();
         Set<ElementFlag> flags = utils.elementFlags(klass);
         if (flags.contains(ElementFlag.PREVIEW)) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriterImpl.java
@@ -171,7 +171,7 @@ public class ConstantsSummaryWriterImpl extends HtmlDocletWriter implements Cons
         //generate links backward only to public classes.
         Content classLink = (utils.isPublic(typeElement) || utils.isProtected(typeElement)) ?
             getLink(new HtmlLinkInfo(configuration,
-                    HtmlLinkInfo.Kind.LINK_TYPE_PARAMS_AND_BOUNDS, typeElement)) :
+                    HtmlLinkInfo.Kind.SHOW_TYPE_PARAMS_IN_LABEL, typeElement)) :
             Text.of(utils.getFullyQualifiedName(typeElement));
 
         PackageElement enclosingPackage  = utils.containingPackage(typeElement);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkFactory.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkFactory.java
@@ -83,6 +83,11 @@ public class HtmlLinkFactory extends LinkFactory {
             title = getClassToolTip(typeElement, isTypeLink);
         }
         Content label = classLinkInfo.getClassLinkLabel(configuration);
+        if (classLinkInfo.context == HtmlLinkInfo.Kind.SHOW_TYPE_PARAMS_IN_LABEL) {
+            // For this kind of link, type parameters are included in the link label
+            // (and obviously not added after the link).
+            label.add(getTypeParameterLinks(classLinkInfo));
+        }
         Set<ElementFlag> flags;
         Element previewTarget;
         boolean showPreview = !classLinkInfo.skipPreview;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkInfo.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkInfo.java
@@ -45,27 +45,33 @@ public class HtmlLinkInfo extends LinkInfo {
 
     public enum Kind {
         /**
-         * Link with just the element name as label.
+         * Creates a link with just the element name as label.
          */
         PLAIN,
         /**
-         * Link with additional preview flag if appropriate.
+         * Creates a link with additional preview flag if appropriate.
          */
         SHOW_PREVIEW,
         /**
-         * Link with additional type parameters as plain text if appropriate.
+         * Creates a link with optional type parameters appended as plain text.
          */
         SHOW_TYPE_PARAMS,
+
         /**
-         * Link with additional type parameters and bounds as plain text if appropriate.
+         * Creates a link with optional type parameters included in the link label.
+         */
+        SHOW_TYPE_PARAMS_IN_LABEL,
+
+        /**
+         * Creates a link with optional type parameters and bounds appended as plain text.
          */
         SHOW_TYPE_PARAMS_AND_BOUNDS,
         /**
-         * Link with additional type parameters as separate link if appropriate.
+         * Creates a link with optional type parameters but no bounds rendered as separate links.
          */
         LINK_TYPE_PARAMS,
         /**
-         * Link with additional type parameters and bounds as separate links if approprate.
+         * Creates a link with optional type parameters and bounds rendered as separate links.
          */
         LINK_TYPE_PARAMS_AND_BOUNDS;
     }
@@ -228,7 +234,10 @@ public class HtmlLinkInfo extends LinkInfo {
 
     @Override
     public boolean showTypeParameters() {
-        return context != Kind.PLAIN && context != Kind.SHOW_PREVIEW;
+        // Type parameters parameters for these kinds of links are either not desired
+        // or already included in the link label.
+        return context != Kind.PLAIN && context != Kind.SHOW_PREVIEW
+                && context != Kind.SHOW_TYPE_PARAMS_IN_LABEL;
     }
 
     @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkInfo.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkInfo.java
@@ -43,35 +43,38 @@ import jdk.javadoc.internal.doclets.toolkit.util.links.LinkInfo;
  */
 public class HtmlLinkInfo extends LinkInfo {
 
+    /**
+     * Enumeration of different kinds of links.
+     */
     public enum Kind {
         /**
-         * Creates a link with just the element name as label.
+         * Link with just the element name as label.
          */
         PLAIN,
         /**
-         * Creates a link with additional preview flag if appropriate.
+         * Link with additional preview flag if appropriate.
          */
         SHOW_PREVIEW,
         /**
-         * Creates a link with optional type parameters appended as plain text.
+         * Link with optional type parameters appended as plain text.
          */
         SHOW_TYPE_PARAMS,
 
         /**
-         * Creates a link with optional type parameters included in the link label.
+         * Link with optional type parameters included in the link label.
          */
         SHOW_TYPE_PARAMS_IN_LABEL,
 
         /**
-         * Creates a link with optional type parameters and bounds appended as plain text.
+         * Link with optional type parameters and bounds appended as plain text.
          */
         SHOW_TYPE_PARAMS_AND_BOUNDS,
         /**
-         * Creates a link with optional type parameters but no bounds rendered as separate links.
+         * Link with optional type parameters but no bounds rendered as separate links.
          */
         LINK_TYPE_PARAMS,
         /**
-         * Creates a link with optional type parameters and bounds rendered as separate links.
+         * Link with optional type parameters and bounds rendered as separate links.
          */
         LINK_TYPE_PARAMS_AND_BOUNDS;
     }
@@ -234,7 +237,7 @@ public class HtmlLinkInfo extends LinkInfo {
 
     @Override
     public boolean showTypeParameters() {
-        // Type parameters parameters for these kinds of links are either not desired
+        // Type parameters for these kinds of links are either not desired
         // or already included in the link label.
         return context != Kind.PLAIN && context != Kind.SHOW_PREVIEW
                 && context != Kind.SHOW_TYPE_PARAMS_IN_LABEL;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
@@ -209,7 +209,7 @@ public class IndexWriter extends HtmlDocletWriter {
             case ANNOTATION_TYPE:
             case INTERFACE:
                 dt = HtmlTree.DT(getLink(new HtmlLinkInfo(configuration,
-                        HtmlLinkInfo.Kind.LINK_TYPE_PARAMS_AND_BOUNDS, (TypeElement) element).style(HtmlStyle.typeNameLink)));
+                        HtmlLinkInfo.Kind.SHOW_TYPE_PARAMS_IN_LABEL, (TypeElement) element).style(HtmlStyle.typeNameLink)));
                 dt.add(" - ");
                 addClassInfo((TypeElement) element, dt);
                 break;

--- a/test/langtools/jdk/javadoc/doclet/testInterface/TestInterface.java
+++ b/test/langtools/jdk/javadoc/doclet/testInterface/TestInterface.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug      4682448 4947464 5029946 8025633 8026567 8035473 8139101 8175200
-             8186332 8186703 8182765 8187288 8261976
+             8186332 8186703 8182765 8187288 8261976 8303349
  * @summary  Verify that the public modifier does not show up in the
  *           documentation for public methods, as recommended by the JLS.
  *           If A implements I and B extends A, B should be in the list of
@@ -217,7 +217,8 @@ public class TestInterface extends JavadocTester {
                 <div class="table-header col-last">Description</div>
                 <div class="col-first even-row-color"><code>static interface&nbsp;</code></div>
                 <div class="col-second even-row-color"><code><a href="Spliterator.OfDouble.html"\
-                 class="type-name-link" title="interface in pkg2">Spliterator.OfDouble</a></code></div>
+                 class="type-name-link" title="interface in pkg2">Spliterator.OfDouble</a></code\
+                ></div>
                 <div class="col-last even-row-color">&nbsp;</div>
                 <div class="col-first odd-row-color"><code>static interface&nbsp;</code></div>
                 <div class="col-second odd-row-color"><code><a href="Spliterator.OfInt.html" cla\
@@ -247,58 +248,42 @@ public class TestInterface extends JavadocTester {
                 <div class="col-last even-row-color all-classes-table all-classes-table-tab2">&n\
                 bsp;</div>
                 <div class="col-first odd-row-color all-classes-table all-classes-table-tab1"><a\
-                 href="pkg2/Spliterator.html" title="interface in pkg2">Spliterator</a>&lt;<a hr\
-                ef="pkg2/Spliterator.html" title="type parameter in Spliterator">T</a>&gt;</div>
-                <div class="col-last odd-row-color all-classes-table all-classes-table-tab1">&nbsp;</div>
+                 href="pkg2/Spliterator.html" title="interface in pkg2">Spliterator&lt;T&gt;</a>\
+                </div>
+                <div class="col-last odd-row-color all-classes-table all-classes-table-tab1">&nb\
+                sp;</div>
                 <div class="col-first even-row-color all-classes-table all-classes-table-tab1"><\
                 a href="pkg2/Spliterator.OfDouble.html" title="interface in pkg2">Spliterator.Of\
                 Double</a></div>
-                <div class="col-last even-row-color all-classes-table all-classes-table-tab1">&nbsp;</div>
+                <div class="col-last even-row-color all-classes-table all-classes-table-tab1">&n\
+                bsp;</div>
                 <div class="col-first odd-row-color all-classes-table all-classes-table-tab1"><a\
-                 href="pkg2/Spliterator.OfInt.html" title="interface in pkg2">Spliterator.OfInt<\
-                /a>&lt;<a href="pkg2/Spliterator.OfInt.html" title="type parameter in Spliterato\
-                r.OfInt">Integer</a>&gt;</div>
-                <div class="col-last odd-row-color all-classes-table all-classes-table-tab1">&nbsp;</div>
+                 href="pkg2/Spliterator.OfInt.html" title="interface in pkg2">Spliterator.OfInt&\
+                lt;Integer&gt;</a></div>
+                <div class="col-last odd-row-color all-classes-table all-classes-table-tab1">&nb\
+                sp;</div>
                 <div class="col-first even-row-color all-classes-table all-classes-table-tab1"><\
                 a href="pkg2/Spliterator.OfPrimitive.html" title="interface in pkg2">Spliterator\
-                .OfPrimitive</a>&lt;<a href="pkg2/Spliterator.OfPrimitive.html" title="type para\
-                meter in Spliterator.OfPrimitive">T</a>,<wbr><a href="pkg2/Spliterator.OfPrimiti\
-                ve.html" title="type parameter in Spliterator.OfPrimitive">T_CONS</a>,<wbr><a hr\
-                ef="pkg2/Spliterator.OfPrimitive.html" title="type parameter in Spliterator.OfPr\
-                imitive">T_SPLITR</a> extends <a href="pkg2/Spliterator.OfPrimitive.html" title=\
-                "interface in pkg2">Spliterator.OfPrimitive</a>&lt;<a href="pkg2/Spliterator.OfP\
-                rimitive.html" title="type parameter in Spliterator.OfPrimitive">T</a>,<wbr><a h\
-                ref="pkg2/Spliterator.OfPrimitive.html" title="type parameter in Spliterator.OfP\
-                rimitive">T_CONS</a>,<wbr><a href="pkg2/Spliterator.OfPrimitive.html" title="typ\
-                e parameter in Spliterator.OfPrimitive">T_SPLITR</a>&gt;&gt;</div>
-                <div class="col-last even-row-color all-classes-table all-classes-table-tab1">&nbsp;</div>""");
+                .OfPrimitive&lt;T,<wbr>T_CONS,<wbr>T_SPLITR&gt;</a></div>
+                <div class="col-last even-row-color all-classes-table all-classes-table-tab1">&n\
+                bsp;</div>""");
         checkOutput("index-all.html", true,
                 """
                 <dt><a href="pkg2/Spliterator.html" class="type-name-link" title="interface in p\
-                kg2">Spliterator</a>&lt;<a href="pkg2/Spliterator.html" title="type parameter in\
-                 Spliterator">T</a>&gt; - Interface in <a href="pkg2/package-summary.html">pkg2</a></dt>
+                kg2">Spliterator&lt;T&gt;</a> - Interface in <a href="pkg2/package-summary.html"\
+                >pkg2</a></dt>
                 <dd>&nbsp;</dd>
                 <dt><a href="pkg2/Spliterator.OfDouble.html" class="type-name-link" title="inter\
                 face in pkg2">Spliterator.OfDouble</a> - Interface in <a href="pkg2/package-summ\
                 ary.html">pkg2</a></dt>
                 <dd>&nbsp;</dd>
                 <dt><a href="pkg2/Spliterator.OfInt.html" class="type-name-link" title="interfac\
-                e in pkg2">Spliterator.OfInt</a>&lt;<a href="pkg2/Spliterator.OfInt.html" title=\
-                "type parameter in Spliterator.OfInt">Integer</a>&gt; - Interface in <a href="pk\
-                g2/package-summary.html">pkg2</a></dt>
+                e in pkg2">Spliterator.OfInt&lt;Integer&gt;</a> - Interface in <a href="pkg2/pac\
+                kage-summary.html">pkg2</a></dt>
                 <dd>&nbsp;</dd>
                 <dt><a href="pkg2/Spliterator.OfPrimitive.html" class="type-name-link" title="in\
-                terface in pkg2">Spliterator.OfPrimitive</a>&lt;<a href="pkg2/Spliterator.OfPrim\
-                itive.html" title="type parameter in Spliterator.OfPrimitive">T</a>,<wbr><a href\
-                ="pkg2/Spliterator.OfPrimitive.html" title="type parameter in Spliterator.OfPrim\
-                itive">T_CONS</a>,<wbr><a href="pkg2/Spliterator.OfPrimitive.html" title="type p\
-                arameter in Spliterator.OfPrimitive">T_SPLITR</a> extends <a href="pkg2/Splitera\
-                tor.OfPrimitive.html" title="interface in pkg2">Spliterator.OfPrimitive</a>&lt;<\
-                a href="pkg2/Spliterator.OfPrimitive.html" title="type parameter in Spliterator.\
-                OfPrimitive">T</a>,<wbr><a href="pkg2/Spliterator.OfPrimitive.html" title="type \
-                parameter in Spliterator.OfPrimitive">T_CONS</a>,<wbr><a href="pkg2/Spliterator.\
-                OfPrimitive.html" title="type parameter in Spliterator.OfPrimitive">T_SPLITR</a>\
-                &gt;&gt; - Interface in <a href="pkg2/package-summary.html">pkg2</a></dt>
+                terface in pkg2">Spliterator.OfPrimitive&lt;T,<wbr>T_CONS,<wbr>T_SPLITR&gt;</a> \
+                - Interface in <a href="pkg2/package-summary.html">pkg2</a></dt>
                 <dd>&nbsp;</dd>""");
     }
 }


### PR DESCRIPTION
Please review a simple change to simplify the format of links to generic types in various JavaDoc index pages. Previously, these included dedicated links for type parameters and bounds, which seems excessive for use in an index. 

Below are before and after screenshots for `Spliterator.ofPrimitive` (which is admittedly an extreme case) and neighboring index entries. Note that now links to generic types match what we do for executables, where the whole signature is used as link label.

Before:
<img width="804" alt="index-generic-links-1" src="https://user-images.githubusercontent.com/15975/221875901-07899cc7-8822-4e59-8b93-51efb6795a83.png">

After:
<img width="546" alt="index-generic-links-2" src="https://user-images.githubusercontent.com/15975/221875944-b3db5fab-4e11-493b-8499-54bfeccbeb65.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303349](https://bugs.openjdk.org/browse/JDK-8303349): Simplify link format for generic types in index pages


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to [eeb0540d](https://git.openjdk.org/jdk/pull/12786/files/eeb0540d11c26111afa816962a6251e1502a7825)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12786/head:pull/12786` \
`$ git checkout pull/12786`

Update a local copy of the PR: \
`$ git checkout pull/12786` \
`$ git pull https://git.openjdk.org/jdk pull/12786/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12786`

View PR using the GUI difftool: \
`$ git pr show -t 12786`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12786.diff">https://git.openjdk.org/jdk/pull/12786.diff</a>

</details>
