### PR TITLE
8303760: Visual Studio should use the primary variant in the IDE

### DIFF
--- a/make/ide/visualstudio/hotspot/CreateVSProject.gmk
+++ b/make/ide/visualstudio/hotspot/CreateVSProject.gmk
@@ -35,8 +35,8 @@ ifeq ($(call isTargetOs, windows), true)
   # The next part is a bit hacky. We include the CompileJvm.gmk to be
   # able to extract flags, but we do not wish to execute the rules.
 
-  # Use server as base for defines and includes
-  JVM_VARIANT=server
+  # Use primary variant for defines and includes
+  JVM_VARIANT := $(JVM_VARIANT_MAIN)
 
   include HotspotCommon.gmk
   include lib/CompileJvm.gmk


### PR DESCRIPTION
Currently support for Visual Studio development always assumes server as the variant to use. More accurately this should instead be set to the primary variant instead