### PR TITLE
8303355: The Depend plugin does fully recompile when primitive type changes

### DIFF
--- a/make/jdk/src/classes/build/tools/depend/Depend.java
+++ b/make/jdk/src/classes/build/tools/depend/Depend.java
@@ -33,6 +33,7 @@ import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ModifiersTree;
+import com.sun.source.tree.PrimitiveTypeTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
 import java.io.File;
@@ -140,9 +141,12 @@ public class Depend implements Plugin {
     public void init(JavacTask jt, String... args) {
         addExports();
 
+        Path internalAPIDigestFile;
+        Map<String, String> internalAPI = new HashMap<>();
         AtomicBoolean noApiChange = new AtomicBoolean();
+        Context context = ((BasicJavacTask) jt).getContext();
+        JavaCompiler compiler = JavaCompiler.instance(context);
         try {
-            Context context = ((BasicJavacTask) jt).getContext();
             Options options = Options.instance(context);
             String modifiedInputs = options.get("modifiedInputs");
             if (modifiedInputs == null) {
@@ -157,8 +161,18 @@ public class Depend implements Plugin {
             Set<Path> modified = Files.readAllLines(Paths.get(modifiedInputs)).stream()
                                                                               .map(Paths::get)
                                                                               .collect(Collectors.toSet());
-            Path internalAPIDigestFile = Paths.get(internalAPIPath);
-            JavaCompiler compiler = JavaCompiler.instance(context);
+            internalAPIDigestFile = Paths.get(internalAPIPath);
+            if (Files.isReadable(internalAPIDigestFile)) {
+                try {
+                    Files.readAllLines(internalAPIDigestFile, StandardCharsets.UTF_8)
+                         .forEach(line -> {
+                             String[] keyAndValue = line.split("=");
+                             internalAPI.put(keyAndValue[0], keyAndValue[1]);
+                         });
+                } catch (IOException ex) {
+                    throw new IllegalStateException(ex);
+                }
+            }
             Class<?> initialFileParserIntf = Class.forName("com.sun.tools.javac.main.JavaCompiler$InitialFileParserIntf");
             Class<?> initialFileParser = Class.forName("com.sun.tools.javac.main.JavaCompiler$InitialFileParser");
             Field initialParserKeyField = initialFileParser.getDeclaredField("initialParserKey");
@@ -169,7 +183,7 @@ public class Depend implements Plugin {
                                            new Class<?>[] {initialFileParserIntf},
                                            new FilteredInitialFileParser(compiler,
                                                                          modified,
-                                                                         internalAPIDigestFile,
+                                                                         internalAPI,
                                                                          noApiChange,
                                                                          debug));
             context.<Object>put(key, initialParserInstance);
@@ -213,7 +227,17 @@ public class Depend implements Plugin {
                         }
                     }
                 }
-                if (te.getKind() == Kind.COMPILATION && !noApiChange.get()) {
+                if (te.getKind() == Kind.COMPILATION && !noApiChange.get() &&
+                    compiler.errorCount() == 0) {
+                    try (OutputStream out = Files.newOutputStream(internalAPIDigestFile)) {
+                        String hashes = internalAPI.entrySet()
+                                                   .stream()
+                                                   .map(e -> e.getKey() + "=" + e.getValue())
+                                                   .collect(Collectors.joining("\n"));
+                        out.write(hashes.getBytes(StandardCharsets.UTF_8));
+                    } catch (IOException ex) {
+                        throw new IllegalStateException(ex);
+                    }
                     String previousSignature = null;
                     File digestFile = new File(args[0]);
                     try (InputStream in = new FileInputStream(digestFile)) {
@@ -258,20 +282,8 @@ public class Depend implements Plugin {
 
     private com.sun.tools.javac.util.List<JCCompilationUnit> doFilteredParse(
             JavaCompiler compiler, Iterable<JavaFileObject> fileObjects, Set<Path> modified,
-            Path internalAPIDigestFile, AtomicBoolean noApiChange,
+            Map<String, String> internalAPI, AtomicBoolean noApiChange,
             boolean debug) {
-        Map<String, String> internalAPI = new LinkedHashMap<>();
-        if (Files.isReadable(internalAPIDigestFile)) {
-            try {
-                Files.readAllLines(internalAPIDigestFile, StandardCharsets.UTF_8)
-                     .forEach(line -> {
-                         String[] keyAndValue = line.split("=");
-                         internalAPI.put(keyAndValue[0], keyAndValue[1]);
-                     });
-            } catch (IOException ex) {
-                throw new IllegalStateException(ex);
-            }
-        }
         Map<JavaFileObject, JCCompilationUnit> files2CUT = new IdentityHashMap<>();
         boolean fullRecompile = modified.stream()
                                         .map(Path::toString)
@@ -289,7 +301,6 @@ public class Depend implements Plugin {
                 result.add(parsed);
             }
         }
-
         if (fullRecompile) {
             for (JavaFileObject jfo : fileObjects) {
                 if (!modified.contains(Path.of(jfo.getName()))) {
@@ -300,15 +311,6 @@ public class Depend implements Plugin {
                     }
                     result.add(parsed);
                 }
-            }
-            try (OutputStream out = Files.newOutputStream(internalAPIDigestFile)) {
-                String hashes = internalAPI.entrySet()
-                                           .stream()
-                                           .map(e -> e.getKey() + "=" + e.getValue())
-                                           .collect(Collectors.joining("\n"));
-                out.write(hashes.getBytes(StandardCharsets.UTF_8));
-            } catch (IOException ex) {
-                throw new IllegalStateException(ex);
             }
         } else {
             noApiChange.set(true);
@@ -878,24 +880,30 @@ public class Depend implements Plugin {
             return super.visitModifiers(node, p);
         }
 
+        @Override
+        public Void visitPrimitiveType(PrimitiveTypeTree node, Void p) {
+            update(node.getPrimitiveTypeKind().name());
+            return super.visitPrimitiveType(node, p);
+        }
+
     }
 
     private class FilteredInitialFileParser implements InvocationHandler {
 
         private final JavaCompiler compiler;
         private final Set<Path> modified;
-        private final Path internalAPIDigestFile;
+        private final Map<String, String> internalAPI;
         private final AtomicBoolean noApiChange;
         private final boolean debug;
 
         public FilteredInitialFileParser(JavaCompiler compiler,
                                          Set<Path> modified,
-                                         Path internalAPIDigestFile,
+                                         Map<String, String> internalAPI,
                                          AtomicBoolean noApiChange,
                                          boolean debug) {
             this.compiler = compiler;
             this.modified = modified;
-            this.internalAPIDigestFile = internalAPIDigestFile;
+            this.internalAPI = internalAPI;
             this.noApiChange = noApiChange;
             this.debug = debug;
         }
@@ -907,7 +915,7 @@ public class Depend implements Plugin {
                 case "parse" -> doFilteredParse(compiler,
                                                 (Iterable<JavaFileObject>) args[0],
                                                 modified,
-                                                internalAPIDigestFile,
+                                                internalAPI,
                                                 noApiChange,
                                                 debug);
                 default -> throw new UnsupportedOperationException();

--- a/make/jdk/src/classes/build/tools/depend/Depend.java
+++ b/make/jdk/src/classes/build/tools/depend/Depend.java
@@ -837,7 +837,7 @@ public class Depend implements Plugin {
                     !isPrivate(((VariableTree) m).getModifiers()) ||
                     isRecordComponent((VariableTree) m);
                 case BLOCK -> false;
-                default -> throw new IllegalStateException("Unexpected tree kind: " + m.getKind());
+                default -> false;
             };
         }
 


### PR DESCRIPTION
The OpenJDK build is using a Plugin called Depend to avoid building Java code unnecessarily. It has two parts, one is checking module APIs (and forces rebuild of dependent modules if a dependency changes), and second takes modified files in a module, and attempts to detect whether it is enough to recompile these files, or if the whole module must be rebuilt.

There's a bug in the second part, it does not track changes in primitive types, so e.g. a change of a type of a public field form `int` to `long` does not cause recompile.

This patch fixes that by visiting the primitive types, and including them in the hash computed for the given file.

There's also another problem - if a module is being recompiled from scratch due to a change in a file hash, the new/updated file hashes are written immediately. And if the compilation consequently fails, the state is not compared to the original hash, but to the hash from the broken compilation, which may lead to missing compilation of some files.

This patch moves the code to write the new hashes to the end of compilation, and only do that when there were no compile-time errors during the compilation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303355](https://bugs.openjdk.org/browse/JDK-8303355): The Depend plugin does fully recompile when primitive type changes


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [63cd6884](https://git.openjdk.org/jdk/pull/12801/files/63cd688419b15f234bb49b9301fe9347ae854821)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12801/head:pull/12801` \
`$ git checkout pull/12801`

Update a local copy of the PR: \
`$ git checkout pull/12801` \
`$ git pull https://git.openjdk.org/jdk pull/12801/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12801`

View PR using the GUI difftool: \
`$ git pr show -t 12801`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12801.diff">https://git.openjdk.org/jdk/pull/12801.diff</a>

</details>
