### PR TITLE
8303442: Clean up w2k_lsa_auth linker parameters

### DIFF
--- a/make/modules/java.security.jgss/Lib.gmk
+++ b/make/modules/java.security.jgss/Lib.gmk
@@ -64,9 +64,7 @@ ifneq ($(BUILD_CRYPTO), false)
         CFLAGS := $(CFLAGS_JDKLIB), \
         LDFLAGS := $(LDFLAGS_JDKLIB) \
             $(call SET_SHARED_LIBRARY_ORIGIN), \
-        LIBS := advapi32.lib Secur32.lib netapi32.lib kernel32.lib user32.lib \
-            gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib \
-            ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib wsock32.lib, \
+        LIBS := advapi32.lib Secur32.lib kernel32.lib ws2_32.lib, \
     ))
 
     TARGETS += $(BUILD_LIBW2K_LSA_AUTH)


### PR DESCRIPTION
Please review this PR that upgrades winsock lib from version 1 (wsock32) to version 2 (ws2_32) and removes unnecessary libs from the build.

With the winsock upgrade we should be able to avoid loading wsock32.dll at runtime. Winsock is only needed for `htonl` function, and wsock32.dll forwards that function to ws2_32 anyway.

All jgss/krb5 (jdk_security4) tests continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303442](https://bugs.openjdk.org/browse/JDK-8303442): Clean up w2k_lsa_auth linker parameters


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12805/head:pull/12805` \
`$ git checkout pull/12805`

Update a local copy of the PR: \
`$ git checkout pull/12805` \
`$ git pull https://git.openjdk.org/jdk pull/12805/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12805`

View PR using the GUI difftool: \
`$ git pr show -t 12805`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12805.diff">https://git.openjdk.org/jdk/pull/12805.diff</a>

</details>
