### PR TITLE
JDK-8303587 Remove VMOutOfMemoryError001 test from the problem list after 8303198

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -165,5 +165,3 @@ vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn001/forceEa
 
 vmTestbase/nsk/stress/except/except012.java 8297977 generic-all
 vmTestbase/nsk/monitoring/ThreadMXBean/ThreadInfo/Multi/Multi005/TestDescription.java 8076494 windows-x64
-
-vmTestbase/nsk/jdi/VMOutOfMemoryException/VMOutOfMemoryException001/VMOutOfMemoryException001.java 8303057 generic-all


### PR DESCRIPTION
Remove VMOutOfMemoryException001.java from the problem list, after JDK-8303198.

The logging of Runtime.exit interfered with out-of-memory exception handling in this test.
Making the logging more robust in JDK-8303198 by handling exceptions restores the conditions expected by this test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303587](https://bugs.openjdk.org/browse/JDK-8303587): Remove VMOutOfMemoryError001 test from the problem list after 8303198


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12859/head:pull/12859` \
`$ git checkout pull/12859`

Update a local copy of the PR: \
`$ git checkout pull/12859` \
`$ git pull https://git.openjdk.org/jdk pull/12859/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12859`

View PR using the GUI difftool: \
`$ git pr show -t 12859`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12859.diff">https://git.openjdk.org/jdk/pull/12859.diff</a>

</details>
