### PR TITLE
8303674: JFR: TypeLibrary class not thread safe

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/TypeLibrary.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/TypeLibrary.java
@@ -97,7 +97,7 @@ public final class TypeLibrary {
         return PrivateAccess.getInstance().newValueDescriptor(EventInstrumentation.FIELD_DURATION, Type.LONG, annos, 0, false, EventInstrumentation.FIELD_DURATION);
     }
 
-    public synchronized static void initialize() {
+    public static synchronized void initialize() {
         List<Type> jvmTypes;
         try {
             jvmTypes = MetadataLoader.createTypes();
@@ -112,12 +112,12 @@ public final class TypeLibrary {
         }
     }
 
-    public synchronized static Collection<Type> getTypes() {
+    public static synchronized Collection<Type> getTypes() {
         return new ArrayList<>(types.values());
     }
 
     // Returned list should be mutable (for in-place sorting)
-    public synchronized static List<Type> getVisibleTypes() {
+    public static synchronized List<Type> getVisibleTypes() {
         List<Type> visible = new ArrayList<>(types.size());
         types.values().forEach(t -> {
             if (t.isVisible()) {
@@ -127,7 +127,7 @@ public final class TypeLibrary {
         return visible;
     }
 
-    public synchronized static Type createAnnotationType(Class<? extends Annotation> a) {
+    public static synchronized Type createAnnotationType(Class<? extends Annotation> a) {
         if (shouldPersist(a)) {
             Type type = defineType(a, Type.SUPER_TYPE_ANNOTATION, false);
             if (type != null) {
@@ -149,7 +149,7 @@ public final class TypeLibrary {
         return null;
     }
 
-    public synchronized static AnnotationElement createAnnotation(Annotation annotation) {
+    public static synchronized AnnotationElement createAnnotation(Annotation annotation) {
         Class<? extends Annotation> annotationType = annotation.annotationType();
         Type type = createAnnotationType(annotationType);
         if (type != null) {
@@ -213,11 +213,11 @@ public final class TypeLibrary {
         return null;
     }
 
-    public synchronized static Type createType(Class<?> clazz) {
+    public static synchronized Type createType(Class<?> clazz) {
         return createType(clazz, Collections.emptyList(), Collections.emptyList());
     }
 
-    public synchronized static Type createType(Class<?> clazz, List<AnnotationElement> dynamicAnnotations, List<ValueDescriptor> dynamicFields) {
+    public static synchronized Type createType(Class<?> clazz, List<AnnotationElement> dynamicAnnotations, List<ValueDescriptor> dynamicFields) {
 
         if (Thread.class == clazz) {
             return Type.THREAD;
@@ -417,7 +417,7 @@ public final class TypeLibrary {
     // from registered event types. Those types that are not reachable can
     // safely be removed
     // Returns true if type was removed
-    public synchronized static boolean clearUnregistered() {
+    public static synchronized boolean clearUnregistered() {
         Logger.log(LogTag.JFR_METADATA, LogLevel.TRACE, "Cleaning out obsolete metadata");
         List<Type> registered = new ArrayList<>();
         for (Type type : types.values()) {
@@ -446,11 +446,11 @@ public final class TypeLibrary {
         return !removeIds.isEmpty();
     }
 
-    public synchronized static void addType(Type type) {
+    public static synchronized void addType(Type type) {
         addTypes(Collections.singletonList(type));
     }
 
-    public synchronized static void addTypes(List<Type> ts) {
+    public static synchronized void addTypes(List<Type> ts) {
         if (!ts.isEmpty()) {
             visitReachable(ts, t -> !types.containsKey(t.getId()), t -> types.put(t.getId(), t));
         }
@@ -498,7 +498,7 @@ public final class TypeLibrary {
         }
     }
 
-    public synchronized static void removeType(long id) {
+    public static synchronized void removeType(long id) {
         types.remove(id);
     }
 }


### PR DESCRIPTION
Could I have review of a PR that makes the TypeLibrary class thread safe. 

The problem occur when an application creates new AnnotationElement to use for dynamic events. The new types/classes need to be added to the type library, but the MetadataRepository lock can't be used for various reasons.

The biggest risk with this change is the introduction of a dead lock between the metadata lock and the type library lock. During testing I added a check to all synchronised methods in MetadataRepository to ensure lock ordering is never violated. 

A better solution may be a separate lock class that TypeLibrary and MetadataRepository could share, but it's a large change and not so suitable for a backport.

Testing: 100 * jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303674](https://bugs.openjdk.org/browse/JDK-8303674): JFR: TypeLibrary class not thread safe


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12884/head:pull/12884` \
`$ git checkout pull/12884`

Update a local copy of the PR: \
`$ git checkout pull/12884` \
`$ git pull https://git.openjdk.org/jdk pull/12884/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12884`

View PR using the GUI difftool: \
`$ git pr show -t 12884`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12884.diff">https://git.openjdk.org/jdk/pull/12884.diff</a>

</details>
