### PR TITLE
8303413: (fs) Ignore polling interval sensitivity modifiers in PollingWatchService

### DIFF
--- a/test/jdk/java/nio/file/WatchService/SensitivityModifier.java
+++ b/test/jdk/java/nio/file/WatchService/SensitivityModifier.java
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4313887
+ * @bug 4313887 8303413
  * @summary Sanity test for JDK-specific sensitivity level watch event modifier
  * @modules jdk.unsupported
  * @library .. /test/lib


### PR DESCRIPTION
Modify `sun.nio.fs.PollingWatchService` to ignore any polling sensitivity modifiers as done by the other `WatchService`s.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8303471](https://bugs.openjdk.org/browse/JDK-8303471) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8303413](https://bugs.openjdk.org/browse/JDK-8303413): (fs) Ignore polling interval sensitivity modifiers in PollingWatchService
 * [JDK-8303471](https://bugs.openjdk.org/browse/JDK-8303471): (fs) Ignore polling interval sensitivity modifiers in PollingWatchService (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12795/head:pull/12795` \
`$ git checkout pull/12795`

Update a local copy of the PR: \
`$ git checkout pull/12795` \
`$ git pull https://git.openjdk.org/jdk pull/12795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12795`

View PR using the GUI difftool: \
`$ git pr show -t 12795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12795.diff">https://git.openjdk.org/jdk/pull/12795.diff</a>

</details>
