### PR TITLE
JDK-8295859 Update Manual Test Groups

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -598,26 +598,29 @@ jdk_nio_networkchannel = \
 
 jdk_core_manual = \
     :jdk_core_manual_no_input \
-    :jdk_core_manual_no_input_security \
-    :jdk_core_manual_requires_human_input
+    :jdk_core_manual_no_input_security
 
 jdk_core_manual_no_input = \
     java/net/HugeDataTransferTest.java \
     java/net/httpclient/BodyProcessorInputStreamTest.java \
     java/net/httpclient/HttpInputStreamTest.java \
-    java/nio/MappedByteBuffer/PmemTest.java \
-    java/rmi/registry/nonLocalRegistry/NonLocalRegistryTest.java \
     java/util/zip/ZipFile/TestZipFile.java \
+    java/util/zip/ZipFile/TestTooManyEntries.java \
     javax/net/ssl/compatibility/AlpnTest.java \
     javax/net/ssl/compatibility/BasicConnectTest.java \
     javax/net/ssl/compatibility/HrrTest.java \
     javax/net/ssl/compatibility/SniTest.java \
     jdk/nio/zipfs/TestLocOffsetFromZip64EF.java \
+    jdk/nio/zipfs/LargeCompressedEntrySizeTest.java \
     java/util/ArrayList/Bug8146568.java \
-    java/util/Vector/Bug8148174.java
+    java/util/Vector/Bug8148174.java \
+    com/sun/net/httpserver/simpleserver/CommandLinePortNotSpecifiedTest.java \
+    com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePortNotSpecifiedTest.java
 
 jdk_core_manual_no_input_security = \
     com/sun/crypto/provider/Cipher/DES/PerformanceTest.java \
+    com/sun/crypto/provider/Cipher/AEAD/GCMIncrementByte4.java \
+    com/sun/crypto/provider/Cipher/AEAD/GCMIncrementDirect4.java \
     com/sun/security/auth/callback/TextCallbackHandler/Default.java \
     com/sun/security/auth/callback/TextCallbackHandler/Password.java \
     com/sun/security/sasl/gsskerb/AuthOnly.java \
@@ -635,13 +638,23 @@ jdk_core_manual_no_input_security = \
     sun/security/smartcardio/TestMultiplePresent.java \
     sun/security/smartcardio/TestPresent.java \
     sun/security/smartcardio/TestTransmit.java \
-    sun/security/tools/jarsigner/compatibility/Compatibility.java \
-    java/security/Policy/Root/Root.java
+    sun/security/tools/jarsigner/compatibility/Compatibility.java
+
+jdk_core_manual_human = \
+    :jdk_core_manual_requires_human_input \
+    :jdk_core_manual_requires_root_privilege
 
 jdk_core_manual_requires_human_input = \
     com/sun/jndi/dns/Test6991580.java \
     java/util/TimeZone/DefaultTimeZoneTest.java \
-    sun/security/tools/keytool/i18n.java
+    sun/security/tools/keytool/i18n.java \
+    java/nio/MappedByteBuffer/PmemTest.java \
+    java/rmi/registry/nonLocalRegistry/NonLocalRegistryTest.java \
+    java/rmi/registry/nonLocalRegistry/NonLocalSkeletonTest.java
+
+jdk_core_manual_requires_root_privilege = \
+    java/security/Policy/Root/Root.java \
+    sun/security/krb5/config/native/TestDynamicStore.java
 
 
 # Test sets for running inside container environment

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -641,18 +641,12 @@ jdk_core_manual_no_input_security = \
     sun/security/tools/jarsigner/compatibility/Compatibility.java
 
 jdk_core_manual_human = \
-    :jdk_core_manual_requires_human_input \
-    :jdk_core_manual_requires_root_privilege
-
-jdk_core_manual_requires_human_input = \
     com/sun/jndi/dns/Test6991580.java \
     java/util/TimeZone/DefaultTimeZoneTest.java \
     sun/security/tools/keytool/i18n.java \
     java/nio/MappedByteBuffer/PmemTest.java \
     java/rmi/registry/nonLocalRegistry/NonLocalRegistryTest.java \
-    java/rmi/registry/nonLocalRegistry/NonLocalSkeletonTest.java
-
-jdk_core_manual_requires_root_privilege = \
+    java/rmi/registry/nonLocalRegistry/NonLocalSkeletonTest.java \
     java/security/Policy/Root/Root.java \
     sun/security/krb5/config/native/TestDynamicStore.java
 

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -640,7 +640,7 @@ jdk_core_manual_no_input_security = \
     sun/security/smartcardio/TestTransmit.java \
     sun/security/tools/jarsigner/compatibility/Compatibility.java
 
-jdk_core_manual_human = \
+jdk_core_manual_interactive = \
     com/sun/jndi/dns/Test6991580.java \
     java/util/TimeZone/DefaultTimeZoneTest.java \
     sun/security/tools/keytool/i18n.java \


### PR DESCRIPTION
The purpose of this task is to add the difference between -manual jdk_core and jdk_core_manual to the jdk_core_manual test goal. Furthermore, in order to streamline the manual test execution process, a new test group called jdk_core_manual_human has been created for manual tests that demand extra preparation or test input.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295859](https://bugs.openjdk.org/browse/JDK-8295859): Update Manual Test Groups


### Reviewers
 * [Mark Sheppard](https://openjdk.org/census#msheppar) (@msheppar - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12840/head:pull/12840` \
`$ git checkout pull/12840`

Update a local copy of the PR: \
`$ git checkout pull/12840` \
`$ git pull https://git.openjdk.org/jdk.git pull/12840/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12840`

View PR using the GUI difftool: \
`$ git pr show -t 12840`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12840.diff">https://git.openjdk.org/jdk/pull/12840.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12840#issuecomment-1452587210)