### PR TITLE
8303749: Serial: Use more strict card table API

### DIFF
--- a/src/hotspot/share/gc/serial/cardTableRS.cpp
+++ b/src/hotspot/share/gc/serial/cardTableRS.cpp
@@ -140,7 +140,7 @@ void CardTableRS::clear_into_younger(Generation* old_gen) {
   // below to avoid missing cards at the fringes. If clear() or
   // invalidate() are changed in the future, this code should
   // be revisited. 20040107.ysr
-  clear(old_gen->prev_used_region());
+  clear_MemRegion(old_gen->prev_used_region());
 }
 
 void CardTableRS::invalidate_or_clear(Generation* old_gen) {
@@ -155,9 +155,9 @@ void CardTableRS::invalidate_or_clear(Generation* old_gen) {
   MemRegion used_mr = old_gen->used_region();
   MemRegion to_be_cleared_mr = old_gen->prev_used_region().minus(used_mr);
   if (!to_be_cleared_mr.is_empty()) {
-    clear(to_be_cleared_mr);
+    clear_MemRegion(to_be_cleared_mr);
   }
-  invalidate(used_mr);
+  dirty_MemRegion(used_mr);
 }
 
 


### PR DESCRIPTION
Simple refactoring to skip an unnecessary guard check.

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303749](https://bugs.openjdk.org/browse/JDK-8303749): Serial: Use more strict card table API


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12902/head:pull/12902` \
`$ git checkout pull/12902`

Update a local copy of the PR: \
`$ git checkout pull/12902` \
`$ git pull https://git.openjdk.org/jdk pull/12902/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12902`

View PR using the GUI difftool: \
`$ git pr show -t 12902`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12902.diff">https://git.openjdk.org/jdk/pull/12902.diff</a>

</details>
