### PR TITLE
8303481: CancelRequestTest assertTrue failing with AssertionError due to java.util.concurrent.CompletionException: java.io.EOFException: EOF reached while reading

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/OutgoingHeaders.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/OutgoingHeaders.java
@@ -80,4 +80,8 @@ public class OutgoingHeaders<T> extends Http2Frame {
         return system;
     }
 
+    @Override
+    public String toString() {
+        return "OutgoingHeaders()";
+    }
 }

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServerConnection.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServerConnection.java
@@ -828,7 +828,10 @@ public class Http2TestServerConnection {
                                 throw new IOException("Unexpected frame");
                             }
                         } else {
-                            q.put(frame);
+                            if (!q.putIfOpen(frame)) {
+                                System.err.printf("Stream %s is closed: dropping %s%n",
+                                        stream, frame);
+                            }
                         }
                     }
                 }

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Queue.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Queue.java
@@ -77,7 +77,7 @@ public class Queue<T> implements ExceptionallyCloseable {
         }
         return true;
     }
-    
+
     // Other close() variants are immediate and abortive
     // This allows whatever is on Q to be processed first.
 

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Queue.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Queue.java
@@ -63,6 +63,7 @@ public class Queue<T> implements ExceptionallyCloseable {
     }
 
     public synchronized boolean putIfOpen(T obj) {
+        Objects.requireNonNull(obj);
         if (!isOpen()) return false;
         queueUp(obj);
         return true;


### PR DESCRIPTION
Please find here a fix that address a robustness issue in our test HTTP/2 server.

Somewhat unrelated to the issue - but making the debug log easier to read - I changed the toString() of OutgoingHeaders to be more meaningful. OutgoingHeaders is a synthetic frame - the toString of the parent class was making it appear as an UNKNOWN frame - which was confusing.

The CancelRequestTest has been observed failing intermittently with this exception:
Got expected exception: java.util.concurrent.ExecutionException: java.io.EOFException: EOF reached while reading
cancelled [jdk.internal.net.http.common.MinimalFuture@3564a02c]jdk.internal.net.http.common.MinimalFuture@3564a02c)[Completed exceptionally: java.util.concurrent.CompletionException: java.io.EOFException: EOF reached while reading] (id=6669)
test CancelRequestTest.testPostSendAsync("http://localhost:49317/http2/x/same/interrupt", true, true): failure
java.lang.AssertionError: expected [true] but found [false]
at org.testng.Assert.fail(Assert.java:99)
at org.testng.Assert.failNotEquals(Assert.java:1037)
at org.testng.Assert.assertTrue(Assert.java:45)
at org.testng.Assert.assertTrue(Assert.java:55)
at CancelRequestTest.testPostSendAsync(CancelRequestTest.java:453)

Analysis of the logs shows that this is due to the Http2TestServer closing the associated connection after failing to queue up a frame for the previously cancelled stream in its connection readLoop. The frame could not be queued because the previous stream was already closed.

DEBUG: [pool-1-thread-4] [10s 773ms] Http2Connection(SocketTube(19)) Closed stream 27
Sent response headers 200
DEBUG: [readLoop] [10s 773ms] FramesDecoder decodes: 9
DEBUG: [readLoop] [10s 773ms] FramesDecoder Tail size is now: 0, current=
DEBUG: [readLoop] [10s 773ms] FramesDecoder Got frame: DATA: length=0, streamid=27, flags=END_STREAM
DEBUG: [readLoop] [10s 773ms] FramesDecoder decodes: 0
DEBUG: [readLoop] [10s 773ms] FramesDecoder Tail size is now: 0, current=
java.io.IOException: closed
at jdk.httpclient.test.lib.http2.BodyOutputStream.write(BodyOutputStream.java:84)
at java.base/java.io.OutputStream.write(OutputStream.java:124)
at CancelRequestTest$HTTPSlowHandler.handle(CancelRequestTest.java:676)
at jdk.httpclient.test.lib.common.HttpServerAdapters$HttpChain$Http2Chain.doFilter(HttpServerAdapters.java:476)
at jdk.httpclient.test.lib.common.HttpServerAdapters$HttpTestServer$Http2TestContext.handle(HttpServerAdapters.java:746)
at jdk.httpclient.test.lib.common.HttpServerAdapters$HttpTestHandler.doHandle(HttpServerAdapters.java:395)
at jdk.httpclient.test.lib.common.HttpServerAdapters$HttpTestHandler.lambda$toHttp2Handler$1(HttpServerAdapters.java:382)
at jdk.httpclient.test.lib.http2.Http2TestServerConnection.handleRequest(Http2TestServerConnection.java:721)
at jdk.httpclient.test.lib.http2.Http2TestServerConnection.lambda$createStream$4(Http2TestServerConnection.java:671)
at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:577)
at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
at java.base/java.lang.Thread.run(Thread.java:1623)
Http server reader thread shutdown
java.io.IOException: stream closed
at jdk.httpclient.test.lib.http2.Queue.put(Queue.java:64)
at jdk.httpclient.test.lib.http2.Http2TestServerConnection.readLoop(Http2TestServerConnection.java:833)
at jdk.httpclient.test.lib.http2.Http2TestServerConnection$ConnectionThread.run(Http2TestServerConnection.java:466)

The readLoop should be more robust to asynchronous closing of HTTP/2 stream, and just drop the frame if the stream is already closed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303481](https://bugs.openjdk.org/browse/JDK-8303481): CancelRequestTest assertTrue failing with AssertionError due to java.util.concurrent.CompletionException: java.io.EOFException: EOF reached while reading


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12850/head:pull/12850` \
`$ git checkout pull/12850`

Update a local copy of the PR: \
`$ git checkout pull/12850` \
`$ git pull https://git.openjdk.org/jdk pull/12850/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12850`

View PR using the GUI difftool: \
`$ git pr show -t 12850`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12850.diff">https://git.openjdk.org/jdk/pull/12850.diff</a>

</details>
