### PR TITLE
8303516: HFAs with nested structs/unions/arrays not handled correctly on AArch64

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -158,25 +158,29 @@ public final class SharedUtils {
     }
 
     public static Class<?> primitiveCarrierForSize(long size, boolean useFloat) {
+        return primitiveLayoutForSize(size, useFloat).carrier();
+    }
+
+    public static ValueLayout primitiveLayoutForSize(long size, boolean useFloat) {
         if (useFloat) {
             if (size == 4) {
-                return float.class;
+                return JAVA_FLOAT;
             } else if (size == 8) {
-                return double.class;
+                return JAVA_DOUBLE;
             }
         } else {
             if (size == 1) {
-                return byte.class;
+                return JAVA_BYTE;
             } else if (size == 2) {
-                return short.class;
+                return JAVA_SHORT;
             } else if (size <= 4) {
-                return int.class;
+                return JAVA_INT;
             } else if (size <= 8) {
-                return long.class;
+                return JAVA_LONG;
             }
         }
 
-        throw new IllegalArgumentException("No type for size: " + size + " isFloat=" + useFloat);
+        throw new IllegalArgumentException("No layout for size: " + size + " isFloat=" + useFloat);
     }
 
     public static Linker getSystemLinker() {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/TypeClass.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/TypeClass.java
@@ -28,7 +28,10 @@ package jdk.internal.foreign.abi.aarch64;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SequenceLayout;
 import java.lang.foreign.ValueLayout;
+import java.util.List;
+import java.util.ArrayList;
 
 public enum TypeClass {
     STRUCT_REGISTER,
@@ -58,15 +61,38 @@ public enum TypeClass {
         return type.bitSize() <= MAX_AGGREGATE_REGS_SIZE * 64;
     }
 
+    static List<MemoryLayout> scalarLayouts(GroupLayout gl) {
+        List<MemoryLayout> out = new ArrayList<>();
+        scalarLayoutsInternal(out, gl);
+        return out;
+    }
+
+    private static void scalarLayoutsInternal(List<MemoryLayout> out, GroupLayout gl) {
+        for (MemoryLayout member : gl.memberLayouts()) {
+            if (member instanceof GroupLayout memberGl) {
+                scalarLayoutsInternal(out, memberGl);
+            } else if (member instanceof SequenceLayout memberSl) {
+                for (long i = 0; i < memberSl.elementCount(); i++) {
+                    out.add(memberSl.elementLayout());
+                }
+            } else {
+                // padding or value layouts
+                out.add(member);
+            }
+        }
+    }
+
     static boolean isHomogeneousFloatAggregate(MemoryLayout type) {
         if (!(type instanceof GroupLayout groupLayout))
             return false;
 
-        final int numElements = groupLayout.memberLayouts().size();
+        List<MemoryLayout> scalarLayouts = scalarLayouts(groupLayout);
+
+        final int numElements = scalarLayouts.size();
         if (numElements > 4 || numElements == 0)
             return false;
 
-        MemoryLayout baseType = groupLayout.memberLayouts().get(0);
+        MemoryLayout baseType = scalarLayouts.get(0);
 
         if (!(baseType instanceof ValueLayout))
             return false;
@@ -75,7 +101,7 @@ public enum TypeClass {
         if (baseArgClass != FLOAT)
            return false;
 
-        for (MemoryLayout elem : groupLayout.memberLayouts()) {
+        for (MemoryLayout elem : scalarLayouts) {
             if (!(elem instanceof ValueLayout))
                 return false;
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/TypeClass.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/TypeClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2021, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -22,20 +22,49 @@
  *
  */
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.GroupLayout;
 import java.lang.foreign.Linker;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.PaddingLayout;
+import java.lang.foreign.SegmentAllocator;
 import java.lang.foreign.SegmentScope;
+import java.lang.foreign.SequenceLayout;
+import java.lang.foreign.StructLayout;
 import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.UnionLayout;
 import java.lang.foreign.ValueLayout;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
+import java.util.random.RandomGenerator;
+
+import static java.lang.foreign.MemoryLayout.PathElement.groupElement;
+import static java.lang.foreign.MemoryLayout.PathElement.sequenceElement;
 
 public class NativeTestHelper {
 
     public static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
+
+    private static final MethodHandle MH_SAVER;
+
+    static {
+        try {
+            MH_SAVER = MethodHandles.lookup().findStatic(NativeTestHelper.class, "saver",
+                    MethodType.methodType(Object.class, Object[].class, List.class, AtomicReference.class, SegmentAllocator.class, int.class));
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
 
     public static boolean isIntegral(MemoryLayout layout) {
         return layout instanceof ValueLayout valueLayout && isIntegral(valueLayout.carrier());
@@ -125,5 +154,128 @@ public class NativeTestHelper {
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public record TestValue (Object value, Consumer<Object> check) {}
+
+    public static TestValue genTestValue(RandomGenerator random, MemoryLayout layout, SegmentAllocator allocator) {
+        if (layout instanceof StructLayout struct) {
+            MemorySegment segment = allocator.allocate(struct);
+            List<Consumer<Object>> fieldChecks = new ArrayList<>();
+            for (MemoryLayout fieldLayout : struct.memberLayouts()) {
+                if (fieldLayout instanceof PaddingLayout) continue;
+                MemoryLayout.PathElement fieldPath = groupElement(fieldLayout.name().orElseThrow());
+                fieldChecks.add(initField(random, segment, struct, fieldLayout, fieldPath, allocator));
+            }
+            return new TestValue(segment, actual -> fieldChecks.forEach(check -> check.accept(actual)));
+        } else if (layout instanceof UnionLayout union) {
+            MemorySegment segment = allocator.allocate(union);
+            List<MemoryLayout> filteredFields = union.memberLayouts().stream()
+                                                                     .filter(l -> !(l instanceof PaddingLayout))
+                                                                     .toList();
+            int fieldIdx = random.nextInt(filteredFields.size());
+            MemoryLayout fieldLayout = filteredFields.get(fieldIdx);
+            MemoryLayout.PathElement fieldPath = groupElement(fieldLayout.name().orElseThrow());
+            Consumer<Object> check = initField(random, segment, union, fieldLayout, fieldPath, allocator);
+            return new TestValue(segment, check);
+        } else if (layout instanceof SequenceLayout array) {
+            MemorySegment segment = allocator.allocate(array);
+            List<Consumer<Object>> elementChecks = new ArrayList<>();
+            for (int i = 0; i < array.elementCount(); i++) {
+                elementChecks.add(initField(random, segment, array, array.elementLayout(), sequenceElement(i), allocator));
+            }
+            return new TestValue(segment, actual -> elementChecks.forEach(check -> check.accept(actual)));
+        } else if (layout instanceof ValueLayout.OfAddress) {
+            MemorySegment value = MemorySegment.ofAddress(random.nextLong());
+            return new TestValue(value, actual -> assertEquals(actual, value));
+        }else if (layout instanceof ValueLayout.OfByte) {
+            byte value = (byte) random.nextInt();
+            return new TestValue(value, actual -> assertEquals(actual, value));
+        } else if (layout instanceof ValueLayout.OfShort) {
+            short value = (short) random.nextInt();
+            return new TestValue(value, actual -> assertEquals(actual, value));
+        } else if (layout instanceof ValueLayout.OfInt) {
+            int value = random.nextInt();
+            return new TestValue(value, actual -> assertEquals(actual, value));
+        } else if (layout instanceof ValueLayout.OfLong) {
+            long value = random.nextLong();
+            return new TestValue(value, actual -> assertEquals(actual, value));
+        } else if (layout instanceof ValueLayout.OfFloat) {
+            float value = random.nextFloat();
+            return new TestValue(value, actual -> assertEquals(actual, value));
+        } else if (layout instanceof ValueLayout.OfDouble) {
+            double value = random.nextDouble();
+            return new TestValue(value, actual -> assertEquals(actual, value));
+        }
+
+        throw new IllegalStateException("Unexpected layout: " + layout);
+    }
+
+    private static Consumer<Object> initField(RandomGenerator random, MemorySegment container, MemoryLayout containerLayout,
+                                              MemoryLayout fieldLayout, MemoryLayout.PathElement fieldPath,
+                                              SegmentAllocator allocator) {
+        TestValue fieldValue = genTestValue(random, fieldLayout, allocator);
+        Consumer<Object> fieldCheck = fieldValue.check();
+        if (fieldLayout instanceof GroupLayout || fieldLayout instanceof SequenceLayout) {
+            UnaryOperator<MemorySegment> slicer = slicer(containerLayout, fieldPath);
+            MemorySegment slice = slicer.apply(container);
+            slice.copyFrom((MemorySegment) fieldValue.value());
+            return actual -> fieldCheck.accept(slicer.apply((MemorySegment) actual));
+        } else {
+            VarHandle accessor = containerLayout.varHandle(fieldPath);
+            //set value
+            accessor.set(container, fieldValue.value());
+            return actual -> fieldCheck.accept(accessor.get((MemorySegment) actual));
+        }
+    }
+
+    private static UnaryOperator<MemorySegment> slicer(MemoryLayout containerLayout, MemoryLayout.PathElement fieldPath) {
+        MethodHandle slicer = containerLayout.sliceHandle(fieldPath);
+        return container -> {
+              try {
+                return (MemorySegment) slicer.invokeExact(container);
+            } catch (Throwable e) {
+                throw new IllegalStateException(e);
+            }
+        };
+    }
+
+    private static void assertEquals(Object actual, Object expected) {
+        if (actual.getClass() != expected.getClass()) {
+            throw new AssertionError("Type mismatch: " + actual.getClass() + " != " + expected.getClass());
+        }
+        if (!actual.equals(expected)) {
+            throw new AssertionError("Not equal: " + actual + " != " + expected);
+        }
+    }
+
+    /**
+     * Make an upcall stub that saves its arguments into the given 'ref' array
+     *
+     * @param fd function descriptor for the upcall stub
+     * @param capturedArgs box to save arguments in
+     * @param arena allocator for making copies of by-value structs
+     * @param retIdx the index of the argument to return
+     * @return return the upcall stub
+     */
+    public static MemorySegment makeArgSaverCB(FunctionDescriptor fd, Arena arena,
+                                               AtomicReference<Object[]> capturedArgs, int retIdx) {
+        MethodHandle target = MethodHandles.insertArguments(MH_SAVER, 1, fd.argumentLayouts(), capturedArgs, arena, retIdx);
+        target = target.asCollector(Object[].class, fd.argumentLayouts().size());
+        target = target.asType(fd.toMethodType());
+        return LINKER.upcallStub(target, fd, arena.scope());
+    }
+
+    private static Object saver(Object[] o, List<MemoryLayout> argLayouts, AtomicReference<Object[]> ref, SegmentAllocator allocator, int retArg) {
+        for (int i = 0; i < o.length; i++) {
+            if (argLayouts.get(i) instanceof GroupLayout gl) {
+                MemorySegment ms = (MemorySegment) o[i];
+                MemorySegment copy = allocator.allocate(gl);
+                copy.copyFrom(ms);
+                o[i] = copy;
+            }
+        }
+        ref.set(o);
+        return retArg != -1 ? o[retArg] : null;
     }
 }

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/foreign/callarranger/TestLinuxAArch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestLinuxAArch64CallArranger.java
@@ -426,4 +426,54 @@ public class TestLinuxAArch64CallArranger extends CallArrangerTestBase {
 
         checkReturnBindings(callingSequence, new Binding[]{});
     }
+
+    @Test
+    public void testFloatArrayStruct() {
+        // should be classified as HFA
+        StructLayout S10 = MemoryLayout.structLayout(
+                MemoryLayout.sequenceLayout(4, C_DOUBLE)
+        );
+        MethodType mt = MethodType.methodType(MemorySegment.class, MemorySegment.class);
+        FunctionDescriptor fd = FunctionDescriptor.of(S10, S10);
+        FunctionDescriptor fdExpected = FunctionDescriptor.of(S10, ADDRESS, ADDRESS, S10); // uses return buffer
+        CallArranger.Bindings bindings = CallArranger.LINUX.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn());
+        CallingSequence callingSequence = bindings.callingSequence();
+        assertEquals(callingSequence.callerMethodType(), mt.insertParameterTypes(0, MemorySegment.class, MemorySegment.class));
+        assertEquals(callingSequence.functionDesc(), fdExpected);
+
+        // This is identical to the non-variadic calling sequence
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { unboxAddress(), vmStore(RETURN_BUFFER_STORAGE, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
+            { dup(),
+                bufferLoad(0, double.class),
+                vmStore(v0, double.class),
+              dup(),
+                bufferLoad(8, double.class),
+                vmStore(v1, double.class),
+              dup(),
+                bufferLoad(16, double.class),
+                vmStore(v2, double.class),
+                bufferLoad(24, double.class),
+                vmStore(v3, double.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{
+            allocate(S10),
+              dup(),
+                 vmLoad(v0, double.class),
+                 bufferStore(0, double.class),
+              dup(),
+                 vmLoad(v1, double.class),
+                 bufferStore(8, double.class),
+              dup(),
+                 vmLoad(v2, double.class),
+                 bufferStore(16, double.class),
+              dup(),
+                 vmLoad(v3, double.class),
+                 bufferStore(24, double.class),
+        });
+    }
 }

--- a/test/jdk/java/foreign/callarranger/TestLinuxAArch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestLinuxAArch64CallArranger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/foreign/callarranger/TestMacOsAArch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestMacOsAArch64CallArranger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -276,6 +276,115 @@ public class TestMacOsAArch64CallArranger extends CallArrangerTestBase {
             { dup(),
                 bufferLoad(0, long.class), vmStore(stackStorage((short) 8, 8), long.class),
                 bufferLoad(8, long.class), vmStore(stackStorage((short) 8, 16), long.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    // structs that are passed field-wise should not have padding after them
+    @Test
+    public void testMacArgsOnStack5() {
+        StructLayout struct = MemoryLayout.structLayout(
+            C_FLOAT
+        );
+        MethodType mt = MethodType.methodType(void.class,
+                long.class, long.class, long.class, long.class,
+                long.class, long.class, long.class, long.class,
+                double.class, double.class, double.class, double.class,
+                double.class, double.class, double.class, double.class,
+                MemorySegment.class, int.class, MemorySegment.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(
+                C_LONG_LONG, C_LONG_LONG, C_LONG_LONG, C_LONG_LONG,
+                C_LONG_LONG, C_LONG_LONG, C_LONG_LONG, C_LONG_LONG,
+                C_DOUBLE, C_DOUBLE, C_DOUBLE, C_DOUBLE,
+                C_DOUBLE, C_DOUBLE, C_DOUBLE, C_DOUBLE,
+                struct, C_INT, C_POINTER);
+        CallArranger.Bindings bindings = CallArranger.MACOS.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn());
+        CallingSequence callingSequence = bindings.callingSequence();
+        assertEquals(callingSequence.callerMethodType(), mt.insertParameterTypes(0, MemorySegment.class));
+        assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
+            { vmStore(r0, long.class) },
+            { vmStore(r1, long.class) },
+            { vmStore(r2, long.class) },
+            { vmStore(r3, long.class) },
+            { vmStore(r4, long.class) },
+            { vmStore(r5, long.class) },
+            { vmStore(r6, long.class) },
+            { vmStore(r7, long.class) },
+            { vmStore(v0, double.class) },
+            { vmStore(v1, double.class) },
+            { vmStore(v2, double.class) },
+            { vmStore(v3, double.class) },
+            { vmStore(v4, double.class) },
+            { vmStore(v5, double.class) },
+            { vmStore(v6, double.class) },
+            { vmStore(v7, double.class) },
+            {
+                bufferLoad(0, int.class),
+                vmStore(stackStorage((short) 4, 0), int.class),
+            },
+            { vmStore(stackStorage((short) 4, 4), int.class) },
+            { unboxAddress(), vmStore(stackStorage((short) 8, 8), long.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    // structs that are passed chunk-wise should have padding before them, as well as after
+    @Test
+    public void testMacArgsOnStack6() {
+        StructLayout struct = MemoryLayout.structLayout(
+            C_INT
+        );
+        MethodType mt = MethodType.methodType(void.class,
+                long.class, long.class, long.class, long.class,
+                long.class, long.class, long.class, long.class,
+                double.class, double.class, double.class, double.class,
+                double.class, double.class, double.class, double.class,
+                int.class, MemorySegment.class, double.class, MemorySegment.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(
+                C_LONG_LONG, C_LONG_LONG, C_LONG_LONG, C_LONG_LONG,
+                C_LONG_LONG, C_LONG_LONG, C_LONG_LONG, C_LONG_LONG,
+                C_DOUBLE, C_DOUBLE, C_DOUBLE, C_DOUBLE,
+                C_DOUBLE, C_DOUBLE, C_DOUBLE, C_DOUBLE,
+                C_INT, struct, C_DOUBLE, C_POINTER);
+        CallArranger.Bindings bindings = CallArranger.MACOS.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn());
+        CallingSequence callingSequence = bindings.callingSequence();
+        assertEquals(callingSequence.callerMethodType(), mt.insertParameterTypes(0, MemorySegment.class));
+        assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
+            { vmStore(r0, long.class) },
+            { vmStore(r1, long.class) },
+            { vmStore(r2, long.class) },
+            { vmStore(r3, long.class) },
+            { vmStore(r4, long.class) },
+            { vmStore(r5, long.class) },
+            { vmStore(r6, long.class) },
+            { vmStore(r7, long.class) },
+            { vmStore(v0, double.class) },
+            { vmStore(v1, double.class) },
+            { vmStore(v2, double.class) },
+            { vmStore(v3, double.class) },
+            { vmStore(v4, double.class) },
+            { vmStore(v5, double.class) },
+            { vmStore(v6, double.class) },
+            { vmStore(v7, double.class) },
+            { vmStore(stackStorage((short) 4, 0), int.class) },
+            {
+                bufferLoad(0, int.class),
+                vmStore(stackStorage((short) 4, 8), int.class),
+            },
+            { vmStore(stackStorage((short) 8, 16), double.class) },
+            { unboxAddress(), vmStore(stackStorage((short) 8, 24), long.class) },
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});

--- a/test/jdk/java/foreign/callarranger/TestMacOsAArch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestMacOsAArch64CallArranger.java
@@ -25,6 +25,7 @@
 /*
  * @test
  * @enablePreview
+ * @requires sun.arch.data.model == "64"
  * @modules java.base/jdk.internal.foreign
  *          java.base/jdk.internal.foreign.abi
  *          java.base/jdk.internal.foreign.abi.aarch64

--- a/test/jdk/java/foreign/nested/TestNested.java
+++ b/test/jdk/java/foreign/nested/TestNested.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @enablePreview
+ * @library ../ /test/lib
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @requires vm.flavor != "zero"
+ * @build NativeTestHelper
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestNested
+ */
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.GroupLayout;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SegmentAllocator;
+import java.lang.foreign.StructLayout;
+import java.lang.foreign.UnionLayout;
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class TestNested extends NativeTestHelper {
+
+    static {
+        System.loadLibrary("Nested");
+    }
+
+    @Test(dataProvider = "nestedLayouts")
+    public void testNested(GroupLayout layout) throws Throwable {
+        try (Arena arena = Arena.openConfined()) {
+            Random random = new Random(0);
+            TestValue testValue = genTestValue(random, layout, arena);
+
+            String funcName = "test_" + layout.name().orElseThrow();
+            FunctionDescriptor downcallDesc = FunctionDescriptor.of(layout, layout, C_POINTER);
+            FunctionDescriptor upcallDesc = FunctionDescriptor.of(layout, layout);
+
+            MethodHandle downcallHandle = downcallHandle(funcName, downcallDesc);
+            AtomicReference<Object[]> returnBox = new AtomicReference<>();
+            MemorySegment stub = makeArgSaverCB(upcallDesc, arena, returnBox, 0);
+
+            MemorySegment returned = (MemorySegment) downcallHandle.invokeExact(
+                    (SegmentAllocator) arena, (MemorySegment) testValue.value(), stub);
+
+            testValue.check().accept(returnBox.get()[0]);
+            testValue.check().accept(returned);
+        }
+    }
+
+    @DataProvider
+    public static Object[][] nestedLayouts() {
+        List<GroupLayout> layouts = List.of(
+                S1, U1, U17, S2, S3, S4, S5, S6, U2, S7, U3, U4, U5, U6, U7, S8, S9, U8, U9, U10, S10,
+                U11, S11, U12, S12, U13, U14, U15, S13, S14, U16, S15);
+        return layouts.stream().map(l -> new Object[]{l}).toArray(Object[][]::new);
+    }
+
+    static final StructLayout S1 = MemoryLayout.structLayout(
+            C_DOUBLE.withName("f0"),
+            C_LONG_LONG.withName("f1"),
+            C_DOUBLE.withName("f2"),
+            C_INT.withName("f3"),
+            MemoryLayout.paddingLayout(32)
+    ).withName("S1");
+    static final UnionLayout U1 = MemoryLayout.unionLayout(
+            C_SHORT.withName("f0"),
+            C_LONG_LONG.withName("f1"),
+            C_SHORT.withName("f2"),
+            MemoryLayout.sequenceLayout(4, MemoryLayout.sequenceLayout(3, C_CHAR)).withName("f3"),
+            MemoryLayout.paddingLayout(128)
+    ).withName("U1");
+    static final UnionLayout U17 = MemoryLayout.unionLayout(
+            C_CHAR.withName("f0"),
+            C_CHAR.withName("f1"),
+            C_LONG_LONG.withName("f2"),
+            C_DOUBLE.withName("f3")
+    ).withName("U17");
+    static final StructLayout S2 = MemoryLayout.structLayout(
+            U17.withName("f0"),
+            MemoryLayout.sequenceLayout(4, C_LONG_LONG).withName("f1"),
+            C_SHORT.withName("f2"),
+            MemoryLayout.paddingLayout(48)
+    ).withName("S2");
+    static final StructLayout S3 = MemoryLayout.structLayout(
+            C_FLOAT.withName("f0"),
+            C_INT.withName("f1"),
+            U1.withName("f2"),
+            S2.withName("f3")
+    ).withName("S3");
+    static final StructLayout S4 = MemoryLayout.structLayout(
+            MemoryLayout.sequenceLayout(2, C_SHORT).withName("f0"),
+            MemoryLayout.paddingLayout(32),
+            S1.withName("f1")
+    ).withName("S4");
+    static final StructLayout S5 = MemoryLayout.structLayout(
+            C_FLOAT.withName("f0"),
+            MemoryLayout.paddingLayout(32),
+            C_POINTER.withName("f1"),
+            S4.withName("f2")
+    ).withName("S5");
+    static final StructLayout S6 = MemoryLayout.structLayout(
+            S5.withName("f0")
+    ).withName("S6");
+    static final UnionLayout U2 = MemoryLayout.unionLayout(
+            C_FLOAT.withName("f0"),
+            C_SHORT.withName("f1"),
+            C_POINTER.withName("f2"),
+            C_FLOAT.withName("f3")
+    ).withName("U2");
+    static final StructLayout S7 = MemoryLayout.structLayout(
+            C_DOUBLE.withName("f0"),
+            C_SHORT.withName("f1"),
+            C_SHORT.withName("f2"),
+            MemoryLayout.paddingLayout(32),
+            C_LONG_LONG.withName("f3")
+    ).withName("S7");
+    static final UnionLayout U3 = MemoryLayout.unionLayout(
+            C_POINTER.withName("f0"),
+            U2.withName("f1"),
+            C_LONG_LONG.withName("f2"),
+            S7.withName("f3")
+    ).withName("U3");
+    static final UnionLayout U4 = MemoryLayout.unionLayout(
+            C_FLOAT.withName("f0")
+    ).withName("U4");
+    static final UnionLayout U5 = MemoryLayout.unionLayout(
+            U3.withName("f0"),
+            MemoryLayout.sequenceLayout(3, C_LONG_LONG).withName("f1"),
+            U4.withName("f2"),
+            C_FLOAT.withName("f3")
+    ).withName("U5");
+    static final UnionLayout U6 = MemoryLayout.unionLayout(
+            C_SHORT.withName("f0"),
+            C_FLOAT.withName("f1"),
+            U5.withName("f2"),
+            C_SHORT.withName("f3")
+    ).withName("U6");
+    static final UnionLayout U7 = MemoryLayout.unionLayout(
+            C_SHORT.withName("f0")
+    ).withName("U7");
+    static final StructLayout S8 = MemoryLayout.structLayout(
+            MemoryLayout.sequenceLayout(3, C_DOUBLE).withName("f0"),
+            U7.withName("f1"),
+            MemoryLayout.paddingLayout(48),
+            C_POINTER.withName("f2"),
+            C_POINTER.withName("f3")
+    ).withName("S8");
+    static final StructLayout S9 = MemoryLayout.structLayout(
+            C_CHAR.withName("f0"),
+            MemoryLayout.paddingLayout(56),
+            MemoryLayout.sequenceLayout(2, C_DOUBLE).withName("f1"),
+            C_CHAR.withName("f2"),
+            MemoryLayout.paddingLayout(56),
+            S8.withName("f3")
+    ).withName("S9");
+    static final UnionLayout U8 = MemoryLayout.unionLayout(
+            C_LONG_LONG.withName("f0"),
+            C_POINTER.withName("f1"),
+            S9.withName("f2")
+    ).withName("U8");
+    static final UnionLayout U9 = MemoryLayout.unionLayout(
+            C_INT.withName("f0"),
+            C_DOUBLE.withName("f1"),
+            MemoryLayout.sequenceLayout(2, C_SHORT).withName("f2"),
+            C_LONG_LONG.withName("f3")
+    ).withName("U9");
+    static final UnionLayout U10 = MemoryLayout.unionLayout(
+            C_LONG_LONG.withName("f0"),
+            U9.withName("f1"),
+            C_CHAR.withName("f2"),
+            C_FLOAT.withName("f3")
+    ).withName("U10");
+    static final StructLayout S10 = MemoryLayout.structLayout(
+            MemoryLayout.sequenceLayout(4, C_DOUBLE).withName("f0")
+    ).withName("S10");
+    static final UnionLayout U11 = MemoryLayout.unionLayout(
+            MemoryLayout.sequenceLayout(3, S10).withName("f0")
+    ).withName("U11");
+    static final StructLayout S11 = MemoryLayout.structLayout(
+            C_SHORT.withName("f0"),
+            C_CHAR.withName("f1"),
+            MemoryLayout.paddingLayout(8)
+    ).withName("S11");
+    static final UnionLayout U12 = MemoryLayout.unionLayout(
+            C_FLOAT.withName("f0"),
+            S11.withName("f1"),
+            C_CHAR.withName("f2"),
+            C_CHAR.withName("f3")
+    ).withName("U12");
+    static final StructLayout S12 = MemoryLayout.structLayout(
+            U12.withName("f0"),
+            C_FLOAT.withName("f1")
+    ).withName("S12");
+    static final UnionLayout U13 = MemoryLayout.unionLayout(
+            C_FLOAT.withName("f0"),
+            S12.withName("f1")
+    ).withName("U13");
+    static final UnionLayout U14 = MemoryLayout.unionLayout(
+            C_INT.withName("f0"),
+            MemoryLayout.sequenceLayout(2, C_POINTER).withName("f1"),
+            MemoryLayout.sequenceLayout(2, MemoryLayout.sequenceLayout(3, C_FLOAT)).withName("f2")
+    ).withName("U14");
+    static final UnionLayout U15 = MemoryLayout.unionLayout(
+            C_POINTER.withName("f0"),
+            C_LONG_LONG.withName("f1"),
+            MemoryLayout.sequenceLayout(1, C_DOUBLE).withName("f2"),
+            C_LONG_LONG.withName("f3")
+    ).withName("U15");
+    static final StructLayout S13 = MemoryLayout.structLayout(
+            C_INT.withName("f0"),
+            C_CHAR.withName("f1"),
+            MemoryLayout.paddingLayout(24),
+            C_POINTER.withName("f2"),
+            C_CHAR.withName("f3"),
+            MemoryLayout.paddingLayout(56)
+    ).withName("S13");
+    static final StructLayout S14 = MemoryLayout.structLayout(
+            C_LONG_LONG.withName("f0")
+    ).withName("S14");
+    static final UnionLayout U16 = MemoryLayout.unionLayout(
+            MemoryLayout.sequenceLayout(4, C_SHORT).withName("f0"),
+            C_INT.withName("f1"),
+            S13.withName("f2"),
+            S14.withName("f3")
+    ).withName("U16");
+    static final StructLayout S15 = MemoryLayout.structLayout(
+            U16.withName("f0"),
+            C_FLOAT.withName("f1"),
+            C_INT.withName("f2"),
+            C_LONG_LONG.withName("f3")
+    ).withName("S15");
+}

--- a/test/jdk/java/foreign/nested/libNested.c
+++ b/test/jdk/java/foreign/nested/libNested.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+struct S1{ double f0; long long f1; double f2; int f3; };
+union U1{ short f0; long long f1; short f2; char f3[4][3]; };
+union U17{ char f0; char f1; long long f2; double f3; };
+struct S2{ union U17 f0; long long f1[4]; short f2; };
+struct S3{ float f0; int f1; union U1 f2; struct S2 f3; };
+struct S4{ short f0[2]; struct S1 f1; };
+struct S5{ float f0; void* f1; struct S4 f2; };
+struct S6{ struct S5 f0; };
+union U2{ float f0; short f1; void* f2; float f3; };
+struct S7{ double f0; short f1; short f2; long long f3; };
+union U3{ void* f0; union U2 f1; long long f2; struct S7 f3; };
+union U4{ float f0; };
+union U5{ union U3 f0; long long f1[3]; union U4 f2; float f3; };
+union U6{ short f0; float f1; union U5 f2; short f3; };
+union U7{ short f0; };
+struct S8{ double f0[3]; union U7 f1; void* f2; void* f3; };
+struct S9{ char f0; double f1[2]; char f2; struct S8 f3; };
+union U8{ long long f0; void* f1; struct S9 f2; };
+union U9{ int f0; double f1; short f2[2]; long long f3; };
+union U10{ long long f0; union U9 f1; char f2; float f3; };
+struct S10{ double f0[4]; };
+union U11{ struct S10 f0[3]; };
+struct S11{ short f0; char f1; };
+union U12{ float f0; struct S11 f1; char f2; char f3; };
+struct S12{ union U12 f0; float f1; };
+union U13{ float f0; struct S12 f1; };
+union U14{ int f0; void* f1[2]; float f2[2][3]; };
+union U15{ void* f0; long long f1; double f2[1]; long long f3; };
+struct S13{ int f0; char f1; void* f2; char f3; };
+struct S14{ long long f0; };
+union U16{ short f0[4]; int f1; struct S13 f2; struct S14 f3; };
+struct S15{ union U16 f0; float f1; int f2; long long f3; };
+
+EXPORT struct S1 test_S1(struct S1 arg, struct S1(*cb)(struct S1)) { return cb(arg); }
+EXPORT union U1 test_U1(union U1 arg, union U1(*cb)(union U1)) { return cb(arg); }
+EXPORT union U17 test_U17(union U17 arg, union U17(*cb)(union U17)) { return cb(arg); }
+EXPORT struct S2 test_S2(struct S2 arg, struct S2(*cb)(struct S2)) { return cb(arg); }
+EXPORT struct S3 test_S3(struct S3 arg, struct S3(*cb)(struct S3)) { return cb(arg); }
+EXPORT struct S4 test_S4(struct S4 arg, struct S4(*cb)(struct S4)) { return cb(arg); }
+EXPORT struct S5 test_S5(struct S5 arg, struct S5(*cb)(struct S5)) { return cb(arg); }
+EXPORT struct S6 test_S6(struct S6 arg, struct S6(*cb)(struct S6)) { return cb(arg); }
+EXPORT union U2 test_U2(union U2 arg, union U2(*cb)(union U2)) { return cb(arg); }
+EXPORT struct S7 test_S7(struct S7 arg, struct S7(*cb)(struct S7)) { return cb(arg); }
+EXPORT union U3 test_U3(union U3 arg, union U3(*cb)(union U3)) { return cb(arg); }
+EXPORT union U4 test_U4(union U4 arg, union U4(*cb)(union U4)) { return cb(arg); }
+EXPORT union U5 test_U5(union U5 arg, union U5(*cb)(union U5)) { return cb(arg); }
+EXPORT union U6 test_U6(union U6 arg, union U6(*cb)(union U6)) { return cb(arg); }
+EXPORT union U7 test_U7(union U7 arg, union U7(*cb)(union U7)) { return cb(arg); }
+EXPORT struct S8 test_S8(struct S8 arg, struct S8(*cb)(struct S8)) { return cb(arg); }
+EXPORT struct S9 test_S9(struct S9 arg, struct S9(*cb)(struct S9)) { return cb(arg); }
+EXPORT union U8 test_U8(union U8 arg, union U8(*cb)(union U8)) { return cb(arg); }
+EXPORT union U9 test_U9(union U9 arg, union U9(*cb)(union U9)) { return cb(arg); }
+EXPORT union U10 test_U10(union U10 arg, union U10(*cb)(union U10)) { return cb(arg); }
+EXPORT struct S10 test_S10(struct S10 arg, struct S10(*cb)(struct S10)) { return cb(arg); }
+EXPORT union U11 test_U11(union U11 arg, union U11(*cb)(union U11)) { return cb(arg); }
+EXPORT struct S11 test_S11(struct S11 arg, struct S11(*cb)(struct S11)) { return cb(arg); }
+EXPORT union U12 test_U12(union U12 arg, union U12(*cb)(union U12)) { return cb(arg); }
+EXPORT struct S12 test_S12(struct S12 arg, struct S12(*cb)(struct S12)) { return cb(arg); }
+EXPORT union U13 test_U13(union U13 arg, union U13(*cb)(union U13)) { return cb(arg); }
+EXPORT union U14 test_U14(union U14 arg, union U14(*cb)(union U14)) { return cb(arg); }
+EXPORT union U15 test_U15(union U15 arg, union U15(*cb)(union U15)) { return cb(arg); }
+EXPORT struct S13 test_S13(struct S13 arg, struct S13(*cb)(struct S13)) { return cb(arg); }
+EXPORT struct S14 test_S14(struct S14 arg, struct S14(*cb)(struct S14)) { return cb(arg); }
+EXPORT union U16 test_U16(union U16 arg, union U16(*cb)(union U16)) { return cb(arg); }
+EXPORT struct S15 test_S15(struct S15 arg, struct S15(*cb)(struct S15)) { return cb(arg); }


### PR DESCRIPTION
Port of: https://github.com/openjdk/panama-foreign/pull/780 Which adds tests for nested structs/unions/arrays, and fixes an issue with nested HFAs on AArch64.

This PR also includes https://github.com/openjdk/panama-foreign/pull/765 which is required for the fix to apply cleanly.

Moving these change sets into the mainline now seems useful for the currently ongoing porting effort on PPC, as well as taking a load off of the JEP PR review which will come later.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303516](https://bugs.openjdk.org/browse/JDK-8303516): HFAs with nested structs/unions/arrays not handled correctly on AArch64


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12831/head:pull/12831` \
`$ git checkout pull/12831`

Update a local copy of the PR: \
`$ git checkout pull/12831` \
`$ git pull https://git.openjdk.org/jdk pull/12831/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12831`

View PR using the GUI difftool: \
`$ git pr show -t 12831`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12831.diff">https://git.openjdk.org/jdk/pull/12831.diff</a>

</details>
