### PR TITLE
JDK-8303443: IGV: Syntax highlighting and resizing for filter editor

### DIFF
--- a/src/utils/IdealGraphVisualizer/Filter/src/main/java/com/sun/hotspot/igv/filter/EditFilterDialog.form
+++ b/src/utils/IdealGraphVisualizer/Filter/src/main/java/com/sun/hotspot/igv/filter/EditFilterDialog.form
@@ -6,14 +6,15 @@
     <Property name="title" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
       <ResourceString bundle="at/ssw/graphanalyzer/filter/Bundle.properties" key="title" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
     </Property>
-    <Property name="resizable" type="boolean" value="false"/>
   </Properties>
   <SyntheticProperties>
     <SyntheticProperty name="formSizePolicy" type="int" value="1"/>
+    <SyntheticProperty name="generateCenter" type="boolean" value="false"/>
   </SyntheticProperties>
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="1"/>
     <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_generateFQN" type="java.lang.Boolean" value="true"/>
     <AuxValue name="FormSettings_generateMnemonicsCode" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_i18nAutoMode" type="java.lang.Boolean" value="true"/>
     <AuxValue name="FormSettings_layoutCodeTarget" type="java.lang.Integer" value="2"/>
@@ -52,22 +53,22 @@
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
-              <EmptySpace max="-2" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="nameLabel" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="nameTextField" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <EmptySpace type="unrelated" min="-2" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="sourceLabel" min="-2" max="-2" attributes="0"/>
-                  <Component id="jScrollPane1" min="-2" pref="337" max="-2" attributes="0"/>
+                  <Component id="jScrollPane1" pref="383" max="32767" attributes="0"/>
               </Group>
-              <EmptySpace pref="16" max="32767" attributes="0"/>
+              <EmptySpace min="-2" pref="16" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="cancelButton" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="okButton" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace max="-2" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -77,13 +78,20 @@
       <AuxValues>
         <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
       </AuxValues>
-
       <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
       <SubComponents>
-        <Component class="javax.swing.JTextPane" name="sourceTextArea">
-          <Properties>
-          </Properties>
-        </Component>
+        <Container class="javax.swing.JPanel" name="jPanel1">
+          <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
+          <SubComponents>
+            <Component class="javax.swing.JTextPane" name="sourceTextArea">
+              <Constraints>
+                <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+                  <BorderConstraints direction="Center"/>
+                </Constraint>
+              </Constraints>
+            </Component>
+          </SubComponents>
+        </Container>
       </SubComponents>
     </Container>
     <Component class="javax.swing.JTextField" name="nameTextField">

--- a/src/utils/IdealGraphVisualizer/Filter/src/main/java/com/sun/hotspot/igv/filter/EditFilterDialog.form
+++ b/src/utils/IdealGraphVisualizer/Filter/src/main/java/com/sun/hotspot/igv/filter/EditFilterDialog.form
@@ -80,10 +80,8 @@
 
       <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
       <SubComponents>
-        <Component class="javax.swing.JTextArea" name="sourceTextArea">
+        <Component class="javax.swing.JTextPane" name="sourceTextArea">
           <Properties>
-            <Property name="columns" type="int" value="20"/>
-            <Property name="rows" type="int" value="5"/>
           </Properties>
         </Component>
       </SubComponents>

