### PR TITLE
8201516: DebugNonSafepoints generates incorrect information

### DIFF
--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -612,8 +612,6 @@ Parse::Parse(JVMState* caller, ciMethod* parse_method, float expected_uses)
   // Parse all the basic blocks.
   do_all_blocks();
 
-  C->set_default_node_notes(caller_nn);
-
   // Check for bailouts during conversion to graph
   if (failing()) {
     if (log)  log->done("parse");
@@ -623,6 +621,10 @@ Parse::Parse(JVMState* caller, ciMethod* parse_method, float expected_uses)
   // Fix up all exiting control flow.
   set_map(entry_map);
   do_exits();
+
+  // Only reset this now, to make sure that debug information emitted
+  // for exiting control flow still refers to the inlined method.
+  C->set_default_node_notes(caller_nn);
 
   if (log)  log->done("parse nodes='%d' live='%d' memory='" SIZE_FORMAT "'",
                       C->unique(), C->live_nodes(), C->node_arena()->used());

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -469,6 +469,11 @@ PhaseRenumberLive::PhaseRenumberLive(PhaseGVN* gvn,
 
   uint worklist_size = worklist->size();
 
+  GrowableArray<Node_Notes*>* old_node_note_array = C->node_note_array();
+  if (old_node_note_array != NULL) {
+    C->set_node_note_array(new (C->comp_arena()) GrowableArray<Node_Notes*> (C->comp_arena(), 8, 0, NULL));
+  }
+
   // Iterate over the set of live nodes.
   for (uint current_idx = 0; current_idx < _useful.size(); current_idx++) {
     Node* n = _useful.at(current_idx);
@@ -483,6 +488,11 @@ PhaseRenumberLive::PhaseRenumberLive(PhaseGVN* gvn,
 
     assert(_old2new_map.at(n->_idx) == -1, "already seen");
     _old2new_map.at_put(n->_idx, current_idx);
+
+    if (old_node_note_array != NULL) {
+      Node_Notes* nn = C->locate_node_notes(old_node_note_array, n->_idx, false);
+      C->set_node_notes_at(current_idx, nn);
+    }
 
     n->set_idx(current_idx); // Update node ID.
 

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -471,7 +471,9 @@ PhaseRenumberLive::PhaseRenumberLive(PhaseGVN* gvn,
 
   GrowableArray<Node_Notes*>* old_node_note_array = C->node_note_array();
   if (old_node_note_array != nullptr) {
-    C->set_node_note_array(new (C->comp_arena()) GrowableArray<Node_Notes*> (C->comp_arena(), 8, 0, nullptr));
+    int new_size = (_useful.size() >> 8) + 1; // The node note array uses blocks, see C->_log2_node_notes_block_size
+    C->set_node_note_array(new (C->comp_arena()) GrowableArray<Node_Notes*> (C->comp_arena(), new_size, 0, nullptr));
+    C->grow_node_notes(C->node_note_array(), new_size);
   }
 
   // Iterate over the set of live nodes.

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -472,6 +472,7 @@ PhaseRenumberLive::PhaseRenumberLive(PhaseGVN* gvn,
   GrowableArray<Node_Notes*>* old_node_note_array = C->node_note_array();
   if (old_node_note_array != nullptr) {
     int new_size = (_useful.size() >> 8) + 1; // The node note array uses blocks, see C->_log2_node_notes_block_size
+    new_size = MAX2(8, new_size);
     C->set_node_note_array(new (C->comp_arena()) GrowableArray<Node_Notes*> (C->comp_arena(), new_size, 0, nullptr));
     C->grow_node_notes(C->node_note_array(), new_size);
   }

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -470,8 +470,8 @@ PhaseRenumberLive::PhaseRenumberLive(PhaseGVN* gvn,
   uint worklist_size = worklist->size();
 
   GrowableArray<Node_Notes*>* old_node_note_array = C->node_note_array();
-  if (old_node_note_array != NULL) {
-    C->set_node_note_array(new (C->comp_arena()) GrowableArray<Node_Notes*> (C->comp_arena(), 8, 0, NULL));
+  if (old_node_note_array != nullptr) {
+    C->set_node_note_array(new (C->comp_arena()) GrowableArray<Node_Notes*> (C->comp_arena(), 8, 0, nullptr));
   }
 
   // Iterate over the set of live nodes.
@@ -489,7 +489,7 @@ PhaseRenumberLive::PhaseRenumberLive(PhaseGVN* gvn,
     assert(_old2new_map.at(n->_idx) == -1, "already seen");
     _old2new_map.at_put(n->_idx, current_idx);
 
-    if (old_node_note_array != NULL) {
+    if (old_node_note_array != nullptr) {
       Node_Notes* nn = C->locate_node_notes(old_node_note_array, n->_idx);
       C->set_node_notes_at(current_idx, nn);
     }

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -490,7 +490,7 @@ PhaseRenumberLive::PhaseRenumberLive(PhaseGVN* gvn,
     _old2new_map.at_put(n->_idx, current_idx);
 
     if (old_node_note_array != NULL) {
-      Node_Notes* nn = C->locate_node_notes(old_node_note_array, n->_idx, false);
+      Node_Notes* nn = C->locate_node_notes(old_node_note_array, n->_idx);
       C->set_node_notes_at(current_idx, nn);
     }
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestDebugInfo.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestDebugInfo.java
@@ -61,7 +61,7 @@ public class TestDebugInfo {
     // Verify that the MemBarRelease emitted at the MyClass constructor exit
     // does not incorrectly reference the caller method in its debug information.
     @Test
-    @IR(failOn = {"MemBarRelease.*test.*bci:-1"}, phase = CompilePhase.BEFORE_MATCHING)
+    @IR(failOn = {"MemBarRelease.*testFinalFieldInit.*bci:-1"}, phase = CompilePhase.BEFORE_MATCHING)
     public static void testFinalFieldInit() {
         array[0] = new MyClass(42);
         array[1] = new MyClass(42);
@@ -71,7 +71,7 @@ public class TestDebugInfo {
     // Verify that the MemBarReleaseLock emitted at the synchronizedMethod exit
     // does not incorrectly reference the caller method in its debug information.
     @Test
-    @IR(failOn = {"MemBarReleaseLock.*test.*bci:-1"}, phase = CompilePhase.BEFORE_MATCHING)
+    @IR(failOn = {"MemBarReleaseLock.*testSynchronized.*bci:-1"}, phase = CompilePhase.BEFORE_MATCHING)
     public static void testSynchronized() {
         try {
             myVal.synchronizedMethod(false);
@@ -114,10 +114,10 @@ public class TestDebugInfo {
 
     // Verify that RenumberLiveNodes preserves the debug information side table.
     @Test
-    @IR(counts = {"StoreB.*name=b3.*useful3.*bci:1.*useful2.*bci:0.*useful1.*bci:0.*test.*bci:9", "= 1"}, phase = CompilePhase.BEFORE_MATCHING)
-    @IR(counts = {"StoreB.*name=b2.*useful2.*bci:4.*useful1.*bci:0.*test.*bci:9", "= 1"}, phase = CompilePhase.BEFORE_MATCHING)
-    @IR(counts = {"StoreB.*name=b1.*useful1.*bci:4.*test.*bci:9", "= 1"}, phase = CompilePhase.BEFORE_MATCHING)
-    @IR(counts = {"StoreB.*name=b0.*test.*bci:13", "= 1"}, phase = CompilePhase.BEFORE_MATCHING)
+    @IR(counts = {"StoreB.*name=b3.*useful3.*bci:1.*useful2.*bci:0.*useful1.*bci:0.*testRenumberLiveNodes.*bci:9", "= 1"}, phase = CompilePhase.BEFORE_MATCHING)
+    @IR(counts = {"StoreB.*name=b2.*useful2.*bci:4.*useful1.*bci:0.*testRenumberLiveNodes.*bci:9", "= 1"}, phase = CompilePhase.BEFORE_MATCHING)
+    @IR(counts = {"StoreB.*name=b1.*useful1.*bci:4.*testRenumberLiveNodes.*bci:9", "= 1"}, phase = CompilePhase.BEFORE_MATCHING)
+    @IR(counts = {"StoreB.*name=b0.*testRenumberLiveNodes.*bci:13", "= 1"}, phase = CompilePhase.BEFORE_MATCHING)
     public static void testRenumberLiveNodes() {
         // This generates ~3700 useless nodes to trigger RenumberLiveNodes
         useless1(42);

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestDebugInfo.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestDebugInfo.java
@@ -86,27 +86,33 @@ public class TestDebugInfo {
     static byte b2 = 0;
     static byte b3 = 0;
 
+    @ForceInline
     public static Integer useless3(Integer val) {
         return ++val;
     }
 
+    @ForceInline
     public static Integer useless2(Integer val) {
         return useless3(useless3(useless3(useless3(useless3(useless3(useless3(useless3(val))))))));
     }
 
+    @ForceInline
     public static Integer useless1(Integer val) {
         return useless2(useless2(useless2(useless2(useless2(useless2(useless2(useless2(val))))))));
     }
 
+    @ForceInline
     public static void useful3() {
         b3 = 3;
     }
 
+    @ForceInline
     public static void useful2() {
         useful3();
         b2 = 2;
     }
 
+    @ForceInline
     public static void useful1() {
         useful2();
         b1 = 1;

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestInlineeExitDebugInfo.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestInlineeExitDebugInfo.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8201516
+ * @summary Verify that debug info at inlined method exits refers to inlinee.
+ * @library /test/lib /
+ * @requires vm.compiler2.enabled
+ * @run driver compiler.c2.irTests.TestInlineeExitDebugInfo
+ */
+public class TestInlineeExitDebugInfo {
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    static class MyClass {
+        final int val;
+
+        @ForceInline
+        public MyClass(int val) {
+            this.val = val;
+        }
+
+        @ForceInline
+        synchronized void synchronizedMethod(boolean throwIt) {
+            if (throwIt) {
+                throw new RuntimeException(); // Make sure there is an exception state
+            }
+        }
+    }
+
+    static Object[] array = new Object[3];
+    static MyClass myVal = new MyClass(42);
+
+    // Verify that the MemBarRelease emitted at the MyClass constructor exit
+    // does not incorrectly reference the caller method in its debug information.
+    @Test
+    @IR(failOn = { "MemBarRelease.*TestInlineeExitDebugInfo::test.*bci:-1" }, phase = CompilePhase.BEFORE_MATCHING)
+    public static void test1() {
+        array[0] = new MyClass(42);
+        array[1] = new MyClass(42);
+        array[2] = new MyClass(42);
+    }
+
+    // Verify that the MemBarReleaseLock emitted at the synchronizedMethod exit
+    // does not incorrectly reference the caller method in its debug information.
+    @Test
+    @IR(failOn = { "MemBarReleaseLock.*TestInlineeExitDebugInfo::test.*bci:-1" }, phase = CompilePhase.BEFORE_MATCHING)
+    public static void test2() {
+        try {
+            myVal.synchronizedMethod(false);
+            myVal.synchronizedMethod(true);
+        } catch (Exception e) {
+            // Ignore
+        }
+    }
+}


### PR DESCRIPTION
C2 emits incorrect debug information when diagnostic `-XX:+DebugNonSafepoints` is enabled. The problem is that renumbering of live nodes (`-XX:+RenumberLiveNodes`) introduced by [JDK-8129847](https://bugs.openjdk.org/browse/JDK-8129847) in JDK 8u92 / JDK 9 does not update the `_node_note_array` side table that links IR node indices to debug information. As a result, after node indices are updated, they point to unrelated debug information.

The [reproducer](https://github.com/jodzga/debugnonsafepoints-problem) shared by the original reporter @jodzga (@jbachorik also reported this issue separately) does not work anymore with recent JDK versions but with a slight adjustment to trigger node renumbering, I could reproduce the wrong JFR method profile:

![Screenshot from 2023-03-01 13-17-48](https://user-images.githubusercontent.com/5312595/222146314-8b5299a8-c1c0-4360-b356-ac6a8c34371c.png)

It suggests that the hottest method of the [Test](https://github.com/jodzga/debugnonsafepoints-problem/blob/f8ed40f24ef6a6bff7f86ea861c022db193ef48a/src/main/java/org/tests/Test.java#L28) is **not** the long running loop in [Test::arraycopy](https://github.com/jodzga/debugnonsafepoints-problem/blob/f8ed40f24ef6a6bff7f86ea861c022db193ef48a/src/main/java/org/tests/Test.java#L56) but several other short running methods. The hot method is not even in the profile. This is obviously wrong.

With the fix, or when running with `-XX:-RenumberLiveNodes` as a workaround, the correct profile looks like this:

![Screenshot from 2023-03-01 13-20-09](https://user-images.githubusercontent.com/5312595/222146316-b036ca7d-8a92-42b7-9570-c29e3cfcc2f2.png)

With the help of the IR framework, it's easy to create a simple regression test (see `testRenumberLiveNodes`).

The fix is to create a new `node_note_array` and copy the debug information to the right index after updating node indices. We do the same in the matcher:
https://github.com/openjdk/jdk/blob/c1e77e05647ca93bb4f39a320a5c7a632e283410/src/hotspot/share/opto/matcher.cpp#L337-L342

Another problem is that `Parse::Parse` calls `C->set_default_node_notes(caller_nn)` before `do_exits`, which resets the `JVMState` to the caller state. We then set the bci to `InvocationEntryBci` in the **caller** `JVMState`. Any new node that is emitted in `do_exits`, for example a `MemBarRelease`, will have that `JVMState` attached and `NonSafepointEmitter::observe_instruction` -> `DebugInformationRecorder::describe_scope` will then use that information when emitting debug info. The resulting debug info is misleading because it suggests that we are at the beginning of the caller method. The tests `testFinalFieldInit` and `testSynchronized` reproduce that scenario.

The fix is to move `set_default_node_notes` down to after `do_exits`.

I find it also misleading that we often emit "synchronization entry" for `InvocationEntryBci` at method entry/exit in the debug info, although there is no synchronization happening. I filed [JDK-8303451](https://bugs.openjdk.org/browse/JDK-8303451) to fix that.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8201516](https://bugs.openjdk.org/browse/JDK-8201516): DebugNonSafepoints generates incorrect information


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12806/head:pull/12806` \
`$ git checkout pull/12806`

Update a local copy of the PR: \
`$ git checkout pull/12806` \
`$ git pull https://git.openjdk.org/jdk pull/12806/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12806`

View PR using the GUI difftool: \
`$ git pr show -t 12806`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12806.diff">https://git.openjdk.org/jdk/pull/12806.diff</a>

</details>
