### PR TITLE
8303690: Prefer ArrayList to LinkedList in com.sun.jmx.mbeanserver.Introspector

### DIFF
--- a/src/java.management/share/classes/com/sun/jmx/mbeanserver/Introspector.java
+++ b/src/java.management/share/classes/com/sun/jmx/mbeanserver/Introspector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,11 +33,11 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.UndeclaredThrowableException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.LinkedList;
 import java.util.Locale;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -446,7 +446,7 @@ public class Introspector {
     /**
      * Throws a NotCompliantMBeanException or a SecurityException.
      * @param notCompliant the class which was under examination
-     * @param cause the raeson why NotCompliantMBeanException should
+     * @param cause the reason why NotCompliantMBeanException should
      *        be thrown.
      * @return nothing - this method always throw an exception.
      *         The return type makes it possible to write
@@ -602,9 +602,7 @@ public class Introspector {
             // return cached methods if possible
             SoftReference<List<Method>> ref = cache.get(clazz);
             if (ref != null) {
-                List<Method> cached = ref.get();
-                if (cached != null)
-                    return cached;
+                return ref.get();
             }
             return null;
         }
@@ -653,7 +651,7 @@ public class Introspector {
             methods = MBeanAnalyzer.eliminateCovariantMethods(methods);
 
             // filter out the non-getter methods
-            List<Method> result = new LinkedList<>();
+            List<Method> result = new ArrayList<>();
             for (Method m: methods) {
                 if (isReadMethod(m)) {
                     // favor isXXX over getXXX


### PR DESCRIPTION
`LinkedList` is used as value in `com.sun.jmx.mbeanserver.Introspector.SimpleIntrospector#cache`
It's created, filled (with `add`) and then iterated. No removes from the head or something like this. `ArrayList` should be preferred as more efficient and widely used collection.
Also I've done some related code cleaned:
1. removed redundand `if` from `SoftReference` value check
2. fixed a typo in javadoc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303690](https://bugs.openjdk.org/browse/JDK-8303690): Prefer ArrayList to LinkedList in com.sun.jmx.mbeanserver.Introspector


### Reviewers
 * [Sergey Tsypanov](https://openjdk.org/census#stsypanov) (@stsypanov - Author)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12839/head:pull/12839` \
`$ git checkout pull/12839`

Update a local copy of the PR: \
`$ git checkout pull/12839` \
`$ git pull https://git.openjdk.org/jdk pull/12839/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12839`

View PR using the GUI difftool: \
`$ git pr show -t 12839`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12839.diff">https://git.openjdk.org/jdk/pull/12839.diff</a>

</details>
