### PR TITLE
8303564: C2: "Bad graph detected in build_loop_late" after a CMove is wrongly split thru phi

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1347,8 +1347,8 @@ void PhaseIdealLoop::split_if_with_blocks_post(Node *n) {
         return; // Compare must be in same blk as if
       }
     } else if (iff->is_CMove()) { // Trying to split-up a CMOVE
-      // Can't split CMove with different control edge.
-      if (iff->in(0) != NULL && iff->in(0) != n_ctrl ) {
+      // Can't split CMove with different control.
+      if (get_ctrl(iff) != n_ctrl) {
         return;
       }
       if (get_ctrl(iff->in(2)) == n_ctrl ||

--- a/test/hotspot/jtreg/compiler/loopopts/TestWrongCMovSplitIf.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestWrongCMovSplitIf.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8303564
+ * @summary C2: "Bad graph detected in build_loop_late" after a CMove is wrongly split thru phi
+ * @run main/othervm -XX:-BackgroundCompilation TestWrongCMovSplitIf
+ */
+
+public class TestWrongCMovSplitIf {
+    private static int[] field1 = new int[1];
+    private static int field3;
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test(true);
+            test(false);
+            testHelper(1000, false);
+        }
+    }
+
+    private static void test(boolean flag) {
+        int i;
+        for (i = 0; i < 2; i++) {
+            for (int j = 0; j < 10; j++) {
+                for (int k = 0; k < 10; k++) {
+
+                }
+            }
+        }
+        field3 = testHelper(i, flag);
+        for (int j = 0; j < 10; j++) {
+            for (int k = 0; k < 10; k++) {
+                for (int l = 0; l < 10; l++) {
+                    for (int m = 0; m < 10; m++) {
+
+                    }
+
+                }
+            }
+        }
+    }
+
+    private static int testHelper(int i, boolean flag) {
+        int stop = 1000;
+        if (i == 2) {
+            if (flag) {
+                stop = 2;
+            } else {
+                stop = 1;
+            }
+        }
+        int f = 0;
+        for (int j = 0; j < stop; j++) {
+            f += field1[0];
+        }
+        return f;
+    }
+}


### PR DESCRIPTION
The following steps lead to the crash:

- In `testHelper()`, the null and range checks for the `field1[0]`
  load are hoisted out of the counted loop by loop predication
  
- As a result, the `field1[0]` load is also out of loop, control
  dependent on a predicate
  
- pre/main/post loops are created, the main loop is unrolled, the `f`
  value that's stored in `field3` is a Phi that merges the values out
  of the 3 loops.

- the `stop` variable that captures the limit of the loop is
  transformed into a `Phi` that merges 1 and 2.
  
- As a result, the Phi that's stored in `field3` now only merges the
  value of the pre and post loop and is transformed into a `CmoveI`
  that merges 2 values dependent on the `field1[0]` `LoadI` that's
  control dependent on a predicate.
  
- On the next round of loop opts, the `CmoveI` is assigned control
  below the predicate but the `Bool`/`CmpI` for the `CmoveI` is
  assigned control above, right below a `Region` that has a `Phi` that
  is input to the `CmpI`. The reason is this logic: 
  https://github.com/rwestrel/jdk/blob/99f5687eb192b249a4a4533578f56b131fb8f234/src/hotspot/share/opto/loopnode.cpp#L5968
  
- The `CmoveI` is split thru phi because the `Bool`/`CmpI` have
  control right below a `Region`. That shouldn't happen because the
  `CmoveI` itself doesn't have control at the `Region` and is actually
  pinned through the `LoadI` below the `Region`.
  
The fix I propose is to check the control of the `CmoveI` before
proceding with split thru phi.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303564](https://bugs.openjdk.org/browse/JDK-8303564): C2: "Bad graph detected in build_loop_late" after a CMove is wrongly split thru phi


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12851/head:pull/12851` \
`$ git checkout pull/12851`

Update a local copy of the PR: \
`$ git checkout pull/12851` \
`$ git pull https://git.openjdk.org/jdk pull/12851/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12851`

View PR using the GUI difftool: \
`$ git pr show -t 12851`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12851.diff">https://git.openjdk.org/jdk/pull/12851.diff</a>

</details>
