### PR TITLE
8303523: Cleanup problem listing of nsk/jvmti/AttachOnDemand/attach002a/TestDescription.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -27,6 +27,7 @@
 #
 #############################################################################
 
+vmTestbase/nsk/jvmti/AttachOnDemand/attach002a/TestDescription.java 8277573 generic-all
 vmTestbase/nsk/jvmti/AttachOnDemand/attach022/TestDescription.java 8277573 generic-all
 vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java 8205957 generic-all
 vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java 8205957 linux-x64,windows-x64

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -146,7 +146,6 @@ vmTestbase/nsk/jvmti/AttachOnDemand/attach045/TestDescription.java 8202971 gener
 vmTestbase/nsk/jvmti/scenarios/jni_interception/JI05/ji05t001/TestDescription.java 8219652 aix-ppc64
 vmTestbase/nsk/jvmti/scenarios/jni_interception/JI06/ji06t001/TestDescription.java 8219652 aix-ppc64
 vmTestbase/nsk/jvmti/SetJNIFunctionTable/setjniftab001/TestDescription.java 8219652 aix-ppc64
-vmTestbase/nsk/jvmti/AttachOnDemand/attach002a/TestDescription.java 8277812 generic-all
 vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java 8073470 linux-all
 vmTestbase/nsk/jvmti/InterruptThread/intrpthrd003/TestDescription.java 8288911 macosx-x64
 


### PR DESCRIPTION
attach002a is problem listed under [JDK-8277812](https://bugs.openjdk.org/browse/JDK-8277812), which has been closed as a dup of [JDK-8277573](https://bugs.openjdk.org/browse/JDK-8277573), so its problem list entry should be updated to reflect this. The other issue is that it is currently in the general problem list, but only occurs with -Xcomp, so it needs to be moved to ProblemList-Xcomp.txt.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303523](https://bugs.openjdk.org/browse/JDK-8303523): Cleanup problem listing of nsk/jvmti/AttachOnDemand/attach002a/TestDescription.java


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12836/head:pull/12836` \
`$ git checkout pull/12836`

Update a local copy of the PR: \
`$ git checkout pull/12836` \
`$ git pull https://git.openjdk.org/jdk pull/12836/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12836`

View PR using the GUI difftool: \
`$ git pr show -t 12836`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12836.diff">https://git.openjdk.org/jdk/pull/12836.diff</a>

</details>
