### PR TITLE
8303562: Remove obsolete comments in os::pd_attempt_reserve_memory_at

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1769,9 +1769,6 @@ char* os::pd_attempt_reserve_memory_at(char* requested_addr, size_t bytes, bool 
   // in one of the methods further up the call chain.  See bug 5044738.
   assert(bytes % os::vm_page_size() == 0, "reserving unexpected size block");
 
-  // Repeatedly allocate blocks until the block is allocated at the
-  // right spot.
-
   // Bsd mmap allows caller to pass an address as hint; give it a try first,
   // if kernel honors the hint then we can return immediately.
   char * addr = anon_mmap(requested_addr, bytes, exec);

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4085,9 +4085,6 @@ char* os::pd_attempt_reserve_memory_at(char* requested_addr, size_t bytes, bool 
   // in one of the methods further up the call chain.  See bug 5044738.
   assert(bytes % os::vm_page_size() == 0, "reserving unexpected size block");
 
-  // Repeatedly allocate blocks until the block is allocated at the
-  // right spot.
-
   // Linux mmap allows caller to pass an address as hint; give it a try first,
   // if kernel honors the hint then we can return immediately.
   char * addr = anon_mmap(requested_addr, bytes);


### PR DESCRIPTION
Hi, Please review this trivial change removing some obsolete code comments in os::pd_attempt_reserve_memory_at. These comments became obsolete after JDK-8224871 which removes the retry loop to mmap random memory in the same function.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303562](https://bugs.openjdk.org/browse/JDK-8303562): Remove obsolete comments in os::pd_attempt_reserve_memory_at


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12849/head:pull/12849` \
`$ git checkout pull/12849`

Update a local copy of the PR: \
`$ git checkout pull/12849` \
`$ git pull https://git.openjdk.org/jdk pull/12849/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12849`

View PR using the GUI difftool: \
`$ git pr show -t 12849`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12849.diff">https://git.openjdk.org/jdk/pull/12849.diff</a>

</details>
