### PR TITLE
8296400: pointCrlIssuers might be null in DistributionPointFetcher::verifyURL

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/certpath/DistributionPointFetcher.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/DistributionPointFetcher.java
@@ -430,7 +430,7 @@ public class DistributionPointFetcher {
                             debug.println("DP relativeName:" + relativeName);
                         }
                         if (indirectCRL) {
-                            if (pointCrlIssuers.size() != 1) {
+                            if (pointCrlIssuers == null || pointCrlIssuers.size() != 1) {
                                 // RFC 5280: there must be only 1 CRL issuer
                                 // name when relativeName is present
                                 if (debug != null) {
@@ -439,6 +439,9 @@ public class DistributionPointFetcher {
                                 }
                                 return false;
                             }
+                            // if pointCrlIssuers is not null, pointCrlIssuer
+                            // will also be non-null or the code would have
+                            // returned before now
                             pointNames = getFullNames
                                 (pointCrlIssuer, relativeName);
                         } else {
@@ -475,11 +478,14 @@ public class DistributionPointFetcher {
                     // verify that one of the names in the IDP matches one of
                     // the names in the cRLIssuer of the cert's DP
                     boolean match = false;
+                    // the DP's fullName and relativeName fields are null
+                    // which means pointCrlIssuers is non-null; the three
+                    // cannot all be missing from a certificate.
                     for (Iterator<GeneralName> t = pointCrlIssuers.iterator();
-                            !match && t.hasNext(); ) {
+                         !match && t.hasNext(); ) {
                         GeneralNameInterface crlIssuerName = t.next().getName();
                         for (Iterator<GeneralName> i = idpNames.iterator();
-                                !match && i.hasNext(); ) {
+                             !match && i.hasNext(); ) {
                             GeneralNameInterface idpName = i.next().getName();
                             match = crlIssuerName.equals(idpName);
                         }

--- a/src/java.base/share/classes/sun/security/provider/certpath/DistributionPointFetcher.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/DistributionPointFetcher.java
@@ -482,10 +482,10 @@ public class DistributionPointFetcher {
                     // which means pointCrlIssuers is non-null; the three
                     // cannot all be missing from a certificate.
                     for (Iterator<GeneralName> t = pointCrlIssuers.iterator();
-                         !match && t.hasNext(); ) {
+                            !match && t.hasNext(); ) {
                         GeneralNameInterface crlIssuerName = t.next().getName();
                         for (Iterator<GeneralName> i = idpNames.iterator();
-                             !match && i.hasNext(); ) {
+                                !match && i.hasNext(); ) {
                             GeneralNameInterface idpName = i.next().getName();
                             match = crlIssuerName.equals(idpName);
                         }


### PR DESCRIPTION
Added null-checks for pointCrlIssuers before it is accessed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296400](https://bugs.openjdk.org/browse/JDK-8296400): pointCrlIssuers might be null in DistributionPointFetcher::verifyURL


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12866/head:pull/12866` \
`$ git checkout pull/12866`

Update a local copy of the PR: \
`$ git checkout pull/12866` \
`$ git pull https://git.openjdk.org/jdk pull/12866/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12866`

View PR using the GUI difftool: \
`$ git pr show -t 12866`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12866.diff">https://git.openjdk.org/jdk/pull/12866.diff</a>

</details>
