### PR TITLE
8300821: UB: Applying non-zero offset to non-null pointer 0xfffffffffffffffe produced null pointer

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -523,7 +523,7 @@ void CodeBuffer::finalize_oop_references(const methodHandle& mh) {
   for (int n = (int) SECT_FIRST; n < (int) SECT_LIMIT; n++) {
     // pull code out of each section
     CodeSection* cs = code_section(n);
-    if (cs->is_empty())  continue;  // skip trivial section
+    if (cs->is_empty() || !cs->has_locs()) continue;  // skip trivial section
     RelocIterator iter(cs);
     while (iter.next()) {
       if (iter.type() == relocInfo::metadata_type) {
@@ -791,7 +791,7 @@ void CodeBuffer::relocate_code_to(CodeBuffer* dest) const {
   for (int n = (int) SECT_FIRST; n < (int)SECT_LIMIT; n++) {
     // pull code out of each section
     const CodeSection* cs = code_section(n);
-    if (cs->is_empty()) continue;  // skip trivial section
+    if (cs->is_empty() || !cs->has_locs()) continue;  // skip trivial section
     CodeSection* dest_cs = dest->code_section(n);
     { // Repair the pc relative information in the code after the move
       RelocIterator iter(dest_cs);

--- a/src/hotspot/share/code/relocInfo.cpp
+++ b/src/hotspot/share/code/relocInfo.cpp
@@ -149,7 +149,8 @@ void RelocIterator::initialize(CompiledMethod* nm, address begin, address limit)
 
 RelocIterator::RelocIterator(CodeSection* cs, address begin, address limit) {
   initialize_misc();
-
+  assert((cs->locs_start() != nullptr) && (cs->locs_end() != nullptr) ||
+         (cs->locs_start() == nullptr) && (cs->locs_end() == nullptr), "valid start and end pointer");
   _current = cs->locs_start()-1;
   _end     = cs->locs_end();
   _addr    = cs->start();


### PR DESCRIPTION
"UndefinedBehaviorSanitizer" (https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) in Xcode running on `java --version` discovered  an Undefined Behavior. The reason is in the `next()` method https://github.com/openjdk/jdk/blob/040f5b55bd03bcc2209ece6eebf223ba1fabf824/src/hotspot/share/asm/codeBuffer.cpp#L798 

In ``RelocIterator::next()`` we get a nullpointer after `_current++`
https://github.com/openjdk/jdk/blob/040f5b55bd03bcc2209ece6eebf223ba1fabf824/src/hotspot/share/code/relocInfo.hpp#L612
But this is actually expected: In the constructor of the iterator `RelocIterator::RelocIterator` we have 
```c++
_current = cs->locs_start()-1;
_end     = cs->locs_end();
```
and in our case locs_start() and locs_end() are `null` - so `_current` is `null`-1. After `_current++` both `_end` and `_current` are `null`. Just after `_current++` we then check if `_current == _end` and return `false` (there is no next reloc info)

## Solution
We want to be able to turn on "UndefinedBehaviorSanitizer" and don't have false positives. So we add a check 
`cs->has_locs()` and only create the iterator if we have reloc info. 

Also added a sanity check in `RelocIterator::RelocIterator` that checks that either both `_current` and `_end` are null or both are not null.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300821](https://bugs.openjdk.org/browse/JDK-8300821): UB: Applying non-zero offset to non-null pointer 0xfffffffffffffffe produced null pointer


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12854/head:pull/12854` \
`$ git checkout pull/12854`

Update a local copy of the PR: \
`$ git checkout pull/12854` \
`$ git pull https://git.openjdk.org/jdk pull/12854/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12854`

View PR using the GUI difftool: \
`$ git pr show -t 12854`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12854.diff">https://git.openjdk.org/jdk/pull/12854.diff</a>

</details>
