### PR TITLE
JDK-8303606: Memory leaks in Arguments::parse_each_vm_init_arg

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -70,7 +70,9 @@
 
 #include <limits>
 
-#define DEFAULT_JAVA_LAUNCHER  "generic"
+static const char _default_java_launcher[] = "generic";
+
+#define DEFAULT_JAVA_LAUNCHER _default_java_launcher
 
 char*  Arguments::_jvm_flags_file               = nullptr;
 char** Arguments::_jvm_flags_array              = nullptr;
@@ -322,15 +324,15 @@ bool needs_module_property_warning = false;
 #define ENABLE_NATIVE_ACCESS "enable.native.access"
 #define ENABLE_NATIVE_ACCESS_LEN 20
 
-void Arguments::add_init_library(const char* name, char* options) {
+void Arguments::add_init_library(const char* name, const char* options) {
   _libraryList.add(new AgentLibrary(name, options, false, nullptr));
 }
 
-void Arguments::add_init_agent(const char* name, char* options, bool absolute_path) {
+void Arguments::add_init_agent(const char* name, const char* options, bool absolute_path) {
   _agentList.add(new AgentLibrary(name, options, absolute_path, nullptr));
 }
 
-void Arguments::add_instrument_agent(const char* name, char* options, bool absolute_path) {
+void Arguments::add_instrument_agent(const char* name, const char* options, bool absolute_path) {
   _agentList.add(new AgentLibrary(name, options, absolute_path, nullptr, true));
 }
 
@@ -1907,6 +1909,9 @@ void Arguments::process_java_compiler_argument(const char* arg) {
 }
 
 void Arguments::process_java_launcher_argument(const char* launcher, void* extra_info) {
+  if (_sun_java_launcher != _default_java_launcher) {
+    os::free(_sun_java_launcher);
+  }
   _sun_java_launcher = os::strdup_check_oom(launcher);
 }
 
@@ -2367,6 +2372,8 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
         }
 #endif // !INCLUDE_JVMTI
         add_init_library(name, options);
+        FREE_C_HEAP_ARRAY(char, name);
+        FREE_C_HEAP_ARRAY(char, options);
       }
     } else if (match_option(option, "--add-reads=", &tail)) {
       if (!create_numbered_module_property("jdk.module.addreads", tail, addreads_count++)) {
@@ -2437,6 +2444,8 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
         }
 #endif // !INCLUDE_JVMTI
         add_init_agent(name, options, is_absolute_path);
+        os::free(name);
+        os::free(options);
       }
     // -javaagent
     } else if (match_option(option, "-javaagent:", &tail)) {
@@ -2450,6 +2459,7 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
         char *options = NEW_C_HEAP_ARRAY(char, length, mtArguments);
         jio_snprintf(options, length, "%s", tail);
         add_instrument_agent("instrument", options, false);
+        FREE_C_HEAP_ARRAY(char, options);
         // java agents need module java.instrument
         if (!create_numbered_module_property("jdk.module.addmods", "java.instrument", addmods_count++)) {
           return JNI_ENOMEM;

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1910,7 +1910,7 @@ void Arguments::process_java_compiler_argument(const char* arg) {
 
 void Arguments::process_java_launcher_argument(const char* launcher, void* extra_info) {
   if (_sun_java_launcher != _default_java_launcher) {
-    os::free(_sun_java_launcher);
+    os::free(const_cast<char*>(_sun_java_launcher));
   }
   _sun_java_launcher = os::strdup_check_oom(launcher);
 }

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -333,12 +333,12 @@ class Arguments : AllStatic {
 
   // -Xrun arguments
   static AgentLibraryList _libraryList;
-  static void add_init_library(const char* name, char* options);
+  static void add_init_library(const char* name, const char* options);
 
   // -agentlib and -agentpath arguments
   static AgentLibraryList _agentList;
-  static void add_init_agent(const char* name, char* options, bool absolute_path);
-  static void add_instrument_agent(const char* name, char* options, bool absolute_path);
+  static void add_init_agent(const char* name, const char* options, bool absolute_path);
+  static void add_instrument_agent(const char* name, const char* options, bool absolute_path);
 
   // Late-binding agents not started via arguments
   static void add_loaded_agent(AgentLibrary *agentLib);


### PR DESCRIPTION
Addresses various memory leaks identified by LSan related to Arguments::parse_each_vm_init_arg.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8303606](https://bugs.openjdk.org/browse/JDK-8303606): Memory leaks in Arguments::parse_each_vm_init_arg


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12867/head:pull/12867` \
`$ git checkout pull/12867`

Update a local copy of the PR: \
`$ git checkout pull/12867` \
`$ git pull https://git.openjdk.org/jdk pull/12867/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12867`

View PR using the GUI difftool: \
`$ git pr show -t 12867`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12867.diff">https://git.openjdk.org/jdk/pull/12867.diff</a>

</details>
