### PR TITLE
JDK-8303354: addCertificatesToKeystore in KeystoreImpl.m needs CFRelease call in early potential CHECK_NULL return

### DIFF
--- a/src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m
+++ b/src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m
@@ -385,16 +385,30 @@ static void addCertificatesToKeystore(JNIEnv *env, jobject keyStore)
     OSErr searchResult = noErr;
 
     jclass jc_KeychainStore = (*env)->FindClass(env, "apple/security/KeychainStore");
-    CHECK_NULL(jc_KeychainStore);
+    if (jc_KeychainStore == NULL) {
+        goto errOut;
+    }
+
     jmethodID jm_createTrustedCertEntry = (*env)->GetMethodID(
             env, jc_KeychainStore, "createTrustedCertEntry", "(Ljava/lang/String;Ljava/util/List;JJ[B)V");
-    CHECK_NULL(jm_createTrustedCertEntry);
+    if (jm_createTrustedCertEntry == NULL) {
+        goto errOut;
+    }
+
     jclass jc_arrayListClass = (*env)->FindClass(env, "java/util/ArrayList");
-    CHECK_NULL(jc_arrayListClass);
+    if (jc_arrayListClass == NULL) {
+        goto errOut;
+    }
+
     jmethodID jm_arrayListCons = (*env)->GetMethodID(env, jc_arrayListClass, "<init>", "()V");
-    CHECK_NULL(jm_arrayListCons);
+    if (jm_arrayListCons == NULL) {
+        goto errOut;
+    }
+
     jmethodID jm_listAdd = (*env)->GetMethodID(env, jc_arrayListClass, "add", "(Ljava/lang/Object;)Z");
-    CHECK_NULL(jm_listAdd);
+    if (jm_listAdd == NULL) {
+        goto errOut;
+    }
 
     do {
         searchResult = SecKeychainSearchCopyNext(keychainItemSearch, &theItem);

--- a/src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m
+++ b/src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -425,7 +425,10 @@ static void addCertificatesToKeystore(JNIEnv *env, jobject keyStore)
 
             // See KeychainStore::createTrustedCertEntry for content of inputTrust
             jobject inputTrust = (*env)->NewObject(env, jc_arrayListClass, jm_arrayListCons);
-            CHECK_NULL(inputTrust);
+            if (inputTrust == NULL) {
+                CFRelease(trustSettings);
+                goto errOut;
+            }
 
             // Dump everything inside trustSettings into inputTrust
             CFIndex count = CFArrayGetCount(trustSettings);


### PR DESCRIPTION
We have a (potential) early return in addCertificatesToKeystore in KeystoreImpl.m . This is implemented by the CHECK_NULL macro. However this missed a CFRelease call.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303354](https://bugs.openjdk.org/browse/JDK-8303354): addCertificatesToKeystore in KeystoreImpl.m needs CFRelease call in early potential CHECK_NULL return


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) ⚠️ Review applies to [5508cdba](https://git.openjdk.org/jdk/pull/12788/files/5508cdba2163cae63c851a8861f932d5c724cef9)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12788/head:pull/12788` \
`$ git checkout pull/12788`

Update a local copy of the PR: \
`$ git checkout pull/12788` \
`$ git pull https://git.openjdk.org/jdk pull/12788/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12788`

View PR using the GUI difftool: \
`$ git pr show -t 12788`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12788.diff">https://git.openjdk.org/jdk/pull/12788.diff</a>

</details>
