### PR TITLE
8303444: AsyncGetCallTrace obtains too few frames with instrumentation agent

### DIFF
--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -90,12 +90,12 @@ bool frame::safe_for_sender(JavaThread *thread) {
   if (_cb != NULL ) {
 
     // First check if frame is complete and tester is reliable
-    // Unfortunately we can only check frame complete for runtime stubs and nmethod
+    // Unfortunately we can only check frame complete for compiled blobs,
     // other generic buffer blobs are more problematic so we just assume they are
     // ok. adapter blobs never have a frame complete and are never ok.
 
     if (!_cb->is_frame_complete_at(_pc)) {
-      if (_cb->is_compiled() || _cb->is_adapter_blob() || _cb->is_runtime_stub()) {
+      if (_cb->is_compiled() || _cb->is_adapter_blob()) {
         return false;
       }
     }


### PR DESCRIPTION
This fixes the bug by removing the faulty completeness check for runtime blobs.

I tested it using the [trace_validation](https://github.com/parttimenerd/trace_validation) tool successfully as described in the issue. I furthermore ran the [jdk-profiling-tester](https://github.com/parttimenerd/jdk-profiling-tester) to ensure that this fix did not introduce any stability issues and ran the serviceability JTREG tests successfully.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303444](https://bugs.openjdk.org/browse/JDK-8303444): AsyncGetCallTrace obtains too few frames with instrumentation agent


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12804/head:pull/12804` \
`$ git checkout pull/12804`

Update a local copy of the PR: \
`$ git checkout pull/12804` \
`$ git pull https://git.openjdk.org/jdk pull/12804/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12804`

View PR using the GUI difftool: \
`$ git pr show -t 12804`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12804.diff">https://git.openjdk.org/jdk/pull/12804.diff</a>

</details>
