### PR TITLE
8303511: C2: assert(get_ctrl(n) == cle_out) during unrolling

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -527,7 +527,7 @@ Node* PhaseIdealLoop::remix_address_expressions(Node* n) {
             n23_loop == n_loop) {
           Node* add1 = new AddPNode(n->in(1), n->in(2)->in(2), n->in(3));
           // Stuff new AddP in the loop preheader
-          register_new_node(add1, n_loop->_head->in(LoopNode::EntryControl));
+          register_new_node(add1, n_loop->_head->as_Loop()->skip_strip_mined(1)->in(LoopNode::EntryControl));
           Node* add2 = new AddPNode(n->in(1), add1, n->in(2)->in(3));
           register_new_node(add2, n_ctrl);
           _igvn.replace_node(n, add2);
@@ -548,7 +548,7 @@ Node* PhaseIdealLoop::remix_address_expressions(Node* n) {
         if (!is_member(n_loop,get_ctrl(I))) {
           Node* add1 = new AddPNode(n->in(1), n->in(2), I);
           // Stuff new AddP in the loop preheader
-          register_new_node(add1, n_loop->_head->in(LoopNode::EntryControl));
+          register_new_node(add1, n_loop->_head->as_Loop()->skip_strip_mined(1)->in(LoopNode::EntryControl));
           Node* add2 = new AddPNode(n->in(1), add1, V);
           register_new_node(add2, n_ctrl);
           _igvn.replace_node(n, add2);

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestAddPAtOuterLoopHead.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestAddPAtOuterLoopHead.java
@@ -62,7 +62,7 @@ public class TestAddPAtOuterLoopHead {
         }
 
 
-        int v  = 0;
+        int v = 0;
         for (int j = 0; j < 2; j++) {
             for (int i = 0; i < 998; i += k) {
                 int l = testHelper(m, j, i);

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestAddPAtOuterLoopHead.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestAddPAtOuterLoopHead.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8303511
+ * @summary C2: assert(get_ctrl(n) == cle_out) during unrolling
+ * @requires vm.gc.Parallel
+ * @run main/othervm -XX:-BackgroundCompilation -XX:+UseParallelGC TestAddPAtOuterLoopHead
+ */
+
+
+import java.util.Arrays;
+
+public class TestAddPAtOuterLoopHead {
+    public static void main(String[] args) {
+        boolean[] flags1 = new boolean[1000];
+        boolean[] flags2 = new boolean[1000];
+        Arrays.fill(flags2, true);
+        for (int i = 0; i < 20_000; i++) {
+            testHelper(42, 42, 43);
+            test(flags1);
+            test(flags2);
+        }
+    }
+
+    private static int test(boolean[] flags) {
+        int[] array = new int[1000];
+
+        int k;
+        for (k = 0; k < 10; k++) {
+            for (int i = 0; i < 2; i++) {
+            }
+        }
+        k = k / 10;
+        int m;
+        for (m = 0; m < 2; m++) {
+            for (int i = 0; i < 2; i++) {
+                for (int j = 0; j < 2; j++) {
+                }
+            }
+        }
+
+
+        int v  = 0;
+        for (int j = 0; j < 2; j++) {
+            for (int i = 0; i < 998; i += k) {
+                int l = testHelper(m, j, i);
+                v = array[i + l];
+                if (flags[i]) {
+                    return v;
+                }
+            }
+        }
+
+        return v;
+    }
+
+    private static int testHelper(int m, int j, int i) {
+        return m == 2 ? j : i;
+    }
+}


### PR DESCRIPTION
In the same round of loop optimizations:

- `PhaseIdealLoop::remix_address_expressions()` creates a new `AddP`
  out of loop. It sets it control to
  `n_loop->_head->in(LoopNode::EntryControl)` which, because the loop is
  strip mined, is an `OuterStripMinedLoop`.
  
- The `LoadI` for that `AddP` is found to only have uses outside the
  loop and is cloned out of the loop. It's referenced by the outer
  loop's safepoint.
  
- The loop is unrolled. Unrolling follows the safepoint's inputs and
  find the new `AddP` with control set to the `OuterStripMinedLoop`
  and the assert fires.
  
No control should be set to an `OuterStripMinedLoop`. The fix is
straightforward and sets the control to the `OuterStripMinedLoop`
entry control.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303511](https://bugs.openjdk.org/browse/JDK-8303511): C2: assert(get_ctrl(n) == cle_out) during unrolling


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [c2787438](https://git.openjdk.org/jdk/pull/12824/files/c2787438192b78dfad1c1c7a2427fd31c5e2c688)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12824/head:pull/12824` \
`$ git checkout pull/12824`

Update a local copy of the PR: \
`$ git checkout pull/12824` \
`$ git pull https://git.openjdk.org/jdk pull/12824/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12824`

View PR using the GUI difftool: \
`$ git pr show -t 12824`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12824.diff">https://git.openjdk.org/jdk/pull/12824.diff</a>

</details>
