### PR TITLE
8303691: Fedora based devkit build should load more packages from archive location

### DIFF
--- a/make/devkit/Tools.gmk
+++ b/make/devkit/Tools.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -71,6 +71,7 @@ else ifeq ($(BASE_OS), Fedora)
     BASE_URL := http://fedora.riscv.rocks/repos-dist/$(BASE_OS_VERSION)/$(ARCH)/Packages/
   else
     DEFAULT_OS_VERSION := 27
+    LATEST_ARCHIVED_OS_VERSION := 35
     ifeq ($(BASE_OS_VERSION), )
       BASE_OS_VERSION := $(DEFAULT_OS_VERSION)
     endif
@@ -79,11 +80,11 @@ else ifeq ($(BASE_OS), Fedora)
     else
       FEDORA_TYPE := fedora/linux
     endif
-    ARCHIVED := $(shell [ $(BASE_OS_VERSION) -lt $(DEFAULT_OS_VERSION) ] && echo true)
-    ifeq ($(ARCHIVED),true)
-      BASE_URL := https://archives.fedoraproject.org/pub/archive/$(FEDORA_TYPE)/releases/$(BASE_OS_VERSION)/Everything/$(ARCH)/os/Packages/
-    else
+    NOT_ARCHIVED := $(shell [ $(BASE_OS_VERSION) -gt $(LATEST_ARCHIVED_OS_VERSION) ] && echo true)
+    ifeq ($(NOT_ARCHIVED),true)
       BASE_URL := https://dl.fedoraproject.org/pub/$(FEDORA_TYPE)/releases/$(BASE_OS_VERSION)/Everything/$(ARCH)/os/Packages/
+    else
+      BASE_URL := https://archives.fedoraproject.org/pub/archive/$(FEDORA_TYPE)/releases/$(BASE_OS_VERSION)/Everything/$(ARCH)/os/Packages/
     endif
   endif
   LINUX_VERSION := Fedora_$(BASE_OS_VERSION)

--- a/make/devkit/Tools.gmk
+++ b/make/devkit/Tools.gmk
@@ -450,7 +450,7 @@ $(BUILDDIR)/$(binutils_ver)/Makefile \
 	  $(PATHPRE) $(ENVS) CFLAGS="-O2 $(CFLAGS)" \
 	      $(BINUTILS_CFG) \
 	      $(CONFIG) \
-        $(LINKER_CONFIG) \
+	      $(LINKER_CONFIG) \
 	      --with-sysroot=$(SYSROOT) \
 	      --disable-nls \
 	      --program-prefix=$(TARGET)- \


### PR DESCRIPTION
When building Fedora based Linux devkits, rpm packages are downloaded from locations at the Fedora project.
The latest/active versions reside under https://dl.fedoraproject.org while older, archived versions live at https://archives.fedoraproject.org.

It seems more releases have been archived in the meanwhile, so e.g. a build based on Fedora 27, which is currently marked as default, would fail.

I suggest to add a variable `LATEST_ARCHIVED_OS_VERSION` in the make file that denotes the Fedora version up to which a download would be attempted from archives. For later releases, the download is done from dl.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303691](https://bugs.openjdk.org/browse/JDK-8303691): Fedora based devkit build should load more packages from archive location


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12888/head:pull/12888` \
`$ git checkout pull/12888`

Update a local copy of the PR: \
`$ git checkout pull/12888` \
`$ git pull https://git.openjdk.org/jdk pull/12888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12888`

View PR using the GUI difftool: \
`$ git pr show -t 12888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12888.diff">https://git.openjdk.org/jdk/pull/12888.diff</a>

</details>