--- a/src/utils/IdealGraphVisualizer/Filter/src/main/java/com/sun/hotspot/igv/filter/EditFilterDialog.java
+++ b/src/utils/IdealGraphVisualizer/Filter/src/main/java/com/sun/hotspot/igv/filter/EditFilterDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/utils/IdealGraphVisualizer/Filter/src/main/java/com/sun/hotspot/igv/filter/EditFilterDialog.java
+++ b/src/utils/IdealGraphVisualizer/Filter/src/main/java/com/sun/hotspot/igv/filter/EditFilterDialog.java
@@ -49,7 +49,7 @@ public class EditFilterDialog extends javax.swing.JDialog {
         this.customFilter = customFilter;
         initComponents();
 
-        sourceTextArea.setFont(new Font("Courier", Font.PLAIN, 12));
+        sourceTextArea.setFont(new Font("Monospaced", Font.PLAIN, 12));
         AbstractDocument doc = (AbstractDocument) sourceTextArea.getDocument();
         doc.setDocumentFilter(new DocumentFilter(){
             private final StyledDocument styledDocument = sourceTextArea.getStyledDocument();

--- a/src/utils/IdealGraphVisualizer/Filter/src/main/java/com/sun/hotspot/igv/filter/EditFilterDialog.java
+++ b/src/utils/IdealGraphVisualizer/Filter/src/main/java/com/sun/hotspot/igv/filter/EditFilterDialog.java
@@ -24,12 +24,10 @@
  */
 package com.sun.hotspot.igv.filter;
 
-import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Font;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import javax.swing.text.*;
 import org.openide.windows.WindowManager;
@@ -136,7 +134,9 @@ public class EditFilterDialog extends javax.swing.JDialog {
      */
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
+
         jScrollPane1 = new javax.swing.JScrollPane();
+        jPanel1 = new javax.swing.JPanel();
         sourceTextArea = new javax.swing.JTextPane();
         nameTextField = new javax.swing.JTextField();
         nameLabel = new javax.swing.JLabel();
@@ -146,26 +146,32 @@ public class EditFilterDialog extends javax.swing.JDialog {
 
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
         setTitle(org.openide.util.NbBundle.getMessage(EditFilterDialog.class, "title")); // NOI18N
-        setResizable(true);
 
-        JPanel panel = new JPanel(new BorderLayout());
-        panel.add(sourceTextArea);
-        jScrollPane1.setViewportView(panel);
+        jPanel1.setLayout(new java.awt.BorderLayout());
+        jPanel1.add(sourceTextArea, java.awt.BorderLayout.CENTER);
 
-        nameTextField.setText("null");
+        jScrollPane1.setViewportView(jPanel1);
+
+        nameTextField.setText(org.openide.util.NbBundle.getMessage(EditFilterDialog.class, "nameTextField.text")); // NOI18N
 
         nameLabel.setText(org.openide.util.NbBundle.getMessage(EditFilterDialog.class, "jLabel1.text")); // NOI18N
 
         sourceLabel.setText(org.openide.util.NbBundle.getMessage(EditFilterDialog.class, "jLabel2.text")); // NOI18N
 
         okButton.setText(org.openide.util.NbBundle.getMessage(EditFilterDialog.class, "jButton1.text")); // NOI18N
-        okButton.addActionListener(evt -> {
-            cancelButtonClicked(evt);
-            okButtonClicked(evt);
+        okButton.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                cancelButtonClicked(evt);
+                okButtonClicked(evt);
+            }
         });
 
         cancelButton.setText(org.openide.util.NbBundle.getMessage(EditFilterDialog.class, "jButton2.text")); // NOI18N
-        cancelButton.addActionListener(this::cancelButtonClicked);
+        cancelButton.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                cancelButtonClicked(evt);
+            }
+        });
 
         org.jdesktop.layout.GroupLayout layout = new org.jdesktop.layout.GroupLayout(getContentPane());
         getContentPane().setLayout(layout);
@@ -180,7 +186,7 @@ public class EditFilterDialog extends javax.swing.JDialog {
                             .add(nameLabel))
                         .add(25, 25, 25)
                         .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                            .add(jScrollPane1, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 695, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE)
+                            .add(jScrollPane1, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 695, Short.MAX_VALUE)
                             .add(nameTextField, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 695, Short.MAX_VALUE)))
                     .add(org.jdesktop.layout.GroupLayout.TRAILING, layout.createSequentialGroup()
                         .add(okButton, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 76, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
@@ -198,8 +204,8 @@ public class EditFilterDialog extends javax.swing.JDialog {
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
                 .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
                     .add(sourceLabel)
-                    .add(jScrollPane1, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 337, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE))
-                    .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                    .add(jScrollPane1, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 383, Short.MAX_VALUE))
+                .add(16, 16, 16)
                 .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
                     .add(cancelButton)
                     .add(okButton))
