### PR TITLE
8303509: Socket setTrafficClass does not work for IPv4 connections when IPv6 enabled

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/Net.java
+++ b/src/java.base/share/classes/sun/nio/ch/Net.java
@@ -446,6 +446,10 @@ public class Net {
 
         boolean mayNeedConversion = (family == UNSPEC);
         setIntOption0(fd, mayNeedConversion, key.level(), key.name(), arg, isIPv6);
+	if (isIPv6 && name == StandardSocketOptions.IP_TOS) {
+	    key = SocketOptionRegistry.findOption(name, StandardProtocolFamily.INET);
+	    setIntOption0(fd, mayNeedConversion, key.level(), key.name(), arg, !isIPv6);
+	}
     }
 
     static Object getSocketOption(FileDescriptor fd, SocketOption<?> name)

--- a/src/java.base/share/classes/sun/nio/ch/Net.java
+++ b/src/java.base/share/classes/sun/nio/ch/Net.java
@@ -446,10 +446,12 @@ public class Net {
 
         boolean mayNeedConversion = (family == UNSPEC);
         setIntOption0(fd, mayNeedConversion, key.level(), key.name(), arg, isIPv6);
-	if (isIPv6 && name == StandardSocketOptions.IP_TOS) {
-	    key = SocketOptionRegistry.findOption(name, StandardProtocolFamily.INET);
-	    setIntOption0(fd, mayNeedConversion, key.level(), key.name(), arg, !isIPv6);
-	}
+
+        // Some platforms also require set IPPROTO level option when socket is IPv6.
+        if (isIPv6 && name == StandardSocketOptions.IP_TOS && shouldSetBothIPv4AndIPv6Options()) {
+             key = SocketOptionRegistry.findOption(name, StandardProtocolFamily.INET);
+             setIntOption0(fd, mayNeedConversion, key.level(), key.name(), arg, !isIPv6);
+        }
     }
 
     static Object getSocketOption(FileDescriptor fd, SocketOption<?> name)


### PR DESCRIPTION
### Issue
This pr try to fix [JDK-8303509](https://bugs.openjdk.org/browse/JDK-8303509): Socket setTrafficClass does not work for IPv4 connections when IPv6 enabled.

### Change Log
When setting traffic class with IPv6 enabled, also set to IPv4 family.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303509](https://bugs.openjdk.org/browse/JDK-8303509): Socket setTrafficClass does not work for IPv4 connections when IPv6 enabled


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12852/head:pull/12852` \
`$ git checkout pull/12852`

Update a local copy of the PR: \
`$ git checkout pull/12852` \
`$ git pull https://git.openjdk.org/jdk pull/12852/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12852`

View PR using the GUI difftool: \
`$ git pr show -t 12852`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12852.diff">https://git.openjdk.org/jdk/pull/12852.diff</a>

</details>
