### PR TITLE
JDK-8303576: addIdentitiesToKeystore in KeystoreImpl.m needs CFRelease call in early potential CHECK_NULL return

### DIFF
--- a/src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m
+++ b/src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m
@@ -289,7 +289,7 @@ static void addIdentitiesToKeystore(JNIEnv *env, jobject keyStore)
         goto errOut;
     }
     jmethodID jm_createKeyEntry = (*env)->GetMethodID(env, jc_KeychainStore, "createKeyEntry", "(Ljava/lang/String;JJ[J[[B)V");
-    if (jm_createKeyEntry) == NULL {
+    if (jm_createKeyEntry == NULL {
         goto errOut;
     }
 

--- a/src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m
+++ b/src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m
@@ -289,7 +289,7 @@ static void addIdentitiesToKeystore(JNIEnv *env, jobject keyStore)
         goto errOut;
     }
     jmethodID jm_createKeyEntry = (*env)->GetMethodID(env, jc_KeychainStore, "createKeyEntry", "(Ljava/lang/String;JJ[J[[B)V");
-    if (jm_createKeyEntry == NULL {
+    if (jm_createKeyEntry == NULL) {
         goto errOut;
     }
 

--- a/src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m
+++ b/src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m
@@ -285,9 +285,14 @@ static void addIdentitiesToKeystore(JNIEnv *env, jobject keyStore)
     OSErr searchResult = noErr;
 
     jclass jc_KeychainStore = (*env)->FindClass(env, "apple/security/KeychainStore");
-    CHECK_NULL(jc_KeychainStore);
+    if (jc_KeychainStore == NULL) {
+        goto errOut;
+    }
     jmethodID jm_createKeyEntry = (*env)->GetMethodID(env, jc_KeychainStore, "createKeyEntry", "(Ljava/lang/String;JJ[J[[B)V");
-    CHECK_NULL(jm_createKeyEntry);
+    if (jm_createKeyEntry) == NULL {
+        goto errOut;
+    }
+
     do {
         searchResult = SecIdentitySearchCopyNext(identitySearch, &theIdentity);
 


### PR DESCRIPTION
Similar to what had been done in [JDK-8303354](https://bugs.openjdk.org/browse/JDK-8303354) , we miss CFRelease on the variable identitySearch in early CHECK_NULL returns potentially done in the function addIdentitiesToKeystore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303576](https://bugs.openjdk.org/browse/JDK-8303576): addIdentitiesToKeystore in KeystoreImpl.m needs CFRelease call in early potential CHECK_NULL return


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**) ⚠️ Review applies to [8dcf5a2c](https://git.openjdk.org/jdk/pull/12905/files/8dcf5a2c08a8d21cd37330efcda61b53ed25dbbe)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12905/head:pull/12905` \
`$ git checkout pull/12905`

Update a local copy of the PR: \
`$ git checkout pull/12905` \
`$ git pull https://git.openjdk.org/jdk pull/12905/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12905`

View PR using the GUI difftool: \
`$ git pr show -t 12905`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12905.diff">https://git.openjdk.org/jdk/pull/12905.diff</a>

</details>
