### PR TITLE
8303411: JFR problem list entry for JDK-8247776 should be removed

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -739,7 +739,6 @@ javax/script/Test7.java                                         8239361 generic-
 # jdk_jfr
 
 jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209 generic-all
-jdk/jfr/event/os/TestThreadContextSwitches.java                 8247776 windows-all
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all


### PR DESCRIPTION
Trivial one liner - please review. 
Ran test 200 times to confirm CNR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303411](https://bugs.openjdk.org/browse/JDK-8303411): JFR problem list entry for JDK-8247776 should be removed


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12796/head:pull/12796` \
`$ git checkout pull/12796`

Update a local copy of the PR: \
`$ git checkout pull/12796` \
`$ git pull https://git.openjdk.org/jdk pull/12796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12796`

View PR using the GUI difftool: \
`$ git pr show -t 12796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12796.diff">https://git.openjdk.org/jdk/pull/12796.diff</a>

</details>
