### PR TITLE
8303421: [BACKOUT] 8303133: Update ProcessTools.startProcess(...) to exit early if process exit before linePredicate is printed.

### DIFF
--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -216,23 +216,15 @@ public final class ProcessTools {
 
         try {
             if (timeout > -1) {
-                // Every second check if line is printed and if process is still alive
-                Utils.waitForCondition(() -> latch.getCount() == 0 || !p.isAlive(),
-                        unit.toMillis(Utils.adjustTimeout(timeout)), 1000);
-
-                if (latch.getCount() > 0) {
-                    if (!p.isAlive()) {
-                        // Give some extra time for the StreamPumper to run after the process completed
-                        Thread.sleep(1000);
-                        if (latch.getCount() > 0) {
-                            throw new RuntimeException("Started process " + name + " terminated before producing the expected output.");
-                        }
-                    } else {
+                if (timeout == 0) {
+                    latch.await();
+                } else {
+                    if (!latch.await(Utils.adjustTimeout(timeout), unit)) {
                         throw new TimeoutException();
                     }
                 }
             }
-        } catch (TimeoutException | RuntimeException | InterruptedException e) {
+        } catch (TimeoutException | InterruptedException e) {
             System.err.println("Failed to start a process (thread dump follows)");
             for (Map.Entry<Thread, StackTraceElement[]> s : Thread.getAllStackTraces().entrySet()) {
                 printStack(s.getKey(), s.getValue());

--- a/test/lib/jdk/test/lib/thread/ProcessThread.java
+++ b/test/lib/jdk/test/lib/thread/ProcessThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -150,21 +150,16 @@ public class ProcessThread extends TestThread {
          */
         @Override
         public void xrun() throws Throwable {
-            try {
-                this.process = ProcessTools.startProcess(name, processBuilder, waitfor);
-            } catch (Throwable t) {
-                System.out.println(String.format("ProcessThread[%s] failed: %s", name, t.toString()));
-                throw t;
-            } finally {
-                // Release when process is started or failed
-                latch.countDown();
-            }
+            this.process = ProcessTools.startProcess(name, processBuilder, waitfor);
+            // Release when process is started
+            latch.countDown();
 
+            // Will block...
             try {
-                output = new OutputAnalyzer(this.process);
-                // Will block...
                 this.process.waitFor();
+                output = new OutputAnalyzer(this.process);
             } catch (Throwable t) {
+                String name = Thread.currentThread().getName();
                 System.out.println(String.format("ProcessThread[%s] failed: %s", name, t.toString()));
                 throw t;
             } finally {


### PR DESCRIPTION
The backout for  8303133: Update ProcessTools.startProcess(...) to exit early if process exit before linePredicate is printed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303421](https://bugs.openjdk.org/browse/JDK-8303421): [BACKOUT] 8303133: Update ProcessTools.startProcess(...) to exit early if process exit before linePredicate is printed.


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12799/head:pull/12799` \
`$ git checkout pull/12799`

Update a local copy of the PR: \
`$ git checkout pull/12799` \
`$ git pull https://git.openjdk.org/jdk pull/12799/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12799`

View PR using the GUI difftool: \
`$ git pr show -t 12799`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12799.diff">https://git.openjdk.org/jdk/pull/12799.diff</a>

</details>
