### PR TITLE
8303577: [JVMCI] OOME causes crash while translating exceptions

### DIFF
--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -752,6 +752,7 @@
   template(encodeThrowable_name,                       "encodeThrowable")                                         \
   template(encodeThrowable_signature,                  "(Ljava/lang/Throwable;JI)I")                              \
   template(decodeAndThrowThrowable_name,               "decodeAndThrowThrowable")                                 \
+  template(decodeAndThrowThrowable_signature,          "(JZ)V")                                                   \
   template(classRedefinedCount_name,                   "classRedefinedCount")                                     \
   template(classLoader_name,                           "classLoader")                                             \
   template(componentType_name,                         "componentType")                                           \

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -392,7 +392,7 @@ class HotSpotToSharedLibraryExceptionTranslation : public ExceptionTranslation {
     JNIAccessMark jni(_to_env, THREAD);
     jni()->CallStaticVoidMethod(JNIJVMCI::VMSupport::clazz(),
                                 JNIJVMCI::VMSupport::decodeAndThrowThrowable_method(),
-                                buffer);
+                                buffer, false);
   }
  public:
   HotSpotToSharedLibraryExceptionTranslation(JVMCIEnv* hotspot_env, JVMCIEnv* jni_env, const Handle& throwable) :
@@ -414,11 +414,12 @@ class SharedLibraryToHotSpotExceptionTranslation : public ExceptionTranslation {
   void decode(JavaThread* THREAD, Klass* vmSupport, jlong buffer) {
     JavaCallArguments jargs;
     jargs.push_long(buffer);
+    jargs.push_int(true);
     JavaValue result(T_VOID);
     JavaCalls::call_static(&result,
                             vmSupport,
                             vmSymbols::decodeAndThrowThrowable_name(),
-                            vmSymbols::long_void_signature(), &jargs, THREAD);
+                            vmSymbols::decodeAndThrowThrowable_signature(), &jargs, THREAD);
   }
  public:
   SharedLibraryToHotSpotExceptionTranslation(JVMCIEnv* hotspot_env, JVMCIEnv* jni_env, jthrowable throwable) :

--- a/src/hotspot/share/jvmci/jvmciJavaClasses.hpp
+++ b/src/hotspot/share/jvmci/jvmciJavaClasses.hpp
@@ -216,7 +216,7 @@
   end_class                                                                                                   \
   start_class(VMSupport, jdk_internal_vm_VMSupport)                                                           \
     jvmci_method(CallStaticIntMethod, GetStaticMethodID, call_static, int, VMSupport, encodeThrowable, encodeThrowable_signature, (JVMCIObject throwable, jlong buffer, int buffer_size)) \
-    jvmci_method(CallStaticVoidMethod, GetStaticMethodID, call_static, void, VMSupport, decodeAndThrowThrowable, long_void_signature, (jlong buffer)) \
+    jvmci_method(CallStaticVoidMethod, GetStaticMethodID, call_static, void, VMSupport, decodeAndThrowThrowable, decodeAndThrowThrowable_signature, (jlong buffer)) \
   end_class                                                                                                   \
   start_class(ArrayIndexOutOfBoundsException, java_lang_ArrayIndexOutOfBoundsException)                       \
     jvmci_constructor(ArrayIndexOutOfBoundsException, "(Ljava/lang/String;)V")                                \

