### PR TITLE
8303681: JFR: RemoteRecordingStream::setMaxAge() should accept null

### DIFF
--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/DiskRepository.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/DiskRepository.java
@@ -409,7 +409,9 @@ final class DiskRepository implements Closeable {
 
     public synchronized void setMaxAge(Duration maxAge) {
         this.maxAge = maxAge;
-        trimToAge(Instant.now().minus(maxAge));
+        if (maxAge != null) {
+            trimToAge(Instant.now().minus(maxAge));
+        }
     }
 
     public synchronized void setMaxSize(long maxSize) {

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
@@ -410,7 +410,6 @@ public final class RemoteRecordingStream implements EventStream {
      *                                  state
      */
     public void setMaxAge(Duration maxAge) {
-        Objects.requireNonNull(maxAge);
         synchronized (lock) {
             repository.setMaxAge(maxAge);
             this.maxAge = maxAge;


### PR DESCRIPTION
Could I have a review of a PR that removes a Objects.requireNonNull from the setMaxAge method in the RemoteRecordingStream. The check was accidentally added when the class was introduced in JDK 16. The specification states that null is accepted (similar to the Recording class). Max age is by default null, but can be set to another duration, for example Duration.ofHours(1), but not set back to null without this change. 

Testing: jdk/jdk/jfr

Thanks
Erik