### PR TITLE
8289765: JDI EventSet/resume/resume008 failed with "ERROR: suspendCounts don't match for : VirtualThread-unparker"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume008.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume008.java
@@ -154,7 +154,7 @@ public class resume008 extends TestDebuggerType1 {
             } else {
 
                 String property = (String) newEvent.request().getProperty("number");
-                display("       got new ThreadStartEvent with propety 'number' == "
+                display("       got new ThreadStartEvent with property 'number' == "
                         + property);
 
                 display("......checking up on EventSet.resume()");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume008.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume008.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,17 +112,17 @@ public class resume008 extends TestDebuggerType1 {
 
                 case 0:
                 eventRequest = settingThreadStartRequest (
-                                       SUSPEND_NONE,   "ThreadStartRequest1");
+                                       SUSPEND_NONE,   "ThreadStartRequest0");
                 break;
 
                 case 1:
                 eventRequest = settingThreadStartRequest (
-                                       SUSPEND_THREAD, "ThreadStartRequest2");
+                                       SUSPEND_THREAD, "ThreadStartRequest1");
                 break;
 
                 case 2:
                 eventRequest = settingThreadStartRequest (
-                                       SUSPEND_ALL,    "ThreadStartRequest3");
+                                       SUSPEND_ALL,    "ThreadStartRequest2");
                 break;
 
 
