### PR TITLE
JDK-8302360  Atomic*.compareAndExchange Javadoc unclear

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -806,7 +806,7 @@ public abstract sealed class VarHandle implements Constable
      * {@code (CT1 ct1, ..., CTn ctn, T expectedValue, T newValue)}
      * , statically represented using varargs.
      * @return {@code true} if successful, otherwise {@code false} if the
-     * witness value was not the same as the {@code expectedValue}.
+     * <em>witness value</em> was not the same as the {@code expectedValue}.
      * @throws UnsupportedOperationException if the access mode is unsupported
      * for this VarHandle.
      * @throws WrongMethodTypeException if the access mode type does not
@@ -839,7 +839,7 @@ public abstract sealed class VarHandle implements Constable
      * @param args the signature-polymorphic parameter list of the form
      * {@code (CT1 ct1, ..., CTn ctn, T expectedValue, T newValue)}
      * , statically represented using varargs.
-     * @return the signature-polymorphic result that is the witness value, which
+     * @return the signature-polymorphic result that is the <em>witness value</em>, which
      * will be the same as the {@code expectedValue} if successful
      * , statically represented using {@code Object}.
      * @throws UnsupportedOperationException if the access mode is unsupported
@@ -874,7 +874,7 @@ public abstract sealed class VarHandle implements Constable
      * @param args the signature-polymorphic parameter list of the form
      * {@code (CT1 ct1, ..., CTn ctn, T expectedValue, T newValue)}
      * , statically represented using varargs.
-     * @return the signature-polymorphic result that is the witness value, which
+     * @return the signature-polymorphic result that is the <em>witness value</em>, which
      * will be the same as the {@code expectedValue} if successful
      * , statically represented using {@code Object}.
      * @throws UnsupportedOperationException if the access mode is unsupported
@@ -909,7 +909,7 @@ public abstract sealed class VarHandle implements Constable
      * @param args the signature-polymorphic parameter list of the form
      * {@code (CT1 ct1, ..., CTn ctn, T expectedValue, T newValue)}
      * , statically represented using varargs.
-     * @return the signature-polymorphic result that is the witness value, which
+     * @return the signature-polymorphic result that is the <em>witness value</em>, which
      * will be the same as the {@code expectedValue} if successful
      * , statically represented using {@code Object}.
      * @throws UnsupportedOperationException if the access mode is unsupported
@@ -936,7 +936,7 @@ public abstract sealed class VarHandle implements Constable
      * {@link #get}.
      *
      * <p>This operation may fail spuriously (typically, due to memory
-     * contention) even if the witness value does match the expected value.
+     * contention) even if the <em>witness value</em> does match the expected value.
      *
      * <p>The method signature is of the form {@code (CT1 ct1, ..., CTn ctn, T expectedValue, T newValue)boolean}.
      *
@@ -949,7 +949,7 @@ public abstract sealed class VarHandle implements Constable
      * {@code (CT1 ct1, ..., CTn ctn, T expectedValue, T newValue)}
      * , statically represented using varargs.
      * @return {@code true} if successful, otherwise {@code false} if the
-     * witness value was not the same as the {@code expectedValue} or if this
+     * <em>witness value</em> was not the same as the {@code expectedValue} or if this
      * operation spuriously failed.
      * @throws UnsupportedOperationException if the access mode is unsupported
      * for this VarHandle.
@@ -973,7 +973,7 @@ public abstract sealed class VarHandle implements Constable
      * {@link #getVolatile}.
      *
      * <p>This operation may fail spuriously (typically, due to memory
-     * contention) even if the witness value does match the expected value.
+     * contention) even if the <em>witness value</em> does match the expected value.
      *
      * <p>The method signature is of the form {@code (CT1 ct1, ..., CTn ctn, T expectedValue, T newValue)boolean}.
      *
@@ -986,7 +986,7 @@ public abstract sealed class VarHandle implements Constable
      * {@code (CT1 ct1, ..., CTn ctn, T expectedValue, T newValue)}
      * , statically represented using varargs.
      * @return {@code true} if successful, otherwise {@code false} if the
