### PR TITLE
JDK-8303605: Memory leaks in Metaspace gtests

### DIFF
--- a/test/hotspot/gtest/gtestMain.cpp
+++ b/test/hotspot/gtest/gtestMain.cpp
@@ -92,6 +92,7 @@ static int init_jvm(int argc, char **argv, bool disable_error_handling, JavaVM**
   JNIEnv* env;
 
   int ret = JNI_CreateJavaVM(jvm_ptr, (void**)&env, &args);
+  delete[] options;
   if (ret == JNI_OK) {
     // CreateJavaVM leaves WXExec context, while gtests
     // calls internal functions assuming running in WXWwrite.

--- a/test/hotspot/gtest/metaspace/metaspaceGtestSparseArray.hpp
+++ b/test/hotspot/gtest/metaspace/metaspaceGtestSparseArray.hpp
@@ -99,6 +99,10 @@ public:
     }
   }
 
+  ~SparseArray() {
+    FREE_C_HEAP_ARRAY(T, _slots);
+  }
+
   T at(int i)              { return _slots[i]; }
   const T at(int i) const  { return _slots[i]; }
   void set_at(int i, T e)  { _slots[i] = e; }

--- a/test/hotspot/gtest/metaspace/test_freeblocks.cpp
+++ b/test/hotspot/gtest/metaspace/test_freeblocks.cpp
@@ -91,6 +91,17 @@ class FreeBlocksTest {
     }
   }
 
+  void deallocate_all() {
+    while (_allocations != nullptr) {
+      allocation_t* a = _allocations;
+      _allocations = a->next;
+      check_marked_range(a->p, a->word_size);
+      _freeblocks.add_block(a->p, a->word_size);
+      delete a;
+      DEBUG_ONLY(_freeblocks.verify();)
+    }
+  }
+
   bool allocate() {
 
     size_t word_size = MAX2(_rgen_allocations.get(), _freeblocks.MinWordSize);
@@ -180,6 +191,10 @@ public:
     // some initial feeding
     _freeblocks.add_block(_fb.get(1024), 1024);
     CHECK_CONTENT(_freeblocks, 1, 1024);
+  }
+
+  ~FreeBlocksTest() {
+    deallocate_all();
   }
 
   static void test_small_allocations() {

--- a/test/hotspot/gtest/metaspace/test_freeblocks.cpp
+++ b/test/hotspot/gtest/metaspace/test_freeblocks.cpp
@@ -79,7 +79,7 @@ class FreeBlocksTest {
     return false;
   }
 
-  void deallocate_top() {
+  bool deallocate_top() {
 
     allocation_t* a = _allocations;
     if (a != NULL) {
@@ -88,18 +88,13 @@ class FreeBlocksTest {
       _freeblocks.add_block(a->p, a->word_size);
       delete a;
       DEBUG_ONLY(_freeblocks.verify();)
+      return true;
     }
+    return false;
   }
 
   void deallocate_all() {
-    while (_allocations != nullptr) {
-      allocation_t* a = _allocations;
-      _allocations = a->next;
-      check_marked_range(a->p, a->word_size);
-      _freeblocks.add_block(a->p, a->word_size);
-      delete a;
-      DEBUG_ONLY(_freeblocks.verify();)
-    }
+    while (deallocate_top());
   }
 
   bool allocate() {

--- a/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
+++ b/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
@@ -503,6 +503,7 @@ TEST_VM(metaspace, virtual_space_node_test_basics) {
   CommitLimiter cl (word_size * 2); // basically, no commit limiter.
 
   VirtualSpaceNode* node = VirtualSpaceNode::create_node(word_size, &cl, &sres, &scomm);
+
   ASSERT_NOT_NULL(node);
   ASSERT_EQ(node->committed_words(), (size_t)0);
   ASSERT_EQ(node->committed_words(), scomm.get());
@@ -538,6 +539,8 @@ TEST_VM(metaspace, virtual_space_node_test_basics) {
   ASSERT_EQ(node->committed_words(), (size_t)0);
   ASSERT_EQ(node->committed_words(), scomm.get());
   DEBUG_ONLY(node->verify_locked();)
+
+  delete node;
 }
 
 // Note: we unfortunately need TEST_VM even though the system tested

--- a/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
+++ b/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
@@ -540,8 +540,8 @@ TEST_VM(metaspace, virtual_space_node_test_basics) {
   DEBUG_ONLY(node->verify_locked();)
 
   delete node;
-  ASSERT_EQ(scomm.get(), 0);
-  ASSERT_EQ(sres.get(), 0);
+  ASSERT_EQ(scomm.get(), size_t{0});
+  ASSERT_EQ(sres.get(), size_t{0});
 }
 
 // Note: we unfortunately need TEST_VM even though the system tested

--- a/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
+++ b/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
@@ -503,7 +503,6 @@ TEST_VM(metaspace, virtual_space_node_test_basics) {
   CommitLimiter cl (word_size * 2); // basically, no commit limiter.
 
   VirtualSpaceNode* node = VirtualSpaceNode::create_node(word_size, &cl, &sres, &scomm);
-
   ASSERT_NOT_NULL(node);
   ASSERT_EQ(node->committed_words(), (size_t)0);
   ASSERT_EQ(node->committed_words(), scomm.get());
@@ -541,6 +540,8 @@ TEST_VM(metaspace, virtual_space_node_test_basics) {
   DEBUG_ONLY(node->verify_locked();)
 
   delete node;
+  ASSERT_EQ(scomm.get(), 0);
+  ASSERT_EQ(sres.get(), 0);
 }
 
 // Note: we unfortunately need TEST_VM even though the system tested

--- a/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
+++ b/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
@@ -540,8 +540,8 @@ TEST_VM(metaspace, virtual_space_node_test_basics) {
   DEBUG_ONLY(node->verify_locked();)
 
   delete node;
-  ASSERT_EQ(scomm.get(), size_t{0});
-  ASSERT_EQ(sres.get(), size_t{0});
+  ASSERT_EQ(scomm.get(), (size_t)0);
+  ASSERT_EQ(sres.get(), (size_t)0);
 }
 
 // Note: we unfortunately need TEST_VM even though the system tested


### PR DESCRIPTION
Fix memory leaks identified while running Metaspace gtests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8303605](https://bugs.openjdk.org/browse/JDK-8303605): Memory leaks in Metaspace gtests


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12865/head:pull/12865` \
`$ git checkout pull/12865`

Update a local copy of the PR: \
`$ git checkout pull/12865` \
`$ git pull https://git.openjdk.org/jdk pull/12865/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12865`

View PR using the GUI difftool: \
`$ git pr show -t 12865`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12865.diff">https://git.openjdk.org/jdk/pull/12865.diff</a>

</details>