@@ -137,6 +137,17 @@ public class resume008 extends TestDebuggerType1 {
 
             EventIterator eventIterator = eventSet.eventIterator();
             Event newEvent = eventIterator.nextEvent();
+            display("       got new event: "  + newEvent);
+
+            // Make sure any spurious ThreadStartEvent got filtered out.
+            if (newEvent instanceof ThreadStartEvent) {
+                ThreadStartEvent t = (ThreadStartEvent)newEvent;
+                if (!t.thread().name().equals(resume008a.THREAD_NAME_PREFIX + i)) {
+                    setFailedStatus("ERROR: ThreadStartEvent is not for expected thread:  " +
+                                    t.thread().name());
+                    return;
+                }
+            }
 
             if ( !(newEvent instanceof ThreadStartEvent)) {
                 setFailedStatus("ERROR: new event is not ThreadStartEvent");
@@ -263,7 +274,6 @@ public class resume008 extends TestDebuggerType1 {
                                                          String property) {
         try {
             ThreadStartRequest tsr = eventRManager.createThreadStartRequest();
-            tsr.addCountFilter(1);
             tsr.setSuspendPolicy(suspendPolicy);
             tsr.putProperty("number", property);
             return tsr;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume008a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume008a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,8 @@ public class resume008a {
     static final int PASSED = 0;
     static final int FAILED = 2;
     static final int PASS_BASE = 95;
+
+    static final String THREAD_NAME_PREFIX = "resume008-thread";
 
     static ArgumentHandler argHandler;
     static Log log;
@@ -95,18 +97,18 @@ public class resume008a {
             switch (i) {
     //------------------------------------------------------  section tested
             case 0:
-                thread0 = JDIThreadFactory.newThread(new Threadresume008a("thread0"));
+                thread0 = JDIThreadFactory.newThread(new Threadresume008a(THREAD_NAME_PREFIX + 0));
                 methodForCommunication();
                 threadStart(thread0);
-                thread1 = JDIThreadFactory.newThread(new Threadresume008a("thread1"));
+                thread1 = JDIThreadFactory.newThread(new Threadresume008a(THREAD_NAME_PREFIX + 1));
                 // Wait for debugger to complete the first test case
-                // before advancing to the first breakpoint
+                // before advancing to the 2nd breakpoint
                 waitForTestCase(0);
                 methodForCommunication();
                 break;
             case 1:
                 threadStart(thread1);
-                thread2 = JDIThreadFactory.newThread(new Threadresume008a("thread2"));
+                thread2 = JDIThreadFactory.newThread(new Threadresume008a(THREAD_NAME_PREFIX + 2));
                 methodForCommunication();
                 break;
             case 2:
@@ -139,6 +141,7 @@ public class resume008a {
     }
     // Synchronize with debugger progression.
     static void waitForTestCase(int t) {
+        log1("waitForTestCase: " + t);
         while (testCase < t) {
             try {
                 Thread.sleep(100);

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/EventFilters.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/EventFilters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -331,16 +331,24 @@ public class EventFilters
     }
 
     public static boolean filtered(Event event) {
-        if (event.toString().contains("VM JFR Buffer Thread"))
-            return true;
-
-        if (event.toString().contains("JFR request timer"))
-            return true;
-
-        // Filter out any carrier thread that starts while running the test.
-        if (event.toString().contains("ForkJoinPool"))
-            return true;
-
+        if (event instanceof ThreadStartEvent) {
+            ThreadStartEvent tse = (ThreadStartEvent)event;
+            String tname = tse.thread().name();
+            String knownThreads[] = {
+                "VM JFR Buffer Thread",
+                "JFR request timer",
+                "Reference Handler",
+                "VirtualThread-unparker",
+                "Common-Cleaner",
+                "FinalizerThread",
+                "ForkJoinPool"
+            };
+            for (String s : knownThreads) {
+                if (tname.startsWith(s)) {
+                    return true;
+                }
+            }
+        }
         return false;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/EventHandler.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/EventHandler.java
@@ -251,6 +251,41 @@ public class EventHandler implements Runnable {
         defaultExceptionRequest.enable();
     }
 
+
+    /**
+     * Creates an EventListener for unexpected ThreadStartEvents. The
+     * events are ignored.
+     */
+    public EventListener createSpuriousThreadStartEventListener(String owner) {
+        /*
+         * This listener catches spurious thread creations that we want to ignore.
+         */
+        return (new EventListener() {
+            boolean handled = false;
+
+            public boolean eventReceived(Event event) {
+                handled = false;
+                if (event instanceof ThreadStartEvent) {
+                    if (EventFilters.filtered(event)) {
+                        display(owner +": Ignoring spurious thread creation: " + event);
+                        handled = true;
+                    }
+                }
+                return handled;
+            }
+
+            public void eventSetComplete(EventSet set) {
+                // If we ignored this event, then we need to resume.
+                if (handled) {
+                    handled = false; // reset for next EventSet that comes in.
+                    display(owner + ": set.resume() after spurious thread creation: " + set);
+                    set.resume();
+                }
+            }
+        }
+        );
+    }
+
     /**
      * This method sets up default listeners.
      */
@@ -343,6 +378,13 @@ public class EventHandler implements Runnable {
             }
         }
         );
+
+        /**
+         * This listener attempt to catch any ThreadStartEvent for a thread not
+         * created by the test. It prevents the "Unexpected event" listener
+         * above from complaining about these events.
+         */
+        addListener(createSpuriousThreadStartEventListener("Default Listener"));
     }
 
     /**
@@ -404,12 +446,13 @@ public class EventHandler implements Runnable {
                             en.set = set;
                             EventHandler.this.notifyAll();
                         }
-                        return true;
+                        return true; // event was handled
                     }
                 }
-                return false;
+                return false; // event was not handled
             }
         };
+
         if (shouldRemoveListeners) {
             display("waitForRequestedEventCommon: enabling remove of listener " + listener);
             listener.enableRemovingThisListener();
@@ -418,6 +461,13 @@ public class EventHandler implements Runnable {
             requests[i].enable();
         }
         addListener(listener);
+
+        /*
+         * This listener skips spurious thread creations that we want to ignore.
+         */
+        EventListener spuriousThreadStartEventListener =
+            createSpuriousThreadStartEventListener("waitForRequestedEventCommon");
+        addListener(spuriousThreadStartEventListener);
 
         /*
          * This listener logs each EventSet received.
@@ -452,6 +502,7 @@ public class EventHandler implements Runnable {
                 requests[i].disable();
             }
         }
+        removeListener(spuriousThreadStartEventListener);
         removeListener(eventLogListener);
         return en;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/EventHandler.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/EventHandler.java
@@ -267,7 +267,7 @@ public class EventHandler implements Runnable {
                 handled = false;
                 if (event instanceof ThreadStartEvent) {
                     if (EventFilters.filtered(event)) {
-                        display(owner +": Ignoring spurious thread creation: " + event);
+                        display(owner + ": Ignoring spurious thread creation: " + event);
                         handled = true;
                     }
                 }


### PR DESCRIPTION
The test failure is caused by the arrival of unexpected ThreadStartEvents, which mess up the debugger side. The events are for threads we normally only see getting created when using virtual threads, such as carrier threads and the VirtualThread-unparker thread. Theoretically this issue could happen without virtual threads due to other VM threads starting up such as Common-Cleaner, but we haven't seen it fail for that reason yet.

The test is testing proper thread suspension for ThreadStartEvent using each of the 3 suspension policy types. The debuggee creates a sequence of 3 debuggee threads, each one's timing coordinated with some complicated synchronization with the debugger using breakpoints and the setting of fields in the debuggee (and careful placement of suspend/resume in the debugger). The ThreadStartRequests that the debugger sets up always use a "count filter" of 1, which means the requests are good for delivering exactly 1 ThreadStartEvent, and any that come after the first will get filtered out. So when an an unexpected ThreadStartEvent arrives for something like a carrier thread, this prematurely moves the debugger on to the next step, and the synchronization with the debuggee gets messed up.

The first step in fixing this test was to remove the count filter, so the request can handle any number of ThreadStartEvents.

The next step was then fixing the test library code in EventHandler.java so it would filter out any undesired ThreadStartEvents, so the test just ends up getting one event, and always for the thread it is expecting. There are a few parts to this. One is improving EventFilters.filter() to filter out more threads that tend to be created during VM startup, including carrier threads and the VirtualThread-unparker thread.

It was necessary to add some calls EventFilters.filter() from EventHandler. This was done by adding a ThreadStartEvent listener for the "spurious" thread starts (those the test debuggee does not create). This listener is added by waitForRequestedEventCommon(), which is indirectly called by the test when is calls waitForRequestedEventSet().

There is a also 2nd place where the ThreadStartEvent listener for "spurious" threads is needed. It is now also installed with the default listeners that are always in place. It is needed when the test is not actually waiting for a ThreadStartEvent, but is waiting for a BreakpointEvent. waitForRequestedEventCommon() is not used in this case (so none of its listeners are installed), but the default listeners are always in place and can be used to filter these ThreadStartEvents. Note this filter will also be in place when calling waitForRequestedEventCommon(), but we can't realy on it when waitForRequestedEventCommon() is used for ThreadStartEvents because the spurious ThreadStartEvent will be seen and returned before we ever get to the default filter. So we actually end up with this ThreadStartEvent listener installed twice during  waitForRequestedEventCommon().

I did a bit of cleanup on the test, mostly renaming of threads and ThreadStartRequests so they are easier to match up with the iteration # we use in both the debuggee and debugger (0, 1, and 2). The only real change in the test itself is removing the filter count, and verifying that the ThreadStartEvent is for the expected thread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289765](https://bugs.openjdk.org/browse/JDK-8289765): JDI EventSet/resume/resume008 failed with "ERROR: suspendCounts don't match for : VirtualThread-unparker"


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [f159416c](https://git.openjdk.org/jdk/pull/12861/files/f159416c9972f14cf96d63d583df389f6173029d)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to [f159416c](https://git.openjdk.org/jdk/pull/12861/files/f159416c9972f14cf96d63d583df389f6173029d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12861/head:pull/12861` \
`$ git checkout pull/12861`

Update a local copy of the PR: \
`$ git checkout pull/12861` \
`$ git pull https://git.openjdk.org/jdk pull/12861/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12861`

View PR using the GUI difftool: \
`$ git pr show -t 12861`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12861.diff">https://git.openjdk.org/jdk/pull/12861.diff</a>

</details>
