### PR TITLE
JDK-8303646: [JVMCI] Add possibility to lookup ResolvedJavaType from jclass.

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -576,6 +576,25 @@ C2V_VMENTRY_NULL(jobject, lookupClass, (JNIEnv* env, jobject, jclass mirror))
   return JVMCIENV->get_jobject(result);
 C2V_END
 
+C2V_VMENTRY_NULL(jobject, lookupJClass, (JNIEnv* env, jobject, jlong jclass_value))
+    if (jclass_value == 0L) {
+        JVMCI_THROW_MSG_NULL(IllegalArgumentException, "jclass must not be zero");
+    }
+    jclass mirror = reinterpret_cast<jclass>(jclass_value);
+    // Since the jclass_value is passed as a jlong, we perform additional checks to prevent the caller from accidentally
+    // sending a value that is not a JNI handle.
+    if (JNIHandles::handle_type(thread, mirror) == JNIInvalidRefType) {
+        JVMCI_THROW_MSG_NULL(IllegalArgumentException, "jclass is not a valid JNI reference");
+    }
+    oop obj = JNIHandles::resolve(mirror);
+    if (!java_lang_Class::is_instance(obj)) {
+        JVMCI_THROW_MSG_NULL(IllegalArgumentException, "jclass must be a reference to the Class object");
+    }
+    JVMCIKlassHandle klass(THREAD, java_lang_Class::as_Klass(obj));
+    JVMCIObject result = JVMCIENV->get_jvmci_type(klass, JVMCI_CHECK_NULL);
+    return JVMCIENV->get_jobject(result);
+C2V_END
+
 C2V_VMENTRY_NULL(jobject, getUncachedStringInPool, (JNIEnv* env, jobject, ARGUMENT_PAIR(cp), jint index))
   constantPoolHandle cp(THREAD, UNPACK_PAIR(ConstantPool, cp));
   constantTag tag = cp->tag_at(index);
@@ -2826,6 +2845,7 @@ JNINativeMethod CompilerToVM::methods[] = {
   {CC "hasNeverInlineDirective",                      CC "(" HS_METHOD2 ")Z",                                                               FN_PTR(hasNeverInlineDirective)},
   {CC "shouldInlineMethod",                           CC "(" HS_METHOD2 ")Z",                                                               FN_PTR(shouldInlineMethod)},
   {CC "lookupType",                                   CC "(" STRING HS_KLASS2 "Z)" HS_RESOLVED_TYPE,                                        FN_PTR(lookupType)},
+  {CC "lookupJClass",                                 CC "(J)" HS_RESOLVED_TYPE,                                                            FN_PTR(lookupJClass)},
   {CC "getArrayType",                                 CC "(C" HS_KLASS2 ")" HS_KLASS,                                                       FN_PTR(getArrayType)},
   {CC "lookupClass",                                  CC "(" CLASS ")" HS_RESOLVED_TYPE,                                                    FN_PTR(lookupClass)},
   {CC "lookupNameInPool",                             CC "(" HS_CONSTANT_POOL2 "I)" STRING,                                                 FN_PTR(lookupNameInPool)},

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -249,6 +249,8 @@ final class CompilerToVM {
 
     native HotSpotResolvedJavaType lookupClass(Class<?> javaClass);
 
+    native HotSpotResolvedJavaType lookupJClass(long jclass);
+
     /**
      * Resolves the entry at index {@code cpi} in {@code constantPool} to an interned String object.
      *

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
@@ -836,6 +836,26 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
         return lookupTypeInternal(name, accessingType, resolve);
     }
 
+    /**
+     * Converts a HotSpot heap JNI {@code hotspot_jclass_value} to a {@link ResolvedJavaType},
+     * provided that the {@code hotspot_jclass_value} is a valid JNI reference to a Java Class. If
+     * this requirement is not met, {@link IllegalArgumentException} is thrown.
+     *
+     * @param hotspot_jclass_value a JNI reference to a {@link Class} value in the HotSpot heap
+     * @return a {@link ResolvedJavaType} for the referenced type
+     * @throws IllegalArgumentException if {@code hotspot_jclass_value} is not a valid JNI reference
+     *             to a {@link Class} object in the HotSpot heap. It is the responsibility of the
+     *             caller to make sure the argument is valid. The checks performed by this method
+     *             are best effort. Hence, the caller must not rely on the checks and corresponding
+     *             exceptions!
+     */
+    public HotSpotResolvedJavaType asResolvedJavaType(long hotspot_jclass_value) {
+        if (hotspot_jclass_value == 0L) {
+            return null;
+        }
+        return compilerToVm.lookupJClass(hotspot_jclass_value);
+    }
+
     JavaType lookupTypeInternal(String name, HotSpotResolvedObjectType accessingType, boolean resolve) {
         // If the name represents a primitive type we can short-circuit the lookup.
         if (name.length() == 1) {


### PR DESCRIPTION
This pull request adds a `jdk.vm.ci.hotspot.HotSpotJVMCIRuntime#asResolvedJavaType(long hotspot_jclass_value)` method, which converts  a HotSpot heap JNI `hotspot_jclass_value` to a `jdk.vm.ci.meta.ResolvedJavaType`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303646](https://bugs.openjdk.org/browse/JDK-8303646): [JVMCI] Add possibility to lookup ResolvedJavaType from jclass.


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12878/head:pull/12878` \
`$ git checkout pull/12878`

Update a local copy of the PR: \
`$ git checkout pull/12878` \
`$ git pull https://git.openjdk.org/jdk pull/12878/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12878`

View PR using the GUI difftool: \
`$ git pr show -t 12878`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12878.diff">https://git.openjdk.org/jdk/pull/12878.diff</a>

</details>
