### PR TITLE
8303260: (fc) FileChannel::transferFrom should support position > size()

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -633,10 +633,10 @@ public abstract class FileChannel
      * bytes free in its output buffer.
      *
      * <p> This method does not modify this channel's position.  If the given
-     * position is greater than or equal to the file's current size then no bytes are
-     * transferred.  If the target channel has a position then bytes are
-     * written starting at that position and then the position is incremented
-     * by the number of bytes written.
+     * position is greater than or equal to the file's current size then no
+     * bytes are transferred.  If the target channel has a position then bytes
+     * are written starting at that position and then the position
+     * is incremented by the number of bytes written.
      *
      * <p> This method is potentially much more efficient than a simple loop
      * that reads from this channel and writes to the target channel.  Many
@@ -701,8 +701,10 @@ public abstract class FileChannel
      * source has reached end-of-stream.
      *
      * <p> This method does not modify this channel's position.  If the given
-     * position is greater than the file's current size then no bytes are
-     * transferred.  If the source channel has a position then bytes are read
+     * position is greater than or equal to the file's current size then the
+     * file will be grown to accommodate the new bytes; the values of any bytes
+     * between the previous end-of-file and the newly-written bytes are
+     * unspecified.  If the source channel has a position then bytes are read
      * starting at that position and then the position is incremented by the
      * number of bytes read.
      *
@@ -761,7 +763,8 @@ public abstract class FileChannel
      * #read(ByteBuffer)} method, except that bytes are read starting at the
      * given file position rather than at the channel's current position.  This
      * method does not modify this channel's position.  If the given position
-     * is greater than or equal to the file's current size then no bytes are read.  </p>
+     * is greater than or equal to the file's current size then no bytes are
+     * read.  </p>
      *
      * @param  dst
      *         The buffer into which bytes are to be transferred
@@ -806,9 +809,10 @@ public abstract class FileChannel
      * #write(ByteBuffer)} method, except that bytes are written starting at
      * the given file position rather than at the channel's current position.
      * This method does not modify this channel's position.  If the given
-     * position is greater than or equal to the file's current size then the file will be
-     * grown to accommodate the new bytes; the values of any bytes between the
-     * previous end-of-file and the newly-written bytes are unspecified.  </p>
+     * position is greater than or equal to the file's current size then the
+     * file will be grown to accommodate the new bytes; the values of any bytes
+     * between the previous end-of-file and the newly-written bytes are
+     * unspecified.  </p>
      *
      * <p> If the file is open in <a href="#append-mode">append mode</a>, then
      * the effect of invoking this method is unspecified.

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -717,7 +717,7 @@ public abstract class FileChannel
      *         The source channel
      *
      * @param  position
-     *         The position within the file at which the transfer is to begin;
+     *         The file position at which the transfer is to begin;
      *         must be non-negative
      *
      * @param  count
@@ -821,7 +821,7 @@ public abstract class FileChannel
      *         The buffer from which bytes are to be transferred
      *
      * @param  position
-     *         The position at which the transfer is to begin;
+     *         The file position at which the transfer is to begin;
      *         must be non-negative
      *
      * @return  The number of bytes written, possibly zero

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -821,7 +821,7 @@ public abstract class FileChannel
      *         The buffer from which bytes are to be transferred
      *
      * @param  position
-     *         The file position at which the transfer is to begin;
+     *         The position at which the transfer is to begin;
      *         must be non-negative
      *
      * @return  The number of bytes written, possibly zero

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -935,8 +935,6 @@ public class FileChannelImpl
             throw new NonWritableChannelException();
         if ((position < 0) || (count < 0))
             throw new IllegalArgumentException();
-        if (position > size())
-            return 0;
 
         // System calls supporting fast transfers might not work on files
         // which advertise zero size such as those in Linux /proc

