### PR TITLE
8303509: Socket setTrafficClass does not work for IPv4 connections when IPv6 enabled

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/Net.java
+++ b/src/java.base/share/classes/sun/nio/ch/Net.java
@@ -100,8 +100,8 @@ public class Net {
     /**
      * Tells whether both IPV6_XXX and IP_XXX socket options should be set on
      * IPv6 sockets. On some kernels, both IPV6_XXX and IP_XXX socket options
-     * need to be set so that the settings are effective for IPv4 multicast
-     * datagrams sent using the socket.
+     * need to be set so that the settings are effective for IPv4 connections
+     * and datagrams.
      */
     static boolean shouldSetBothIPv4AndIPv6Options() {
         return shouldSetBothIPv4AndIPv6Options0();

--- a/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
@@ -948,24 +948,6 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
         return options;
     }
 
-    /**
-     * Sets a IPPROTO_IPV6/IPPROTO level socket. Some platforms require both
-     * IPPROTO_IPV6 and IPPROTO socket options to be set when the socket is IPv6.
-     * In that case, the IPPROTO socket option is set on a best effort basis.
-     */
-    private <T> void setIpProtoSocketOption(SocketOption<T> opt, T value)
-        throws IOException
-    {
-        ProtocolFamily family = family();
-        Net.setSocketOption(fd, family, opt, value);
-        if (family == StandardProtocolFamily.INET6
-                && Net.shouldSetBothIPv4AndIPv6Options()) {
-            try {
-                Net.setSocketOption(fd, StandardProtocolFamily.INET, opt, value);
-            } catch (IOException ignore) { }
-        }
-    }
-
     @Override
     protected <T> void setOption(SocketOption<T> opt, T value) throws IOException {
         if (!supportedOptions().contains(opt))
@@ -974,10 +956,9 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
             throw new IllegalArgumentException("Invalid value '" + value + "'");
         synchronized (stateLock) {
             ensureOpen();
-
             if (opt == StandardSocketOptions.IP_TOS) {
                 // maps to IPV6_TCLASS and/or IP_TOS
-                setIpProtoSocketOption(opt, value);
+                Net.setIpSocketOption(fd, family(), opt, value);
             } else if (opt == StandardSocketOptions.SO_REUSEADDR) {
                 boolean b = (boolean) value;
                 if (Net.useExclusiveBind()) {
@@ -1051,7 +1032,7 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
                 }
                 case IP_TOS: {
                     int i = intValue(value, "IP_TOS");
-                    setIpProtoSocketOption(StandardSocketOptions.IP_TOS, i);
+                    Net.setIpSocketOption(fd, family(), StandardSocketOptions.IP_TOS, i);
                     break;
                 }
                 case TCP_NODELAY: {

--- a/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
@@ -272,8 +272,8 @@ class SocketChannelImpl
 
             if (isNetSocket()) {
                 if (name == StandardSocketOptions.IP_TOS) {
-                    // special handling for IP_TOS
-                    Net.setSocketOption(fd, family, name, value);
+                    // maps to IPV6_TCLASS and/or IP_TOS
+                    Net.setIpSocketOption(fd, family, name, value);
                     return this;
                 }
                 if (name == StandardSocketOptions.SO_REUSEADDR && Net.useExclusiveBind()) {

--- a/src/java.base/unix/native/libnio/ch/Net.c
+++ b/src/java.base/unix/native/libnio/ch/Net.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -159,10 +159,10 @@ JNIEXPORT jboolean JNICALL
 Java_sun_nio_ch_Net_shouldSetBothIPv4AndIPv6Options0(JNIEnv* env, jclass cl)
 {
 #if defined(__linux__)
-    /* Set both IPv4 and IPv6 socket options when setting multicast options */
+    /* Set both IPv4 and IPv6 socket options when setting IPPROTO_IPV6 options */
     return JNI_TRUE;
 #else
-    /* Do not set both IPv4 and IPv6 socket options when setting multicast options */
+    /* Do not set both IPv4 and IPv6 socket options when setting IPPROTO_IPV6 options */
     return JNI_FALSE;
 #endif
 }

--- a/src/java.base/windows/native/libnio/ch/Net.c
+++ b/src/java.base/windows/native/libnio/ch/Net.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,7 +126,7 @@ Java_sun_nio_ch_Net_isExclusiveBindAvailable(JNIEnv *env, jclass clazz) {
 JNIEXPORT jboolean JNICALL
 Java_sun_nio_ch_Net_shouldSetBothIPv4AndIPv6Options0(JNIEnv* env, jclass cl)
 {
-    /* Set both IPv4 and IPv6 socket options when setting multicast options */
+    /* Set both IPv4 and IPv6 socket options when setting IPPROTO_IPV6 options */
     return JNI_TRUE;
 }
 


### PR DESCRIPTION
This is a small update to the underlying implementation of Socket.setTrafficClass so that it attempts to set the IP_TOS socket option when the socket is IPv6 and the operating system allows this option to be set on IPv6 sockets. The change is deliberately limited to the SocketImpl and SocketChannel implementation to avoid impacting DatagramChannel.

Socket.setTrafficClass is specified as a hint. For TCP connections it is possible on some platforms to set IP_TOS on an unbound socket to the ToS value to use in the SYN packet when establishing a connection. Setting it after a connection is established is possible on some platforms too. The JDK uses IPv6 sockets since JDK 1.4 so it gets a bit more complicated due to patchy support for IP_TOS.

- Linux allows IP_TOS to be set on an IPv6 socket at any time. If set on an unbound socket then the ToS will have the expected value when establishing a connection and it can be changed any time after connecting.
- macOS doesn't allow IP_TOS to be set on an IPv6 socket and it doesn't use the IPV6_TCLASS value as the IPv4 ToS. So on macOS, you have to use an IPv4 socket and set IP_TOS before connecting the socket.
- Windows hasn't allowed applications change the ToS for a long time. It allows the IP_TOS to be set on an unbound IPv6 socket but the value is not used.

The bug report report is Socket.setTrafficClass hasn't worked on Linux since JDK 13 when the SocketImpl was replaced. The workaround is to run with-Djava.net.preferIPv4=true. 

The proposed change is to just attempt to set both IPV6_TCLASS and IP_TOS when the socket is IPv6 and the operating system allows IPPROTO level sockets to be setup on IPv6 sockets. At some point I'd like to replace the underlying socket options implementation as it no longer needs to be in libnet, and that would be the limit to re-visit the equivalent in the channel implementations.

I had to use tcpdump and strace to test the changes, I don't think it's possible to create an automated test for this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303509](https://bugs.openjdk.org/browse/JDK-8303509): Socket setTrafficClass does not work for IPv4 connections when IPv6 enabled


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - Committer) ⚠️ Review applies to [c6766a4d](https://git.openjdk.org/jdk/pull/12872/files/c6766a4d971dc056cabbf270b1eda8162c62f13e)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12872/head:pull/12872` \
`$ git checkout pull/12872`

Update a local copy of the PR: \
`$ git checkout pull/12872` \
`$ git pull https://git.openjdk.org/jdk pull/12872/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12872`

View PR using the GUI difftool: \
`$ git pr show -t 12872`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12872.diff">https://git.openjdk.org/jdk/pull/12872.diff</a>

</details>
