### PR TITLE
8171156: Class java.util.LocaleISOData has outdated information for country Code NP

### DIFF
--- a/src/java.base/share/classes/java/util/LocaleISOData.java
+++ b/src/java.base/share/classes/java/util/LocaleISOData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -393,7 +393,7 @@ class LocaleISOData {
         + "NI" + "NIC"  // Nicaragua, Republic of
         + "NL" + "NLD"  // Netherlands, Kingdom of the
         + "NO" + "NOR"  // Norway, Kingdom of
-        + "NP" + "NPL"  // Nepal, Kingdom of
+        + "NP" + "NPL"  // Nepal, Federal Democratic Republic of
         + "NR" + "NRU"  // Nauru, Republic of
         + "NU" + "NIU"  // Niue, Republic of
         + "NZ" + "NZL"  // New Zealand


### PR DESCRIPTION
The java.util.LocaleISOData.isoCountryTable has an incorrect formal name for Nepal. 

According to [Wikipedia](https://en.wikipedia.org/wiki/Nepal) and the [UN](https://www.un.int/protocol/sites/www.un.int/files/Protocol%20and%20Liaison%20Service/officialnamesofcountries.pdf), Nepal's formal name should be  `Federal Democratic Republic of Nepal`, not `Kingdom of Nepal`. It is only a comment, however there is no reason it should not be corrected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8171156](https://bugs.openjdk.org/browse/JDK-8171156): Class java.util.LocaleISOData has outdated information for country Code NP


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12912/head:pull/12912` \
`$ git checkout pull/12912`

Update a local copy of the PR: \
`$ git checkout pull/12912` \
`$ git pull https://git.openjdk.org/jdk pull/12912/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12912`

View PR using the GUI difftool: \
`$ git pr show -t 12912`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12912.diff">https://git.openjdk.org/jdk/pull/12912.diff</a>

</details>
