### PR TITLE
8303440: The "ZonedDateTime.parse" may not accept the "UTC+XX" zone id

### DIFF
--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -4666,8 +4666,10 @@ public final class DateTimeFormatterBuilder {
                     if (length >= position + 3 && context.charEquals(text.charAt(position + 2), 'C')) {
                         // There are localized zone texts that start with "UTC", e.g.
                         // "UTC\u221210:00" (MINUS SIGN instead of HYPHEN-MINUS) in French.
-                        // Exclude those ZoneText cases.
-                        if (!(this instanceof ZoneTextPrinterParser)) {
+                        // Exclude those cases.
+                        if (length == position + 3 ||
+                                context.charEquals(text.charAt(position + 3), '+') ||
+                                context.charEquals(text.charAt(position + 3), '-')) {
                             return parseOffsetBased(context, text, position, position + 3, OffsetIdPrinterParser.INSTANCE_ID_ZERO);
                         }
                     } else {

--- a/test/jdk/java/time/test/java/time/format/TestUTCParse.java
+++ b/test/jdk/java/time/test/java/time/format/TestUTCParse.java
@@ -60,10 +60,10 @@ public class TestUTCParse {
     @Test
     public void testUTCShortNameRoundTrip() {
         var fmt = DateTimeFormatter.ofPattern("z", Locale.FRANCE);
-        var now = ZonedDateTime.of(2023, 3, 3, 0, 0, 0, 0, ZoneId.of("America/Los_Angeles"));
-        var formatted = fmt.format(now);
+        var zdt = ZonedDateTime.of(2023, 3, 3, 0, 0, 0, 0, ZoneId.of("America/Los_Angeles"));
+        var formatted = fmt.format(zdt);
         assertEquals(formatted, "UTC\u221208:00");
-        assertEquals(fmt.parse(formatted).query(TemporalQueries.zoneId()), now.getZone());
+        assertEquals(fmt.parse(formatted).query(TemporalQueries.zoneId()), zdt.getZone());
     }
 
     @Test(dataProvider = "utcZoneIdStrings")

--- a/test/jdk/java/time/test/java/time/format/TestUTCParse.java
+++ b/test/jdk/java/time/test/java/time/format/TestUTCParse.java
@@ -43,7 +43,7 @@ import static org.testng.Assert.assertEquals;
 public class TestUTCParse {
 
     static {
-        // Assuming CLDR's SHORT name for "America/Los_Angeles
+        // Assuming CLDR's SHORT name for "America/Los_Angeles"
         // produces "UTC\u212208:00"
         System.setProperty("java.locale.providers", "CLDR");
     }
@@ -60,7 +60,7 @@ public class TestUTCParse {
     @Test
     public void testUTCShortNameRoundTrip() {
         var fmt = DateTimeFormatter.ofPattern("z", Locale.FRANCE);
-        var now = ZonedDateTime.now(ZoneId.of("America/Los_Angeles"));
+        var now = ZonedDateTime.of(2023, 3, 3, 0, 0, 0, 0, ZoneId.of("America/Los_Angeles"));
         var formatted = fmt.format(now);
         assertEquals(formatted, "UTC\u221208:00");
         assertEquals(fmt.parse(formatted).query(TemporalQueries.zoneId()), now.getZone());

--- a/test/jdk/java/time/test/java/time/format/TestUTCParse.java
+++ b/test/jdk/java/time/test/java/time/format/TestUTCParse.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @modules jdk.localedata
+ * @bug 8303440
+ * @summary Test parsing "UTC-XX:XX" text works correctly
+ */
+package test.java.time.format;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.TextStyle;
+import java.time.temporal.TemporalQueries;
+import java.util.Locale;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+
+public class TestUTCParse {
+
+    static {
+        // Assuming CLDR's SHORT name for "America/Los_Angeles
+        // produces "UTC\u212208:00"
+        System.setProperty("java.locale.providers", "CLDR");
+    }
+
+    @DataProvider
+    public Object[][] utcZoneIdStrings() {
+        return new Object[][] {
+            {"UTC"},
+            {"UTC+01:30"},
+            {"UTC-01:30"},
+        };
+    }
+
+    @Test
+    public void testUTCShortNameRoundTrip() {
+        var fmt = DateTimeFormatter.ofPattern("z", Locale.FRANCE);
+        var now = ZonedDateTime.now(ZoneId.of("America/Los_Angeles"));
+        var formatted = fmt.format(now);
+        assertEquals(formatted, "UTC\u221208:00");
+        assertEquals(fmt.parse(formatted).query(TemporalQueries.zoneId()), now.getZone());
+    }
+
+    @Test(dataProvider = "utcZoneIdStrings")
+    public void testUTCOffsetRoundTrip(String zidString) {
+        var fmt = new DateTimeFormatterBuilder()
+                .appendZoneText(TextStyle.NARROW)
+                .toFormatter();
+        var zid = ZoneId.of(zidString);
+        assertEquals(fmt.parse(zidString).query(TemporalQueries.zoneId()), zid);
+    }
+}


### PR DESCRIPTION
This change is to fix a regression caused by the fix to [JDK-8234347](https://bugs.openjdk.org/browse/JDK-8234347). The previous fix was simply disabling offset-based parsing if the parser was text-based. Instead, check if it is an offset or not by explicitly comparing the character with '+'/'-' and continue offset parsing if it is.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303440](https://bugs.openjdk.org/browse/JDK-8303440): The "ZonedDateTime.parse" may not accept the "UTC+XX" zone id


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [5cda8482](https://git.openjdk.org/jdk/pull/12868/files/5cda8482e6d68c02550134b67a1064827d5db6c0)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12868/head:pull/12868` \
`$ git checkout pull/12868`

Update a local copy of the PR: \
`$ git checkout pull/12868` \
`$ git pull https://git.openjdk.org/jdk pull/12868/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12868`

View PR using the GUI difftool: \
`$ git pr show -t 12868`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12868.diff">https://git.openjdk.org/jdk/pull/12868.diff</a>

</details>
