### PR TITLE
8303923: ZipOutStream::putEntry should include an apiNote to indicate that the STORED compression method  should be used when writing directory entries

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
@@ -192,7 +192,7 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
      * The current time will be used if the entry has no set modification time.
      *
      * @apiNote When writing a directory entry, the STORED compression method
-     * should be used and the size and crc values should be set to 0:
+     * should be used and the size and CRC-32 values should be set to 0:
      *
      * {@snippet lang="java" :
      *     ZipEntry e = ...;

--- a/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
@@ -195,7 +195,7 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
      * should be used and the size and crc values should be set to 0:
      *
      * {@snippet lang="java" :
-     *     ZipEntry e = new ZipEntry("dir/");
+     *     ZipEntry e = ...;
      *     if (e.isDirectory()) {
      *         e.setMethod(ZipEntry.STORED);
      *         e.setSize(0);

--- a/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
@@ -191,6 +191,22 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
      * <p>
      * The current time will be used if the entry has no set modification time.
      *
+     * @apiNote When writing a directory entry, the STORED compression method
+     * should be used and the size and crc values should be set to 0:
+     *
+     * {@snippet lang="java" :
+     *     ZipEntry e = new ZipEntry("dir/");
+     *     if (e.isDirectory()) {
+     *         e.setMethod(ZipEntry.STORED);
+     *         e.setSize(0);
+     *         e.setCrc(0);
+     *     }
+     *     stream.putNextEntry(e);
+     * }
+     *
+     * This ensures strict compliance with the ZIP specification and
+     * allows optimal performance when processing directory entries.
+     *
      * @param     e the ZIP entry to be written
      * @throws    ZipException if a ZIP format error has occurred
      * @throws    IOException if an I/O error has occurred

--- a/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
@@ -195,14 +195,14 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
      * should be used and the size and CRC-32 values should be set to 0:
      *
      * {@snippet lang="java" :
-     *     ZipEntry e = ...;
+     *     ZipEntry e = new ZipEntry(entryName);
      *     if (e.isDirectory()) {
      *         e.setMethod(ZipEntry.STORED);
      *         e.setSize(0);
      *         e.setCrc(0);
      *     }
      *     stream.putNextEntry(e);
-     * }
+     *}
      *
      * This ensures strict compliance with the ZIP specification and
      * allows optimal performance when processing directory entries.

--- a/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
@@ -194,7 +194,7 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
      * @apiNote When writing a directory entry, the STORED compression method
      * should be used and the size and CRC-32 values should be set to 0:
      *
-     * {@snippet lang="java" :
+     * {@snippet lang = "java":
      *     ZipEntry e = new ZipEntry(entryName);
      *     if (e.isDirectory()) {
      *         e.setMethod(ZipEntry.STORED);
@@ -204,8 +204,7 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
      *     stream.putNextEntry(e);
      *}
      *
-     * This ensures strict compliance with the ZIP specification and
-     * allows optimal performance when processing directory entries.
+     * This allows optimal performance when processing directory entries.
      *
      * @param     e the ZIP entry to be written
      * @throws    ZipException if a ZIP format error has occurred


### PR DESCRIPTION
ZipOutputStream currently writes directory entries using the DEFLATED compression method. This does not strictly comply with the APPNOTE.TXT specification and is also about 10x slower than using the STORED compression method.

Because of these concerns, `ZipOutputStream.putNextEntry` should be updated with an `@apiNote` recommending
the use of the STORED compression method for directory entries.

Suggested CSR in the first comment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8303925](https://bugs.openjdk.org/browse/JDK-8303925) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8303923](https://bugs.openjdk.org/browse/JDK-8303923): ZipOutStream::putEntry should include an apiNote to indicate that the STORED compression method  should be used when writing directory entries
 * [JDK-8303925](https://bugs.openjdk.org/browse/JDK-8303925): ZipOutStream::putEntry should include an apiNote to indicate that the STORED compression method  should be used when writing directory entries (**CSR**)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12899/head:pull/12899` \
`$ git checkout pull/12899`

Update a local copy of the PR: \
`$ git checkout pull/12899` \
`$ git pull https://git.openjdk.org/jdk.git pull/12899/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12899`

View PR using the GUI difftool: \
`$ git pr show -t 12899`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12899.diff">https://git.openjdk.org/jdk/pull/12899.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12899#issuecomment-1475185435)