### PR TITLE
JDK-8303476: Add the runtime version in the release file of a JDK image

### DIFF
--- a/make/ReleaseFile.gmk
+++ b/make/ReleaseFile.gmk
@@ -51,6 +51,7 @@ define create-info-file
   $(if $(VENDOR_VERSION_STRING), \
     $(call info-file-item, "IMPLEMENTOR_VERSION", "$(VENDOR_VERSION_STRING)"))
   $(call info-file-item, "JAVA_VERSION_DATE", "$(VERSION_DATE)")
+  $(call info-file-item, "JAVA_RUNTIME_VERSION", "$(VERSION_STRING)")
   $(call info-file-item, "OS_NAME", "$(RELEASE_FILE_OS_NAME)")
   $(call info-file-item, "OS_ARCH", "$(RELEASE_FILE_OS_ARCH)")
   $(call info-file-item, "LIBC", "$(RELEASE_FILE_LIBC)")

--- a/test/jdk/build/releaseFile/CheckReleaseFile.java
+++ b/test/jdk/build/releaseFile/CheckReleaseFile.java
@@ -81,7 +81,7 @@ public class CheckReleaseFile {
                     continue;
                 }
 
-                // grab IMPLEMENTOR line
+                // grab JAVA_RUNTIME_VERSION line
                 if (readIn.startsWith("JAVA_RUNTIME_VERSION=")) {
                     runtimeVersion = readIn;
                     continue;

--- a/test/jdk/build/releaseFile/CheckReleaseFile.java
+++ b/test/jdk/build/releaseFile/CheckReleaseFile.java
@@ -1,6 +1,5 @@
-
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +23,9 @@
 
 /*
  * @test
- * @bug 8193660
- * @summary Check SOURCE line in "release" file for closedjdk
- * @run main CheckSource
+ * @bug 8193660 8303476
+ * @summary Check SOURCE line and JAVA_RUNTIME_VERSION in "release" file
+ * @run main CheckReleaseFile
  */
 
 import java.io.BufferedReader;
@@ -37,18 +36,21 @@ import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class CheckSource {
+public class CheckReleaseFile {
 
     public static final String SRC_HASH_REGEXP = ":((hg)|(git)):[a-z0-9]*\\+?";
 
-    CheckSource(String dataFile, boolean isOpenJDK) {
+    private final boolean isOpenJDK;
+    CheckReleaseFile(String dataFile, boolean isOpenJDK) {
+        this.isOpenJDK = isOpenJDK;
         // Read data files
-        readFile(dataFile, isOpenJDK);
+        readFile(dataFile);
     }
 
-    private void readFile(String fileName, boolean isOpenJDK) {
+    private void readFile(String fileName) {
         String fishForSOURCE = null;
         String implementor = null;
+        String runtimeVersion = null;
 
         File file = new File(fileName);
 
@@ -78,6 +80,12 @@ public class CheckSource {
                     implementor = readIn;
                     continue;
                 }
+
+                // grab IMPLEMENTOR line
+                if (readIn.startsWith("JAVA_RUNTIME_VERSION=")) {
+                    runtimeVersion = readIn;
+                    continue;
+                }
             }
         } catch (FileNotFoundException fileExcept) {
             throw new RuntimeException("File " + fileName +
@@ -91,6 +99,23 @@ public class CheckSource {
         if (fishForSOURCE == null) {
             throw new RuntimeException("SOURCE line was not found!");
         }
+
+        // Check if implementor is Oracle
+        boolean isOracle = (implementor != null) && implementor.contains("Oracle Corporation");
+        checkSource(fishForSOURCE, isOracle);
+
+        if (runtimeVersion == null) {
+            throw new RuntimeException("JAVA_RUNTIME_VERSION line was not found!");
+        }
+        String expected = "JAVA_RUNTIME_VERSION=\"" + Runtime.version() + "\"";
+        if (!expected.equals(runtimeVersion)) {
+            throw new RuntimeException("Mismatched runtime version: " +
+                    runtimeVersion + " expected: " + expected);
+        }
+    }
+
+    private void checkSource(String fishForSOURCE, boolean isOracle) {
+
         System.out.println("The source string found: " + fishForSOURCE);
 
         // Extract the value of SOURCE=
@@ -101,8 +126,6 @@ public class CheckSource {
         }
         String valueString = valueMatcher.group(1);
 
-        // Check if implementor is Oracle
-        boolean isOracle = (implementor != null) && implementor.contains("Oracle Corporation");
 
         String[] values = valueString.split(" ");
 
@@ -144,6 +167,6 @@ public class CheckSource {
         System.out.println("JDK Path : " + jdkPath);
         System.out.println("Runtime Name : " + runtime);
 
-        new CheckSource(jdkPath + "/release", runtime.contains("OpenJDK"));
+        new CheckReleaseFile(jdkPath + "/release", runtime.contains("OpenJDK"));
     }
 }


### PR DESCRIPTION
`$JAVA_HOME/release` file currently includes `JAVA_VERSION`  which is the version 
number plus the pre-release identifier for example "21-ea".    The build number 
and additional build information are useful in identifying the information 
about a JDK image but not available.  This proposes to add a new entry in the release file:
```
JAVA_RUNTIME_VERSION="$(VSTR)"
```
where `$(VSTR)` is the string represented by `Runtime::version()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8303479](https://bugs.openjdk.org/browse/JDK-8303479) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8303476](https://bugs.openjdk.org/browse/JDK-8303476): Add the runtime version in the release file of a JDK image
 * [JDK-8303479](https://bugs.openjdk.org/browse/JDK-8303479): Add JAVA_RUNTIME_VERSION in the release file of a JDK image (**CSR**)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12813/head:pull/12813` \
`$ git checkout pull/12813`

Update a local copy of the PR: \
`$ git checkout pull/12813` \
`$ git pull https://git.openjdk.org/jdk pull/12813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12813`

View PR using the GUI difftool: \
`$ git pr show -t 12813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12813.diff">https://git.openjdk.org/jdk/pull/12813.diff</a>

</details>