@@ -223,6 +229,7 @@ private void cancelButtonClicked(java.awt.event.ActionEvent evt) {//GEN-FIRST:ev
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton cancelButton;
+    private javax.swing.JPanel jPanel1;
     private javax.swing.JScrollPane jScrollPane1;
     private javax.swing.JLabel nameLabel;
     private javax.swing.JTextField nameTextField;

--- a/src/utils/IdealGraphVisualizer/Filter/src/main/java/com/sun/hotspot/igv/filter/EditFilterDialog.java
+++ b/src/utils/IdealGraphVisualizer/Filter/src/main/java/com/sun/hotspot/igv/filter/EditFilterDialog.java
@@ -24,6 +24,14 @@
  */
 package com.sun.hotspot.igv.filter;
 
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Font;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.text.*;
 import org.openide.windows.WindowManager;
 
 /**
@@ -32,7 +40,7 @@ import org.openide.windows.WindowManager;
  */
 public class EditFilterDialog extends javax.swing.JDialog {
 
-    private CustomFilter customFilter;
+    private final CustomFilter customFilter;
     private boolean accepted;
 
     /** Creates new form EditFilterDialog */
@@ -40,6 +48,78 @@ public class EditFilterDialog extends javax.swing.JDialog {
         super(WindowManager.getDefault().getMainWindow(), true);
         this.customFilter = customFilter;
         initComponents();
+
+        sourceTextArea.setFont(new Font("Courier", Font.PLAIN, 12));
+        AbstractDocument doc = (AbstractDocument) sourceTextArea.getDocument();
+        doc.setDocumentFilter(new DocumentFilter(){
+            private final StyledDocument styledDocument = sourceTextArea.getStyledDocument();
+            private final StyleContext styleContext = StyleContext.getDefaultStyleContext();
+            private final AttributeSet blueAttributeSet = styleContext.addAttribute(styleContext.getEmptySet(), StyleConstants.Foreground, new Color(8,8,255));
+            private final AttributeSet greenAttributeSet = styleContext.addAttribute(styleContext.getEmptySet(), StyleConstants.Foreground, new Color(80,160,80));
+            private final AttributeSet greyAttributeSet = styleContext.addAttribute(styleContext.getEmptySet(), StyleConstants.Foreground, Color.GRAY);
+            private final AttributeSet blackAttributeSet = styleContext.addAttribute(styleContext.getEmptySet(), StyleConstants.Foreground, Color.BLACK);
+            private final Pattern comments_pattern = Pattern.compile("(?://.*)|(/\\*(?:.|[\\n\\r])*?\\*/)");
+            private final Pattern quote_pattern = Pattern.compile("([\"'])((?:\\\\\\1|(?:(?!\\1)).)*)(\\1)");
+            private final Pattern keywords_pattern = buildKeywordsPattern();
+            private final String tabSpaces = "  ";
+
+
+            private Pattern buildKeywordsPattern() {
+                StringBuilder pattern = new StringBuilder();
+                String[] keywords = new String[]{"await","break","case","catch","class","const","continue","debugger",
+                        "default","delete","do","else","enum","export","extends","false","finally","for","function",
+                        "if","implements","import","in","instanceof","interface","let","new","null","package","private",
+                        "protected","public","return","super","switch","static","this","throw","try","true","typeof",
+                        "var","void","while","with","yield"
+                };
+                for (String keyword : keywords) {
+                    pattern.append("\\b").append(keyword).append("\\b|");
+                }
+                if (pattern.length()>0) {
+                    pattern.deleteCharAt(pattern.length()-1);
+                }
+                return Pattern.compile(pattern.toString());
+            }
+
+            @Override
+            public void insertString(FilterBypass fb, int offset, String text, AttributeSet attrs) throws BadLocationException {
+                text = text.replace("\t", tabSpaces);
+                super.insertString(fb, offset, text, attrs);
+                SwingUtilities.invokeLater(this::updateSyntaxHighlighting);
+            }
+
+            @Override
+            public void remove(FilterBypass fb, int offset, int length) throws BadLocationException {
+                super.remove(fb, offset, length);
+                SwingUtilities.invokeLater(this::updateSyntaxHighlighting);
+            }
+
+            @Override
+            public void replace(FilterBypass fb, int offset, int length, String text, AttributeSet attrs) throws BadLocationException {
+                text = text.replace("\t", tabSpaces);
+                super.replace(fb, offset, length, text, attrs);
+                SwingUtilities.invokeLater(this::updateSyntaxHighlighting);
+            }
+
+            private void updateSyntaxHighlighting() {
+                styledDocument.setCharacterAttributes(0, sourceTextArea.getText().length(), blackAttributeSet, true);
+
+                Matcher keyword_matcher = keywords_pattern.matcher(sourceTextArea.getText());
+                while (keyword_matcher.find()) {
+                    styledDocument.setCharacterAttributes(keyword_matcher.start(), keyword_matcher.end() - keyword_matcher.start(), blueAttributeSet, false);
+                }
+
+                Matcher quote_matcher = quote_pattern.matcher(sourceTextArea.getText());
+                while (quote_matcher.find()) {
+                    styledDocument.setCharacterAttributes(quote_matcher.start(), quote_matcher.end() - quote_matcher.start(), greenAttributeSet, false);
+                }
+
+                Matcher comments_matcher = comments_pattern.matcher(sourceTextArea.getText());
+                while (comments_matcher.find()) {
+                    styledDocument.setCharacterAttributes(comments_matcher.start(), comments_matcher.end() - comments_matcher.start(), greyAttributeSet, false);
+                }
+            }
+        });
 
         sourceTextArea.setText(customFilter.getCode());
         nameTextField.setText(customFilter.getName());
@@ -56,9 +136,8 @@ public class EditFilterDialog extends javax.swing.JDialog {
      */
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
-
         jScrollPane1 = new javax.swing.JScrollPane();
-        sourceTextArea = new javax.swing.JTextArea();
+        sourceTextArea = new javax.swing.JTextPane();
         nameTextField = new javax.swing.JTextField();
         nameLabel = new javax.swing.JLabel();
         sourceLabel = new javax.swing.JLabel();
@@ -67,11 +146,11 @@ public class EditFilterDialog extends javax.swing.JDialog {
 
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
         setTitle(org.openide.util.NbBundle.getMessage(EditFilterDialog.class, "title")); // NOI18N
-        setResizable(false);
+        setResizable(true);
 
-        sourceTextArea.setColumns(20);
-        sourceTextArea.setRows(5);
-        jScrollPane1.setViewportView(sourceTextArea);
+        JPanel panel = new JPanel(new BorderLayout());
+        panel.add(sourceTextArea);
+        jScrollPane1.setViewportView(panel);
 
         nameTextField.setText("null");
 
@@ -80,19 +159,13 @@ public class EditFilterDialog extends javax.swing.JDialog {
         sourceLabel.setText(org.openide.util.NbBundle.getMessage(EditFilterDialog.class, "jLabel2.text")); // NOI18N
 
         okButton.setText(org.openide.util.NbBundle.getMessage(EditFilterDialog.class, "jButton1.text")); // NOI18N
-        okButton.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                cancelButtonClicked(evt);
-                okButtonClicked(evt);
-            }
+        okButton.addActionListener(evt -> {
+            cancelButtonClicked(evt);
+            okButtonClicked(evt);
         });
 
         cancelButton.setText(org.openide.util.NbBundle.getMessage(EditFilterDialog.class, "jButton2.text")); // NOI18N
-        cancelButton.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                cancelButtonClicked(evt);
-            }
-        });
+        cancelButton.addActionListener(this::cancelButtonClicked);
 
         org.jdesktop.layout.GroupLayout layout = new org.jdesktop.layout.GroupLayout(getContentPane());
         getContentPane().setLayout(layout);
@@ -107,7 +180,7 @@ public class EditFilterDialog extends javax.swing.JDialog {
                             .add(nameLabel))
                         .add(25, 25, 25)
                         .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                            .add(jScrollPane1, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 695, Short.MAX_VALUE)
+                            .add(jScrollPane1, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 695, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE)
                             .add(nameTextField, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 695, Short.MAX_VALUE)))
                     .add(org.jdesktop.layout.GroupLayout.TRAILING, layout.createSequentialGroup()
                         .add(okButton, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 76, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
@@ -125,8 +198,8 @@ public class EditFilterDialog extends javax.swing.JDialog {
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
                 .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
                     .add(sourceLabel)
-                    .add(jScrollPane1, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 337, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED, 16, Short.MAX_VALUE)
+                    .add(jScrollPane1, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 337, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE))
+                    .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
                 .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
                     .add(cancelButton)
                     .add(okButton))
@@ -155,7 +228,7 @@ private void cancelButtonClicked(java.awt.event.ActionEvent evt) {//GEN-FIRST:ev
     private javax.swing.JTextField nameTextField;
     private javax.swing.JButton okButton;
     private javax.swing.JLabel sourceLabel;
-    private javax.swing.JTextArea sourceTextArea;
+    private javax.swing.JTextPane sourceTextArea;
     // End of variables declaration//GEN-END:variables
 
 }

--- a/src/utils/IdealGraphVisualizer/FilterWindow/src/main/java/com/sun/hotspot/igv/filterwindow/FilterTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/FilterWindow/src/main/java/com/sun/hotspot/igv/filterwindow/FilterTopComponent.java
@@ -412,9 +412,9 @@ public final class FilterTopComponent extends TopComponent implements LookupList
             try {
                 if (!fileObject.getName().equals(filter.getName())) {
                     FileLock lock = fileObject.lock();
-                    fileObject.move(lock, fileObject.getParent(), filter.getName(), "");
+                    fileObject.move(lock, fileObject.getParent(), filter.getName(), "js");
                     lock.releaseLock();
-                    FileObject newFileObject = fileObject.getParent().getFileObject(filter.getName());
+                    FileObject newFileObject = fileObject.getParent().getFileObject(filter.getName() + ".js");
                     fileObject = newFileObject;
                 }
 
@@ -457,8 +457,6 @@ public final class FilterTopComponent extends TopComponent implements LookupList
                     sb.append("\n");
                 }
                 code = sb.toString();
-            } catch (FileNotFoundException ex) {
-                Exceptions.printStackTrace(ex);
             } catch (IOException ex) {
                 Exceptions.printStackTrace(ex);
             } finally {
@@ -472,7 +470,6 @@ public final class FilterTopComponent extends TopComponent implements LookupList
 
             String displayName = fo.getName();
 
-
             final CustomFilter cf = new CustomFilter(displayName, code, engine);
             map.put(displayName, cf);
 
@@ -483,8 +480,6 @@ public final class FilterTopComponent extends TopComponent implements LookupList
             if (enabled != null && (boolean) enabled) {
                 enabledSet.add(cf);
             }
-
-            cf.getChangedEvent().addListener(new FilterChangedListener(fo, cf));
 
             customFilters.add(cf);
         }
