### PR TITLE
8303527: update for deprecated sprintf for jdk.hotspot.agent

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
@@ -231,7 +231,7 @@ static bool process_doesnt_exist(pid_t pid) {
   FILE *fp = NULL;
   const char state_string[] = "State:";
 
-  sprintf(fname, "/proc/%d/status", pid);
+  snprintf(fname, sizeof(fname), "/proc/%d/status", pid);
   fp = fopen(fname, "r");
   if (fp == NULL) {
     print_debug("can't open /proc/%d/status file\n", pid);
@@ -350,7 +350,7 @@ static bool read_lib_info(struct ps_prochandle* ph) {
   char buf[PATH_MAX];
   FILE *fp = NULL;
 
-  sprintf(fname, "/proc/%d/maps", ph->pid);
+  snprintf(fname, sizeof(fname), "/proc/%d/maps", ph->pid);
   fp = fopen(fname, "r");
   if (fp == NULL) {
     print_debug("can't open /proc/%d/maps file\n", ph->pid);

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
+++ b/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
@@ -185,7 +185,7 @@ static void throwNewDebuggerException(JNIEnv* env, const char* errMsg) {
   do { \
     const HRESULT hr = (v); \
     if (hr != S_OK) { \
-      size_t errmsg_size = new char[strlen(str) + 32;
+      size_t errmsg_size = strlen(str) + 32;
       AutoArrayPtr<char> errmsg(new char[errmsg_size]); \
       if (errmsg == nullptr) { \
         THROW_NEW_DEBUGGER_EXCEPTION_(str, retValue); \

--- a/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
+++ b/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
@@ -185,11 +185,12 @@ static void throwNewDebuggerException(JNIEnv* env, const char* errMsg) {
   do { \
     const HRESULT hr = (v); \
     if (hr != S_OK) { \
-      AutoArrayPtr<char> errmsg(new char[strlen(str) + 32]); \
+      size_t errmsg_size = new char[strlen(str) + 32;
+      AutoArrayPtr<char> errmsg(new char[errmsg_size]); \
       if (errmsg == nullptr) { \
         THROW_NEW_DEBUGGER_EXCEPTION_(str, retValue); \
       } else { \
-        sprintf(errmsg, "%s (hr: 0x%08X)", str, hr); \
+        snprintf(errmsg, errmsg_size, "%s (hr: 0x%08X)", str, hr); \
         THROW_NEW_DEBUGGER_EXCEPTION_(errmsg, retValue); \
       } \
     } \

--- a/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
+++ b/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
@@ -185,7 +185,7 @@ static void throwNewDebuggerException(JNIEnv* env, const char* errMsg) {
   do { \
     const HRESULT hr = (v); \
     if (hr != S_OK) { \
-      size_t errmsg_size = strlen(str) + 32;
+      size_t errmsg_size = strlen(str) + 32; \
       AutoArrayPtr<char> errmsg(new char[errmsg_size]); \
       if (errmsg == nullptr) { \
         THROW_NEW_DEBUGGER_EXCEPTION_(str, retValue); \


### PR DESCRIPTION
Hi,

May I have this update reviewed?

The sprintf is deprecated in Xcode 14 because of security concerns. The issue was addressed in [JDK-8296812](https://bugs.openjdk.org/browse/JDK-8296812) for building failure, and [JDK-8299378](https://bugs.openjdk.org/browse/JDK-8299378)/[JDK-8299635](https://bugs.openjdk.org/browse/JDK-8299635)/[JDK-8301132](https://bugs.openjdk.org/browse/JDK-8301132) for testing issues . This is a break-down update for sprintf uses in jdk.hotspot.agent module.

Thanks,
Xuelei

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303527](https://bugs.openjdk.org/browse/JDK-8303527): update for deprecated sprintf for jdk.hotspot.agent


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12837/head:pull/12837` \
`$ git checkout pull/12837`

Update a local copy of the PR: \
`$ git checkout pull/12837` \
`$ git pull https://git.openjdk.org/jdk pull/12837/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12837`

View PR using the GUI difftool: \
`$ git pr show -t 12837`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12837.diff">https://git.openjdk.org/jdk/pull/12837.diff</a>

</details>