--- a/src/java.base/share/classes/jdk/internal/vm/VMSupport.java
+++ b/src/java.base/share/classes/jdk/internal/vm/VMSupport.java
@@ -113,15 +113,35 @@ public class VMSupport {
     public static native String getVMTemporaryDirectory();
 
     /**
-     * Decodes the exception encoded in {@code buffer} and throws it.
+     * Decodes the exception encoded in {@code errorOrBuffer} and throws it.
      *
-     * @param buffer a native byte buffer containing an exception encoded by
+     * @param errorOrBuffer an error code or a native byte errorOrBuffer containing an exception encoded by
+     *            {@link #encodeThrowable}. Error code values and their meanings are:
+     *
+     *            <pre>
+     *             0: native memory for the errorOrBuffer could not be allocated
+     *            -1: an OutOfMemoryError was thrown while encoding the exception
+     *            -2: some other throwable was thrown while encoding the exception
+     *            </pre>
+     * @param errorOrBuffer a native byte errorOrBuffer containing an exception encoded by
      *            {@link #encodeThrowable}
+     * @param inJVMHeap [@code true} if executing in the JVM heap, {@code false} otherwise
      */
-    public static void decodeAndThrowThrowable(long buffer) throws Throwable {
-        int encodingLength = U.getInt(buffer);
+    public static void decodeAndThrowThrowable(long errorOrBuffer, boolean inJVMHeap) throws Throwable {
+        if (errorOrBuffer >= -2L && errorOrBuffer <= 0) {
+            String context = String.format("while encoding an exception to translate it %s the JVM heap",
+                    inJVMHeap ? "to" : "from");
+            if (errorOrBuffer == 0) {
+                throw new InternalError("native errorOrBuffer could not be allocated " + context);
+            }
+            if (errorOrBuffer == -1L) {
+                throw new OutOfMemoryError("OutOfMemoryError occurred " + context);
+            }
+            throw new InternalError("unexpected problem occurred " + context);
+        }
+        int encodingLength = U.getInt(errorOrBuffer);
         byte[] encoding = new byte[encodingLength];
-        U.copyMemory(null, buffer + 4, encoding, Unsafe.ARRAY_BYTE_BASE_OFFSET, encodingLength);
+        U.copyMemory(null, errorOrBuffer + 4, encoding, Unsafe.ARRAY_BYTE_BASE_OFFSET, encodingLength);
         throw TranslatedException.decodeThrowable(encoding);
     }
 

--- a/test/jdk/jdk/internal/vm/TestTranslatedException.java
+++ b/test/jdk/jdk/internal/vm/TestTranslatedException.java
@@ -80,7 +80,7 @@ public class TestTranslatedException {
                     bufferSize = -res;
                 } else {
                     try {
-                        VMSupport.decodeAndThrowThrowable(buffer);
+                        VMSupport.decodeAndThrowThrowable(buffer, true);
                         throw new AssertionError("expected decodeAndThrowThrowable to throw an exception");
                     } catch (Throwable decoded) {
                         assertThrowableEquals(throwable, decoded);


### PR DESCRIPTION
JDK-8297431 added code for special handling of OutOfMemoryError when translating an exception between libjvmci and HotSpot[1].
Unfortunately, this code was deleted by JDK-8298099 when moving the exception translation mechanism to VMSupport[2].
This causes the VM to crash when an OOME occurs while translating an exception from HotSpot to libjvmci.
This PR revives the deleted code.

This bug was found by running `test/jdk/java/util/concurrent/locks/Lock/OOMEInAQS.java` on libgraal. The fix now makes the test pass.

Note that the code modified in `src/java.base/share/classes/jdk/internal/vm/VMSupport.java` is JVMCI specific and was original added by [JDK-8298099](https://git.openjdk.org/jdk/pull/11513).

[1] https://github.com/openjdk/jdk/commit/952e10055135613e8ea2b818a4f35842936f5633#diff-4d3a3b7e7e12e1d5b4cf3e4677d9e0de5e9df3bbf1bbfa0d8d43d12098d67dc4R222-R234
[2] https://github.com/openjdk/jdk/commit/8b69a2e434ad2fa3369079622b57afb973d5bd9a#diff-7292551772c27b7152a3333f03cbbad90a897c5e37c6a97d4026be835e6d8fe1R121-R125

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303577](https://bugs.openjdk.org/browse/JDK-8303577): [JVMCI] OOME causes crash while translating exceptions


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12857/head:pull/12857` \
`$ git checkout pull/12857`

Update a local copy of the PR: \
`$ git checkout pull/12857` \
`$ git pull https://git.openjdk.org/jdk pull/12857/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12857`

View PR using the GUI difftool: \
`$ git pr show -t 12857`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12857.diff">https://git.openjdk.org/jdk/pull/12857.diff</a>

</details>
