### PR TITLE
8252255: Blurry rendering of SwingNode with HiDPI scaling in JavaFX

### DIFF
--- a/src/jdk.unsupported.desktop/share/classes/jdk/swing/interop/LightweightFrameWrapper.java
+++ b/src/jdk.unsupported.desktop/share/classes/jdk/swing/interop/LightweightFrameWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,6 +58,13 @@ public class LightweightFrameWrapper {
     public void notifyDisplayChanged(final int scaleFactor) {
         if (lwFrame != null) {
             lwFrame.notifyDisplayChanged(scaleFactor, scaleFactor);
+        }
+    }
+
+    public void notifyDisplayChanged(final double scaleFactorX,
+                                     final double scaleFactorY) {
+        if (lwFrame != null) {
+            lwFrame.notifyDisplayChanged(scaleFactorX, scaleFactorY);
         }
     }
 


### PR DESCRIPTION
Refactor-ed Swing interop was calling `JLightweightFrame.notifyDisplayChanged()` with [wrong scale factor](https://github.com/openjdk/jfx/blob/master/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/newimpl/SwingNodeInteropN.java#L71-L76) 
as it was passing integer scale and not double so scalefactor of 1.25 is being passed as 1.0 to JLightwieightFrame
Due to this, the `imagebuffer `which is created for lightweight container to paint its content to an offscreen image 
is created with wrong[ width/height ](https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/sun/swing/JLightweightFrame.java#L457)
Fix is made to have Swing interop call double version of the method to get correct scale factor and set the imagebuffer properly.

I guess we could remove the int version of the method (which anyways is deprecated) and cleanup Swing interop code to just utilise the double version, as all platforms we support uses floating scale, but that cleanup can be done separately for another day

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8252255](https://bugs.openjdk.org/browse/JDK-8252255): Blurry rendering of SwingNode with HiDPI scaling in JavaFX


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - Author)
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12848/head:pull/12848` \
`$ git checkout pull/12848`

Update a local copy of the PR: \
`$ git checkout pull/12848` \
`$ git pull https://git.openjdk.org/jdk pull/12848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12848`

View PR using the GUI difftool: \
`$ git pr show -t 12848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12848.diff">https://git.openjdk.org/jdk/pull/12848.diff</a>

</details>
