### PR TITLE
8274264: Not all of G1 young collection verification honors the verification type

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -970,8 +970,11 @@ void G1CollectedHeap::verify_before_full_collection(bool explicit_gc) {
   if (!VerifyBeforeGC) {
     return;
   }
+  if (!G1HeapVerifier::should_verify(G1HeapVerifier::G1VerifyFull)) {
+    return;
+  }
   _verifier->verify_region_sets_optional();
-  _verifier->verify_before_gc(G1HeapVerifier::G1VerifyFull);
+  _verifier->verify_before_gc();
   _verifier->verify_bitmap_clear(true /* above_tams_only */);
 }
 
@@ -1009,9 +1012,12 @@ void G1CollectedHeap::verify_after_full_collection() {
   if (!VerifyAfterGC) {
     return;
   }
+  if (!G1HeapVerifier::should_verify(G1HeapVerifier::G1VerifyFull)) {
+    return;
+  }
   _hrm.verify_optional();
   _verifier->verify_region_sets_optional();
-  _verifier->verify_after_gc(G1HeapVerifier::G1VerifyFull);
+  _verifier->verify_after_gc();
   _verifier->verify_bitmap_clear(false /* above_tams_only */);
 
   // At this point there should be no regions in the
@@ -2573,11 +2579,14 @@ void G1CollectedHeap::verify_before_young_collection(G1HeapVerifier::G1VerifyTyp
   if (!VerifyBeforeGC) {
     return;
   }
+  if (!G1HeapVerifier::should_verify(type)) {
+    return;
+  }
   Ticks start = Ticks::now();
   _verifier->prepare_for_verify();
   _verifier->verify_region_sets_optional();
   _verifier->verify_dirty_young_regions();
-  _verifier->verify_before_gc(type);
+  _verifier->verify_before_gc();
   verify_numa_regions("GC Start");
   phase_times()->record_verify_before_time_ms((Ticks::now() - start).seconds() * MILLIUNITS);
 }
@@ -2586,8 +2595,11 @@ void G1CollectedHeap::verify_after_young_collection(G1HeapVerifier::G1VerifyType
   if (!VerifyAfterGC) {
     return;
   }
+  if (!G1HeapVerifier::should_verify(type)) {
+    return;
+  }
   Ticks start = Ticks::now();
-  _verifier->verify_after_gc(type);
+  _verifier->verify_after_gc();
   verify_numa_regions("GC End");
   _verifier->verify_region_sets_optional();
   phase_times()->record_verify_after_time_ms((Ticks::now() - start).seconds() * MILLIUNITS);

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1071,14 +1071,14 @@ void G1ConcurrentMark::verify_during_pause(G1HeapVerifier::G1VerifyType type,
 
   const char* caller = verify_location_string(location);
 
-  if (VerifyDuringGC) {
+  if (VerifyDuringGC && G1HeapVerifier::should_verify(type)) {
     GCTraceTime(Debug, gc, phases) debug(caller, _gc_timer_cm);
 
     size_t const BufLen = 512;
     char buffer[BufLen];
 
     jio_snprintf(buffer, BufLen, "During GC (%s)", caller);
-    verifier->verify(type, VerifyOption::G1UseConcMarking, buffer);
+    verifier->verify(VerifyOption::G1UseConcMarking, buffer);
 
     // Only check bitmap in Remark, and not at After-Verification because the regions
     // already have their TAMS'es reset.

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -551,19 +551,19 @@ void G1HeapVerifier::prepare_for_verify() {
   }
 }
 
-void G1HeapVerifier::verify(G1VerifyType type, VerifyOption vo, const char* msg) {
-  if (should_verify(type) && _g1h->total_collections() >= VerifyGCStartAt) {
+void G1HeapVerifier::verify(VerifyOption vo, const char* msg) {
+  if (_g1h->total_collections() >= VerifyGCStartAt) {
     prepare_for_verify();
     Universe::verify(vo, msg);
   }
 }
 
-void G1HeapVerifier::verify_before_gc(G1VerifyType type) {
-  verify(type, VerifyOption::G1UseConcMarking, "Before GC");
+void G1HeapVerifier::verify_before_gc() {
+  verify(VerifyOption::G1UseConcMarking, "Before GC");
 }
 
-void G1HeapVerifier::verify_after_gc(G1VerifyType type) {
-  verify(type, VerifyOption::G1UseConcMarking, "After GC");
+void G1HeapVerifier::verify_after_gc() {
+  verify(VerifyOption::G1UseConcMarking, "After GC");
 }
 
 void G1HeapVerifier::verify_bitmap_clear(bool from_tams) {

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.hpp
@@ -66,9 +66,9 @@ public:
   void verify_region_sets_optional() { DEBUG_ONLY(verify_region_sets();) }
 
   void prepare_for_verify();
-  void verify(G1VerifyType type, VerifyOption vo, const char* msg);
-  void verify_before_gc(G1VerifyType type);
-  void verify_after_gc(G1VerifyType type);
+  void verify(VerifyOption vo, const char* msg);
+  void verify_before_gc();
+  void verify_after_gc();
 
   void verify_bitmap_clear(bool above_tams_only);
 


### PR DESCRIPTION
Checking whether verification is required before running any of the verification steps.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274264](https://bugs.openjdk.org/browse/JDK-8274264): Not all of G1 young collection verification honors the verification type


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12818/head:pull/12818` \
`$ git checkout pull/12818`

Update a local copy of the PR: \
`$ git checkout pull/12818` \
`$ git pull https://git.openjdk.org/jdk pull/12818/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12818`

View PR using the GUI difftool: \
`$ git pr show -t 12818`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12818.diff">https://git.openjdk.org/jdk/pull/12818.diff</a>

</details>
