### PR TITLE
8303623: Compiler should disallow non-standard UTF-8 string encodings

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -2453,7 +2453,12 @@ public class LambdaToMethod extends TreeTranslator {
 
         @Override
         protected void append(byte[] ba) {
-            Name name = names.fromUtf(ba);
+            Name name;
+            try {
+                name = names.fromUtf(ba);
+            } catch (InvalidUtfException e) {
+                throw new AssertionError(e);
+            }
             sb.append(name.toString());
         }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -474,7 +474,7 @@ public class Lower extends TreeTranslator {
                 .fromString(target.syntheticNameChar() +
                             "SwitchMap" +
                             target.syntheticNameChar() +
-                            names.fromUtf(ClassWriter.externalize(forEnum.type.tsym.flatName())).toString()
+                            ClassWriter.externalize(forEnum.type.tsym.flatName().toString())
                             .replace('/', '.')
                             .replace('.', target.syntheticNameChar()));
             ClassSymbol outerCacheClass = outerCacheClass();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassFile.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassFile.java
@@ -165,24 +165,8 @@ public class ClassFile {
      * Note: the naming is the inverse of that used by JVMS 4.2 The Internal Form Of Names,
      * which defines "internal name" to be the form using "/" instead of "."
      */
-    public static byte[] internalize(Name name) {
-        return internalize(name.getByteArray(), name.getByteOffset(), name.getByteLength());
-    }
-
-    /**
-     * Return external representation of buf[offset..offset+len-1], converting '.' to '/'.
-     *
-     * Note: the naming is the inverse of that used by JVMS 4.2 The Internal Form Of Names,
-     * which defines "internal name" to be the form using "/" instead of "."
-     */
-    public static byte[] externalize(byte[] buf, int offset, int len) {
-        byte[] translated = new byte[len];
-        for (int j = 0; j < len; j++) {
-            byte b = buf[offset + j];
-            if (b == '.') translated[j] = (byte) '/';
-            else translated[j] = b;
-        }
-        return translated;
+    public static Name internalize(Name name) {
+        return name.table.names.fromString(name.toString().replace('/', '.'));
     }
 
     /**
@@ -191,7 +175,17 @@ public class ClassFile {
      * Note: the naming is the inverse of that used by JVMS 4.2 The Internal Form Of Names,
      * which defines "internal name" to be the form using "/" instead of "."
      */
-    public static byte[] externalize(Name name) {
-        return externalize(name.getByteArray(), name.getByteOffset(), name.getByteLength());
+    public static Name externalize(Name name) {
+        return name.table.names.fromString(externalize(name.toString()));
+    }
+
+    /**
+     * Return external representation of given name, converting '/' to '.'.
+     *
+     * Note: the naming is the inverse of that used by JVMS 4.2 The Internal Form Of Names,
+     * which defines "internal name" to be the form using "/" instead of "."
+     */
+    public static String externalize(String name) {
+        return name.replace('.', '/');
     }
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ModuleNameReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ModuleNameReader.java
@@ -27,6 +27,7 @@ package com.sun.tools.javac.jvm;
 import com.sun.tools.javac.util.ByteBuffer;
 import com.sun.tools.javac.util.ByteBuffer.UnderflowException;
 import com.sun.tools.javac.util.Convert;
+import com.sun.tools.javac.util.InvalidUtfException;
 import com.sun.tools.javac.util.Name.NameMapper;
 
 import java.io.IOException;
@@ -157,7 +158,7 @@ public class ModuleNameReader {
         return res;
     }
 
-    NameMapper<String> utf8Mapper(boolean internalize) {
+    PoolReader.Utf8Mapper<String> utf8Mapper(boolean internalize) {
         return internalize ?
                 (buf, offset, len) ->
                     Convert.utf2string(ClassFile.internalize(buf, offset, len)) :

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolWriter.java
@@ -42,6 +42,7 @@ import com.sun.tools.javac.jvm.PoolConstant.Dynamic;
 import com.sun.tools.javac.jvm.PoolConstant.Dynamic.BsmKey;
 import com.sun.tools.javac.jvm.PoolConstant.NameAndType;
 import com.sun.tools.javac.util.ByteBuffer;
+import com.sun.tools.javac.util.InvalidUtfException;
 import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.Name;
 import com.sun.tools.javac.util.Names;
@@ -324,7 +325,11 @@ public class PoolWriter {
         }
 
         protected Name toName() {
-            return sigbuf.toName(names);
+            try {
+                return sigbuf.toName(names);
+            } catch (InvalidUtfException e) {
+                throw new AssertionError(e);
+            }
         }
     }
 
@@ -365,7 +370,7 @@ public class PoolWriter {
                     Type ct = (Type)c;
                     Name name = ct.hasTag(ARRAY) ?
                             typeSig(ct) :
-                            names.fromUtf(externalize(ct.tsym.flatName()));
+                            externalize(ct.tsym.flatName());
                     poolbuf.appendByte(tag);
                     poolbuf.appendChar(putName(name));
                     if (ct.hasTag(CLASS)) {
@@ -396,7 +401,7 @@ public class PoolWriter {
                 }
                 case ClassFile.CONSTANT_Package: {
                     PackageSymbol pkg = (PackageSymbol)c;
-                    Name pkgName = names.fromUtf(externalize(pkg.flatName()));
+                    Name pkgName = externalize(pkg.flatName());
                     poolbuf.appendByte(tag);
                     poolbuf.appendChar(putName(pkgName));
                     break;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -2432,6 +2432,9 @@ compiler.misc.bad.const.pool.tag=\
 compiler.misc.bad.const.pool.tag.at=\
     bad constant pool tag: {0} at {1}
 
+compiler.misc.bad.utf8.byte.sequence.at=\
+    bad UTF-8 byte sequence at {1}
+
 compiler.misc.unexpected.const.pool.tag.at=\
     unexpected constant pool tag: {0} at {1}
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/ByteBuffer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/ByteBuffer.java
@@ -272,8 +272,9 @@ public class ByteBuffer {
     }
 
     /** Convert contents to name.
+     *  @throws InvalidUtfException if invalid Modified UTF-8 is encountered
      */
-    public Name toName(Names names) {
+    public Name toName(Names names) throws InvalidUtfException {
         return names.fromUtf(elems, 0, length);
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/InvalidUtfException.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/InvalidUtfException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.tools.javac.util;
+
+/**
+ * Exception thrown when invalid Modified UTF-8 is encountered.
+ *
+ * @see Convert#utf2chars
+ * @see Convert#utfValidate
+ */
+public class InvalidUtfException extends Exception {
+
+    private static final long serialVersionUID = 0;
+
+    private final int offset;
+
+    public InvalidUtfException(int offset) {
+        this.offset = offset;
+    }
+
+    /** Get the {@code byte[]} array offset at which the invalid data was found.
+     */
+    public int getOffset() {
+        return offset;
+    }
+}

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Name.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Name.java
@@ -87,7 +87,11 @@ public abstract class Name implements javax.lang.model.element.Name, PoolConstan
         byte[] bs = new byte[len + n.getByteLength()];
         getBytes(bs, 0);
         n.getBytes(bs, len);
-        return table.fromUtf(bs, 0, bs.length);
+        try {
+            return table.fromUtf(bs, 0, bs.length);
+        } catch (InvalidUtfException e) {
+            throw new AssertionError(e);
+        }
     }
 
     /** Return the concatenation of this name, the given ASCII
@@ -99,7 +103,11 @@ public abstract class Name implements javax.lang.model.element.Name, PoolConstan
         getBytes(bs, 0);
         bs[len] = (byte) c;
         n.getBytes(bs, len+1);
-        return table.fromUtf(bs, 0, bs.length);
+        try {
+            return table.fromUtf(bs, 0, bs.length);
+        } catch (InvalidUtfException e) {
+            throw new AssertionError(e);
+        }
     }
 
     /** An arbitrary but consistent complete order among all Names.
@@ -149,14 +157,22 @@ public abstract class Name implements javax.lang.model.element.Name, PoolConstan
      */
     public Name subName(int start, int end) {
         if (end < start) end = start;
-        return table.fromUtf(getByteArray(), getByteOffset() + start, end - start);
+        try {
+            return table.fromUtf(getByteArray(), getByteOffset() + start, end - start);
+        } catch (InvalidUtfException e) {
+            throw new AssertionError(e);
+        }
     }
 
     /** Return the string representation of this name.
      */
     @Override
     public String toString() {
-        return Convert.utf2string(getByteArray(), getByteOffset(), getByteLength());
+        try {
+            return Convert.utf2string(getByteArray(), getByteOffset(), getByteLength());
+        } catch (InvalidUtfException e) {
+            throw new AssertionError(e);
+        }
     }
 
     /** Return the Utf8 representation of this name.
@@ -228,14 +244,15 @@ public abstract class Name implements javax.lang.model.element.Name, PoolConstan
         /** Get the name for the bytes in array cs.
          *  Assume that bytes are in utf8 format.
          */
-        public Name fromUtf(byte[] cs) {
+        public Name fromUtf(byte[] cs) throws InvalidUtfException {
             return fromUtf(cs, 0, cs.length);
         }
 
         /** get the name for the bytes in cs[start..start+len-1].
          *  Assume that bytes are in utf8 format.
+         *  @throws InvalidUtfException if invalid Modified UTF-8 is encountered
          */
-        public abstract Name fromUtf(byte[] cs, int start, int len);
+        public abstract Name fromUtf(byte[] cs, int start, int len) throws InvalidUtfException;
 
         /** Release any resources used by this table.
          */

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
@@ -420,11 +420,11 @@ public class Names {
         return table.fromString(s);
     }
 
-    public Name fromUtf(byte[] cs) {
+    public Name fromUtf(byte[] cs) throws InvalidUtfException {
         return table.fromUtf(cs);
     }
 
-    public Name fromUtf(byte[] cs, int start, int len) {
+    public Name fromUtf(byte[] cs, int start, int len) throws InvalidUtfException {
         return table.fromUtf(cs, start, len);
     }
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/SharedNameTable.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/SharedNameTable.java
@@ -119,7 +119,8 @@ public class SharedNameTable extends Name.Table {
     }
 
     @Override
-    public Name fromUtf(byte[] cs, int start, int len) {
+    public Name fromUtf(byte[] cs, int start, int len) throws InvalidUtfException {
+        Convert.utfValidate(cs, start, len);
         int h = hashValue(cs, start, len) & hashMask;
         NameImpl n = hashes[h];
         byte[] names = this.bytes;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/UnsharedNameTable.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/UnsharedNameTable.java
@@ -81,11 +81,16 @@ public class UnsharedNameTable extends Name.Table {
     public Name fromChars(char[] cs, int start, int len) {
         byte[] name = new byte[len * 3];
         int nbytes = Convert.chars2utf(cs, start, name, 0, len);
-        return fromUtf(name, 0, nbytes);
+        return fromValidUtf(name, 0, nbytes);
     }
 
     @Override
-    public Name fromUtf(byte[] cs, int start, int len) {
+    public Name fromUtf(byte[] cs, int start, int len) throws InvalidUtfException {
+        Convert.utfValidate(cs, start, len);
+        return fromValidUtf(cs, start, len);
+    }
+
+    private Name fromValidUtf(byte[] cs, int start, int len) {
         int h = hashValue(cs, start, len) & hashMask;
 
         HashEntry element = hashes[h];

--- a/test/langtools/tools/javac/classreader/InvalidModifiedUtf8Test.java
+++ b/test/langtools/tools/javac/classreader/InvalidModifiedUtf8Test.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8303623
+ * @summary Compiler should disallow non-standard UTF-8 string encodings
+ */
+
+import com.sun.tools.javac.Main;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.util.Arrays;
+
+public class InvalidModifiedUtf8Test {
+
+    //
+    // What this test does (repeatedly):
+    //  1. Compile a Java source file for ClassX normally
+    //  2. Modify the UTF-8 inside the ClassX classfile so that it is
+    //     still valid structurally but uses a non-standard way of
+    //     encoding some character (according to "Modified UTF-8").
+    //  3. Compile a Java source file for RefClass that references ClassX
+    //  4. Verify that the compiler gives a "bad UTF-8" error
+    //
+
+    // We change c3 a8 -> c3 e8 (illegal second byte not of the form 0x10xxxxxx)
+    private static final String SOURCE_0 = """
+        interface Class0 {
+            void ABC\u00e8();       // encodes to: 41 42 43 c3 a8
+        }
+    """;
+
+    // We change e1 80 80 -> e1 80 40 (illegal third byte not of the form 0x10xxxxxx)
+    private static final String SOURCE_1 = """
+        interface Class1 {
+            void ABC\u1000();       // encodes to: 41 42 43 e1 80 80
+        }
+    """;
+
+    // We change c4 80 -> c1 81 (illegal two-byte encoding for one-byte value)
+    private static final String SOURCE_2 = """
+        interface Class2 {
+            void ABC\u0100();       // encodes to: 41 42 43 c4 00
+        }
+    """;
+
+    // We change e1 80 80 -> e0 84 80 (illegal three-byte encoding for two-byte value)
+    private static final String SOURCE_3 = """
+        interface Class3 {
+            void ABC\u1000();       // encodes to: 41 42 43 e1 80 80
+        }
+    """;
+
+    // We change 44 -> 00 (illegal one-byte encoding of 0x0000)
+    private static final String SOURCE_4 = """
+        interface Class4 {
+            void ABCD();            // encodes to: 41 42 43 44
+        }
+    """;
+
+    // This is the source file that references one of the above
+    private static final String REF_SOURCE = """
+        interface RefClass extends CLASSNAME {
+        }
+    """;
+
+    private static String[] SOURCES = new String[] {
+        SOURCE_0,
+        SOURCE_1,
+        SOURCE_2,
+        SOURCE_3,
+        SOURCE_4,
+    };
+    private static String[][] MODIFICATIONS = new String[][] {
+        {   "414243c3a8",
+            "414243c3e8"    },
+        {   "414243e18080",
+            "414243e18040"  },
+        {   "414243c480",
+            "414243c181"    },
+        {   "414243e18080",
+            "414243e08480"  },
+        {   "41424344",
+            "41424300"      },
+    };
+
+    private static File[] SOURCE_FILES = new File[] {
+        new File("Class0.java"),
+        new File("Class1.java"),
+        new File("Class2.java"),
+        new File("Class3.java"),
+        new File("Class4.java"),
+    };
+    private static File[] CLASS_FILES = new File[] {
+        new File("Class0.class"),
+        new File("Class1.class"),
+        new File("Class2.class"),
+        new File("Class3.class"),
+        new File("Class4.class"),
+    };
+
+    public static String bytes2string(byte[] array) {
+        char[] buf = new char[array.length * 2];
+        for (int i = 0; i < array.length; i++) {
+            int value = array[i] & 0xff;
+            buf[i * 2] = Character.forDigit(value >> 4, 16);
+            buf[i * 2 + 1] = Character.forDigit(value & 0xf, 16);
+        }
+        return new String(buf);
+    }
+
+    public static byte[] string2bytes(String string) {
+        byte[] buf = new byte[string.length() / 2];
+        for (int i = 0; i < string.length(); i += 2) {
+            int value = Integer.parseInt(string.substring(i, i + 2), 16);
+            buf[i / 2] = (byte)value;
+        }
+        return buf;
+    }
+
+    private static void createSourceFile(String content, File file) throws IOException {
+        System.err.println("creating: " + file);
+        try (PrintStream output = new PrintStream(new FileOutputStream(file))) {
+            output.println(content);
+        }
+    }
+
+    private static void writeFile(File file, byte[] content) throws IOException {
+        System.err.println("writing: " + file);
+        try (FileOutputStream output = new FileOutputStream(file)) {
+            Files.write(file.toPath(), content);
+        }
+    }
+
+    private static void compileRefClass(File file, String expectedError) {
+        final StringWriter diags = new StringWriter();
+        final String[] params = new String[] {
+            "-classpath",
+            ".",
+            "-XDrawDiagnostics",
+            file.toString()
+        };
+        System.err.println("compiling: " + file);
+        int ret = Main.compile(params, new PrintWriter(diags, true));
+        if (expectedError != null && ret == 0)
+            throw new AssertionError("compilation succeeded, but expected error \"" + expectedError + "\"");
+        else if (expectedError == null && ret != 0)
+            throw new AssertionError("compilation failed, but expected success:\n" + diags);
+        if (expectedError != null && !diags.toString().contains(expectedError))
+            throw new AssertionError("error message not found:\n  expected: \"" + expectedError + "\"\n  found:" + diags);
+    }
+
+    public static void main(String... args) throws Exception {
+
+        // Create source files
+        for (int i = 0; i < 5; i++)
+            createSourceFile(SOURCES[i], SOURCE_FILES[i]);
+
+        // Compile source files
+        for (int i = 0; i < 5; i++) {
+            final File sourceFile = SOURCE_FILES[i];
+            int ret = Main.compile(new String[] { sourceFile.toString() });
+            if (ret != 0)
+                throw new AssertionError("compilation of " + sourceFile + " failed");
+        }
+
+        // Now compile REF_SOURCE against each classfile without and then with the modification.
+        // When compiling without the modification, everything should be normal.
+        // When compiling with the modification, an error should be generated.
+        for (int i = 0; i < 5; i++) {
+            final String className = "Class" + i;
+            final File classFile = CLASS_FILES[i];
+
+            // Create reference source file
+            final File refSource = new File("RefClass.java");
+            createSourceFile(REF_SOURCE.replaceAll("CLASSNAME", className), refSource);
+
+            // Do a normal compilation
+            compileRefClass(refSource, null);
+
+            // Now corrupt the class file
+            System.err.println("modifying: " + classFile);
+            final String[] mod = MODIFICATIONS[i];
+            final byte[] data1 = Files.readAllBytes(classFile.toPath());
+            final byte[] data2 = string2bytes(bytes2string(data1).replaceAll(mod[0], mod[1]));
+            if (Arrays.equals(data2, data1))
+                throw new AssertionError("modification of " + classFile + " failed");
+            writeFile(classFile, data2);
+
+            // Do a corrupt compilation
+            compileRefClass(refSource, "compiler.misc.bad.utf8.byte.sequence.at");
+        }
+    }
+}

--- a/test/langtools/tools/javac/diags/examples.not-yet.txt
+++ b/test/langtools/tools/javac/diags/examples.not-yet.txt
@@ -57,6 +57,7 @@ compiler.misc.bad.enclosing.method                      # bad class file
 compiler.misc.bad.runtime.invisible.param.annotations   # bad class file
 compiler.misc.bad.signature                             # bad class file
 compiler.misc.bad.requires.flag                         # bad class file
+compiler.misc.bad.utf8.byte.sequence.at                 # bad class file
 compiler.misc.bad.type.annotation.value
 compiler.misc.class.file.not.found                      # ClassReader
 compiler.misc.class.file.wrong.class


### PR DESCRIPTION
This patch is a precursor to upcoming refactoring to address these related bugs:
* [JDK-8269957](https://bugs.openjdk.org/browse/JDK-8269957) - facilitate alternate impls of NameTable and Name
* [JDK-8268622](https://bugs.openjdk.org/browse/JDK-8268622) - Performance issues in javac `Name` class

In any multi-byte UTF-8 sequence, the bytes after the first byte are supposed to all look like `10xxxxxx`. But the code in `Convert.utf2chars()` is not checking that, so e.g., you could have `11xxxxxx` instead and it would encode the same character even though the UTF-8 bytes are different. For example, the character "è" normally encodes as `c3 a8`, but `Convert.utf2chars()` would also accept `c3 e8` or `c3 28` for "è". Another way to have non-standard encodings is by using more bytes than necessary. For example, you could encode the character `0x0100` as three bytes `e0 84 80`, but it should really be encoded as two bytes `c4 80`.

This leniency poses a problem because the current `Name.Table` implementations store UTF-8 byte sequences, not characters. So the same `Name` could be encoded two different ways, which would cause it to be added to the hash table twice. This violates the guarantee of uniqueness provided by `Name.Table` and could even potentially create a security concern (depending on how the compiler is being used).

But regardless of that, JVMS §4.4.7 describes "Modified UTF-8" for encoded strings, and it does not allow for non-standard encodings. Instead, you'll get something like this:
```
$ java Test
Error: LinkageError occurred while loading main class Test
	java.lang.ClassFormatError: Illegal UTF8 string in constant pool in class file Test
```
So the compiler should also reject any invalid classfiles containing them.

This patch makes `Convert.utf2chars()` throw a new checked exception `InvalidUtfException` and refactors accordingly, and adds a few minor cleanups along the way.