### PR TITLE
8303412: Update linux_x64-to-linux_aarch64 cross compilation devkit at Oracle

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1048,7 +1048,7 @@ var getJibProfilesDependencies = function (input, common) {
         linux_x64: "gcc11.2.0-OL6.4+1.0",
         macosx: "Xcode12.4+1.1",
         windows_x64: "VS2022-17.1.0+1.1",
-        linux_aarch64: "gcc11.2.0-OL7.6+1.0",
+        linux_aarch64: input.build_cpu == "x64" ? "gcc11.2.0-OL7.6+1.1" : "gcc11.2.0-OL7.6+1.0",
         linux_arm: "gcc8.2.0-Fedora27+1.0",
         linux_ppc64le: "gcc8.2.0-Fedora27+1.0",
         linux_s390x: "gcc8.2.0-Fedora27+1.0",


### PR DESCRIPTION
Update the devkit used for cross compiling linux-aarch64 binaries on linux-x64 at Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303412](https://bugs.openjdk.org/browse/JDK-8303412): Update linux_x64-to-linux_aarch64 cross compilation devkit at Oracle


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12793/head:pull/12793` \
`$ git checkout pull/12793`

Update a local copy of the PR: \
`$ git checkout pull/12793` \
`$ git pull https://git.openjdk.org/jdk pull/12793/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12793`

View PR using the GUI difftool: \
`$ git pr show -t 12793`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12793.diff">https://git.openjdk.org/jdk/pull/12793.diff</a>

</details>
