### PR TITLE
8303622: JFR: Missing message with Objects.requireNonNull

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/AnnotationElement.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/AnnotationElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -329,7 +329,7 @@ public final class AnnotationElement {
      *         it exists, else {@code null}
      */
     public final <A> A getAnnotation(Class<? extends Annotation> annotationType) {
-        Objects.requireNonNull(annotationType);
+        Objects.requireNonNull(annotationType, "annotationType");
         return type.getAnnotation(annotationType);
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -693,8 +693,8 @@ public final class Recording implements Closeable {
     }
 
     private void setSetting(String id, String value) {
-        Objects.requireNonNull(id);
-        Objects.requireNonNull(value);
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(value, "value");
         internal.setSetting(id, value);
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -193,7 +193,7 @@ public sealed class RecordedObject
      * @see #getFields()
      */
     public boolean hasField(String name) {
-        Objects.requireNonNull(name);
+        Objects.requireNonNull(name, "name");
         for (ValueDescriptor v : objectContext.fields) {
             if (v.getName().equals(name)) {
                 return true;

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingFile.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -267,6 +267,7 @@ public final class RecordingFile implements Closeable {
      *         {@code checkRead} method denies read access to the file.
      */
     public static List<RecordedEvent> readAllEvents(Path path) throws IOException {
+        Objects.requireNonNull(path, "path");
         try (RecordingFile r = new RecordingFile(path)) {
             List<RecordedEvent> list = new ArrayList<>();
             while (r.hasMoreEvents()) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -441,7 +441,7 @@ public final class RecordingStream implements AutoCloseable, EventStream {
      * @since 17
      */
     public void dump(Path destination) throws IOException {
-        Objects.requireNonNull(destination);
+        Objects.requireNonNull(destination, "destination");
         Object recorder = PrivateAccess.getInstance().getPlatformRecorder();
         synchronized (recorder) {
             RecordingState state = recording.getState();

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,8 +109,8 @@ public final class RemoteRecordingStream implements EventStream {
 
         @Override
         public void with(String name, String value) {
-            Objects.requireNonNull(name);
-            Objects.requireNonNull(value);
+            Objects.requireNonNull(name, "name");
+            Objects.requireNonNull(value, "value");
             // FlightRecorderMXBean implementation always returns
             // new instance of Map so no need to create new here.
             Map<String, String> newSettings = getEventSettings();
@@ -210,12 +210,12 @@ public final class RemoteRecordingStream implements EventStream {
     }
 
     @SuppressWarnings("removal")
-    private RemoteRecordingStream(MBeanServerConnection connection, Path dir, boolean delete) throws IOException {
-        Objects.requireNonNull(connection);
-        Objects.requireNonNull(dir);
+    private RemoteRecordingStream(MBeanServerConnection connection, Path directory, boolean delete) throws IOException {
+        Objects.requireNonNull(connection, "connection");
+        Objects.requireNonNull(directory, "directory");
         accessControllerContext = AccessController.getContext();
         // Make sure users can't implement malicious version of a Path object.
-        path = Paths.get(dir.toString());
+        path = Paths.get(directory.toString());
         if (!Files.exists(path)) {
             throw new IOException("Download directory doesn't exist");
         }
@@ -334,7 +334,7 @@ public final class RemoteRecordingStream implements EventStream {
      * @see Recording#setSettings(Map)
      */
     public void setSettings(Map<String, String> settings) {
-        Objects.requireNonNull(settings);
+        Objects.requireNonNull(settings, "settings");
         try {
             mbean.setRecordingSettings(recordingId, settings);
         } catch (Exception e) {
@@ -355,7 +355,7 @@ public final class RemoteRecordingStream implements EventStream {
      *
      */
     public EventSettings disable(String name) {
-        Objects.requireNonNull(name);
+        Objects.requireNonNull(name, "name");
         EventSettings s = ManagementSupport.newEventSettings(new RemoteSettings(mbean, recordingId));
         try {
             return s.with(name + "#" + ENABLED, "false");
@@ -379,7 +379,7 @@ public final class RemoteRecordingStream implements EventStream {
      * @see EventType
      */
     public EventSettings enable(String name) {
-        Objects.requireNonNull(name);
+        Objects.requireNonNull(name, "name");
         EventSettings s = ManagementSupport.newEventSettings(new RemoteSettings(mbean, recordingId));
         try {
             return s.with(name + "#" + ENABLED, "true");
@@ -657,7 +657,7 @@ public final class RemoteRecordingStream implements EventStream {
      * @since 17
      */
     public void dump(Path destination) throws IOException {
-        Objects.requireNonNull(destination);
+        Objects.requireNonNull(destination, "destination");
         long id = -1;
         try {
             FileDump fileDump;


### PR DESCRIPTION
Could I have a review of a PR that adds a few missing message to Objects.requireNonNull for public API methods.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303622](https://bugs.openjdk.org/browse/JDK-8303622): JFR: Missing message with Objects.requireNonNull


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12885/head:pull/12885` \
`$ git checkout pull/12885`

Update a local copy of the PR: \
`$ git checkout pull/12885` \
`$ git pull https://git.openjdk.org/jdk pull/12885/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12885`

View PR using the GUI difftool: \
`$ git pr show -t 12885`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12885.diff">https://git.openjdk.org/jdk/pull/12885.diff</a>

</details>