--- a/test/jdk/java/nio/channels/FileChannel/TransferFromExtend.java
+++ b/test/jdk/java/nio/channels/FileChannel/TransferFromExtend.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8303260
+ * @summary Test transferFrom to a position greater than size
+ * @library .. /test/lib
+ * @build jdk.test.lib.RandomFactory
+ * @run main TransferFromExtend
+ * @key randomness
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Random;
+import jdk.test.lib.RandomFactory;
+
+import static java.nio.file.StandardOpenOption.*;
+
+public class TransferFromExtend {
+    private static final Random RND = RandomFactory.getRandom();
+
+    private static final int ITERATIONS = 10;
+
+    private static final int TARGET_INITIAL_POS_MAX    = 1024;
+    private static final int FAST_TRANSFER_SIZE_MIN    = 16*1024 + 1;
+    private static final int FAST_TRANSFER_SIZE_MAX    = 500*1024;
+    private static final int TARGET_OFFSET_POS_MIN     = 1;
+    private static final int TARGET_OFFSET_POS_MAX     = 2048;
+    private static final int GENERIC_TRANSFER_SIZE_MAX = 64*1024;
+
+    public static void main(String[] args) throws IOException {
+        for (int i = 1; i <= ITERATIONS; i++) {
+            System.out.printf("Iteration %d of %d%n", i, ITERATIONS);
+            test();
+        }
+    }
+
+    private static final void test() throws IOException {
+        Path dir = Path.of(System.getProperty("test.dir", "."));
+        Path file = Files.createTempFile(dir, "foo", "bar");
+        try (FileChannel fc = FileChannel.open(file, DELETE_ON_CLOSE,
+                                               READ, WRITE)) {
+            fc.position(RND.nextInt(TARGET_INITIAL_POS_MAX));
+            fc.write(ByteBuffer.wrap(new byte[] {(byte)42}));
+            fromDirectlyOrMapped(dir, fc);
+            fromArbitrary(fc);
+        }
+    }
+
+    //
+    // Test the direct and memory-mapped paths. At present the direct path
+    // is implemented only on Linux. The mapped path will be taken only if
+    // there is no direct path and the size of the transfer is more than 16K.
+    // This method therefore tests the direct path on Linux and the mapped
+    // path on other platforms.
+    //
+    private static void fromDirectlyOrMapped(Path dir, FileChannel target)
+        throws IOException {
+        Path file = Files.createTempFile(dir, "foo", "bar");
+        try (FileChannel src = FileChannel.open(file, DELETE_ON_CLOSE,
+                                                READ, WRITE)) {
+            int bufSize = FAST_TRANSFER_SIZE_MIN +
+                RND.nextInt(FAST_TRANSFER_SIZE_MAX - FAST_TRANSFER_SIZE_MIN);
+            byte[] bytes = new byte[bufSize];
+            RND.nextBytes(bytes);
+            src.write(ByteBuffer.wrap(bytes), 0);
+
+            final long size = target.size();
+            final long position = size + TARGET_OFFSET_POS_MIN +
+                RND.nextInt(TARGET_OFFSET_POS_MAX - TARGET_OFFSET_POS_MIN);
+            final long count = src.size();
+            final long transferred = target.transferFrom(src, position, count);
+            if (transferred != count)
+                throw new RuntimeException(transferred + " != " + count);
+            ByteBuffer buf = ByteBuffer.allocate((int)count);
+            target.read(buf, position);
+            if (!Arrays.equals(buf.array(), bytes))
+                throw new RuntimeException("arrays unequal");
+        }
+    }
+
+    //
+    // Test the arbitrary source path. This method tests the
+    // generic path on all platforms.
+    //
+    private static void fromArbitrary(FileChannel target)
+        throws IOException {
+        int bufSize = 1 + RND.nextInt(GENERIC_TRANSFER_SIZE_MAX - 1);
+        byte[] bytes = new byte[bufSize];
+        RND.nextBytes(bytes);
+        ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+        try (ReadableByteChannel src = Channels.newChannel(bais)) {
+            final long size = target.size();
+            final long position = size + TARGET_OFFSET_POS_MIN +
+                RND.nextInt(TARGET_OFFSET_POS_MAX - TARGET_OFFSET_POS_MIN);
+            final long count = bytes.length;
+            final long transferred = target.transferFrom(src, position, count);
+            if (transferred != count)
+                throw new RuntimeException(transferred + " != " + count);
+            ByteBuffer buf = ByteBuffer.allocate((int)count);
+            target.read(buf, position);
+            if (!Arrays.equals(buf.array(), bytes))
+                throw new RuntimeException("arrays unequal");
+        }
+    }
+}


### PR DESCRIPTION
Enhance `FileChannel::transferFrom` to extend the channel's file if `position > size()`. This is consistent with `FileChannel::write(ByteBuffer, long)`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8303474](https://bugs.openjdk.org/browse/JDK-8303474) to be approved

### Issues
 * [JDK-8303260](https://bugs.openjdk.org/browse/JDK-8303260): (fc) FileChannel::transferFrom should support position &gt; size()
 * [JDK-8303474](https://bugs.openjdk.org/browse/JDK-8303474): (fc) FileChannel::transferFrom should support position &gt; size() (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12797/head:pull/12797` \
`$ git checkout pull/12797`

Update a local copy of the PR: \
`$ git checkout pull/12797` \
`$ git pull https://git.openjdk.org/jdk.git pull/12797/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12797`

View PR using the GUI difftool: \
`$ git pr show -t 12797`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12797.diff">https://git.openjdk.org/jdk/pull/12797.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12797#issuecomment-1449189863)