### PR TITLE
8303486: [REDO] Update ProcessTools.startProcess(...) to exit early if process exit before linePredicate is printed.

### DIFF
--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -216,9 +216,11 @@ public final class ProcessTools {
 
         try {
             if (timeout > -1) {
+
+                long timeoutMs = timeout == 0 ? -1: unit.toMillis(Utils.adjustTimeout(timeout));
                 // Every second check if line is printed and if process is still alive
                 Utils.waitForCondition(() -> latch.getCount() == 0 || !p.isAlive(),
-                        unit.toMillis(Utils.adjustTimeout(timeout)), 1000);
+                       timeoutMs , 1000);
 
                 if (latch.getCount() > 0) {
                     if (!p.isAlive()) {

--- a/test/lib/jdk/test/lib/thread/ProcessThread.java
+++ b/test/lib/jdk/test/lib/thread/ProcessThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -150,16 +150,21 @@ public class ProcessThread extends TestThread {
          */
         @Override
         public void xrun() throws Throwable {
-            this.process = ProcessTools.startProcess(name, processBuilder, waitfor);
-            // Release when process is started
-            latch.countDown();
-
-            // Will block...
             try {
-                this.process.waitFor();
-                output = new OutputAnalyzer(this.process);
+                this.process = ProcessTools.startProcess(name, processBuilder, waitfor);
             } catch (Throwable t) {
-                String name = Thread.currentThread().getName();
+                System.out.println(String.format("ProcessThread[%s] failed: %s", name, t.toString()));
+                throw t;
+            } finally {
+                // Release when process is started or failed
+                latch.countDown();
+            }
+
+            try {
+                output = new OutputAnalyzer(this.process);
+                // Will block...
+                this.process.waitFor();
+            } catch (Throwable t) {
                 System.out.println(String.format("ProcessThread[%s] failed: %s", name, t.toString()));
                 throw t;
             } finally {


### PR DESCRIPTION
It is the 2nd attempt to fix
[JDK-8303133](https://bugs.openjdk.org/browse/JDK-8303133) Update ProcessTools.startProcess(...) to exit early if the process exit before linePredicate is printed.

The first fix failed because it runs
Utils.waitForCondition(BooleanSupplier condition, long timeout, long sleepTime) { ..}
with 0 as no timeout and not -1 as required.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303486](https://bugs.openjdk.org/browse/JDK-8303486): [REDO] Update ProcessTools.startProcess(...) to exit early if process exit before linePredicate is printed.


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12815/head:pull/12815` \
`$ git checkout pull/12815`

Update a local copy of the PR: \
`$ git checkout pull/12815` \
`$ git pull https://git.openjdk.org/jdk pull/12815/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12815`

View PR using the GUI difftool: \
`$ git pr show -t 12815`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12815.diff">https://git.openjdk.org/jdk/pull/12815.diff</a>

</details>
