### PR TITLE
8281941: Change CDS warning messages to use Unified Logging

### DIFF
--- a/src/hotspot/share/cds/classListWriter.cpp
+++ b/src/hotspot/share/cds/classListWriter.cpp
@@ -55,7 +55,7 @@ void ClassListWriter::write(const InstanceKlass* k, const ClassFileStream* cfs) 
   assert(is_enabled(), "must be");
 
   if (!ClassLoader::has_jrt_entry()) {
-    warning("DumpLoadedClassList and CDS are not supported in exploded build");
+    log_warning(cds)("DumpLoadedClassList and CDS are not supported in exploded build");
     DumpLoadedClassList = nullptr;
     return;
   }

--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -345,7 +345,7 @@ public:
   void doit() {
     ResourceMark rm;
     if (AllowArchivingWithJavaAgent) {
-      warning("This archive was created with AllowArchivingWithJavaAgent. It should be used "
+      log_info(cds)("This archive was created with AllowArchivingWithJavaAgent. It should be used "
               "for testing purposes only and should not be used in a production environment");
     }
     FileMapInfo::check_nonempty_dir_in_shared_path_table();
@@ -370,7 +370,7 @@ void DynamicArchive::check_for_dynamic_dump() {
       vm_exit_during_initialization("-XX:+RecordDynamicDumpInfo" __THEMSG, nullptr);
     } else {
       assert(ArchiveClassesAtExit != nullptr, "sanity");
-      warning("-XX:ArchiveClassesAtExit" __THEMSG);
+      log_warning(cds)("-XX:ArchiveClassesAtExit" __THEMSG);
     }
 #undef __THEMSG
     DynamicDumpSharedSpaces = false;

--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -345,7 +345,7 @@ public:
   void doit() {
     ResourceMark rm;
     if (AllowArchivingWithJavaAgent) {
-      log_info(cds)("This archive was created with AllowArchivingWithJavaAgent. It should be used "
+      log_warning(cds)("This archive was created with AllowArchivingWithJavaAgent. It should be used "
               "for testing purposes only and should not be used in a production environment");
     }
     FileMapInfo::check_nonempty_dir_in_shared_path_table();

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1044,13 +1044,13 @@ bool FileMapInfo::validate_shared_path_table() {
     assert(shared_path(0)->is_modules_image(), "first shared_path must be the modules image");
     if (header()->app_class_paths_start_index() > 1) {
       DynamicDumpSharedSpaces = false;
-      warning(
+      log_warning(cds)(
         "Dynamic archiving is disabled because base layer archive has appended boot classpath");
     }
     if (header()->num_module_paths() > 0) {
       if (!check_module_paths()) {
         DynamicDumpSharedSpaces = false;
-        warning(
+        log_warning(cds)(
           "Dynamic archiving is disabled because base layer archive has a different module path");
       }
     }
@@ -1135,7 +1135,7 @@ void FileMapInfo::validate_non_existent_class_paths() {
        i++) {
     SharedClassPathEntry* ent = shared_path(i);
     if (!ent->check_non_existent()) {
-      warning("Archived non-system classes are disabled because the "
+      log_warning("Archived non-system classes are disabled because the "
               "file %s exists", ent->name());
       header()->set_has_platform_or_app_classes(false);
     }
@@ -2386,14 +2386,14 @@ bool FileMapInfo::map_heap_regions(int first, int max,  bool is_open_archive,
 
   // Check that regions are within the java heap
   if (!G1CollectedHeap::heap()->check_archive_addresses(regions, num_regions)) {
-    log_info(cds)("UseSharedSpaces: Unable to allocate region, range is not within java heap.");
+    log_info(cds)("Unable to allocate region, range is not within java heap.");
     return false;
   }
 
   // allocate from java heap
   if (!G1CollectedHeap::heap()->alloc_archive_regions(
              regions, num_regions, is_open_archive)) {
-    log_info(cds)("UseSharedSpaces: Unable to allocate region, java heap range is already in use.");
+    log_info(cds)("Unable to allocate region, java heap range is already in use.");
     return false;
   }
 
@@ -2409,7 +2409,7 @@ bool FileMapInfo::map_heap_regions(int first, int max,  bool is_open_archive,
     if (base == nullptr || base != addr) {
       // dealloc the regions from java heap
       dealloc_heap_regions(regions, num_regions);
-      log_info(cds)("UseSharedSpaces: Unable to map at required address in java heap. "
+      log_info(cds)("Unable to map at required address in java heap. "
                     INTPTR_FORMAT ", size = " SIZE_FORMAT " bytes",
                     p2i(addr), regions[i].byte_size());
       return false;
@@ -2419,7 +2419,7 @@ bool FileMapInfo::map_heap_regions(int first, int max,  bool is_open_archive,
     if (VerifySharedSpaces && !r->check_region_crc()) {
       // dealloc the regions from java heap
       dealloc_heap_regions(regions, num_regions);
-      log_info(cds)("UseSharedSpaces: mapped heap regions are corrupt");
+      log_info(cds)("mapped heap regions are corrupt");
       return false;
     }
   }
@@ -2645,7 +2645,7 @@ bool FileMapHeader::validate() {
   // header data
   const char* prop = Arguments::get_property("java.system.class.loader");
   if (prop != nullptr) {
-    warning("Archived non-system classes are disabled because the "
+    log_warning(cds)("Archived non-system classes are disabled because the "
             "java.system.class.loader property is specified (value = \"%s\"). "
             "To use archived non-system classes, this property must not be set", prop);
     _has_platform_or_app_classes = false;
@@ -2684,7 +2684,7 @@ bool FileMapHeader::validate() {
   }
 
   if (_allow_archiving_with_java_agent) {
-    warning("This archive was created with AllowArchivingWithJavaAgent. It should be used "
+    log_info(cds)("This archive was created with AllowArchivingWithJavaAgent. It should be used "
             "for testing purposes only and should not be used in a production environment");
   }
 

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1135,7 +1135,7 @@ void FileMapInfo::validate_non_existent_class_paths() {
        i++) {
     SharedClassPathEntry* ent = shared_path(i);
     if (!ent->check_non_existent()) {
-      log_warning("Archived non-system classes are disabled because the "
+      log_warning(cds)("Archived non-system classes are disabled because the "
               "file %s exists", ent->name());
       header()->set_has_platform_or_app_classes(false);
     }
@@ -2684,7 +2684,7 @@ bool FileMapHeader::validate() {
   }
 
   if (_allow_archiving_with_java_agent) {
-    log_info(cds)("This archive was created with AllowArchivingWithJavaAgent. It should be used "
+    log_warning(cds)("This archive was created with AllowArchivingWithJavaAgent. It should be used "
             "for testing purposes only and should not be used in a production environment");
   }
 

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -560,7 +560,7 @@ void VM_PopulateDumpSharedSpace::doit() {
   }
 
   if (AllowArchivingWithJavaAgent) {
-    warning("This archive was created with AllowArchivingWithJavaAgent. It should be used "
+    log_info(cds)("This archive was created with AllowArchivingWithJavaAgent. It should be used "
             "for testing purposes only and should not be used in a production environment");
   }
 
@@ -941,7 +941,7 @@ void MetaspaceShared::initialize_runtime_shared_and_meta_spaces() {
   } else {
     set_shared_metaspace_range(nullptr, nullptr, nullptr);
     if (DynamicDumpSharedSpaces) {
-      warning("-XX:ArchiveClassesAtExit is unsupported when base CDS archive is not loaded. Run with -Xlog:cds for more info.");
+      log_warning(cds)("-XX:ArchiveClassesAtExit is unsupported when base CDS archive is not loaded. Run with -Xlog:cds for more info.");
     }
     UseSharedSpaces = false;
     // The base archive cannot be mapped. We cannot dump the dynamic shared archive.

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -560,7 +560,7 @@ void VM_PopulateDumpSharedSpace::doit() {
   }
 
   if (AllowArchivingWithJavaAgent) {
-    log_info(cds)("This archive was created with AllowArchivingWithJavaAgent. It should be used "
+    log_warning(cds)("This archive was created with AllowArchivingWithJavaAgent. It should be used "
             "for testing purposes only and should not be used in a production environment");
   }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/SpecifySysLoaderProp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/SpecifySysLoaderProp.java
@@ -44,7 +44,7 @@ public class SpecifySysLoaderProp {
     String jarFileName = "sysloader.jar";
     String appJar = TestCommon.getTestJar(jarFileName);
     TestCommon.testDump(appJar, TestCommon.list("ReportMyLoader"));
-    String warning = "VM warning: Archived non-system classes are disabled because the java.system.class.loader property is specified";
+    String warning = "Archived non-system classes are disabled because the java.system.class.loader property is specified";
 
 
     // (0) Baseline. Do not specify -Djava.system.class.loader

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchiveConsistency.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchiveConsistency.java
@@ -242,7 +242,7 @@ public class ArchiveConsistency extends DynamicArchiveTestBase {
             "-cp",
             appJar, mainClass)
             .assertNormalExit(output -> {
-                output.shouldContain("VM warning: -XX:ArchiveClassesAtExit is unsupported when base CDS archive is not loaded");
+                output.shouldContain("-XX:ArchiveClassesAtExit is unsupported when base CDS archive is not loaded");
             });
       }
     }

--- a/test/lib/jdk/test/lib/cds/CDSTestUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSTestUtils.java
@@ -44,7 +44,7 @@ import jtreg.SkippedException;
 // This class contains common test utilities for testing CDS
 public class CDSTestUtils {
     public static final String MSG_RANGE_NOT_WITHIN_HEAP =
-        "UseSharedSpaces: Unable to allocate region, range is not within java heap.";
+        "Unable to allocate region, range is not within java heap.";
     public static final String MSG_RANGE_ALREADT_IN_USE =
         "Unable to allocate region, java heap range is already in use.";
     public static final String MSG_DYNAMIC_NOT_SUPPORTED =


### PR DESCRIPTION
As an addendum to previous commits that changed CDS logging, this replaces the remaining log messages with Unified logging. There are also old warning messages that used to be prefixed with UseSharedSpaces which have been updated along with their tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281941](https://bugs.openjdk.org/browse/JDK-8281941): Change CDS warning messages to use Unified Logging


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12890/head:pull/12890` \
`$ git checkout pull/12890`

Update a local copy of the PR: \
`$ git checkout pull/12890` \
`$ git pull https://git.openjdk.org/jdk pull/12890/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12890`

View PR using the GUI difftool: \
`$ git pr show -t 12890`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12890.diff">https://git.openjdk.org/jdk/pull/12890.diff</a>

</details>