-     * witness value was not the same as the {@code expectedValue} or if this
+     * <em>witness value</em> was not the same as the {@code expectedValue} or if this
      * operation spuriously failed.
      * @throws UnsupportedOperationException if the access mode is unsupported
      * for this VarHandle.
@@ -1010,7 +1010,7 @@ public abstract sealed class VarHandle implements Constable
      * {@link #getAcquire}.
      *
      * <p>This operation may fail spuriously (typically, due to memory
-     * contention) even if the witness value does match the expected value.
+     * contention) even if the <em>witness value</em> does match the expected value.
      *
      * <p>The method signature is of the form {@code (CT1 ct1, ..., CTn ctn, T expectedValue, T newValue)boolean}.
      *
@@ -1024,7 +1024,7 @@ public abstract sealed class VarHandle implements Constable
      * {@code (CT1 ct1, ..., CTn ctn, T expectedValue, T newValue)}
      * , statically represented using varargs.
      * @return {@code true} if successful, otherwise {@code false} if the
-     * witness value was not the same as the {@code expectedValue} or if this
+     * <em>witness value</em> was not the same as the {@code expectedValue} or if this
      * operation spuriously failed.
      * @throws UnsupportedOperationException if the access mode is unsupported
      * for this VarHandle.
@@ -1048,7 +1048,7 @@ public abstract sealed class VarHandle implements Constable
      * {@link #get}.
      *
      * <p>This operation may fail spuriously (typically, due to memory
-     * contention) even if the witness value does match the expected value.
+     * contention) even if the <em>witness value</em> does match the expected value.
      *
      * <p>The method signature is of the form {@code (CT1 ct1, ..., CTn ctn, T expectedValue, T newValue)boolean}.
      *
@@ -1062,7 +1062,7 @@ public abstract sealed class VarHandle implements Constable
      * {@code (CT1 ct1, ..., CTn ctn, T expectedValue, T newValue)}
      * , statically represented using varargs.
      * @return {@code true} if successful, otherwise {@code false} if the
-     * witness value was not the same as the {@code expectedValue} or if this
+     * <em>witness value</em> was not the same as the {@code expectedValue} or if this
      * operation spuriously failed.
      * @throws UnsupportedOperationException if the access mode is unsupported
      * for this VarHandle.

