### PR TITLE
8204550: NMT: RegionIterator does not need to keep _current_size

### DIFF
--- a/src/hotspot/share/services/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.cpp
@@ -581,10 +581,9 @@ private:
   const size_t  _size;
 
   address _current_start;
-  size_t  _current_size;
 public:
   RegionIterator(address start, size_t size) :
-    _start(start), _size(size), _current_start(start), _current_size(size) {
+    _start(start), _size(size), _current_start(start) {
   }
 
   // return true if committed region is found
@@ -597,14 +596,12 @@ bool RegionIterator::next_committed(address& committed_start, size_t& committed_
   if (end() <= _current_start) return false;
 
   const size_t page_sz = os::vm_page_size();
-  assert(_current_start + _current_size == end(), "Must be");
-  if (os::committed_in_range(_current_start, _current_size, committed_start, committed_size)) {
+  const size_t current_size = end() - _current_start;
+  if (os::committed_in_range(_current_start, current_size, committed_start, committed_size)) {
     assert(committed_start != nullptr, "Must be");
     assert(committed_size > 0 && is_aligned(committed_size, os::vm_page_size()), "Must be");
 
-    size_t remaining_size = (_current_start + _current_size) - (committed_start + committed_size);
     _current_start = committed_start + committed_size;
-    _current_size = remaining_size;
     return true;
   } else {
     return false;


### PR DESCRIPTION
Hi,

This is just a small cleanup where an unnecessary class variable is removed.

Quoting the issue:

>class RegionIteretor does not need to keep _current_size, since that one can be calculated from the three remaining points (start, end of reserved size and current search pointer). 

Please consider, thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8204550](https://bugs.openjdk.org/browse/JDK-8204550): NMT: RegionIterator does not need to keep _current_size


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Gerard Ziemski](https://openjdk.org/census#gziemski) (@gerard-ziemski - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12828/head:pull/12828` \
`$ git checkout pull/12828`

Update a local copy of the PR: \
`$ git checkout pull/12828` \
`$ git pull https://git.openjdk.org/jdk pull/12828/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12828`

View PR using the GUI difftool: \
`$ git pr show -t 12828`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12828.diff">https://git.openjdk.org/jdk/pull/12828.diff</a>

</details>
