### PR TITLE
8302508: Add timestamp to the output TraceCompilerThreads

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -904,6 +904,21 @@ JavaThread* CompileBroker::make_thread(ThreadType type, jobject thread_handle, C
   return new_thread;
 }
 
+static bool trace_compiler_threads() {
+  LogTarget(Debug, jit, thread) lt;
+  return TraceCompilerThreads || lt.is_enabled();
+}
+
+static void print_compiler_threads(stringStream& msg) {
+  if (TraceCompilerThreads) {
+    tty->print_cr("%7d %s", (int)tty->time_stamp().milliseconds(), msg.as_string());
+  }
+  LogTarget(Debug, jit, thread) lt;
+  if (lt.is_enabled()) {
+    LogStream ls(lt);
+    ls.print_cr("%s", msg.as_string());
+  }
+}
 
 void CompileBroker::init_compiler_threads() {
   // Ensure any exceptions lead to vm_exit_during_initialization.
@@ -943,11 +958,13 @@ void CompileBroker::init_compiler_threads() {
       JavaThread *ct = make_thread(compiler_t, thread_handle, _c2_compile_queue, _compilers[1], THREAD);
       assert(ct != nullptr, "should have been handled for initial thread");
       _compilers[1]->set_num_compiler_threads(i + 1);
-      if (TraceCompilerThreads) {
+      if (trace_compiler_threads()) {
         ResourceMark rm;
         ThreadsListHandle tlh;  // name() depends on the TLH.
         assert(tlh.includes(ct), "ct=" INTPTR_FORMAT " exited unexpectedly.", p2i(ct));
-        tty->print_cr("Added initial compiler thread %s", ct->name());
+        stringStream msg;
+        msg.print("Added initial compiler thread %s", ct->name());
+        print_compiler_threads(msg);
       }
     }
   }
@@ -964,11 +981,13 @@ void CompileBroker::init_compiler_threads() {
       JavaThread *ct = make_thread(compiler_t, thread_handle, _c1_compile_queue, _compilers[0], THREAD);
       assert(ct != nullptr, "should have been handled for initial thread");
       _compilers[0]->set_num_compiler_threads(i + 1);
-      if (TraceCompilerThreads) {
+      if (trace_compiler_threads()) {
         ResourceMark rm;
         ThreadsListHandle tlh;  // name() depends on the TLH.
         assert(tlh.includes(ct), "ct=" INTPTR_FORMAT " exited unexpectedly.", p2i(ct));
-        tty->print_cr("Added initial compiler thread %s", ct->name());
+        stringStream msg;
+        msg.print("Added initial compiler thread %s", ct->name());
+        print_compiler_threads(msg);
       }
     }
   }
@@ -1026,10 +1045,12 @@ void CompileBroker::possibly_add_compiler_threads(JavaThread* THREAD) {
           thread_oop = create_thread_oop(name_buffer, THREAD);
         }
         if (HAS_PENDING_EXCEPTION) {
-          if (TraceCompilerThreads) {
+          if (trace_compiler_threads()) {
             ResourceMark rm;
-            tty->print_cr("JVMCI compiler thread creation failed:");
-            PENDING_EXCEPTION->print();
+            stringStream msg;
+            msg.print_cr("JVMCI compiler thread creation failed:");
+            PENDING_EXCEPTION->print_on(&msg);
+            print_compiler_threads(msg);
           }
           CLEAR_PENDING_EXCEPTION;
           break;
@@ -1044,12 +1065,14 @@ void CompileBroker::possibly_add_compiler_threads(JavaThread* THREAD) {
       JavaThread *ct = make_thread(compiler_t, compiler2_object(i), _c2_compile_queue, _compilers[1], THREAD);
       if (ct == nullptr) break;
       _compilers[1]->set_num_compiler_threads(i + 1);
-      if (TraceCompilerThreads) {
+      if (trace_compiler_threads()) {
         ResourceMark rm;
         ThreadsListHandle tlh;  // name() depends on the TLH.
         assert(tlh.includes(ct), "ct=" INTPTR_FORMAT " exited unexpectedly.", p2i(ct));
-        tty->print_cr("Added compiler thread %s (available memory: %dMB, available non-profiled code cache: %dMB)",
-                      ct->name(), (int)(available_memory/M), (int)(available_cc_np/M));
+        stringStream msg;
+        msg.print("Added compiler thread %s (available memory: %dMB, available non-profiled code cache: %dMB)",
+                  ct->name(), (int)(available_memory/M), (int)(available_cc_np/M));
+        print_compiler_threads(msg);
       }
     }
   }
@@ -1065,12 +1088,14 @@ void CompileBroker::possibly_add_compiler_threads(JavaThread* THREAD) {
       JavaThread *ct = make_thread(compiler_t, compiler1_object(i), _c1_compile_queue, _compilers[0], THREAD);
       if (ct == nullptr) break;
       _compilers[0]->set_num_compiler_threads(i + 1);
-      if (TraceCompilerThreads) {
+      if (trace_compiler_threads()) {
         ResourceMark rm;
         ThreadsListHandle tlh;  // name() depends on the TLH.
         assert(tlh.includes(ct), "ct=" INTPTR_FORMAT " exited unexpectedly.", p2i(ct));
-        tty->print_cr("Added compiler thread %s (available memory: %dMB, available profiled code cache: %dMB)",
-                      ct->name(), (int)(available_memory/M), (int)(available_cc_p/M));
+        stringStream msg;
+        msg.print("Added compiler thread %s (available memory: %dMB, available profiled code cache: %dMB)",
+                  ct->name(), (int)(available_memory/M), (int)(available_cc_p/M));
+        print_compiler_threads(msg);
       }
     }
   }
@@ -1885,9 +1910,12 @@ void CompileBroker::compiler_thread_loop() {
         // Access compiler_count under lock to enforce consistency.
         MutexLocker only_one(CompileThread_lock);
         if (can_remove(thread, true)) {
-          if (TraceCompilerThreads) {
-            tty->print_cr("Removing compiler thread %s after " JLONG_FORMAT " ms idle time",
-                          thread->name(), thread->idle_time_millis());
+          if (trace_compiler_threads()) {
+            ResourceMark rm;
+            stringStream msg;
+            msg.print("Removing compiler thread %s after " JLONG_FORMAT " ms idle time",
+                      thread->name(), thread->idle_time_millis());
+            print_compiler_threads(msg);
           }
 
           // Notify compiler that the compiler thread is about to stop


### PR DESCRIPTION
Having timestamps added to the output of TraceCompilerThreads will be helpful in understanding how frequently the compiler threads are being added or removed.

I did that and also added UL output.

```
java -XX:+TraceCompilerThreads -XX:+PrintCompilation -version

     86 Added initial compiler thread C2 CompilerThread0
     86 Added initial compiler thread C1 CompilerThread0
     92    1       3       java.lang.Object::<init> (1 bytes)
     96    2       3       java.lang.String::coder (15 bytes)

java -Xlog:jit+thread=debug -Xlog:jit+compilation=debug -version

[0.078s][debug][jit,thread] Added initial compiler thread C2 CompilerThread0
[0.078s][debug][jit,thread] Added initial compiler thread C1 CompilerThread0
[0.083s][debug][jit,compilation]    1       3       java.lang.Object::<init> (1 bytes)
[0.087s][debug][jit,compilation]    2       3       java.lang.String::coder (15 bytes)
```

Tested tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302508](https://bugs.openjdk.org/browse/JDK-8302508): Add timestamp to the output TraceCompilerThreads


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12898/head:pull/12898` \
`$ git checkout pull/12898`

Update a local copy of the PR: \
`$ git checkout pull/12898` \
`$ git pull https://git.openjdk.org/jdk pull/12898/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12898`

View PR using the GUI difftool: \
`$ git pr show -t 12898`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12898.diff">https://git.openjdk.org/jdk/pull/12898.diff</a>

</details>
