### PR TITLE
8303392: Runtime.exec and ProcessBuilder.start should use System logger

### DIFF
--- a/src/java.base/share/classes/java/lang/ProcessBuilder.java
+++ b/src/java.base/share/classes/java/lang/ProcessBuilder.java
@@ -191,7 +191,7 @@ import sun.security.action.GetPropertyAction;
 public final class ProcessBuilder
 {
     // Lazily and racy initialize when needed, racy is ok, any logger is ok
-    private static System.Logger LOGGER ;
+    private static System.Logger LOGGER;
 
     private List<String> command;
     private File directory;
@@ -199,10 +199,6 @@ public final class ProcessBuilder
     private boolean redirectErrorStream;
     private Redirect[] redirects;
 
-    private static System.Logger initLogger() {
-        System.Logger logger = System.getLogger("java.lang.ProcessBuilder");
-        return logger.isLoggable(System.Logger.Level.DEBUG) ? logger : null;
-    }
     /**
      * Constructs a process builder with the specified operating
      * system program and arguments.  This constructor does <i>not</i>

--- a/src/java.base/share/classes/java/lang/ProcessBuilder.java
+++ b/src/java.base/share/classes/java/lang/ProcessBuilder.java
@@ -1082,10 +1082,10 @@ public final class ProcessBuilder
      * Logging of the information is enabled when the logging level of the
      * {@linkplain System#getLogger(String) system logger} named {@code java.lang.ProcessBuilder}
      * is {@link System.Logger.Level#DEBUG Level.DEBUG} or {@link System.Logger.Level#TRACE Level.TRACE}.
-     * When enabled for {@code Level.DEBUG} only the command, directory, stack trace,
-     * and process id are logged.
-     * When enabled for {@code Level.TRACE} the arguments are included with the command,
-     * directory, stack trace, and process id.
+     * When enabled for {@code Level.DEBUG} only the process id, directory, command, and stack trace
+     * are logged.
+     * When enabled for {@code Level.TRACE} the arguments are included with the process id,
+     * directory, command, and stack trace.
      *
      * @see Runtime#exec(String[], String[], java.io.File)
      */
@@ -1299,7 +1299,7 @@ public final class ProcessBuilder
      *          If the operating system does not support the creation of processes
      *
      * @implNote
-     * The start of each process is logged by {@link ProcessBuilder#start()}.
+     * Each created process is logged, see {@link ProcessBuilder#start()} for details.
      *
      * @throws IOException if an I/O error occurs
      * @since 9

--- a/src/java.base/share/classes/java/lang/ProcessBuilder.java
+++ b/src/java.base/share/classes/java/lang/ProcessBuilder.java
@@ -1147,12 +1147,11 @@ public final class ProcessBuilder
             if (logger.isLoggable(System.Logger.Level.DEBUG)) {
                 boolean detail = logger.isLoggable(System.Logger.Level.TRACE);
                 var level = (detail) ? System.Logger.Level.TRACE : System.Logger.Level.DEBUG;
-                var cmdargs = (detail) ? String.join(" ", cmdarray) : cmdarray[0];
+                var cmdargs = (detail) ? String.join("\" \"", cmdarray) : cmdarray[0];
                 RuntimeException stackTraceEx = new RuntimeException("ProcessBuilder.start() debug");
-                LOGGER.log(level, "ProcessBuilder.start(): " +
-                                "cmd: " + cmdargs +
-                                ", dir: " + dir +
-                                ", pid: " + process.pid(),
+                LOGGER.log(level, "ProcessBuilder.start(): pid: " + process.pid() +
+                        ", dir: " + dir +
+                        ", cmd: \"" + cmdargs + "\"",
                         stackTraceEx);
             }
             return process;

--- a/src/java.base/share/classes/java/lang/ProcessBuilder.java
+++ b/src/java.base/share/classes/java/lang/ProcessBuilder.java
@@ -1299,7 +1299,7 @@ public final class ProcessBuilder
      *          If the operating system does not support the creation of processes
      *
      * @implNote
-     * Each created process is logged, see {@link ProcessBuilder#start()} for details.
+     * Logging of each process created can be enabled, see {@link ProcessBuilder#start()} for details.
      *
      * @throws IOException if an I/O error occurs
      * @since 9

--- a/src/java.base/share/classes/java/lang/ProcessBuilder.java
+++ b/src/java.base/share/classes/java/lang/ProcessBuilder.java
@@ -1075,6 +1075,11 @@ public final class ProcessBuilder
      *
      * @throws IOException if an I/O error occurs
      *
+     * @implNote
+     * If the {@linkplain System#getLogger(String) system logger} for {@code java.lang.ProcessBuilder}
+     * is enabled with logging level {@link System.Logger.Level#DEBUG Level.DEBUG} the stack trace
+     * of the call to {@code ProcessBuilder.start()} is logged.
+     *
      * @see Runtime#exec(String[], String[], java.io.File)
      */
     public Process start() throws IOException {
@@ -1284,6 +1289,9 @@ public final class ProcessBuilder
      *
      * @throws  UnsupportedOperationException
      *          If the operating system does not support the creation of processes
+     *
+     * @implNote
+     * The start of each process is logged by {@link ProcessBuilder#start()}.
      *
      * @throws IOException if an I/O error occurs
      * @since 9

--- a/src/java.base/share/classes/java/lang/ProcessBuilder.java
+++ b/src/java.base/share/classes/java/lang/ProcessBuilder.java
@@ -1072,7 +1072,8 @@ public final class ProcessBuilder
      * @throws IOException if an I/O error occurs
      *
      * @implNote
-     * Logging of the command, arguments, directory, stack trace, and process id can be enabled.
+     * In the reference implementation, logging of the command, arguments, directory,
+     * stack trace, and process id can be enabled.
      * The logged information may contain sensitive security information and the potential exposure
      * of the information should be carefully reviewed.
      * Logging of the information is enabled when the logging level of the
@@ -1295,7 +1296,8 @@ public final class ProcessBuilder
      *          If the operating system does not support the creation of processes
      *
      * @implNote
-     * Logging of each process created can be enabled, see {@link ProcessBuilder#start()} for details.
+     * In the reference implementation, logging of each process created can be enabled,
+     * see {@link ProcessBuilder#start()} for details.
      *
      * @throws IOException if an I/O error occurs
      * @since 9

--- a/src/java.base/share/classes/java/lang/Runtime.java
+++ b/src/java.base/share/classes/java/lang/Runtime.java
@@ -401,7 +401,7 @@ public class Runtime {
      *          If {@code command} is empty
      *
      * @implNote
-     * The new process creation is logged by {@link ProcessBuilder#start()}.
+     * The process created is logged, see {@link ProcessBuilder#start()} for details.
      *
      * @see     #exec(String[], String[], File)
      * @see     ProcessBuilder
@@ -465,7 +465,7 @@ public class Runtime {
      *          If {@code command} is empty
      *
      * @implNote
-     * The new process creation is logged by {@link ProcessBuilder#start()}.
+     * The process created is logged, see {@link ProcessBuilder#start()} for details.
      *
      * @see     ProcessBuilder
      * @since 1.3
@@ -513,7 +513,7 @@ public class Runtime {
      *          (has length {@code 0})
      *
      * @implNote
-     * The new process creation is logged by {@link ProcessBuilder#start()}.
+     * The process created is logged, see {@link ProcessBuilder#start()} for details.
      *
      * @see     ProcessBuilder
      */
@@ -559,7 +559,7 @@ public class Runtime {
      *          (has length {@code 0})
      *
      * @implNote
-     * The new process creation is logged by {@link ProcessBuilder#start()}.
+     * The process created is logged, see {@link ProcessBuilder#start()} for details.
      *
      * @see     ProcessBuilder
      */
@@ -657,7 +657,7 @@ public class Runtime {
      *          (has length {@code 0})
      *
      * @implNote
-     * The new process creation is logged by {@link ProcessBuilder#start()}.
+     * The process created is logged, see {@link ProcessBuilder#start()} for details.
      *
      * @see     ProcessBuilder
      * @since 1.3

--- a/src/java.base/share/classes/java/lang/Runtime.java
+++ b/src/java.base/share/classes/java/lang/Runtime.java
@@ -350,7 +350,7 @@ public class Runtime {
      *          If {@code command} is empty
      *
      * @implNote
-     * The process created is logged, see {@link ProcessBuilder#start()} for details.
+     * Logging of the created process can be enabled, see {@link ProcessBuilder#start()} for details.
      *
      * @see     #exec(String[], String[], File)
      * @see     ProcessBuilder
@@ -401,7 +401,7 @@ public class Runtime {
      *          If {@code command} is empty
      *
      * @implNote
-     * The process created is logged, see {@link ProcessBuilder#start()} for details.
+     * Logging of the created process can be enabled, see {@link ProcessBuilder#start()} for details.
      *
      * @see     #exec(String[], String[], File)
      * @see     ProcessBuilder
@@ -465,7 +465,7 @@ public class Runtime {
      *          If {@code command} is empty
      *
      * @implNote
-     * The process created is logged, see {@link ProcessBuilder#start()} for details.
+     * Logging of the created process can be enabled, see {@link ProcessBuilder#start()} for details.
      *
      * @see     ProcessBuilder
      * @since 1.3
@@ -513,7 +513,7 @@ public class Runtime {
      *          (has length {@code 0})
      *
      * @implNote
-     * The process created is logged, see {@link ProcessBuilder#start()} for details.
+     * Logging of the created process can be enabled, see {@link ProcessBuilder#start()} for details.
      *
      * @see     ProcessBuilder
      */
@@ -559,7 +559,7 @@ public class Runtime {
      *          (has length {@code 0})
      *
      * @implNote
-     * The process created is logged, see {@link ProcessBuilder#start()} for details.
+     * Logging of the created process can be enabled, see {@link ProcessBuilder#start()} for details.
      *
      * @see     ProcessBuilder
      */
@@ -657,7 +657,7 @@ public class Runtime {
      *          (has length {@code 0})
      *
      * @implNote
-     * The process created is logged, see {@link ProcessBuilder#start()} for details.
+     * Logging of the created process can be enabled, see {@link ProcessBuilder#start()} for details.
      *
      * @see     ProcessBuilder
      * @since 1.3

--- a/src/java.base/share/classes/java/lang/Runtime.java
+++ b/src/java.base/share/classes/java/lang/Runtime.java
@@ -350,7 +350,7 @@ public class Runtime {
      *          If {@code command} is empty
      *
      * @implNote
-     * The new process creation is logged by {@link ProcessBuilder#start()}.
+     * The process created is logged, see {@link ProcessBuilder#start()} for details.
      *
      * @see     #exec(String[], String[], File)
      * @see     ProcessBuilder

--- a/src/java.base/share/classes/java/lang/Runtime.java
+++ b/src/java.base/share/classes/java/lang/Runtime.java
@@ -349,6 +349,9 @@ public class Runtime {
      * @throws  IllegalArgumentException
      *          If {@code command} is empty
      *
+     * @implNote
+     * The new process creation is logged by {@link ProcessBuilder#start()}.
+     *
      * @see     #exec(String[], String[], File)
      * @see     ProcessBuilder
      */
@@ -396,6 +399,9 @@ public class Runtime {
      *
      * @throws  IllegalArgumentException
      *          If {@code command} is empty
+     *
+     * @implNote
+     * The new process creation is logged by {@link ProcessBuilder#start()}.
      *
      * @see     #exec(String[], String[], File)
      * @see     ProcessBuilder
@@ -458,6 +464,9 @@ public class Runtime {
      * @throws  IllegalArgumentException
      *          If {@code command} is empty
      *
+     * @implNote
+     * The new process creation is logged by {@link ProcessBuilder#start()}.
+     *
      * @see     ProcessBuilder
      * @since 1.3
      */
@@ -503,6 +512,9 @@ public class Runtime {
      *          If {@code cmdarray} is an empty array
      *          (has length {@code 0})
      *
+     * @implNote
+     * The new process creation is logged by {@link ProcessBuilder#start()}.
+     *
      * @see     ProcessBuilder
      */
     public Process exec(String[] cmdarray) throws IOException {
@@ -545,6 +557,9 @@ public class Runtime {
      * @throws  IndexOutOfBoundsException
      *          If {@code cmdarray} is an empty array
      *          (has length {@code 0})
+     *
+     * @implNote
+     * The new process creation is logged by {@link ProcessBuilder#start()}.
      *
      * @see     ProcessBuilder
      */
@@ -640,6 +655,9 @@ public class Runtime {
      * @throws  IndexOutOfBoundsException
      *          If {@code cmdarray} is an empty array
      *          (has length {@code 0})
+     *
+     * @implNote
+     * The new process creation is logged by {@link ProcessBuilder#start()}.
      *
      * @see     ProcessBuilder
      * @since 1.3

--- a/src/java.base/share/classes/java/lang/Runtime.java
+++ b/src/java.base/share/classes/java/lang/Runtime.java
@@ -350,7 +350,8 @@ public class Runtime {
      *          If {@code command} is empty
      *
      * @implNote
-     * Logging of the created process can be enabled, see {@link ProcessBuilder#start()} for details.
+     * In the reference implementation, logging of the created process can be enabled,
+     * see {@link ProcessBuilder#start()} for details.
      *
      * @see     #exec(String[], String[], File)
      * @see     ProcessBuilder
@@ -401,7 +402,8 @@ public class Runtime {
      *          If {@code command} is empty
      *
      * @implNote
-     * Logging of the created process can be enabled, see {@link ProcessBuilder#start()} for details.
+     * In the reference implementation, logging of the created process can be enabled,
+     * see {@link ProcessBuilder#start()} for details.
      *
      * @see     #exec(String[], String[], File)
      * @see     ProcessBuilder
@@ -465,7 +467,8 @@ public class Runtime {
      *          If {@code command} is empty
      *
      * @implNote
-     * Logging of the created process can be enabled, see {@link ProcessBuilder#start()} for details.
+     * In the reference implementation, logging of the created process can be enabled,
+     * see {@link ProcessBuilder#start()} for details.
      *
      * @see     ProcessBuilder
      * @since 1.3
@@ -513,7 +516,8 @@ public class Runtime {
      *          (has length {@code 0})
      *
      * @implNote
-     * Logging of the created process can be enabled, see {@link ProcessBuilder#start()} for details.
+     * In the reference implementation, logging of the created process can be enabled,
+     * see {@link ProcessBuilder#start()} for details.
      *
      * @see     ProcessBuilder
      */
@@ -559,7 +563,8 @@ public class Runtime {
      *          (has length {@code 0})
      *
      * @implNote
-     * Logging of the created process can be enabled, see {@link ProcessBuilder#start()} for details.
+     * In the reference implementation, logging of the created process can be enabled,
+     * see {@link ProcessBuilder#start()} for details.
      *
      * @see     ProcessBuilder
      */
@@ -657,7 +662,8 @@ public class Runtime {
      *          (has length {@code 0})
      *
      * @implNote
-     * Logging of the created process can be enabled, see {@link ProcessBuilder#start()} for details.
+     * In the reference implementation, logging of the created process can be enabled,
+     * see {@link ProcessBuilder#start()} for details.
      *
      * @see     ProcessBuilder
      * @since 1.3

--- a/test/jdk/java/lang/ProcessBuilder/ProcessLogging-FINE.properties
+++ b/test/jdk/java/lang/ProcessBuilder/ProcessLogging-FINE.properties
@@ -1,0 +1,8 @@
+############################################################
+#  	Enable logging java.lang.ProcessBuilder to the console
+############################################################
+
+handlers= java.util.logging.ConsoleHandler
+
+java.util.logging.ConsoleHandler.level = ALL
+java.lang.ProcessBuilder.level = FINE

--- a/test/jdk/java/lang/ProcessBuilder/ProcessLogging-FINER.properties
+++ b/test/jdk/java/lang/ProcessBuilder/ProcessLogging-FINER.properties
@@ -1,0 +1,8 @@
+############################################################
+#  	Enable logging java.lang.ProcessBuilder to the console
+############################################################
+
+handlers= java.util.logging.ConsoleHandler
+
+java.util.logging.ConsoleHandler.level = ALL
+java.lang.ProcessBuilder.level = FINER

--- a/test/jdk/java/lang/ProcessBuilder/ProcessLogging-INFO.properties
+++ b/test/jdk/java/lang/ProcessBuilder/ProcessLogging-INFO.properties
@@ -1,0 +1,8 @@
+############################################################
+#  	Enable logging java.lang.ProcessBuilder to the console
+############################################################
+
+handlers= java.util.logging.ConsoleHandler
+
+java.util.logging.ConsoleHandler.level = ALL
+java.lang.ProcessBuilder.level = INFO

--- a/test/jdk/java/lang/ProcessBuilder/ProcessStartLoggingTest.java
+++ b/test/jdk/java/lang/ProcessBuilder/ProcessStartLoggingTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.logging.StreamHandler;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.ParameterizedTest;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/*
+ * @test
+ * @summary verify logging of ProcessBuilder.start()
+ * @run junit/othervm ProcessStartLoggingTest
+ */
+public class ProcessStartLoggingTest {
+
+    private static final String TEST_JDK = System.getProperty("test.jdk");
+    private static final String TEST_SRC = System.getProperty("test.src");
+
+    private static Object HOLD_LOGGER;
+
+    /**
+     * Launch a process with the arguments.
+     * @param args 1 or strings passed directly to ProcessBuilder as command and arguments.
+     */
+    public static void main(String[] args) throws InterruptedException {
+        if (System.getProperty("ThrowingHandler") != null) {
+            HOLD_LOGGER = ProcessStartLoggingTest.ThrowingHandler.installHandler();
+        }
+        try {
+            ProcessBuilder pb = new ProcessBuilder(args);
+            Process p = pb.start();
+            int status = p.waitFor();
+            if (status != 0) {
+                System.out.println("exitValue: " + status);
+            }
+        } catch (IOException ioe) {
+            System.out.println("ProcessBuilder.start() threw IOException: " + ioe);
+        }
+    }
+
+    /**
+     * Test various log level settings, and none.
+     * @return a stream of arguments for parameterized test
+     */
+    private static Stream<Arguments> logParamProvider() {
+        return Stream.of(
+                // Logging enabled with level DEBUG
+                Arguments.of(List.of("-Djava.util.logging.config.file=" +
+                                Path.of(TEST_SRC, "ProcessLogging-FINE.properties").toString()),
+                        List.of("echo", "echo1"),
+                        "ProcessBuilder.start(): [echo, echo1], pid:"),
+                // Logging disabled due to level
+                Arguments.of(List.of("-Djava.util.logging.config.file=" +
+                                Path.of(TEST_SRC, "ProcessLogging-INFO.properties").toString()),
+                        List.of("echo", "echo2"),
+                        ""),
+                // Console logger
+                Arguments.of(List.of("--limit-modules", "java.base",
+                                "-Djdk.system.logger.level=DEBUG"),
+                        List.of("echo", "echo3"),
+                        "ProcessBuilder.start(): [echo, echo3], pid:"),
+                // Console logger
+                Arguments.of(List.of(),
+                        List.of("echo", "echo4"),
+                        ""),
+                // Throwing Handler
+                Arguments.of(List.of("-DThrowingHandler",
+                                "-Djava.util.logging.config.file=" +
+                                        Path.of(TEST_SRC, "ProcessLogging-FINE.properties").toString()),
+                        List.of("echo", "echo5"),
+                        "Logging failed: Exception in publish, ProcessBuilder.start():")
+        );
+    }
+
+    /**
+     * Check that the logger output of a launched process contains the expected message.
+     *
+     * @param logArgs Arguments to configure logging in the java test process
+     * @param childArgs the args passed to the child to be invoked as a Process
+     * @param expectMessage log should contain the message
+     */
+    @ParameterizedTest
+    @MethodSource("logParamProvider")
+    public void checkLogger(List<String> logArgs, List<String> childArgs, String expectMessage) {
+        ProcessBuilder pb = new ProcessBuilder();
+        pb.redirectErrorStream(true);
+
+        List<String> cmd = pb.command();
+        cmd.add(Path.of(TEST_JDK,"bin", "java").toString());
+        cmd.addAll(logArgs);
+        cmd.add(this.getClass().getName());
+        cmd.addAll(childArgs);
+
+        try {
+            Process process = pb.start();
+            try (BufferedReader reader = process.inputReader()) {
+                List<String> lines = reader.lines().toList();
+                boolean match = (expectMessage.isEmpty())
+                        ? lines.size() == 0
+                        : lines.stream().filter(s -> s.contains(expectMessage)).findFirst().isPresent();
+                if (!match) {
+                    // Output lines for debug
+                    System.err.println("Expected> \"" + expectMessage + "\"");
+                    lines.forEach(l -> System.err.println("Actual>   \"" + l+ "\""));
+                    fail("Unexpected log contents");
+                }
+            }
+            int result = process.waitFor();
+            assertEquals(0, result, "Exit status");
+        } catch (IOException | InterruptedException ex) {
+            fail(ex);
+        }
+    }
+
+    /**
+     * A LoggingHandler that throws an Exception.
+     */
+    public static class ThrowingHandler extends StreamHandler {
+
+        // Install this handler for java.lang.ProcessBuilder
+        public static Logger installHandler() {
+            Logger logger = Logger.getLogger("java.lang.ProcessBuilder");
+            logger.addHandler(new ProcessStartLoggingTest.ThrowingHandler());
+            return logger;
+        }
+
+        @Override
+        public synchronized void publish(LogRecord record) {
+            throw new RuntimeException("Exception in publish");
+        }
+    }
+}


### PR DESCRIPTION
Runtime.exec and ProcessBuilder.start methods create a new operating system process with the program and arguments. Many applications configure a logging subsystem to monitor application events. Logging a process start message with the program, arguments, and stack trace can identify the caller and purpose.
Logging the process start event is complementary to the process start event generated for JFR (Java Flight Recorder).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8303619](https://bugs.openjdk.org/browse/JDK-8303619) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8303392](https://bugs.openjdk.org/browse/JDK-8303392): Runtime.exec and ProcessBuilder.start should use System logger
 * [JDK-8303619](https://bugs.openjdk.org/browse/JDK-8303619): Runtime.exec and ProcessBuilder.start should use System logger (**CSR**)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [0f172bab](https://git.openjdk.org/jdk/pull/12862/files/0f172bab516992a07a72f052efed5757b6443d21)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [47c3ab63](https://git.openjdk.org/jdk/pull/12862/files/47c3ab63559d88d720ec343cb70c9d1f4c3ce093)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**) ⚠️ Review applies to [32f05be9](https://git.openjdk.org/jdk/pull/12862/files/32f05be991d219a3011765b34eb3b6ba769334ac)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12862/head:pull/12862` \
`$ git checkout pull/12862`

Update a local copy of the PR: \
`$ git checkout pull/12862` \
`$ git pull https://git.openjdk.org/jdk.git pull/12862/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12862`

View PR using the GUI difftool: \
`$ git pr show -t 12862`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12862.diff">https://git.openjdk.org/jdk/pull/12862.diff</a>

</details>
