### PR TITLE
JDK-8303678: [JVMCI] Add possibility to convert object JavaConstant to jobject.

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
@@ -858,6 +858,26 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
         }
     }
 
+    /**
+     * Gets the {@code jobject} value wrapped by {@code peerObject}. The returned "naked" value is
+     * only valid as long as {@code peerObject} is valid. Note that the latter may be shorter than
+     * the lifetime of {@code peerObject}. As such, this method should only be used to pass an
+     * object parameter across a JNI call from the JVMCI shared library to HotSpot. This method must
+     * only be called from within the JVMCI shared library.
+     *
+     * @param peerObject a reference to an object in the peer runtime
+     * @return the {@code jobject} value wrapped by {@code peerObject}
+     * @throws IllegalArgumentException if the current runtime is not the JVMCI shared library or
+     *             {@code peerObject} is not a peer object reference
+     */
+    public long getJObjectValue(HotSpotObjectConstant peerObject) {
+        if (peerObject instanceof IndirectHotSpotObjectConstantImpl) {
+            IndirectHotSpotObjectConstantImpl remote = (IndirectHotSpotObjectConstantImpl) peerObject;
+            return remote.getHandle();
+        }
+        throw new IllegalArgumentException("Cannot get jobject value for " + peerObject + " (" + peerObject.getClass().getName() + ")");
+    }
+
     @Override
     public JVMCIBackend getHostJVMCIBackend() {
         return hostBackend;


### PR DESCRIPTION
This pull request adds a `jdk.vm.ci.hotspot.HotSpotJVMCIRuntime#getJObjectValue(HotSpotObjectConstant peerObject)` method, which gets a reference to an object in the peer runtime wrapped by the `jdk.vm.ci.hotspot.IndirectHotSpotObjectConstantImpl`. The reference is returned as a HotSpot heap JNI jobject.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303678](https://bugs.openjdk.org/browse/JDK-8303678): [JVMCI] Add possibility to convert object JavaConstant to jobject.


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12882/head:pull/12882` \
`$ git checkout pull/12882`

Update a local copy of the PR: \
`$ git checkout pull/12882` \
`$ git pull https://git.openjdk.org/jdk pull/12882/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12882`

View PR using the GUI difftool: \
`$ git pr show -t 12882`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12882.diff">https://git.openjdk.org/jdk/pull/12882.diff</a>

</details>
