### PR TITLE
JDK-8303794: IEEEremainder problems are causing test failures after JDK-8302801

### DIFF
--- a/src/java.base/share/classes/java/lang/FdLibm.java
+++ b/src/java.base/share/classes/java/lang/FdLibm.java
@@ -3301,4 +3301,157 @@ class FdLibm {
             return (jx >= 0)? z: -z;
         }
     }
+
+    static final class Remainder {
+        private Remainder() {throw new UnsupportedOperationException();}
+
+        static double compute(double x) {
+            int hx,hp;
+            /*unsigned*/ int sx, lx, lp;
+            double p_half;
+
+            hx = __HI(x);           /* high word of x */
+            lx = __LO(x);           /* low  word of x */
+            hp = __HI(p);           /* high word of p */
+            lp = __LO(p);           /* low  word of p */
+            sx = hx&0x80000000;
+            hp &= 0x7fffffff;
+            hx &= 0x7fffffff;
+
+            /* purge off exception values */
+            if ((hp | lp) == 0) return (x*p)/(x*p);      /* p = 0 */
+            if((hx >= 0x7ff00000) ||                   /* x not finite */
+               ((hp >= 0x7ff00000) &&                   /* p is NaN */
+                (((hp - 0x7ff00000) | lp) != 0)))
+                return (x*p)/(x*p);
+
+            if (hp <= 0x7fdfffff) x = fmod(x,p+p);  /* now x < 2p */
+            if (((hx - hp)|(lx - lp))==0) return zero*x;
+            x  = Math.abs(x);
+            p  = Math.abs(p);
+            if (hp < 0x00200000) {
+                if(x+x > p) {
+                    x -= p;
+                    if(x + x >= p) x -= p;
+                }
+            } else {
+                p_half = 0.5*p;
+                if(x > p_half) {
+                    x -= p;
+                    if(x >= p_half) x -= p;
+                }
+            }
+            __HI(x) ^= sx;
+            return x;
+        }
+
+        static double fmod(double x, double y) {
+            int n,hx,hy,hz,ix,iy,sx,i;
+            /*unsigned*/ int lx,ly,lz;
+
+            hx = __HI(x);           /* high word of x */
+            lx = __LO(x);           /* low  word of x */
+            hy = __HI(y);           /* high word of y */
+            ly = __LO(y);           /* low  word of y */
+            sx = hx&0x80000000;             /* sign of x */
+            hx ^=sx;                /* |x| */
+            hy &= 0x7fffffff;       /* |y| */
+
+            /* purge off exception values */
+            if((hy|ly)==0||(hx>=0x7ff00000)||       /* y=0,or x not finite */
+               ((hy|((ly | -ly) >> 31))>0x7ff00000))     /* or y is NaN */
+                return (x*y)/(x*y);
+            if(hx <=hy) {
+                if((hx<hy)||(Intger.compareUnsigned(lx, ly) < 0)) return x;      /* |x|<|y| return x */
+                if(lx==ly)
+                    return Zero[sx>>>31];  /* |x|=|y| return x*0*/ // unsigned shift
+            }
+
+            /* determine ix = ilogb(x) */
+            if(hx<0x00100000) {     /* subnormal x */
+                if(hx==0) {
+                    for (ix = -1043, i=lx; i>0; i<<=1) ix -=1;
+                } else {
+                    for (ix = -1022,i=(hx<<11); i>0; i<<=1) ix -=1;
+                }
+            } else ix = (hx>>20)-1023;
+
+            /* determine iy = ilogb(y) */
+            if(hy<0x00100000) {     /* subnormal y */
+                if(hy==0) {
+                    for (iy = -1043, i=ly; i>0; i<<=1) iy -=1;
+                } else {
+                    for (iy = -1022,i=(hy<<11); i>0; i<<=1) iy -=1;
+                }
+            } else iy = (hy>>20)-1023;
+
+            /* set up {hx,lx}, {hy,ly} and align y to x */
+            if(ix >= -1022)
+                hx = 0x00100000|(0x000fffff&hx);
+            else {          /* subnormal x, shift x to normal */
+                n = -1022-ix;
+                if(n<=31) {
+                    hx = (hx<<n)|(lx>>>(32-n)); // unsigned shift
+                    lx <<= n;
+                } else {
+                    hx = lx<<(n-32);
+                    lx = 0;
+                }
+            }
+            if(iy >= -1022)
+                hy = 0x00100000|(0x000fffff&hy);
+            else {          /* subnormal y, shift y to normal */
+                n = -1022-iy;
+                if(n<=31) {
+                    hy = (hy<<n)|(ly>>>(32-n)); // unsigned shift
+                    ly <<= n;
+                } else {
+                    hy = ly<<(n-32);
+                    ly = 0;
+                }
+            }
+
+            /* fix point fmod */
+            n = ix - iy;
+            while(n--) {
+                hz=hx-hy;lz=lx-ly; if(Integer.compareUnsigned(lx, ly) < 0 ) hz -= 1;
+                if(hz<0){hx = hx+hx+(lx>>>31); lx = lx+lx;} // unsigned shift
+                else {
+                    if((hz|lz)==0)          /* return sign(x)*0 */
+                        return Zero[(unsigned)sx>>31];
+                    hx = hz+hz+(lz>>>31); lx = lz+lz; // unsigned shift
+                }
+            }
+            hz=hx-hy;lz=lx-ly; if(Integer.compareUnsigned(lx, ly) < 0) hz -= 1;
+            if(hz>=0) {hx=hz;lx=lz;}
+
+            /* convert back to floating value and restore the sign */
+            if((hx|lx)==0)                  /* return sign(x)*0 */
+                return Zero[(unsigned)sx>>31];
+            while(Integer.compareUnsigned(hx, 0x00100000) < 0) {          /* normalize x */
+                hx = hx+hx+(lx>>31); lx = lx+lx;
+                iy -= 1;
+            }
+            if(iy>= -1022) {        /* normalize output */
+                hx = ((hx-0x00100000)|((iy+1023)<<20));
+                __HI(x) = hx|sx;
+                __LO(x) = lx;
+            } else {                /* subnormal output */
+                n = -1022 - iy;
+                if(n<=20) {
+                    lx = (lx>>>n)|(hx<<(32-n)); // unsigned shift
+                    hx >>= n;
+                } else if (n<=31) {
+                    lx = (hx<<(32-n))|(lx>>>n); hx = sx; // unsigned shift
+                } else {
+                    lx = hx>>(n-32); hx = sx;
+                }
+                __HI(x) = hx|sx;
+                __LO(x) = lx;
+                x *= one;           /* create necessary signal */
+            }
+            return x;               /* exact output */
+        }
+    }
+
 }

