### PR TITLE
8303495: Unused path parameter in ClassLoader::add_to_app_classpath_entries(JavaThread* current, char* path, ...)

### DIFF
--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -802,7 +802,6 @@ void ClassLoader::add_to_boot_append_entries(ClassPathEntry *new_entry) {
 // loading app classes. Instead, the app class are loaded by the
 // jdk/internal/loader/ClassLoaders$AppClassLoader instance.
 void ClassLoader::add_to_app_classpath_entries(JavaThread* current,
-                                               const char* path,
                                                ClassPathEntry* entry,
                                                bool check_for_duplicates) {
 #if INCLUDE_CDS
@@ -853,7 +852,7 @@ bool ClassLoader::update_class_path_entry_list(JavaThread* current,
     if (is_boot_append) {
       add_to_boot_append_entries(new_entry);
     } else {
-      add_to_app_classpath_entries(current, path, new_entry, check_for_duplicates);
+      add_to_app_classpath_entries(current, new_entry, check_for_duplicates);
     }
     return true;
   } else {

--- a/src/hotspot/share/classfile/classLoader.hpp
+++ b/src/hotspot/share/classfile/classLoader.hpp
@@ -223,7 +223,6 @@ class ClassLoader: AllStatic {
   CDS_ONLY(static void setup_app_search_path(JavaThread* current, const char* class_path);)
   CDS_ONLY(static void setup_module_search_path(JavaThread* current, const char* path);)
   static void add_to_app_classpath_entries(JavaThread* current,
-                                           const char* path,
                                            ClassPathEntry* entry,
                                            bool check_for_duplicates);
   CDS_ONLY(static void add_to_module_path_entries(const char* path,


### PR DESCRIPTION
The path parameter is no longer used in the method `ClassLoader::add_to_app_classpath_entries` so it can be safely removed. Verified with tier 1-4 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303495](https://bugs.openjdk.org/browse/JDK-8303495): Unused path parameter in  ClassLoader::add_to_app_classpath_entries(JavaThread* current, char* path, ...)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12889/head:pull/12889` \
`$ git checkout pull/12889`

Update a local copy of the PR: \
`$ git checkout pull/12889` \
`$ git pull https://git.openjdk.org/jdk pull/12889/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12889`

View PR using the GUI difftool: \
`$ git pr show -t 12889`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12889.diff">https://git.openjdk.org/jdk/pull/12889.diff</a>

</details>
