### PR TITLE
8301622: ProcessTools.java compilation gets ThreadDeath deprecation warning

### DIFF
--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -824,9 +824,6 @@ public final class ProcessTools {
         }
 
         public void uncaughtException(Thread t, Throwable e) {
-            if (e instanceof Error && t.getState() == State.TERMINATED) {
-                return;
-            }
             e.printStackTrace(System.err);
             uncaughtThrowable = e;
         }

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.lang.Thread.State;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.Charset;
@@ -823,7 +824,7 @@ public final class ProcessTools {
         }
 
         public void uncaughtException(Thread t, Throwable e) {
-            if (e instanceof ThreadDeath) {
+            if (e instanceof Error && t.getState() == State.TERMINATED) {
                 return;
             }
             e.printStackTrace(System.err);


### PR DESCRIPTION
### Description
The use of `ThreadDeath` is replaced with checking the exception be of type `Error` and the thread is `TERMINATED`.


### Test
local and mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301622](https://bugs.openjdk.org/browse/JDK-8301622): ProcessTools.java compilation gets ThreadDeath deprecation warning


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12827/head:pull/12827` \
`$ git checkout pull/12827`

Update a local copy of the PR: \
`$ git checkout pull/12827` \
`$ git pull https://git.openjdk.org/jdk pull/12827/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12827`

View PR using the GUI difftool: \
`$ git pr show -t 12827`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12827.diff">https://git.openjdk.org/jdk/pull/12827.diff</a>

</details>
