### PR TITLE
8303151: DCmd framework cleanups

### DIFF
--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -56,6 +56,7 @@
 #include "services/diagnosticFramework.hpp"
 #include "services/heapDumper.hpp"
 #include "services/management.hpp"
+#include "services/nmtDCmd.hpp"
 #include "services/writeableFlags.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/events.hpp"
@@ -153,14 +154,9 @@ void DCmdRegistrant::register_dcmds(){
 #if INCLUDE_CDS
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<DumpSharedArchiveDCmd>(full_export, true, false));
 #endif // INCLUDE_CDS
-}
 
-#ifndef HAVE_EXTRA_DCMD
-void DCmdRegistrant::register_dcmds_ext(){
-   // Do nothing here
+  DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<NMTDCmd>(full_export, true, false));
 }
-#endif
-
 
 HelpDCmd::HelpDCmd(outputStream* output, bool heap) : DCmdWithParser(output, heap),
   _all("-all", "Show help for all commands", "BOOLEAN", false, "false"),

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -81,7 +81,7 @@ static void loadAgentModule(TRAPS) {
                          THREAD);
 }
 
-void DCmdRegistrant::register_dcmds(){
+void DCmd::register_dcmds(){
   // Registration of the diagnostic commands
   // First argument specifies which interfaces will export the command
   // Second argument specifies if the command is enabled

--- a/src/hotspot/share/services/diagnosticFramework.hpp
+++ b/src/hotspot/share/services/diagnosticFramework.hpp
@@ -310,6 +310,11 @@ public:
   // main method to invoke the framework
   static void parse_and_execute(DCmdSource source, outputStream* out, const char* cmdline,
                                 char delim, TRAPS);
+
+  // Convenience method to register Dcmds, without a need to change
+  // management.cpp every time.
+  static void register_dcmds();
+
 };
 
 class DCmdWithParser : public DCmd {
@@ -450,18 +455,6 @@ private:
       return 0;
     }
   }
-};
-
-// This class provides a convenient way to register Dcmds, without a need to change
-// management.cpp every time. The body of this method resides in
-// diagnosticCommand.cpp.
-
-class DCmdRegistrant : public AllStatic {
-
-private:
-    static void register_dcmds();
-
-    friend class Management;
 };
 
 #endif // SHARE_SERVICES_DIAGNOSTICFRAMEWORK_HPP

--- a/src/hotspot/share/services/diagnosticFramework.hpp
+++ b/src/hotspot/share/services/diagnosticFramework.hpp
@@ -453,8 +453,8 @@ private:
 };
 
 // This class provides a convenient way to register Dcmds, without a need to change
-// management.cpp every time. Body of these two methods resides in
-// diagnosticCommand.cpp
+// management.cpp every time. The body of this method resides in
+// diagnosticCommand.cpp.
 
 class DCmdRegistrant : public AllStatic {
 

--- a/src/hotspot/share/services/diagnosticFramework.hpp
+++ b/src/hotspot/share/services/diagnosticFramework.hpp
@@ -460,7 +460,6 @@ class DCmdRegistrant : public AllStatic {
 
 private:
     static void register_dcmds();
-    static void register_dcmds_ext();
 
     friend class Management;
 };

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -61,7 +61,6 @@
 #include "services/heapDumper.hpp"
 #include "services/lowMemoryDetector.hpp"
 #include "services/gcNotifier.hpp"
-#include "services/nmtDCmd.hpp"
 #include "services/management.hpp"
 #include "services/memoryManager.hpp"
 #include "services/memoryPool.hpp"
@@ -146,10 +145,6 @@ void Management::init() {
 
   // Registration of the diagnostic commands
   DCmdRegistrant::register_dcmds();
-  DCmdRegistrant::register_dcmds_ext();
-  uint32_t full_export = DCmd_Source_Internal | DCmd_Source_AttachAPI
-                         | DCmd_Source_MBean;
-  DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<NMTDCmd>(full_export, true, false));
 }
 
 void Management::initialize(TRAPS) {

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -144,7 +144,7 @@ void Management::init() {
   _optional_support.isRemoteDiagnosticCommandsSupported = 1;
 
   // Registration of the diagnostic commands
-  DCmdRegistrant::register_dcmds();
+  DCmd::register_dcmds();
 }
 
 void Management::initialize(TRAPS) {


### PR DESCRIPTION
Whilst working on the DCmd code I noticed two items that could be cleaned up:

1. The `NMTDCmd` is registered after the call to `register_dcmds()` instead of inside it.

2. The "extension" mechanism to define external DCmds (as added by [JDK-7132515](https://bugs.openjdk.org/browse/JDK-7132515) for `UnlockCommercialFeatures`) is no longer needed.

Testing: tiers 1-3

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303151](https://bugs.openjdk.org/browse/JDK-8303151): DCmd framework cleanups


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - Committer) ⚠️ Review applies to [4e8d6b56](https://git.openjdk.org/jdk/pull/12847/files/4e8d6b565d4d55bc5b61891836b1df38ed42d345)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [7f29eba9](https://git.openjdk.org/jdk/pull/12847/files/7f29eba924d08a1d4a818b0a0bd1e597b2ef863c)
 * [Yi Yang](https://openjdk.org/census#yyang) (@y1yang0 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12847/head:pull/12847` \
`$ git checkout pull/12847`

Update a local copy of the PR: \
`$ git checkout pull/12847` \
`$ git pull https://git.openjdk.org/jdk pull/12847/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12847`

View PR using the GUI difftool: \
`$ git pr show -t 12847`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12847.diff">https://git.openjdk.org/jdk/pull/12847.diff</a>

</details>
