### PR TITLE
8303405: fix @returnss typo in ReflectionFactory

### DIFF
--- a/src/java.base/share/classes/jdk/internal/reflect/ReflectionFactory.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/ReflectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -479,7 +479,7 @@ public class ReflectionFactory {
      * Returns a MethodHandle for {@code writeReplace} on the serializable class
      * or null if no match found.
      * @param cl a serializable class
-     * @returnss the {@code writeReplace} MethodHandle or {@code null} if not found
+     * @return the {@code writeReplace} MethodHandle or {@code null} if not found
      */
     public final MethodHandle writeReplaceForSerialization(Class<?> cl) {
         return getReplaceResolveForSerialization(cl, "writeReplace");
@@ -489,7 +489,7 @@ public class ReflectionFactory {
      * Returns a MethodHandle for {@code readResolve} on the serializable class
      * or null if no match found.
      * @param cl a serializable class
-     * @returns the {@code writeReplace} MethodHandle or {@code null} if not found
+     * @return the {@code writeReplace} MethodHandle or {@code null} if not found
      */
     public final MethodHandle readResolveForSerialization(Class<?> cl) {
         return getReplaceResolveForSerialization(cl, "readResolve");
@@ -500,7 +500,7 @@ public class ReflectionFactory {
      * signature constraints.
      * @param cl a serializable class
      * @param methodName the method name to find
-     * @returns a MethodHandle for the method or {@code null} if not found or
+     * @return a MethodHandle for the method or {@code null} if not found or
      *       has the wrong signature.
      */
     private MethodHandle getReplaceResolveForSerialization(Class<?> cl,
@@ -567,7 +567,7 @@ public class ReflectionFactory {
 
     /**
      * Return the accessible constructor for OptionalDataException signaling eof.
-     * @returns the eof constructor for OptionalDataException
+     * @return the eof constructor for OptionalDataException
      */
     public final Constructor<OptionalDataException> newOptionalDataExceptionForSerialization() {
         try {
@@ -731,7 +731,7 @@ public class ReflectionFactory {
      * otherwise.
      * @param cl1 a class
      * @param cl2 another class
-     * @returns true if the two classes are in the same classloader and package
+     * @return true if the two classes are in the same classloader and package
      */
     private static boolean packageEquals(Class<?> cl1, Class<?> cl2) {
         assert !cl1.isArray() && !cl2.isArray();


### PR DESCRIPTION
The following typo: `@returnss` was reported on line _482 of Reflection Factory.java_.

In addition to fixing that, I have replaced multiple instances of `@returns` with `@return` in the same file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303405](https://bugs.openjdk.org/browse/JDK-8303405): fix @returnss typo in ReflectionFactory


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [Martin Buchholz](https://openjdk.org/census#martin) (@Martin-Buchholz - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12794/head:pull/12794` \
`$ git checkout pull/12794`

Update a local copy of the PR: \
`$ git checkout pull/12794` \
`$ git pull https://git.openjdk.org/jdk pull/12794/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12794`

View PR using the GUI difftool: \
`$ git pr show -t 12794`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12794.diff">https://git.openjdk.org/jdk/pull/12794.diff</a>

</details>
