### PR TITLE
JDK-8303575: adjust Xen handling on Linux aarch64

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -609,18 +609,20 @@ void VM_Version::check_virtualizations() {
   if (check_info_file(pname_file, "KVM", KVM, "VMWare", VMWare)) {
     return;
   }
-  check_info_file(tname_file, "Xen", XenHVM, NULL, NoDetectedVirtualization);
+  check_info_file(tname_file, "Xen", XenPVHVM, NULL, NoDetectedVirtualization);
 #endif
 }
 
 void VM_Version::print_platform_virtualization_info(outputStream* st) {
 #if defined(LINUX)
-    VirtualizationType vrt = VM_Version::get_detected_virtualization();
-    if (vrt == KVM) {
-      st->print_cr("KVM virtualization detected");
-    } else if (vrt == VMWare) {
-      st->print_cr("VMWare virtualization detected");
-    }
+  VirtualizationType vrt = VM_Version::get_detected_virtualization();
+  if (vrt == KVM) {
+    st->print_cr("KVM virtualization detected");
+  } else if (vrt == VMWare) {
+    st->print_cr("VMWare virtualization detected");
+  } else if (vrt == XenPVHVM) {
+    st->print_cr("Xen virtualization detected");
+  }
 #endif
 }
 

--- a/src/hotspot/share/jfr/periodic/jfrOSInterface.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrOSInterface.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -253,6 +253,8 @@ const char* JfrOSInterface::virtualization_name() {
   VirtualizationType vrt = VM_Version::get_detected_virtualization();
   if (vrt == XenHVM) {
     return "Xen hardware-assisted virtualization";
+  } else if (vrt == XenPVHVM) {
+    return "Xen optimized paravirtualization";
   } else if (vrt == KVM) {
     return "KVM virtualization";
   } else if (vrt == VMWare) {

--- a/src/hotspot/share/runtime/abstract_vm_version.hpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.hpp
@@ -31,6 +31,7 @@
 typedef enum {
   NoDetectedVirtualization,
   XenHVM,
+  XenPVHVM, // mix-mode on Linux aarch64
   KVM,
   VMWare,
   HyperV,


### PR DESCRIPTION
After [JDK-8301050](https://bugs.openjdk.org/browse/JDK-8301050) the Xen handling on aarch64 should be slightly adjusted.
The output in VM_Version::print_platform_virtualization_info was missed and needs to be added for Xen.
Additionally a new XenPVHVM virtualization type could be introduced because this describes the Xen on aarch64 better.
See also https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/virtualization-on-arm-with-xen where the naming is used.