### PR TITLE
8299779: Test tools/jpackage/share/jdk/jpackage/tests/MainClassTest.java timed out

### DIFF
--- a/test/jdk/tools/jpackage/share/jdk/jpackage/tests/MainClassTest.java
+++ b/test/jdk/tools/jpackage/share/jdk/jpackage/tests/MainClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ import static jdk.jpackage.tests.MainClassTest.Script.MainClassType.*;
  * @build jdk.jpackage.test.*
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @compile MainClassTest.java
- * @run main/othervm/timeout=540 -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=720 -Xmx512m jdk.jpackage.test.Main
  *  --jpt-run=jdk.jpackage.tests.MainClassTest
  */
 


### PR DESCRIPTION
- Fixed by increasing test timeout. Fix verified on host which reproduced issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299779](https://bugs.openjdk.org/browse/JDK-8299779): Test tools/jpackage/share/jdk/jpackage/tests/MainClassTest.java timed out


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12896/head:pull/12896` \
`$ git checkout pull/12896`

Update a local copy of the PR: \
`$ git checkout pull/12896` \
`$ git pull https://git.openjdk.org/jdk pull/12896/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12896`

View PR using the GUI difftool: \
`$ git pr show -t 12896`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12896.diff">https://git.openjdk.org/jdk/pull/12896.diff</a>

</details>
