### PR TITLE
8303582: Reduce duplication in jdk/java/foreign tests

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -241,8 +241,4 @@ public final class Utils {
         }
         return MemoryLayout.structLayout(layouts.toArray(MemoryLayout[]::new));
     }
-
-    public static int byteWidthOfPrimitive(Class<?> primitive) {
-        return Wrapper.forPrimitiveType(primitive).bitWidth() / 8;
-    }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -29,17 +29,22 @@ package jdk.internal.foreign;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SegmentAllocator;
+import java.lang.foreign.StructLayout;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.vm.annotation.ForceInline;
+import sun.invoke.util.Wrapper;
+
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 
 /**
@@ -198,5 +203,46 @@ public final class Utils {
                 ((byteAlignment & (byteAlignment - 1)) != 0L)) {
             throw new IllegalArgumentException("Invalid alignment constraint : " + byteAlignment);
         }
+    }
+
+    private static long computePadding(long offset, long align) {
+        boolean isAligned = offset == 0 || offset % align == 0;
+        if (isAligned) {
+            return 0;
+        } else {
+            long gap = offset % align;
+            return align - gap;
+        }
+    }
+
+    /**
+     * {@return return a struct layout constructed from the given elements, with padding
+     * computed automatically so that they are naturally aligned}.
+     *
+     * @param elements the structs' fields
+     */
+    public static StructLayout computePaddedStructLayout(MemoryLayout... elements) {
+        long offset = 0L;
+        List<MemoryLayout> layouts = new ArrayList<>();
+        long align = 0;
+        for (MemoryLayout l : elements) {
+            long padding = computePadding(offset, l.bitAlignment());
+            if (padding != 0) {
+                layouts.add(MemoryLayout.paddingLayout(padding));
+                offset += padding;
+            }
+            layouts.add(l);
+            align = Math.max(align, l.bitAlignment());
+            offset += l.bitSize();
+        }
+        long padding = computePadding(offset, align);
+        if (padding != 0) {
+            layouts.add(MemoryLayout.paddingLayout(padding));
+        }
+        return MemoryLayout.structLayout(layouts.toArray(MemoryLayout[]::new));
+    }
+
+    public static int byteWidthOfPrimitive(Class<?> primitive) {
+        return Wrapper.forPrimitiveType(primitive).bitWidth() / 8;
     }
 }

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -43,6 +43,8 @@ import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
@@ -56,8 +58,14 @@ public class NativeTestHelper {
     public static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
 
     private static final MethodHandle MH_SAVER;
+    private static final RandomGenerator DEFAULT_RANDOM;
 
     static {
+        int seed = Integer.getInteger("NativeTestHelper.DEFAULT_RANDOM.seed", ThreadLocalRandom.current().nextInt());
+        System.out.println("NativeTestHelper::DEFAULT_RANDOM.seed = " + seed);
+        System.out.println("Re-run with '-DNativeTestHelper.DEFAULT_RANDOM.seed=" + seed + "' to reproduce");
+        DEFAULT_RANDOM = new Random(seed);
+
         try {
             MH_SAVER = MethodHandles.lookup().findStatic(NativeTestHelper.class, "saver",
                     MethodType.methodType(Object.class, Object[].class, List.class, AtomicReference.class, SegmentAllocator.class, int.class));
@@ -115,7 +123,7 @@ public class NativeTestHelper {
      */
     public static final ValueLayout.OfAddress C_POINTER = ValueLayout.ADDRESS.withBitAlignment(64).asUnbounded();
 
-    private static final Linker LINKER = Linker.nativeLinker();
+    public static final Linker LINKER = Linker.nativeLinker();
 
     private static final MethodHandle FREE = LINKER.downcallHandle(
             LINKER.defaultLookup().find("free").get(), FunctionDescriptor.ofVoid(C_POINTER));
@@ -157,6 +165,10 @@ public class NativeTestHelper {
     }
 
     public record TestValue (Object value, Consumer<Object> check) {}
+
+    public static TestValue genTestValue(MemoryLayout layout, SegmentAllocator allocator) {
+        return genTestValue(DEFAULT_RANDOM, layout, allocator);
+    }
 
     public static TestValue genTestValue(RandomGenerator random, MemoryLayout layout, SegmentAllocator allocator) {
         if (layout instanceof StructLayout struct) {

--- a/test/jdk/java/foreign/TestDowncallBase.java
+++ b/test/jdk/java/foreign/TestDowncallBase.java
@@ -22,6 +22,7 @@
  *
  */
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.Linker;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemorySegment;
@@ -29,17 +30,15 @@ import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.SegmentAllocator;
 import java.lang.invoke.MethodHandle;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 public class TestDowncallBase extends CallGeneratorHelper {
 
-    static Linker LINKER = Linker.nativeLinker();
-
     Object doCall(MemorySegment symbol, SegmentAllocator allocator, FunctionDescriptor descriptor, Object[] args) throws Throwable {
         MethodHandle mh = downcallHandle(LINKER, symbol, allocator, descriptor);
-        Object res = mh.invokeWithArguments(args);
-        return res;
+        return mh.invokeWithArguments(args);
     }
 
     static FunctionDescriptor function(Ret ret, List<ParamType> params, List<StructFieldType> fields, List<MemoryLayout> prefix) {
@@ -50,15 +49,17 @@ public class TestDowncallBase extends CallGeneratorHelper {
                 FunctionDescriptor.of(paramLayouts[prefix.size()], paramLayouts);
     }
 
-    static Object[] makeArgs(List<ParamType> params, List<StructFieldType> fields, List<Consumer<Object>> checks, List<MemoryLayout> prefix) throws ReflectiveOperationException {
-        Object[] args = new Object[prefix.size() + params.size()];
+    static Object[] makeArgs(Arena arena, FunctionDescriptor descriptor, List<Consumer<Object>> checks, int returnIdx) {
+        List<MemoryLayout> argLayouts = descriptor.argumentLayouts();
+        TestValue[] args = new TestValue[argLayouts.size()];
         int argNum = 0;
-        for (MemoryLayout layout : prefix) {
-            args[argNum++] = makeArg(layout, null, false);
+        for (MemoryLayout layout : argLayouts) {
+            args[argNum++] = genTestValue(layout, arena);
         }
-        for (int i = 0 ; i < params.size() ; i++) {
-            args[argNum++] = makeArg(params.get(i).layout(fields), checks, i == 0);
+
+        if (descriptor.returnLayout().isPresent()) {
+            checks.add(args[returnIdx].check());
         }
-        return args;
+        return Stream.of(args).map(TestValue::value).toArray();
     }
 }

--- a/test/jdk/java/foreign/TestDowncallScope.java
+++ b/test/jdk/java/foreign/TestDowncallScope.java
@@ -25,6 +25,7 @@
  * @test
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncallBase
  *
  * @run testng/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
@@ -62,8 +63,8 @@ public class TestDowncallScope extends TestDowncallBase {
         List<Consumer<Object>> checks = new ArrayList<>();
         MemorySegment addr = findNativeOrThrow(fName);
         FunctionDescriptor descriptor = function(ret, paramTypes, fields);
-        Object[] args = makeArgs(paramTypes, fields, checks);
         try (Arena arena = Arena.openShared()) {
+            Object[] args = makeArgs(arena, descriptor, checks);
             boolean needsScope = descriptor.returnLayout().map(GroupLayout.class::isInstance).orElse(false);
             SegmentAllocator allocator = needsScope ?
                     SegmentAllocator.nativeAllocator(arena.scope()) :
@@ -83,8 +84,8 @@ public class TestDowncallScope extends TestDowncallBase {
         return function(ret, params, fields, List.of());
     }
 
-    static Object[] makeArgs(List<ParamType> params, List<StructFieldType> fields, List<Consumer<Object>> checks) throws ReflectiveOperationException {
-        return makeArgs(params, fields, checks, List.of());
+    static Object[] makeArgs(Arena arena, FunctionDescriptor descriptor, List<Consumer<Object>> checks) {
+        return makeArgs(arena, descriptor, checks, 0);
     }
 
 }

--- a/test/jdk/java/foreign/TestDowncallStack.java
+++ b/test/jdk/java/foreign/TestDowncallStack.java
@@ -25,6 +25,7 @@
  * @test
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncallBase
  *
  * @run testng/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
@@ -34,11 +35,7 @@
 
 import org.testng.annotations.Test;
 
-import java.lang.foreign.Arena;
-import java.lang.foreign.FunctionDescriptor;
-import java.lang.foreign.GroupLayout;
-import java.lang.foreign.MemorySegment;
-import java.lang.foreign.SegmentAllocator;
+import java.lang.foreign.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
@@ -58,11 +55,11 @@ public class TestDowncallStack extends TestDowncallBase {
         List<Consumer<Object>> checks = new ArrayList<>();
         MemorySegment addr = findNativeOrThrow("s" + fName);
         FunctionDescriptor descriptor = functionStack(ret, paramTypes, fields);
-        Object[] args = makeArgsStack(paramTypes, fields, checks);
         try (Arena arena = Arena.openShared()) {
+            Object[] args = makeArgsStack(arena, descriptor, checks);
             boolean needsScope = descriptor.returnLayout().map(GroupLayout.class::isInstance).orElse(false);
             SegmentAllocator allocator = needsScope ?
-                    SegmentAllocator.nativeAllocator(arena.scope()) :
+                    arena :
                     THROWING_ALLOCATOR;
             Object res = doCall(addr, allocator, descriptor, args);
             if (ret == CallGeneratorHelper.Ret.NON_VOID) {
@@ -79,8 +76,8 @@ public class TestDowncallStack extends TestDowncallBase {
         return function(ret, params, fields, STACK_PREFIX_LAYOUTS);
     }
 
-    static Object[] makeArgsStack(List<ParamType> params, List<StructFieldType> fields, List<Consumer<Object>> checks) throws ReflectiveOperationException {
-        return makeArgs(params, fields, checks, STACK_PREFIX_LAYOUTS);
+    static Object[] makeArgsStack(Arena arena, FunctionDescriptor descriptor, List<Consumer<Object>> checks) {
+        return makeArgs(arena, descriptor, checks, STACK_PREFIX_LAYOUTS.size());
     }
 
 }

--- a/test/jdk/java/foreign/TestMatrix.java
+++ b/test/jdk/java/foreign/TestMatrix.java
@@ -34,6 +34,7 @@
 /* @test id=UpcallHighArity-FF
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
  * @run testng/othervm/native/manual
@@ -46,6 +47,7 @@
 /* @test id=UpcallHighArity-TF
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
  * @run testng/othervm/native/manual
@@ -58,6 +60,7 @@
 /* @test id=UpcallHighArity-FT
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
  * @run testng/othervm/native/manual
@@ -70,6 +73,7 @@
 /* @test id=UpcallHighArity-TT
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
  * @run testng/othervm/native/manual
@@ -82,6 +86,7 @@
 /* @test id=DowncallScope-F
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncallBase
  *
  * @run testng/othervm/native/manual
@@ -93,6 +98,7 @@
 /* @test id=DowncallScope-T
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncallBase
  *
  * @run testng/othervm/native/manual
@@ -104,6 +110,7 @@
 /* @test id=DowncallStack-F
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncallBase
  *
  * @run testng/othervm/native/manual
@@ -115,6 +122,7 @@
 /* @test id=DowncallStack-T
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncallBase
  *
  * @run testng/othervm/native/manual
@@ -126,6 +134,7 @@
 /* @test id=UpcallScope-FF
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
  * @run testng/othervm/native/manual
@@ -138,6 +147,7 @@
 /* @test id=UpcallScope-TF
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
  * @run testng/othervm/native/manual
@@ -150,6 +160,7 @@
 /* @test id=UpcallScope-FT
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
  * @run testng/othervm/native/manual
@@ -162,6 +173,7 @@
 /* @test id=UpcallScope-TT
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
  * @run testng/othervm/native/manual
@@ -174,6 +186,7 @@
 /* @test id=UpcallAsync-FF
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
  * @run testng/othervm/native/manual
@@ -186,6 +199,7 @@
 /* @test id=UpcallAsync-TF
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
  * @run testng/othervm/native/manual
@@ -198,6 +212,7 @@
 /* @test id=UpcallAsync-FT
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
  * @run testng/othervm/native/manual
@@ -210,6 +225,7 @@
 /* @test id=UpcallAsync-TT
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
  * @run testng/othervm/native/manual
@@ -222,6 +238,7 @@
 /* @test id=UpcallStack-FF
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
  * @run testng/othervm/native/manual
@@ -234,6 +251,7 @@
 /* @test id=UpcallStack-TF
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
  * @run testng/othervm/native/manual
@@ -246,6 +264,7 @@
 /* @test id=UpcallStack-FT
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
  * @run testng/othervm/native/manual
@@ -258,6 +277,7 @@
 /* @test id=UpcallStack-TT
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
  * @run testng/othervm/native/manual
@@ -271,6 +291,7 @@
  * @test id=VarArgs
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper
  *
  * @run testng/othervm/native/manual

--- a/test/jdk/java/foreign/TestUpcallAsync.java
+++ b/test/jdk/java/foreign/TestUpcallAsync.java
@@ -26,6 +26,7 @@
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
  * @requires !vm.musl
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
  * @run testng/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
@@ -33,21 +34,17 @@
  *   TestUpcallAsync
  */
 
-import java.lang.foreign.Arena;
-import java.lang.foreign.FunctionDescriptor;
-import java.lang.foreign.GroupLayout;
-import java.lang.foreign.MemoryLayout;
-import java.lang.foreign.MemorySegment;
+import java.lang.foreign.*;
 
 import org.testng.annotations.Test;
 
-import java.lang.foreign.SegmentScope;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 public class TestUpcallAsync extends TestUpcallBase {
@@ -60,29 +57,35 @@ public class TestUpcallAsync extends TestUpcallBase {
     @Test(dataProvider="functions", dataProviderClass=CallGeneratorHelper.class)
     public void testUpcallsAsync(int count, String fName, Ret ret, List<ParamType> paramTypes, List<StructFieldType> fields) throws Throwable {
         List<Consumer<Object>> returnChecks = new ArrayList<>();
-        List<Consumer<Object[]>> argChecks = new ArrayList<>();
+        List<Consumer<Object>> argChecks = new ArrayList<>();
         MemorySegment addr = findNativeOrThrow(fName);
         try (Arena arena = Arena.openShared()) {
             FunctionDescriptor descriptor = function(ret, paramTypes, fields);
-            MethodHandle mh = downcallHandle(ABI, addr, arena, descriptor);
-            Object[] args = makeArgs(SegmentScope.auto(), ret, paramTypes, fields, returnChecks, argChecks);
+            MethodHandle mh = downcallHandle(LINKER, addr, arena, descriptor);
+            AtomicReference<Object[]> capturedArgs = new AtomicReference<>();
+            Object[] args = makeArgs(capturedArgs, arena, descriptor, returnChecks, argChecks, 0);
 
             mh = mh.asSpreader(Object[].class, args.length);
             mh = MethodHandles.insertArguments(mh, 0, (Object) args);
             FunctionDescriptor callbackDesc = descriptor.returnLayout()
                     .map(FunctionDescriptor::of)
                     .orElse(FunctionDescriptor.ofVoid());
-            MemorySegment callback = ABI.upcallStub(mh, callbackDesc, arena.scope());
+            MemorySegment callback = LINKER.upcallStub(mh, callbackDesc, arena.scope());
 
             MethodHandle invoker = asyncInvoker(ret, ret == Ret.VOID ? null : paramTypes.get(0), fields);
 
             Object res = (descriptor.returnLayout().isPresent() &&
                          descriptor.returnLayout().get() instanceof GroupLayout)
-                    ? invoker.invoke(arena.scope(), callback)
+                    ? invoker.invoke(arena, callback)
                     : invoker.invoke(callback);
-            argChecks.forEach(c -> c.accept(args));
+
             if (ret == Ret.NON_VOID) {
                 returnChecks.forEach(c -> c.accept(res));
+            }
+
+            Object[] capturedArgsArr = capturedArgs.get();
+            for (int i = 0; i < capturedArgsArr.length; i++) {
+                argChecks.get(i).accept(capturedArgsArr[i]);
             }
         }
     }
@@ -93,7 +96,7 @@ public class TestUpcallAsync extends TestUpcallBase {
         if (ret == Ret.VOID) {
             String name = "call_async_V";
             return INVOKERS.computeIfAbsent(name, symbol ->
-                    ABI.downcallHandle(
+                    LINKER.downcallHandle(
                             findNativeOrThrow(symbol),
                             FunctionDescriptor.ofVoid(C_POINTER)));
         }
@@ -106,7 +109,7 @@ public class TestUpcallAsync extends TestUpcallBase {
             MemoryLayout returnLayout = returnType.layout(fields);
             FunctionDescriptor desc = FunctionDescriptor.of(returnLayout, C_POINTER);
 
-            return ABI.downcallHandle(invokerSymbol, desc);
+            return LINKER.downcallHandle(invokerSymbol, desc);
         });
     }
 

--- a/test/jdk/java/foreign/TestUpcallScope.java
+++ b/test/jdk/java/foreign/TestUpcallScope.java
@@ -25,6 +25,7 @@
  * @test
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
  * @run testng/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
@@ -33,6 +34,7 @@
  */
 
 import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemorySegment;
 
 import org.testng.annotations.Test;
@@ -40,6 +42,7 @@ import org.testng.annotations.Test;
 import java.lang.invoke.MethodHandle;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 public class TestUpcallScope extends TestUpcallBase {
@@ -51,16 +54,23 @@ public class TestUpcallScope extends TestUpcallBase {
     @Test(dataProvider="functions", dataProviderClass=CallGeneratorHelper.class)
     public void testUpcalls(int count, String fName, Ret ret, List<ParamType> paramTypes, List<StructFieldType> fields) throws Throwable {
         List<Consumer<Object>> returnChecks = new ArrayList<>();
-        List<Consumer<Object[]>> argChecks = new ArrayList<>();
+        List<Consumer<Object>> argChecks = new ArrayList<>();
         MemorySegment addr = findNativeOrThrow(fName);
         try (Arena arena = Arena.openConfined()) {
-            MethodHandle mh = downcallHandle(ABI, addr, arena, function(ret, paramTypes, fields));
-            Object[] args = makeArgs(arena.scope(), ret, paramTypes, fields, returnChecks, argChecks);
-            Object[] callArgs = args;
-            Object res = mh.invokeWithArguments(callArgs);
-            argChecks.forEach(c -> c.accept(args));
+            FunctionDescriptor descriptor = function(ret, paramTypes, fields);
+            MethodHandle mh = downcallHandle(LINKER, addr, arena, descriptor);
+            AtomicReference<Object[]> capturedArgs = new AtomicReference<>();
+            Object[] args = makeArgs(capturedArgs, arena, descriptor, returnChecks, argChecks, 0);
+
+            Object res = mh.invokeWithArguments(args);
+
             if (ret == Ret.NON_VOID) {
                 returnChecks.forEach(c -> c.accept(res));
+            }
+
+            Object[] capturedArgsArr = capturedArgs.get();
+            for (int i = 0; i < capturedArgsArr.length; i++) {
+                argChecks.get(i).accept(capturedArgsArr[i]);
             }
         }
     }

--- a/test/jdk/java/foreign/TestVarArgs.java
+++ b/test/jdk/java/foreign/TestVarArgs.java
@@ -26,31 +26,29 @@
  * @test
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @modules java.base/jdk.internal.foreign
  * @run testng/othervm --enable-native-access=ALL-UNNAMED -Dgenerator.sample.factor=17 TestVarArgs
  */
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.Linker;
 import java.lang.foreign.FunctionDescriptor;
-import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.PaddingLayout;
-import java.lang.foreign.ValueLayout;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.lang.foreign.SegmentAllocator;
+import java.lang.foreign.SegmentScope;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
 
 import static java.lang.foreign.MemoryLayout.PathElement.*;
-import static org.testng.Assert.*;
 
 public class TestVarArgs extends CallGeneratorHelper {
 
@@ -73,13 +71,13 @@ public class TestVarArgs extends CallGeneratorHelper {
     @Test(dataProvider = "variadicFunctions")
     public void testVarArgs(int count, String fName, Ret ret, // ignore this stuff
                             List<ParamType> paramTypes, List<StructFieldType> fields) throws Throwable {
-        List<Arg> args = makeArgs(paramTypes, fields);
-
         try (Arena arena = Arena.openConfined()) {
+            List<Arg> args = makeArgs(arena, paramTypes, fields);
             MethodHandle checker = MethodHandles.insertArguments(MH_CHECK, 2, args);
             MemorySegment writeBack = LINKER.upcallStub(checker, FunctionDescriptor.ofVoid(C_INT, C_POINTER), arena.scope());
-            MemorySegment callInfo = MemorySegment.allocateNative(CallInfo.LAYOUT, arena.scope());;
-            MemorySegment argIDs = MemorySegment.allocateNative(MemoryLayout.sequenceLayout(args.size(), C_INT), arena.scope());;
+            MemorySegment callInfo = arena.allocate(CallInfo.LAYOUT);
+            MemoryLayout layout = MemoryLayout.sequenceLayout(args.size(), C_INT);
+            MemorySegment argIDs = arena.allocate(layout);
 
             MemorySegment callInfoPtr = callInfo;
 
@@ -103,7 +101,7 @@ public class TestVarArgs extends CallGeneratorHelper {
             List<Object> argValues = new ArrayList<>();
             argValues.add(callInfoPtr); // call info
             argValues.add(args.size());  // size
-            args.forEach(a -> argValues.add(a.value));
+            args.forEach(a -> argValues.add(a.value()));
 
             downcallHandle.invokeWithArguments(argValues);
 
@@ -163,16 +161,15 @@ public class TestVarArgs extends CallGeneratorHelper {
         return downcalls.toArray(new Object[0][]);
     }
 
-    private static List<Arg> makeArgs(List<ParamType> paramTypes, List<StructFieldType> fields) throws ReflectiveOperationException {
+    private static List<Arg> makeArgs(Arena arena, List<ParamType> paramTypes, List<StructFieldType> fields) {
         List<Arg> args = new ArrayList<>();
         for (ParamType pType : paramTypes) {
             MemoryLayout layout = pType.layout(fields);
-            List<Consumer<Object>> checks = new ArrayList<>();
-            Object arg = makeArg(layout, checks, true);
+            TestValue testValue = genTestValue(layout, arena);
             Arg.NativeType type = Arg.NativeType.of(pType.type(fields));
             args.add(pType == ParamType.STRUCT
-                ? Arg.structArg(type, layout, arg, checks)
-                : Arg.primitiveArg(type, layout, arg, checks));
+                ? Arg.structArg(type, layout, testValue)
+                : Arg.primitiveArg(type, layout, testValue));
         }
         return args;
     }
@@ -181,11 +178,10 @@ public class TestVarArgs extends CallGeneratorHelper {
         Arg varArg = args.get(index);
         MemoryLayout layout = varArg.layout;
         MethodHandle getter = varArg.getter;
-        List<Consumer<Object>> checks = varArg.checks;
         try (Arena arena = Arena.openConfined()) {
             MemorySegment seg = MemorySegment.ofAddress(ptr.address(), layout.byteSize(), arena.scope());
             Object obj = getter.invoke(seg);
-            checks.forEach(check -> check.accept(obj));
+            varArg.check(obj);
         } catch (Throwable e) {
             throw new RuntimeException(e);
         }
@@ -208,26 +204,33 @@ public class TestVarArgs extends CallGeneratorHelper {
     }
 
     private static final class Arg {
+        private final TestValue value;
+
         final NativeType id;
         final MemoryLayout layout;
-        final Object value;
         final MethodHandle getter;
-        final List<Consumer<Object>> checks;
 
-        private Arg(NativeType id, MemoryLayout layout, Object value, MethodHandle getter, List<Consumer<Object>> checks) {
+        private Arg(NativeType id, MemoryLayout layout, TestValue value, MethodHandle getter) {
             this.id = id;
             this.layout = layout;
             this.value = value;
             this.getter = getter;
-            this.checks = checks;
         }
 
-        private static Arg primitiveArg(NativeType id, MemoryLayout layout, Object value, List<Consumer<Object>> checks) {
-            return new Arg(id, layout, value, layout.varHandle().toMethodHandle(VarHandle.AccessMode.GET), checks);
+        private static Arg primitiveArg(NativeType id, MemoryLayout layout, TestValue value) {
+            return new Arg(id, layout, value, layout.varHandle().toMethodHandle(VarHandle.AccessMode.GET));
         }
 
-        private static Arg structArg(NativeType id, MemoryLayout layout, Object value, List<Consumer<Object>> checks) {
-            return new Arg(id, layout, value, MethodHandles.identity(MemorySegment.class), checks);
+        private static Arg structArg(NativeType id, MemoryLayout layout, TestValue value) {
+            return new Arg(id, layout, value, MethodHandles.identity(MemorySegment.class));
+        }
+
+        public void check(Object actual) {
+            value.check().accept(actual);
+        }
+
+        public Object value() {
+            return value.value();
         }
 
         enum NativeType {


### PR DESCRIPTION
Port of: https://github.com/openjdk/panama-foreign/pull/804 which reduces duplication in the test code by switching test value generation over to a common method in `NativeTestHelper`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303582](https://bugs.openjdk.org/browse/JDK-8303582): Reduce duplication in jdk/java/foreign tests


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12856/head:pull/12856` \
`$ git checkout pull/12856`

Update a local copy of the PR: \
`$ git checkout pull/12856` \
`$ git pull https://git.openjdk.org/jdk pull/12856/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12856`

View PR using the GUI difftool: \
`$ git pr show -t 12856`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12856.diff">https://git.openjdk.org/jdk/pull/12856.diff</a>

</details>