--- a/src/java.base/share/classes/java/lang/StrictMath.java
+++ b/src/java.base/share/classes/java/lang/StrictMath.java
@@ -389,7 +389,9 @@ public final class StrictMath {
      * @return  the remainder when {@code f1} is divided by
      *          {@code f2}.
      */
-    public static native double IEEEremainder(double f1, double f2);
+    public static double IEEEremainder(double f1, double f2) {
+        return Fdlibm.Remainder.compute(f1, f2);
+    }
 
     /**
      * Returns the smallest (closest to negative infinity)

--- a/src/java.base/share/classes/java/lang/StrictMath.java
+++ b/src/java.base/share/classes/java/lang/StrictMath.java
@@ -390,7 +390,7 @@ public final class StrictMath {
      *          {@code f2}.
      */
     public static double IEEEremainder(double f1, double f2) {
-        return Fdlibm.Remainder.compute(f1, f2);
+        return FdLibm.Remainder.compute(f1, f2);
     }
 
     /**


### PR DESCRIPTION
Quick port of IEEEremainder; sorry for missing this earlier. Will add targeted tests in a follow-up fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303794](https://bugs.openjdk.org/browse/JDK-8303794): IEEEremainder problems are causing test failures after JDK-8302801 (**Bug** - P2) ⚠️ Issue is not open.


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12915/head:pull/12915` \
`$ git checkout pull/12915`

Update a local copy of the PR: \
`$ git checkout pull/12915` \
`$ git pull https://git.openjdk.org/jdk.git pull/12915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12915`

View PR using the GUI difftool: \
`$ git pr show -t 12915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12915.diff">https://git.openjdk.org/jdk/pull/12915.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12915#issuecomment-1459133557)