@@ -512,6 +507,10 @@ public final class FilterTopComponent extends TopComponent implements LookupList
 
         for (CustomFilter cf : customFilters) {
             sequence.addFilter(cf);
+            FileObject fo = getFileObject(cf);
+            FilterChangedListener listener = new FilterChangedListener(fo, cf);
+            listener.changed(cf);
+            cf.getChangedEvent().addListener(listener);
             if (enabledSet.contains(cf)) {
                 filterChain.addFilter(cf);
             }
@@ -597,10 +596,10 @@ public final class FilterTopComponent extends TopComponent implements LookupList
     }
 
     private FileObject getFileObject(CustomFilter cf) {
-        FileObject fo = FileUtil.getConfigRoot().getFileObject(FOLDER_ID + "/" + cf.getName());
+        FileObject fo = FileUtil.getConfigRoot().getFileObject(FOLDER_ID + "/" + cf.getName() + ".js");
         if (fo == null) {
             try {
-                fo = FileUtil.getConfigRoot().getFileObject(FOLDER_ID).createData(cf.getName());
+                fo = FileUtil.getConfigRoot().getFileObject(FOLDER_ID).createData(cf.getName() + ".js");
             } catch (IOException ex) {
                 Exceptions.printStackTrace(ex);
             }

--- a/src/utils/IdealGraphVisualizer/FilterWindow/src/main/java/com/sun/hotspot/igv/filterwindow/FilterTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/FilterWindow/src/main/java/com/sun/hotspot/igv/filterwindow/FilterTopComponent.java
@@ -412,9 +412,9 @@ public final class FilterTopComponent extends TopComponent implements LookupList
             try {
                 if (!fileObject.getName().equals(filter.getName())) {
                     FileLock lock = fileObject.lock();
-                    fileObject.move(lock, fileObject.getParent(), filter.getName(), "js");
+                    fileObject.move(lock, fileObject.getParent(), filter.getName(), "");
                     lock.releaseLock();
-                    FileObject newFileObject = fileObject.getParent().getFileObject(filter.getName() + ".js");
+                    FileObject newFileObject = fileObject.getParent().getFileObject(filter.getName());
                     fileObject = newFileObject;
                 }
 
@@ -457,6 +457,8 @@ public final class FilterTopComponent extends TopComponent implements LookupList
                     sb.append("\n");
                 }
                 code = sb.toString();
+            } catch (FileNotFoundException ex) {
+                Exceptions.printStackTrace(ex);
             } catch (IOException ex) {
                 Exceptions.printStackTrace(ex);
             } finally {
@@ -470,6 +472,7 @@ public final class FilterTopComponent extends TopComponent implements LookupList
 
             String displayName = fo.getName();
 
+
             final CustomFilter cf = new CustomFilter(displayName, code, engine);
             map.put(displayName, cf);
 
@@ -480,6 +483,8 @@ public final class FilterTopComponent extends TopComponent implements LookupList
             if (enabled != null && (boolean) enabled) {
                 enabledSet.add(cf);
             }
+
+            cf.getChangedEvent().addListener(new FilterChangedListener(fo, cf));
 
             customFilters.add(cf);
         }
@@ -507,10 +512,6 @@ public final class FilterTopComponent extends TopComponent implements LookupList
 
         for (CustomFilter cf : customFilters) {
             sequence.addFilter(cf);
-            FileObject fo = getFileObject(cf);
-            FilterChangedListener listener = new FilterChangedListener(fo, cf);
-            listener.changed(cf);
-            cf.getChangedEvent().addListener(listener);
             if (enabledSet.contains(cf)) {
                 filterChain.addFilter(cf);
             }
@@ -596,10 +597,10 @@ public final class FilterTopComponent extends TopComponent implements LookupList
     }
 
     private FileObject getFileObject(CustomFilter cf) {
-        FileObject fo = FileUtil.getConfigRoot().getFileObject(FOLDER_ID + "/" + cf.getName() + ".js");
+        FileObject fo = FileUtil.getConfigRoot().getFileObject(FOLDER_ID + "/" + cf.getName());
         if (fo == null) {
             try {
-                fo = FileUtil.getConfigRoot().getFileObject(FOLDER_ID).createData(cf.getName() + ".js");
+                fo = FileUtil.getConfigRoot().getFileObject(FOLDER_ID).createData(cf.getName());
             } catch (IOException ex) {
                 Exceptions.printStackTrace(ex);
             }


### PR DESCRIPTION
In the Filter window of the IdealGraphVisualizer (IGV) the user can double-click on a filter to edit the javascript code. 

- Previously, the code window was not resizable and had no syntax highlighting
<img width="782" alt="editor_old" src="https://user-images.githubusercontent.com/71546117/222137737-1042b272-2c4f-4ae2-929d-2c5d285818e4.png">

- Now, the code window can be resized by the user and has basic syntax highlighting for `keywords`, `strings` and `comments`
<img width="727" alt="editor_new" src="https://user-images.githubusercontent.com/71546117/222137687-892ba36d-4a76-4769-ada7-7982ea59a5ac.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303443](https://bugs.openjdk.org/browse/JDK-8303443): IGV: Syntax highlighting and resizing for filter editor


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12803/head:pull/12803` \
`$ git checkout pull/12803`

Update a local copy of the PR: \
`$ git checkout pull/12803` \
`$ git pull https://git.openjdk.org/jdk pull/12803/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12803`

View PR using the GUI difftool: \
`$ git pr show -t 12803`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12803.diff">https://git.openjdk.org/jdk/pull/12803.diff</a>

</details>