--- a/src/java.base/share/classes/java/util/concurrent/atomic/AtomicBoolean.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/AtomicBoolean.java
@@ -260,7 +260,7 @@ public class AtomicBoolean implements java.io.Serializable {
      *
      * @param expectedValue the expected value
      * @param newValue the new value
-     * @return the witness value, which will be the same as the
+     * @return the <em>witness value</em>, which will be the same as the
      * expected value if successful
      * @since 9
      */
@@ -278,7 +278,7 @@ public class AtomicBoolean implements java.io.Serializable {
      *
      * @param expectedValue the expected value
      * @param newValue the new value
-     * @return the witness value, which will be the same as the
+     * @return the <em>witness value</em>, which will be the same as the
      * expected value if successful
      * @since 9
      */
@@ -296,7 +296,7 @@ public class AtomicBoolean implements java.io.Serializable {
      *
      * @param expectedValue the expected value
      * @param newValue the new value
-     * @return the witness value, which will be the same as the
+     * @return the <em>witness value</em>, which will be the same as the
      * expected value if successful
      * @since 9
      */

--- a/src/java.base/share/classes/java/util/concurrent/atomic/AtomicInteger.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/AtomicInteger.java
@@ -465,7 +465,7 @@ public class AtomicInteger extends Number implements java.io.Serializable {
      *
      * @param expectedValue the expected value
      * @param newValue the new value
-     * @return the witness value, which will be the same as the
+     * @return the <em>witness value</em>, which will be the same as the
      * expected value if successful
      * @since 9
      */
@@ -481,7 +481,7 @@ public class AtomicInteger extends Number implements java.io.Serializable {
      *
      * @param expectedValue the expected value
      * @param newValue the new value
-     * @return the witness value, which will be the same as the
+     * @return the <em>witness value</em>, which will be the same as the
      * expected value if successful
      * @since 9
      */
@@ -497,7 +497,7 @@ public class AtomicInteger extends Number implements java.io.Serializable {
      *
      * @param expectedValue the expected value
      * @param newValue the new value
-     * @return the witness value, which will be the same as the
+     * @return the <em>witness value</em>, which will be the same as the
      * expected value if successful
      * @since 9
      */

--- a/src/java.base/share/classes/java/util/concurrent/atomic/AtomicIntegerArray.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/AtomicIntegerArray.java
@@ -470,7 +470,7 @@ public class AtomicIntegerArray implements java.io.Serializable {
      * @param i the index
      * @param expectedValue the expected value
      * @param newValue the new value
-     * @return the witness value, which will be the same as the
+     * @return the <em>witness value</em>, which will be the same as the
      * expected value if successful
      * @since 9
      */
@@ -488,7 +488,7 @@ public class AtomicIntegerArray implements java.io.Serializable {
      * @param i the index
      * @param expectedValue the expected value
      * @param newValue the new value
-     * @return the witness value, which will be the same as the
+     * @return the <em>witness value</em>, which will be the same as the
      * expected value if successful
      * @since 9
      */
@@ -506,7 +506,7 @@ public class AtomicIntegerArray implements java.io.Serializable {
      * @param i the index
      * @param expectedValue the expected value
      * @param newValue the new value
-     * @return the witness value, which will be the same as the
+     * @return the <em>witness value</em>, which will be the same as the
      * expected value if successful
      * @since 9
      */

--- a/src/java.base/share/classes/java/util/concurrent/atomic/AtomicLong.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/AtomicLong.java
@@ -478,7 +478,7 @@ public class AtomicLong extends Number implements java.io.Serializable {
      *
      * @param expectedValue the expected value
      * @param newValue the new value
-     * @return the witness value, which will be the same as the
+     * @return the <em>witness value</em>, which will be the same as the
      * expected value if successful
      * @since 9
      */
@@ -494,7 +494,7 @@ public class AtomicLong extends Number implements java.io.Serializable {
      *
      * @param expectedValue the expected value
      * @param newValue the new value
-     * @return the witness value, which will be the same as the
+     * @return the <em>witness value</em>, which will be the same as the
      * expected value if successful
      * @since 9
      */
@@ -510,7 +510,7 @@ public class AtomicLong extends Number implements java.io.Serializable {
      *
      * @param expectedValue the expected value
      * @param newValue the new value
-     * @return the witness value, which will be the same as the
+     * @return the <em>witness value</em>, which will be the same as the
      * expected value if successful
      * @since 9
      */

--- a/src/java.base/share/classes/java/util/concurrent/atomic/AtomicLongArray.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/AtomicLongArray.java
@@ -470,7 +470,7 @@ public class AtomicLongArray implements java.io.Serializable {
      * @param i the index
      * @param expectedValue the expected value
      * @param newValue the new value
-     * @return the witness value, which will be the same as the
+     * @return the <em>witness value</em>, which will be the same as the
      * expected value if successful
      * @since 9
      */
@@ -488,7 +488,7 @@ public class AtomicLongArray implements java.io.Serializable {
      * @param i the index
      * @param expectedValue the expected value
      * @param newValue the new value
-     * @return the witness value, which will be the same as the
+     * @return the <em>witness value</em>, which will be the same as the
      * expected value if successful
      * @since 9
      */
@@ -506,7 +506,7 @@ public class AtomicLongArray implements java.io.Serializable {
      * @param i the index
      * @param expectedValue the expected value
      * @param newValue the new value
-     * @return the witness value, which will be the same as the
+     * @return the <em>witness value</em>, which will be the same as the
      * expected value if successful
      * @since 9
      */

--- a/src/java.base/share/classes/java/util/concurrent/atomic/AtomicReference.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/AtomicReference.java
@@ -353,8 +353,8 @@ public class AtomicReference<V> implements java.io.Serializable {
      *
      * @param expectedValue the expected value
      * @param newValue the new value
-     * @return the witness value, which will be the same as the
-     * expected value if successful
+     * @return the <em>witness value</em>, which is the current value
+     * at the time of the operation.
      * @since 9
      */
     public final V compareAndExchange(V expectedValue, V newValue) {
@@ -369,7 +369,7 @@ public class AtomicReference<V> implements java.io.Serializable {
      *
      * @param expectedValue the expected value
      * @param newValue the new value
-     * @return the witness value, which will be the same as the
+     * @return the <em>witness value</em>, which will be the same as the
      * expected value if successful
      * @since 9
      */
@@ -385,7 +385,7 @@ public class AtomicReference<V> implements java.io.Serializable {
      *
      * @param expectedValue the expected value
      * @param newValue the new value
-     * @return the witness value, which will be the same as the
+     * @return the <em>witness value</em>, which will be the same as the
      * expected value if successful
      * @since 9
      */

--- a/src/java.base/share/classes/java/util/concurrent/atomic/AtomicReference.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/AtomicReference.java
@@ -353,8 +353,8 @@ public class AtomicReference<V> implements java.io.Serializable {
      *
      * @param expectedValue the expected value
      * @param newValue the new value
-     * @return the <em>witness value</em>, which is the current value
-     * at the time of the operation.
+     * @return the <em>witness value</em>, which will be the same as the
+     * expected value if successful
      * @since 9
      */
     public final V compareAndExchange(V expectedValue, V newValue) {

--- a/src/java.base/share/classes/java/util/concurrent/atomic/AtomicReferenceArray.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/AtomicReferenceArray.java
@@ -434,7 +434,7 @@ public class AtomicReferenceArray<E> implements java.io.Serializable {
      * @param i the index
      * @param expectedValue the expected value
      * @param newValue the new value
-     * @return the witness value, which will be the same as the
+     * @return the <em>witness value</em>, which will be the same as the
      * expected value if successful
      * @since 9
      */
@@ -452,7 +452,7 @@ public class AtomicReferenceArray<E> implements java.io.Serializable {
      * @param i the index
      * @param expectedValue the expected value
      * @param newValue the new value
-     * @return the witness value, which will be the same as the
+     * @return the <em>witness value</em>, which will be the same as the
      * expected value if successful
      * @since 9
      */
@@ -470,7 +470,7 @@ public class AtomicReferenceArray<E> implements java.io.Serializable {
      * @param i the index
      * @param expectedValue the expected value
      * @param newValue the new value
-     * @return the witness value, which will be the same as the
+     * @return the <em>witness value</em>, which will be the same as the
      * expected value if successful
      * @since 9
      */


### PR DESCRIPTION
I think the following proposal is very non-invasive and merely draws attention to the fact that "witness value" is a specific term related to the notion of these atomic methods.

It's a small change which I think provides additional clarity, see JBS for the discussion on the topic.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302360](https://bugs.openjdk.org/browse/JDK-8302360): Atomic*.compareAndExchange Javadoc unclear


### Reviewers
 * [Martin Buchholz](https://openjdk.org/census#martin) (@Martin-Buchholz - **Reviewer**) ⚠️ Review applies to [923d23d0](https://git.openjdk.org/jdk/pull/12880/files/923d23d0cf3229aaeeebb57827a3930b36ff1ed9)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12880/head:pull/12880` \
`$ git checkout pull/12880`

Update a local copy of the PR: \
`$ git checkout pull/12880` \
`$ git pull https://git.openjdk.org/jdk pull/12880/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12880`

View PR using the GUI difftool: \
`$ git pr show -t 12880`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12880.diff">https://git.openjdk.org/jdk/pull/12880.diff</a>

</details>
