### PR TITLE
JDK-8303465: KeyStore of type KeychainStore, provider Apple shows different behavior after 8278449

### DIFF
--- a/src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m
+++ b/src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m
@@ -416,11 +416,18 @@ static void addCertificatesToKeystore(JNIEnv *env, jobject keyStore)
                 goto errOut;
             }
 
-            // Only add certificates with trusted settings
+            // Only add certificates with trusted settings, use all 3 domains
+            // see https://developer.apple.com/documentation/security/sectrustsettingsdomain
             CFArrayRef trustSettings;
             if (SecTrustSettingsCopyTrustSettings(certRef, kSecTrustSettingsDomainUser, &trustSettings)
                     == errSecItemNotFound) {
-                continue;
+                if (SecTrustSettingsCopyTrustSettings(certRef, kSecTrustSettingsDomainAdmin, &trustSettings)
+                        == errSecItemNotFound) {
+                    if (SecTrustSettingsCopyTrustSettings(certRef, kSecTrustSettingsDomainSystem, &trustSettings)
+                            == errSecItemNotFound) {
+                        continue;
+                    }
+                }
             }
 
             // See KeychainStore::createTrustedCertEntry for content of inputTrust


### PR DESCRIPTION
After 8278449, we seem to ignore in the call

`  if (SecTrustSettingsCopyTrustSettings(certRef, kSecTrustSettingsDomainUser, &trustSettings) == errSecItemNotFound) `

all trusted certs from admin and system domains, so a lot more certs are ignored than necessary.
Probably we should take at least the certs with trust settings from kSecTrustSettingsDomainUser, kSecTrustSettingsDomainAdmin and kSecTrustSettingsDomainSystem domains .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303465](https://bugs.openjdk.org/browse/JDK-8303465): KeyStore of type KeychainStore, provider Apple shows different behavior after 8278449


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12829/head:pull/12829` \
`$ git checkout pull/12829`

Update a local copy of the PR: \
`$ git checkout pull/12829` \
`$ git pull https://git.openjdk.org/jdk.git pull/12829/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12829`

View PR using the GUI difftool: \
`$ git pr show -t 12829`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12829.diff">https://git.openjdk.org/jdk/pull/12829.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12829#issuecomment-1451885828)